### PR TITLE
Fix gcc10 warning in KDTreeLinkerAlgo

### DIFF
--- a/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
+++ b/CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h
@@ -226,7 +226,7 @@ void KDTreeLinkerAlgo<DATA, DIM>::recSearch(int current, const KDTreeBox<DIM> &t
       bool isInside = true;
       for (unsigned i = 0; i < DIM; ++i) {
         float dimCurr = nodePool_.dims[i][current];
-        isInside *= (dimCurr >= trackBox.dimmin[i]) & (dimCurr <= trackBox.dimmax[i]);
+        isInside &= (dimCurr >= trackBox.dimmin[i]) & (dimCurr <= trackBox.dimmax[i]);
       }
       if (isInside) {
         closestNeighbour->push_back(nodePool_.data[current]);


### PR DESCRIPTION
#### PR description:

Switched to using bitwise operation instead of multiplication.

I did not decide to switch to the boolean operation (&&) because of the comment in the code a few lines above the change.

#### PR validation:
The code compiles without a warning using gcc 10.
