### PR TITLE
DD4hep: Fix TOB g4 Overlaps

### DIFF
--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBAxCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBAxCableAlgo.cc
@@ -62,7 +62,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     rout = sectorRout;
     startphi = sectorStartPhi[i];
     deltaphi = 0.5 * (widthphi - sectorDeltaPhi_B);
-    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, deltaphi));
+    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, startphi + deltaphi));
     LogDebug("TOBGeom") << solid.name() << " Tubs made of " << sectorMaterial_A[i] << " from "
                         << convertRadToDeg(startphi) << " to " << convertRadToDeg((startphi + deltaphi)) << " with Rin "
                         << rin << " Rout " << rout << " ZHalf " << dz;
@@ -75,7 +75,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     name = "TOBAxService_" + sectorNumber[i] + "B";
     startphi += deltaphi;
     deltaphi = sectorDeltaPhi_B;
-    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, deltaphi));
+    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, startphi + deltaphi));
     LogDebug("TOBGeom") << solid.name() << " Tubs made of " << sectorMaterial_B[i] << " from "
                         << convertRadToDeg(startphi) << " to " << convertRadToDeg((startphi + deltaphi)) << " with Rin "
                         << rin << " Rout " << rout << " ZHalf " << dz;
@@ -89,7 +89,7 @@ static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, 
     name = "TOBAxService_" + sectorNumber[i] + "C";
     startphi += deltaphi;
     deltaphi = 0.5 * (widthphi - sectorDeltaPhi_B);
-    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, deltaphi));
+    solid = ns.addSolid(name, Tube(rin, rout, dz, startphi, startphi + deltaphi));
     LogDebug("TOBGeom") << solid.name() << " Tubs made of " << sectorMaterial_C[i] << " from "
                         << convertRadToDeg(startphi) << " to " << convertRadToDeg((startphi + deltaphi)) << " with Rin "
                         << rin << " Rout " << rout << " ZHalf " << dz;

--- a/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4Hep_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4Hep_cfg.py
@@ -21,7 +21,7 @@ process.g4SimHits.G4CheckOverlap.Depth      = cms.int32(-1)
 # tells if NodeName is G4Region or G4PhysicalVolume
 process.g4SimHits.G4CheckOverlap.RegionFlag = cms.bool(False)
 # list of names
-process.g4SimHits.G4CheckOverlap.NodeNames  = cms.vstring('OCMS')
+process.g4SimHits.G4CheckOverlap.NodeNames  = cms.vstring('OCMS_1')
 # enable dump gdml file 
 process.g4SimHits.G4CheckOverlap.gdmlFlag   = cms.bool(False)
 # if defined a G4PhysicsVolume info is printed


### PR DESCRIPTION
#### PR description:

TOB presented overlaps that were not seen before by using the overlaps configuration file:

```
cmsShow -c overlaps.fwc --sim-geom-file cmsDD4HepGeom.root --tgeo-name=CMS
```

Overlaps being fixed were found by running g4 check:

```
cmsRun SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4Hep_cfg.py
```

###### Master
![Screenshot from 2020-08-19 15-05-04](https://user-images.githubusercontent.com/16821717/90679398-18c29600-e22e-11ea-8eb4-13a3b1a23506.png)

###### Reference
![Screenshot from 2020-08-19 15-07-53](https://user-images.githubusercontent.com/16821717/90679399-18c29600-e22e-11ea-8e0a-4d6e525126c8.png)

###### ThisPr
![Screenshot from 2020-08-19 15-11-49](https://user-images.githubusercontent.com/16821717/90679685-87075880-e22e-11ea-9e90-60c3df4d196b.png)


#### PR validation:

```
$cmsRun g4OverlapCheckDD4Hep_cfg.py 2>DD4heloOVL.txt  # Go for some coffee
$grep TOB DD4heloOVL.txt # No output expected
```

#### Notes:

Partially related to: https://github.com/cms-sw/cmssw/issues/31143
Further validation steps: https://github.com/cms-sw/cmssw/pull/27689
@ghugo83: This may be of your interest :)