### PR TITLE
Patatrack integration - GPU beamspot data format and transfer (4/N)

### DIFF
--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,0 +1,8 @@
+<use name="rootcore"/>
+<use name="CUDADataFormats/Common"/>
+<use name="DataFormats/Common"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
+
+<export>
+    <lib name="1"/>
+</export>

--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -1,0 +1,32 @@
+#ifndef CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
+#define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+
+#include <cuda_runtime.h>
+
+class BeamSpotCUDA {
+public:
+  // alignas(128) doesn't really make sense as there is only one
+  // beamspot per event?
+  struct Data {
+    float x, y, z;  // position
+    // TODO: add covariance matrix
+
+    float sigmaZ;
+    float beamWidthX, beamWidthY;
+    float dxdz, dydz;
+    float emittanceX, emittanceY;
+    float betaStar;
+  };
+
+  BeamSpotCUDA() = default;
+  BeamSpotCUDA(Data const* data_h, cudaStream_t stream);
+
+  Data const* data() const { return data_d_.get(); }
+
+private:
+  cms::cuda::device::unique_ptr<Data> data_d_;
+};
+
+#endif

--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -1,15 +1,14 @@
 #ifndef CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 #define CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h
 
-#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-
 #include <cuda_runtime.h>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
 class BeamSpotCUDA {
 public:
-  // alignas(128) doesn't really make sense as there is only one
-  // beamspot per event?
-  struct Data {
+  // align to the CUDA L1 cache line size
+  struct alignas(128) Data {
     float x, y, z;  // position
     // TODO: add covariance matrix
 
@@ -20,13 +19,26 @@ public:
     float betaStar;
   };
 
+  // default constructor, required by cms::cuda::Product<BeamSpotCUDA>
   BeamSpotCUDA() = default;
-  BeamSpotCUDA(Data const* data_h, cudaStream_t stream);
 
+  // constructor that allocates cached device memory on the given CUDA stream
+  BeamSpotCUDA(cudaStream_t stream) { data_d_ = cms::cuda::make_device_unique<Data>(stream); }
+
+  // movable, non-copiable
+  BeamSpotCUDA(BeamSpotCUDA const&) = delete;
+  BeamSpotCUDA(BeamSpotCUDA&&) = default;
+  BeamSpotCUDA& operator=(BeamSpotCUDA const&) = delete;
+  BeamSpotCUDA& operator=(BeamSpotCUDA&&) = default;
+
+  Data* data() { return data_d_.get(); }
   Data const* data() const { return data_d_.get(); }
+
+  cms::cuda::device::unique_ptr<Data>& ptr() { return data_d_; }
+  cms::cuda::device::unique_ptr<Data> const& ptr() const { return data_d_; }
 
 private:
   cms::cuda::device::unique_ptr<Data> data_d_;
 };
 
-#endif
+#endif  // CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h

--- a/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
+++ b/CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h
@@ -3,27 +3,16 @@
 
 #include <cuda_runtime.h>
 
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 
 class BeamSpotCUDA {
 public:
-  // align to the CUDA L1 cache line size
-  struct alignas(128) Data {
-    float x, y, z;  // position
-    // TODO: add covariance matrix
-
-    float sigmaZ;
-    float beamWidthX, beamWidthY;
-    float dxdz, dydz;
-    float emittanceX, emittanceY;
-    float betaStar;
-  };
-
   // default constructor, required by cms::cuda::Product<BeamSpotCUDA>
   BeamSpotCUDA() = default;
 
   // constructor that allocates cached device memory on the given CUDA stream
-  BeamSpotCUDA(cudaStream_t stream) { data_d_ = cms::cuda::make_device_unique<Data>(stream); }
+  BeamSpotCUDA(cudaStream_t stream) { data_d_ = cms::cuda::make_device_unique<BeamSpotPOD>(stream); }
 
   // movable, non-copiable
   BeamSpotCUDA(BeamSpotCUDA const&) = delete;
@@ -31,14 +20,14 @@ public:
   BeamSpotCUDA& operator=(BeamSpotCUDA const&) = delete;
   BeamSpotCUDA& operator=(BeamSpotCUDA&&) = default;
 
-  Data* data() { return data_d_.get(); }
-  Data const* data() const { return data_d_.get(); }
+  BeamSpotPOD* data() { return data_d_.get(); }
+  BeamSpotPOD const* data() const { return data_d_.get(); }
 
-  cms::cuda::device::unique_ptr<Data>& ptr() { return data_d_; }
-  cms::cuda::device::unique_ptr<Data> const& ptr() const { return data_d_; }
+  cms::cuda::device::unique_ptr<BeamSpotPOD>& ptr() { return data_d_; }
+  cms::cuda::device::unique_ptr<BeamSpotPOD> const& ptr() const { return data_d_; }
 
 private:
-  cms::cuda::device::unique_ptr<Data> data_d_;
+  cms::cuda::device::unique_ptr<BeamSpotPOD> data_d_;
 };
 
 #endif  // CUDADataFormats_BeamSpot_interface_BeamSpotCUDA_h

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -1,0 +1,9 @@
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+
+BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cudaStream_t stream) {
+  data_d_ = cms::cuda::make_device_unique<Data>(stream);
+  cudaCheck(cudaMemcpyAsync(data_d_.get(), data_h, sizeof(Data), cudaMemcpyHostToDevice, stream));
+}

--- a/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
+++ b/CUDADataFormats/BeamSpot/src/BeamSpotCUDA.cc
@@ -1,9 +1,0 @@
-#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
-
-#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-
-BeamSpotCUDA::BeamSpotCUDA(Data const* data_h, cudaStream_t stream) {
-  data_d_ = cms::cuda::make_device_unique<Data>(stream);
-  cudaCheck(cudaMemcpyAsync(data_d_.get(), data_h, sizeof(Data), cudaMemcpyHostToDevice, stream));
-}

--- a/CUDADataFormats/BeamSpot/src/classes.h
+++ b/CUDADataFormats/BeamSpot/src/classes.h
@@ -1,0 +1,8 @@
+#ifndef CUDADataFormats_BeamSpot_classes_h
+#define CUDADataFormats_BeamSpot_classes_h
+
+#include "CUDADataFormats/Common/interface/Product.h"
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+
+#endif

--- a/CUDADataFormats/BeamSpot/src/classes.h
+++ b/CUDADataFormats/BeamSpot/src/classes.h
@@ -5,4 +5,4 @@
 #include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-#endif
+#endif  // CUDADataFormats_BeamSpot_classes_h

--- a/CUDADataFormats/BeamSpot/src/classes_def.xml
+++ b/CUDADataFormats/BeamSpot/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="cms::cuda::Product<BeamSpotCUDA>" persistent="false"/>
+  <class name="edm::Wrapper<cms::cuda::Product<BeamSpotCUDA>>" persistent="false"/>
+</lcgdict>

--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -103,7 +103,7 @@ fastSim.toReplaceWith(localrecoTask, _fastSim_localrecoTask)
 from RecoLocalCalo.Castor.Castor_cff import *
 from RecoLocalCalo.Configuration.hcalGlobalReco_cff import *
 
-globalreco_trackingTask = cms.Task(offlineBeamSpot,
+globalreco_trackingTask = cms.Task(offlineBeamSpotTask,
                           MeasurementTrackerEventPreSplitting, # unclear where to put this
                           siPixelClusterShapeCachePreSplitting, # unclear where to put this
                           standalonemuontrackingTask,
@@ -117,7 +117,7 @@ trackingLowPU.toReplaceWith(globalreco_trackingTask, _globalreco_tracking_LowPUT
 ##########################################
 # offlineBeamSpot is reconstructed before mixing in fastSim
 ##########################################
-_fastSim_globalreco_trackingTask = globalreco_trackingTask.copyAndExclude([offlineBeamSpot,MeasurementTrackerEventPreSplitting,siPixelClusterShapeCachePreSplitting])
+_fastSim_globalreco_trackingTask = globalreco_trackingTask.copyAndExclude([offlineBeamSpotTask,MeasurementTrackerEventPreSplitting,siPixelClusterShapeCachePreSplitting])
 fastSim.toReplaceWith(globalreco_trackingTask,_fastSim_globalreco_trackingTask)
 
 _phase2_timing_layer_globalreco_trackingTask = globalreco_trackingTask.copy()
@@ -212,7 +212,7 @@ reconstruction_trackingOnlyTask = cms.Task(localrecoTask,globalreco_trackingTask
 reconstruction_trackingOnly = cms.Sequence(reconstruction_trackingOnlyTask)
 reconstruction_pixelTrackingOnlyTask = cms.Task(
     pixeltrackerlocalrecoTask,
-    offlineBeamSpot,
+    offlineBeamSpotTask,
     siPixelClusterShapeCachePreSplitting,
     recopixelvertexingTask
 )

--- a/DataFormats/BeamSpot/interface/BeamSpotPOD.h
+++ b/DataFormats/BeamSpot/interface/BeamSpotPOD.h
@@ -1,0 +1,20 @@
+#ifndef DataFormats_BeamSpot_interface_BeamSpotPOD_h
+#define DataFormats_BeamSpot_interface_BeamSpotPOD_h
+
+// This struct is a transient-only, simplified representation of the beamspot
+// data used as the underlying type for data transfers and operations in
+// heterogeneous code (e.g. in CUDA code).
+
+// The covariance matrix is not used in that code, so is left out here.
+
+// align to the CUDA L1 cache line size
+struct alignas(128) BeamSpotPOD {
+  float x, y, z;  // position
+  float sigmaZ;
+  float beamWidthX, beamWidthY;
+  float dxdz, dydz;
+  float emittanceX, emittanceY;
+  float betaStar;
+};
+
+#endif  // DataFormats_BeamSpot_interface_BeamSpotPOD_h

--- a/DataFormats/BeamSpot/src/classes.h
+++ b/DataFormats/BeamSpot/src/classes.h
@@ -1,8 +1,3 @@
-
-#include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "Math/Cartesian3D.h"
-#include "DataFormats/Math/interface/Vector3D.h"
-#include "Math/Polar3D.h"
-#include "Math/CylindricalEta3D.h"
-#include "DataFormats/Math/interface/Vector.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
+#include "DataFormats/Common/interface/Wrapper.h"

--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -4,4 +4,7 @@
    <version ClassVersion="10" checksum="915260007"/>
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>
+
+  <class name="BeamSpotPOD" persistent="false"/>
+  <class name="edm::Wrapper<BeamSpotPOD>" persistent="false"/>
 </lcgdict>

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
@@ -1,0 +1,83 @@
+#include "CUDADataFormats/Common/interface/Product.h"
+#include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_noncached_unique_ptr.h"
+
+#include <cuda_runtime.h>
+
+namespace {
+  class BSHost {
+  public:
+    BSHost() : bs{cms::cuda::make_host_noncached_unique<BeamSpotCUDA::Data>(cudaHostAllocWriteCombined)} {}
+    BeamSpotCUDA::Data* get() { return bs.get(); }
+
+  private:
+    cms::cuda::host::noncached::unique_ptr<BeamSpotCUDA::Data> bs;
+  };
+}  // namespace
+
+class BeamSpotToCUDA : public edm::global::EDProducer<edm::StreamCache<BSHost>> {
+public:
+  explicit BeamSpotToCUDA(const edm::ParameterSet& iConfig);
+  ~BeamSpotToCUDA() override = default;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  std::unique_ptr<BSHost> beginStream(edm::StreamID) const override {
+    edm::Service<CUDAService> cs;
+    if (cs->enabled()) {
+      return std::make_unique<BSHost>();
+    } else {
+      return nullptr;
+    }
+  }
+  void produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+private:
+  edm::EDGetTokenT<reco::BeamSpot> bsGetToken_;
+  edm::EDPutTokenT<cms::cuda::Product<BeamSpotCUDA>> bsPutToken_;
+};
+
+BeamSpotToCUDA::BeamSpotToCUDA(const edm::ParameterSet& iConfig)
+    : bsGetToken_{consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("src"))},
+      bsPutToken_{produces<cms::cuda::Product<BeamSpotCUDA>>()} {}
+
+void BeamSpotToCUDA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("offlineBeamSpot"));
+  descriptions.add("offlineBeamSpotCUDA", desc);
+}
+
+void BeamSpotToCUDA::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  cms::cuda::ScopedContextProduce ctx{streamID};
+
+  const reco::BeamSpot& bs = iEvent.get(bsGetToken_);
+
+  BeamSpotCUDA::Data* bsHost = streamCache(streamID)->get();
+
+  bsHost->x = bs.x0();
+  bsHost->y = bs.y0();
+  bsHost->z = bs.z0();
+
+  bsHost->sigmaZ = bs.sigmaZ();
+  bsHost->beamWidthX = bs.BeamWidthX();
+  bsHost->beamWidthY = bs.BeamWidthY();
+  bsHost->dxdz = bs.dxdz();
+  bsHost->dydz = bs.dydz();
+  bsHost->emittanceX = bs.emittanceX();
+  bsHost->emittanceY = bs.emittanceY();
+  bsHost->betaStar = bs.betaStar();
+
+  ctx.emplace(iEvent, bsPutToken_, bsHost, ctx.stream());
+}
+
+DEFINE_FWK_MODULE(BeamSpotToCUDA);

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
@@ -68,7 +68,7 @@ BeamSpotToCUDA::BeamSpotToCUDA(const edm::ParameterSet& iConfig)
 void BeamSpotToCUDA::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src", edm::InputTag("offlineBeamSpot"));
-  descriptions.add("offlineBeamSpotCUDA", desc);
+  descriptions.add("offlineBeamSpotToCUDA", desc);
 }
 
 void BeamSpotToCUDA::produce(edm::StreamID streamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotToCUDA.cc
@@ -3,6 +3,7 @@
 #include "CUDADataFormats/BeamSpot/interface/BeamSpotCUDA.h"
 #include "CUDADataFormats/Common/interface/Product.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/BeamSpot/interface/BeamSpotPOD.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -19,7 +20,7 @@ namespace {
 
   class BeamSpotHost {
   public:
-    BeamSpotHost() : data_h_{cms::cuda::make_host_noncached_unique<BeamSpotCUDA::Data>(cudaHostAllocWriteCombined)} {}
+    BeamSpotHost() : data_h_{cms::cuda::make_host_noncached_unique<BeamSpotPOD>(cudaHostAllocWriteCombined)} {}
 
     BeamSpotHost(BeamSpotHost const&) = delete;
     BeamSpotHost(BeamSpotHost&&) = default;
@@ -27,14 +28,14 @@ namespace {
     BeamSpotHost& operator=(BeamSpotHost const&) = delete;
     BeamSpotHost& operator=(BeamSpotHost&&) = default;
 
-    BeamSpotCUDA::Data* data() { return data_h_.get(); }
-    BeamSpotCUDA::Data const* data() const { return data_h_.get(); }
+    BeamSpotPOD* data() { return data_h_.get(); }
+    BeamSpotPOD const* data() const { return data_h_.get(); }
 
-    cms::cuda::host::noncached::unique_ptr<BeamSpotCUDA::Data>& ptr() { return data_h_; }
-    cms::cuda::host::noncached::unique_ptr<BeamSpotCUDA::Data> const& ptr() const { return data_h_; }
+    cms::cuda::host::noncached::unique_ptr<BeamSpotPOD>& ptr() { return data_h_; }
+    cms::cuda::host::noncached::unique_ptr<BeamSpotPOD> const& ptr() const { return data_h_; }
 
   private:
-    cms::cuda::host::noncached::unique_ptr<BeamSpotCUDA::BeamSpotCUDA::Data> data_h_;
+    cms::cuda::host::noncached::unique_ptr<BeamSpotPOD> data_h_;
   };
 
 }  // namespace

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -1,13 +1,12 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="FWCore/Utilities"/>
-<use name="FWCore/ServiceRegistry"/>
-<use name="CondFormats/BeamSpotObjects"/>
-<use name="CondFormats/DataRecord"/>
-<use name="CondCore/DBOutputService"/>
-
 <use name="root"/>
 <use name="rootminuit"/>
+<use name="CondCore/DBOutputService"/>
+<use name="CondFormats/BeamSpotObjects"/>
+<use name="CondFormats/DataRecord"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
+<use name="FWCore/Utilities"/>
 <use name="RecoVertex/BeamSpotProducer"/>
 
 <library file="BeamSpotProducer.cc" name="BeamSpotProducer">
@@ -40,4 +39,10 @@
 <library file="OfflineToTransientBeamSpotESProducer.cc" name="OfflineToTransientBeamSpotESProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
-
+<library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+  <use name="cuda"/>
+  <use name="CUDADataFormats/BeamSpot"/>
+  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="HeterogeneousCore/CUDAServices"/>
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
@@ -1,4 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
+from RecoVertex.BeamSpotProducer.offlineBeamSpotCUDA_cfi import offlineBeamSpotCUDA
 
+offlineBeamSpotTask = cms.Task(offlineBeamSpot)
+
+from Configuration.ProcessModifiers.gpu_cff import gpu
+_offlineBeamSpotTask_gpu = offlineBeamSpotTask.copy()
+_offlineBeamSpotTask_gpu.add(offlineBeamSpotCUDA)
+gpu.toReplaceWith(offlineBeamSpotTask, _offlineBeamSpotTask_gpu)

--- a/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
+++ b/RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py
@@ -1,11 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoVertex.BeamSpotProducer.BeamSpot_cfi import *
-from RecoVertex.BeamSpotProducer.offlineBeamSpotCUDA_cfi import offlineBeamSpotCUDA
+from RecoVertex.BeamSpotProducer.offlineBeamSpotToCUDA_cfi import offlineBeamSpotToCUDA
 
 offlineBeamSpotTask = cms.Task(offlineBeamSpot)
 
 from Configuration.ProcessModifiers.gpu_cff import gpu
 _offlineBeamSpotTask_gpu = offlineBeamSpotTask.copy()
-_offlineBeamSpotTask_gpu.add(offlineBeamSpotCUDA)
+_offlineBeamSpotTask_gpu.add(offlineBeamSpotToCUDA)
 gpu.toReplaceWith(offlineBeamSpotTask, _offlineBeamSpotTask_gpu)


### PR DESCRIPTION
#### PR description:

Transfer the beamspot data to the GPU, for use by the reconstruction algorithms running on the GPU.

Implement a BeamSpotCUDA transient data format.
Implement the beamspot host-to-device transfer in a dedicated EDProducer, making use of beginStream()-allocated write-combined memory and asynchronous copies for the transfer.

#### PR validation:

Changes in use in the Patatrack releases.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Includes changes from
  - https://github.com/cms-patatrack/cmssw/pull/318: Move BeamSpot transfer to GPU to its own producer
  - https://github.com/cms-patatrack/cmssw/pull/355: Reorganize CUDAScopedContext
  - https://github.com/cms-patatrack/cmssw/pull/364: Move event and stream caches, and caching allocators out from CUDAService
  - https://github.com/cms-patatrack/cmssw/pull/387: Fix clang warnings
  - https://github.com/cms-patatrack/cmssw/pull/389: Replace use of API wrapper stream and event with plain CUDA, part 1
  - https://github.com/cms-patatrack/cmssw/pull/395: Replace CUDA API wrapper memory operations with native CUDA calls
  - https://github.com/cms-patatrack/cmssw/pull/416: Drop obsolete heterogenous framework
  - https://github.com/cms-patatrack/cmssw/pull/432: Load CUDAService from Services_cff, and only if gpu modifier is active
  - https://github.com/cms-patatrack/cmssw/pull/429: Implement changes from the CUDA framework review
  - https://github.com/cms-patatrack/cmssw/pull/433: Simplify the offlineBeamSpotCUDA configuration
  - https://github.com/cms-patatrack/cmssw/pull/530: Update the BeamSpotCUDA class
