### PR TITLE
[11_1_X] update the B-Field configuration at beginRun in SimG4Core/GeometryProducer

### DIFF
--- a/SimG4Core/GeometryProducer/src/GeometryProducer.cc
+++ b/SimG4Core/GeometryProducer/src/GeometryProducer.cc
@@ -101,7 +101,7 @@ void GeometryProducer::beginLuminosityBlock(edm::LuminosityBlock &, edm::EventSe
   //     updateMagneticField( es );
 }
 
-void GeometryProducer::beginRun(const edm::Run &, const edm::EventSetup &) {}
+void GeometryProducer::beginRun(const edm::Run &run, const edm::EventSetup &es) { updateMagneticField(es); }
 
 void GeometryProducer::endRun(const edm::Run &, const edm::EventSetup &) {}
 


### PR DESCRIPTION
backport of #31203

#### PR description:

This simple fix allows to be able to run the G4 refitting for alignment purposes on real data preventing a segfault, when crossing run boundaries described to occur in [this thread](https://hypernews.cern.ch/HyperNews/CMS/get/tracker-material/144.html).

#### PR validation:

The test configuration at `/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/MP/MPproduction/mp3344/jobData/job181/ the.py` runs successfully (**caveat** for testing, the changes at: [cms-trackeralign:g4Refitting_10_6_X](https://github.com/cms-sw/cmssw/compare/CMSSW_10_6_X...cms-trackeralign:g4Refitting_10_6_X?expand=1) need to be merged first).

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #31203