### PR TITLE
change return type of geomTracker to derived class (TrackerGeometry vs TrackingGeometry)

### DIFF
--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h
@@ -43,6 +43,7 @@ class DetLayer;
 class FreeTrajectoryState;
 class TrajectoryStateOnSurface;
 class NavigationSchool;
+class TrackingGeometry;
 
 class ConversionSeedFinder {
 public:

--- a/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h
@@ -26,6 +26,8 @@
 #include <vector>
 
 class TransientInitialStateEstimator;
+class TrackerGeometry;
+
 class ConversionTrackFinder {
 public:
   ConversionTrackFinder(const edm::ParameterSet& config, const BaseCkfTrajectoryBuilder* trajectoryBuilder);

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
@@ -1,7 +1,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h"
 // Field
 // Geometry

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionSeedFinder.cc
@@ -1,5 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionSeedFinder.h"
 // Field
 // Geometry

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
@@ -1,7 +1,6 @@
 //
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h"
 //
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h"

--- a/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/ConversionTrackFinder.cc
@@ -1,6 +1,8 @@
 //
 #include "RecoEgamma/EgammaPhotonAlgos/interface/ConversionTrackFinder.h"
 //
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"
 #include "RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"

--- a/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/MuonCkfTrajectoryBuilder.cc
@@ -1,7 +1,7 @@
 #include "RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -6,6 +6,7 @@
 
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <memory>
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.cc
@@ -7,6 +7,7 @@
 #include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOIFromL2.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include <memory>
 

--- a/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
@@ -4,7 +4,6 @@
 #include "TrackingTools/MeasurementDet/interface/MeasurementDetSystem.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -17,6 +16,7 @@ class SiStripRecHitMatcher;
 class StMeasurementConditionSet;
 class PxMeasurementConditionSet;
 class Phase2OTMeasurementConditionSet;
+class TrackerGeometry;
 
 class MeasurementTracker : public MeasurementDetSystem {
 public:
@@ -33,7 +33,7 @@ public:
 
   ~MeasurementTracker() override;
 
-  const TrackingGeometry* geomTracker() const { return theTrackerGeom; }
+  const TrackerGeometry* geomTracker() const { return theTrackerGeom; }
 
   const GeometricSearchTracker* geometricSearchTracker() const { return theGeometricSearchTracker; }
 

--- a/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
@@ -62,7 +62,7 @@ public:
   const std::vector<bool> &phase2OTClustersToSkip() const { return thePhase2OTClustersToSkip; }
 
   // forwarded calls
-  const TrackingGeometry *geomTracker() const { return measurementTracker().geomTracker(); }
+  const TrackerGeometry *geomTracker() const { return measurementTracker().geomTracker(); }
   const GeometricSearchTracker *geometricSearchTracker() const { return measurementTracker().geometricSearchTracker(); }
 
   /// Previous MeasurementDetSystem interface

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -9,7 +9,6 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -34,6 +33,7 @@ class SiStripRecHitMatcher;
 class GluedGeomDet;
 class StackGeomDet;
 class SiPixelFedCabling;
+class TrackerGeometry;
 
 class dso_hidden MeasurementTrackerImpl final : public MeasurementTracker {
 public:
@@ -70,7 +70,7 @@ public:
 
   ~MeasurementTrackerImpl() override;
 
-  const TrackingGeometry* geomTracker() const { return theTrackerGeom; }
+  const TrackerGeometry* geomTracker() const { return theTrackerGeom; }
 
   const GeometricSearchTracker* geometricSearchTracker() const { return theGeometricSearchTracker; }
 


### PR DESCRIPTION
#31192 plus review changes (I messed up the rebase so started over..)

nominally this PR is to work around errors flagged by modules build. There is a mix of TrackerGeometry and TrackingGeometry (esp in Egamma) that I don't fully understand the logic of as there is presumably only one relevant derived type from TrackingGeometry (which is TrackerGeometry) for anything that is not a muon algorithm

This is a minimal change - I didn't attempt a cleanup in RecoEgamma.

