### PR TITLE
Modify HCAL reco pulse shape for Run 3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -69,17 +69,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v6', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v6', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v6',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v7',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v7',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v7', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '110X_mcRun4_realistic_v3'
 }


### PR DESCRIPTION
#### PR description:

This PR updates the HCAL reco pulse shape (record `HcalRecoParamsRcd`) for Run 3. After the switch to always assuming eight pulses in the pulse fit, an energy scale offset was observed in zero-pileup samples (slide 1 of [1]). With the modified reco pulse shape assumption, most of the energy scale offset is recovered (slide 3 of [1]).

[1] https://indico.cern.ch/event/945213/contributions/3974345/attachments/2086514/3505289/HCAL_AlCaDB_10_08_201.pdf

The global tag diffs are as follows:

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v6/112X_mcRun3_2021_design_v7

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v6/112X_mcRun3_2021_realistic_v7

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v6/112X_mcRun3_2021cosmics_realistic_deco_v7

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v7/112X_mcRun3_2021_realistic_HI_v8

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v6/112X_mcRun3_2023_realistic_v7

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v6/112X_mcRun3_2024_realistic_v7

#### PR validation:

Please see the [presentation by the HCAL group](https://indico.cern.ch/event/945213/#28-update-and-validation-of-hc) for details of the validation. In addition, a technical test was performed:

`runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport. A test GT for the 2021 realistic scenario will be created in 11_1_X and a backport may be considered.