### PR TITLE
Move "wmsplit" dict build to a static method, remove circular import (backport to 11_0_X)

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -161,15 +161,19 @@ class MatrixInjector(object):
 
         self.chainDicts={}
 
-
-    def prepare(self,mReader, directories, mode='init'):
+    @staticmethod
+    def get_wmsplit():
+        """
+        Return a "wmsplit" dictionary that contain non-default LumisPerJob values
+        """
+        wmsplit = {}
         try:
             #from Configuration.PyReleaseValidation.relval_steps import wmsplit
             wmsplit = {}
             wmsplit['DIGIHI']=5
             wmsplit['RECOHI']=5
             wmsplit['HLTD']=5
-            wmsplit['RECODreHLT']=2  
+            wmsplit['RECODreHLT']=2
             wmsplit['DIGIPU']=4
             wmsplit['DIGIPU1']=4
             wmsplit['RECOPU1']=1
@@ -249,8 +253,8 @@ class MatrixInjector(object):
             wmsplit['HLTDR2_2018']=1
             wmsplit['HLTDR2_2018_BadHcalMitig']=1
             wmsplit['Hadronizer']=1
-            wmsplit['DIGIUP15']=1 
-            wmsplit['RECOUP15']=1 
+            wmsplit['DIGIUP15']=1
+            wmsplit['RECOUP15']=1
             wmsplit['RECOAODUP15']=5
             wmsplit['DBLMINIAODMCUP15NODQM']=5
             wmsplit['DigiFull']=5
@@ -258,7 +262,7 @@ class MatrixInjector(object):
             wmsplit['DigiFullPU']=1
             wmsplit['RecoFullPU']=1
             wmsplit['RECOHID11']=1
-            wmsplit['DigiFullTriggerPU_2026D17PU'] = 1 
+            wmsplit['DigiFullTriggerPU_2026D17PU'] = 1
             wmsplit['RecoFullGlobalPU_2026D17PU']=1
             wmsplit['DIGIUP17']=1
             wmsplit['RECOUP17']=1
@@ -276,13 +280,14 @@ class MatrixInjector(object):
             wmsplit['HYBRIDZSHI2015']=1
             wmsplit['RECOHID15']=1
             wmsplit['RECOHID18']=1
-                                    
-            #import pprint
-            #pprint.pprint(wmsplit)            
-        except:
-            print("Not set up for step splitting")
-            wmsplit={}
+        except Exception as ex:
+            print('Exception while building a wmsplit dictionary: %s' % (str(ex)))
+            return {}
 
+        return wmsplit
+
+    def prepare(self,mReader, directories, mode='init'):
+        wmsplit = MatrixInjector.get_wmsplit()
         acqEra=False
         for (n,dir) in directories.items():
             chainDict=copy.deepcopy(self.defaultChain)

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from collections import OrderedDict
 import six
-from .MatrixUtil import merge
+from .MatrixUtil import merge, Kby
 
 # DON'T CHANGE THE ORDER, only append new keys. Otherwise the numbering for the runTheMatrix tests will change.
 
@@ -627,7 +627,6 @@ for year in upgradeKeys:
         if 'PU' in key: continue
         defaultDataSets[key] = ''
 
-from  Configuration.PyReleaseValidation.relval_steps import Kby
 
 class UpgradeFragment(object):
     def __init__(self, howMuch, dataset):


### PR DESCRIPTION
#### PR description:
Same as #31122

#### PR validation:
Ran runTheMatrix.py with commented-out submission to computing and added prints to see if values are picked up from the moved "wmsplit" dictionary. Code did not crash and print statements printed expected values from "wmsplit".

#### If this PR is a backport please specify the original PR and why you need to backport that PR:
This is a backport of #31122
This is needed for the currently developed RelVal machine by PdmV.