### PR TITLE
[RPC] Removing the RPCDcsInfo module from RPC online client

### DIFF
--- a/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/rpc_dqm_sourceclient-live_cfg.py
@@ -101,9 +101,6 @@ process.rpcMergerdigidqm.RecHitLabel = cms.InputTag("rpcMergerRecHits")
 
 #######################################################
 
-################# DCS Info ######################
-process.load("DQM.RPCMonitorDigi.RPCDcsInfo_cfi")
-
 ################# DQM Client Modules ############
 process.load("DQM.RPCMonitorClient.RPCDqmClient_cfi")
 process.rpcdqmclient.RPCDqmClientList = cms.untracked.vstring("RPCMultiplicityTest", "RPCDeadChannelTest", "RPCClusterSizeTest", "RPCOccupancyTest","RPCNoisyStripTest")
@@ -156,7 +153,7 @@ process.rpcSource = cms.Sequence( process.rpcunpacker
                       * (process.rpcRecHits + process.rpcMergerRecHits)
                       * process.scalersRawToDigi
                       * (process.rpcdigidqm + process.rpcMergerdigidqm)
-                      * process.rpcMonitorRaw*process.rpcDcsInfo*process.qTesterRPC
+                      * process.rpcMonitorRaw*process.qTesterRPC
                     )
 process.rpcClient = cms.Sequence(process.rpcdqmclient*process.rpcMergerdqmclient*process.rpcChamberQuality*process.rpcChamberQualityMerger*process.rpcEventSummary*process.rpcEventSummaryMerger*process.dqmEnv*process.dqmSaver)
 process.p = cms.Path(process.hltTriggerTypeFilter*process.rpcSource*process.rpcClient)


### PR DESCRIPTION
#### PR description:

After #31056 is merged, there was the unit test failed in all IBs. Thank you for announcing this @mrodozov 
That failing occurred from the RPC online client because the RPCDcsInfo module is called in there despite the module already removed in the RPCMonitorDigi.

If the RPCDcsInfo process will be removed from RPC online client, there will be no more test failing in all IBs.

#### PR validation:

I tested this with
$ cmsRun rpc_dqm_sourceclient-live_cfg.py inputFiles="root://cms-xrd-global.cern.ch//eos/cms/store/user/cmsbuild/store/express/Commissioning2019/ExpressCosmics/FEVT/Express-v1/000/334/393/00000/D0F052ED-9CA5-F547-BA73-2AA370D51AE8.root" runNumber=334393 unitTest=True

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
#31056 

@jfernan2 I make this PR to fix the online client error. Thanks a lot for helping me to fix this issue!

