### PR TITLE
Backport of #30674 (Major updates for Custom JME NanoAODs) to 10_6_X

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -3,94 +3,78 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 
+from CommonTools.PileupAlgos.Puppi_cff import puppi
+
+from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdCalculator, pileupJetId
+from RecoJets.JetProducers.PileupJetID_cfi import _chsalgos_81x, _chsalgos_94x, _chsalgos_102x
+
 from PhysicsTools.NanoAOD.common_cff import Var, P4Vars
-from PhysicsTools.NanoAOD.jets_cff import jetTable
+from PhysicsTools.NanoAOD.jets_cff   import jetTable, jetCorrFactorsNano, updatedJets, finalJets, qgtagger
+from PhysicsTools.NanoAOD.jets_cff   import genJetTable, genJetFlavourAssociation, genJetFlavourTable
 
 from PhysicsTools.PatAlgos.tools.jetCollectionTools import GenJetAdder, RecoJetAdder
+from PhysicsTools.PatAlgos.tools.jetTools import supportedJetAlgos
+from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 
 import copy
 
+bTagCSVV2    = ['pfDeepCSVJetTags:probb','pfDeepCSVJetTags:probbb','pfDeepCSVJetTags:probc']
+bTagCMVAV2   = ['pfCombinedMVAV2BJetTags']
+bTagDeepCSV  = ['pfCombinedInclusiveSecondaryVertexV2BJetTags']
+bTagDeepJet  = [
+  'pfDeepFlavourJetTags:probb','pfDeepFlavourJetTags:probbb','pfDeepFlavourJetTags:problepb',
+  'pfDeepFlavourJetTags:probc','pfDeepFlavourJetTags:probuds','pfDeepFlavourJetTags:probg'
+]
+bTagDiscriminatorsForAK4 = bTagCSVV2+bTagCMVAV2+bTagDeepCSV+bTagDeepJet
+
 #
 # By default, these collections are saved in NanoAODs:
-# - ak4gen (GenJet in NanoAOD)
-# - ak8gen (GenJetAK8 in NanoAOD)
+# - ak4gen (GenJet in NanoAOD), slimmedGenJets in MiniAOD 
+# - ak8gen (GenJetAK8 in NanoAOD), slimmedGenJetsAK8 in MiniAOD 
 # Below is a list of genjets that we can save in NanoAOD. Set 
 # "enabled" to true if you want to store the jet collection
 config_genjets = [
   { 
-    "jet"     : "ak5gen",    
-    "enabled" : False, 
-  }, 
-  { 
-    "jet"     : "ak6gen",    
-    "enabled" : False, 
-  }, 
-  { 
-    "jet"     : "ak7gen",    
-    "enabled" : False, 
-  },
-  { 
-    "jet"     : "ak9gen",    
+    "jet"     : "ak8gen",    
     "enabled" : False, 
   },  
-  { 
-    "jet"     : "ak10gen", 
-    "enabled" : False,   
-  }, 
 ]
 config_genjets = list(filter(lambda k: k['enabled'], config_genjets))
 #
 # GenJets info in NanoAOD
 #
 nanoInfo_genjets = {
-  "ak5gen"  : {
-    "name" : "GenJetAK5",
-    "doc"  : "AK5 jets",
-  },
-  "ak6gen"  : {
-    "name" : "GenJetAK6",
-    "doc"  : "AK6 jets",
-  },
-  "ak7gen"  : {
-    "name" : "GenJetAK7",
-    "doc"  : "AK9 jets",
-  },
-  "ak9gen"  : {
-    "name" : "GenJetAK9",
-    "doc"  : "AK9 jets",
-  },
-  "ak10gen"  : {
-    "name" : "GenJetAK10",
-    "doc"  : "AK10 jets",
+  "ak8gen"  : {
+    "name" : "GenJetAK8",
+    "doc"  : "AK8 Gen jets",
   },
 }
 #
-# By default, these collections  are saved in NanoAODs:
-# - ak4pfchs   (Jet    in NanoAOD) 
-# - ak8pfpuppi (FatJet in NanoAOD)
-# By default, the ak4pfchs (Jet) and ak8pfpuppi (FatJet) collections 
-# are saved in NanoAODs. 
-# Below is a list of recojets that we can save in NanoAOD. Set "enabled" 
-# to true if you want to store the recojet collection.
+# By default, these collections are saved in the main NanoAODs:
+# - ak4pfchs   (Jet    in NanoAOD), slimmedJets in MiniAOD  
+# - ak8pfpuppi (FatJet in NanoAOD), slimmedJetsAK8 in MiniAOD 
+# Below is a list of recojets that we can save in NanoAOD. Set 
+# "enabled" to true if you want to store the recojet collection.
 #
 config_recojets = [
-  { 
-    "jet"     : "ak4pfpuppi", 
-    "enabled" : True,   
-    "inputCollection"  : "slimmedJetsPuppi", #Exist in MiniAOD
-    "genJetsCollection": "slimmedGenJets",   
-  }, 
   { 
     "jet" : "ak4calo",    
     "enabled" : True,     
     "inputCollection"  : "slimmedCaloJets", #Exist in MiniAOD
-    "genJetsCollection": "slimmedGenJets",  
+    "genJetsCollection": "AK4GenJetsNoNu",  
   }, 
   { 
     "jet" : "ak4pf",  
     "enabled" : True,        
+    "inputCollection" : "",
+    "genJetsCollection": "AK4GenJetsNoNu",  
+  }, 
+  { 
+    "jet" : "ak4pfpuppi",  
+    "enabled" : True,        
     "inputCollection" : "",                 
-    "genJetsCollection": "slimmedGenJets",  
+    "genJetsCollection": "AK4GenJetsNoNu",  
+    "bTagDiscriminators": bTagDiscriminatorsForAK4
   }, 
   { 
     "jet" : "ak8pf",  
@@ -104,18 +88,6 @@ config_recojets = [
     "inputCollection" : "",                 
     "genJetsCollection": "slimmedGenJetsAK8",
   },
-  { 
-    "jet" : "ak6pf",  
-    "enabled" : False,  
-    "inputCollection" : "",                 
-    "genJetsCollection": "AK6GenJetsNoNu",    
-  },
-  { 
-    "jet" : "ak10pf", 
-    "enabled" : False,  
-    "inputCollection" : "",                 
-    "genJetsCollection": "AK10GenJetsNoNu",
-  },
 ]
 config_recojets = list(filter(lambda k: k['enabled'], config_recojets))
 #
@@ -123,363 +95,781 @@ config_recojets = list(filter(lambda k: k['enabled'], config_recojets))
 #
 nanoInfo_recojets = {
   "ak4pfpuppi" : {
-    "name" : "JetPUPPI",
-    "doc"  : "AK4PFPUPPI jets", 
+    "name"  : "JetPuppi",
+    "doc"   : "AK4 PF Puppi jets with JECs applied, after basic selection (pt > 2)",  
+    "ptcut" : "pt > 2",      
+    "doQGL" : True,
+    "doPUIDVar": True,
+    "doBTag": True,
+  },
+  "ak4pf" : {
+    "name"  : "JetPF",
+    "doc"   : "AK4 PF jets with JECs applied, after basic selection (pt > 2)",
+    "ptcut" : "pt > 2",   
   },
   "ak4calo" : {
     "name": "JetCalo",
-    "doc" : "AK4Calo jets",   
-  },
-  "ak4pf" : {
-    "name": "JetPF",
-    "doc" : "AK4PF jets",     
-  },
-  "ak8pf" : {
-    "name": "FatJetPF",
-    "doc" : "AK8PF jets", 
+    "doc" : "AK4 Calo jets with JECs applied",
   },
   "ak8pfchs" : {
-    "name" : "FatJetCHS",
-    "doc"  : "AK8PFCHS jets",   
+    "name"  : "FatJetCHS",
+    "doc"   : "AK8 PF CHS jets with JECs applied, after basic selection (pt > 100)", 
+    "ptcut" : "pt > 100"    
   },
-  "ak6pf" : {
-    "name": "JetAK6PF",
-    "doc" : "AK6PF jets",
-  },
-  "ak10pf" : {
-    "name" : "FatJetAK10PF",
-    "doc"  : "AK10PF jets", 
+  "ak8pf" : {
+    "name"  : "FatJetPF",
+    "doc"   : "AK8 PF jets with JECs applied, after basic selection (pt > 100)", 
+    "ptcut" : "pt > 100", 
   },
 }
 
-#
-# The reco jet names already exists 
-# in NanoAOD.
-#
-recojetNameInNano = [ "Jet", "FatJet" ]
-#
-# The gen jet names already exists 
-# in NanoAOD.
-#
-genjetNameInNano = [ "GenJet", "GenJetAK8" ]
 
-JETVARS = cms.PSet(P4Vars,
-  HFHEF     = Var("HFHadronEnergyFraction()", float, doc = "energy fraction in forward hadronic calorimeter", precision = 6),
-  HFEMEF    = Var("HFEMEnergyFraction()",     float, doc = "energy fraction in forward EM calorimeter",       precision = 6),
+
+GENJETVARS = cms.PSet(P4Vars,
+  nConstituents   = jetTable.variables.nConstituents,
+)
+PFJETVARS = cms.PSet(P4Vars,
+  rawFactor       = jetTable.variables.rawFactor,
+  area            = jetTable.variables.area,
+  chHEF           = jetTable.variables.chHEF,
+  neHEF           = jetTable.variables.neHEF,
+  chEmEF          = jetTable.variables.chEmEF,
+  neEmEF          = jetTable.variables.neEmEF,
+  muEF            = jetTable.variables.muEF,
+  hfHEF           = Var("HFHadronEnergyFraction()",float,doc = "hadronic energy fraction in HF",precision = 6),
+  hfEmEF          = Var("HFEMEnergyFraction()",float,doc = "electromagnetic energy fraction in HF",precision = 6),
+  nMuons          = jetTable.variables.nMuons,
+  nElectrons      = jetTable.variables.nElectrons,
+  nConstituents   = jetTable.variables.nConstituents,
+  nConstChHads    = Var("chargedHadronMultiplicity()",int,doc="number of charged hadrons in the jet"),
+  nConstNeuHads   = Var("neutralHadronMultiplicity()",int,doc="number of neutral hadrons in the jet"),
+  nConstHFHads    = Var("HFHadronMultiplicity()", int,doc="number of HF hadrons in the jet"),
+  nConstHFEMs     = Var("HFEMMultiplicity()",int,doc="number of HF EMs in the jet"),
+  nConstMuons     = Var("muonMultiplicity()",int,doc="number of muons in the jet"),
+  nConstElecs     = Var("electronMultiplicity()",int,doc="number of electrons in the jet"),
+  nConstPhotons   = Var("photonMultiplicity()",int,doc="number of photons in the jet"),
+)
+PUIDVARS = cms.PSet(
+  puId_dR2Mean    = Var("userFloat('puId_dR2Mean')",float,doc="pT^2-weighted average square distance of jet constituents from the jet axis (PileUp ID BDT input variable)", precision= 6),
+  puId_majW       = Var("userFloat('puId_majW')",float,doc="major axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision= 6)  ,
+  puId_minW       = Var("userFloat('puId_minW')",float,doc="minor axis of jet ellipsoid in eta-phi plane (PileUp ID BDT input variable)", precision= 6)  ,
+  puId_frac01     = Var("userFloat('puId_frac01')",float,doc="fraction of constituents' pT contained within dR <0.1 (PileUp ID BDT input variable)", precision= 6)  ,
+  puId_frac02     = Var("userFloat('puId_frac02')",float,doc="fraction of constituents' pT contained within 0.1< dR <0.2 (PileUp ID BDT input variable)", precision= 6) ,
+  puId_frac03     = Var("userFloat('puId_frac03')",float,doc="fraction of constituents' pT contained within 0.2< dR <0.3 (PileUp ID BDT input variable)", precision= 6) ,
+  puId_frac04     = Var("userFloat('puId_frac04')",float,doc="fraction of constituents' pT contained within 0.3< dR <0.4 (PileUp ID BDT input variable)", precision= 6) ,
+  puId_ptD        = Var("userFloat('puId_ptD')",float,doc="pT-weighted average pT of constituents (PileUp ID BDT input variable)", precision= 6) ,
+  puId_beta       = Var("userFloat('puId_beta')",float,doc="fraction of pT of charged constituents associated to PV (PileUp ID BDT input variable)", precision= 6) ,
+  puId_pull       = Var("userFloat('puId_pull')",float,doc="magnitude of pull vector (PileUp ID BDT input variable)", precision= 6) ,
+  puId_jetR       = Var("userFloat('puId_jetR')",float,doc="fraction of jet pT carried by the leading constituent (PileUp ID BDT input variable)", precision= 6) ,
+  puId_jetRchg    = Var("userFloat('puId_jetRchg')",float,doc="fraction of jet pT carried by the leading charged constituent (PileUp ID BDT input variable)", precision= 6) ,
+  puId_nCharged   = Var("userInt('puId_nCharged')",int,doc="number of charged constituents (PileUp ID BDT input variable)"),
+)
+QGLVARS = cms.PSet(
+  qgl_axis2       =  Var("userFloat('qgl_axis2')",float,doc="ellipse minor jet axis (Quark vs Gluon likelihood input variable)", precision= 6),
+  qgl_ptD         =  Var("userFloat('qgl_ptD')",float,doc="pT-weighted average pT of constituents (Quark vs Gluon likelihood input variable)", precision= 6),
+  qgl_mult        =  Var("userInt('qgl_mult')", int,doc="PF candidates multiplicity (Quark vs Gluon likelihood input variable)"),
+)
+BTAGVARS = cms.PSet(
+  btagCMVA  = jetTable.variables.btagCMVA,
+  btagDeepB = jetTable.variables.btagDeepB,
+  btagCSVV2 = jetTable.variables.btagCSVV2,
+  btagDeepC = jetTable.variables.btagDeepC,
+)
+DEEPJETVARS = cms.PSet(
+  btagDeepFlavB   = jetTable.variables.btagDeepFlavB,
+  btagDeepFlavC   = jetTable.variables.btagDeepFlavC,
+  btagDeepFlavG   = Var("bDiscriminator('pfDeepFlavourJetTags:probg')",float,doc="DeepFlavour gluon tag raw score",precision=10),
+  btagDeepFlavUDS = Var("bDiscriminator('pfDeepFlavourJetTags:probuds')",float,doc="DeepFlavour uds tag raw score",precision=10)
+)
+CALOJETVARS = cms.PSet(P4Vars,
   area      = jetTable.variables.area,
-  chHEF     = jetTable.variables.chHEF,
-  neHEF     = jetTable.variables.neHEF,
-  chEmEF    = jetTable.variables.chEmEF,
-  neEmEF    = jetTable.variables.neEmEF,
-  muEF      = jetTable.variables.muEF,
   rawFactor = jetTable.variables.rawFactor,
-  jetId     = jetTable.variables.jetId,
-  jercCHPUF = jetTable.variables.jercCHPUF,
-  jercCHF   = jetTable.variables.jercCHF,
+  emf       = Var("emEnergyFraction()", float, doc = "electromagnetic energy fraction", precision = 10),
 )
 
-#============================================
+
+#******************************************
 #
-# TableGenJetAdder
 #
-#============================================
-class TableGenJetAdder(object):
+# Reco Jets related functions
+# 
+#
+#******************************************
+def AddJetID(proc, jetName="", jetSrc="", jetTableName="", jetSequenceName=""):
   """
-  Tool to store gen jet variables in NanoAOD for customized
-  gen jet collections.
+  Setup modules to calculate PF jet ID 
   """
-  def __init__(self):
-    self.main = []
 
-  def getSequence(self, proc):
-    """
-    Tool to add 
-    """
-    tasks = self.main
-
-    resultSequence = cms.Sequence()
-    for idx, task in enumerate(tasks):
-      if idx == 0:
-        resultSequence = cms.Sequence(getattr(proc, task))
-      else:
-        resultSequence.insert(idx, getattr(proc, task))
-    return resultSequence
-
-  def addTable(self, proc, genJetInfo):
-    currentTasks = []
-    
-    print("custom_jme_cff::TableGenJetAdder::addTable: Adding Table for GenJet Collection: {}".format(genJetInfo.jet))
-    
-    name = nanoInfo_genjets[genJetInfo.jet]["name"]
-    doc  = nanoInfo_genjets[genJetInfo.jet]["doc"]
-    
-    if name in genjetNameInNano:
-      raise RuntimeError('GenJet collection name (%s) taken in NanoAOD for %s' %(name, genJetInfo.jet))
-
-    #
-    # GenJet Table
-    #
-    table = "{}Table".format(genJetInfo.jetTagName)
-    genJetsCollection = "{}{}{}".format(genJetInfo.jetAlgo.upper(), genJetInfo.jetSize, 'GenJetsNoNu')
-    setattr(proc, table, cms.EDProducer("SimpleCandidateFlatTableProducer",
-        src       = cms.InputTag(genJetsCollection),
-        cut       = cms.string(""),
-        name      = cms.string(name),
-        doc       = cms.string('{} (generator level)'.format(doc)),
-        singleton = cms.bool(False),
-        extension = cms.bool(False),
-        variables = cms.PSet(P4Vars,
-        area      = jetTable.variables.area,
-        ),
-      )
-    )    
-    currentTasks.append(table)
-
-    #
-    # GenJet Flavour Table
-    #
-    genFlavour = "{}Flavour".format(genJetInfo.jetTagName)
-    genFlavourTable = "{}Table".format(genFlavour)
-    if genFlavourTable in self.main:
-      raise ValueError("Step '%s' already implemented" % genFlavourTable)
-    setattr(proc, genFlavourTable, cms.EDProducer("GenJetFlavourTableProducer",
-        name            = cms.string(name),
-        src             = cms.InputTag(genJetsCollection),
-        cut             = cms.string(""),
-        deltaR          = cms.double(0.1),
-        jetFlavourInfos = cms.InputTag(genFlavour),
-      )
+  isPUPPIJet = True if "Puppi" in jetName else False
+  
+  looseJetId = "looseJetId{}".format(jetName)
+  setattr(proc, looseJetId, proc.looseJetId.clone(
+      src = jetSrc,
+      filterParams=proc.looseJetId.filterParams.clone(
+        version ="WINTER16"
+      ),
     )
-    currentTasks.append(genFlavourTable)
-    self.main.extend(currentTasks)
+  )
 
-#============================================
-#
-# TableRecoJetAdder
-#
-#============================================
-class TableRecoJetAdder(object):
-  """
-  Tool to store reco jet variables in NanoAOD for customized
-  reco jet collections.
-  """
-  def __init__(self):
-    self.main = []
-
-  def getSequence(self, proc):
-    tasks = self.main
-
-    resultSequence = cms.Sequence()
-    for idx, task in enumerate(tasks):
-      if idx == 0:
-        resultSequence = cms.Sequence(getattr(proc, task))
-      else:
-        resultSequence.insert(idx, getattr(proc, task))
-    return resultSequence
-
-  def addTable(self, proc, recoJetInfo):
-
-    currentTasks = []
-
-    print("custom_jme_cff::TableRecoJetAdder::addTable: Adding Table for Reco Jet Collection: {}".format(recoJetInfo.jet))
-
-    name = nanoInfo_recojets[recoJetInfo.jet]["name"]
-    doc  = nanoInfo_recojets[recoJetInfo.jet]["doc"]
-
-    if name in recojetNameInNano:
-      raise RuntimeError('RecoJet collection name (%s) taken in NanoAOD for %s' %(name, recoJetInfo.jet))
-
-    table = "{}Table".format(recoJetInfo.jetTagName)
-    if recoJetInfo.skipUserData:
-      if recoJetInfo.doCalo:
-        tableContents = cms.PSet(
-          P4Vars,
-          area      = jetTable.variables.area,
-          rawFactor = jetTable.variables.rawFactor,
-          emf       = Var("emEnergyFraction()", float, doc = "electromagnetic energy fraction", precision = 10),
-        )
-      else:
-        tableContents = cms.PSet(
-          P4Vars,
-          area      = jetTable.variables.area,
-          rawFactor = jetTable.variables.rawFactor,
-        )
-    elif "puppi" in recoJetInfo.jet:
-      tableContents = JETVARS.clone(
-        puppiMultiplicity = Var("userFloat('patPuppiJetSpecificProducer:puppiMultiplicity')",float,doc="Sum of PUPPI weights of particles in the jet", precision= 6),
-        neutralPuppiMultiplicity = Var("userFloat('patPuppiJetSpecificProducer:neutralPuppiMultiplicity')",float,doc="Sum of PUPPI weights of neutral particles in the jet", precision= 6)
-      )
-    else:
-      tableContents = JETVARS.clone()
-    
-    updatedJets = "updatedJets{}".format(recoJetInfo.jetTagName)
-    setattr(proc, table, cms.EDProducer("SimpleCandidateFlatTableProducer",
-        src       = cms.InputTag(updatedJets),
-        cut       = cms.string(""),
-        name      = cms.string(name),
-        doc       = cms.string(doc),
-        singleton = cms.bool(False),
-        extension = cms.bool(False),
-        variables = tableContents,
-      )
+  tightJetId = "tightJetId{}".format(jetName)
+  setattr(proc, tightJetId, proc.tightJetId.clone(
+      src = jetSrc,
+      filterParams=proc.tightJetId.filterParams.clone(
+        version = "SUMMER18{}".format("PUPPI" if isPUPPIJet else "")
+      ),
     )
-    currentTasks.append(table)
-
-    self.main.extend(currentTasks)
-
-def AddPileUpJetIDVars(proc):
-
-  print("custom_jme_cff::AddPileUpJetIDVars: Recalculate pile-up jet ID variables and save them")
-
-  #
-  # Recalculate PUJet ID variables
-  #
-  from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdCalculator
-  proc.pileupJetIdCalculatorAK4PFCHS = pileupJetIdCalculator.clone(
-    jets = "updatedJets",
-    vertexes  = "offlineSlimmedPrimaryVertices",
-    inputIsCorrected = True,
-    applyJec  = False 
   )
-  proc.jetSequence.insert(proc.jetSequence.index(proc.updatedJets)+1, proc.pileupJetIdCalculatorAK4PFCHS)
-
-  #
-  # Get the variables
-  #
-  proc.puJetVarAK4PFCHS = cms.EDProducer("PileupJetIDVarProducer",
-    srcJet = cms.InputTag("updatedJets"),    
-    srcPileupJetId = cms.InputTag("pileupJetIdCalculatorAK4PFCHS")
+  
+  tightJetIdLepVeto = "tightJetIdLepVeto{}".format(jetName)
+  setattr(proc, tightJetIdLepVeto, proc.tightJetIdLepVeto.clone(
+      src = jetSrc,
+      filterParams=proc.tightJetIdLepVeto.filterParams.clone(
+        version = "SUMMER18{}".format("PUPPI" if isPUPPIJet else "")
+      ),
+    )
   )
-  proc.jetSequence.insert(proc.jetSequence.index(proc.jercVars)+1, proc.puJetVarAK4PFCHS)
-
+  run2_jme_2016.toModify(getattr(proc, tightJetId) .filterParams,        version = "WINTER16" )
+  run2_jme_2016.toModify(getattr(proc, tightJetIdLepVeto) .filterParams, version = "WINTER16" )
+  run2_jme_2017.toModify(getattr(proc, tightJetId) .filterParams,        version = "WINTER17{}".format("PUPPI" if isPUPPIJet else ""))
+  run2_jme_2017.toModify(getattr(proc, tightJetIdLepVeto) .filterParams, version = "WINTER17{}".format("PUPPI" if isPUPPIJet else ""))
+  
   #
-  # Save variables as userFloats and userInts in each jet
+  # Save variables as userInts in each jet
   # 
-  proc.updatedJetsWithUserData.userFloats.dR2Mean  = cms.InputTag("puJetVarAK4PFCHS:dR2Mean")
-  proc.updatedJetsWithUserData.userFloats.majW     = cms.InputTag("puJetVarAK4PFCHS:majW")
-  proc.updatedJetsWithUserData.userFloats.minW     = cms.InputTag("puJetVarAK4PFCHS:minW")
-  proc.updatedJetsWithUserData.userFloats.frac01   = cms.InputTag("puJetVarAK4PFCHS:frac01")
-  proc.updatedJetsWithUserData.userFloats.frac02   = cms.InputTag("puJetVarAK4PFCHS:frac02")
-  proc.updatedJetsWithUserData.userFloats.frac03   = cms.InputTag("puJetVarAK4PFCHS:frac03")
-  proc.updatedJetsWithUserData.userFloats.frac04   = cms.InputTag("puJetVarAK4PFCHS:frac04")
-  proc.updatedJetsWithUserData.userFloats.ptD      = cms.InputTag("puJetVarAK4PFCHS:ptD")
-  proc.updatedJetsWithUserData.userFloats.beta     = cms.InputTag("puJetVarAK4PFCHS:beta")
-  proc.updatedJetsWithUserData.userFloats.pull     = cms.InputTag("puJetVarAK4PFCHS:pull")
-  proc.updatedJetsWithUserData.userFloats.jetR     = cms.InputTag("puJetVarAK4PFCHS:jetR")
-  proc.updatedJetsWithUserData.userFloats.jetRchg  = cms.InputTag("puJetVarAK4PFCHS:jetRchg")
-  proc.updatedJetsWithUserData.userInts.nCharged   = cms.InputTag("puJetVarAK4PFCHS:nCharged")
+  patJetWithUserData = "{}WithUserData".format(jetSrc)
+  getattr(proc, patJetWithUserData).userInts.tightId = cms.InputTag(tightJetId)
+  getattr(proc, patJetWithUserData).userInts.tightIdLepVeto = cms.InputTag(tightJetIdLepVeto)
+  run2_jme_2016.toModify(getattr(proc, patJetWithUserData).userInts, looseId = cms.InputTag(looseJetId))
 
   #
   # Specfiy variables in the jetTable to save in NanoAOD
   #
-  proc.jetTable.variables.dR2Mean  = Var("userFloat('dR2Mean')", float, doc="pT^2-weighted average square distance of jet constituents from the jet axis", precision= 6)  
-  proc.jetTable.variables.majW     = Var("userFloat('majW')",    float, doc="major axis of jet ellipsoid in eta-phi plane", precision= 6)  
-  proc.jetTable.variables.minW     = Var("userFloat('minW')",    float, doc="minor axis of jet ellipsoid in eta-phi plane", precision= 6)  
-  proc.jetTable.variables.frac01   = Var("userFloat('frac01')",  float, doc="frac of constituents' pT contained within dR<0.1", precision= 6)  
-  proc.jetTable.variables.frac02   = Var("userFloat('frac02')",  float, doc="frac of constituents' pT contained within 0.1<dR<0.2", precision= 6) 
-  proc.jetTable.variables.frac03   = Var("userFloat('frac03')",  float, doc="frac of constituents' pT contained within 0.2<dR<0.3", precision= 6) 
-  proc.jetTable.variables.frac04   = Var("userFloat('frac04')",  float, doc="frac of constituents' pT contained within 0.3<dR<0.4", precision= 6) 
-  proc.jetTable.variables.ptD      = Var("userFloat('ptD')",     float, doc="pT-weighted average pT of constituents", precision= 6) 
-  proc.jetTable.variables.beta     = Var("userFloat('beta')",    float, doc="fraction of pT of charged constituents associated to PV", precision= 6) 
-  proc.jetTable.variables.pull     = Var("userFloat('pull')",    float, doc="magnitude of pull vector", precision= 6) 
-  proc.jetTable.variables.jetR     = Var("userFloat('jetR')",    float, doc="fraction of jet pT carried by the leading constituent", precision= 6) 
-  proc.jetTable.variables.jetRchg  = Var("userFloat('jetRchg')", float, doc="fraction of jet pT carried by the leading charged constituent", precision= 6) 
-  proc.jetTable.variables.nCharged = Var("userInt('nCharged')",  int, doc="number of charged constituents")
+  getattr(proc, jetTableName).variables.jetId = Var("userInt('tightId')*2+4*userInt('tightIdLepVeto')",int,doc="Jet ID flags bit1 is loose (always false in 2017 since it does not exist), bit2 is tight, bit3 is tightLepVeto")
+  run2_jme_2016.toModify(getattr(proc, jetTableName).variables, jetId = Var("userInt('tightIdLepVeto')*4+userInt('tightId')*2+userInt('looseId')",int, doc="Jet ID flags bit1 is loose, bit2 is tight, bit3 is tightLepVeto"))
 
-def PrepJMECustomNanoAOD(process,runOnMC):
-  #
-  # Additional variables to AK4GenJets 
-  #
-  process.genJetTable.variables.area = JETVARS.area
-  #
-  # Additional variables to AK8GenJets
-  #
-  process.genJetAK8Table.variables.area = JETVARS.area
-  #
-  # Additional variables for AK4PFCHS 
-  #
-  process.jetTable.variables.HFHEF  = JETVARS.HFHEF
-  process.jetTable.variables.HFEMEF = JETVARS.HFEMEF
-  #
-  # Additional variables to AK8PFPUPPI
-  #
-  # These variables are not stored for AK8PFCHS (slimmedJetsAK8)
-  # in MiniAOD if their pt < 170 GeV. Hence the conditional fill.
-  #
-  process.fatJetTable.variables.chHEF  = Var("?isPFJet()?chargedHadronEnergyFraction():-1", float, doc="charged Hadron Energy Fraction",                  precision = 6)
-  process.fatJetTable.variables.neHEF  = Var("?isPFJet()?neutralHadronEnergyFraction():-1", float, doc="neutral Hadron Energy Fraction",                  precision = 6)
-  process.fatJetTable.variables.chEmEF = Var("?isPFJet()?chargedEmEnergyFraction():-1",     float, doc="charged Electromagnetic Energy Fraction",         precision = 6)
-  process.fatJetTable.variables.neEmEF = Var("?isPFJet()?neutralEmEnergyFraction():-1",     float, doc="neutral Electromagnetic Energy Fraction",         precision = 6)
-  process.fatJetTable.variables.muEF   = Var("?isPFJet()?muonEnergyFraction():-1",          float, doc="muon Energy Fraction",                            precision = 6)
-  process.fatJetTable.variables.HFHEF  = Var("?isPFJet()?HFHadronEnergyFraction():-1",      float, doc="energy fraction in forward hadronic calorimeter", precision = 6)
-  process.fatJetTable.variables.HFEMEF = Var("?isPFJet()?HFEMEnergyFraction():-1",          float, doc="energy fraction in forward EM calorimeter",       precision = 6)
-  #
-  #
-  #
-  process.jercVarsFatJet = process.jercVars.clone(
-    srcJet = "updatedJetsAK8",
-    maxDR = 0.8,
-  )
-  process.jetSequence.insert(process.jetSequence.index(process.updatedJetsAK8WithUserData), process.jercVarsFatJet)
+  getattr(proc,jetSequenceName).insert(getattr(proc,jetSequenceName).index(getattr(proc, jetSrc))+1, getattr(proc, tightJetId))
+  getattr(proc,jetSequenceName).insert(getattr(proc,jetSequenceName).index(getattr(proc, tightJetId))+1, getattr(proc, tightJetIdLepVeto))
   
-  process.updatedJetsAK8WithUserData.userFloats.jercCHPUF = cms.InputTag(
-    "%s:chargedHadronPUEnergyFraction"  % process.jercVarsFatJet.label()
-  )
-  process.updatedJetsAK8WithUserData.userFloats.jercCHF = cms.InputTag(
-    "%s:chargedHadronCHSEnergyFraction" % process.jercVarsFatJet.label()
-  )
-  process.fatJetTable.variables.jercCHPUF = JETVARS.jercCHPUF
-  process.fatJetTable.variables.jercCHF   = JETVARS.jercCHF
+  setattr(proc,"_"+jetSequenceName+"_2016", getattr(proc,jetSequenceName).copy())
+  getattr(proc,"_"+jetSequenceName+"_2016").insert(getattr(proc, "_"+jetSequenceName+"_2016").index(getattr(proc, tightJetId)), getattr(proc, looseJetId))
+  run2_jme_2016.toReplaceWith(getattr(proc,jetSequenceName), getattr(proc, "_"+jetSequenceName+"_2016"))
+
+  return proc
+
+def AddPileUpJetIDVars(proc, jetName="", jetSrc="", jetTableName="", jetSequenceName=""):
+  """
+  Setup modules to calculate pileup jet ID input variables for PF jet
+  """
+
   #
+  # Calculate pileup jet ID variables
+  #
+  puJetIdVarsCalculator = "puJetIdCalculator{}".format(jetName) 
+  setattr(proc, puJetIdVarsCalculator, pileupJetIdCalculator.clone(
+      jets = jetSrc,
+      vertexes  = "offlineSlimmedPrimaryVertices",
+      inputIsCorrected = True,
+      applyJec  = False,
+      usePuppi = True if "Puppi" in jetName else False
+    )
+  )
+  getattr(proc,jetSequenceName).insert(getattr(proc,jetSequenceName).index(getattr(proc, jetSrc))+1, getattr(proc, puJetIdVarsCalculator))
+
+  #
+  # Get the variables
+  #
+  puJetIDVar = "puJetIDVar{}".format(jetName)
+  setattr(proc, puJetIDVar, cms.EDProducer("PileupJetIDVarProducer",
+      srcJet = cms.InputTag(jetSrc),    
+      srcPileupJetId = cms.InputTag(puJetIdVarsCalculator)
+    )
+  )
+  getattr(proc,jetSequenceName).insert(getattr(proc,jetSequenceName).index(getattr(proc, puJetIdVarsCalculator))+1, getattr(proc, puJetIDVar))
+
+  #
+  # Save variables as userFloats and userInts for each jet
   # 
+  patJetWithUserData = "{}WithUserData".format(jetSrc)
+  getattr(proc,patJetWithUserData).userFloats.puId_dR2Mean  = cms.InputTag("{}:dR2Mean".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_majW     = cms.InputTag("{}:majW".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_minW     = cms.InputTag("{}:minW".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_frac01   = cms.InputTag("{}:frac01".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_frac02   = cms.InputTag("{}:frac02".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_frac03   = cms.InputTag("{}:frac03".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_frac04   = cms.InputTag("{}:frac04".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_ptD      = cms.InputTag("{}:ptD".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_beta     = cms.InputTag("{}:beta".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_pull     = cms.InputTag("{}:pull".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_jetR     = cms.InputTag("{}:jetR".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userFloats.puId_jetRchg  = cms.InputTag("{}:jetRchg".format(puJetIDVar))
+  getattr(proc,patJetWithUserData).userInts.puId_nCharged   = cms.InputTag("{}:nCharged".format(puJetIDVar))
+
+  #
+  # Specfiy variables in the jet table to save in NanoAOD
+  #
+  getattr(proc,jetTableName).variables.puId_dR2Mean  = PUIDVARS.puId_dR2Mean 
+  getattr(proc,jetTableName).variables.puId_majW     = PUIDVARS.puId_majW    
+  getattr(proc,jetTableName).variables.puId_minW     = PUIDVARS.puId_minW    
+  getattr(proc,jetTableName).variables.puId_frac01   = PUIDVARS.puId_frac01  
+  getattr(proc,jetTableName).variables.puId_frac02   = PUIDVARS.puId_frac02  
+  getattr(proc,jetTableName).variables.puId_frac03   = PUIDVARS.puId_frac03  
+  getattr(proc,jetTableName).variables.puId_frac04   = PUIDVARS.puId_frac04  
+  getattr(proc,jetTableName).variables.puId_ptD      = PUIDVARS.puId_ptD      
+  getattr(proc,jetTableName).variables.puId_beta     = PUIDVARS.puId_beta    
+  getattr(proc,jetTableName).variables.puId_pull     = PUIDVARS.puId_pull     
+  getattr(proc,jetTableName).variables.puId_jetR     = PUIDVARS.puId_jetR    
+  getattr(proc,jetTableName).variables.puId_jetRchg  = PUIDVARS.puId_jetRchg 
+  getattr(proc,jetTableName).variables.puId_nCharged = PUIDVARS.puId_nCharged 
+
+  return proc
+
+def AddQGLTaggerVars(proc, jetName="", jetSrc="", jetTableName="", jetSequenceName="", calculateQGLVars=False):
+  """
+  Schedule the QGTagger module to calculate input variables to the QG likelihood 
+  """
+
+  QGLTagger="qgtagger{}".format(jetName)
+  patJetWithUserData="{}WithUserData".format(jetSrc)
+
+  if calculateQGLVars:
+    setattr(proc, QGLTagger, qgtagger.clone(
+        srcJets=jetSrc
+      )
+    )
+
+  #
+  # Save variables as userFloats and userInts for each jet
   # 
-  process.finalJets.cut             = "" # 15 -> 10
-  process.finalJetsAK8.cut          = "" # 170 -> 170
-  process.genJetTable.cut           = "" # 10 -> 8
-  process.genJetFlavourTable.cut    = "" # 10 -> 8
-  process.genJetAK8Table.cut        = "" # 100 -> 80
-  process.genJetAK8FlavourTable.cut = "" # 100 -> 80
+  getattr(proc,patJetWithUserData).userFloats.qgl_axis2 = cms.InputTag(QGLTagger+":axis2")
+  getattr(proc,patJetWithUserData).userFloats.qgl_ptD   = cms.InputTag(QGLTagger+":ptD")
+  getattr(proc,patJetWithUserData).userInts.qgl_mult    = cms.InputTag(QGLTagger+":mult")
+
+  #
+  # Specfiy variables in the jet table to save in NanoAOD
+  #
+  getattr(proc,jetTableName).variables.qgl_axis2 =  QGLVARS.qgl_axis2
+  getattr(proc,jetTableName).variables.qgl_ptD   =  QGLVARS.qgl_ptD
+  getattr(proc,jetTableName).variables.qgl_mult  =  QGLVARS.qgl_mult
+
+  if calculateQGLVars:
+    getattr(proc,jetSequenceName).insert(getattr(proc,jetSequenceName).index(getattr(proc, jetSrc))+1, getattr(proc, QGLTagger))
+
+  return proc
+
+def AddBTaggingScores(proc, jetTableName=""):
+  """
+  Store b-tagging scores from various algortihm
+  """
+
+  getattr(proc, jetTableName).variables.btagCMVA      = jetTable.variables.btagCMVA
+  getattr(proc, jetTableName).variables.btagDeepB     = jetTable.variables.btagDeepB
+  getattr(proc, jetTableName).variables.btagCSVV2     = jetTable.variables.btagCSVV2
+  getattr(proc, jetTableName).variables.btagDeepC     = jetTable.variables.btagDeepC
+  getattr(proc, jetTableName).variables.btagDeepFlavB = jetTable.variables.btagDeepFlavB
+  getattr(proc, jetTableName).variables.btagDeepFlavC = jetTable.variables.btagDeepFlavC
+
+  return proc
+
+def AddDeepJetGluonLQuarkScores(proc, jetTableName=""):
+  """
+  Store DeepJet raw score in jetTable for gluon and light quark
+  """
+
+  getattr(proc, jetTableName).variables.btagDeepFlavG   = DEEPJETVARS.btagDeepFlavG  
+  getattr(proc, jetTableName).variables.btagDeepFlavUDS = DEEPJETVARS.btagDeepFlavUDS
+
+  return proc
+
+def AddNewPatJets(proc, recoJetInfo, runOnMC):
+  """
+  Add patJet into custom nanoAOD
+  """
+
+  jetName = recoJetInfo.jetUpper
+  payload = recoJetInfo.jetCorrPayload 
+  doPF    = recoJetInfo.doPF
+  doCalo  = recoJetInfo.doCalo
+
+  if recoJetInfo.inputCollection != "":
+    patJetFinalColl = recoJetInfo.inputCollection
+  else: 
+    patJetFinalColl = "selectedUpdatedPatJets{}Final".format(jetName)
+
+  if doCalo:
+    patJetFinalColl = "selectedPatJets{}".format(jetName)
+
+  nanoInfoForJet = nanoInfo_recojets[recoJetInfo.jet]
+  jetTablePrefix = nanoInfoForJet["name"]
+  jetTableDoc    = nanoInfoForJet["doc"]
+  ptcut          = nanoInfoForJet["ptcut"] if "ptcut" in nanoInfoForJet else ""
+  doPUIDVar      = nanoInfoForJet["doPUIDVar"] if "doPUIDVar" in nanoInfoForJet else False
+  doQGL          = nanoInfoForJet["doQGL"] if "doQGL" in nanoInfoForJet else False
+  doBTag         = nanoInfoForJet["doBTag"] if "doBTag" in nanoInfoForJet else False
+
+  SavePatJets(proc, 
+    jetName, payload, patJetFinalColl, jetTablePrefix, jetTableDoc, doPF, doCalo, 
+    ptcut=ptcut, doPUIDVar=doPUIDVar, doQGL=doQGL, doBTag=doBTag, runOnMC=runOnMC
+  )
+
+  return proc
+
+def SavePatJets(proc, jetName, payload, patJetFinalColl, jetTablePrefix, jetTableDoc, 
+                doPF, doCalo, ptcut="", doPUIDVar=False, doQGL=False, doBTag=False, runOnMC=False):
+  """
+  Schedule modules for a given patJet collection and save its variables into custom NanoAOD
+  """
+
+  #
+  # Setup jet correction factors
+  #
+  jetCorrFactors = "jetCorrFactorsNano{}".format(jetName)
+  setattr(proc, jetCorrFactors, jetCorrFactorsNano.clone(
+      src = patJetFinalColl,
+      payload = payload,
+    )
+  )
+
+  #
+  # Update jets
+  #
+  srcJets = "updatedJets{}".format(jetName)
+  setattr(proc, srcJets, updatedJets.clone(
+      jetSource = patJetFinalColl,
+      jetCorrFactorsSource=[jetCorrFactors],
+    )
+  )
+   
+  #
+  # Setup UserDataEmbedder
+  #
+  srcJetsWithUserData = "updatedJets{}WithUserData".format(jetName)
+  setattr(proc, srcJetsWithUserData, cms.EDProducer("PATJetUserDataEmbedder",
+      src = cms.InputTag(srcJets),
+      userFloats = cms.PSet(),    
+      userInts = cms.PSet(),
+    )
+  )
+  
+  #
+  # Filter jets with pt cut
+  #
+  finalJetsForTable = "finalJets{}".format(jetName)
+  setattr(proc, finalJetsForTable, finalJets.clone(
+      src = srcJetsWithUserData,
+      cut = ptcut
+    )
+  )
+
+  #
+  # Save jets in table
+  #
+  tableContent = PFJETVARS
+  if doCalo:
+    tableContent =  CALOJETVARS
+
+  jetTable = "jet{}Table".format(jetName)
+  setattr(proc,jetTable, cms.EDProducer("SimpleCandidateFlatTableProducer",
+      src = cms.InputTag(finalJetsForTable),
+      cut = cms.string(""), # Don't specify cuts here
+      name = cms.string(jetTablePrefix),
+      doc  = cms.string(jetTableDoc),
+      singleton = cms.bool(False), # the number of entries is variable
+      extension = cms.bool(False), # this is the main table for the jets
+      variables = cms.PSet(tableContent)
+    )
+  )
+  getattr(proc,jetTable).variables.pt.precision=10
+
+  #
+  # Save MC-only jet variables in table
+  #
+  jetMCTable = "jet{}MCTable".format(jetName)
+  setattr(proc, jetMCTable, cms.EDProducer("SimpleCandidateFlatTableProducer",
+      src = cms.InputTag(finalJetsForTable),
+      cut = getattr(proc,jetTable).cut,
+      name = cms.string(jetTablePrefix),
+      singleton = cms.bool(False),
+      extension = cms.bool(True), # this is an extension table
+      variables = cms.PSet(
+        partonFlavour = Var("partonFlavour()", int, doc="flavour from parton matching"),
+        hadronFlavour = Var("hadronFlavour()", int, doc="flavour from hadron ghost clustering"),
+        genJetIdx = Var("?genJetFwdRef().backRef().isNonnull()?genJetFwdRef().backRef().key():-1", int, doc="index of matched gen jet"),
+      )
+    )
+  )
+
+  #
+  # Define the jet modules sequence first
+  #
+  jetSequenceName = "jet{}Sequence".format(jetName)
+  setattr(proc, jetSequenceName, cms.Sequence(
+      getattr(proc,jetCorrFactors)+
+      getattr(proc,srcJets)+
+      getattr(proc,srcJetsWithUserData)+
+      getattr(proc,finalJetsForTable)
+    )
+  )
+
+  #
+  # Define the jet table sequences 
+  #
+  jetTableSequenceName = "jet{}TablesSequence".format(jetName)
+  setattr(proc, jetTableSequenceName, cms.Sequence(getattr(proc,jetTable)))
+
+  jetTableSequenceMCName = "jet{}MCTablesSequence".format(jetName)
+  setattr(proc, jetTableSequenceMCName, cms.Sequence(getattr(proc,jetMCTable)))
+  
+  if runOnMC:
+    proc.nanoSequenceMC += getattr(proc,jetSequenceName)
+    proc.nanoSequenceMC += getattr(proc,jetTableSequenceName)
+    proc.nanoSequenceMC += getattr(proc,jetTableSequenceMCName)
+  else:
+    proc.nanoSequence += getattr(proc,jetSequenceName)
+    proc.nanoSequence += getattr(proc,jetTableSequenceName)
+
+  #
+  # Schedule plugins to calculate Jet ID, PileUp Jet ID input variables, and Quark-Gluon Likehood input variables.
+  #
+  if doPF:
+    proc = AddJetID(proc, jetName=jetName, jetSrc=srcJets, jetTableName=jetTable, jetSequenceName=jetSequenceName)
+    if doPUIDVar:
+      proc = AddPileUpJetIDVars(proc, jetName=jetName, jetSrc=srcJets, jetTableName=jetTable, jetSequenceName=jetSequenceName)
+    if doQGL:
+      proc = AddQGLTaggerVars(proc,jetName=jetName, jetSrc=srcJets, jetTableName=jetTable, jetSequenceName=jetSequenceName, calculateQGLVars=True)
+  
+  #
+  # Save b-tagging algorithm scores. Should only be done for jet collection with b-tagging 
+  # calculated when reclustered or collection saved with b-tagging info in MiniAOD
+  # 
+  if doBTag:
+    AddBTaggingScores(proc,jetTableName=jetTable)
+    AddDeepJetGluonLQuarkScores(proc,jetTableName=jetTable)
+
+  return proc
+
+def ReclusterAK4CHSJets(proc, recoJA, runOnMC):
+  """
+  Recluster AK4 CHS jets and replace slimmedJets
+  that is used as default to save AK4 CHS jets 
+  in NanoAODs.  
+  """
+  print("custom_jme_cff::ReclusterAK4CHSJets: Recluster AK4 PF CHS jets")
+
+  #
+  # Recluster AK4 CHS jets
+  #
+  cfg = { 
+    "jet" : "ak4pfchs",   
+    "inputCollection" : "",                 
+    "genJetsCollection": "AK4GenJetsNoNu",
+    "bTagDiscriminators": bTagDiscriminatorsForAK4
+  }
+  recoJetInfo = recoJA.addRecoJetCollection(proc, **cfg) 
+
+  jetName = recoJetInfo.jetUpper
+  patJetFinalColl = "selectedUpdatedPatJets{}Final".format(jetName)
+  
+  #
+  # Change the input jet source for jetCorrFactorsNano 
+  # and updatedJets
+  # 
+  proc.jetCorrFactorsNano.src=patJetFinalColl
+  proc.updatedJets.jetSource=patJetFinalColl
+
+  #
+  # Change pt cut
+  #
+  proc.finalJets.cut = "pt > 2"
+  proc.simpleCleanerTable.jetSel = "pt > 10" # Change this from 15 -> 10 
+
+  #
+  # Add variables 
+  #
+  proc.jetTable.variables.hfHEF         = PFJETVARS.hfHEF
+  proc.jetTable.variables.hfEmEF        = PFJETVARS.hfEmEF
+  proc.jetTable.variables.nConstChHads  = PFJETVARS.nConstChHads
+  proc.jetTable.variables.nConstNeuHads = PFJETVARS.nConstNeuHads
+  proc.jetTable.variables.nConstHFHads  = PFJETVARS.nConstHFHads
+  proc.jetTable.variables.nConstHFEMs   = PFJETVARS.nConstHFEMs
+  proc.jetTable.variables.nConstMuons   = PFJETVARS.nConstMuons
+  proc.jetTable.variables.nConstElecs   = PFJETVARS.nConstElecs
+  proc.jetTable.variables.nConstPhotons = PFJETVARS.nConstPhotons
+
+  proc.jetTable.doc = cms.string("AK4 PF CHS Jets with JECs applied, after basic selection (pt > 2)")
+
+  #
+  # Setup pileup jet ID with 80X training.
+  # 
+  # pileupJetId80X = "pileupJetId80X"
+  # setattr(proc, pileupJetId80X, pileupJetId.clone(
+  #     jets="updatedJets",
+  #     algos=cms.VPSet(_chsalgos_81x),
+  #     inputIsCorrected=True,
+  #     applyJec=False,
+  #     vertexes="offlineSlimmedPrimaryVertices"
+  #   )
+  # )
+  # proc.jetSequence.insert(proc.jetSequence.index(proc.pileupJetId94X), getattr(proc, pileupJetId80X)) 
+
+  # proc.updatedJetsWithUserData.userInts.puId80XfullId = cms.InputTag('pileupJetId80X:fullId')
+  # run2_jme_2016.toModify(proc.updatedJetsWithUserData.userFloats, puId80XDisc = cms.InputTag("pileupJetId80X:fullDiscriminant"))
+
+  # proc.jetTable.variables.puId = Var("userInt('puId80XfullId')", int, doc="Pilup ID flags with 80X (2016) training")
+  # run2_jme_2016.toModify(proc.jetTable.variables, puIdDisc = Var("userFloat('puId80XDisc')",float,doc="Pilup ID discriminant with 80X (2016) training",precision=10))
+
   #
   # Add variables for pileup jet ID studies.
   #
-  AddPileUpJetIDVars(process)
+  proc = AddPileUpJetIDVars(proc, 
+    jetName="", 
+    jetSrc="updatedJets", 
+    jetTableName="jetTable",
+    jetSequenceName="jetSequence"
+  )
+  #
+  # Add variables for quark guon likelihood tagger studies.
+  # Save variables as userFloats and userInts in each jet
+  #
+  proc.updatedJetsWithUserData.userFloats.qgl_axis2 = cms.InputTag("qgtagger:axis2")
+  proc.updatedJetsWithUserData.userFloats.qgl_ptD   = cms.InputTag("qgtagger:ptD")
+  proc.updatedJetsWithUserData.userInts.qgl_mult    = cms.InputTag("qgtagger:mult")
+  #
+  # Specfiy variables in the jetTable to save in NanoAOD
+  #
+  proc.jetTable.variables.qgl_axis2 =  QGLVARS.qgl_axis2
+  proc.jetTable.variables.qgl_ptD   =  QGLVARS.qgl_ptD
+  proc.jetTable.variables.qgl_mult  =  QGLVARS.qgl_mult
+  #
+  # Save DeepJet raw score for gluon and light quarks
+  #
+  proc.jetTable.variables.btagDeepFlavG   = DEEPJETVARS.btagDeepFlavG  
+  proc.jetTable.variables.btagDeepFlavUDS = DEEPJETVARS.btagDeepFlavUDS
 
-  ######################################################################################################################
+  return proc
+
+def AddVariablesForAK8PuppiJets(proc):
+  """
+  Add more variables for AK8 PFPUPPI jets
+  """
 
   #
-  # Add GenJets to NanoAOD
+  #  These variables are not stored for AK8PFCHS (slimmedJetsAK8)
+  #  in MiniAOD if their pt < 170 GeV. Hence the conditional fill.
   #
+  proc.fatJetTable.variables.chHEF  = Var("?isPFJet()?chargedHadronEnergyFraction():-1", float, doc="charged Hadron Energy Fraction", precision = 6)
+  proc.fatJetTable.variables.neHEF  = Var("?isPFJet()?neutralHadronEnergyFraction():-1", float, doc="neutral Hadron Energy Fraction", precision = 6)
+  proc.fatJetTable.variables.chEmEF = Var("?isPFJet()?chargedEmEnergyFraction():-1", float, doc="charged Electromagnetic Energy Fraction", precision = 6)
+  proc.fatJetTable.variables.neEmEF = Var("?isPFJet()?neutralEmEnergyFraction():-1", float, doc="neutral Electromagnetic Energy Fraction", precision = 6)
+  proc.fatJetTable.variables.muEF   = Var("?isPFJet()?muonEnergyFraction():-1", float, doc="muon Energy Fraction", precision = 6)
+  proc.fatJetTable.variables.hfHEF  = Var("?isPFJet()?HFHadronEnergyFraction():-1", float, doc="energy fraction in forward hadronic calorimeter", precision = 6)
+  proc.fatJetTable.variables.hfEmEF = Var("?isPFJet()?HFEMEnergyFraction():-1", float, doc="energy fraction in forward EM calorimeter", precision = 6)
+  proc.fatJetTable.variables.nConstChHads   = Var("?isPFJet()?chargedHadronMultiplicity():-1",int, doc="number of charged hadrons in the jet")
+  proc.fatJetTable.variables.nConstNeuHads  = Var("?isPFJet()?neutralHadronMultiplicity():-1",int, doc="number of neutral hadrons in the jet")
+  proc.fatJetTable.variables.nConstHFHads   = Var("?isPFJet()?HFHadronMultiplicity():-1", int, doc="number of HF Hadrons in the jet")
+  proc.fatJetTable.variables.nConstHFEMs    = Var("?isPFJet()?HFEMMultiplicity():-1", int, doc="number of HF EMs in the jet")
+  proc.fatJetTable.variables.nConstMuons    = Var("?isPFJet()?muonMultiplicity():-1", int, doc="number of muons in the jet")
+  proc.fatJetTable.variables.nConstElecs    = Var("?isPFJet()?electronMultiplicity():-1", int, doc="number of electrons in the jet")
+  proc.fatJetTable.variables.nConstPhotons  = Var("?isPFJet()?photonMultiplicity():-1", int, doc="number of photons in the jet")
+
+  return proc
+#******************************************
+#
+#
+# Gen Jets related functions
+# 
+#
+#******************************************
+def AddNewGenJets(proc, genJetInfo):
+  """
+  Add genJet into custom nanoAOD
+  """
+
+  genJetName         = genJetInfo.jetUpper
+  genJetAlgo         = genJetInfo.jetAlgo
+  genJetSize         = genJetInfo.jetSize
+  genJetSizeNr       = genJetInfo.jetSizeNr
+  genJetFinalColl    = "{}{}{}".format(genJetAlgo.upper(), genJetSize, "GenJetsNoNu")
+  genJetTablePrefix  = nanoInfo_genjets[genJetInfo.jet]["name"]
+  genJetTableDoc     = nanoInfo_genjets[genJetInfo.jet]["doc"]
+
+  SaveGenJets(proc, genJetName, genJetAlgo, genJetSizeNr, genJetFinalColl, genJetTablePrefix, genJetTableDoc, runOnMC=False)
+
+  return proc
+
+def SaveGenJets(proc, genJetName, genJetAlgo, genJetSizeNr, genJetFinalColl, genJetTablePrefix, genJetTableDoc, runOnMC=False):
+  """
+  Schedule modules for a given genJet collection and save its variables into custom NanoAOD
+  """
+
+  genJetTableThisJet = "jet{}Table".format(genJetName)
+  setattr(proc, genJetTableThisJet, genJetTable.clone(
+      src       = genJetFinalColl,
+      cut       = "pt > 1",
+      name      = genJetTablePrefix,
+      doc       = genJetTableDoc,
+      variables = GENJETVARS
+    )
+  )
+
+  genJetFlavourAssociationThisJet = "genJet{}FlavourAssociation".format(genJetName)
+  setattr(proc, genJetFlavourAssociationThisJet, genJetFlavourAssociation.clone(
+      jets           = getattr(proc,genJetTableThisJet).src,
+      jetAlgorithm   = supportedJetAlgos[genJetAlgo],
+      rParam         = genJetSizeNr,
+    )
+  )
+
+  genJetFlavourTableThisJet = "genJet{}FlavourTable".format(genJetName)
+  setattr(proc, genJetFlavourTableThisJet, genJetFlavourTable.clone(
+      name            = getattr(proc,genJetTableThisJet).name,
+      src             = getattr(proc,genJetTableThisJet).src,
+      cut             = getattr(proc,genJetTableThisJet).cut,
+      jetFlavourInfos = genJetFlavourAssociationThisJet,
+    )
+  )
+
+  genJetSequenceName = "genJet{}Sequence".format(genJetName)
+  setattr(proc, genJetSequenceName, cms.Sequence(
+      getattr(proc,genJetTableThisJet)+
+      getattr(proc,genJetFlavourAssociationThisJet)+
+      getattr(proc,genJetFlavourTableThisJet)
+    )
+  )
+  proc.nanoSequenceMC.insert(proc.nanoSequenceMC.index(proc.jetMC)+1, getattr(proc,genJetSequenceName)) 
+
+  return proc
+
+def ReclusterAK4GenJets(proc, genJA):
+  """
+  Recluster AK4 Gen jets and replace 
+  slimmedGenJets that is used as default 
+  to save AK4 Gen jets in NanoAODs. 
+  """
+  print("custom_jme_cff::ReclusterAK4GenJets: Recluster AK4 Gen jets")
+
+  #
+  # Recluster AK4 Gen jet
+  #
+  cfg = { 
+    "jet" : "ak4gen",   
+  }
+  genJetInfo = genJA.addGenJetCollection(proc, **cfg)
+
+  genJetName            = genJetInfo.jetUpper
+  genJetAlgo            = genJetInfo.jetAlgo
+  genJetSize            = genJetInfo.jetSize
+  genJetSizeNr          = genJetInfo.jetSizeNr
+  selectedPatGenJets    = "{}{}{}".format(genJetAlgo.upper(), genJetSize, "GenJetsNoNu")
+  
+  #
+  # Change jet source to the newly clustered jet collection. Set very low pt cut for jets 
+  # to be stored in the GenJet Table
+  #
+  proc.genJetTable.src = selectedPatGenJets
+  proc.genJetTable.cut = "pt > 1"
+  proc.genJetTable.doc  ="AK4 Gen jets (made with visible genparticles)"
+
+  genJetFlavourAssociationThisJet = "genJet{}FlavourAssociation".format(genJetName)
+  setattr(proc, genJetFlavourAssociationThisJet, genJetFlavourAssociation.clone(
+      jets           = proc.genJetTable.src,
+      jetAlgorithm   = supportedJetAlgos[genJetAlgo],
+      rParam         = genJetSizeNr,
+    )
+  )
+  proc.jetMC.insert(proc.jetMC.index(proc.genJetFlavourTable), getattr(proc, genJetFlavourAssociationThisJet)) 
+  return proc
+
+def AddVariablesForAK4GenJets(proc):
+  proc.genJetTable.variables.nConstituents = GENJETVARS.nConstituents
+  return proc
+
+def AddVariablesForAK8GenJets(proc):
+  proc.genJetAK8Table.variables.nConstituents = GENJETVARS.nConstituents
+  return proc
+
+#===========================================================================
+#
+# Misc. functions
+#
+#===========================================================================
+def RemoveAllJetPtCuts(proc):
+  """
+  Remove default pt cuts for all jets set in jets_cff.py 
+  """
+
+  proc.finalJets.cut             = "" # 15 -> 10
+  proc.finalJetsAK8.cut          = "" # 170 -> 170
+  proc.genJetTable.cut           = "" # 10 -> 8
+  proc.genJetFlavourTable.cut    = "" # 10 -> 8
+  proc.genJetAK8Table.cut        = "" # 100 -> 80
+  proc.genJetAK8FlavourTable.cut = "" # 100 -> 80
+
+  return proc
+
+#===========================================================================
+#
+# CUSTOMIZATION function
+#
+#===========================================================================
+def PrepJMECustomNanoAOD(process,runOnMC):
+  
+  ############################################################################
+  # Remove all default jet pt cuts from jets_cff.py
+  ############################################################################
+  process = RemoveAllJetPtCuts(process)
+
+  ###########################################################################
+  #
+  # Gen-level jets related functions. Only for MC.
+  #
+  ###########################################################################
   genJA = GenJetAdder()
-  tableGenJA = TableGenJetAdder()
-
-  for jetConfig in config_genjets:
-    cfg = { k : v for k, v in jetConfig.items() if k != "enabled" }
-    genJetInfo = genJA.addGenJetCollection(process, **cfg)
-    tableGenJA.addTable(process, genJetInfo)
-
-  #
-  # Add RecoJets to NanoAOD
-  #
-  recoJA = RecoJetAdder(runOnMC=runOnMC)
-  tableRecoJA = TableRecoJetAdder()
-
-  for jetConfig in config_recojets:
-    cfg = { k : v for k, v in jetConfig.items() if k != "enabled" }
-    recoJetInfo = recoJA.addRecoJetCollection(process, **cfg)
-    tableRecoJA.addTable(process, recoJetInfo)
-    
   if runOnMC:
-    process.nanoSequenceMC += genJA.getSequence(process)
-    process.nanoSequenceMC += recoJA.getSequence(process)
-    process.nanoSequenceMC += tableGenJA.getSequence(process)
-    process.nanoSequenceMC += tableRecoJA.getSequence(process)
-  else:
-    process.nanoSequence  += recoJA.getSequence(process)
-    process.nanoSequence  += tableRecoJA.getSequence(process)
+    ############################################################################
+    # Save additional variables for AK8 GEN jets
+    ############################################################################
+    process = AddVariablesForAK8GenJets(process)
+    ###########################################################################
+    # Recluster AK4 GEN jets
+    ###########################################################################
+    process = ReclusterAK4GenJets(process, genJA)
+    process = AddVariablesForAK4GenJets(process)
+    ###########################################################################
+    # Add additional GEN jets to NanoAOD
+    ###########################################################################
+    for jetConfig in config_genjets:
+      cfg = { k : v for k, v in jetConfig.items() if k != "enabled"}
+      genJetInfo = genJA.addGenJetCollection(process, **cfg)
+      AddNewGenJets(process, genJetInfo)
+
+  ###########################################################################
+  #
+  # Reco-level jets related functions. For both MC and data.
+  #
+  ###########################################################################
+  recoJA = RecoJetAdder(runOnMC=runOnMC)
+  ###########################################################################
+  # Save additional variables for AK8Puppi jets
+  ###########################################################################
+  process = AddVariablesForAK8PuppiJets(process)
+  ###########################################################################
+  # Recluster AK4 CHS jets and replace "slimmedJets"
+  ###########################################################################
+  process = ReclusterAK4CHSJets(process, recoJA, runOnMC)
+  ###########################################################################
+  # Add additional Reco jets to NanoAOD
+  ###########################################################################
+  for jetConfig in config_recojets:
+    cfg = { k : v for k, v in jetConfig.items() if k != "enabled"}
+    recoJetInfo = recoJA.addRecoJetCollection(process, **cfg)
+    AddNewPatJets(process, recoJetInfo, runOnMC)
+  
+  return process
 
 def PrepJMECustomNanoAOD_MC(process):
   PrepJMECustomNanoAOD(process,runOnMC=True)
+  return process
 
 def PrepJMECustomNanoAOD_Data(process):
   PrepJMECustomNanoAOD(process,runOnMC=False)
-  
+  return process

--- a/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetCollectionTools.py
@@ -2,23 +2,23 @@ import FWCore.ParameterSet.Config as cms
 
 from FWCore.GuiBrowsers.ConfigToolBase import *
 
-from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
-from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
+from CommonTools.PileupAlgos.Puppi_cff      import puppi
+from CommonTools.PileupAlgos.softKiller_cfi import softKiller
 
-from RecoJets.JetProducers.PFJetParameters_cfi import PFJetParameters
-from RecoJets.JetProducers.GenJetParameters_cfi import GenJetParameters
+from RecoJets.JetProducers.PFJetParameters_cfi         import PFJetParameters
+from RecoJets.JetProducers.GenJetParameters_cfi        import GenJetParameters
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import AnomalousCellParameters
-from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJetsCS
 
-from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection, supportedJetAlgos
+from RecoJets.JetProducers.ak4GenJets_cfi  import ak4GenJets
+from RecoJets.JetProducers.ak4PFJets_cfi   import ak4PFJets, ak4PFJetsCHS, ak4PFJetsPuppi, ak4PFJetsSK, ak4PFJetsCS 
+from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets 
+
 from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cfi import updatedPatJets
-from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import patJetCorrFactors
-
+from PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi  import patJetCorrFactors
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetFlavourId_cff import patJetFlavourAssociation
 
-from CommonTools.PileupAlgos.Puppi_cff import puppi
-from CommonTools.PileupAlgos.softKiller_cfi import softKiller
+from PhysicsTools.PatAlgos.tools.jetTools import supportedJetAlgos, addJetCollection, updateJetCollection
+from PhysicsTools.PatAlgos.tools.helpers  import getPatAlgosToolsTask, addToProcessAndTask
 
 import re
 
@@ -50,9 +50,9 @@ class GenJetInfo(object):
     jetMatch = jetRegex.match(jet.lower())
     if not jetMatch:
       raise RuntimeError('Invalid jet collection: %s' % jet)
-    self.jetAlgo     = jetMatch.group(algoKey)
-    self.jetSize     = jetMatch.group(sizeKey)
-    self.jetSizeNr = float(self.jetSize) / 10.
+    self.jetAlgo    = jetMatch.group(algoKey)
+    self.jetSize    = jetMatch.group(sizeKey)
+    self.jetSizeNr  = float(self.jetSize) / 10.
 
 #============================================
 #
@@ -68,29 +68,20 @@ class GenJetAdder(object):
     self.main = []
     self.gpLabel = "prunedGenParticles"
 
-  def getSequence(self, proc):
-    tasks = self.prerequisites + self.main
+  def addProcessAndTask(self, proc, label, module):
+    task = getPatAlgosToolsTask(proc)
+    addToProcessAndTask(label, module, proc, task)
 
-    resultSequence = cms.Sequence()
-    for idx, task in enumerate(tasks):
-      if idx == 0:
-        resultSequence = cms.Sequence(getattr(proc, task))
-      else:
-        resultSequence.insert(idx, getattr(proc, task))
-    return resultSequence
-  
   def addGenJetCollection(self,
       proc,
       jet,
       inputCollection    = "",
       genName            = "",
-      minPt              = 5.,
     ):
     print("jetCollectionTools::GenJetAdder::addGenJetCollection: Adding Gen Jet Collection: {}".format(jet))
-    currentTasks = []
 
     #
-    # Decide which jet collection we're dealing with
+    # Decide which genJet collection we are dealing with
     #
     jetLower = jet.lower()
     jetUpper = jet.upper()
@@ -99,7 +90,7 @@ class GenJetAdder(object):
 
     #=======================================================
     #
-    # If gen jet collection in MiniAOD is not 
+    # If genJet collection in MiniAOD is not 
     # specified, build the genjet collection.
     #
     #========================================================
@@ -110,7 +101,7 @@ class GenJetAdder(object):
       #
       packedGenPartNoNu = "packedGenParticlesForJetsNoNu"
       if packedGenPartNoNu not in self.prerequisites:
-        setattr(proc, packedGenPartNoNu, cms.EDFilter("CandPtrSelector",
+        self.addProcessAndTask(proc, packedGenPartNoNu, cms.EDFilter("CandPtrSelector",
             src = cms.InputTag("packedGenParticles"),
             cut = cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16"),
           )
@@ -120,26 +111,13 @@ class GenJetAdder(object):
       # Create the GenJet collection
       #
       genJetsCollection = "{}{}{}".format(genJetInfo.jetAlgo.upper(), genJetInfo.jetSize, 'GenJetsNoNu')
-      setattr(proc, genJetsCollection, ak4GenJets.clone(
+      self.addProcessAndTask(proc, genJetsCollection, ak4GenJets.clone(
           src           = packedGenPartNoNu,
           jetAlgorithm  = cms.string(supportedJetAlgos[genJetInfo.jetAlgo]),
           rParam        = cms.double(genJetInfo.jetSizeNr),
         )
       )
       self.prerequisites.append(genJetsCollection)
-    #
-    # GenJet Flavour Labelling
-    #
-    genFlavour = "{}Flavour".format(genJetInfo.jetTagName)
-    setattr(proc, genFlavour, patJetFlavourAssociation.clone(
-        jets         = cms.InputTag(genJetsCollection),
-        jetAlgorithm = cms.string(supportedJetAlgos[genJetInfo.jetAlgo]),
-        rParam       = cms.double(genJetInfo.jetSizeNr),
-      )
-    )
-
-    currentTasks.append(genFlavour)
-    self.main.extend(currentTasks)
 
     return genJetInfo
 
@@ -183,12 +161,15 @@ class RecoJetInfo(object):
     self.jetSizeNr = float(self.jetSize) / 10.
 
     self.doCalo = self.jetReco == "calo"
+    self.doPF   = self.jetReco == "pf"
+
     self.doCS   = self.jetPUMethod == "cs"
     self.skipUserData = self.doCalo or (self.jetPUMethod in [ "puppi", "sk" ] and inputCollection == "")
     
     self.jetCorrPayload = "{}{}{}".format(
       self.jetAlgo.upper(), self.jetSize, "Calo" if self.doCalo else self.jetReco.upper()
     )
+
     if self.jetPUMethod == "puppi":
       self.jetCorrPayload += "Puppi"
     elif self.jetPUMethod in [ "cs", "sk" ]:
@@ -203,13 +184,11 @@ class RecoJetInfo(object):
 #============================================
 class RecoJetAdder(object):
   """
-  Tool to schedule modules for building a recojet collection with input MiniAODs
+  Tool to schedule modules for building a patJet collection from MiniAODs
   """
   def __init__(self,runOnMC=True):    
     self.prerequisites = []
     self.main = []
-    self.bTagDiscriminators = ["None"] # No b-tagging by default
-    self.JETCorrLevels = [ "L1FastJet", "L2Relative", "L3Absolute" ]
     self.pfLabel = "packedPFCandidates"
     self.pvLabel = "offlineSlimmedPrimaryVertices"
     self.svLabel = "slimmedSecondaryVertices"
@@ -217,45 +196,32 @@ class RecoJetAdder(object):
     self.elLabel = "slimmedElectrons"
     self.gpLabel = "prunedGenParticles"
     self.runOnMC = runOnMC
+    self.patJetsInMiniAOD = ["slimmedJets", "slimmedJetsAK8", "slimmedJetsPuppi", "slimmedCaloJets"]
 
-  def getSequence(self, proc):
-    tasks = self.prerequisites + self.main
-
-    resultSequence = cms.Sequence()
-    for idx, task in enumerate(tasks):
-      if idx == 0:
-        resultSequence = cms.Sequence(getattr(proc, task))
-      else:
-        resultSequence.insert(idx, getattr(proc, task))
-    return resultSequence
+  def addProcessAndTask(self, proc, label, module):
+    task = getPatAlgosToolsTask(proc)
+    addToProcessAndTask(label, module, proc, task)
   
   def addRecoJetCollection(self,
     proc,
     jet,
     inputCollection    = "",
     genJetsCollection  = "",
-    minPt              = 5.,
-    bTagDiscriminators = None,
-    JETCorrLevels      = None,
+    bTagDiscriminators = ["None"],
+    JETCorrLevels      = ["L1FastJet", "L2Relative", "L3Absolute", "L2L3Residual"],
     ):
     print("jetCollectionTools::RecoJetAdder::addRecoJetCollection: Adding Reco Jet Collection: {}".format(jet))
 
     currentTasks = []
 
-    if inputCollection and inputCollection not in [
-        "slimmedJets", "slimmedJetsAK8", "slimmedJetsPuppi", "slimmedCaloJets",
-      ]:
+    if inputCollection and inputCollection not in self.patJetsInMiniAOD:
       raise RuntimeError("Invalid input collection: %s" % inputCollection)
-
-    if bTagDiscriminators is None:
-      bTagDiscriminators = self.bTagDiscriminators
-
-    if JETCorrLevels is None:
-      JETCorrLevels = self.JETCorrLevels
     
+    #=======================================================
     #
-    # Decide which jet collection we're dealing with
+    # Figure out which jet collection we're dealing with
     #
+    #=======================================================
     recoJetInfo = RecoJetInfo(jet, inputCollection)
     jetLower = recoJetInfo.jetLower
     jetUpper = recoJetInfo.jetUpper
@@ -272,8 +238,8 @@ class RecoJetAdder(object):
     
     #=======================================================
     #
-    # If jet collection in MiniAOD is not 
-    # specified, build the jet collection.
+    # If the patJet collection in MiniAOD is not specified, 
+    # we have to build the patJet collection from scratch.
     #
     #========================================================
     if not inputCollection or recoJetInfo.doCalo:
@@ -285,7 +251,7 @@ class RecoJetAdder(object):
       #
       #========================================================
       #
-      # Set up PF candidates
+      # Specify PF candidates
       #
       pfCand = self.pfLabel
       #
@@ -293,8 +259,11 @@ class RecoJetAdder(object):
       # 
       if recoJetInfo.jetPUMethod not in [ "", "cs" ]:
         pfCand += recoJetInfo.jetPUMethod
+
+      
       #
-      #
+      # Setup modules to perform PU mitigation for 
+      # PF candidates
       #
       if pfCand not in self.prerequisites:
         #
@@ -306,8 +275,7 @@ class RecoJetAdder(object):
         # CHS
         #
         elif recoJetInfo.jetPUMethod == "chs":
-          setattr(proc, pfCand,
-            cms.EDFilter("CandPtrSelector",
+          self.addProcessAndTask(proc, pfCand, cms.EDFilter("CandPtrSelector",
               src = cms.InputTag(self.pfLabel),
               cut = cms.string("fromPV"),
             )
@@ -317,10 +285,11 @@ class RecoJetAdder(object):
         # PUPPI
         #
         elif recoJetInfo.jetPUMethod == "puppi":
-          setattr(proc, pfCand,
-            puppi.clone(
-              candName   = self.pfLabel,
+          self.addProcessAndTask(proc, pfCand, puppi.clone(
+              candName = self.pfLabel,
               vertexName = self.pvLabel,
+              clonePackedCands = True,
+              useExistingWeights = True,
             )
           )
           self.prerequisites.append(pfCand)
@@ -328,10 +297,9 @@ class RecoJetAdder(object):
         # Softkiller
         #
         elif recoJetInfo.jetPUMethod == "sk":
-          setattr(proc, pfCand,
-            softKiller.clone(
+          self.addProcessAndTask(proc, pfCand, softKiller.clone(
               PFCandidates = self.pfLabel,
-              rParam       = recoJetInfo.jetSizeNr,
+              rParam = recoJetInfo.jetSizeNr,
             )
           )
           self.prerequisites.append(pfCand)
@@ -344,29 +312,52 @@ class RecoJetAdder(object):
       #
       #============================================
       if not recoJetInfo.doCalo:
-        jetCollection = '{}Collection'.format(tagName)
+        jetCollection = '{}Collection'.format(jetUpper)
 
         if jetCollection in self.main:
           raise ValueError("Step '%s' already implemented" % jetCollection)
-
-        setattr(proc, jetCollection, ak4PFJetsCS.clone(
-            src                       = pfCand,
-            doAreaFastjet             = True,
-            jetPtMin                  = minPt,
-            jetAlgorithm              = supportedJetAlgos[recoJetInfo.jetAlgo],
-            rParam                    = recoJetInfo.jetSizeNr,
-            useConstituentSubtraction = recoJetInfo.doCS,
-            csRParam                  = 0.4 if recoJetInfo.doCS else -1.,
-            csRho_EtaMax              = PFJetParameters.Rho_EtaMax if recoJetInfo.doCS else -1.,
-            useExplicitGhosts         = recoJetInfo.doCS or recoJetInfo.jetPUMethod == "sk",
+        #
+        # Cluster new jet
+        #
+        if recoJetInfo.jetPUMethod == "chs":
+          self.addProcessAndTask(proc, jetCollection, ak4PFJetsCHS.clone(
+              src = pfCand,
+            )
+          )
+        elif recoJetInfo.jetPUMethod == "puppi":
+          self.addProcessAndTask(proc, jetCollection, ak4PFJetsPuppi.clone(
+              src = pfCand,
+            )
+          )
+        elif recoJetInfo.jetPUMethod == "sk":
+          self.addProcessAndTask(proc, pfCand, ak4PFJetsSK.clone(
+              src = pfCand,
+            )
+          )
+        elif recoJetInfo.jetPUMethod == "cs":
+          self.addProcessAndTask(proc, jetCollection, ak4PFJetsCS.clone(
+            src = pfCand,
           )
         )
+        else:
+          self.addProcessAndTask(proc, jetCollection, ak4PFJets.clone(
+            src = pfCand,
+          )
+        )
+        getattr(proc, jetCollection).jetAlgorithm = supportedJetAlgos[recoJetInfo.jetAlgo]
+        getattr(proc, jetCollection).rParam = recoJetInfo.jetSizeNr
         currentTasks.append(jetCollection)
       else:
         jetCollection = inputCollection
       
+
+      #=============================================
       #
-      # PATify
+      # Make patJet collection
+      #
+      #=============================================
+      #
+      # Jet correction 
       #
       if recoJetInfo.jetPUMethod == "puppi":
         jetCorrLabel = "Puppi"
@@ -374,10 +365,7 @@ class RecoJetAdder(object):
         jetCorrLabel = "chs"
       else:
         jetCorrLabel = recoJetInfo.jetPUMethod
-      
-      #
-      # Jet correction
-      #
+
       jetCorrections = (
         "{}{}{}{}".format(
           recoJetInfo.jetAlgo.upper(),
@@ -388,10 +376,12 @@ class RecoJetAdder(object):
         JETCorrLevels,
         "None",
       )
-      
+
+      postfix = "Recluster" if inputCollection == "" else ""
       addJetCollection(
         proc,
-        labelName          = tagName,
+        labelName          = jetUpper,
+        postfix            = postfix,
         jetSource          = cms.InputTag(jetCollection),
         algo               = recoJetInfo.jetAlgo,
         rParam             = recoJetInfo.jetSizeNr,
@@ -400,150 +390,45 @@ class RecoJetAdder(object):
         svSource           = cms.InputTag(self.svLabel),
         muSource           = cms.InputTag(self.muLabel),
         elSource           = cms.InputTag(self.elLabel),
-        btagDiscriminators = bTagDiscriminators if not recoJetInfo.doCalo else [ "None" ],
-        jetCorrections     = jetCorrections,
         genJetCollection   = cms.InputTag(genJetsCollection),
         genParticles       = cms.InputTag(self.gpLabel),
+        jetCorrections     = jetCorrections,
       )
+
+      #
+      # Need to set this explicitly for PUPPI jets
+      #
+      if recoJetInfo.jetPUMethod == "puppi":
+        getattr(proc, "patJetFlavourAssociation{}{}".format(tagName,postfix)).weights = cms.InputTag(pfCand)
 
       getJetMCFlavour = not recoJetInfo.doCalo and recoJetInfo.jetPUMethod != "cs"
-
       if not self.runOnMC: #Remove modules for Gen-level object matching
-        delattr(proc, 'patJetGenJetMatch{}'.format(tagName))
-        delattr(proc, 'patJetPartonMatch{}'.format(tagName))
+        delattr(proc, 'patJetGenJetMatch{}{}'.format(tagName,postfix))
+        delattr(proc, 'patJetPartonMatch{}{}'.format(tagName,postfix))
         getJetMCFlavour = False 
+      setattr(getattr(proc, "patJets{}{}".format(tagName,postfix)), "getJetMCFlavour", cms.bool(getJetMCFlavour))
 
-      setattr(getattr(proc, "patJets{}".format(tagName)),           "getJetMCFlavour", cms.bool(getJetMCFlavour))
-      setattr(getattr(proc, "patJetCorrFactors{}".format(tagName)), "payload",         cms.string(recoJetInfo.jetCorrPayload))
-      selJet = "selectedPatJets{}".format(tagName)
-    else:
-      selJet = inputCollection
-
-    if not recoJetInfo.skipUserData:
+      selectedPatJetCollection = "selectedPatJets{}{}".format(tagName,postfix)      
+      #=============================================
       #
+      # Update the patJet collection. 
+      # This is where we setup 
+      # -  JEC
+      # -  b-tagging discriminators  
       # 
-      #
-      jercVar = "jercVars{}".format(tagName)
-      if jercVar in self.main:
-        raise ValueError("Step '%s' already implemented" % jercVar)
-      setattr(proc, jercVar, proc.jercVars.clone(srcJet = selJet))
-      currentTasks.append(jercVar)
-      #
-      # JetID Loose
-      #
-      looseJetId = "looseJetId{}".format(tagName)
-      if looseJetId in self.main:
-        raise ValueError("Step '%s' already implemented" % looseJetId)
-      setattr(proc, looseJetId, proc.looseJetId.clone(
-          src = selJet,
-          filterParams=proc.looseJetId.filterParams.clone(
-            version ="WINTER16"
-          ),
-        )
+      #=============================================
+      updateJetCollection(
+        proc,
+        labelName          = jetUpper,
+        postfix            = "Final",
+        jetSource          = cms.InputTag(selectedPatJetCollection),
+        jetCorrections     = jetCorrections,
+        btagDiscriminators = bTagDiscriminators,
       )
-      currentTasks.append(looseJetId)
-      #
-      # JetID Tight
-      #      
-      tightJetId = "tightJetId{}".format(tagName)
-      if tightJetId in self.main:
-        raise ValueError("Step '%s' already implemented" % tightJetId)
-      setattr(proc, tightJetId, proc.tightJetId.clone(
-          src = selJet,
-          filterParams=proc.tightJetId.filterParams.clone(
-            version = "SUMMER18{}".format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
-          ),
-        )
-      )
-      tightJetIdObj = getattr(proc, tightJetId)
-      run2_jme_2016.toModify(
-        tightJetIdObj.filterParams, 
-          version = "WINTER16"
-      )
-      run2_jme_2017.toModify(
-        tightJetIdObj.filterParams, 
-          version = 'WINTER17{}'.format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
-      )
-      currentTasks.append(tightJetId)
-      #
-      # JetID TightLepVeto 
-      #
-      tightJetIdLepVeto = "tightJetIdLepVeto{}".format(tagName)
-      if tightJetIdLepVeto in self.main:
-        raise ValueError("Step '%s' already implemented" % tightJetIdLepVeto)
-      setattr(proc, tightJetIdLepVeto, proc.tightJetIdLepVeto.clone(
-          src = selJet,
-          filterParams=proc.tightJetIdLepVeto.filterParams.clone(
-            version = "SUMMER18{}".format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else "")
-          ),
-        )
-      )
-      tightJetIdLepVetoObj = getattr(proc, tightJetIdLepVeto)
-      run2_jme_2016.toModify(
-        tightJetIdLepVetoObj.filterParams, 
-        version = "WINTER16"
-      )
-      run2_jme_2017.toModify(
-        tightJetIdLepVetoObj.filterParams, 
-          version = 'WINTER17{}'.format("PUPPI" if recoJetInfo.jetPUMethod == "puppi" else ""),
-      )
-      currentTasks.append(tightJetIdLepVeto)
-      #
-      # 
-      #
-      selectedPatJetsWithUserData = "{}WithUserData".format(selJet)
-      if selectedPatJetsWithUserData in self.main:
-        raise ValueError("Step '%s' already implemented" % selectedPatJetsWithUserData)
-      setattr(proc, selectedPatJetsWithUserData,
-        cms.EDProducer("PATJetUserDataEmbedder",
-          src = cms.InputTag(selJet),
-          userFloats = cms.PSet(
-            jercCHPUF = cms.InputTag("{}:chargedHadronPUEnergyFraction".format(jercVar)),
-            jercCHF   = cms.InputTag("{}:chargedHadronCHSEnergyFraction".format(jercVar)),
-          ),
-          userInts = cms.PSet(
-            tightId        = cms.InputTag(tightJetId),
-            tightIdLepVeto = cms.InputTag(tightJetIdLepVeto),
-          ),
-        )
-      )
-      selectedPatJetsWithUserDataObj = getattr(proc, selectedPatJetsWithUserData)
-      run2_jme_2016.toModify(selectedPatJetsWithUserDataObj.userInts,
-        looseId  = cms.InputTag(looseJetId),
-      )
-      currentTasks.append(selectedPatJetsWithUserData)
+
+      patJetFinalCollection="selectedUpdatedPatJets{}{}".format(tagName,"Final")
     else:
-      selectedPatJetsWithUserData = "selectedPatJets{}".format(tagName)
-  
-    #
-    # Not sure why we can't re-use patJetCorrFactors* created by addJetCollection() 
-    # (even cloning doesn't work) Let's just create our own
-    #
-    jetCorrFactors = "jetCorrFactors{}".format(tagName)
-    if jetCorrFactors in self.main:
-      raise ValueError("Step '%s' already implemented" % jetCorrFactors)
-
-    setattr(proc, jetCorrFactors, patJetCorrFactors.clone(
-        src             = selectedPatJetsWithUserData,
-        levels          = JETCorrLevels,
-        primaryVertices = self.pvLabel,
-        payload         = recoJetInfo.jetCorrPayload,
-        rho             = "fixedGridRhoFastjetAll{}".format("Calo" if recoJetInfo.doCalo else ""),
-      )
-    )
-    currentTasks.append(jetCorrFactors)
-
-    updatedJets = "updatedJets{}".format(tagName)
-    if updatedJets in self.main:
-      raise ValueError("Step '%s' already implemented" % updatedJets)
-    
-    setattr(proc, updatedJets, updatedPatJets.clone(
-        addBTagInfo          = False,
-        jetSource            = selectedPatJetsWithUserData,
-        jetCorrFactorsSource = [jetCorrFactors],
-      )
-    )
-    currentTasks.append(updatedJets)
+      patJetFinalCollection = inputCollection
 
     self.main.extend(currentTasks)
 


### PR DESCRIPTION
Backport from #30674 

**PR description:**

This PR adds major updates to scripts needed for Custom JME NanoAODs production. The major changes are:

1. AK4 CHS jets, AK4 Puppi jets and AK4 Gen jets are reclustered from MiniAODs and are used to replace slimmedJets, slimmedJetsPuppi and slimmedGenJets. The rationale behind this is to store very low pt jets (as low as 2 GeV) needed for jet energy scale and resolution studies by JERC group.

2. AK4 Puppi jets have almost the same set of variables stored as AK4 CHS jets. To be used for performance comparison studies between AK4 CHS jets and AK4 Puppi jets.

3. Add PF jet multiplicity variables for different PF candidate types.


**if this PR is a backport please specify the original PR:**

Original PR is #30674 

**NOTE**: Requires NanoAODv7 to be backported (#31063) and then an earlier backport (#29290) to be merged first before this PR can be merged.