### PR TITLE
Define (GEN) only eventcontent

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -8,6 +8,9 @@ import FWCore.ParameterSet.Config as cms
 #  LHE:
 #    include pure LHE production
 #
+#  GEN:
+#    include GEN only information
+#
 #  RAW , RECO, AOD:
 #    include reconstruction content
 #
@@ -145,6 +148,19 @@ LHEEventContent = cms.PSet(
     splitLevel = cms.untracked.int32(0),
 )
 LHEEventContent.outputCommands.extend(GeneratorInterfaceLHE.outputCommands)
+#
+#
+# GEN Data Tier definition
+# include GeneratorInterfaceLHE in case of pLHEGEN campaign
+#
+GENEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    splitLevel = cms.untracked.int32(0),
+)
+GENEventContent.outputCommands.extend(GeneratorInterfaceLHE.outputCommands)
+GENEventContent.outputCommands.extend(GeneratorInterfaceRAW.outputCommands)
+GENEventContent.outputCommands.extend(RecoGenJetsFEVT.outputCommands)
+GENEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
 #
 #
 # RAW Data Tier definition

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -161,6 +161,7 @@ GENEventContent.outputCommands.extend(GeneratorInterfaceLHE.outputCommands)
 GENEventContent.outputCommands.extend(GeneratorInterfaceRAW.outputCommands)
 GENEventContent.outputCommands.extend(RecoGenJetsFEVT.outputCommands)
 GENEventContent.outputCommands.extend(RecoGenMETFEVT.outputCommands)
+GENEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 #
 #
 # RAW Data Tier definition


### PR DESCRIPTION
#### PR description:
This PR is to define GEN (only) eventcontent. Currently,
- GEN campaign: RAWSIM is used. This is fine as SIM content will not be produced.
- GEN-SIM campaign: RAWSIM is used to keep GS. However, if we want to keep GEN-only, and let GS be the transient product, we need to config manually.

#### PR validation:
Using
`cmsDriver.py MinBias_13TeV_pythia8_TuneCUETP8M1_cfi --conditions auto:phase1_2018_realistic -n 10 --era Run2_2018 --eventcontent GEN,RAWSIM -s GEN,SIM --datatier GEN,GEN-SIM --beamspot Realistic25ns13TeVEarly2018Collision --geometry DB:Extended --python MinBias_13TeV_pythia8_TuneCUETP8M1_2018_GenSim.py --no_exec --fileout file:test.root --nThreads 8 -n 10`
give GEN content as expected:

> GenEventInfoProduct                   "generator"          ""         "SIM"     
> ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<float>,ROOT::Math::DefaultCoordinateSystemTag>    "genParticles"       "xyz0"     "SIM"     
> double                                "ak4GenJets"         "rho"      "SIM"     
> double                                "ak4GenJetsNoNu"     "rho"      "SIM"     
> double                                "ak8GenJets"         "rho"      "SIM"     
> double                                "ak8GenJetsNoNu"     "rho"      "SIM"     
> double                                "ak4GenJets"         "sigma"    "SIM"     
> double                                "ak4GenJetsNoNu"     "sigma"    "SIM"     
> double                                "ak8GenJets"         "sigma"    "SIM"     
> double                                "ak8GenJetsNoNu"     "sigma"    "SIM"     
> edm::HepMCProduct                     "generatorSmeared"   ""         "SIM"     
> float                                 "genParticles"       "t0"       "SIM"     
> vector<double>                        "ak4GenJets"         "rhos"     "SIM"     
> vector<double>                        "ak4GenJetsNoNu"     "rhos"     "SIM"     
> vector<double>                        "ak8GenJets"         "rhos"     "SIM"     
> vector<double>                        "ak8GenJetsNoNu"     "rhos"     "SIM"     
> vector<double>                        "ak4GenJets"         "sigmas"   "SIM"     
> vector<double>                        "ak4GenJetsNoNu"     "sigmas"   "SIM"     
> vector<double>                        "ak8GenJets"         "sigmas"   "SIM"     
> vector<double>                        "ak8GenJetsNoNu"     "sigmas"   "SIM"     
> vector<int>                           "genParticles"       ""         "SIM"     
> vector<reco::GenJet>                  "ak4GenJets"         ""         "SIM"     
> vector<reco::GenJet>                  "ak4GenJetsNoNu"     ""         "SIM"     
> vector<reco::GenJet>                  "ak8GenJets"         ""         "SIM"     
> vector<reco::GenJet>                  "ak8GenJetsNoNu"     ""         "SIM"     
> vector<reco::GenMET>                  "genMetCalo"         ""         "SIM"     
> vector<reco::GenMET>                  "genMetTrue"         ""         "SIM"     
> vector<reco::GenParticle>             "genParticles"       ""         "SIM"

Note that, the transient product is confined from McM side, not by cmsDriver.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Should be backporting 10_6 in case the new campaign will use GEN-SIM instead of GEN and SIM separately.
