### PR TITLE
add needed deps and clean up buildfile of DataFormats/L1TCorrelator

### DIFF
--- a/DataFormats/L1TCorrelator/BuildFile.xml
+++ b/DataFormats/L1TCorrelator/BuildFile.xml
@@ -1,5 +1,7 @@
+<use name="DataFormats/HepMCCandidate"/>
+<use name="DataFormats/L1TMuon"/>
+<use name="DataFormats/Math"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Phase2TrackerDigi"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="rootrflx"/>


### PR DESCRIPTION
modules build complained about missing DataFormats/L1TMuon dependency. I've updated the buildfile to match all direct dependencies of the package.