### PR TITLE
Refine RuInfo payload inspector

### DIFF
--- a/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
+++ b/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
@@ -13,6 +13,8 @@
 
 namespace RunInfoPI {
 
+  enum state { fake = 0, valid = 1, invalid = 2 };
+
   // values are taken from https://github.com/cms-sw/cmssw/blob/master/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc#L74-L75
   constexpr std::array<int, 7> nominalCurrents{{-1, 0, 9558, 14416, 16819, 18268, 19262}};
   constexpr std::array<float, 7> nominalFields{{3.8, 0., 2., 3., 3.5, 3.8, 4.}};

--- a/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
+++ b/CondCore/RunInfoPlugins/interface/RunInfoPayloadInspectoHelper.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <string>
+#include <ctime>
 #include "TH1.h"
 #include "TH2.h"
 #include "TStyle.h"
@@ -26,7 +27,7 @@ namespace RunInfoPI {
     m_avg_current,           // float
     m_max_current,           // float
     m_min_current,           // float
-    m_run_intervall_micros,  // float
+    m_run_interval_seconds,  // float
     m_fedIN,                 // unsigned int
     m_BField,                // float
     END_OF_TYPES
@@ -43,6 +44,28 @@ namespace RunInfoPI {
       }
     }
     return nominalFields[i];
+  }
+
+  /************************************************/
+  float runDuration(const std::shared_ptr<RunInfo>& payload) {
+    // calculation of the run duration in seconds
+    time_t start_time = payload->m_start_time_ll;
+    ctime(&start_time);
+    time_t end_time = payload->m_stop_time_ll;
+    ctime(&end_time);
+    return difftime(end_time, start_time) / 1.0e+6;
+  }
+
+  /************************************************/
+  std::string runStartTime(const std::shared_ptr<RunInfo>& payload) {
+    const time_t start_time = payload->m_start_time_ll / 1.0e+6;
+    return std::asctime(std::gmtime(&start_time));
+  }
+
+  /************************************************/
+  std::string runEndTime(const std::shared_ptr<RunInfo>& payload) {
+    const time_t end_time = payload->m_stop_time_ll / 1.0e+6;
+    return std::asctime(std::gmtime(&end_time));
   }
 
   /************************************************/
@@ -64,8 +87,8 @@ namespace RunInfoPI {
         return "max current [A]";
       case m_min_current:
         return "min current [A]";
-      case m_run_intervall_micros:
-        return "run duration [#mus]";
+      case m_run_interval_seconds:
+        return "run duration [s]";
       case m_fedIN:
         return "n. FEDs";
       case m_BField:

--- a/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
+++ b/CondCore/RunInfoPlugins/plugins/RunInfo_PayloadInspector.cc
@@ -188,29 +188,30 @@ namespace {
   *************************************************/
 
   template <RunInfoPI::parameters param>
-  class RunInfoCurrentHistory : public cond::payloadInspector::HistoryPlot<RunInfo, float> {
+  class RunInfoCurrentHistory : public cond::payloadInspector::HistoryPlot<RunInfo, std::pair<bool, float> > {
   public:
     RunInfoCurrentHistory()
-        : cond::payloadInspector::HistoryPlot<RunInfo, float>(getStringFromTypeEnum(param),
-                                                              getStringFromTypeEnum(param) + " value") {}
+        : cond::payloadInspector::HistoryPlot<RunInfo, std::pair<bool, float> >(
+              getStringFromTypeEnum(param), getStringFromTypeEnum(param) + " value") {}
     ~RunInfoCurrentHistory() override = default;
 
-    float getFromPayload(RunInfo& payload) override {
+    std::pair<bool, float> getFromPayload(RunInfo& payload) override {
+      bool isRealRun = ((payload.m_run) != -1);
       float fieldIntensity = RunInfoPI::theBField(payload.m_avg_current);
 
       switch (param) {
         case RunInfoPI::m_start_current:
-          return payload.m_start_current;
+          return std::make_pair(isRealRun, payload.m_start_current);
         case RunInfoPI::m_stop_current:
-          return payload.m_stop_current;
+          return std::make_pair(isRealRun, payload.m_stop_current);
         case RunInfoPI::m_avg_current:
-          return payload.m_avg_current;
+          return std::make_pair(isRealRun, payload.m_avg_current);
         case RunInfoPI::m_max_current:
-          return payload.m_max_current;
+          return std::make_pair(isRealRun, payload.m_max_current);
         case RunInfoPI::m_min_current:
-          return payload.m_min_current;
+          return std::make_pair(isRealRun, payload.m_min_current);
         case RunInfoPI::m_BField:
-          return fieldIntensity;
+          return std::make_pair(isRealRun, fieldIntensity);
         default:
           edm::LogWarning("LogicError") << "Unknown parameter: " << param;
           break;

--- a/CondCore/RunInfoPlugins/test/plot2JsonTimeSeries.py
+++ b/CondCore/RunInfoPlugins/test/plot2JsonTimeSeries.py
@@ -1,0 +1,121 @@
+################################################
+##
+## Example usage: python plot2JsonTimeSeries.py --file json_vanilla_short.json --label 'master branch' --file2 json_short.json --label2 'this PR'
+##
+################################################
+
+from __future__ import print_function
+import json
+import ROOT
+from array import array
+from pprint import pprint
+from optparse import OptionParser
+
+ROOT.gROOT.SetBatch(True)
+ROOT.TGaxis.SetMaxDigits(6);
+
+parser = OptionParser()
+parser.add_option("-f", "--file", dest="filename",
+                  help="open FILE and extract info", metavar="FILE")
+
+parser.add_option("-l", "--label", dest="label",
+                  help="label for the first file", metavar="LABEL")
+
+parser.add_option("-g", "--file2", dest="filename2",
+                  help="open FILE 2 and extract info", metavar="FILE2")
+
+parser.add_option("-m", "--label2", dest="label2",
+                  help="label for the second file", metavar="LABEL2")
+
+parser.add_option("-q", "--quiet",
+                  action="store_false", dest="verbose", default=False,
+                  help="don't print status messages to stdout")
+
+(options, args) = parser.parse_args()
+
+with open(options.filename) as data_file:    
+    data = json.load(data_file)
+    values = data["data"]
+    annotations = data["annotations"]
+    title   = annotations["title"]
+    x_label = annotations["x_label"]
+    y_label = annotations["y_label"]
+
+
+with open(options.filename2) as data_file2:    
+    data2 = json.load(data_file2)
+    values2 = data2["data"]
+    annotations2 = data2["annotations"]
+    title2   = annotations2["title"]
+    x_label2 = annotations2["x_label"]
+    y_label2 = annotations2["y_label"]
+
+bins=len(values)
+bins2=len(values2)
+
+'''
+ahhh the magic of list comprehension
+$%#&!@ excepted it does not work!!!
+
+xvalues = [values[i]['x'] for i in range(0,bins)]
+yvalues = [values[i]['y'] for i in range(0,bins)]
+xvalues2 = [values2[i]['x'] for i in range(0,bins2)]
+yvalues2 = [values2[i]['y'] for i in range(0,bins2)]
+
+print(xvalues,yvalues)
+print(xvalues2,yvalues2)
+'''
+
+xvalues, yvalues = array( 'd' ), array( 'd' )
+xvalues2, yvalues2 = array( 'd' ), array( 'd' )
+
+for i in range (bins):
+    xvalues.append(values[i]['x'])
+    yvalues.append(values[i]['y'])
+
+for i in range (bins2):
+    xvalues2.append(values2[i]['x'])
+    yvalues2.append(values2[i]['y'])
+
+graph1=ROOT.TGraph(bins,xvalues,yvalues)
+graph2=ROOT.TGraph(bins2,xvalues2,yvalues2)
+
+canv=ROOT.TCanvas("c1","c1",1200,800)
+canv.SetGrid()
+canv.cd()
+
+graph1.SetTitle(title)
+graph1.GetXaxis().SetTitle(x_label)
+graph1.GetYaxis().SetTitle(y_label)
+
+graph1.SetMarkerSize(1.4)
+graph2.SetMarkerSize(1.5)
+
+graph1.SetMarkerStyle(ROOT.kOpenCircle)
+graph2.SetMarkerStyle(ROOT.kFullSquare)
+
+graph1.SetMarkerColor(ROOT.kRed)
+graph2.SetMarkerColor(ROOT.kBlue)
+
+graph1.SetLineColor(ROOT.kRed)
+graph2.SetLineColor(ROOT.kBlue)
+
+graph1.GetYaxis().SetRangeUser(-0.1,5.)
+
+graph1.Draw("APL")
+graph2.Draw("PLSame")
+
+TLegend = ROOT.TLegend(0.10,0.80,0.40,0.90)
+TLegend.AddEntry(graph1,options.label,"LP")
+TLegend.AddEntry(graph2,options.label2,"LP")
+
+TLegend.Draw("same")
+
+canv.Update()
+#canv.GetFrame().SetFillColor( 11 )
+canv.GetFrame().SetBorderSize( 12 )
+canv.Modified()
+canv.Update()
+
+outfilename="comparison_"+options.label+"_vs_"+options.label2+"_json.png"
+canv.SaveAs(outfilename.replace(" ",""))

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -63,6 +63,13 @@ namespace cond {
     template <typename V>
     std::string serializeValue(const std::string& entryLabel, const V& value) {
       std::stringstream ss;
+
+      // N.B.:
+      //  This hack is to output a line to stringstream only in case the
+      //  return type of getFromPayload is a std::pair<bool, float>
+      //  and the bool is true. This allows to control which points should
+      //  enter the trend and which should not.
+
       if constexpr (std::is_same_v<V, std::pair<bool, float>>) {
         if (value.first) {
           ss << "\"" << entryLabel << "\":" << value.second;
@@ -127,6 +134,11 @@ namespace cond {
       for (auto d : data) {
         auto serializedX = serializeValue("x", std::get<0>(d));
         auto serializedY = serializeValue("y", std::get<1>(d));
+
+        // N.B.:
+        //  we output to JSON only if the stringstream
+        //  from serializeValue is not empty
+
         if (!serializedY.empty()) {
           if (!first) {
             ss << ",";

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <type_traits>
 
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
@@ -62,7 +63,13 @@ namespace cond {
     template <typename V>
     std::string serializeValue(const std::string& entryLabel, const V& value) {
       std::stringstream ss;
-      ss << "\"" << entryLabel << "\":" << value;
+      if constexpr (std::is_same_v<V, std::pair<bool, float>>) {
+        if (value.first) {
+          ss << "\"" << entryLabel << "\":" << value.second;
+        }
+      } else {
+        ss << "\"" << entryLabel << "\":" << value;
+      }
       return ss.str();
     }
 
@@ -98,7 +105,7 @@ namespace cond {
       ss << "\"version\": \"" << JSON_FORMAT_VERSION << "\",";
       ss << "\"annotations\": {";
       bool first = true;
-      for (auto a : annotations.m) {
+      for (const auto& a : annotations.m) {
         if (!first)
           ss << ",";
         ss << "\"" << a.first << "\":\"" << a.second << "\"";
@@ -118,10 +125,15 @@ namespace cond {
       ss << "\"data\": [";
       bool first = true;
       for (auto d : data) {
-        if (!first)
-          ss << ",";
-        ss << " { " << serializeValue("x", std::get<0>(d)) << ", " << serializeValue("y", std::get<1>(d)) << " }";
-        first = false;
+        auto serializedX = serializeValue("x", std::get<0>(d));
+        auto serializedY = serializeValue("y", std::get<1>(d));
+        if (!serializedY.empty()) {
+          if (!first) {
+            ss << ",";
+          }
+          ss << " { " << serializedX << ", " << serializedY << " }";
+          first = false;
+        }
       }
       ss << "]";
       ss << "}";
@@ -516,7 +528,6 @@ namespace cond {
         }
         return true;
       }
-
       virtual Y getFromPayload(PayloadType& payload) = 0;
     };
 


### PR DESCRIPTION
#### PR description:

The goal of this PR is two-fold
   1. first: is to improve the graphical appearance of the output of the `RunInfoParameters` plotting class. This now contains human readable run start and end times as well as small descriptor if the payload is valid, invalid or fake. 
   2. second: at the moment, the trend plots of values vs run-number (e.g. `RunInfoBFieldHistory`) are polluted by fake payloads which in production are interposed between valid ones. In order to discard them in plotting a hack in `CondCore/Utilities/interface/PayloadInspector.h` has been introduced in order to treat the case in which the return type of `getFromPayload` is a `std::pair<bool, float>`, where the boolean stores the information whether the payload is fake or not.

#### PR validation:

This a graphical display with this [script](https://github.com/mmusich/cmssw/blob/3cf29b197c640f47e218fd2f93f5aa6f9788966d/CondCore/RunInfoPlugins/test/plot2JsonTimeSeries.py) of the output of running the command:
```python
getPayloadData.py --plugin pluginRunInfo_PayloadInspector --plot plot_RunInfoBFieldHistory --tag runinfo_31X_hlt --time_type Run --iovs '{"start_iov": "312000", "end_iov": "312260"}' --db Prod --test ;
```
with this branch and the master branch, showing how the fake payloads are epurated.

![comparison_masterbranch_vs_thisPR_json](https://user-images.githubusercontent.com/5082376/90001252-7fc1d700-dc91-11ea-97e2-55630001dc29.png)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.