### PR TITLE
Adding protection against for empty Primary Vertices in DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc a

### DIFF
--- a/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
+++ b/DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc
@@ -93,6 +93,10 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
     edm::LogError("TrackToTrackComparisonHists") << "referencePVHandle not found, skipping event";
     return;
   }
+  if (referencePVHandle->empty()) {
+    edm::LogInfo("TrackToTrackComparisonHists") << "referencePVHandle->size is 0 ";
+    return;
+  }
   reco::Vertex referencePV = referencePVHandle->at(0);
 
   //
@@ -118,6 +122,10 @@ void TrackToTrackComparisonHists::analyze(const edm::Event& iEvent, const edm::E
   iEvent.getByToken(monitoredPVToken_, monitoredPVHandle);
   if (!monitoredTracksHandle.isValid()) {
     edm::LogError("TrackToTrackComparisonHists") << "monitoredPVHandle not found, skipping event";
+    return;
+  }
+  if (monitoredPVHandle->empty()) {
+    edm::LogInfo("TrackToTrackComparisonHists") << "monitoredPVHandle->size is 0 ";
     return;
   }
   reco::Vertex monitoredPV = monitoredPVHandle->at(0);


### PR DESCRIPTION
Fix in  DQM/TrackingMonitorSource/src/TrackToTrackComparisonHists.cc for empty Primary Vertices
See #31040  for more detail.

#### PR validation:

Validated with runTheMatrix commands particularly those listed here:
https://cms-sw.github.io/relvalLogDetail.html#slc7_amd64_gcc820;CMSSW_11_2_X_2020-08-21-2300


