### PR TITLE
Clean up CondTools/DQM configurations and add unit tests

### DIFF
--- a/CondTools/DQM/python/DQMXMLFileEventSetupAnalyzer_cfi.py
+++ b/CondTools/DQM/python/DQMXMLFileEventSetupAnalyzer_cfi.py
@@ -1,28 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from DQMServices.Core.DQMStore_cfg import *
-from CondCore.DBCommon.CondDBSetup_cfi import *
-
 dqmXMLFileGetter=cms.EDAnalyzer("DQMXMLFileEventSetupAnalyzer",
                                 labelToGet = cms.string('GenericXML')
                                 ) 
 
-## ReferenceRetrieval = cms.ESSource("PoolDBESSource",
-##                                   CondDBSetup,
-##                                   connect = cms.string('sqlite_file:DQMReferenceHistogramTest.db'),
-##                                   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-##                                   messageLevel = cms.untracked.int32(1), #3 for high verbosity
-##                                   timetype = cms.string('runnumber'),
-##                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
-##                                                              tag = cms.string('ROOTFILE_DQM_Test10')
-##                                                              )
-##                                                     )
-##                                   )
-##
-## RecordDataGetter = cms.EDAnalyzer("EventSetupRecordDataGetter",
-##                              toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
-##                                                         data = cms.vstring('ROOTFILE_DQM_Test10')
-##                                                         )
-##                                                ),
-##                              verbose = cms.untracked.bool(False)
-##                              )

--- a/CondTools/DQM/src/DQMXMLFileSourceHandler.cc
+++ b/CondTools/DQM/src/DQMXMLFileSourceHandler.cc
@@ -44,7 +44,7 @@ namespace popcon {
       edm::LogInfo("DQMXMLFileSourceHandler") << ss.str();
     }
     edm::LogInfo("DQMXMLFileSourceHandler") << "runnumber/first since = " << m_since << std::endl;
-    if (m_since <= this->tagInfo().lastInterval.since) {
+    if (this->tagInfo().size > 0 && m_since <= this->tagInfo().lastInterval.since) {
       edm::LogInfo("DQMXMLFileSourceHandler")
           << "[DQMXMLFileSourceHandler::getNewObjects] \nthe current starting iov " << m_since
           << "\nis not compatible with the last iov (" << this->tagInfo().lastInterval.since << ") open for the object "

--- a/CondTools/DQM/test/BuildFile.xml
+++ b/CondTools/DQM/test/BuildFile.xml
@@ -1,0 +1,12 @@
+<environment>
+  <bin name="testCondToolsDQMUpload" file="testPayloadWriting.cpp">
+    <flags TEST_RUNNER_ARGS=" /bin/bash CondTools/DQM/test test_write.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+
+  <bin name="testCondToolsDQMRead" file="testPayloadReading.cpp">
+    <flags PRE_TEST="testCondToolsDQMUpload"/>
+    <flags TEST_RUNNER_ARGS=" /bin/bash CondTools/DQM/test test_read.sh"/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+</environment>

--- a/CondTools/DQM/test/DQMUploadXMLFile.py
+++ b/CondTools/DQM/test/DQMUploadXMLFile.py
@@ -7,11 +7,10 @@ process.MessageLogger=cms.Service("MessageLogger",
                                   destinations=cms.untracked.vstring("cout")
                                   )
 
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.CondDBCommon.connect = cms.string('sqlite_file:testXML.db')
-process.CondDBCommon.DBParameters.authenticationPath = cms.untracked.string('')
-process.CondDBCommon.BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService')
-
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = cms.string('sqlite_file:testXML.db')
+process.CondDB.DBParameters.authenticationPath = cms.untracked.string('')
+process.CondDB.BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService')
 #process.CondDBCommon.DBParameters.messageLevel = cms.untracked.int32(3) #3 for high verbosity
 
 process.source = cms.Source("EmptyIOVSource", #needed to EvSetup in order to load data
@@ -22,24 +21,22 @@ process.source = cms.Source("EmptyIOVSource", #needed to EvSetup in order to loa
                             )
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
-                                          process.CondDBCommon,
+                                          process.CondDB,
                                           timetype = cms.untracked.string('runnumber'),
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('FileBlob'),
-                                                                     tag = cms.string('XML_pixels_1')
+                                                                     tag = cms.string('XML_test')
                                                                      )
                                                             ),
-                                          logconnect = cms.untracked.string('sqlite_file:XMLFILE_TestLog.db')                                     
+                                          logconnect = cms.untracked.string('sqlite_file:XMLFILE_TestLog.db')
                                           )
 
 process.dqmxmlFileTest = cms.EDAnalyzer("DQMXMLFilePopConAnalyzer",
                                         record = cms.string('FileBlob'),
                                         loggingOn = cms.untracked.bool(True), #always True, needs to create the log db
                                         SinceAppendMode = cms.bool(True),
-                                        Source = cms.PSet(XMLFile = cms.untracked.string("sipixel_qualitytest_config.xml"),
-    #"/afs/cern.ch/cms/sw/slc4_ia32_gcc345/cms/cmssw/CMSSW_3_3_0/src/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml"),
-    #"/afs/cern.ch/cms/sw/slc4_ia32_gcc345/cms/cmssw/CMSSW_3_3_0/src/DQM/SiPixelMonitorClient/test/sipixel_qualitytest_config.xml"),
-                                                          firstSince = cms.untracked.uint64(124275), #1, 43434, 46335, 51493, 51500
-                                                          debug = cms.untracked.bool(False),
+                                        Source = cms.PSet(XMLFile = cms.untracked.string("/cvmfs/cms.cern.ch/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_2/src/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml"),
+                                                          firstSince = cms.untracked.uint64(2), 
+                                                          debug = cms.untracked.bool(True),
                                                           zip = cms.untracked.bool(False)
                                                           )
                                         )

--- a/CondTools/DQM/test/DQMUploadXMLFile.py
+++ b/CondTools/DQM/test/DQMUploadXMLFile.py
@@ -35,7 +35,7 @@ process.dqmxmlFileTest = cms.EDAnalyzer("DQMXMLFilePopConAnalyzer",
                                         loggingOn = cms.untracked.bool(True), #always True, needs to create the log db
                                         SinceAppendMode = cms.bool(True),
                                         Source = cms.PSet(XMLFile = cms.untracked.string("/cvmfs/cms.cern.ch/slc7_amd64_gcc820/cms/cmssw/CMSSW_11_1_2/src/DQM/SiStripMonitorClient/data/sistrip_qualitytest_config_tier0.xml"),
-                                                          firstSince = cms.untracked.uint64(2), 
+                                                          firstSince = cms.untracked.uint64(1),
                                                           debug = cms.untracked.bool(True),
                                                           zip = cms.untracked.bool(False)
                                                           )

--- a/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
+++ b/CondTools/DQM/test/DQMXMLFileEventSetupAnalyzer_cfg.py
@@ -2,11 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('XMLFILERETRIEVER')
 
-# setting the Global Tag
+####################################################################
+# Get the GlogalTag
+####################################################################
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-process.GlobalTag.connect = "sqlite_file:./tagDB.db" 
-process.GlobalTag.globaltag = 'MY_GT::All' 
-process.GlobalTag.DumpStat = cms.untracked.bool(True)
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run3_data_promptlike', '')
+#process.GlobalTag.DumpStat = cms.untracked.bool(True)  # optional if you want it to be verbose
 
 # import of standard configurations
 process.load("DQMServices.Core.DQMStore_cfg")
@@ -16,29 +18,15 @@ process.DQMStore.verboseQT = cms.untracked.int32(0)
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 # Input source
-from CondCore.DBCommon.CondDBSetup_cfi import *
-
 process.source = cms.Source("EmptyIOVSource",
                             timetype = cms.string('runnumber'),
                             firstValue = cms.uint64(1),
                             lastValue = cms.uint64(1),
                             interval = cms.uint64(1)
                             )
-                                      
-#process.XmlRetrieval_2 = cms.ESSource("PoolDBESSource",
-#                                      CondDBSetup,
-#                                      connect = cms.string('sqlite_file:./testXML.db'),
-#                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
-#                                      messageLevel = cms.untracked.int32(1),
-#                                      timetype = cms.string('runnumber'),
-#                                      toGet = cms.VPSet(cms.PSet(record = cms.string('DQMXMLFileRcd'),
-#                                                                 tag = cms.string('XML_pixels_1'),
-#                                                                 label=cms.untracked.string('XML2_mio')
-#                                                                 )
-#                                                        )
-#                                      )
 
-#process.XmlRetrieval_1 = cms.ESSource("PoolDBESSource",
+# from CondCore.CondDB.CondDB_cfi import *
+# process.XmlRetrieval_1 = cms.ESSource("PoolDBESSource",
 #                                      CondDBSetup,
 #                                      connect = cms.string('sqlite_file:./testXML.db'),
 #                                      BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
@@ -51,10 +39,28 @@ process.source = cms.Source("EmptyIOVSource",
 #                                                        )
 #                                      )
 
+# process.ReferenceRetrieval = cms.ESSource("PoolDBESSource",
+#                                   CondDBSetup,
+#                                   connect = cms.string('sqlite_file:DQMReferenceHistogramTest.db'),
+#                                   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+#                                   messageLevel = cms.untracked.int32(1), #3 for high verbosity
+#                                   timetype = cms.string('runnumber'),
+#                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
+#                                                              tag = cms.string('ROOTFILE_DQM')
+#                                                              )
+#                                                     )
+#                                   )
+#
 
-process.load('CondTools/DQM/DQMXMLFileEventSetupAnalyzer_cfi')
-process.dqmXMLFileGetter.labelToGet = cms.string('fuffa')
-
+# process.RecordDataGetter = cms.EDAnalyzer("EventSetupRecordDataGetter",
+#                                   toGet = cms.VPSet(cms.PSet(record = cms.string('DQMReferenceHistogramRootFileRcd'),
+#                                                          data = cms.vstring('ROOTFILE_DQM_Test10')
+#                                                          )
+#                                                 ),
+#                                   verbose = cms.untracked.bool(False)
+#                                   )
+                                      
+process.load('CondTools.DQM.DQMXMLFileEventSetupAnalyzer_cfi')
+process.dqmXMLFileGetter.labelToGet = cms.string('SiPixelDQMQTests')
 process.path = cms.Path(process.dqmXMLFileGetter)
 
-#process.path = cms.Path()

--- a/CondTools/DQM/test/testPayloadReading.cpp
+++ b/CondTools/DQM/test/testPayloadReading.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/CondTools/DQM/test/testPayloadWriting.cpp
+++ b/CondTools/DQM/test/testPayloadWriting.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/CondTools/DQM/test/test_read.sh
+++ b/CondTools/DQM/test/test_read.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+echo "TESTING CondTools/DQM ..."
+cmsRun ${LOCAL_TEST_DIR}/DQMXMLFileEventSetupAnalyzer_cfg.py unitTest=True || die "Failure running testCondToolsDQMRead" $?

--- a/CondTools/DQM/test/test_write.sh
+++ b/CondTools/DQM/test/test_write.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+function die { echo $1: status $2 ; exit $2; }
+
+if test -f "testXML.db"; then
+    echo "==> removing pre-existing testXML.db"
+    rm -f testXML.db
+fi
+
+echo "TESTING CondTools/DQM ..."
+cmsRun ${LOCAL_TEST_DIR}/DQMUploadXMLFile.py || die "Failure running testCondToolsDQMUpload" $?


### PR DESCRIPTION
#### PR description:

There is renewed interest in using the `DQMXMLFileRcd` in Database to store Pixel / Strip / Tracking DQM QTests configurations. I therefore refresh the configuration files in that package and also provide unit tests to allow reading / writing of  `DQMXMLFileRcd` to be exercised in IB tests.

#### PR validation:

Relies on the unit tests introduced in this PR which run to completion.
 
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.

cc:
@sroychow @arossi83 @gbenelli
