### PR TITLE
Adding xangle and beta* filter

### DIFF
--- a/CondTools/RunInfo/plugins/BuildFile.xml
+++ b/CondTools/RunInfo/plugins/BuildFile.xml
@@ -42,3 +42,7 @@
 <library file="RunInfoTestESProducer.cc" name="CondToolsRunInfoTestESProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="XangleBetaStarFilter.cc">
+  <flags EDM_PLUGIN="1"/>
+</library>

--- a/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
+++ b/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
@@ -31,7 +31,7 @@ private:
   double beta_star_min_;
   double beta_star_max_;
 
-  virtual bool filter(edm::Event &, const edm::EventSetup &) override;
+  bool filter(edm::Event &, const edm::EventSetup &) override;
 };
 
 //----------------------------------------------------------------------------------------------------

--- a/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
+++ b/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
@@ -1,0 +1,78 @@
+/****************************************************************************
+ * Authors:
+ *   Jan Kašpar
+ ****************************************************************************/
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "CondFormats/RunInfo/interface/LHCInfo.h"
+#include "CondFormats/DataRecord/interface/LHCInfoRcd.h"
+
+//----------------------------------------------------------------------------------------------------
+
+class XangleBetaStarFilter : public edm::EDFilter
+{
+  public:
+    explicit XangleBetaStarFilter(const edm::ParameterSet&);
+
+    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+  private:
+    edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+
+    double xangle_min_;
+    double xangle_max_;
+
+    double beta_star_min_;
+    double beta_star_max_;
+
+    virtual bool filter(edm::Event &, const edm::EventSetup &) override;
+};
+
+//----------------------------------------------------------------------------------------------------
+
+XangleBetaStarFilter::XangleBetaStarFilter(const edm::ParameterSet& iConfig) :
+  lhcInfoToken_(esConsumes<LHCInfo, LHCInfoRcd>(edm::ESInputTag{"", iConfig.getParameter<std::string>("lhcInfoLabel")})),
+
+  xangle_min_(iConfig.getParameter<double>("xangle_min")),
+  xangle_max_(iConfig.getParameter<double>("xangle_max")),
+  beta_star_min_(iConfig.getParameter<double>("beta_star_min")),
+  beta_star_max_(iConfig.getParameter<double>("beta_star_max"))
+{
+}
+
+//----------------------------------------------------------------------------------------------------
+
+void XangleBetaStarFilter::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+
+  desc.add<std::string>("lhcInfoLabel", "")->setComment("label of the LHCInfo record");
+
+  desc.add<double>("xangle_min", 0.);
+  desc.add<double>("xangle_max", 1000.);
+
+  desc.add<double>("beta_star_min", 0.);
+  desc.add<double>("beta_star_max", 1000.);
+
+  descriptions.add("xangleBetaStarFilter", desc);
+}
+
+//----------------------------------------------------------------------------------------------------
+
+bool XangleBetaStarFilter::filter(edm::Event& /*iEvent*/, const edm::EventSetup& iSetup)
+{
+  const auto &lhcInfo = iSetup.getData(lhcInfoToken_);
+
+  return (xangle_min_ <= lhcInfo.crossingAngle() && lhcInfo.crossingAngle() < xangle_max_)
+    && (beta_star_min_ <= lhcInfo.betaStar() && lhcInfo.betaStar() < beta_star_max_);
+}
+
+//----------------------------------------------------------------------------------------------------
+
+DEFINE_FWK_MODULE(XangleBetaStarFilter);

--- a/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
+++ b/CondTools/RunInfo/plugins/XangleBetaStarFilter.cc
@@ -16,36 +16,34 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class XangleBetaStarFilter : public edm::EDFilter
-{
-  public:
-    explicit XangleBetaStarFilter(const edm::ParameterSet&);
+class XangleBetaStarFilter : public edm::EDFilter {
+public:
+  explicit XangleBetaStarFilter(const edm::ParameterSet &);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  private:
-    edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+private:
+  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
 
-    double xangle_min_;
-    double xangle_max_;
+  double xangle_min_;
+  double xangle_max_;
 
-    double beta_star_min_;
-    double beta_star_max_;
+  double beta_star_min_;
+  double beta_star_max_;
 
-    virtual bool filter(edm::Event &, const edm::EventSetup &) override;
+  virtual bool filter(edm::Event &, const edm::EventSetup &) override;
 };
 
 //----------------------------------------------------------------------------------------------------
 
-XangleBetaStarFilter::XangleBetaStarFilter(const edm::ParameterSet& iConfig) :
-  lhcInfoToken_(esConsumes<LHCInfo, LHCInfoRcd>(edm::ESInputTag{"", iConfig.getParameter<std::string>("lhcInfoLabel")})),
+XangleBetaStarFilter::XangleBetaStarFilter(const edm::ParameterSet &iConfig)
+    : lhcInfoToken_(
+          esConsumes<LHCInfo, LHCInfoRcd>(edm::ESInputTag{"", iConfig.getParameter<std::string>("lhcInfoLabel")})),
 
-  xangle_min_(iConfig.getParameter<double>("xangle_min")),
-  xangle_max_(iConfig.getParameter<double>("xangle_max")),
-  beta_star_min_(iConfig.getParameter<double>("beta_star_min")),
-  beta_star_max_(iConfig.getParameter<double>("beta_star_max"))
-{
-}
+      xangle_min_(iConfig.getParameter<double>("xangle_min")),
+      xangle_max_(iConfig.getParameter<double>("xangle_max")),
+      beta_star_min_(iConfig.getParameter<double>("beta_star_min")),
+      beta_star_max_(iConfig.getParameter<double>("beta_star_max")) {}
 
 //----------------------------------------------------------------------------------------------------
 
@@ -65,12 +63,11 @@ void XangleBetaStarFilter::fillDescriptions(edm::ConfigurationDescriptions &desc
 
 //----------------------------------------------------------------------------------------------------
 
-bool XangleBetaStarFilter::filter(edm::Event& /*iEvent*/, const edm::EventSetup& iSetup)
-{
+bool XangleBetaStarFilter::filter(edm::Event & /*iEvent*/, const edm::EventSetup &iSetup) {
   const auto &lhcInfo = iSetup.getData(lhcInfoToken_);
 
-  return (xangle_min_ <= lhcInfo.crossingAngle() && lhcInfo.crossingAngle() < xangle_max_)
-    && (beta_star_min_ <= lhcInfo.betaStar() && lhcInfo.betaStar() < beta_star_max_);
+  return (xangle_min_ <= lhcInfo.crossingAngle() && lhcInfo.crossingAngle() < xangle_max_) &&
+         (beta_star_min_ <= lhcInfo.betaStar() && lhcInfo.betaStar() < beta_star_max_);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CondTools/RunInfo/test/xangleBetaStarFilter_test_cfg.py
+++ b/CondTools/RunInfo/test/xangleBetaStarFilter_test_cfg.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+# define global tag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '106X_dataRun2_v28', '')
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+  statistics = cms.untracked.vstring(),
+  destinations = cms.untracked.vstring('cout'),
+  cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('WARNING')
+  )
+)
+
+# data source
+process.source = cms.Source("PoolSource",
+  fileNames = cms.untracked.vstring("/store/data/Run2018D/EGamma/MINIAOD/12Nov2019_UL2018-v4/280000/FF9D0498-30CA-7241-A85C-6F4F272A7A16.root")
+)
+
+#process.maxEvents = cms.untracked.PSet(
+#  input = cms.untracked.int32(1000)
+#)
+
+# filter
+process.load("CondTools.RunInfo.xangleBetaStarFilter_cfi")
+process.xangleBetaStarFilter.xangle_min = 150
+process.xangleBetaStarFilter.xangle_max = 170
+
+# plotters
+process.plotterBefore = cms.EDAnalyzer("CTPPSLHCInfoPlotter",
+  lhcInfoLabel = cms.string(""),
+  outputFile = cms.string("output_before_filter.root")
+)
+
+process.plotterAfter = cms.EDAnalyzer("CTPPSLHCInfoPlotter",
+  lhcInfoLabel = cms.string(""),
+  outputFile = cms.string("output_after_filter.root")
+)
+
+# path
+process.p = cms.Path(
+    process.plotterBefore
+    * process.xangleBetaStarFilter
+    * process.plotterAfter
+)


### PR DESCRIPTION
#### PR description:

This PR adds a crossing-angle and beta* filter. This is expected to be useful for subdetectors depending on the LHC settings, e.g. (CT)PPS.

The new filter is not used in any central workflow, thus no changes are expected.

#### PR validation:

The filter has been tested with the included config ``CondTools/RunInfo/test/xangleBetaStarFilter_test_cfg.py`` which runs on a 2018D miniAOD file and filters events taken with 150 <= xangle < 170. The xangle and beta* histograms, before (blue) and after (red dashed) the filter show the expected behaviour:

![make_cmp](https://user-images.githubusercontent.com/17830858/90410626-e5a3c980-e0aa-11ea-9491-cfef6edba6f8.png)
