### PR TITLE
Remove dead assignments in EventFilter/Utilities/DirManager and Validation/RecoTrack/SiStripTrackingRecHitsValid

### DIFF
--- a/EventFilter/Utilities/src/DirManager.cc
+++ b/EventFilter/Utilities/src/DirManager.cc
@@ -19,6 +19,7 @@ namespace evf {
     closedir(dir);
     return maxrun;
   }
+
   std::string DirManager::findHighestRunDir() {
     std::string retval = dir_ + "/";
     std::string tmpdir;
@@ -59,13 +60,12 @@ namespace evf {
     retval += tmpdir;
     return retval;
   }
+
   bool DirManager::checkDirEmpty(std::string &d) {
-    int filecount = 0;
     DIR *dir = opendir(d.c_str());
-    struct dirent *buf;
-    while ((buf = readdir(dir))) {
-      filecount++;
+    while (readdir(dir)) {
+      return false;
     }
-    return (filecount == 0);
+    return true;
   }
 }  // namespace evf

--- a/EventFilter/Utilities/src/DirManager.cc
+++ b/EventFilter/Utilities/src/DirManager.cc
@@ -62,10 +62,11 @@ namespace evf {
   }
 
   bool DirManager::checkDirEmpty(std::string &d) {
+    int filecount = 0;
     DIR *dir = opendir(d.c_str());
     while (readdir(dir)) {
-      return false;
+      filecount++;
     }
-    return true;
+    return (filecount == 0);
   }
 }  // namespace evf

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -1201,23 +1201,20 @@ void SiStripTrackingRecHitsValid::rechitanalysis_matched(LocalVector ldir,
     float dist = std::numeric_limits<float>::max();
     float distx = std::numeric_limits<float>::max();
     float disty = std::numeric_limits<float>::max();
-    std::pair<LocalPoint, LocalVector> closestPair;
-    PSimHit *closest = nullptr;
-
-    const StripGeomDetUnit *partnerstripdet = static_cast<const StripGeomDetUnit *>(gluedDet->stereoDet());
-    std::pair<LocalPoint, LocalVector> hitPair;
 
     if (matchedmonorstereo == MatchStatus::matched) {
+      const StripGeomDetUnit *partnerstripdet = static_cast<const StripGeomDetUnit *>(gluedDet->stereoDet());
+      std::pair<LocalPoint, LocalVector> hitPair;
+      std::pair<LocalPoint, LocalVector> closestPair;
       for (auto &m : matched) {
         //project simhit;
         hitPair = projectHit(m, partnerstripdet, gluedDet->surface());
         distx = fabs(rechitpro.x - hitPair.first.x());
         disty = fabs(rechitpro.y - hitPair.first.y());
-        dist = sqrt(distx * distx + disty * disty);
+        dist = distx * distx + disty * disty;
         if (dist < mindist) {
           mindist = dist;
           closestPair = hitPair;
-          closest = &m;
         }
       }
       float closestX = closestPair.first.x();
@@ -1227,12 +1224,12 @@ void SiStripTrackingRecHitsValid::rechitanalysis_matched(LocalVector ldir,
       rechitpro.pullx = ((rechit)->localPosition().x() - closestX) / sqrt(error.xx());
       rechitpro.pully = ((rechit)->localPosition().y() - closestY) / sqrt(error.yy());
     } else if (matchedmonorstereo == MatchStatus::monoHit) {
+      PSimHit *closest = nullptr;
       for (auto &m : matched) {
         //project simhit;
         dist = abs((monohit)->localPosition().x() - m.localPosition().x());
         if (dist < mindist) {
           mindist = dist;
-          closestPair = hitPair;
           closest = &m;
         }
       }
@@ -1242,12 +1239,12 @@ void SiStripTrackingRecHitsValid::rechitanalysis_matched(LocalVector ldir,
       rechitpro.pullx = (rechit->localPosition().x() - closestX) / sqrt(error.xx());
       rechitpro.pullxMF = (rechitpro.resxMF) / sqrt(Merror.uu());
     } else if (matchedmonorstereo == MatchStatus::stereoHit) {
+      PSimHit *closest = nullptr;
       for (auto &m : matched) {
         //project simhit;
         dist = abs((stereohit)->localPosition().x() - m.localPosition().x());
         if (dist < mindist) {
           mindist = dist;
-          closestPair = hitPair;
           closest = &m;
         }
       }


### PR DESCRIPTION
#### PR description:

Motivated by some finding of the static analyzer, dead assignments removal and some little cleanup were allowed in the following files:
-  EventFilter/Utilities/src/DirManager.cc
- Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc

#### PR validation:

It builds