### PR TITLE
Added Z of the central detector for very forward simulation

### DIFF
--- a/SimG4Core/Application/interface/StackingAction.h
+++ b/SimG4Core/Application/interface/StackingAction.h
@@ -54,6 +54,7 @@ private:
   double kmaxIon, kmaxNeutron, kmaxProton;
   double kmaxGamma;
   double maxTrackTime;
+  double maxZCentralCMS;
   unsigned int numberTimes;
   std::vector<double> maxTrackTimes;
   std::vector<std::string> maxTimeNames;

--- a/SimG4Core/Application/interface/SteppingAction.h
+++ b/SimG4Core/Application/interface/SteppingAction.h
@@ -24,7 +24,8 @@ enum TrackStatus {
   sOutOfTime = 3,
   sLowEnergy = 4,
   sLowEnergyInVacuum = 5,
-  sEnergyDepNaN = 6
+  sEnergyDepNaN = 6,
+  sVeryForward = 7
 };
 
 class SteppingAction : public G4UserSteppingAction {
@@ -52,6 +53,7 @@ private:
   double theCriticalEnergyForVacuum;
   double theCriticalDensity;
   double maxTrackTime;
+  double maxZCentralCMS;
   std::vector<double> maxTrackTimes, ekinMins;
   std::vector<std::string> maxTimeNames, ekinNames, ekinParticles;
   std::vector<std::string> deadRegionNames;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -14,13 +14,13 @@ common_heavy_suppression = cms.PSet(
 )
 
 common_maximum_time = cms.PSet(
-    MaxTrackTime  = cms.double(500.0),
-    MaxTimeNames  = cms.vstring('ZDCRegion'),
-    MaxTrackTimes = cms.vdouble(2000.0),
-    #DeadRegions   = cms.vstring('QuadRegion','CastorRegion','InterimRegion'),
+    MaxTrackTime  = cms.double(500.0), # ns
+    MaxTimeNames  = cms.vstring(),
+    MaxTrackTimes = cms.vdouble(),     # ns
+    MaxZCentralCMS = cms.double(50.0), # m
     DeadRegions   = cms.vstring('QuadRegion','InterimRegion'),
-    CriticalEnergyForVacuum = cms.double(2.0),
-    CriticalDensity         = cms.double(1e-15)
+    CriticalEnergyForVacuum = cms.double(2.0),   # MeV
+    CriticalDensity         = cms.double(1e-15)  # g/cm3
 )
 
 common_UsePMT = cms.PSet(
@@ -188,6 +188,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         ThresholdTrials           = cms.untracked.int32(10)
     ),
     Generator = cms.PSet(
+        common_maximum_time,
         HectorEtaCut,
         HepMCProductLabel = cms.InputTag('generatorSmeared'),
         ApplyPCuts = cms.bool(True),
@@ -567,21 +568,34 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
         IgnoreTrackID   = cms.bool(False),
     ),
 )
-
-
 ##
-## Change the HFShowerLibrary file used for Run 2
+## Change the HFShowerLibrary file from Run 2
 ##
 from Configuration.Eras.Modifier_run2_common_cff import run2_common
 run2_common.toModify( g4SimHits.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v4.root' )
 run2_common.toModify( g4SimHits.HFShower, ProbMax = 0.5)
 
+##
+## Change HCAL numbering scheme in 2017
+##
 from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify( g4SimHits, HCalSD = dict( TestNumberingScheme = True ) )
+
+##
+## Disable Castor from Run 3
+##
+from Configuration.Eras.Modifier_run3_common_cff import run3_common
+run3_common.toModify( g4SimHits, CastorSD = dict( useShowerLibrary = False ) ) 
+
+##
+## Change ECAL time slices
+##
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
 phase2_timing.toModify( g4SimHits.ECalSD,
                              StoreLayerTimeSim = cms.untracked.bool(True),
                              TimeSliceUnit = cms.double(0.001) )
-
+##
+## DD4Hep migration
+##
 from Configuration.ProcessModifiers.dd4hep_cff import dd4hep
 dd4hep.toModify( g4SimHits, g4GeometryDD4hepSource = True )

--- a/SimG4Core/Application/src/StackingAction.cc
+++ b/SimG4Core/Application/src/StackingAction.cc
@@ -20,13 +20,14 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   trackNeutrino = p.getParameter<bool>("TrackNeutrino");
   killHeavy = p.getParameter<bool>("KillHeavy");
   killGamma = p.getParameter<bool>("KillGamma");
-  kmaxGamma = p.getParameter<double>("GammaThreshold") * MeV;
-  kmaxIon = p.getParameter<double>("IonThreshold") * MeV;
-  kmaxProton = p.getParameter<double>("ProtonThreshold") * MeV;
-  kmaxNeutron = p.getParameter<double>("NeutronThreshold") * MeV;
+  kmaxGamma = p.getParameter<double>("GammaThreshold") * CLHEP::MeV;
+  kmaxIon = p.getParameter<double>("IonThreshold") * CLHEP::MeV;
+  kmaxProton = p.getParameter<double>("ProtonThreshold") * CLHEP::MeV;
+  kmaxNeutron = p.getParameter<double>("NeutronThreshold") * CLHEP::MeV;
   killDeltaRay = p.getParameter<bool>("KillDeltaRay");
-  limitEnergyForVacuum = p.getParameter<double>("CriticalEnergyForVacuum") * MeV;
+  limitEnergyForVacuum = p.getParameter<double>("CriticalEnergyForVacuum") * CLHEP::MeV;
   maxTrackTime = p.getParameter<double>("MaxTrackTime") * ns;
+  maxZCentralCMS = p.getParameter<double>("MaxZCentralCMS") * CLHEP::m;
   maxTrackTimes = p.getParameter<std::vector<double> >("MaxTrackTimes");
   maxTimeNames = p.getParameter<std::vector<std::string> >("MaxTimeNames");
   deadRegionNames = p.getParameter<std::vector<std::string> >("DeadRegions");
@@ -46,8 +47,8 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   regionCastor = nullptr;
   regionWorld = nullptr;
 
-  gRusRoEnerLim = p.getParameter<double>("RusRoGammaEnergyLimit") * MeV;
-  nRusRoEnerLim = p.getParameter<double>("RusRoNeutronEnergyLimit") * MeV;
+  gRusRoEnerLim = p.getParameter<double>("RusRoGammaEnergyLimit") * CLHEP::MeV;
+  nRusRoEnerLim = p.getParameter<double>("RusRoNeutronEnergyLimit") * CLHEP::MeV;
 
   gRusRoEcal = p.getParameter<double>("RusRoEcalGamma");
   gRusRoHcal = p.getParameter<double>("RusRoHcalGamma");
@@ -92,28 +93,29 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
       << " Tracker: " << savePDandCinTracker << " in Calo: " << savePDandCinCalo << " in Muon: " << savePDandCinMuon
       << " everywhere: " << savePDandCinAll << "\n  saveFirstSecondary"
       << ": " << saveFirstSecondary << " Tracking neutrino flag: " << trackNeutrino
-      << " Kill Delta Ray flag: " << killDeltaRay << " Kill hadrons/ions flag: " << killHeavy;
+      << " Kill Delta Ray flag: " << killDeltaRay << " Kill hadrons/ions flag: " << killHeavy
+      << " MaxZCentralCMS = " << maxZCentralCMS / CLHEP::m << " m";
 
   if (killHeavy) {
-    edm::LogVerbatim("SimG4CoreApplication") << "StackingAction kill protons below " << kmaxProton / MeV
-                                             << " MeV, neutrons below " << kmaxNeutron / MeV << " MeV and ions"
-                                             << " below " << kmaxIon / MeV << " MeV";
+    edm::LogVerbatim("SimG4CoreApplication") << "StackingAction kill protons below " << kmaxProton / CLHEP::MeV
+                                             << " MeV, neutrons below " << kmaxNeutron / CLHEP::MeV << " MeV and ions"
+                                             << " below " << kmaxIon / CLHEP::MeV << " MeV";
   }
   killExtra = killDeltaRay || killHeavy || killInCalo || killInCaloEfH;
 
   edm::LogVerbatim("SimG4CoreApplication") << "StackingAction kill tracks with "
-                                           << "time larger than " << maxTrackTime / ns << " ns ";
+                                           << "time larger than " << maxTrackTime / CLHEP::ns << " ns ";
   numberTimes = maxTimeNames.size();
   if (0 < numberTimes) {
     for (unsigned int i = 0; i < numberTimes; ++i) {
       edm::LogVerbatim("SimG4CoreApplication")
-          << "StackingAction MaxTrackTime for " << maxTimeNames[i] << " is " << maxTrackTimes[i] << " ns ";
-      maxTrackTimes[i] *= ns;
+          << "          MaxTrackTime for " << maxTimeNames[i] << " is " << maxTrackTimes[i] << " ns ";
+      maxTrackTimes[i] *= CLHEP::ns;
     }
   }
   if (limitEnergyForVacuum > 0.0) {
     edm::LogVerbatim("SimG4CoreApplication")
-        << "StackingAction LowDensity regions - kill if E < " << limitEnergyForVacuum / MeV << " MeV";
+        << "StackingAction LowDensity regions - kill if E < " << limitEnergyForVacuum / CLHEP::MeV << " MeV";
     printRegions(lowdensRegions, "LowDensity");
   }
   if (deadRegions.size() > 0.0) {
@@ -123,7 +125,7 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   if (gRRactive) {
     edm::LogVerbatim("SimG4CoreApplication")
         << "StackingAction: "
-        << "Russian Roulette for gamma Elimit(MeV)= " << gRusRoEnerLim / MeV << "\n"
+        << "Russian Roulette for gamma Elimit(MeV)= " << gRusRoEnerLim / CLHEP::MeV << "\n"
         << "                 ECAL Prob= " << gRusRoEcal << "\n"
         << "                 HCAL Prob= " << gRusRoHcal << "\n"
         << "             MuonIron Prob= " << gRusRoMuonIron << "\n"
@@ -134,7 +136,7 @@ StackingAction::StackingAction(const TrackingAction* trka, const edm::ParameterS
   if (nRRactive) {
     edm::LogVerbatim("SimG4CoreApplication")
         << "StackingAction: "
-        << "Russian Roulette for neutron Elimit(MeV)= " << nRusRoEnerLim / MeV << "\n"
+        << "Russian Roulette for neutron Elimit(MeV)= " << nRusRoEnerLim / CLHEP::MeV << "\n"
         << "                 ECAL Prob= " << nRusRoEcal << "\n"
         << "                 HCAL Prob= " << nRusRoHcal << "\n"
         << "             MuonIron Prob= " << nRusRoMuonIron << "\n"
@@ -182,17 +184,24 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track* aTrac
   } else {
     // secondary
     const G4Region* reg = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+
     // definetly killed tracks
     if (aTrack->GetTrackStatus() == fStopAndKill) {
       classification = fKill;
     } else if (!trackNeutrino && (abspdg == 12 || abspdg == 14 || abspdg == 16 || abspdg == 18)) {
       classification = fKill;
-    } else if (isItOutOfTimeWindow(reg, aTrack)) {
-      classification = fKill;
-    }
 
-    // potentially good for tracking
-    else {
+    } else if (std::abs(aTrack->GetPosition().z()) >= maxZCentralCMS) {
+      // very forward secondary
+      const G4Track* mother = trackAction->geant4Track();
+      newTA->secondary(aTrack, *mother, 0);
+
+    } else if (isItOutOfTimeWindow(reg, aTrack)) {
+      // time window check
+      classification = fKill;
+
+    } else {
+      // potentially good for tracking
       double ke = aTrack->GetKineticEnergy();
 
       // kill tracks in specific regions

--- a/SimG4Core/Generators/interface/Generator.h
+++ b/SimG4Core/Generators/interface/Generator.h
@@ -55,6 +55,7 @@ private:
   double theDecRCut2;
   double theEtaCutForHector;
   double theDecLenCut;
+  double maxZCentralCMS;
   int verbose;
   LumiMonitorFilter *fLumiFilter;
   HepMC::GenEvent *evt_;


### PR DESCRIPTION
#### PR description:
Several modifications which affect MC histories:
  1) introduced parameter Zmax for central detector (current default 50 m)
  2) if a primary vertex is outside Zmax no cuts are applied to secondaries
  3) SteppingAction - if a step happens at Z outside Zmax no region or time cuts are applied
  4) StackingAction - if a new track is outside Zmax no region or time cut is applied 
  5) Castor shower library is disabled 

#### PR validation:
 ZDC hits are recovered, history of simulation is changed, so no regression is expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
not expected today

