### PR TITLE
Adapt track-vertex association in PUPPI (v15) [10_6_X]

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -31,6 +31,8 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   fEtaMinUseDZ = iConfig.getParameter<double>("EtaMinUseDeltaZ");
   fPtMaxCharged = iConfig.getParameter<double>("PtMaxCharged");
   fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
+  fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
+  fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
   fUseExistingWeights     = iConfig.getParameter<bool>("useExistingWeights");
   fUseWeightsNoLep        = iConfig.getParameter<bool>("useWeightsNoLep");
   fClonePackedCands       = iConfig.getParameter<bool>("clonePackedCands");
@@ -98,8 +100,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     const reco::Vertex *closestVtx = nullptr;
     double pDZ    = -9999; 
     double pD0    = -9999; 
-    int    pVtxId = -9999; 
-    bool lFirst = true;
+    uint pVtxId = 0;
     const pat::PackedCandidate *lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
     if(lPack == nullptr ) {
 
@@ -107,6 +108,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       double curdz = 9999;
       int closestVtxForUnassociateds = -9999;
       const reco::TrackRef aTrackRef = pPF->trackRef();
+      bool lFirst = true;
       for(auto const& aV : *pvCol) {
         if(lFirst) {
           if ( aTrackRef.isNonnull()) {
@@ -147,8 +149,12 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       pReco.id = 0; 
       if (std::abs(pReco.charge) == 0){ pReco.id = 0; }
       else{
-        if (tmpFromPV == 0){ pReco.id = 2; } // 0 is associated to PU vertex
-        else if (tmpFromPV == 3){ pReco.id = 1; }
+        if (tmpFromPV == 0) {
+          pReco.id = 2;
+          if (fNumOfPUVtxsForCharged > 0 and (pVtxId <= fNumOfPUVtxsForCharged) and
+                (std::abs(pDZ) < fDZCutForChargedFromPUVtxs))
+            pReco.id = 1;
+        } else if (tmpFromPV == 3){ pReco.id = 1; }
         else if (tmpFromPV == 1 || tmpFromPV == 2){ 
           pReco.id = 0;
           if ((fPtMaxCharged > 0) and (pReco.pt > fPtMaxCharged))
@@ -173,8 +179,18 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       pReco.id = 0; 
       if (std::abs(pReco.charge) == 0){ pReco.id = 0; }
       if (std::abs(pReco.charge) > 0){
-        if (lPack->fromPV() == 0){ pReco.id = 2; } // 0 is associated to PU vertex
-        else if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)){ pReco.id = 1; }
+        if (lPack->fromPV() == 0){
+          pReco.id = 2;
+          if ((fNumOfPUVtxsForCharged > 0) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) {
+            for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged && puVtx_idx < pvCol->size();
+               ++puVtx_idx) {
+              if (lPack->fromPV(puVtx_idx) >= 2) {
+                pReco.id = 1;
+                break;
+              }
+            }
+          }
+        } else if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)){ pReco.id = 1; }
         else if (lPack->fromPV() == (pat::PackedCandidate::PVTight) || lPack->fromPV() == (pat::PackedCandidate::PVLoose)){ 
           pReco.id = 0;
           if ((fPtMaxCharged > 0) and (pReco.pt > fPtMaxCharged))
@@ -361,6 +377,8 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<double>("EtaMaxCharged", 99999.);
   desc.add<double>("PtMaxNeutrals", 200.);
   desc.add<double>("PtMaxNeutralsStartSlope", 0.);
+  desc.add<uint>("NumOfPUVtxsForCharged", 0);
+  desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
   desc.add<bool>("useExistingWeights", false);
   desc.add<bool>("useWeightsNoLep", false);
   desc.add<bool>("clonePackedCands", false);

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -54,6 +54,8 @@ private:
 	double fEtaMinUseDZ;
         double fPtMaxCharged;
 	double fEtaMaxCharged;
+	uint fNumOfPUVtxsForCharged;
+	double fDZCutForChargedFromPUVtxs;
 	bool fUseExistingWeights;
 	bool fUseWeightsNoLep;
 	bool fClonePackedCands;

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -31,6 +31,8 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        UseDeltaZCut   = cms.bool(True),
                        EtaMinUseDeltaZ = cms.double(0.),
                        DeltaZCut      = cms.double(0.3),
+                       NumOfPUVtxsForCharged = cms.uint32(0),
+                       DeltaZCutForChargedFromPUVtxs = cms.double(0.2),
 		       PtMaxCharged   = cms.double(0.),
 		       EtaMaxCharged   = cms.double(99999.),
 		       PtMaxNeutrals  = cms.double(200.),
@@ -121,5 +123,30 @@ run2_miniAOD_UL.toModify(
     puppi,
     EtaMinUseDeltaZ = 2.4,
     PtMaxCharged = 20.,
-    PtMaxNeutralsStartSlope = 20.
+    PtMaxNeutralsStartSlope = 20.,
+    NumOfPUVtxsForCharged = 2,
+    algos = cms.VPSet(
+                        cms.PSet(
+                         etaMin = cms.vdouble(-0.01), # include particles with eta==0 (proper fix is in #31174)
+                         etaMax = cms.vdouble(2.5),
+                         ptMin  = cms.vdouble(0.),
+                         MinNeutralPt   = cms.vdouble(0.2),
+                         MinNeutralPtSlope   = cms.vdouble(0.015),
+                         RMSEtaSF = cms.vdouble(1.0),
+                         MedEtaSF = cms.vdouble(1.0),
+                         EtaMaxExtrap = cms.double(2.0),
+                         puppiAlgos = puppiCentral
+                        ),
+                        cms.PSet(
+                         etaMin              = cms.vdouble( 2.5,  3.0),
+                         etaMax              = cms.vdouble( 3.0, 10.0),
+                         ptMin               = cms.vdouble( 0.0,  0.0),
+                         MinNeutralPt        = cms.vdouble( 1.7,  2.0),
+                         MinNeutralPtSlope   = cms.vdouble(0.08, 0.08),
+                         RMSEtaSF            = cms.vdouble(1.20, 0.95),
+                         MedEtaSF            = cms.vdouble(0.90, 0.75),
+                         EtaMaxExtrap        = cms.double( 2.0),
+                         puppiAlgos = puppiForward
+                        )
+     )
 )

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -125,28 +125,5 @@ run2_miniAOD_UL.toModify(
     PtMaxCharged = 20.,
     PtMaxNeutralsStartSlope = 20.,
     NumOfPUVtxsForCharged = 2,
-    algos = cms.VPSet(
-                        cms.PSet(
-                         etaMin = cms.vdouble(-0.01), # include particles with eta==0 (proper fix is in #31174)
-                         etaMax = cms.vdouble(2.5),
-                         ptMin  = cms.vdouble(0.),
-                         MinNeutralPt   = cms.vdouble(0.2),
-                         MinNeutralPtSlope   = cms.vdouble(0.015),
-                         RMSEtaSF = cms.vdouble(1.0),
-                         MedEtaSF = cms.vdouble(1.0),
-                         EtaMaxExtrap = cms.double(2.0),
-                         puppiAlgos = puppiCentral
-                        ),
-                        cms.PSet(
-                         etaMin              = cms.vdouble( 2.5,  3.0),
-                         etaMax              = cms.vdouble( 3.0, 10.0),
-                         ptMin               = cms.vdouble( 0.0,  0.0),
-                         MinNeutralPt        = cms.vdouble( 1.7,  2.0),
-                         MinNeutralPtSlope   = cms.vdouble(0.08, 0.08),
-                         RMSEtaSF            = cms.vdouble(1.20, 0.95),
-                         MedEtaSF            = cms.vdouble(0.90, 0.75),
-                         EtaMaxExtrap        = cms.double( 2.0),
-                         puppiAlgos = puppiForward
-                        )
-     )
+    algos = { 0 : dict(etaMin = {-0.01}) } # include particles with eta==0 (proper fix is in #31174)
 )

--- a/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
+++ b/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-def UpdatePuppiTuneV14(process, runOnMC=True):
+def UpdatePuppiTuneV15(process, runOnMC=True):
   #
   # Adapt for re-running PUPPI
   #
-  print("customizePuppiTune_cff::UpdatePuppiTuneV14: Recomputing PUPPI with Tune v14, slimmedJetsPuppi and slimmedMETsPuppi")
+  print("customizePuppiTune_cff::UpdatePuppiTuneV15: Recomputing PUPPI with Tune v15, slimmedJetsPuppi and slimmedMETsPuppi")
   from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
   task = getPatAlgosToolsTask(process)
   from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
@@ -12,7 +12,7 @@ def UpdatePuppiTuneV14(process, runOnMC=True):
   process.puppi.useExistingWeights = False
   process.puppiNoLep.useExistingWeights = False
   from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-  runMetCorAndUncFromMiniAOD(process,isData=(not runOnMC),metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi",recoMetFromPFCs=True,pfCandColl=cms.InputTag("puppiForMET"))
+  runMetCorAndUncFromMiniAOD(process,isData=(not runOnMC),metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi",recoMetFromPFCs=True)
   from PhysicsTools.PatAlgos.patPuppiJetSpecificProducer_cfi import patPuppiJetSpecificProducer
   addToProcessAndTask('patPuppiJetSpecificProducer', patPuppiJetSpecificProducer.clone(src=cms.InputTag("patJetsPuppi")), process, task)
   from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
@@ -26,17 +26,21 @@ def UpdatePuppiTuneV14(process, runOnMC=True):
   del process.updatedPatJetsPuppiJetSpecific
   process.puppiSequence = cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi+process.patPuppiJetSpecificProducer+process.slimmedJetsPuppi)
   #
-  # Adapt for PUPPI tune V14
+  # Adapt for PUPPI tune V15
   #
   process.puppi.PtMaxCharged = 20.
   process.puppi.EtaMinUseDeltaZ = 2.4
   process.puppi.PtMaxNeutralsStartSlope = 20.
+  process.puppi.NumOfPUVtxsForCharged = 2
+  process.puppi.algos[0].etaMin = [-0.01]
   process.puppiNoLep.PtMaxCharged = 20.
   process.puppiNoLep.EtaMinUseDeltaZ = 2.4
   process.puppiNoLep.PtMaxNeutralsStartSlope = 20.
+  process.puppiNoLep.NumOfPUVtxsForCharged = 2
+  process.puppiNoLep.algos[0].etaMin = [-0.01]
 
-def UpdatePuppiTuneV14_MC(process):
-  UpdatePuppiTuneV14(process,runOnMC=True)
+def UpdatePuppiTuneV15_MC(process):
+  UpdatePuppiTuneV15(process,runOnMC=True)
 
-def UpdatePuppiTuneV14_Data(process):
-  UpdatePuppiTuneV14(process,runOnMC=False)
+def UpdatePuppiTuneV15_Data(process):
+  UpdatePuppiTuneV15(process,runOnMC=False)

--- a/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
+++ b/CommonTools/PileupAlgos/python/customizePuppiTune_cff.py
@@ -12,7 +12,7 @@ def UpdatePuppiTuneV15(process, runOnMC=True):
   process.puppi.useExistingWeights = False
   process.puppiNoLep.useExistingWeights = False
   from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
-  runMetCorAndUncFromMiniAOD(process,isData=(not runOnMC),metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi",recoMetFromPFCs=True)
+  runMetCorAndUncFromMiniAOD(process,isData=(not runOnMC),metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi",recoMetFromPFCs=True,pfCandColl=cms.InputTag("puppiForMET"))
   from PhysicsTools.PatAlgos.patPuppiJetSpecificProducer_cfi import patPuppiJetSpecificProducer
   addToProcessAndTask('patPuppiJetSpecificProducer', patPuppiJetSpecificProducer.clone(src=cms.InputTag("patJetsPuppi")), process, task)
   from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection


### PR DESCRIPTION
#### PR description:

This introduces a change for Era run2_miniAOD_UL (#27889) in the treatment of the track-vertex association for charged particles in PUPPI. The new version is called v15.
The vertex association is adapted to deal with split vertices in high hadronic activity events (more on this here: https://indico.cern.ch/event/944339/contributions/3968152/attachments/2086414/3505127/splitverticesandhighptjets.pdf).
Charged particles associated to one of the leading two pileup vertices by the vertex fit (fromPV=0), but found within dz<0.2 of the primary vertex are treated as coming from the primary vertex.
This reduces MET tails due to particles that are wrongly associated to a PU vertex, when the PV is reconstructed as 2-3 split vertices.
The overall impact on jet response, jet efficiency, fake rate, boosted object tagging is negligible.
Thus JEC and SFs derived with PUPPI v14 are applicable to PUPPI v15.
A summary of the studies is in:
https://indico.cern.ch/event/942994/contributions/3978585/attachments/2088015/3508036/puppiv15summary-1.pdf
An additional check on softdrop mass response for high pT AK8 jets can be found here:
https://indico.cern.ch/event/942994/#7-virtual-impact-of-puppi-tune

In addition rare cases with particle eta==0 that are not treated in PuppiContainer are handled by adapting the eta range start at -0.01. A permanent fix for this is in #31174.

#### PR validation:

scram b run-tests
runTheMatrix.py -l limited

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #31174