### PR TITLE
Fix HLT JEC conditions for 2018 MC [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -55,17 +55,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
     'phase1_2017_cosmics_peak' :  '111X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '111X_upgrade2018_design_v1',
+    'phase1_2018_design'       :  '111X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '110X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi' :  '111X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '111X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #31050.

This PR corresponds to the same update performed in PR #30221 but for 2018 MC rather than Run-3 MC. It also corresponds to the same payloads used for the 2018 IOVs updated in PR #30984.  

The GT diffs are as follows:

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_design_v1/111X_upgrade2018_design_v2

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_v1/111X_upgrade2018_realistic_v2

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_upgrade2018_realistic_HI_v5/111X_upgrade2018_realistic_HI_v1

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_HEfail_v1/111X_upgrade2018_realistic_HEfail_v2

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_deco_v1/111X_upgrade2018cosmics_realistic_deco_v2

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_peak_v1/111X_upgrade2018cosmics_realistic_peak_v2

For the 2018 HI scenario, the obsolete, unlabeled `SiPixel2DTemplateDBObjectRcd` tag is removed. This change is purely technical.

#### PR validation:

Please see PR #30221 and PR #30984 and references therein for details of the physics validation. In addition, I have verified that these payloads are the same as those actually used by the HLT in 2018.

In addition, a technical test was performed: `runTheMatrix.py -l limited,11224.0,11024.2,7.3,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #31050.
