### PR TITLE
improving performance of PuppiProducer

### DIFF
--- a/CommonTools/PileupAlgos/BuildFile.xml
+++ b/CommonTools/PileupAlgos/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="root"/>
 <use name="rootcore"/>
-<use name="fastjet"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CommonTools/PileupAlgos/interface/PuppiAlgo.h
+++ b/CommonTools/PileupAlgos/interface/PuppiAlgo.h
@@ -35,6 +35,8 @@ public:
   inline double rms() const { return cur_RMS; }
   inline double median() const { return cur_Med; }
 
+  inline double etaMaxExtrap() const { return fEtaMaxExtrap; }
+
 private:
   unsigned int fNAlgos;
   std::vector<double> fEtaMax;

--- a/CommonTools/PileupAlgos/interface/PuppiCandidate.h
+++ b/CommonTools/PileupAlgos/interface/PuppiCandidate.h
@@ -1,29 +1,13 @@
-#ifndef CommonTools_PileupAlgos_PuppiCandidate
-#define CommonTools_PileupAlgos_PuppiCandidate
+#ifndef CommonTools_PileupAlgos_PuppiCandidate_h
+#define CommonTools_PileupAlgos_PuppiCandidate_h
 
-#include "fastjet/PseudoJet.hh"
-
-// Extension of fastjet::PseudoJet that caches eta and some other info
-// Puppi uses register to decide between NHs, PV CHs, and PU CHs.
-class PuppiCandidate : public fastjet::PseudoJet {
-public:
-  using fastjet::PseudoJet::PseudoJet;
-  double pseudorapidity() const {
-    _ensure_valid_eta();
-    return _eta;
-  }
-  double eta() const { return pseudorapidity(); }
-  void _ensure_valid_eta() const {
-    if (_eta == fastjet::pseudojet_invalid_rap)
-      _eta = fastjet::PseudoJet::pseudorapidity();
-  }
-  void set_info(int puppi_register) { _puppi_register = puppi_register; }
-  inline int puppi_register() const { return _puppi_register; }
-
-private:
-  // variable names in fastjet style
-  mutable double _eta = fastjet::pseudojet_invalid_rap;
-  int _puppi_register;
+struct PuppiCandidate {
+  double pt{0};
+  double eta{0};
+  double phi{0};
+  double m{0};
+  double rapidity{0};
+  int id{0};
 };
 
 #endif

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -2,8 +2,8 @@
 #define COMMONTOOLS_PUPPI_PUPPICONTAINER_H_
 
 #include "CommonTools/PileupAlgos/interface/PuppiAlgo.h"
-#include "CommonTools/PileupAlgos/interface/RecoObj.h"
 #include "CommonTools/PileupAlgos/interface/PuppiCandidate.h"
+#include "CommonTools/PileupAlgos/interface/RecoObj.h"
 
 class PuppiContainer {
 public:
@@ -13,7 +13,6 @@ public:
   void setNPV(int iNPV) { fNPV = iNPV; }
 
   std::vector<PuppiCandidate> const &pfParticles() const { return fPFParticles; }
-  std::vector<PuppiCandidate> const &pvParticles() const { return fChargedPV; }
   std::vector<double> const &puppiWeights();
   const std::vector<double> &puppiRawAlphas() { return fRawAlphas; }
   const std::vector<double> &puppiAlphas() { return fVals; }
@@ -43,7 +42,8 @@ protected:
   bool fPuppiDiagnostics;
   const std::vector<RecoObj> *fRecoParticles;
   std::vector<PuppiCandidate> fPFParticles;
-  std::vector<PuppiCandidate> fChargedPV;
+  std::vector<PuppiCandidate> fPFParticlesForVar;
+  std::vector<PuppiCandidate> fPFParticlesForVarChargedPV;
   std::vector<double> fWeights;
   std::vector<double> fVals;
   std::vector<double> fRawAlphas;
@@ -62,7 +62,6 @@ protected:
   double fPtMaxNeutralsStartSlope;
   int fNAlgos;
   int fNPV;
-  double fPVFrac;
   std::vector<PuppiAlgo> fPuppiAlgo;
 };
 #endif

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -18,7 +18,6 @@
 #include "DataFormats/Common/interface/Association.h"
 //Main File
 #include "CommonTools/PileupAlgos/plugins/PuppiProducer.h"
-#include "CommonTools/PileupAlgos/interface/PuppiCandidate.h"
 
 // ------------------------------------------------------------------------------------------
 PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {

--- a/CommonTools/PileupAlgos/src/PuppiAlgo.cc
+++ b/CommonTools/PileupAlgos/src/PuppiAlgo.cc
@@ -85,24 +85,24 @@ void PuppiAlgo::fixAlgoEtaBin(int i_eta) {
 }
 
 void PuppiAlgo::add(const PuppiCandidate &iParticle, const double &iVal, const unsigned int iAlgo) {
-  if (iParticle.pt() < fRMSPtMin[iAlgo])
+  if (iParticle.pt < fRMSPtMin[iAlgo])
     return;
   // Change from SRR : Previously used fastjet::PseudoJet::user_index to decide the particle type.
   // In CMSSW we use the user_index to specify the index in the input collection, so I invented
   // a new mechanism using the fastjet UserInfo functionality. Of course, it's still just an integer
   // but that interface could be changed (or augmented) if desired / needed.
-  int puppi_id = iParticle.puppi_register();
+  int puppi_id = iParticle.id;
   if (puppi_id == std::numeric_limits<int>::lowest()) {
     throw cms::Exception("PuppiRegisterNotSet") << "The puppi register is not set. This must be set before use.\n";
   }
 
   // added by Nhan -- for all eta regions, compute mean/RMS from the central charged PU
-  if ((std::abs(iParticle.eta()) < fEtaMaxExtrap) && (puppi_id == 2)) {
+  if ((std::abs(iParticle.eta) < fEtaMaxExtrap) && (puppi_id == 2)) {
     fPups.push_back(iVal);
     fNCount[iAlgo]++;
   }
   // for the low PU case, correction.  for checking that the PU-only median will be below the PV particles
-  if (std::abs(iParticle.eta()) < fEtaMaxExtrap && (puppi_id == 1))
+  if (std::abs(iParticle.eta) < fEtaMaxExtrap && (puppi_id == 1))
     fPupsPV.push_back(iVal);
 }
 
@@ -158,7 +158,6 @@ void PuppiAlgo::computeMedRMS(const unsigned int &iAlgo) {
 
   if (fAdjust[iAlgo]) {
     //Adjust the p-value to correspond to the median
-    std::sort(fPupsPV.begin(), fPupsPV.end());
     int lNPV = 0;
     for (unsigned int i0 = 0; i0 < fPupsPV.size(); i0++)
       if (fPupsPV[i0] <= lMed)

--- a/CommonTools/PileupAlgos/src/PuppiCandidate.cc
+++ b/CommonTools/PileupAlgos/src/PuppiCandidate.cc
@@ -1,1 +1,0 @@
-#include "CommonTools/PileupAlgos/interface/PuppiCandidate.h"

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -7,6 +7,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
+#include "fastjet/PseudoJet.hh"
+
 using namespace std;
 
 PuppiContainer::PuppiContainer(const edm::ParameterSet &iConfig) {
@@ -30,39 +32,46 @@ PuppiContainer::PuppiContainer(const edm::ParameterSet &iConfig) {
 void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
   //Clear everything
   fPFParticles.resize(0);
-  fChargedPV.resize(0);
+  fPFParticlesForVar.resize(0);
+  fPFParticlesForVarChargedPV.resize(0);
   fWeights.resize(0);
   fVals.resize(0);
   fRawAlphas.resize(0);
   fAlphaMed.resize(0);
   fAlphaRMS.resize(0);
-  //fChargedNoPV.resize(0);
-  //Link to the RecoObjects
-  fPVFrac = 0.;
   fNPV = 1.;
+  //Link to the RecoObjects
   fRecoParticles = &iRecoObjects;
+  fPFParticles.reserve(iRecoObjects.size());
+  fPFParticlesForVar.reserve(iRecoObjects.size());
+  fPFParticlesForVarChargedPV.reserve(iRecoObjects.size());
   for (auto const &rParticle : *fRecoParticles) {
-    PuppiCandidate curPseudoJet;
-    // float nom = sqrt((rParticle.m)*(rParticle.m) + (rParticle.pt)*(rParticle.pt)*(cosh(rParticle.eta))*(cosh(rParticle.eta))) + (rParticle.pt)*sinh(rParticle.eta);//hacked
-    // float denom = sqrt((rParticle.m)*(rParticle.m) + (rParticle.pt)*(rParticle.pt));//hacked
-    // float rapidity = log(nom/denom);//hacked
+    fastjet::PseudoJet curPseudoJet;
     if (edm::isFinite(rParticle.rapidity)) {
       curPseudoJet.reset_PtYPhiM(rParticle.pt, rParticle.rapidity, rParticle.phi, rParticle.m);  //hacked
     } else {
       curPseudoJet.reset_PtYPhiM(0, 99., 0, 0);  //skipping may have been a better choice
     }
-    //curPseudoJet.reset_PtYPhiM(rParticle.pt,rParticle.eta,rParticle.phi,rParticle.m);
-    // fill puppi_register
-    curPseudoJet.set_info(rParticle.id);
-    // fill vector of pseudojets for internal references
-    fPFParticles.push_back(curPseudoJet);
+    PuppiCandidate pCand;
+    pCand.pt = curPseudoJet.pt();
+    pCand.eta = curPseudoJet.eta();
+    pCand.rapidity = curPseudoJet.rap();
+    pCand.phi = curPseudoJet.phi();
+    pCand.m = curPseudoJet.m();
+    pCand.id = rParticle.id;
+
+    fPFParticles.push_back(pCand);
     //Take Charged particles associated to PV
+    if (std::abs(rParticle.id) == 3)
+      continue;
+    fPFParticlesForVar.push_back(pCand);
     if (std::abs(rParticle.id) == 1)
-      fChargedPV.push_back(curPseudoJet);
-    //if(rParticle.id == 3) _chargedNoPV.push_back(curPseudoJet);
+      fPFParticlesForVarChargedPV.push_back(pCand);
+    //if(rParticle.id == 3) _chargedNoPV.push_back(pCand);
     // if(fNPV < rParticle.vtxId) fNPV = rParticle.vtxId;
   }
 }
+
 PuppiContainer::~PuppiContainer() {}
 
 double PuppiContainer::goodVar(PuppiCandidate const &iPart,
@@ -77,70 +86,51 @@ double PuppiContainer::var_within_R(int iId,
                                     const PuppiCandidate &centre,
                                     const double R) {
   if (iId == -1)
-    return 1;
+    return 1.;
 
-  //this is a circle in rapidity-phi
-  //it would make more sense to have var definition consistent
-  //fastjet::Selector sel = fastjet::SelectorCircle(R);
-  //sel.set_reference(centre);
-  //the original code used Selector infrastructure: it is too heavy here
-  //logic of SelectorCircle is preserved below
+  double const r2(R * R);
+  double var(0.);
 
-  vector<double> near_dR2s;
-  near_dR2s.reserve(std::min(50UL, particles.size()));
-  vector<double> near_pts;
-  near_pts.reserve(std::min(50UL, particles.size()));
-  const double r2 = R * R;
-  for (auto const &part : particles) {
-    if (part.puppi_register() == 3)
-      continue;
-    //squared_distance is in (y,phi) coords: rap() has faster access -> check it first
-    if (std::abs(part.rap() - centre.rap()) < R && part.squared_distance(centre) < r2) {
-      near_dR2s.push_back(reco::deltaR2(part, centre));
-      near_pts.push_back(part.pt());
+  for (auto const &cand : particles) {
+    if (std::abs(cand.rapidity - centre.rapidity) < R) {
+      auto const dr2y(reco::deltaR2(cand.rapidity, cand.phi, centre.rapidity, centre.phi));
+      if (dr2y < r2) {
+        auto const dr2(reco::deltaR2(cand.eta, cand.phi, centre.eta, centre.phi));
+        if (dr2 < 0.0001)
+          continue;
+        auto const pt(cand.pt);
+        if (iId == 5)
+          var += (pt * pt / dr2);
+        else if (iId == 4)
+          var += pt;
+        else if (iId == 3)
+          var += (1. / dr2);
+        else if (iId == 2)
+          var += (1. / dr2);
+        else if (iId == 1)
+          var += pt;
+        else if (iId == 0)
+          var += (pt / dr2);
+      }
     }
   }
-  double var = 0;
-  //double lSumPt = 0;
-  //if(iId == 1) for(auto  pt : near_pts) lSumPt += pt;
-  auto nParts = near_dR2s.size();
-  for (auto i = 0UL; i < nParts; ++i) {
-    auto dr2 = near_dR2s[i];
-    auto pt = near_pts[i];
-    if (dr2 < 0.0001)
-      continue;
-    if (iId == 0)
-      var += (pt / dr2);
-    else if (iId == 1)
-      var += pt;
-    else if (iId == 2)
-      var += (1. / dr2);
-    else if (iId == 3)
-      var += (1. / dr2);
-    else if (iId == 4)
-      var += pt;
-    else if (iId == 5)
-      var += (pt * pt / dr2);
-  }
-  if (iId == 1)
-    var += centre.pt();  //Sum in a cone
-  else if (iId == 0 && var != 0)
+
+  if ((var != 0.) and ((iId == 0) or (iId == 3) or (iId == 5)))
     var = log(var);
-  else if (iId == 3 && var != 0)
-    var = log(var);
-  else if (iId == 5 && var != 0)
-    var = log(var);
+  else if (iId == 1)
+    var += centre.pt;
+
   return var;
 }
+
 //In fact takes the median not the average
 void PuppiContainer::getRMSAvg(int iOpt,
                                std::vector<PuppiCandidate> const &iConstits,
                                std::vector<PuppiCandidate> const &iParticles,
                                std::vector<PuppiCandidate> const &iChargedParticles) {
   for (unsigned int i0 = 0; i0 < iConstits.size(); i0++) {
-    double pVal = -1;
     //Calculate the Puppi Algo to use
-    int pPupId = getPuppiId(iConstits[i0].pt(), iConstits[i0].eta());
+    int pPupId = getPuppiId(iConstits[i0].pt, iConstits[i0].eta);
     if (pPupId == -1 || fPuppiAlgo[pPupId].numAlgos() <= iOpt) {
       fVals.push_back(-1);
       continue;
@@ -150,40 +140,46 @@ void PuppiContainer::getRMSAvg(int iOpt,
     bool pCharged = fPuppiAlgo[pPupId].isCharged(iOpt);
     double pCone = fPuppiAlgo[pPupId].coneSize(iOpt);
     //Compute the Puppi Metric
-    if (!pCharged)
-      pVal = goodVar(iConstits[i0], iParticles, pAlgo, pCone);
-    if (pCharged)
-      pVal = goodVar(iConstits[i0], iChargedParticles, pAlgo, pCone);
+    double pVal = -1;
+    // calculate goodVar only for candidates that (1) will not be assigned a predefined weight (e.g 0, 1),
+    // or (2) are required for computations inside puppi-algos (see call to PuppiAlgo::add below)
+    if (((not(fApplyCHS and ((iConstits[i0].id == 1) or (iConstits[i0].id == 2)))) and (iConstits[i0].id != 3)) or
+        ((std::abs(iConstits[i0].eta) < fPuppiAlgo[pPupId].etaMaxExtrap()) and
+         ((iConstits[i0].id == 1) or (iConstits[i0].id == 2)))) {
+      pVal = goodVar(iConstits[i0], pCharged ? iChargedParticles : iParticles, pAlgo, pCone);
+    }
     fVals.push_back(pVal);
-    //if(std::isnan(pVal) || std::isinf(pVal)) cerr << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt() << " -- " << iConstits[i0].eta() << endl;
+    //if(std::isnan(pVal) || std::isinf(pVal)) cerr << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt << " -- " << iConstits[i0].eta << endl;
     if (!edm::isFinite(pVal)) {
-      LogDebug("NotFound") << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt() << " -- "
-                           << iConstits[i0].eta() << endl;
+      LogDebug("NotFound") << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt << " -- " << iConstits[i0].eta
+                           << endl;
       continue;
     }
 
-    // // fPuppiAlgo[pPupId].add(iConstits[i0],pVal,iOpt);
-    //code added by Nhan, now instead for every algorithm give it all the particles
+    // code added by Nhan: now instead for every algorithm give it all the particles
     for (int i1 = 0; i1 < fNAlgos; i1++) {
-      pAlgo = fPuppiAlgo[i1].algoId(iOpt);
-      pCharged = fPuppiAlgo[i1].isCharged(iOpt);
-      pCone = fPuppiAlgo[i1].coneSize(iOpt);
-      double curVal = -1;
+      // skip cands outside of algo's etaMaxExtrap, as they would anyway be ignored inside PuppiAlgo::add (see end of the block)
+      if (not((std::abs(iConstits[i0].eta) < fPuppiAlgo[i1].etaMaxExtrap()) and
+              ((iConstits[i0].id == 1) or (iConstits[i0].id == 2))))
+        continue;
+
+      auto curVal(pVal);
+      // recompute goodVar if algo has changed
       if (i1 != pPupId) {
-        if (!pCharged)
-          curVal = goodVar(iConstits[i0], iParticles, pAlgo, pCone);
-        if (pCharged)
-          curVal = goodVar(iConstits[i0], iChargedParticles, pAlgo, pCone);
-      } else {  //no need to repeat the computation
-        curVal = pVal;
+        pAlgo = fPuppiAlgo[i1].algoId(iOpt);
+        pCharged = fPuppiAlgo[i1].isCharged(iOpt);
+        pCone = fPuppiAlgo[i1].coneSize(iOpt);
+        curVal = goodVar(iConstits[i0], pCharged ? iChargedParticles : iParticles, pAlgo, pCone);
       }
-      //std::cout << "i1 = " << i1 << ", curVal = " << curVal << ", eta = " << iConstits[i0].eta() << ", pupID = " << pPupId << std::endl;
+
       fPuppiAlgo[i1].add(iConstits[i0], curVal, iOpt);
     }
   }
+
   for (int i0 = 0; i0 < fNAlgos; i0++)
     fPuppiAlgo[i0].computeMedRMS(iOpt);
 }
+
 //In fact takes the median not the average
 void PuppiContainer::getRawAlphas(int iOpt,
                                   std::vector<PuppiCandidate> const &iConstits,
@@ -191,25 +187,22 @@ void PuppiContainer::getRawAlphas(int iOpt,
                                   std::vector<PuppiCandidate> const &iChargedParticles) {
   for (int j0 = 0; j0 < fNAlgos; j0++) {
     for (unsigned int i0 = 0; i0 < iConstits.size(); i0++) {
-      double pVal = -1;
       //Get the Puppi Sub Algo (given iteration)
       int pAlgo = fPuppiAlgo[j0].algoId(iOpt);
       bool pCharged = fPuppiAlgo[j0].isCharged(iOpt);
       double pCone = fPuppiAlgo[j0].coneSize(iOpt);
       //Compute the Puppi Metric
-      if (!pCharged)
-        pVal = goodVar(iConstits[i0], iParticles, pAlgo, pCone);
-      if (pCharged)
-        pVal = goodVar(iConstits[i0], iChargedParticles, pAlgo, pCone);
+      double const pVal = goodVar(iConstits[i0], pCharged ? iChargedParticles : iParticles, pAlgo, pCone);
       fRawAlphas.push_back(pVal);
       if (!edm::isFinite(pVal)) {
-        LogDebug("NotFound") << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt() << " -- "
-                             << iConstits[i0].eta() << endl;
+        LogDebug("NotFound") << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt << " -- "
+                             << iConstits[i0].eta << endl;
         continue;
       }
     }
   }
 }
+
 int PuppiContainer::getPuppiId(float iPt, float iEta) {
   int lId = -1;
   for (int i0 = 0; i0 < fNAlgos; i0++) {
@@ -257,10 +250,10 @@ std::vector<double> const &PuppiContainer::puppiWeights() {
     lNMaxAlgo = std::max(fPuppiAlgo[i0].numAlgos(), lNMaxAlgo);
   //Run through all compute mean and RMS
   for (int i0 = 0; i0 < lNMaxAlgo; i0++) {
-    getRMSAvg(i0, fPFParticles, fPFParticles, fChargedPV);
+    getRMSAvg(i0, fPFParticles, fPFParticlesForVar, fPFParticlesForVarChargedPV);
   }
   if (fPuppiDiagnostics)
-    getRawAlphas(0, fPFParticles, fPFParticles, fChargedPV);
+    getRawAlphas(0, fPFParticles, fPFParticlesForVar, fPFParticlesForVarChargedPV);
 
   std::vector<double> pVals;
   pVals.reserve(lNParticles);
@@ -309,18 +302,16 @@ std::vector<double> const &PuppiContainer::puppiWeights() {
                                    << " -- id :  " << rParticle.id << " --  NAlgos: " << lNAlgos << std::endl;
     }
     //Basic Cuts
-    if (pWeight * fPFParticles[i0].pt() < fPuppiAlgo[pPupId].neutralPt(fNPV) && rParticle.id == 0)
+    if (pWeight * fPFParticles[i0].pt < fPuppiAlgo[pPupId].neutralPt(fNPV) && rParticle.id == 0)
       pWeight = 0;  //threshold cut on the neutral Pt
     // Protect high pT photons (important for gamma to hadronic recoil balance)
-    if ((fPtMaxPhotons > 0) && (rParticle.pdgId == 22) && (std::abs(fPFParticles[i0].eta()) < fEtaMaxPhotons) &&
-        (fPFParticles[i0].pt() > fPtMaxPhotons))
+    if ((fPtMaxPhotons > 0) && (rParticle.pdgId == 22) && (std::abs(fPFParticles[i0].eta) < fEtaMaxPhotons) &&
+        (fPFParticles[i0].pt > fPtMaxPhotons))
       pWeight = 1.;
     // Protect high pT neutrals
     else if ((fPtMaxNeutrals > 0) && (rParticle.id == 0))
-      pWeight =
-          std::clamp((fPFParticles[i0].pt() - fPtMaxNeutralsStartSlope) / (fPtMaxNeutrals - fPtMaxNeutralsStartSlope),
-                     pWeight,
-                     1.);
+      pWeight = std::clamp(
+          (fPFParticles[i0].pt - fPtMaxNeutralsStartSlope) / (fPtMaxNeutrals - fPtMaxNeutralsStartSlope), pWeight, 1.);
     if (pWeight < fPuppiWeightCut)
       pWeight = 0;  //==> Elminate the low Weight stuff
     if (fInvert)

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -71,7 +71,6 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     // charged candidates assigned to LV
     if (std::abs(rParticle.id) == 1)
       fPFParticlesForVarChargedPV.push_back(pCand);
-    //if(rParticle.id == 3) _chargedNoPV.push_back(pCand);
     // if(fNPV < rParticle.vtxId) fNPV = rParticle.vtxId;
   }
 }
@@ -153,7 +152,7 @@ void PuppiContainer::getRMSAvg(int iOpt,
       pVal = goodVar(iConstits[i0], pCharged ? iChargedParticles : iParticles, pAlgo, pCone);
     }
     fVals.push_back(pVal);
-    //if(std::isnan(pVal) || std::isinf(pVal)) cerr << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt << " -- " << iConstits[i0].eta << endl;
+
     if (!edm::isFinite(pVal)) {
       LogDebug("NotFound") << "====> Value is Nan " << pVal << " == " << iConstits[i0].pt << " -- " << iConstits[i0].eta
                            << endl;

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -91,17 +91,17 @@ double PuppiContainer::var_within_R(int iId,
   if (iId == -1)
     return 1.;
 
-  double const r2(R * R);
-  double var(0.);
+  double const r2 = R * R;
+  double var = 0.;
 
   for (auto const &cand : particles) {
     if (std::abs(cand.rapidity - centre.rapidity) < R) {
-      auto const dr2y(reco::deltaR2(cand.rapidity, cand.phi, centre.rapidity, centre.phi));
+      auto const dr2y = reco::deltaR2(cand.rapidity, cand.phi, centre.rapidity, centre.phi);
       if (dr2y < r2) {
-        auto const dr2(reco::deltaR2(cand.eta, cand.phi, centre.eta, centre.phi));
+        auto const dr2 = reco::deltaR2(cand.eta, cand.phi, centre.eta, centre.phi);
         if (dr2 < 0.0001)
           continue;
-        auto const pt(cand.pt);
+        auto const pt = cand.pt;
         if (iId == 5)
           var += (pt * pt / dr2);
         else if (iId == 4)
@@ -166,7 +166,7 @@ void PuppiContainer::getRMSAvg(int iOpt,
               ((iConstits[i0].id == 1) or (iConstits[i0].id == 2))))
         continue;
 
-      auto curVal(pVal);
+      auto curVal = pVal;
       // recompute goodVar if algo has changed
       if (i1 != pPupId) {
         pAlgo = fPuppiAlgo[i1].algoId(iOpt);

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -7,8 +7,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/isFinite.h"
 
-#include "fastjet/PseudoJet.hh"
-
 using namespace std;
 
 PuppiContainer::PuppiContainer(const edm::ParameterSet &iConfig) {
@@ -46,19 +44,21 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
   fPFParticlesForVar.reserve(iRecoObjects.size());
   fPFParticlesForVarChargedPV.reserve(iRecoObjects.size());
   for (auto const &rParticle : *fRecoParticles) {
-    fastjet::PseudoJet curPseudoJet;
-    if (edm::isFinite(rParticle.rapidity)) {
-      curPseudoJet.reset_PtYPhiM(rParticle.pt, rParticle.rapidity, rParticle.phi, rParticle.m);  //hacked
-    } else {
-      curPseudoJet.reset_PtYPhiM(0, 99., 0, 0);  //skipping may have been a better choice
-    }
     PuppiCandidate pCand;
-    pCand.pt = curPseudoJet.pt();
-    pCand.eta = curPseudoJet.eta();
-    pCand.rapidity = curPseudoJet.rap();
-    pCand.phi = curPseudoJet.phi();
-    pCand.m = curPseudoJet.m();
     pCand.id = rParticle.id;
+    if (edm::isFinite(rParticle.rapidity)) {
+      pCand.pt = rParticle.pt;
+      pCand.eta = rParticle.eta;
+      pCand.rapidity = rParticle.rapidity;
+      pCand.phi = rParticle.phi;
+      pCand.m = rParticle.m;
+    } else {
+      pCand.pt = 0.;
+      pCand.eta = 99.;
+      pCand.rapidity = 99.;
+      pCand.phi = 0.;
+      pCand.m = 0.;
+    }
 
     fPFParticles.push_back(pCand);
 

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -61,10 +61,14 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     pCand.id = rParticle.id;
 
     fPFParticles.push_back(pCand);
-    //Take Charged particles associated to PV
+
+    // skip candidates to be ignored in the computation
+    // of PUPPI's alphas (e.g. electrons and muons if puppiNoLep=True)
     if (std::abs(rParticle.id) == 3)
       continue;
+
     fPFParticlesForVar.push_back(pCand);
+    // charged candidates assigned to LV
     if (std::abs(rParticle.id) == 1)
       fPFParticlesForVarChargedPV.push_back(pCand);
     //if(rParticle.id == 3) _chargedNoPV.push_back(pCand);


### PR DESCRIPTION
#### PR description:

This PR is an attempt to improve the performance (in terms of execution time) of the `PuppiProducer` plugin.

No changes in the outputs are expected.

Most of these technical changes are not in the producer itself, but in the `PuppiContainer` class; all changes are related (directly or indirectly) to the function `var_within_R` (the "alpha" variable on which the PUPPI weight is based), which appears to be the most time-consuming part of the algorithm.

The table below summarizes a few timing estimates for the `puppi` module in the RECO step for a Run-3 and Phase-2 workflow.

| wf | time pre-PR [ms] | time post-PR [ms] |
|---:|---:|---:|
| Run-3 RECO [(QCD MC)](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FRelValQCD_FlatPt_15_3000HS_14%2FCMSSW_11_2_0_pre3-PU_112X_mcRun3_2021_realistic_v5-v1%2FGEN-SIM-DIGI-RAW&instance=prod/global)    |  74.2 |  33.2 |
| Phase-2 RECO [(QCD MC)](https://cmsweb.cern.ch/das/request?input=dataset%3D%2FRelValQCD_Pt15To7000_Flat_14%2FCMSSW_11_2_0_pre3-PU25ns_110X_mcRun4_realistic_v3_2026D49PU200_rsb-v1%2FGEN-SIM-DIGI-RAW&instance=prod/global) |  620.1 | 255.9  |

The numbers are taken from the `FastTimerService`, running on 100 events; they suggest that the overall reduction in timing is approx. 55-60%.

Here is a short summary of the changes in the PR (below, `goodVar` and `var_within_R` are used interchangeably, since the former function is simply a call to the latter):

* `PuppiCandidate` is converted to a simple `struct`, removing its inheritance from `fastjet::PseudoJet` (looking at the PUPPI implementation as a whole, the usage of `fastjet` does not seem necessary); this change accounts for most of the speedup (approx. 35-40% speedup);

* skip the calculation of `goodVar` when not needed, e.g. for candidates that are assigned a default weight (0, or 1); this seems to bring roughly a 10-15% improvement in performance.

* another bit of speedup is obtained by taking one condition (`puppi_id != 3`) out of `var_within_R`, and using it just once in `PuppiContainer::initialize` to fill the collections later used as inputs to `goodVar`; this leads to adding one more data member (a `vector` of `PuppiCandidate`s) to the `PuppiContainer` class.

In this PR, there are two spots where things could certainly be improved (but improving them will lead to small changes in the outputs):

* in `PuppiContainer::initialize`, an instance of `fastjet::PseudoJet` ([here](https://github.com/cms-sw/cmssw/compare/master...missirol:devel_112X_puppi_speedup2?expand=1#diff-920ad87cd21790b241508fda9a732044R49)) is used to obtain the 4-momenta of the candidates used by PUPPI; this was the only way I could find to maintain the same numbers as pre-PR (this may be due to the fact that the inputs used for `reset_PtYPhiM` are floats, and then `fastjet` recomputes and stores the p4 using doubles); one way to simplify this (assuming the differences in the outputs are ultimately not significant) would be to remove `PuppiCandidate` altogether and simply use the `RecoObj` class already in use in the `PuppiProducer` (maybe, changing the floats in `RecoObj` to doubles).

* in `goodVar`, the `DeltaR2` between two given candidates is calculated (at most) twice ([here](https://github.com/cms-sw/cmssw/compare/master...missirol:devel_112X_puppi_speedup2?expand=1#diff-920ad87cd21790b241508fda9a732044R96)), first with rapidity, then with pseudo-rapidity; this is not modified by this PR (otherwise, the outputs would inevitably change), but maybe it’s something that could be simplified.

FYI: @ahinzmann @lathomas @kirschen

#### PR validation:

Checked that the PUPPI weights of all PF candidates are unchanged for 200 events (100 for a Run-3 workflow, and 100 for a Phase-2 workflow), for both `puppi` (used for jets) and `puppiNoLep` (used for MET).
Standard workflows, i.e. `runTheMatrix.py -l limited -i all --ibeos`, ran successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A
