### PR TITLE
Selector by region ( 11.1.x backport )

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackSelectorByRegion.cc
@@ -1,0 +1,81 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
+
+#include <vector>
+#include <memory>
+
+class TrackSelectorByRegion final : public edm::global::EDProducer<> {
+public:
+  explicit TrackSelectorByRegion(const edm::ParameterSet& conf)
+      : produceCollection_(conf.getParameter<bool>("produceTrackCollection")),
+        produceMask_(conf.getParameter<bool>("produceMask")),
+        tracksToken_(consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("tracks"))),
+        inputTrkRegionToken_(consumes<edm::OwnVector<TrackingRegion>>(conf.getParameter<edm::InputTag>("regions"))),
+        outputTracksToken_(produceCollection_ ? produces<reco::TrackCollection>()
+                                              : edm::EDPutTokenT<reco::TrackCollection>{}),
+        outputMaskToken_(produceMask_ ? produces<std::vector<bool>>() : edm::EDPutTokenT<std::vector<bool>>{}) {}
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("tracks", edm::InputTag("hltPixelTracks"));
+    desc.add<edm::InputTag>("regions", edm::InputTag(""));
+    desc.add<bool>("produceTrackCollection", true);
+    desc.add<bool>("produceMask", true);
+    descriptions.add("trackSelectorByRegion", desc);
+  }
+
+private:
+  using MaskCollection = std::vector<bool>;
+
+  void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup&) const override {
+    if (not produceCollection_ and not produceMask_)
+      return;
+
+    auto const& regions = iEvent.get(inputTrkRegionToken_);
+    auto const& tracks = iEvent.get(tracksToken_);
+    MaskCollection mask(tracks.size(), false);  // output mask
+
+    for (auto const& region : regions) {
+      region.checkTracks(tracks, mask);
+    }
+
+    if (produceCollection_) {
+      reco::TrackCollection output_tracks;  // output collection with a (shallow) copy of the selected tracks
+      size_t size = 0;
+      // count the number of selected tracks
+      for (size_t i = 0; i < mask.size(); i++) {
+        size += mask[i];
+      }
+      output_tracks.reserve(size);
+      for (size_t i = 0; i < mask.size(); i++) {
+        if (mask[i])
+          output_tracks.push_back(tracks[i]);
+      }
+      iEvent.emplace(outputTracksToken_, std::move(output_tracks));
+    }
+    if (produceMask_) {
+      iEvent.emplace(outputMaskToken_, std::move(mask));
+    }
+  }
+
+  const bool produceCollection_;
+  const bool produceMask_;
+  const edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  const edm::EDGetTokenT<edm::OwnVector<TrackingRegion>> inputTrkRegionToken_;
+  const edm::EDPutTokenT<reco::TrackCollection> outputTracksToken_;
+  const edm::EDPutTokenT<std::vector<bool>> outputMaskToken_;
+};
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(TrackSelectorByRegion);

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicTrackingRegion.h
@@ -94,6 +94,10 @@ public:
     return nullptr;
   }
 
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
+
   std::unique_ptr<TrackingRegion> clone() const override { return std::make_unique<CosmicTrackingRegion>(*this); }
 
   std::string name() const override { return "CosmicTrackingRegion"; }

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -48,7 +48,6 @@ void CosmicTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std:
   }
 }
 
-
 TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::EventSetup& es,
                                                 const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicTrackingRegion.cc
@@ -24,6 +24,31 @@ namespace {
 
 using namespace std;
 
+void CosmicTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+
+  assert(mask.size() == tracks.size());
+  int i = -1;
+  for (auto const& track : tracks) {
+    i++;
+    if (mask[i])
+      continue;
+
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+
+    mask[i] = true;
+  }
+}
+
+
 TrackingRegion::Hits CosmicTrackingRegion::hits(const edm::EventSetup& es,
                                                 const SeedingLayerSetsHits::SeedingLayer& layer) const {
   TrackingRegion::Hits result;

--- a/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/GlobalTrackingRegion.h
@@ -43,6 +43,10 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
+
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
                                               const edm::EventSetup& iSetup,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -175,6 +175,11 @@ public:
 
   TrackingRegion::Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const override;
 
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
+
+
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
                                               const edm::EventSetup& iSetup,

--- a/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h
@@ -179,7 +179,6 @@ public:
   /// Does not reset the elements corresponding to the tracks that are not compatible.
   void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const override;
 
-
   std::unique_ptr<HitRZCompatibility> checkRZ(const DetLayer* layer,
                                               const Hit& outerHit,
                                               const edm::EventSetup& iSetup,

--- a/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
+++ b/RecoTracker/TkTrackingRegions/interface/TrackingRegion.h
@@ -15,6 +15,8 @@
 #include "RecoTracker/TkTrackingRegions/interface/HitEtaCheck.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitRCheck.h"
 #include "RecoTracker/TkTrackingRegions/interface/HitZCheck.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
@@ -95,6 +97,17 @@ public:
 
   /// get hits from layer compatible with region constraints
   virtual Hits hits(const edm::EventSetup& es, const SeedingLayerSetsHits::SeedingLayer& layer) const = 0;
+
+  /// Set the elements of the mask corresponding to the tracks that are compatable with the region.
+  /// Does not reset the elements corresponding to the tracks that are not compatible.
+  virtual void checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const = 0;
+
+  /// return a boolean mask over the TrackCollection reflecting the compatibility of each track with the region constraints
+  std::vector<bool> checkTracks(reco::TrackCollection const& tracks) const {
+    std::vector<bool> region_mask(tracks.size(), false);
+    checkTracks(tracks, region_mask);
+    return region_mask;
+  }
 
   /// clone region with new vertex position
   std::unique_ptr<TrackingRegion> restrictedRegion(const GlobalPoint& originPos,

--- a/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/GlobalTrackingRegion.cc
@@ -115,3 +115,27 @@ std::unique_ptr<HitRZCompatibility> GlobalTrackingRegion::checkRZ(const DetLayer
     return std::make_unique<HitRCheck>(rzConstraint, HitRCheck::Margin(corr, corr));
   }
 }
+
+void GlobalTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+
+  assert(mask.size() == tracks.size());
+  int i = -1;
+  for (auto const& track : tracks) {
+    i++;
+    if (mask[i])
+      continue;
+
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+
+    mask[i] = true;
+  }
+}

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -79,7 +79,6 @@ void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& t
   }
 }
 
-
 RectangularEtaPhiTrackingRegion::UseMeasurementTracker RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(
     const std::string& name) {
   std::string tmp = name;

--- a/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
+++ b/RecoTracker/TkTrackingRegions/src/RectangularEtaPhiTrackingRegion.cc
@@ -32,6 +32,7 @@
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "TrackingTools/KalmanUpdators/interface/EtaPhiMeasurementEstimator.h"
+#include "DataFormats/Math/interface/normalizedPhi.h"
 
 #include <iostream>
 #include <algorithm>
@@ -46,6 +47,38 @@ namespace {
 
 using namespace PixelRecoUtilities;
 using namespace std;
+
+void RectangularEtaPhiTrackingRegion::checkTracks(reco::TrackCollection const& tracks, std::vector<bool>& mask) const {
+  const math::XYZPoint regOrigin(origin().x(), origin().y(), origin().z());
+  auto phi0 = phiDirection() + 0.5 * (phiMargin().right() - phiMargin().left());
+  auto dphi = 0.5 * (phiMargin().right() + phiMargin().left());
+
+  assert(mask.size() == tracks.size());
+  int i = -1;
+  for (auto const& track : tracks) {
+    i++;
+    if (mask[i])
+      continue;
+
+    if (track.pt() < ptMin()) {
+      continue;
+    }
+    if (!etaRange().inside(track.eta())) {
+      continue;
+    }
+    if (std::abs(proxim(track.phi(), phi0) - phi0) > dphi) {
+      continue;
+    }
+    if (std::abs(track.dxy(regOrigin)) > originRBound()) {
+      continue;
+    }
+    if (std::abs(track.dz(regOrigin)) > originZBound()) {
+      continue;
+    }
+    mask[i] = true;
+  }
+}
+
 
 RectangularEtaPhiTrackingRegion::UseMeasurementTracker RectangularEtaPhiTrackingRegion::stringToUseMeasurementTracker(
     const std::string& name) {


### PR DESCRIPTION
#### PR description:

This module is an EDProducer that can take in a track collection and a tracking region , then produce the subset track collection with tracks that are compliant to the constraints in tracking region

As per [suggestion](https://github.com/cms-sw/cmssw/pull/31055#issuecomment-671899619) , this is a backport for a PR ([31055](https://github.com/cms-sw/cmssw/pull/31055))  in CMSSW_11_2_X_  which inturn was a development over another PR [29359](https://github.com/cms-sw/cmssw/pull/29359) .

#### PR validation:
[link](https://indico.cern.ch/event/939462/contributions/3969981/attachments/2084986/3502599/TrackSelectorByRegion.pdf) to TSG presentation for quick referance 

A brief overview for the rslts for CMSSW_11_1_0 for RelValZMM_14 ('111X_mcRun3_2021_realistic_v6')

RvR := Regionally reconstructed tracks passing the selector
GvR := Global pixel tracks passing the selector
RegReco := Regionally reconstructed
#### TrackingRegion  :  hltIterL3MuonPixelTracksTrackingRegions, TrackCollection  :  hltIterL3MuonPixelTracks
* Total number of events triggered evts    :    15350
* Regionally reconstructed tracks          :    17239
* Total RvR Tracks                         :    16618
* Missed RegReco Tracks in  RvR Tracks     :    621
* Total GvR Tracks                         :    16695
* Matched RegReco Tracks in  GvR Tracks    :    16613
* Missed RegReco Tracks in  GvR Tracks     :    626
* Addtional Tracks in GvR                  :    82

#### TrackingRegion  :  hltPixelTracksTrackingRegionsL3MuonNoVtx, TrackCollection  :  hltPixelTracksL3MuonNoVtx
* Total number of events triggered evts    :    8289
* Regionally reconstructed tracks          :    221748
* Total RvR Tracks                         :    130068
* Missed RegReco Tracks in  RvR Tracks     :    91680
* Total GvR Tracks                         :    130074
* Matched RegReco Tracks in  GvR Tracks    :    129626
* Missed RegReco Tracks in  GvR Tracks     :    92122
* Addtional Tracks in GvR                  :    448

### Validation scheme

After setting up the environment use HLTrigger/Configuration/test/cmsDriver.csh to generate config file`RelVal_HLT_Reco_GRun_MC.py`
```
cd $CMSSW_BASE/src/HLTrigger/Configuration/test/
./cmsDriver.csh
```
To use [customizeForSelectorByRegion.py](https://cernbox.cern.ch/index.php/s/WTIPYndKB39bOmB) customizing python script, that adds the comparison modules to the menu (this will generate an additional root file) , copy [customizeForSelectorByRegion.py](https://cernbox.cern.ch/index.php/s/WTIPYndKB39bOmB) to the same folder as the config file
 
To the config file, add :
```
from customizeForSelectorByRegion import *
process=customizeForTrackSelectorByRegionValidation(process)
```
then run
```
cmsRun RelVal_HLT_Reco_GRun_MC.py
```
to obtain comparison statistics for various modules in the customization, one can use [analyse.py](https://cernbox.cern.ch/index.php/s/eL0xVal9D9TVHqe)
```
python analyze.py
```
running this script will show a brief overview of the comparison statistics
