### PR TITLE
optimize PFDisplacedVertexCandidateFinder::link

### DIFF
--- a/CommonTools/Utils/interface/KinematicTables.h
+++ b/CommonTools/Utils/interface/KinematicTables.h
@@ -22,6 +22,16 @@ namespace edm {
                                        col::Phi::filler([](Object const& x) { return x.phi(); }))};
     }
 
+    using PtEtaPhiTable = edm::soa::Table<col::Pt, col::Eta, col::Phi>;
+
+    template <class Object>
+    PtEtaPhiTable makePtEtaPhiTable(std::vector<Object> const& objects) {
+      return {objects,
+              edm::soa::column_fillers(col::Pt::filler([](Object const& x) { return x.pt(); }),
+                                       col::Eta::filler([](Object const& x) { return x.eta(); }),
+                                       col::Phi::filler([](Object const& x) { return x.phi(); }))};
+    }
+
     template <class Object>
     auto makeEtaPhiTableLazy(std::vector<Object> const& objects) {
       return LazyResult(&makeEtaPhiTable<Object>, objects);

--- a/CommonTools/Utils/interface/KinematicTables.h
+++ b/CommonTools/Utils/interface/KinematicTables.h
@@ -14,6 +14,7 @@ namespace edm {
 
     using EtaPhiTable = edm::soa::Table<col::Eta, col::Phi>;
     using EtaPhiTableView = edm::soa::TableView<col::Eta, col::Phi>;
+    using PtEtaPhiTable = edm::soa::Table<col::Pt, col::Eta, col::Phi>;
 
     template <class Object>
     EtaPhiTable makeEtaPhiTable(std::vector<Object> const& objects) {
@@ -22,7 +23,10 @@ namespace edm {
                                        col::Phi::filler([](Object const& x) { return x.phi(); }))};
     }
 
-    using PtEtaPhiTable = edm::soa::Table<col::Pt, col::Eta, col::Phi>;
+    template <class Object>
+    auto makeEtaPhiTableLazy(std::vector<Object> const& objects) {
+      return LazyResult(&makeEtaPhiTable<Object>, objects);
+    }
 
     template <class Object>
     PtEtaPhiTable makePtEtaPhiTable(std::vector<Object> const& objects) {
@@ -30,11 +34,6 @@ namespace edm {
               edm::soa::column_fillers(col::Pt::filler([](Object const& x) { return x.pt(); }),
                                        col::Eta::filler([](Object const& x) { return x.eta(); }),
                                        col::Phi::filler([](Object const& x) { return x.phi(); }))};
-    }
-
-    template <class Object>
-    auto makeEtaPhiTableLazy(std::vector<Object> const& objects) {
-      return LazyResult(&makeEtaPhiTable<Object>, objects);
     }
 
   }  // namespace soa

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -7,6 +7,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "CommonTools/Utils/interface/KinematicTables.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -150,6 +151,8 @@ private:
 
   // Tracker geometry for extrapolation
   const MagneticField* magField_;
+
+  edm::soa::PtEtaPhiTable el_table_;
 };
 
 #endif

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -81,7 +81,7 @@ private:
   void link(const reco::TrackBaseRef& el1,
             const reco::TrackBaseRef& el2,
             double& dist,
-            GlobalPoint& P,
+            GlobalPoint& crossing_point,
             reco::PFDisplacedVertexCandidate::VertexLinkTest& linktest);
 
   /// Compute missing links in the displacedVertexCandidates

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -153,7 +153,7 @@ private:
   // Tracker geometry for extrapolation
   const MagneticField* magField_;
 
-  edm::soa::PtEtaPhiTable el_table_;
+  edm::soa::PtEtaPhiTable track_table_;
 };
 
 #endif

--- a/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h
@@ -8,6 +8,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "CommonTools/Utils/interface/KinematicTables.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -199,7 +199,6 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
                                             double& dist,
                                             GlobalPoint& P,
                                             PFDisplacedVertexCandidate::VertexLinkTest& vertexLinkTest) {
-
   using namespace edm::soa::col;
   const auto iel1 = el1.key();
   const auto iel2 = el2.key();

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -226,6 +226,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
 
   // Fill the parameters
   dist = theMinimum_.distance();
+  P = theMinimum_.crossingPoint();
 
   vertexLinkTest = PFDisplacedVertexCandidate::LINKTEST_DCA;  //rechit by default
 
@@ -234,8 +235,6 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
     dist = -1;
     return;
   }
-
-  P = theMinimum_.crossingPoint();
 
   // Check if the closses approach point is too close to the primary vertex/beam pipe
   double rho2 = P.x() * P.x() + P.y() * P.y();

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -119,9 +119,9 @@ PFDisplacedVertexCandidateFinder::IE PFDisplacedVertexCandidateFinder::associate
 
   if (last != eventTracks_.end()) {
     double dist = -1;
-    GlobalPoint P(0, 0, 0);
+    GlobalPoint crossing_point(0, 0, 0);
     PFDisplacedVertexCandidate::VertexLinkTest linktest;
-    link(*last, *next, dist, P, linktest);
+    link(*last, *next, dist, crossing_point, linktest);
 
     if (dist < -0.5) {
 #ifdef PFLOW_DEBUG
@@ -137,7 +137,8 @@ PFDisplacedVertexCandidateFinder::IE PFDisplacedVertexCandidateFinder::associate
       if (debug_)
         cout << "link parameters "
              << " *next = " << (*next).key() << " *last = " << (*last).key() << "  dist = " << dist
-             << " P.x = " << P.x() << " P.y = " << P.y() << " P.z = " << P.z() << endl;
+             << " P.x = " << crossing_point.x() << " P.y = " << crossing_point.y() << " P.z = " << crossing_point.z()
+             << endl;
 #endif
     }
   } else {
@@ -197,7 +198,7 @@ PFDisplacedVertexCandidateFinder::IE PFDisplacedVertexCandidateFinder::associate
 void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
                                             const TrackBaseRef& el2,
                                             double& dist,
-                                            GlobalPoint& P,
+                                            GlobalPoint& crossing_point,
                                             PFDisplacedVertexCandidate::VertexLinkTest& vertexLinkTest) {
   using namespace edm::soa::col;
   const auto iel1 = el1.key();
@@ -226,7 +227,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
 
   // Fill the parameters
   dist = theMinimum_.distance();
-  P = theMinimum_.crossingPoint();
+  crossing_point = theMinimum_.crossingPoint();
 
   vertexLinkTest = PFDisplacedVertexCandidate::LINKTEST_DCA;  //rechit by default
 
@@ -237,7 +238,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
   }
 
   // Check if the closses approach point is too close to the primary vertex/beam pipe
-  double rho2 = P.x() * P.x() + P.y() * P.y();
+  double rho2 = crossing_point.x() * crossing_point.x() + crossing_point.y() * crossing_point.y();
 
   if (rho2 < primaryVertexCut2_) {
     dist = -1;
@@ -253,7 +254,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
     dist = -1;
     return;
   }
-  if (fabs(P.z()) > tec_z_limit) {
+  if (fabs(crossing_point.z()) > tec_z_limit) {
     dist = -1;
     return;
   }

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -73,7 +73,7 @@ void PFDisplacedVertexCandidateFinder::setInput(const edm::Handle<TrackCollectio
       eventTrackTrajectories_[i] = getGlobalTrajectoryParameters(trk);
     }
   }
-  el_table_ = edm::soa::makePtEtaPhiTable(*trackh);
+  track_table_ = edm::soa::makePtEtaPhiTable(*trackh);
 }
 
 // -------- Main function which find vertices -------- //
@@ -180,12 +180,12 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
   using namespace edm::soa::col;
   const auto iel1 = el1.key();
   const auto iel2 = el2.key();
-  const auto pt1 = el_table_.get<Pt>(iel1);
-  const auto pt2 = el_table_.get<Pt>(iel2);
-  const auto eta1 = el_table_.get<Eta>(iel1);
-  const auto eta2 = el_table_.get<Eta>(iel2);
-  const auto phi1 = el_table_.get<Phi>(iel1);
-  const auto phi2 = el_table_.get<Phi>(iel2);
+  const auto pt1 = track_table_.get<Pt>(iel1);
+  const auto pt2 = track_table_.get<Pt>(iel2);
+  const auto eta1 = track_table_.get<Eta>(iel1);
+  const auto eta2 = track_table_.get<Eta>(iel2);
+  const auto phi1 = track_table_.get<Phi>(iel1);
+  const auto phi2 = track_table_.get<Phi>(iel2);
 
   if (std::abs(eta1 - eta2) > 1) {
     dist = -1;

--- a/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/PFDisplacedVertexCandidateFinder.cc
@@ -26,7 +26,7 @@ PFDisplacedVertexCandidateFinder::PFDisplacedVertexCandidateFinder()
 
 PFDisplacedVertexCandidateFinder::~PFDisplacedVertexCandidateFinder() {
   LogDebug("PFDisplacedVertexCandidateFinder")
-      << "~PFDisplacedVertexCandidateFinder - number of remaining elements: " << eventTracks_.size() << endl;
+      << "~PFDisplacedVertexCandidateFinder - number of remaining elements: " << eventTracks_.size();
 }
 
 void PFDisplacedVertexCandidateFinder::setPrimaryVertex(edm::Handle<reco::VertexCollection> mainVertexHandle,
@@ -187,11 +187,11 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
   const auto phi1 = el_table_.get<Phi>(iel1);
   const auto phi2 = el_table_.get<Phi>(iel2);
 
-  if (fabs(eta1 - eta2) > 1) {
+  if (std::abs(eta1 - eta2) > 1) {
     dist = -1;
     return;
   }
-  if (pt1 > 2 && pt2 > 2 && fabs(phi1 - phi2) > 1) {
+  if (pt1 > 2 && pt2 > 2 && std::abs(phi1 - phi2) > 1) {
     dist = -1;
     return;
   }
@@ -204,8 +204,9 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
 
   // Fill the parameters
   dist = theMinimum_.distance();
+  LogDebug("PFDisplacedVertexCandidateFinder") << "link iel1=" << iel1 << " iel2=" << iel2 << " dist=" << dist;
   crossingPoint = theMinimum_.crossingPoint();
-  //std::cout << "ie1=" << iel1 << " ie2=" << iel2 << " pt1=" << pt1 << " pt2=" << pt2 << " eta1=" << eta1 << " eta2=" << eta2 << " phi1=" << phi1 << " phi2=" << phi2 << " dist=" << dist << std::endl;
+
   vertexLinkTest = PFDisplacedVertexCandidate::LINKTEST_DCA;  //rechit by default
 
   // Check if the link test fails
@@ -231,7 +232,7 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
     dist = -1;
     return;
   }
-  if (fabs(crossingPoint.z()) > tec_z_limit) {
+  if (std::abs(crossingPoint.z()) > tec_z_limit) {
     dist = -1;
     return;
   }
@@ -268,7 +269,6 @@ void PFDisplacedVertexCandidateFinder::link(const TrackBaseRef& el1,
 // In the Candidate
 void PFDisplacedVertexCandidateFinder::packLinks(PFDisplacedVertexCandidate& vertexCandidate) {
   const vector<TrackBaseRef>& els = vertexCandidate.elements();
-
 
   //First Loop: update all link data
   for (unsigned i1 = 0; i1 < els.size(); i1++) {
@@ -322,7 +322,7 @@ bool PFDisplacedVertexCandidateFinder::goodPtResolution(const TrackBaseRef& trac
     return false;
   }
   //  cout << "dxy = " << dxy << endl;
-  if (fabs(dxy) < dxy_ && pt < pt_min_prim_)
+  if (std::abs(dxy) < dxy_ && pt < pt_min_prim_)
     return false;
   //  if (fabs(dxy) < 0.2 && pt < 0.8) return false;
 
@@ -340,7 +340,7 @@ ostream& operator<<(std::ostream& out, const PFDisplacedVertexCandidateFinder& a
 
   out << " Tracks selection based on " << std::endl;
   out << " pvtx_ = " << a.pvtx_ << std::endl;
-  out << " fabs(dxy) < " << a.dxy_ << " and pt < " << a.pt_min_prim_ << std::endl;
+  out << " std::abs(dxy) < " << a.dxy_ << " and pt < " << a.pt_min_prim_ << std::endl;
   out << " nChi2 < " << a.nChi2_max_ << " and pt < " << a.pt_min_ << std::endl;
 
   out << endl;


### PR DESCRIPTION
#### PR description:

Technical optimization of `PFDisplacedVertexCandidateFinder::link` as suggested in https://github.com/cms-sw/cmssw/issues/30955. Cache pt, eta, phi values using SOA, rearrange the calculations to do the crossing-point evaluation only when needed. A further refactoring of this class could be done (fabs, revisit recursive associate algo) but was not addressed so far.

#### PR validation:

workflow `23434.21` has been run with no change in output.

Initial checks show about a 25% speed improvement for `PFDisplacedVertexCandidateFinder::link` and `PFDisplacedVertexCandidateProducer::produce` correspondingly.

before:
```
[149]       1.5     128.48      16.64 / 111.84     PFDisplacedVertexCandidateFinder::link(edm::RefToBase<reco::Track> const&, edm::RefToBase<reco::Track> const&, double&, Point3DBase<float, GlobalTag>&, reco::PFDisplacedVertexCandidate::VertexLinkTest&)
            1.0  .........      87.30 / 97.57        TwoTrackMinimumDistance::calculate(GlobalTrajectoryParameters const&, GlobalTrajectoryParameters const&) [185]
            0.3  .........      21.68 / 132.91       __ieee754_log_avx [144]
            0.0  .........       1.67 / 2.96         edm::refitem::GetRefPtrImpl<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track>, unsigned int>::getRefPtr_(edm::RefCore const&, unsigned int) [2203]
            0.0  .........       0.61 / 3.16         log [2161]
            0.0  .........       0.20 / 0.21         edm::reftobase::Holder<reco::Track, edm::Ref<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track> > >::getPtr() const [5773]
            0.0  .........       0.10 / 0.12         TwoTrackMinimumDistance::distance() const [6931]
            0.0  .........       0.09 / 97.25        __ieee754_atan2_avx [187]
            0.0  .........       0.08 / 0.08         TwoTrackMinimumDistance::crossingPoint() const [7761]
            0.0  .........       0.05 / 10.34        edm::reftobase::Holder<reco::Track, edm::Ref<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track> > >::key() const [1493]
            0.0  .........       0.04 / 49.53        _init [306]
```

after:
```
[186]       1.1      96.53       3.82 / 92.71      PFDisplacedVertexCandidateFinder::link(edm::RefToBase<reco::Track> const&, edm::RefToBase<reco::Track> const&, double&, Point3DBase<float, GlobalTag>&, reco::PFDisplacedVertexCandidate::VertexLinkTest&)
            1.1  .........      92.39 / 102.49       TwoTrackMinimumDistance::calculate(GlobalTrajectoryParameters const&, GlobalTrajectoryParameters const&) [178]
            0.0  .........       0.17 / 0.18         TwoTrackMinimumDistance::distance() const [6143]
            0.0  .........       0.07 / 10.12        edm::reftobase::Holder<reco::Track, edm::Ref<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track, std::allocator<reco::Track> >, reco::Track> > >::key() const [1504]
            0.0  .........       0.04 / 0.06         TwoTrackMinimumDistance::crossingPoint() const [8743]
            0.0  .........       0.03 / 51.14        _init [296]
```

The majority of time of `PFDisplacedVertexCandidateFinder::link` is now spent in `TwoTrackMinimumDistance::calculate` if I interpret the igprof output correctly. I think it could be useful to understand if there are algorithmic improvements available.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

A backport is not planned at this moment.