### PR TITLE
Adapt track-vertex association in PUPPI (v15)

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -159,7 +159,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
             pReco.id = 3;
           else if (tmpFromPV == 0) {
             pReco.id = 2;
-            if (fNumOfPUVtxsForCharged > 0 and (pVtxId <= fNumOfPUVtxsForCharged) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs))
+            if (fNumOfPUVtxsForCharged > 0 and (pVtxId <= fNumOfPUVtxsForCharged) and
+                (std::abs(pDZ) < fDZCutForChargedFromPUVtxs))
               pReco.id = 1;
           } else if (tmpFromPV == 3)
             pReco.id = 1;
@@ -193,7 +194,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           } else if (lPack->fromPV() == 0) {
             pReco.id = 2;
             if ((fNumOfPUVtxsForCharged > 0) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) {
-              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged && puVtx_idx < pvCol->size(); ++puVtx_idx) {
+              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged && puVtx_idx < pvCol->size();
+                   ++puVtx_idx) {
                 if (lPack->fromPV(puVtx_idx) >= 2) {
                   pReco.id = 1;
                   break;

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -157,9 +157,11 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         } else {
           if (fPuppiNoLep && isLepton)
             pReco.id = 3;
-          else if (tmpFromPV == 0)
-            pReco.id = ((pVtxId <= fNumOfPUVtxsForCharged) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) ? 1 : 2;
-          else if (tmpFromPV == 3)
+          else if (tmpFromPV == 0) {
+            pReco.id = 2;
+            if (fNumOfPUVtxsForCharged > 0 and (pVtxId <= fNumOfPUVtxsForCharged) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs))
+              pReco.id = 1;
+          } else if (tmpFromPV == 3)
             pReco.id = 1;
           else if (tmpFromPV == 1 || tmpFromPV == 2) {
             pReco.id = 0;
@@ -191,10 +193,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           } else if (lPack->fromPV() == 0) {
             pReco.id = 2;
             if ((fNumOfPUVtxsForCharged > 0) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) {
-              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged; ++puVtx_idx) {
-                if (puVtx_idx >= pvCol->size()) {
-                  break;
-                } else if (lPack->fromPV(puVtx_idx) >= 2) {
+              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged && puVtx_idx < pvCol->size(); ++puVtx_idx) {
+                if (lPack->fromPV(puVtx_idx) >= 2) {
                   pReco.id = 1;
                   break;
                 }

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -32,6 +32,8 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
   fPtMaxPhotons = iConfig.getParameter<double>("PtMaxPhotons");
   fEtaMaxPhotons = iConfig.getParameter<double>("EtaMaxPhotons");
+  fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
+  fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
   fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
@@ -97,8 +99,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       const reco::Vertex* closestVtx = nullptr;
       double pDZ = -9999;
       double pD0 = -9999;
-      int pVtxId = -9999;
-      bool lFirst = true;
+      uint pVtxId = 0;
       bool isLepton = ((std::abs(pReco.pdgId) == 11) || (std::abs(pReco.pdgId) == 13));
       const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
       if (lPack == nullptr) {
@@ -106,6 +107,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         double curdz = 9999;
         int closestVtxForUnassociateds = -9999;
         const reco::TrackRef aTrackRef = pPF->trackRef();
+        bool lFirst = true;
         for (auto const& aV : *pvCol) {
           if (lFirst) {
             if (aTrackRef.isNonnull()) {
@@ -155,12 +157,11 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         } else {
           if (fPuppiNoLep && isLepton)
             pReco.id = 3;
-          else if (tmpFromPV == 0) {
-            pReco.id = 2;
-          }  // 0 is associated to PU vertex
-          else if (tmpFromPV == 3) {
+          else if (tmpFromPV == 0)
+            pReco.id = ((pVtxId <= fNumOfPUVtxsForCharged) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) ? 1 : 2;
+          else if (tmpFromPV == 3)
             pReco.id = 1;
-          } else if (tmpFromPV == 1 || tmpFromPV == 2) {
+          else if (tmpFromPV == 1 || tmpFromPV == 2) {
             pReco.id = 0;
             if ((fPtMaxCharged > 0) and (pReco.pt > fPtMaxCharged))
               pReco.id = 1;
@@ -185,12 +186,21 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
           pReco.id = 0;
         }
         if (std::abs(pReco.charge) > 0) {
-          if (fPuppiNoLep && isLepton)
+          if (fPuppiNoLep && isLepton) {
             pReco.id = 3;
-          else if (lPack->fromPV() == 0) {
+          } else if (lPack->fromPV() == 0) {
             pReco.id = 2;
-          }  // 0 is associated to PU vertex
-          else if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)) {
+            if ((fNumOfPUVtxsForCharged > 0) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) {
+              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged; ++puVtx_idx) {
+                if (puVtx_idx >= pvCol->size()) {
+                  break;
+                } else if (lPack->fromPV(puVtx_idx) >= 2) {
+                  pReco.id = 1;
+                  break;
+                }
+              }
+            }
+          } else if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)) {
             pReco.id = 1;
           } else if (lPack->fromPV() == (pat::PackedCandidate::PVTight) ||
                      lPack->fromPV() == (pat::PackedCandidate::PVLoose)) {
@@ -373,6 +383,8 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("EtaMaxPhotons", 2.5);
   desc.add<double>("PtMaxNeutrals", 200.);
   desc.add<double>("PtMaxNeutralsStartSlope", 0.);
+  desc.add<uint>("NumOfPUVtxsForCharged", 0);
+  desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);
   desc.add<bool>("clonePackedCands", false);
   desc.add<int>("vtxNdofCut", 4);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -62,12 +62,14 @@ private:
   bool fPuppiNoLep;
   bool fUseFromPVLooseTight;
   bool fUseDZ;
-  float fDZCut;
+  double fDZCut;
   double fEtaMinUseDZ;
   double fPtMaxCharged;
   double fEtaMaxCharged;
   double fPtMaxPhotons;
   double fEtaMaxPhotons;
+  uint fNumOfPUVtxsForCharged;
+  double fDZCutForChargedFromPUVtxs;
   bool fUseExistingWeights;
   bool fClonePackedCands;
   int fVtxNdofCut;

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -31,6 +31,8 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        UseDeltaZCut   = cms.bool(True),
                        EtaMinUseDeltaZ = cms.double(2.4),
                        DeltaZCut      = cms.double(0.3),
+                       NumOfPUVtxsForCharged = cms.uint32(2),
+                       DeltaZCutForChargedFromPUVtxs = cms.double(0.2),
 		       PtMaxCharged   = cms.double(20.),
 		       EtaMaxCharged   = cms.double(99999.),
 		       PtMaxPhotons = cms.double(-1.),
@@ -95,6 +97,7 @@ phase2_common.toModify(
     PtMaxCharged = -1.,
     PtMaxNeutralsStartSlope = 0.,
     DeltaZCut = cms.double(0.1),
+    NumOfPUVtxsForCharged = 0,
     algos = cms.VPSet( 
         cms.PSet( 
              etaMin = cms.vdouble(0.,  2.5),

--- a/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
+++ b/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-def UpdatePuppiTuneV14(process, runOnMC=True):
+def UpdatePuppiTuneV15(process, runOnMC=True):
   #
   # Adapt for re-running PUPPI
   #
-  print("customizePuppiTune_cff::UpdatePuppiTuneV14: Recomputing PUPPI with Tune v14, slimmedJetsPuppi and slimmedMETsPuppi")
+  print("customizePuppiTune_cff::UpdatePuppiTuneV15: Recomputing PUPPI with Tune v15, slimmedJetsPuppi and slimmedMETsPuppi")
   from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
   task = getPatAlgosToolsTask(process)
   from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
@@ -26,17 +26,19 @@ def UpdatePuppiTuneV14(process, runOnMC=True):
   del process.updatedPatJetsPuppiJetSpecific
   process.puppiSequence = cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi+process.patPuppiJetSpecificProducer+process.slimmedJetsPuppi)
   #
-  # Adapt for PUPPI tune V14
+  # Adapt for PUPPI tune V15
   #
   process.puppi.PtMaxCharged = 20.
   process.puppi.EtaMinUseDeltaZ = 2.4
   process.puppi.PtMaxNeutralsStartSlope = 20.
+  process.puppi.NumOfPUVtxsForCharged = 2
   process.puppiNoLep.PtMaxCharged = 20.
   process.puppiNoLep.EtaMinUseDeltaZ = 2.4
   process.puppiNoLep.PtMaxNeutralsStartSlope = 20.
+  process.puppiNoLep.NumOfPUVtxsForCharged = 2
 
-def UpdatePuppiTuneV14_MC(process):
-  UpdatePuppiTuneV14(process,runOnMC=True)
+def UpdatePuppiTuneV15_MC(process):
+  UpdatePuppiTuneV15(process,runOnMC=True)
 
-def UpdatePuppiTuneV14_Data(process):
-  UpdatePuppiTuneV14(process,runOnMC=False)
+def UpdatePuppiTuneV15_Data(process):
+  UpdatePuppiTuneV15(process,runOnMC=False)

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -215,7 +215,7 @@ int PuppiContainer::getPuppiId(float iPt, float iEta) {
   for (int i0 = 0; i0 < fNAlgos; i0++) {
     int nEtaBinsPerAlgo = fPuppiAlgo[i0].etaBins();
     for (int i1 = 0; i1 < nEtaBinsPerAlgo; i1++) {
-      if ((std::abs(iEta) > fPuppiAlgo[i0].etaMin(i1)) && (std::abs(iEta) < fPuppiAlgo[i0].etaMax(i1))) {
+      if ((std::abs(iEta) >= fPuppiAlgo[i0].etaMin(i1)) && (std::abs(iEta) < fPuppiAlgo[i0].etaMax(i1))) {
         fPuppiAlgo[i0].fixAlgoEtaBin(i1);
         if (iPt > fPuppiAlgo[i0].ptMin()) {
           lId = i0;


### PR DESCRIPTION
#### PR description:

This introduces a change in the treatment of the track-vertex association for charged particles in PUPPI. The new version is called v15.
The vertex association is adapted to deal with split vertices in high hadronic activity events (more on this here: https://indico.cern.ch/event/944339/contributions/3968152/attachments/2086414/3505127/splitverticesandhighptjets.pdf).
Charged particles associated to one of the leading two pileup vertices by the vertex fit (fromPV=0), but found within dz<0.2 of the primary vertex are treated as coming from the primary vertex.
This reduces MET tails due to particles that are wrongly associated to a PU vertex, when the PV is reconstructed as 2-3 split vertices.
The overall impact on jet response, jet efficiency, fake rate, boosted object tagging is negligible.
Thus JEC and SFs derived with PUPPI v14 are applicable to PUPPI v15.
A summary of the studies is in:
https://indico.cern.ch/event/942994/contributions/3978585/attachments/2088015/3508036/puppiv15summary-1.pdf
An additional check on softdrop mass response for high pT AK8 jets can be found here:
https://indico.cern.ch/event/942994/#7-virtual-impact-of-puppi-tune

In addition a ">" to ">=" change is made in PuppiContainer to properly handle rare cases with particle eta==0.

#### PR validation:

scram b run-tests
runTheMatrix.py -l limited

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Plan to backport to 10_6 for UL-re-MiniAOD: #31214