### PR TITLE
Cleanup of the PFTrack class

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrack.h
@@ -77,10 +77,6 @@ namespace reco {
       trajectoryPoints_[index] = measurement;
     }
 
-    /// calculate posrep_ once and for all for each point
-    /// \todo where is posrep? profile and see if it's necessary.
-    void calculatePositionREP();
-
     /// \return electric charge
     double charge() const { return charge_; }
 

--- a/DataFormats/ParticleFlowReco/interface/PFTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrack.h
@@ -112,10 +112,6 @@ namespace reco {
       return trajectoryPoints_.begin() + indexOutermost_;
     }
 
-    void setColor(int color) { color_ = color; }
-
-    int color() const { return color_; }
-
   protected:
     /// maximal number of tracking layers
     static const unsigned int nMaxTrackingLayers_;
@@ -131,9 +127,6 @@ namespace reco {
 
     /// index outermost tracker measurement
     unsigned int indexOutermost_;
-
-    /// color (transient)
-    int color_;
   };
   std::ostream& operator<<(std::ostream& out, const PFTrack& track);
 

--- a/DataFormats/ParticleFlowReco/src/GsfPFRecTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/GsfPFRecTrack.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "Math/GenVector/PositionVector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
-// #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace reco;
 GsfPFRecTrack::GsfPFRecTrack(double charge,
@@ -15,11 +14,6 @@ GsfPFRecTrack::GsfPFRecTrack(double charge,
 }
 
 void GsfPFRecTrack::addBrem(const reco::PFBrem& brem) { pfBremVec_.push_back(brem); }
-
-void GsfPFRecTrack::calculateBremPositionREP() {
-  for (unsigned j = 0; j < pfBremVec_.size(); ++j)
-    pfBremVec_[j].calculatePositionREP();
-}
 
 void GsfPFRecTrack::addConvBremPFRecTrackRef(const reco::PFRecTrackRef& pfrectracksref) {
   assoPFRecTrack_.push_back(pfrectracksref);

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -8,12 +8,12 @@ using namespace std;
 
 const unsigned PFTrack::nMaxTrackingLayers_ = 17;
 
-PFTrack::PFTrack() : charge_(0.), indexInnermost_(0), indexOutermost_(0), color_(1) {
+PFTrack::PFTrack() : charge_(0.), indexInnermost_(0), indexOutermost_(0) {
   // prepare vector of trajectory points for propagated positions
   trajectoryPoints_.reserve(PFTrajectoryPoint::NLayers + nMaxTrackingLayers_);
 }
 
-PFTrack::PFTrack(double charge) : charge_(charge), indexInnermost_(0), indexOutermost_(0), color_(1) {
+PFTrack::PFTrack(double charge) : charge_(charge), indexInnermost_(0), indexOutermost_(0) {
   // prepare vector of trajectory points for propagated positions
   trajectoryPoints_.reserve(PFTrajectoryPoint::NLayers + nMaxTrackingLayers_);
 }
@@ -22,8 +22,7 @@ PFTrack::PFTrack(const PFTrack& other)
     : charge_(other.charge_),
       trajectoryPoints_(other.trajectoryPoints_),
       indexInnermost_(other.indexInnermost_),
-      indexOutermost_(other.indexOutermost_),
-      color_(other.color_) {}
+      indexOutermost_(other.indexOutermost_) {}
 
 void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
   //   cout<<"adding "<<trajPt<<endl;

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -2,6 +2,7 @@
 #include "Math/GenVector/PositionVector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace reco;
 using namespace std;
@@ -25,7 +26,6 @@ PFTrack::PFTrack(const PFTrack& other)
       indexOutermost_(other.indexOutermost_) {}
 
 void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
-  //   cout<<"adding "<<trajPt<<endl;
 
   if (trajPt.isTrackerLayer()) {
     if (!indexOutermost_) {  // first time a measurement is added
@@ -34,9 +34,8 @@ void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
         for (unsigned iPt = trajectoryPoints_.size(); iPt < PFTrajectoryPoint::BeamPipeOrEndVertex + 1; iPt++)
           trajectoryPoints_.push_back(dummyPt);
       } else if (trajectoryPoints_.size() > PFTrajectoryPoint::BeamPipeOrEndVertex + 1) {
-        // throw an exception here
-        //      edm::LogError("PFTrack")<<"trajectoryPoints_.size() is too large = "
-        //                              <<trajectoryPoints_.size()<<"\n";
+	edm::LogWarning("PFTrack")<<"trajectoryPoints_.size() is too large = "
+				  <<trajectoryPoints_.size();
       }
       indexOutermost_ = indexInnermost_ = PFTrajectoryPoint::BeamPipeOrEndVertex + 1;
     } else
@@ -45,13 +44,6 @@ void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
   // Use push_back instead of insert in order to gain time
   trajectoryPoints_.push_back(trajPt);
 
-  //   cout<<"adding point "<<*this<<endl;
-}
-
-void PFTrack::calculatePositionREP() {
-  //for(unsigned i=0; i<trajectoryPoints_.size(); i++) {
-  //  trajectoryPoints_[i].calculatePositionREP();
-  //}
 }
 
 const reco::PFTrajectoryPoint& PFTrack::extrapolatedPoint(unsigned layerid) const {
@@ -61,7 +53,6 @@ const reco::PFTrajectoryPoint& PFTrack::extrapolatedPoint(unsigned layerid) cons
                                       << " #traj meas = " << nTrajectoryMeasurements()
                                       << " #traj points = " << trajectoryPoints_.size() << endl
                                       << (*this);
-    // assert(0);
   }
   if (layerid < indexInnermost_)
     return trajectoryPoints_[layerid];

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -26,7 +26,6 @@ PFTrack::PFTrack(const PFTrack& other)
       indexOutermost_(other.indexOutermost_) {}
 
 void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
-
   if (trajPt.isTrackerLayer()) {
     if (!indexOutermost_) {  // first time a measurement is added
       if (trajectoryPoints_.size() < PFTrajectoryPoint::BeamPipeOrEndVertex + 1) {
@@ -34,8 +33,7 @@ void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
         for (unsigned iPt = trajectoryPoints_.size(); iPt < PFTrajectoryPoint::BeamPipeOrEndVertex + 1; iPt++)
           trajectoryPoints_.push_back(dummyPt);
       } else if (trajectoryPoints_.size() > PFTrajectoryPoint::BeamPipeOrEndVertex + 1) {
-	edm::LogWarning("PFTrack")<<"trajectoryPoints_.size() is too large = "
-				  <<trajectoryPoints_.size();
+        edm::LogWarning("PFTrack") << "trajectoryPoints_.size() is too large = " << trajectoryPoints_.size();
       }
       indexOutermost_ = indexInnermost_ = PFTrajectoryPoint::BeamPipeOrEndVertex + 1;
     } else
@@ -43,7 +41,6 @@ void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
   }
   // Use push_back instead of insert in order to gain time
   trajectoryPoints_.push_back(trajPt);
-
 }
 
 const reco::PFTrajectoryPoint& PFTrack::extrapolatedPoint(unsigned layerid) const {

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -75,7 +75,8 @@
 
   
 
-  <class name="reco::PFTrack" ClassVersion="10">
+  <class name="reco::PFTrack" ClassVersion="11">
+   <version ClassVersion="11" checksum="1666908047"/>
    <version ClassVersion="10" checksum="496926148"/>
   </class>
 <!--    <class name="edm::RefToBase<reco::Track>"/>
@@ -97,7 +98,8 @@
   <class name="edm::Wrapper<std::vector<reco::PFTrajectoryPoint> >"/>
 
   <class name="edm::RefVector<std::vector<reco::PFBlock>,reco::PFBlock,edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
-  <class name="reco::PFRecTrack" ClassVersion="12">
+  <class name="reco::PFRecTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="2549841209"/>
    <version ClassVersion="12" checksum="2850643502"/>
    <version ClassVersion="11" checksum="2924298092"/>
    <version ClassVersion="10" checksum="2979491836"/>
@@ -107,7 +109,8 @@
   <class name="std::vector<reco::PFRecTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::PFRecTrack> >"/>
 
-  <class name="reco::GsfPFRecTrack" ClassVersion="12">
+  <class name="reco::GsfPFRecTrack" ClassVersion="13">
+   <version ClassVersion="13" checksum="974620889"/>
    <version ClassVersion="12" checksum="2203231294"/>
    <version ClassVersion="11" checksum="2592328732"/>
    <version ClassVersion="10" checksum="3411096264"/>
@@ -117,7 +120,8 @@
   <class name="std::vector<reco::GsfPFRecTrack>"/>
   <class name="edm::Wrapper<std::vector<reco::GsfPFRecTrack> >"/>
 
-  <class name="reco::PFBrem" ClassVersion="12">
+  <class name="reco::PFBrem" ClassVersion="13">
+   <version ClassVersion="13" checksum="1718201023"/>
    <version ClassVersion="12" checksum="3001582852"/>
    <version ClassVersion="11" checksum="1785919010"/>
    <version ClassVersion="10" checksum="3922569476"/>
@@ -125,7 +129,8 @@
   <class name="std::vector<reco::PFBrem>"/>
 
 
-  <class name="reco::PFSimParticle" ClassVersion="11">
+  <class name="reco::PFSimParticle" ClassVersion="12">
+   <version ClassVersion="12" checksum="3693440976"/>
    <version ClassVersion="11" checksum="3190131965"/>
    <version ClassVersion="10" checksum="545237333"/>
   </class>

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -55,7 +55,6 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
   const PFRecTrackCollection& PfRTkColl = *(thePfRecTrackCol.product());
   reco::PFRecTrackCollection::const_iterator pft = PfRTkColl.begin();
   reco::PFRecTrackCollection::const_iterator pftend = PfRTkColl.end();
-  //PFEnergyCalibration pfcalib_;
 
   vector<PFRecTrackRef> AllPFRecTracks;
   AllPFRecTracks.clear();
@@ -264,7 +263,6 @@ void ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>
       float MinDist = 100000.;
       float EE_calib = 0.;
       PFRecTrack pfrectrack = *AllPFRecTracks[iPF];
-      pfrectrack.calculatePositionREP();
       // Find and ECAL associated cluster
       for (PFClusterCollection::const_iterator clus = theEClus.begin(); clus != theEClus.end(); clus++) {
         // Removed unusd variable, left this in case it has side effects

--- a/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
+++ b/RecoParticleFlow/PFTracking/src/PFTrackTransformer.cc
@@ -545,7 +545,6 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
         brem.addPoint(dummyHOLayer);
       }
     }
-    brem.calculatePositionREP();
     pftrack.addBrem(brem);
     iTrajPos++;
   }
@@ -744,7 +743,6 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
     }
   }
 
-  brem.calculatePositionREP();
   pftrack.addBrem(brem);
   iTrajPos++;
 
@@ -908,7 +906,6 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
       }
     }
 
-    brem.calculatePositionREP();
     pftrack.addBrem(brem);
     iTrajPos++;
   }
@@ -1161,7 +1158,6 @@ bool PFTrackTransformer::addPointsAndBrems(reco::GsfPFRecTrack& pftrack,
         brem.addPoint(dummyHOLayer);
       }
     }
-    brem.calculatePositionREP();
     pftrack.addBrem(brem);
     iTrajPos++;
   }


### PR DESCRIPTION
#### PR description:

Removing an obsolete "color" data member from the PFTrack class. This is triggered by #31149 done for the PFCluster class. We also used this opportunity to remove calculatePositionREP for PFTrack as it has not been doing anything.

#### PR validation:

Compiles. And, checked with the matrix test 11634.0 (ttbar 2021).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@bendavid 