### PR TITLE
add missing Rtypes.h include in hcalCalibUtils.h

### DIFF
--- a/Calibration/HcalCalibAlgos/interface/hcalCalibUtils.h
+++ b/Calibration/HcalCalibAlgos/interface/hcalCalibUtils.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <map>
+#include "Rtypes.h"
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"


### PR DESCRIPTION
missing include seen by modules IB