### PR TITLE
Fix CondDB unit tests

### DIFF
--- a/CondCore/CondDB/test/testConnectionPool.cpp
+++ b/CondCore/CondDB/test/testConnectionPool.cpp
@@ -114,8 +114,8 @@ int main(int argc, char** argv) {
   edm::ParameterSet pSet;
   pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
   psets.push_back(pSet);
-  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-  static const edm::ServiceRegistry::Operate operate(services);
+  const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  const edm::ServiceRegistry::Operate operate(services);
 
   std::array<std::string, 2> connectionStrings{
       {"frontier://FrontierPrep/CMS_CONDITIONS",

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -24,8 +24,8 @@ int main(int argc, char** argv) {
   edm::ParameterSet pSet;
   pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
   psets.push_back(pSet);
-  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-  static const edm::ServiceRegistry::Operate operate(services);
+  const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  const edm::ServiceRegistry::Operate operate(services);
 
   std::string connectionString("frontier://FrontierProd/CMS_CONDITIONS");
   std::cout << "# Connecting with db in " << connectionString << std::endl;

--- a/CondCore/CondDB/test/testRunInfo2.cpp
+++ b/CondCore/CondDB/test/testRunInfo2.cpp
@@ -45,8 +45,8 @@ int main(int argc, char** argv) {
   edm::ParameterSet pSet;
   pSet.addParameter("@service_type", std::string("SiteLocalConfigService"));
   psets.push_back(pSet);
-  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
-  static const edm::ServiceRegistry::Operate operate(services);
+  const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  const edm::ServiceRegistry::Operate operate(services);
   int ret = 0;
   std::string connectionString0("frontier://FrontierProd/CMS_CONDITIONS");
   //std::string connectionString0("frontier://FrontierProd/CMS_CONDITIONS");


### PR DESCRIPTION
This fixes the CondDB unit tests for CC8. Valgrind generated the following [a] output which point to the deletion of `edm::ServiceToken` causing these unit tests to fail.

@makortel , @Dr15Jones , does this change makes any sense? No idea why removing the `static` allows these tests to run under CC8

[a]
```
==21221== Invalid read of size 4
==21221==    at 0x407060: __exchange_and_add (atomicity.h:49)
==21221==    by 0x407060: __exchange_and_add_dispatch (atomicity.h:82)
==21221==    by 0x407060: __exchange_and_add_dispatch (atomicity.h:78)
==21221==    by 0x407060: _M_release (shared_ptr_base.h:152)
==21221==    by 0x407060: ~__shared_count (shared_ptr_base.h:728)
==21221==    by 0x407060: ~__shared_ptr (shared_ptr_base.h:1167)
==21221==    by 0x407060: ~shared_ptr (shared_ptr.h:103)
==21221==    by 0x407060: edm::ServiceToken::~ServiceToken() (ServiceToken.h:40)
==21221==    by 0x7AE1E9B: __run_exit_handlers (in /usr/lib64/libc-2.28.so)
==21221==    by 0x7AE1FCF: exit (in /usr/lib64/libc-2.28.so)
==21221==    by 0x7ACB6A9: (below main) (in /usr/lib64/libc-2.28.so)
==21221==  Address 0x8d23378 is 8 bytes inside a block of size 2,672 free'd
==21221==    at 0x4035DD0: operator delete(void*) (in /cvmfs/cms-ib.cern.ch/nweek-02643/cc8_amd64_gcc8/external/valgrind/3.15.0-bcolbf2/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21221==    by 0x41C8EE7: _M_release (shared_ptr_base.h:171)
==21221==    by 0x41C8EE7: _M_release (shared_ptr_base.h:148)
==21221==    by 0x41C8EE7: operator= (shared_ptr_base.h:747)
==21221==    by 0x41C8EE7: operator= (shared_ptr_base.h:1078)
==21221==    by 0x41C8EE7: operator= (shared_ptr.h:103)
==21221==    by 0x41C8EE7: edm::ServiceRegistry::unsetContext(edm::ServiceToken const&) (ServiceRegistry.cc:58)
==21221==    by 0x406F88: edm::ServiceRegistry::Operate::~Operate() (ServiceRegistry.h:43)
==21221==    by 0x7AE1E9B: __run_exit_handlers (in /usr/lib64/libc-2.28.so)
==21221==    by 0x7AE1FCF: exit (in /usr/lib64/libc-2.28.so)
==21221==    by 0x7ACB6A9: (below main) (in /usr/lib64/libc-2.28.so)
==21221==  Block was alloc'd at
==21221==    at 0x4034DB2: operator new(unsigned long) (in /cvmfs/cms-ib.cern.ch/nweek-02643/cc8_amd64_gcc8/external/valgrind/3.15.0-bcolbf2/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==21221==    by 0x41C9017: allocate (new_allocator.h:111)
==21221==    by 0x41C9017: allocate (alloc_traits.h:436)
==21221==    by 0x41C9017: __allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<edm::serviceregistry::ServicesManager, std::allocator<edm::serviceregistry::ServicesManager>, (__gnu_cxx::_Lock_policy)2> > > (allocated_ptr.h:97)
==21221==    by 0x41C9017: __shared_count<edm::serviceregistry::ServicesManager, std::allocator<edm::serviceregistry::ServicesManager>, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&> (shared_ptr_base.h:675)
==21221==    by 0x41C9017: __shared_ptr<std::allocator<edm::serviceregistry::ServicesManager>, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&> (shared_ptr_base.h:1342)
==21221==    by 0x41C9017: shared_ptr<std::allocator<edm::serviceregistry::ServicesManager>, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&> (shared_ptr.h:359)
==21221==    by 0x41C9017: allocate_shared<edm::serviceregistry::ServicesManager, std::allocator<edm::serviceregistry::ServicesManager>, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&> (shared_ptr.h:706)
==21221==    by 0x41C9017: make_shared<edm::serviceregistry::ServicesManager, std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&> (shared_ptr.h:722)
==21221==    by 0x41C9017: edm::ServiceRegistry::createSet(std::vector<edm::ParameterSet, std::allocator<edm::ParameterSet> >&) (ServiceRegistry.cc:77)
==21221==    by 0x406AAC: main (testFrontier.cpp:27)

```