### PR TITLE
Add GEM plus/minus HV states

### DIFF
--- a/DataFormats/OnlineMetaData/interface/DCSRecord.h
+++ b/DataFormats/OnlineMetaData/interface/DCSRecord.h
@@ -45,6 +45,8 @@ public:
     FPIX,
     ESp,
     ESm,
+    GEMp,
+    GEMm,
     Last
   };
 
@@ -67,6 +69,10 @@ public:
 
   /// Return the current of the CMS magnet in A
   float magnetCurrent() const { return magnetCurrent_; }
+
+  /// Return the magnetic field of the CMS magnet in T
+  /// The precision is 0.6 to 1.8 mT in the range of a current from 9500 to 18164 A (from Vyacheslav.Klyukhin@cern.ch)
+  float magneticField() const { return (0.0002067 * magnetCurrent_ + 0.0557973); }
 
 private:
   edm::Timestamp timestamp_;

--- a/DataFormats/OnlineMetaData/interface/DCSRecord.h
+++ b/DataFormats/OnlineMetaData/interface/DCSRecord.h
@@ -20,7 +20,7 @@
 class DCSRecord {
 public:
   // Adding new partitions requires to add a new bitset definition with
-  // the correct dimension to DataFormats/StdDictionaries/src/classes_def_others.xml 
+  // the correct dimension to DataFormats/StdDictionaries/src/classes_def_others.xml
   enum Partition {
     EBp,
     EBm,

--- a/DataFormats/OnlineMetaData/interface/DCSRecord.h
+++ b/DataFormats/OnlineMetaData/interface/DCSRecord.h
@@ -19,6 +19,8 @@
 
 class DCSRecord {
 public:
+  // Adding new partitions requires to add a new bitset definition with
+  // the correct dimension to DataFormats/StdDictionaries/src/classes_def_others.xml 
   enum Partition {
     EBp,
     EBm,

--- a/DataFormats/OnlineMetaData/src/DCSRecord.cc
+++ b/DataFormats/OnlineMetaData/src/DCSRecord.cc
@@ -6,7 +6,8 @@
 
 const DCSRecord::ParitionNames DCSRecord::partitionNames_ = {
     {"EBp",  "EBm",  "EEp",    "EEm", "HBHEa",  "HBHEb", "HBHEc", "HF",   "HO",   "RPC",  "DT0", "DTp", "DTm",
-     "CSCp", "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm", "BPIX", "FPIX", "ESp", "ESm"}};
+     "CSCp", "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm", "BPIX", "FPIX", "ESp", "ESm",
+     "GEMm", "GEMp"}};
 
 DCSRecord::DCSRecord() : timestamp_(edm::Timestamp::invalidTimestamp()), magnetCurrent_(-1) {}
 

--- a/DataFormats/OnlineMetaData/src/DCSRecord.cc
+++ b/DataFormats/OnlineMetaData/src/DCSRecord.cc
@@ -5,9 +5,8 @@
 #include "DataFormats/OnlineMetaData/interface/OnlineMetaDataRaw.h"
 
 const DCSRecord::ParitionNames DCSRecord::partitionNames_ = {
-    {"EBp",  "EBm",  "EEp",    "EEm", "HBHEa",  "HBHEb", "HBHEc", "HF",   "HO",   "RPC",  "DT0", "DTp", "DTm",
-     "CSCp", "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm", "BPIX", "FPIX", "ESp", "ESm",
-     "GEMm", "GEMp"}};
+    {"EBp",  "EBm",    "EEp", "EEm",    "HBHEa", "HBHEb", "HBHEc", "HF",   "HO",   "RPC", "DT0", "DTp",  "DTm", "CSCp",
+     "CSCm", "CASTOR", "ZDC", "TIBTID", "TOB",   "TECp",  "TECm",  "BPIX", "FPIX", "ESp", "ESm", "GEMm", "GEMp"}};
 
 DCSRecord::DCSRecord() : timestamp_(edm::Timestamp::invalidTimestamp()), magnetCurrent_(-1) {}
 

--- a/DataFormats/OnlineMetaData/src/classes_def.xml
+++ b/DataFormats/OnlineMetaData/src/classes_def.xml
@@ -4,7 +4,8 @@
     <field name="romanPotNames_" transient="true"/>
     <field name="statusNames_" transient="true"/>
   </class>
-  <class name="DCSRecord" ClassVersion="3">
+  <class name="DCSRecord" ClassVersion="4">
+    <version ClassVersion="4" checksum="920984468"/>
     <version ClassVersion="3" checksum="2537350258"/>
     <field name="partitionNames_" transient="true"/>
   </class>

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -9,6 +9,7 @@
  <class name="std::bitset<7>"/>
  <class name="std::bitset<15>"/>
  <class name="std::bitset<25>"/>
+ <class name="std::bitset<27>"/>
  <class name="std::bitset<64>"/>
  <class name="std::bitset<96>"/>
  <class name="std::deque<int>"/>


### PR DESCRIPTION
#### PR description:

Add the HV state for GEM minus/plus partitions, which will be used for run 3. The raw data does not contain this information, yet. No change is expected for older data.

#### PR validation:

None. The change is trivial.
