### PR TITLE
Add a service to handle MPI initialisation

### DIFF
--- a/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
@@ -1,0 +1,4 @@
+<use name="openmpi"/>
+<use name="FWCore/Framework"/>
+<use name="FWCore/ParameterSet"/>
+<flags EDM_PLUGIN="1"/>

--- a/HeterogeneousCore/MPIServices/plugins/MPIService.cc
+++ b/HeterogeneousCore/MPIServices/plugins/MPIService.cc
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+
+#include <mpi.h>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+namespace {
+  const char* const mpi_thread_support_level[] = {
+      "MPI_THREAD_SINGLE",      // only one thread will execute (the process is single-threaded)
+      "MPI_THREAD_FUNNELED",    // only the thread that called MPI_Init_thread will make MPI calls
+      "MPI_THREAD_SERIALIZED",  // only one thread will make MPI library calls at one time
+      "MPI_THREAD_MULTIPLE"     // multiple threads may call MPI at once with no restrictions
+  };
+}
+
+class MPIService {
+public:
+  MPIService(edm::ParameterSet const& config);
+  ~MPIService();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+};
+
+MPIService::MPIService(edm::ParameterSet const& config) {
+  // initializes the MPI execution environment, requesting multi-threading support
+  int provided;
+  MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &provided);
+  if (provided < MPI_THREAD_MULTIPLE) {
+    throw cms::Exception("UnsupportedFeature")
+        << "CMSSW requires the " << mpi_thread_support_level[MPI_THREAD_MULTIPLE]
+        << " multithreading support level, but the MPI library provides only the " << mpi_thread_support_level[provided]
+        << " level.";
+  } else {
+    edm::LogInfo log("MPIService");
+
+    // get the number of processes
+    int world_size;
+    MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+    log << "MPI_COMM_WORLD size: " << world_size << '\n';
+
+    // get the rank of the process
+    int world_rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    log << "MPI_COMM_WORLD rank: " << world_rank << '\n';
+
+    // get the name of the processor
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+    int name_len;
+    MPI_Get_processor_name(processor_name, &name_len);
+    log << "MPI processor name:  " << processor_name << '\n';
+
+    log << "The MPI library provides the " << mpi_thread_support_level[provided] << " multithreading support level\n";
+    log << "MPI successfully initialised";
+  }
+}
+
+MPIService::~MPIService() {
+  // terminate the MPI execution environment
+  MPI_Finalize();
+}
+
+void MPIService::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  descriptions.add("MPIService", desc);
+  descriptions.setComment(R"(This Service provides a common interface to MPI configuration for the CMSSW job.)");
+}
+
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+DEFINE_FWK_SERVICE_MAKER(MPIService, edm::serviceregistry::ParameterSetMaker<MPIService>);

--- a/HeterogeneousCore/MPIServices/test/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/test/BuildFile.xml
@@ -1,0 +1,1 @@
+<test name="TestHeterogeneousCoreMPIServices" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/MPIServices/test/testMPIService.py"/>

--- a/HeterogeneousCore/MPIServices/test/testMPIService.py
+++ b/HeterogeneousCore/MPIServices/test/testMPIService.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process( "TEST" )
+
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('HeterogeneousCore.MPIServices.MPIService_cfi')
+process.MessageLogger.categories.append("MPIService")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32( 0 )
+)


### PR DESCRIPTION
#### PR description:

Add an `MPIService` to handle
  - MPI initialisation requiring multithreading support
  - `LogInfo` of some MPI environment information
  - MPI finalisation

Add a python configuration to test the `MPIService`.

Any other service or module that uses MPI should require this service, to guarantee that MPI is initialised/finalised in the correct order.

#### PR validation:

```log
$ scram b runtests
...
Creating test log file logs/slc7_amd64_gcc820/testing.log
Package HeterogeneousCore/MPIServices: Running test TestHeterogeneousCoreMPIServices
 
===== Test "TestHeterogeneousCoreMPIServices" ====
%MSG-i MPIService:  (NoModuleName) 16-Aug-2020 14:36:28 CEST pre-events
MPI_COMM_WORLD size: 1
MPI_COMM_WORLD rank: 0
MPI processor name:  fu-c2a02-37-02
The MPI library provides the MPI_THREAD_MULTIPLE multithreading support level
MPI successfully initialised
%MSG

=============================================

MessageLogger Summary

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------

dropped waiting message count 0

---> test TestHeterogeneousCoreMPIServices succeeded
 
^^^^ End Test TestHeterogeneousCoreMPIServices ^^^^
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR includes the work from:
  - cms-patatrack#151 Add a simple MPIService to handle MPI initialisation
  - cms-patatrack#535 Update messages and add a test file for the MPIService