### PR TITLE
[FastSimulation/TrackingRecHitProducer] Move boost spirit headers to source file

### DIFF
--- a/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
@@ -5,13 +5,7 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <boost/config/warning_disable.hpp>
-#include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/qi_rule.hpp>
-#include <boost/lambda/lambda.hpp>
-#include <boost/spirit/include/phoenix.hpp>
-#include <boost/phoenix/bind/bind_member_function.hpp>
-#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/variant/recursive_variant.hpp>
 
 #include <iostream>
 #include <cstdlib>
@@ -213,69 +207,6 @@ struct WalkAST {
     std::cout << ')';
   }
 };
-
-template <typename ITERATOR>
-struct TrackerDetIdSelectorGrammar : boost::spirit::qi::grammar<ITERATOR,
-                                                                ExpressionAST(),
-                                                                boost::spirit::ascii::space_type,
-                                                                boost::spirit::qi::locals<ExpressionAST> > {
-  boost::spirit::qi::rule<ITERATOR, std::string(), boost::spirit::ascii::space_type> identifierFctRule;
-
-  boost::spirit::qi::rule<ITERATOR, ExpressionAST(), boost::spirit::ascii::space_type> identifierRule, expressionRule;
-
-  boost::spirit::qi::
-      rule<ITERATOR, ExpressionAST(), boost::spirit::ascii::space_type, boost::spirit::qi::locals<ExpressionAST> >
-          comboRule;
-
-  TrackerDetIdSelectorGrammar() : TrackerDetIdSelectorGrammar::base_type(comboRule) {
-    namespace qi = boost::spirit::qi;
-    namespace ascii = boost::spirit::ascii;
-    namespace phoenix = boost::phoenix;
-
-    identifierFctRule = qi::lexeme[+qi::alpha[qi::_val += qi::_1]];
-
-    identifierRule = (qi::true_[qi::_val = 1] | qi::false_[qi::_val = 0]) | (qi::int_[qi::_val = qi::_1]) |
-                     identifierFctRule[qi::_val = qi::_1];
-
-    comboRule = (expressionRule[qi::_a = qi::_1] >>
-                 *((qi::lit("&&") >> expressionRule[qi::_a = qi::_a && qi::_1]) |
-                   (qi::lit("||") >> expressionRule[qi::_a = qi::_a || qi::_1])))[qi::_val = qi::_a];
-
-    expressionRule = qi::lit("(") >> comboRule[qi::_val = qi::_1] >> qi::lit(")") |
-                     (identifierRule >> qi::lit(">") >> identifierRule)[qi::_val = qi::_1 > qi::_2] |
-                     (identifierRule >> qi::lit(">=") >> identifierRule)[qi::_val = qi::_1 >= qi::_2] |
-                     (identifierRule >> qi::lit("<") >> identifierRule)[qi::_val = qi::_1 < qi::_2] |
-                     (identifierRule >> qi::lit("<=") >> identifierRule)[qi::_val = qi::_1 <= qi::_2] |
-                     (identifierRule >> qi::lit("==") >> identifierRule)[qi::_val = qi::_1 == qi::_2] |
-                     (identifierRule >> qi::lit("!=") >> identifierRule)[qi::_val = qi::_1 != qi::_2] |
-                     identifierRule[qi::_val = qi::_1];
-  }
-};
-
-bool TrackerDetIdSelector::passSelection(std::string selectionStr) const {
-  std::string::const_iterator begin = selectionStr.cbegin();
-  std::string::const_iterator end = selectionStr.cend();
-
-  TrackerDetIdSelectorGrammar<std::string::const_iterator> grammar;
-  ExpressionAST exprAST;
-
-  bool success = boost::spirit::qi::phrase_parse(begin, end, grammar, boost::spirit::ascii::space, exprAST);
-  if (begin != end) {
-    throw cms::Exception("FastSimulation/TrackingRecHitProducer/TrackerDetIdSelector",
-                         "parsing selection '" + selectionStr + "' failed at " +
-                             std::string(selectionStr.cbegin(), begin) + "^^^" + std::string(begin, end));
-  }
-  if (!success) {
-    throw cms::Exception("FastSimulation/TrackingRecHitProducer/TrackerDetIdSelector",
-                         "parsing selection '" + selectionStr + "' failed.");
-  }
-  /* Comment out for debugging
-    WalkAST walker(_detId,_trackerTopology);
-    walker(exprAST);
-    std::cout<<std::endl;
-    */
-  return exprAST.evaluate(_detId, _trackerTopology);
-}
 
 int ExpressionAST::evaluate(const DetId& detId, const TrackerTopology& trackerTopology) const {
   return boost::apply_visitor(Accessor(detId, trackerTopology), this->expr);

--- a/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/TrackerDetIdSelector.h
@@ -104,7 +104,7 @@ public:
   TrackerDetIdSelector(const DetId& detId, const TrackerTopology& trackerTopology)
       : _detId(detId), _trackerTopology(trackerTopology) {}
 
-  bool passSelection(std::string selectionStr) const;
+  bool passSelection(const std::string& selectionStr) const;
 };
 
 class Accessor : public boost::static_visitor<int> {

--- a/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
@@ -163,7 +163,7 @@ struct TrackerDetIdSelectorGrammar : boost::spirit::qi::grammar<ITERATOR,
   }
 };
 
-bool TrackerDetIdSelector::passSelection(std::string selectionStr) const {
+bool TrackerDetIdSelector::passSelection(const std::string& selectionStr) const {
   std::string::const_iterator begin = selectionStr.cbegin();
   std::string::const_iterator end = selectionStr.cend();
 

--- a/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/TrackerDetIdSelector.cc
@@ -2,6 +2,12 @@
 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 
+#include <boost/config/warning_disable.hpp>
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/qi_rule.hpp>
+#include <boost/spirit/include/qi_grammar.hpp>
+#include <boost/spirit/include/phoenix.hpp>
+
 #define DETIDFCT(NAME) NAME, [](const TrackerTopology& trackerTopology, const DetId& detId) -> int
 
 #define TOPOFCT(NAME) \
@@ -117,4 +123,67 @@ ExpressionAST operator||(ExpressionAST const& lhs, ExpressionAST const& rhs) {
 ExpressionAST& ExpressionAST::operator!() {
   expr = UnaryOP(UnaryOP::OP::NEG, expr);
   return *this;
+}
+
+template <typename ITERATOR>
+struct TrackerDetIdSelectorGrammar : boost::spirit::qi::grammar<ITERATOR,
+                                                                ExpressionAST(),
+                                                                boost::spirit::ascii::space_type,
+                                                                boost::spirit::qi::locals<ExpressionAST> > {
+  boost::spirit::qi::rule<ITERATOR, std::string(), boost::spirit::ascii::space_type> identifierFctRule;
+
+  boost::spirit::qi::rule<ITERATOR, ExpressionAST(), boost::spirit::ascii::space_type> identifierRule, expressionRule;
+
+  boost::spirit::qi::
+      rule<ITERATOR, ExpressionAST(), boost::spirit::ascii::space_type, boost::spirit::qi::locals<ExpressionAST> >
+          comboRule;
+
+  TrackerDetIdSelectorGrammar() : TrackerDetIdSelectorGrammar::base_type(comboRule) {
+    namespace qi = boost::spirit::qi;
+    namespace ascii = boost::spirit::ascii;
+    namespace phoenix = boost::phoenix;
+
+    identifierFctRule = qi::lexeme[+qi::alpha[qi::_val += qi::_1]];
+
+    identifierRule = (qi::true_[qi::_val = 1] | qi::false_[qi::_val = 0]) | (qi::int_[qi::_val = qi::_1]) |
+                     identifierFctRule[qi::_val = qi::_1];
+
+    comboRule = (expressionRule[qi::_a = qi::_1] >>
+                 *((qi::lit("&&") >> expressionRule[qi::_a = qi::_a && qi::_1]) |
+                   (qi::lit("||") >> expressionRule[qi::_a = qi::_a || qi::_1])))[qi::_val = qi::_a];
+
+    expressionRule = qi::lit("(") >> comboRule[qi::_val = qi::_1] >> qi::lit(")") |
+                     (identifierRule >> qi::lit(">") >> identifierRule)[qi::_val = qi::_1 > qi::_2] |
+                     (identifierRule >> qi::lit(">=") >> identifierRule)[qi::_val = qi::_1 >= qi::_2] |
+                     (identifierRule >> qi::lit("<") >> identifierRule)[qi::_val = qi::_1 < qi::_2] |
+                     (identifierRule >> qi::lit("<=") >> identifierRule)[qi::_val = qi::_1 <= qi::_2] |
+                     (identifierRule >> qi::lit("==") >> identifierRule)[qi::_val = qi::_1 == qi::_2] |
+                     (identifierRule >> qi::lit("!=") >> identifierRule)[qi::_val = qi::_1 != qi::_2] |
+                     identifierRule[qi::_val = qi::_1];
+  }
+};
+
+bool TrackerDetIdSelector::passSelection(std::string selectionStr) const {
+  std::string::const_iterator begin = selectionStr.cbegin();
+  std::string::const_iterator end = selectionStr.cend();
+
+  TrackerDetIdSelectorGrammar<std::string::const_iterator> grammar;
+  ExpressionAST exprAST;
+
+  bool success = boost::spirit::qi::phrase_parse(begin, end, grammar, boost::spirit::ascii::space, exprAST);
+  if (begin != end) {
+    throw cms::Exception("FastSimulation/TrackingRecHitProducer/TrackerDetIdSelector",
+                         "parsing selection '" + selectionStr + "' failed at " +
+                             std::string(selectionStr.cbegin(), begin) + "^^^" + std::string(begin, end));
+  }
+  if (!success) {
+    throw cms::Exception("FastSimulation/TrackingRecHitProducer/TrackerDetIdSelector",
+                         "parsing selection '" + selectionStr + "' failed.");
+  }
+  /* Comment out for debugging
+    WalkAST walker(_detId,_trackerTopology);
+    walker(exprAST);
+    std::cout<<std::endl;
+    */
+  return exprAST.evaluate(_detId, _trackerTopology);
 }


### PR DESCRIPTION
#### PR description:
We can move the boost spirit includes to the implementation file.
Since TrackerDetIdSelectorGrammar is only used here, we can isolate it in the source file. 
This change will increase modularity, and possibly helps us with c++20 clang modules.

#### PR validation:
Code compiled

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
@vgvassilev @davidlange6 
