### PR TITLE
Switch to UL jet ID in NanoAOD [10_6_X]

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -76,6 +76,8 @@ run2_jme_2016.toModify( tightJetId.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVeto.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetId.filterParams, version = "WINTER17" )
 run2_jme_2017.toModify( tightJetIdLepVeto.filterParams, version = "WINTER17" )
+run2_miniAOD_UL.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
+run2_miniAOD_UL.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
 
 
 looseJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
@@ -103,6 +105,8 @@ run2_jme_2016.toModify( tightJetIdAK8.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetIdAK8.filterParams, version = "WINTER17PUPPI" )
 run2_jme_2017.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER17PUPPI" )
+run2_miniAOD_UL.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
+run2_miniAOD_UL.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
 
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
 
 from  PhysicsTools.NanoAOD.common_cff import *
 from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *
@@ -77,8 +77,8 @@ run2_jme_2016.toModify( tightJetId.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVeto.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetId.filterParams, version = "WINTER17" )
 run2_jme_2017.toModify( tightJetIdLepVeto.filterParams, version = "WINTER17" )
-run2_miniAOD_UL.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
-run2_miniAOD_UL.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
+run2_miniAOD_devel.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
+run2_miniAOD_devel.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
 
 
 looseJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
@@ -106,8 +106,8 @@ run2_jme_2016.toModify( tightJetIdAK8.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetIdAK8.filterParams, version = "WINTER17PUPPI" )
 run2_jme_2017.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER17PUPPI" )
-run2_miniAOD_UL.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
-run2_miniAOD_UL.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
+run2_miniAOD_devel.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
+run2_miniAOD_devel.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
 
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 
 from  PhysicsTools.NanoAOD.common_cff import *
 from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -3,6 +3,7 @@ from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_miniAOD_devel_cff import run2_miniAOD_devel
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
 
 from  PhysicsTools.NanoAOD.common_cff import *
 from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *
@@ -77,8 +78,9 @@ run2_jme_2016.toModify( tightJetId.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVeto.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetId.filterParams, version = "WINTER17" )
 run2_jme_2017.toModify( tightJetIdLepVeto.filterParams, version = "WINTER17" )
-run2_miniAOD_devel.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
-run2_miniAOD_devel.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
+for modifier in run2_nanoAOD_106Xv1, run2_miniAOD_devel:
+  modifier.toModify( tightJetId.filterParams, version = "RUN2ULCHS" )
+  modifier.toModify( tightJetIdLepVeto.filterParams, version = "RUN2ULCHS" )
 
 
 looseJetIdAK8 = cms.EDProducer("PatJetIDValueMapProducer",
@@ -106,8 +108,9 @@ run2_jme_2016.toModify( tightJetIdAK8.filterParams, version = "WINTER16" )
 run2_jme_2016.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER16" )
 run2_jme_2017.toModify( tightJetIdAK8.filterParams, version = "WINTER17PUPPI" )
 run2_jme_2017.toModify( tightJetIdLepVetoAK8.filterParams, version = "WINTER17PUPPI" )
-run2_miniAOD_devel.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
-run2_miniAOD_devel.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
+for modifier in run2_nanoAOD_106Xv1, run2_miniAOD_devel:
+  modifier.toModify( tightJetIdAK8.filterParams, version = "RUN2ULPUPPI" )
+  modifier.toModify( tightJetIdLepVetoAK8.filterParams, version = "RUN2ULPUPPI" )
 
 
 bJetVars = cms.EDProducer("JetRegressionVarProducer",


### PR DESCRIPTION
#### PR description:

Switch Jet ID for UL-RECO in NanoAOD.
ID was introduced in #30638.

#### PR validation:

Impact on jet distributions checked in #30638.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport from #31125.