### PR TITLE
Fix undefined behavior in CaloPoint

### DIFF
--- a/FastSimulation/CaloGeometryTools/interface/CaloPoint.h
+++ b/FastSimulation/CaloGeometryTools/interface/CaloPoint.h
@@ -20,7 +20,7 @@ public:
   typedef math::XYZVector XYZPoint;
 
   /// Empty constructor
-  CaloPoint() : XYZPoint() { ; };
+  CaloPoint() : XYZPoint(), side_{NONE} {}
   //  /// Constructor from DetId, side and position.
   //  CaloPoint(DetId cell, CaloDirection side, const XYZPoint& position);
   //


### PR DESCRIPTION
#### PR description:

Always set the enum value to an allowed value.

This was uncovered by the UBSAN IB

#### PR validation:

Code compiles.