### PR TITLE
Fix UL jet ID working point in DQM

### DIFF
--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -104,7 +104,7 @@ jetDQMAnalyzerAk4PFUncleaned=jetDQMAnalyzerAk4CaloUncleaned.clone(
        bypassAllPVChecks  = cms.bool(False),
     ),
     #for PFJets: LOOSE,TIGHT
-    JetIDQuality               = cms.string("LOOSE"),
+    JetIDQuality               = cms.string("TIGHT"),
     #options for Calo and JPT: PURE09,DQM09,CRAFT08
     #for PFJets: RUN2ULCHS for 11_1_X onwards
     JetIDVersion               = cms.string("RUN2ULCHS"),


### PR DESCRIPTION
#### PR description:

followup from #30638.
Use TIGHT working point of UL jet ID in DQM (since LOOSE is not supported and automatically switched to TIGHT after printing a warning).
Fixing issue #31171.
No differences, apart from less warnings in log files are expected from this PR.

#### PR validation:

runTheMatrix.py -l 30234.0
logs of step 3 don't show the warning reported in the issue anymore.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
