### PR TITLE
Add modules to produce a boolean value, and filter based on it

### DIFF
--- a/FWCore/Modules/src/BooleanFilter.cc
+++ b/FWCore/Modules/src/BooleanFilter.cc
@@ -1,0 +1,32 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+  class BooleanFilter : public global::EDFilter<> {
+  public:
+    explicit BooleanFilter(ParameterSet const& config)
+        : token_(consumes<bool>(config.getParameter<edm::InputTag>("src"))) {}
+
+    bool filter(StreamID sid, Event& event, EventSetup const& setup) const final { return event.get(token_); }
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    const edm::EDGetTokenT<bool> token_;
+  };
+
+  void BooleanFilter::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("src", edm::InputTag());
+    descriptions.addWithDefaultLabel(desc);
+    descriptions.setComment("This EDFilter accepts or rejects events based on the boolean value read from \"src\".");
+  }
+}  // namespace edm
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edm::BooleanFilter;
+DEFINE_FWK_MODULE(BooleanFilter);

--- a/FWCore/Modules/src/BooleanProducer.cc
+++ b/FWCore/Modules/src/BooleanProducer.cc
@@ -1,0 +1,33 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+  class BooleanProducer : public global::EDProducer<> {
+  public:
+    explicit BooleanProducer(ParameterSet const& config)
+        : value_(config.getParameter<bool>("value")), token_(produces<bool>()) {}
+
+    void produce(StreamID sid, Event& event, EventSetup const& setup) const final { event.emplace(token_, value_); }
+
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+
+  private:
+    const bool value_;
+    const edm::EDPutTokenT<bool> token_;
+  };
+
+  void BooleanProducer::fillDescriptions(ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<bool>("value", false);
+    descriptions.addWithDefaultLabel(desc);
+    descriptions.setComment("This EDProducer produces a boolean value according to the \"value\" parameter.");
+  }
+}  // namespace edm
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using edm::BooleanProducer;
+DEFINE_FWK_MODULE(BooleanProducer);


### PR DESCRIPTION
#### PR description:

Add two modules:
  - `BooleanProducer` reads a boolean value from the configuration, and "produces" it into the event;
  - `BooleanFilter` reads a boolean value from the event, and accepts or rejects the event based on it.

Together with a `SwitchProducer`, these modules allow recording in the events' `TriggerResults` which of the branches was taken.

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport #31221 for use in the next MWGR.