### PR TITLE
correct inlining and update header guards

### DIFF
--- a/CondCore/Utilities/interface/Payload2XMLModule.h
+++ b/CondCore/Utilities/interface/Payload2XMLModule.h
@@ -31,7 +31,7 @@ namespace {  // Avoid cluttering the global namespace.
       sdataBuf.pubsetbuf(const_cast<char *>(payloadData.c_str()), payloadData.size());
 
       std::istream inBuffer(&sdataBuf);
-      eos::portable_iarchive ia(inBuffer);
+      cond::serialization::InputArchive ia(inBuffer);
       payload.reset(new PayloadType);
       ia >> (*payload);
 

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -67,7 +67,7 @@ namespace cond {
     }
 
     template <>
-    std::string serializeValue(const std::string& entryLabel, const std::string& value) {
+    inline std::string serializeValue(const std::string& entryLabel, const std::string& value) {
       std::stringstream ss;
       ss << "\"" << entryLabel << "\":\"" << value << "\"";
       return ss.str();
@@ -93,7 +93,7 @@ namespace cond {
       return ss.str();
     }
 
-    std::string serializeAnnotations(const PlotAnnotations& annotations) {
+    inline std::string serializeAnnotations(const PlotAnnotations& annotations) {
       std::stringstream ss;
       ss << "\"version\": \"" << JSON_FORMAT_VERSION << "\",";
       ss << "\"annotations\": {";
@@ -149,7 +149,7 @@ namespace cond {
       return ss.str();
     }
 
-    std::string serialize(const PlotAnnotations& annotations, const std::string& imageFileName) {
+    inline std::string serialize(const PlotAnnotations& annotations, const std::string& imageFileName) {
       std::stringstream ss;
       ss << "{";
       ss << serializeAnnotations(annotations);

--- a/CondFormats/Serialization/interface/Archive.h
+++ b/CondFormats/Serialization/interface/Archive.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef CondFormats_Serialization_Archive_hh
+#define CondFormats_Serialization_Archive_hh
 
 // Missing in EOS' portable archive
 #include <cassert>
@@ -21,3 +22,5 @@ namespace cond {
 
   }  // namespace serialization
 }  // namespace cond
+
+#endif

--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -82,7 +82,8 @@
  */
 /*****************************************************************************/
 
-#pragma once
+#ifndef portable_iarchive_hpp
+#define portable_iarchive_hpp
 
 #include <istream>
 
@@ -494,3 +495,5 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(eos::polymorphic_portable_iarchive)
 // }  // namespace boost
 //
 // #endif
+
+#endif

--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -82,8 +82,8 @@
  */
 /*****************************************************************************/
 
-#ifndef portable_iarchive_hpp
-#define portable_iarchive_hpp
+#ifndef CondFormats_Serialization_portable_iarchive_hpp
+#define CondFormats_Serialization_portable_iarchive_hpp
 
 #include <istream>
 

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -85,7 +85,8 @@
  */
 /*****************************************************************************/
 
-#pragma once
+#ifndef portable_oarchive_hpp
+#define portable_oarchive_hpp
 
 #include <ostream>
 
@@ -493,3 +494,5 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(eos::polymorphic_portable_oarchive)
 // }  // namespace boost
 //
 // #endif
+
+#endif

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -85,8 +85,8 @@
  */
 /*****************************************************************************/
 
-#ifndef portable_oarchive_hpp
-#define portable_oarchive_hpp
+#ifndef CondFormats_Serialization_portable_oarchive_hpp
+#define CondFormats_Serialization_portable_oarchive_hpp
 
 #include <ostream>
 


### PR DESCRIPTION
Explicit template specializations have strong linkage and need to be marked inline... Errors arise in modules IB due to these (we aren't sure why they don't in normal IBs). Also follow coding rules for header guards (also needed for modules builds)