### PR TITLE
Extend setConsumes() to EDModules for EDGetTokenT and ESGetToken

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -81,6 +81,12 @@ namespace edm {
       m_consumer->consumesMany<B>(id);
     }
 
+    template <BranchType B = InEvent, typename ProductType>
+    ConsumesCollector& setConsumes(EDGetTokenT<ProductType>& token, edm::InputTag const& tag) {
+      m_consumer->setConsumes<B>(token, tag);
+      return *this;
+    }
+
     // For consuming event-setup products
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
     auto esConsumes() {
@@ -95,6 +101,18 @@ namespace edm {
     template <typename ESProduct, Transition Tr = Transition::Event>
     auto esConsumes(eventsetup::EventSetupRecordKey const& key, ESInputTag const& tag) {
       return m_consumer->esConsumes<ESProduct, Tr>(key, tag);
+    }
+
+    template <Transition Tr = Transition::Event, typename ESProduct, typename ESRecord>
+    ConsumesCollector& setConsumes(ESGetToken<ESProduct, ESRecord>& token) {
+      m_consumer->setConsumes<Tr>(token);
+      return *this;
+    }
+
+    template <Transition Tr = Transition::Event, typename ESProduct, typename ESRecord>
+    ConsumesCollector& setConsumes(ESGetToken<ESProduct, ESRecord>& token, ESInputTag const& tag) {
+      m_consumer->setConsumes<Tr>(token, tag);
+      return *this;
     }
 
   private:

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -177,6 +177,11 @@ namespace edm {
       recordConsumes(B, id, edm::InputTag{}, true);
     }
 
+    template <BranchType B = InEvent, typename ProductType>
+    void setConsumes(EDGetTokenT<ProductType>& token, edm::InputTag const& tag) {
+      token = consumes<ProductType, B>(tag);
+    }
+
     // For consuming event-setup products
     template <typename ESProduct, typename ESRecord, Transition Tr = Transition::Event>
     auto esConsumes() {
@@ -193,6 +198,16 @@ namespace edm {
                                     eventsetup::heterocontainer::HCTypeTag::make<ESProduct>(),
                                     tag);
       return ESGetToken<ESProduct, ESRecord>{static_cast<unsigned int>(Tr), index, labelFor(index)};
+    }
+
+    template <Transition Tr = Transition::Event, typename ESProduct, typename ESRecord>
+    void setConsumes(ESGetToken<ESProduct, ESRecord>& token) {
+      token = esConsumes<ESProduct, ESRecord, Tr>();
+    }
+
+    template <Transition Tr = Transition::Event, typename ESProduct, typename ESRecord>
+    void setConsumes(ESGetToken<ESProduct, ESRecord>& token, ESInputTag const& tag) {
+      token = esConsumes<ESProduct, ESRecord, Tr>(tag);
     }
 
   private:

--- a/FWCore/Integration/test/RunLumiESAnalyzer.cc
+++ b/FWCore/Integration/test/RunLumiESAnalyzer.cc
@@ -13,6 +13,7 @@
 //         Created:  18 April 2019
 
 #include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -76,18 +77,20 @@ namespace edmtest {
     edm::ESGetToken<IOVTestInfo, ESTestRecordC> const esToken_;
     edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenBeginRun_;
     edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenBeginLumi_;
-    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenEndLumi_;
-    edm::ESGetToken<IOVTestInfo, ESTestRecordC> const tokenEndRun_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> tokenEndLumi_;
+    edm::ESGetToken<IOVTestInfo, ESTestRecordC> tokenEndRun_;
   };
 
   RunLumiESAnalyzer::RunLumiESAnalyzer(edm::ParameterSet const&)
       : esToken_{esConsumes<IOVTestInfo, ESTestRecordC>(edm::ESInputTag("", ""))},
         tokenBeginRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginRun>(edm::ESInputTag("", ""))},
         tokenBeginLumi_{
-            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", ""))},
-        tokenEndLumi_{
-            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndLuminosityBlock>(edm::ESInputTag("", ""))},
-        tokenEndRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndRun>(edm::ESInputTag("", ""))} {}
+            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", ""))} {
+    // to test setConsumes()
+    setConsumes<edm::Transition::EndLuminosityBlock>(tokenEndLumi_);
+    auto cc = consumesCollector();
+    cc.setConsumes<edm::Transition::EndRun>(tokenEndRun_);
+  }
 
   std::unique_ptr<UnsafeCache> RunLumiESAnalyzer::beginStream(edm::StreamID iID) const {
     return std::make_unique<UnsafeCache>();


### PR DESCRIPTION
#### PR description:

This PR extends the [`setConsumes()` API currently available in ESProducers](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHowToGetDataFromES#In_ESProducer) to EDModules for both `EDGetTokenT<T>` and `ESGetToken<T, Rec>`. Resolves https://github.com/cms-sw/cmssw/issues/30828.

#### PR validation:

Framework unit tests run.