### PR TITLE
Moved boost includes to the implementation file

### DIFF
--- a/CommonTools/CandAlgos/interface/decayParser.h
+++ b/CommonTools/CandAlgos/interface/decayParser.h
@@ -25,8 +25,6 @@
 #include <vector>
 #include <iostream>
 #include <string>
-#include <boost/spirit/include/classic_core.hpp>
-#include <boost/spirit/include/classic_push_back_actor.hpp>
 #include "FWCore/Utilities/interface/InputTag.h"
 
 // forward declarations

--- a/CommonTools/CandAlgos/src/decayParser.cc
+++ b/CommonTools/CandAlgos/src/decayParser.cc
@@ -11,6 +11,10 @@
 // $Id: decayParser.cc,v 1.1 2009/03/03 13:50:55 llista Exp $
 //
 #include "CommonTools/CandAlgos/interface/decayParser.h"
+
+#include <boost/spirit/include/classic_core.hpp>
+#include <boost/spirit/include/classic_push_back_actor.hpp>
+
 #include <vector>
 
 using namespace boost::spirit;


### PR DESCRIPTION


#### PR description:

Since boost headers are only used in the implementation. We could move the boost includes to the implementation file.
This change will increase modularity, and possibly helps us with c++20 clang modules.

#### PR validation:
Code compiled and passed on runTheMatrix test

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
@vgvassilev @davidlange6 
