### PR TITLE
Move "wmsplit" dict build to a static method, remove circular import

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -172,132 +172,138 @@ class MatrixInjector(object):
 
         self.chainDicts={}
 
-
-    def prepare(self,mReader, directories, mode='init'):
+    @staticmethod
+    def get_wmsplit():
+        """
+        Return a "wmsplit" dictionary that contain non-default LumisPerJob values
+        """
+        wmsplit = {}
         try:
-            #from Configuration.PyReleaseValidation.relval_steps import wmsplit
-            wmsplit = {}
-            wmsplit['DIGIHI']=5
-            wmsplit['RECOHI']=5
-            wmsplit['HLTD']=5
-            wmsplit['RECODreHLT']=2  
-            wmsplit['DIGIPU']=4
-            wmsplit['DIGIPU1']=4
-            wmsplit['RECOPU1']=1
-            wmsplit['DIGIUP15_PU50']=1
-            wmsplit['RECOUP15_PU50']=1
-            wmsplit['DIGIUP15_PU25']=1
-            wmsplit['RECOUP15_PU25']=1
-            wmsplit['DIGIUP15_PU25HS']=1
-            wmsplit['RECOUP15_PU25HS']=1
-            wmsplit['DIGIHIMIX']=5
-            wmsplit['RECOHIMIX']=5
-            wmsplit['RECODSplit']=1
-            wmsplit['SingleMuPt10_UP15_ID']=1
-            wmsplit['DIGIUP15_ID']=1
-            wmsplit['RECOUP15_ID']=1
-            wmsplit['TTbar_13_ID']=1
-            wmsplit['SingleMuPt10FS_ID']=1
-            wmsplit['TTbarFS_ID']=1
-            wmsplit['RECODR2_50nsreHLT']=5
-            wmsplit['RECODR2_25nsreHLT']=5
-            wmsplit['RECODR2_2016reHLT']=5
-            wmsplit['RECODR2_50nsreHLT_HIPM']=5
-            wmsplit['RECODR2_25nsreHLT_HIPM']=5
-            wmsplit['RECODR2_2016reHLT_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimSingleMu']=1
-            wmsplit['RECODR2_2016reHLT_skimDoubleEG']=1
-            wmsplit['RECODR2_2016reHLT_skimMuonEG']=1
-            wmsplit['RECODR2_2016reHLT_skimJetHT']=1
-            wmsplit['RECODR2_2016reHLT_skimMET']=1
-            wmsplit['RECODR2_2016reHLT_skimSinglePh']=1
-            wmsplit['RECODR2_2016reHLT_skimMuOnia']=1
-            wmsplit['RECODR2_2016reHLT_skimSingleMu_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimDoubleEG_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimMuonEG_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimJetHT_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimMET_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimSinglePh_HIPM']=1
-            wmsplit['RECODR2_2016reHLT_skimMuOnia_HIPM']=1
-            wmsplit['RECODR2_2017reHLT_Prompt']=1
-            wmsplit['RECODR2_2017reHLT_skimSingleMu_Prompt_Lumi']=1
-            wmsplit['RECODR2_2017reHLT_skimDoubleEG_Prompt']=1
-            wmsplit['RECODR2_2017reHLT_skimMET_Prompt']=1
-            wmsplit['RECODR2_2017reHLT_skimMuOnia_Prompt']=1
-            wmsplit['RECODR2_2017reHLT_Prompt_L1TEgDQM']=1
-            wmsplit['RECODR2_2018reHLT_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimSingleMu_Prompt_Lumi']=1
-            wmsplit['RECODR2_2018reHLT_skimDoubleEG_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimMET_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimMuOnia_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM']=1
-            wmsplit['RECODR2_2018reHLT_skimMuonEG_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimCharmonium_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_HEfail']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig']=1
-            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Prompt']=1
-            wmsplit['RECODR2_2018reHLT_ZBPrompt']=1
-            wmsplit['RECODR2_2018reHLT_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimSingleMu_Offline_Lumi']=1
-            wmsplit['RECODR2_2018reHLT_skimDoubleEG_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimMET_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimMuOnia_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM']=1
-            wmsplit['RECODR2_2018reHLT_skimMuonEG_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimCharmonium_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_HEfail']=1
-            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_BadHcalMitig']=1
-            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Offline']=1
-            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Offline']=1
-            wmsplit['RECODR2_2018reHLT_ZBOffline']=1
-            wmsplit['HLTDR2_50ns']=1
-            wmsplit['HLTDR2_25ns']=1
-            wmsplit['HLTDR2_2016']=1
-            wmsplit['HLTDR2_2017']=1
-            wmsplit['HLTDR2_2018']=1
-            wmsplit['HLTDR2_2018_BadHcalMitig']=1
-            wmsplit['Hadronizer']=1
-            wmsplit['DIGIUP15']=1 
-            wmsplit['RECOUP15']=1 
-            wmsplit['RECOAODUP15']=5
-            wmsplit['DBLMINIAODMCUP15NODQM']=5
-            wmsplit['Digi']=5
-            wmsplit['Reco']=5
-            wmsplit['DigiPU']=1
-            wmsplit['RecoPU']=1
-            wmsplit['RECOHID11']=1
-            wmsplit['DIGIUP17']=1
-            wmsplit['RECOUP17']=1
-            wmsplit['DIGIUP17_PU25']=1
-            wmsplit['RECOUP17_PU25']=1
-            wmsplit['DIGICOS_UP16']=1
-            wmsplit['RECOCOS_UP16']=1
-            wmsplit['DIGICOS_UP17']=1
-            wmsplit['RECOCOS_UP17']=1
-            wmsplit['DIGICOS_UP18']=1
-            wmsplit['RECOCOS_UP18']=1
-            wmsplit['DIGICOS_UP21']=1
-            wmsplit['RECOCOS_UP21']=1
-            wmsplit['HYBRIDRepackHI2015VR']=1
-            wmsplit['HYBRIDZSHI2015']=1
-            wmsplit['RECOHID15']=1
-            wmsplit['RECOHID18']=1
+            wmsplit['DIGIHI'] = 5
+            wmsplit['RECOHI'] = 5
+            wmsplit['HLTD'] = 5
+            wmsplit['RECODreHLT'] = 2
+            wmsplit['DIGIPU'] = 4
+            wmsplit['DIGIPU1'] = 4
+            wmsplit['RECOPU1'] = 1
+            wmsplit['DIGIUP15_PU50'] = 1
+            wmsplit['RECOUP15_PU50'] = 1
+            wmsplit['DIGIUP15_PU25'] = 1
+            wmsplit['RECOUP15_PU25'] = 1
+            wmsplit['DIGIUP15_PU25HS'] = 1
+            wmsplit['RECOUP15_PU25HS'] = 1
+            wmsplit['DIGIHIMIX'] = 5
+            wmsplit['RECOHIMIX'] = 5
+            wmsplit['RECODSplit'] = 1
+            wmsplit['SingleMuPt10_UP15_ID'] = 1
+            wmsplit['DIGIUP15_ID'] = 1
+            wmsplit['RECOUP15_ID'] = 1
+            wmsplit['TTbar_13_ID'] = 1
+            wmsplit['SingleMuPt10FS_ID'] = 1
+            wmsplit['TTbarFS_ID'] = 1
+            wmsplit['RECODR2_50nsreHLT'] = 5
+            wmsplit['RECODR2_25nsreHLT'] = 5
+            wmsplit['RECODR2_2016reHLT'] = 5
+            wmsplit['RECODR2_50nsreHLT_HIPM'] = 5
+            wmsplit['RECODR2_25nsreHLT_HIPM'] = 5
+            wmsplit['RECODR2_2016reHLT_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimSingleMu'] = 1
+            wmsplit['RECODR2_2016reHLT_skimDoubleEG'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMuonEG'] = 1
+            wmsplit['RECODR2_2016reHLT_skimJetHT'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMET'] = 1
+            wmsplit['RECODR2_2016reHLT_skimSinglePh'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMuOnia'] = 1
+            wmsplit['RECODR2_2016reHLT_skimSingleMu_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimDoubleEG_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMuonEG_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimJetHT_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMET_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimSinglePh_HIPM'] = 1
+            wmsplit['RECODR2_2016reHLT_skimMuOnia_HIPM'] = 1
+            wmsplit['RECODR2_2017reHLT_Prompt'] = 1
+            wmsplit['RECODR2_2017reHLT_skimSingleMu_Prompt_Lumi'] = 1
+            wmsplit['RECODR2_2017reHLT_skimDoubleEG_Prompt'] = 1
+            wmsplit['RECODR2_2017reHLT_skimMET_Prompt'] = 1
+            wmsplit['RECODR2_2017reHLT_skimMuOnia_Prompt'] = 1
+            wmsplit['RECODR2_2017reHLT_Prompt_L1TEgDQM'] = 1
+            wmsplit['RECODR2_2018reHLT_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimSingleMu_Prompt_Lumi'] = 1
+            wmsplit['RECODR2_2018reHLT_skimDoubleEG_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMET_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMuOnia_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimEGamma_Prompt_L1TEgDQM'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMuonEG_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimCharmonium_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_HEfail'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Prompt_BadHcalMitig'] = 1
+            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Prompt'] = 1
+            wmsplit['RECODR2_2018reHLT_ZBPrompt'] = 1
+            wmsplit['RECODR2_2018reHLT_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimSingleMu_Offline_Lumi'] = 1
+            wmsplit['RECODR2_2018reHLT_skimDoubleEG_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMET_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMuOnia_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimEGamma_Offline_L1TEgDQM'] = 1
+            wmsplit['RECODR2_2018reHLT_skimMuonEG_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimCharmonium_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_HEfail'] = 1
+            wmsplit['RECODR2_2018reHLT_skimJetHT_Offline_BadHcalMitig'] = 1
+            wmsplit['RECODR2_2018reHLTAlCaTkCosmics_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_skimDisplacedJet_Offline'] = 1
+            wmsplit['RECODR2_2018reHLT_ZBOffline'] = 1
+            wmsplit['HLTDR2_50ns'] = 1
+            wmsplit['HLTDR2_25ns'] = 1
+            wmsplit['HLTDR2_2016'] = 1
+            wmsplit['HLTDR2_2017'] = 1
+            wmsplit['HLTDR2_2018'] = 1
+            wmsplit['HLTDR2_2018_BadHcalMitig'] = 1
+            wmsplit['Hadronizer'] = 1
+            wmsplit['DIGIUP15'] = 1
+            wmsplit['RECOUP15'] = 1
+            wmsplit['RECOAODUP15'] = 5
+            wmsplit['DBLMINIAODMCUP15NODQM'] = 5
+            wmsplit['Digi'] = 5
+            wmsplit['Reco'] = 5
+            wmsplit['DigiPU'] = 1
+            wmsplit['RecoPU'] = 1
+            wmsplit['RECOHID11'] = 1
+            wmsplit['DIGIUP17'] = 1
+            wmsplit['RECOUP17'] = 1
+            wmsplit['DIGIUP17_PU25'] = 1
+            wmsplit['RECOUP17_PU25'] = 1
+            wmsplit['DIGICOS_UP16'] = 1
+            wmsplit['RECOCOS_UP16'] = 1
+            wmsplit['DIGICOS_UP17'] = 1
+            wmsplit['RECOCOS_UP17'] = 1
+            wmsplit['DIGICOS_UP18'] = 1
+            wmsplit['RECOCOS_UP18'] = 1
+            wmsplit['DIGICOS_UP21'] = 1
+            wmsplit['RECOCOS_UP21'] = 1
+            wmsplit['HYBRIDRepackHI2015VR'] = 1
+            wmsplit['HYBRIDZSHI2015'] = 1
+            wmsplit['RECOHID15'] = 1
+            wmsplit['RECOHID18'] = 1
             # automate for phase 2
             from .upgradeWorkflowComponents import upgradeKeys
             for key in upgradeKeys[2026]:
-                if not "PU" in key: continue
-                wmsplit['DigiTriggerPU_'+key] = 1
-                wmsplit['RecoGlobalPU_'+key] = 1
-                         
-            #import pprint
-            #pprint.pprint(wmsplit)            
-        except:
-            print("Not set up for step splitting")
-            wmsplit={}
+                if 'PU' not in key:
+                    continue
 
+                wmsplit['DigiTriggerPU_' + key] = 1
+                wmsplit['RecoGlobalPU_' + key] = 1
+
+        except Exception as ex:
+            print('Exception while building a wmsplit dictionary: %s' % (str(ex)))
+            return {}
+
+        return wmsplit
+
+    def prepare(self, mReader, directories, mode='init'):
+        wmsplit = MatrixInjector.get_wmsplit()
         acqEra=False
         for (n,dir) in directories.items():
             chainDict=copy.deepcopy(self.defaultChain)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from collections import OrderedDict
 import six
-from .MatrixUtil import merge
+from .MatrixUtil import merge, Kby
 import re
 
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
@@ -1040,7 +1040,6 @@ for year in upgradeKeys:
         if 'PU' in key: continue
         defaultDataSets[key] = ''
 
-from  Configuration.PyReleaseValidation.relval_steps import Kby
 
 class UpgradeFragment(object):
     def __init__(self, howMuch, dataset):


### PR DESCRIPTION
#### PR description:

Move hardcoded "wmsplit" dictionary to a separate method so other scripts and tools would be able to use these values. There are no changes to how MatrixInjector.py works and it's interface, except one additional method. This is needed for the currently developed RelVal machine by PdmV.

During development I noticed that `upgradeWorkflowComponents.py` imports `Kby` from `relval_steps.py`:
```
from  Configuration.PyReleaseValidation.relval_steps import Kby
```
and 
`relval_steps.py` import from `upgradeWorkflowComponents.py`:
```
from .upgradeWorkflowComponents import step3_trackingOnly
...
from .upgradeWorkflowComponents import digiPremixLocalPileup
...
from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
```

Which in my test case lead to a circular import. `Kby` imported from `relval_steps.py` is defined in `MatrixUtil.py`, so I changed `Kby` in `upgradeWorkflowComponents.py` to be imported from `MatrixUtil.py` in rather than `relval_steps.py`.

#### PR validation:

Ran runTheMatrix.py with commented-out submission to computing and added prints to see if values are picked up from the moved "wmsplit" dictionary. Code did not crash and print statements printed expected values from "wmsplit".

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.
