### PR TITLE
Simplify specifying consumes

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -114,7 +114,7 @@ namespace edm {
     }
 
     template <Transition Tr = Transition::Event>
-    [[nodiscard]] constexpr auto esConsumes(ESInputTag tag) noexcept {
+    [[nodiscard]] auto esConsumes(ESInputTag tag) noexcept {
       return ConsumesCollectorWithTagESAdaptor<Tr>(*this, std::move(tag));
     }
 
@@ -159,7 +159,8 @@ namespace edm {
   };
 
   template <BranchType B>
-  struct ConsumesCollectorAdaptor {
+  class ConsumesCollectorAdaptor {
+  public:
     ConsumesCollectorAdaptor(ConsumesCollector iBase, edm::InputTag iTag) : m_consumer(iBase), m_tag(std::move(iTag)) {}
 
     template <typename TYPE>

--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -131,29 +131,35 @@ namespace edm {
   template <Transition TR>
   class ConsumesCollectorESAdaptor {
   public:
-    explicit ConsumesCollectorESAdaptor(ConsumesCollector iBase) : m_consumer(std::move(iBase)) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() {
       return m_consumer.template esConsumes<TYPE, REC, TR>();
     }
 
   private:
+    //only ConsumesCollector is allowed to make an instance of this class
+    friend class ConsumesCollector;
+
+    explicit ConsumesCollectorESAdaptor(ConsumesCollector iBase) : m_consumer(std::move(iBase)) {}
+
     ConsumesCollector m_consumer;
   };
 
   template <Transition TR>
   class ConsumesCollectorWithTagESAdaptor {
   public:
-    ConsumesCollectorWithTagESAdaptor(ConsumesCollector iBase, ESInputTag iTag)
-        : m_consumer(std::move(iBase)), m_tag(std::move(iTag)) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() {
       return m_consumer.template esConsumes<TYPE, REC, TR>(m_tag);
     }
 
   private:
+    //only ConsumesCollector is allowed to make an instance of this class
+    friend class ConsumesCollector;
+
+    ConsumesCollectorWithTagESAdaptor(ConsumesCollector iBase, ESInputTag iTag)
+        : m_consumer(std::move(iBase)), m_tag(std::move(iTag)) {}
+
     ConsumesCollector m_consumer;
     ESInputTag const& m_tag;
   };
@@ -161,14 +167,17 @@ namespace edm {
   template <BranchType B>
   class ConsumesCollectorAdaptor {
   public:
-    ConsumesCollectorAdaptor(ConsumesCollector iBase, edm::InputTag iTag) : m_consumer(iBase), m_tag(std::move(iTag)) {}
-
     template <typename TYPE>
     EDGetTokenT<TYPE> consumes() {
       return m_consumer.template consumes<TYPE, B>(m_tag);
     }
 
   private:
+    //only ConsumesCollector is allowed to make an instance of this class
+    friend class ConsumesCollector;
+
+    ConsumesCollectorAdaptor(ConsumesCollector iBase, edm::InputTag iTag) : m_consumer(iBase), m_tag(std::move(iTag)) {}
+
     ConsumesCollector m_consumer;
     edm::InputTag const m_tag;
   };

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -298,29 +298,33 @@ namespace edm {
   template <Transition TR>
   class EDConsumerBaseESAdaptor {
   public:
-    EDConsumerBaseESAdaptor(EDConsumerBase* iBase) : m_consumer(iBase) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() const {
       return m_consumer->template esConsumes<TYPE, REC, TR>();
     }
 
   private:
+    //only EDConsumerBase is allowed to make an instance of this class
+    friend class EDConsumerBase;
+    EDConsumerBaseESAdaptor(EDConsumerBase* iBase) : m_consumer(iBase) {}
+
     EDConsumerBase* m_consumer;
   };
 
   template <Transition TR>
   class EDConsumerBaseWithTagESAdaptor {
   public:
-    EDConsumerBaseWithTagESAdaptor(EDConsumerBase* iBase, ESInputTag iTag) noexcept
-        : m_consumer(iBase), m_tag(std::move(iTag)) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() const {
       return m_consumer->template esConsumes<TYPE, REC, TR>(m_tag);
     }
 
   private:
+    //only EDConsumerBase is allowed to make an instance of this class
+    friend class EDConsumerBase;
+    EDConsumerBaseWithTagESAdaptor(EDConsumerBase* iBase, ESInputTag iTag) noexcept
+        : m_consumer(iBase), m_tag(std::move(iTag)) {}
+
     EDConsumerBase* m_consumer;
     ESInputTag const m_tag;
   };
@@ -328,15 +332,17 @@ namespace edm {
   template <BranchType B>
   class EDConsumerBaseAdaptor {
   public:
-    EDConsumerBaseAdaptor(EDConsumerBase* iBase, edm::InputTag iTag) noexcept
-        : m_consumer(iBase), m_tag(std::move(iTag)) {}
-
     template <typename TYPE>
     EDGetTokenT<TYPE> consumes() const {
       return m_consumer->template consumes<TYPE, B>(m_tag);
     }
 
   private:
+    //only EDConsumerBase is allowed to make an instance of this class
+    friend class EDConsumerBase;
+    EDConsumerBaseAdaptor(EDConsumerBase* iBase, edm::InputTag iTag) noexcept
+        : m_consumer(iBase), m_tag(std::move(iTag)) {}
+
     EDConsumerBase* m_consumer;
     edm::InputTag const m_tag;
   };

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -218,7 +218,7 @@ namespace edm {
     }
 
     template <Transition Tr = Transition::Event>
-    [[nodiscard]] constexpr auto esConsumes(ESInputTag tag) noexcept {
+    [[nodiscard]] auto esConsumes(ESInputTag tag) noexcept {
       return EDConsumerBaseWithTagESAdaptor<Tr>(this, std::move(tag));
     }
 
@@ -296,7 +296,8 @@ namespace edm {
   };
 
   template <Transition TR>
-  struct EDConsumerBaseESAdaptor {
+  class EDConsumerBaseESAdaptor {
+  public:
     EDConsumerBaseESAdaptor(EDConsumerBase* iBase) : m_consumer(iBase) {}
 
     template <typename TYPE, typename REC>
@@ -309,7 +310,8 @@ namespace edm {
   };
 
   template <Transition TR>
-  struct EDConsumerBaseWithTagESAdaptor {
+  class EDConsumerBaseWithTagESAdaptor {
+  public:
     EDConsumerBaseWithTagESAdaptor(EDConsumerBase* iBase, ESInputTag iTag) noexcept
         : m_consumer(iBase), m_tag(std::move(iTag)) {}
 
@@ -324,7 +326,8 @@ namespace edm {
   };
 
   template <BranchType B>
-  struct EDConsumerBaseAdaptor {
+  class EDConsumerBaseAdaptor {
+  public:
     EDConsumerBaseAdaptor(EDConsumerBase* iBase, edm::InputTag iTag) noexcept
         : m_consumer(iBase), m_tag(std::move(iTag)) {}
 

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -299,7 +299,7 @@ namespace edm {
   class EDConsumerBaseESAdaptor {
   public:
     template <typename TYPE, typename REC>
-    ESGetToken<TYPE, REC> consumes() const {
+    ESGetToken<TYPE, REC> consumes() {
       return m_consumer->template esConsumes<TYPE, REC, TR>();
     }
 
@@ -315,7 +315,7 @@ namespace edm {
   class EDConsumerBaseWithTagESAdaptor {
   public:
     template <typename TYPE, typename REC>
-    ESGetToken<TYPE, REC> consumes() const {
+    ESGetToken<TYPE, REC> consumes() {
       return m_consumer->template esConsumes<TYPE, REC, TR>(m_tag);
     }
 
@@ -333,7 +333,7 @@ namespace edm {
   class EDConsumerBaseAdaptor {
   public:
     template <typename TYPE>
-    EDGetTokenT<TYPE> consumes() const {
+    EDGetTokenT<TYPE> consumes() {
       return m_consumer->template consumes<TYPE, B>(m_tag);
     }
 

--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -179,28 +179,32 @@ namespace edm {
 
   class ESConsumesCollectorAdaptor {
   public:
-    explicit ESConsumesCollectorAdaptor(ESConsumesCollector* iBase) : m_consumer(iBase) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() {
       return m_consumer->template consumesFrom<TYPE, REC>();
     }
 
   private:
+    //only ESConsumesCollector is allowed to make an instance of this class
+    friend class ESConsumesCollector;
+    explicit ESConsumesCollectorAdaptor(ESConsumesCollector* iBase) : m_consumer(iBase) {}
+
     ESConsumesCollector* m_consumer;
   };
 
   class ESConsumesCollectorWithTagAdaptor {
   public:
-    ESConsumesCollectorWithTagAdaptor(ESConsumesCollector* iBase, ESInputTag iTag)
-        : m_consumer(iBase), m_tag(std::move(iTag)) {}
-
     template <typename TYPE, typename REC>
     ESGetToken<TYPE, REC> consumes() {
       return m_consumer->template consumesFrom<TYPE, REC>(m_tag);
     }
 
   private:
+    //only ESConsumesCollector is allowed to make an instance of this class
+    friend class ESConsumesCollector;
+    ESConsumesCollectorWithTagAdaptor(ESConsumesCollector* iBase, ESInputTag iTag)
+        : m_consumer(iBase), m_tag(std::move(iTag)) {}
+
     ESConsumesCollector* m_consumer;
     ESInputTag const m_tag;
   };

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -61,7 +61,7 @@ namespace {
     IntsConsumer(std::vector<edm::InputTag> const& iTags) {
       m_tokens.reserve(iTags.size());
       for (auto const& tag : iTags) {
-        m_tokens.push_back(consumes<std::vector<int>>(tag));
+        m_tokens.emplace_back(consumes(tag));
       }
     }
 
@@ -74,7 +74,7 @@ namespace {
       m_tokens.reserve(iTags.size());
       m_mayTokens.reserve(iMayTags.size());
       for (auto const& tag : iTags) {
-        m_tokens.push_back(consumes<std::vector<int>>(tag));
+        m_tokens.emplace_back(consumes(tag));
       }
       for (auto const& tag : iMayTags) {
         m_mayTokens.push_back(mayConsume<std::vector<int>>(tag));
@@ -109,7 +109,7 @@ namespace {
       collectorCopy2 = std::move(collectorCopy1);
 
       for (auto const& tag : iTags) {
-        m_tokens.push_back(collectorCopy2.consumes<std::vector<int>>(tag));
+        m_tokens.emplace_back(collectorCopy2.consumes(tag));
       }
     }
 

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -613,6 +613,17 @@ namespace {
     [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token4(
         consumesCollector().esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("Blah")));
   }
+  {
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token1;
+    token1 = consumesCollector().esConsumes();
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token2;
+    token2 = consumesCollector().esConsumes(edm::ESInputTag("Blah"));
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token3;
+    token3 = consumesCollector().esConsumes<edm::Transition::BeginRun>();
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token4;
+    token4 = consumesCollector().esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("Blah"));
+  }
+
 }  // namespace
 }
 ;

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -590,128 +590,134 @@ namespace {
     ESGetToken<edm::eventsetup::test::DummyData, edm::DefaultRecord> m_token;
   };
 
-  class EDConsumesCollectorConsumer : public edm::EDConsumerBase {
-    EDConsumesCollectorConsumer() {
+  //This just tests that the constructs will properly compile
+  class [[maybe_unused]] EDConsumesCollectorConsumer
+      : public edm::EDConsumerBase{EDConsumesCollectorConsumer(){using edm::eventsetup::test::DummyData;
+  {
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token1(
+        consumesCollector().esConsumes<DummyData, edm::DefaultRecord>());
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
+        consumesCollector().esConsumes<DummyData, edm::DefaultRecord>(edm::ESInputTag("Blah")));
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token3(
+        consumesCollector().esConsumes<DummyData, edm::DefaultRecord, edm::Transition::BeginRun>());
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token4(
+        consumesCollector().esConsumes<DummyData, edm::DefaultRecord, edm::Transition::BeginRun>(
+            edm::ESInputTag("Blah")));
+  }
+  {
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token1(consumesCollector().esConsumes());
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
+        consumesCollector().esConsumes(edm::ESInputTag("Blah")));
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token3(
+        consumesCollector().esConsumes<edm::Transition::BeginRun>());
+    [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token4(
+        consumesCollector().esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("Blah")));
+  }
+}  // namespace
+}
+;
+
+class ConsumesProducer : public ESProducer {
+public:
+  ConsumesProducer() : token_{setWhatProduced(this, "consumes").consumes<edm::eventsetup::test::DummyData>()} {}
+  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
+    auto const& data = iRecord.get(token_);
+    return std::make_unique<edm::eventsetup::test::DummyData>(data);
+  }
+
+private:
+  edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
+};
+
+class ConsumesFromProducer : public ESProducer {
+public:
+  ConsumesFromProducer()
+      : token_{setWhatProduced(this, "consumesFrom").consumesFrom<edm::eventsetup::test::DummyData, DummyRecord>()} {}
+  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
+    auto const& data = iRecord.get(token_);
+    return std::make_unique<edm::eventsetup::test::DummyData>(data);
+  }
+
+private:
+  edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
+};
+
+class SetConsumesProducer : public ESProducer {
+public:
+  SetConsumesProducer() { setWhatProduced(this, "setConsumes").setConsumes(token_); }
+  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
+    auto const& data = iRecord.get(token_);
+    return std::make_unique<edm::eventsetup::test::DummyData>(data);
+  }
+
+private:
+  edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
+};
+
+//This is used only to test compilation
+class [[maybe_unused]] ESConsumesCollectorProducer : public ESProducer {
+public:
+  struct Helper {
+    Helper(ESConsumesCollector iCollector) {
       using edm::eventsetup::test::DummyData;
       {
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token1(
-            consumesCollector().esConsumes<DummyData, edm::DefaultRecord>());
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
-            consumesCollector().esConsumes<DummyData, edm::DefaultRecord>(edm::ESInputTag("Blah")));
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token3(
-            consumesCollector().esConsumes<DummyData, edm::DefaultRecord, edm::Transition::BeginRun>());
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token4(
-            consumesCollector().esConsumes<DummyData, edm::DefaultRecord, edm::Transition::BeginRun>(
-                edm::ESInputTag("Blah")));
+        [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token1(
+            iCollector.consumesFrom<DummyData, edm::DefaultRecord>());
+        [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
+            iCollector.consumesFrom<DummyData, edm::DefaultRecord>(edm::ESInputTag("Blah")));
       }
       {
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token1(consumesCollector().esConsumes());
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token2(consumesCollector().esConsumes(edm::ESInputTag("Blah")));
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token3(
-            consumesCollector().esConsumes<edm::Transition::BeginRun>());
-        edm::ESGetToken<DummyData, edm::DefaultRecord> token4(
-            consumesCollector().esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("Blah")));
+        [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token1(iCollector.consumes());
+        [[maybe_unused]] edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
+            iCollector.consumes(edm::ESInputTag("Blah")));
       }
     }
   };
 
-  class ConsumesProducer : public ESProducer {
-  public:
-    ConsumesProducer() : token_{setWhatProduced(this, "consumes").consumes<edm::eventsetup::test::DummyData>()} {}
-    std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
-      auto const& data = iRecord.get(token_);
-      return std::make_unique<edm::eventsetup::test::DummyData>(data);
+  ESConsumesCollectorProducer() : helper_(setWhatProduced(this, "consumesCollector")) {}
+
+  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
+    return std::unique_ptr<edm::eventsetup::test::DummyData>();
+  }
+
+private:
+  Helper helper_;
+};
+
+class SetMayConsumeProducer : public ESProducer {
+public:
+  SetMayConsumeProducer(bool iSucceed) : succeed_(iSucceed) {
+    setWhatProduced(this, label(iSucceed))
+        .setMayConsume(
+            token_,
+            [iSucceed](auto& get, edm::ESTransientHandle<edm::eventsetup::test::DummyData> const& handle) {
+              if (iSucceed) {
+                return get("", "");
+              }
+              return get.nothing();
+            },
+            edm::ESProductTag<edm::eventsetup::test::DummyData, DummyRecord>("", ""));
+  }
+  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
+    auto const& data = iRecord.getHandle(token_);
+    CPPUNIT_ASSERT(data.isValid() == succeed_);
+    if (data.isValid()) {
+      return std::make_unique<edm::eventsetup::test::DummyData>(*data);
     }
+    return std::unique_ptr<edm::eventsetup::test::DummyData>();
+  }
 
-  private:
-    edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
-  };
-
-  class ConsumesFromProducer : public ESProducer {
-  public:
-    ConsumesFromProducer()
-        : token_{setWhatProduced(this, "consumesFrom").consumesFrom<edm::eventsetup::test::DummyData, DummyRecord>()} {}
-    std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
-      auto const& data = iRecord.get(token_);
-      return std::make_unique<edm::eventsetup::test::DummyData>(data);
+private:
+  static const char* label(bool iSucceed) noexcept {
+    if (iSucceed) {
+      return "setMayConsumeSucceed";
     }
+    return "setMayConsumeFail";
+  }
 
-  private:
-    edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
-  };
-
-  class SetConsumesProducer : public ESProducer {
-  public:
-    SetConsumesProducer() { setWhatProduced(this, "setConsumes").setConsumes(token_); }
-    std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
-      auto const& data = iRecord.get(token_);
-      return std::make_unique<edm::eventsetup::test::DummyData>(data);
-    }
-
-  private:
-    edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
-  };
-
-  class ESConsumesCollectorProducer : public ESProducer {
-  public:
-    struct Helper {
-      Helper(ESConsumesCollector iCollector) {
-        using edm::eventsetup::test::DummyData;
-        {
-          edm::ESGetToken<DummyData, edm::DefaultRecord> token1(
-              iCollector.consumesFrom<DummyData, edm::DefaultRecord>());
-          edm::ESGetToken<DummyData, edm::DefaultRecord> token2(
-              iCollector.consumesFrom<DummyData, edm::DefaultRecord>(edm::ESInputTag("Blah")));
-        }
-        {
-          edm::ESGetToken<DummyData, edm::DefaultRecord> token1(iCollector.consumes());
-          edm::ESGetToken<DummyData, edm::DefaultRecord> token2(iCollector.consumes(edm::ESInputTag("Blah")));
-        }
-      }
-    };
-
-    ESConsumesCollectorProducer() : helper_(setWhatProduced(this, "consumesCollector")) {}
-
-    std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord);
-
-  private:
-    Helper helper_;
-  };
-
-  class SetMayConsumeProducer : public ESProducer {
-  public:
-    SetMayConsumeProducer(bool iSucceed) : succeed_(iSucceed) {
-      setWhatProduced(this, label(iSucceed))
-          .setMayConsume(
-              token_,
-              [iSucceed](auto& get, edm::ESTransientHandle<edm::eventsetup::test::DummyData> const& handle) {
-                if (iSucceed) {
-                  return get("", "");
-                }
-                return get.nothing();
-              },
-              edm::ESProductTag<edm::eventsetup::test::DummyData, DummyRecord>("", ""));
-    }
-    std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
-      auto const& data = iRecord.getHandle(token_);
-      CPPUNIT_ASSERT(data.isValid() == succeed_);
-      if (data.isValid()) {
-        return std::make_unique<edm::eventsetup::test::DummyData>(*data);
-      }
-      return std::unique_ptr<edm::eventsetup::test::DummyData>();
-    }
-
-  private:
-    static const char* label(bool iSucceed) noexcept {
-      if (iSucceed) {
-        return "setMayConsumeSucceed";
-      }
-      return "setMayConsumeFail";
-    }
-
-    edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
-    bool succeed_;
-  };
+  edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
+  bool succeed_;
+};
 
 }  // namespace
 

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -247,7 +247,7 @@ void testEventsetupRecord::getTest() {
 
 namespace {
   struct DummyDataConsumer : public EDConsumerBase {
-    explicit DummyDataConsumer(ESInputTag const& iTag) : m_token{esConsumes<Dummy, DummyRecord>(iTag)} {}
+    explicit DummyDataConsumer(ESInputTag const& iTag) : m_token{esConsumes(iTag)} {}
 
     void prefetch(eventsetup::EventSetupRecordImpl const& iRec) const {
       auto const& proxies = this->esGetTokenIndicesVector(edm::Transition::Event);

--- a/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
+++ b/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
@@ -41,7 +41,7 @@ namespace edmtest {
   class DeleteEarlyReader : public edm::global::EDAnalyzer<> {
   public:
     DeleteEarlyReader(edm::ParameterSet const& pset)
-        : getToken_(consumes<DeleteEarly>(pset.getUntrackedParameter<edm::InputTag>("tag"))) {}
+        : getToken_(consumes(pset.getUntrackedParameter<edm::InputTag>("tag"))) {}
 
     void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const&) const override { e.get(getToken_); }
 

--- a/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/RunLumiEventAnalyzer.cc
@@ -42,7 +42,7 @@ namespace edmtest {
           "expectedRunLumiEvents1", std::vector<unsigned long long>());
     }
     if (dumpTriggerResults_) {
-      triggerResultsToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
+      triggerResultsToken_ = consumes(edm::InputTag("TriggerResults"));
     }
   }
 

--- a/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/TestESDummyDataAnalyzer.cc
@@ -63,8 +63,8 @@ TestESDummyDataAnalyzer::TestESDummyDataAnalyzer(const edm::ParameterSet& iConfi
     : m_expectedValue{iConfig.getParameter<int>("expected")},
       m_nEventsValue{iConfig.getUntrackedParameter<int>("nEvents", 0)},
       m_totalNEvents{iConfig.getUntrackedParameter<int>("totalNEvents", -1)},
-      m_esTokenBeginRun{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord, edm::Transition::BeginRun>()},
-      m_esToken{esConsumes<edm::eventsetup::test::DummyData, edm::DefaultRecord>()} {}
+      m_esTokenBeginRun{esConsumes<edm::Transition::BeginRun>()},
+      m_esToken{esConsumes()} {}
 
 void TestESDummyDataAnalyzer::analyze(const edm::Event&, const edm::EventSetup& iSetup) {
   using namespace edm;

--- a/FWCore/Framework/test/stubs/TestGetPathStatus.cc
+++ b/FWCore/Framework/test/stubs/TestGetPathStatus.cc
@@ -35,8 +35,8 @@ namespace edmtest {
   TestGetPathStatus::TestGetPathStatus(edm::ParameterSet const& pset)
       : expectedStates_(pset.getParameter<std::vector<int>>("expectedStates")),
         expectedIndexes_(pset.getParameter<std::vector<unsigned int>>("expectedIndexes")),
-        tokenPathStatus_(consumes<edm::PathStatus>(pset.getParameter<edm::InputTag>("pathStatusTag"))),
-        tokenEndPathStatus_(consumes<edm::EndPathStatus>(pset.getParameter<edm::InputTag>("endPathStatusTag"))) {}
+        tokenPathStatus_(consumes(pset.getParameter<edm::InputTag>("pathStatusTag"))),
+        tokenEndPathStatus_(consumes(pset.getParameter<edm::InputTag>("endPathStatusTag"))) {}
 
   void TestGetPathStatus::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const&) const {
     auto const& pathStatus = event.get(tokenPathStatus_);

--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -84,7 +84,7 @@ namespace edmtest {
         bitMask_(ps.getParameter<int>("bitMask")),
         hltbits_(0),
         expectTriggerResults_(ps.getUntrackedParameter<bool>("expectTriggerResults", true)),
-        resultsToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))) {}
+        resultsToken_(consumes(edm::InputTag("TriggerResults"))) {}
 
   TestOutputModule::~TestOutputModule() {}
 

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -75,7 +75,7 @@ namespace edmtest {
     MultipleIntsAnalyzer(edm::ParameterSet const& iPSet) {
       auto const& tags = iPSet.getUntrackedParameter<std::vector<edm::InputTag>>("getFromModules");
       for (auto const& tag : tags) {
-        m_tokens.emplace_back(consumes<IntProduct>(tag));
+        m_tokens.emplace_back(consumes(tag));
       }
     }
 

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -308,7 +308,7 @@ namespace edmtest {
   class IntProducerFromTransient : public edm::global::EDProducer<> {
   public:
     explicit IntProducerFromTransient(edm::ParameterSet const&)
-        : putToken_{produces<IntProduct>()}, getToken_{consumes<TransientIntProduct>(edm::InputTag{"TransientThing"})} {}
+        : putToken_{produces<IntProduct>()}, getToken_{consumes(edm::InputTag{"TransientThing"})} {}
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
 
   private:
@@ -355,7 +355,7 @@ namespace edmtest {
           onlyGetOnEvent_(p.getUntrackedParameter<unsigned int>("onlyGetOnEvent", 0u)) {
       auto const& labels = p.getParameter<std::vector<edm::InputTag>>("labels");
       for (auto const& label : labels) {
-        tokens_.emplace_back(consumes<IntProduct>(label));
+        tokens_.emplace_back(consumes(label));
       }
     }
     void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
@@ -516,37 +516,37 @@ namespace edmtest {
       {
         auto tag = p.getParameter<edm::InputTag>("consumesBeginProcessBlock");
         if (not tag.label().empty()) {
-          bpbGet_ = consumes<IntProduct, edm::InProcess>(tag);
+          bpbGet_ = consumes<edm::InProcess>(tag);
         }
       }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesBeginRun");
         if (not tag.label().empty()) {
-          brGet_ = consumes<IntProduct, edm::InRun>(tag);
+          brGet_ = consumes<edm::InRun>(tag);
         }
       }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesBeginLuminosityBlock");
         if (not tag.label().empty()) {
-          blGet_ = consumes<IntProduct, edm::InLumi>(tag);
+          blGet_ = consumes<edm::InLumi>(tag);
         }
       }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesEndLuminosityBlock");
         if (not tag.label().empty()) {
-          elGet_ = consumes<IntProduct, edm::InLumi>(tag);
+          elGet_ = consumes<edm::InLumi>(tag);
         }
       }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesEndRun");
         if (not tag.label().empty()) {
-          erGet_ = consumes<IntProduct, edm::InRun>(tag);
+          erGet_ = consumes<edm::InRun>(tag);
         }
       }
       {
         auto tag = p.getParameter<edm::InputTag>("consumesEndProcessBlock");
         if (not tag.label().empty()) {
-          epbGet_ = consumes<IntProduct, edm::InProcess>(tag);
+          epbGet_ = consumes<edm::InProcess>(tag);
         }
       }
     }

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -41,8 +41,7 @@ namespace edmtest {
 
   public:
     explicit IntVecRefVectorProducer(edm::ParameterSet const& p)
-        : target_{consumes<std::vector<int>>(p.getParameter<edm::InputTag>("target"))},
-          select_(p.getParameter<int>("select")) {
+        : target_{consumes(p.getParameter<edm::InputTag>("target"))}, select_(p.getParameter<int>("select")) {
       produces<product_type>();
     }
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
@@ -87,7 +86,7 @@ namespace edmtest {
 
   public:
     explicit IntVecRefToBaseVectorProducer(edm::ParameterSet const& p)
-        : target_{consumes<edm::View<int>>(p.getParameter<edm::InputTag>("target"))} {
+        : target_{consumes(p.getParameter<edm::InputTag>("target"))} {
       produces<product_type>();
     }
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
@@ -120,7 +119,7 @@ namespace edmtest {
 
   public:
     explicit IntVecPtrVectorProducer(edm::ParameterSet const& p)
-        : target_{consumes<edm::View<int>>(p.getParameter<edm::InputTag>("target"))} {
+        : target_{consumes(p.getParameter<edm::InputTag>("target"))} {
       produces<product_type>();
     }
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;
@@ -154,7 +153,7 @@ namespace edmtest {
 
   public:
     explicit IntVecStdVectorPtrProducer(edm::ParameterSet const& p)
-        : target_(consumes<edm::View<int>>(p.getParameter<edm::InputTag>("target"))) {
+        : target_(consumes(p.getParameter<edm::InputTag>("target"))) {
       produces<product_type>();
     }
     virtual void produce(edm::StreamID, edm::Event& e, edm::EventSetup const& c) const override;

--- a/FWCore/Integration/test/ConcurrentIOVAnalyzer.cc
+++ b/FWCore/Integration/test/ConcurrentIOVAnalyzer.cc
@@ -44,8 +44,8 @@ namespace edmtest {
 
   ConcurrentIOVAnalyzer::ConcurrentIOVAnalyzer(edm::ParameterSet const& pset)
       : checkExpectedValues_{pset.getUntrackedParameter<bool>("checkExpectedValues")},
-        esTokenFromESSource_{esConsumes<IOVTestInfo, ESTestRecordI>(edm::ESInputTag("", ""))},
-        esTokenFromESProducer_{esConsumes<IOVTestInfo, ESTestRecordI>(edm::ESInputTag("", "fromESProducer"))} {}
+        esTokenFromESSource_{esConsumes(edm::ESInputTag("", ""))},
+        esTokenFromESProducer_{esConsumes(edm::ESInputTag("", "fromESProducer"))} {}
 
   void ConcurrentIOVAnalyzer::analyze(edm::StreamID, edm::Event const& event, edm::EventSetup const& eventSetup) const {
     auto lumiNumber = event.eventAuxiliary().luminosityBlock();

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -34,7 +34,7 @@ namespace edmtest {
   ESTestAnalyzerA::ESTestAnalyzerA(edm::ParameterSet const& pset)
       : runsToGetDataFor_(pset.getParameter<std::vector<int>>("runsToGetDataFor")),
         expectedValues_(pset.getUntrackedParameter<std::vector<int>>("expectedValues")),
-        token_(esConsumes<ESTestDataA, ESTestRecordA>()) {
+        token_(esConsumes()) {
     assert(expectedValues_.empty() or expectedValues_.size() == runsToGetDataFor_.size());
   }
 

--- a/FWCore/Integration/test/ExistingDictionaryTestModules.cc
+++ b/FWCore/Integration/test/ExistingDictionaryTestModules.cc
@@ -51,10 +51,9 @@ namespace edmtest {
   class ExistingDictionaryTestAnalyzer : public edm::global::EDAnalyzer<> {
   public:
     explicit ExistingDictionaryTestAnalyzer(edm::ParameterSet const& iConfig)
-        : intToken_{consumes<int>(iConfig.getParameter<edm::InputTag>("src"))},
-          vecUniqIntToken_{consumes<std::vector<std::unique_ptr<int>>>(iConfig.getParameter<edm::InputTag>("src"))},
-          vecUniqIntProdToken_{
-              consumes<std::vector<std::unique_ptr<IntProduct>>>(iConfig.getParameter<edm::InputTag>("src"))},
+        : intToken_{consumes(iConfig.getParameter<edm::InputTag>("src"))},
+          vecUniqIntToken_{consumes(iConfig.getParameter<edm::InputTag>("src"))},
+          vecUniqIntProdToken_{consumes(iConfig.getParameter<edm::InputTag>("src"))},
           testVecUniqInt_{iConfig.getParameter<bool>("testVecUniqInt")} {}
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/FWCore/Integration/test/RunLumiESAnalyzer.cc
+++ b/FWCore/Integration/test/RunLumiESAnalyzer.cc
@@ -81,13 +81,11 @@ namespace edmtest {
   };
 
   RunLumiESAnalyzer::RunLumiESAnalyzer(edm::ParameterSet const&)
-      : esToken_{esConsumes<IOVTestInfo, ESTestRecordC>(edm::ESInputTag("", ""))},
-        tokenBeginRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginRun>(edm::ESInputTag("", ""))},
-        tokenBeginLumi_{
-            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", ""))},
-        tokenEndLumi_{
-            esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndLuminosityBlock>(edm::ESInputTag("", ""))},
-        tokenEndRun_{esConsumes<IOVTestInfo, ESTestRecordC, edm::Transition::EndRun>(edm::ESInputTag("", ""))} {}
+      : esToken_{esConsumes(edm::ESInputTag("", ""))},
+        tokenBeginRun_{esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", ""))},
+        tokenBeginLumi_{esConsumes<edm::Transition::BeginLuminosityBlock>(edm::ESInputTag("", ""))},
+        tokenEndLumi_{esConsumes<edm::Transition::EndLuminosityBlock>(edm::ESInputTag("", ""))},
+        tokenEndRun_{esConsumes<edm::Transition::EndRun>(edm::ESInputTag("", ""))} {}
 
   std::unique_ptr<UnsafeCache> RunLumiESAnalyzer::beginStream(edm::StreamID iID) const {
     return std::make_unique<UnsafeCache>();

--- a/FWCore/Integration/test/SwitchProducerProvenanceAnalyzer.cc
+++ b/FWCore/Integration/test/SwitchProducerProvenanceAnalyzer.cc
@@ -30,8 +30,8 @@ namespace edmtest {
   };
 
   SwitchProducerProvenanceAnalyzer::SwitchProducerProvenanceAnalyzer(edm::ParameterSet const& iConfig)
-      : inputToken1_(consumes<IntProduct>(iConfig.getParameter<edm::InputTag>("src1"))),
-        inputToken2_(consumes<IntProduct>(iConfig.getParameter<edm::InputTag>("src2"))),
+      : inputToken1_(consumes(iConfig.getParameter<edm::InputTag>("src1"))),
+        inputToken2_(consumes(iConfig.getParameter<edm::InputTag>("src2"))),
         producerPrefix_(iConfig.getParameter<std::string>("producerPrefix")),
         aliasMode_(iConfig.getParameter<bool>("aliasMode")) {}
 

--- a/FWCore/Integration/test/ThingAnalyzer.cc
+++ b/FWCore/Integration/test/ThingAnalyzer.cc
@@ -48,11 +48,11 @@ namespace edmtest {
   };
 
   ThingAnalyzer::ThingAnalyzer(edm::ParameterSet const& iPSet)
-      : beginRun_(consumes<ThingCollection, edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("beginRun"))),
-        beginLumi_(consumes<ThingCollection, edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("beginLumi"))),
-        event_(consumes<ThingCollection>(iPSet.getUntrackedParameter<edm::InputTag>("event"))),
-        endLumi_(consumes<ThingCollection, edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("endLumi"))),
-        endRun_(consumes<ThingCollection, edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("endRun"))) {}
+      : beginRun_(consumes<edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("beginRun"))),
+        beginLumi_(consumes<edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("beginLumi"))),
+        event_(consumes(iPSet.getUntrackedParameter<edm::InputTag>("event"))),
+        endLumi_(consumes<edm::InLumi>(iPSet.getUntrackedParameter<edm::InputTag>("endLumi"))),
+        endRun_(consumes<edm::InRun>(iPSet.getUntrackedParameter<edm::InputTag>("endRun"))) {}
 
   void ThingAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;

--- a/FWCore/Utilities/interface/EDGetToken.h
+++ b/FWCore/Utilities/interface/EDGetToken.h
@@ -36,14 +36,19 @@ namespace edm {
     friend class EDConsumerBase;
 
   public:
-    EDGetToken() : m_value{s_uninitializedValue} {}
+    constexpr EDGetToken() noexcept : m_value{s_uninitializedValue} {}
 
     template <typename T>
-    EDGetToken(EDGetTokenT<T> iOther) : m_value{iOther.m_value} {}
+    constexpr EDGetToken(EDGetTokenT<T> iOther) noexcept : m_value{iOther.m_value} {}
+
+    constexpr EDGetToken(const EDGetToken&) noexcept = default;
+    constexpr EDGetToken(EDGetToken&&) noexcept = default;
+    constexpr EDGetToken& operator=(const EDGetToken&) noexcept = default;
+    constexpr EDGetToken& operator=(EDGetToken&&) noexcept = default;
 
     // ---------- const member functions ---------------------
-    unsigned int index() const { return m_value; }
-    bool isUninitialized() const { return m_value == s_uninitializedValue; }
+    constexpr unsigned int index() const noexcept { return m_value; }
+    constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }
 
   private:
     //for testing
@@ -51,7 +56,7 @@ namespace edm {
 
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
-    explicit EDGetToken(unsigned int iValue) : m_value(iValue) {}
+    constexpr explicit EDGetToken(unsigned int iValue) noexcept : m_value(iValue) {}
 
     // ---------- member data --------------------------------
     unsigned int m_value;
@@ -63,11 +68,30 @@ namespace edm {
     friend class EDGetToken;
 
   public:
-    EDGetTokenT() : m_value{s_uninitializedValue} {}
+    constexpr EDGetTokenT() : m_value{s_uninitializedValue} {}
 
+    constexpr EDGetTokenT(const EDGetTokenT<T>&) noexcept = default;
+    constexpr EDGetTokenT(EDGetTokenT<T>&&) noexcept = default;
+    constexpr EDGetTokenT& operator=(const EDGetTokenT<T>&) noexcept = default;
+    constexpr EDGetTokenT& operator=(EDGetTokenT<T>&&) noexcept = default;
+
+    template <typename ADAPTER>
+    constexpr explicit EDGetTokenT(ADAPTER&& iAdapter) : EDGetTokenT(iAdapter.template consumes<T>()) {}
+
+    template <typename ADAPTER>
+    constexpr EDGetTokenT& operator=(ADAPTER&& iAdapter) {
+      EDGetTokenT<T> temp(iAdapter.template consumes<T>());
+      m_value = temp.m_value;
+
+      return *this;
+    }
+
+    //Needed to avoid EDGetTokenT(ADAPTER&&) from being called instead
+    // when we can use C++20 concepts we can avoid the problem using a constraint
+    constexpr EDGetTokenT(EDGetTokenT& iOther) noexcept : m_value{iOther.m_value} {}
     // ---------- const member functions ---------------------
-    unsigned int index() const { return m_value; }
-    bool isUninitialized() const { return m_value == s_uninitializedValue; }
+    constexpr unsigned int index() const noexcept { return m_value; }
+    constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }
 
   private:
     //for testing
@@ -75,7 +99,7 @@ namespace edm {
 
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
 
-    explicit EDGetTokenT(unsigned int iValue) : m_value(iValue) {}
+    constexpr explicit EDGetTokenT(unsigned int iValue) noexcept : m_value(iValue) {}
 
     // ---------- member data --------------------------------
     unsigned int m_value;

--- a/FWCore/Utilities/interface/EDGetToken.h
+++ b/FWCore/Utilities/interface/EDGetToken.h
@@ -89,6 +89,10 @@ namespace edm {
     //Needed to avoid EDGetTokenT(ADAPTER&&) from being called instead
     // when we can use C++20 concepts we can avoid the problem using a constraint
     constexpr EDGetTokenT(EDGetTokenT& iOther) noexcept : m_value{iOther.m_value} {}
+
+    constexpr EDGetTokenT& operator=(EDGetTokenT<T>& iOther) {
+      return (*this = const_cast<const EDGetTokenT<T>&>(iOther));
+    }
     // ---------- const member functions ---------------------
     constexpr unsigned int index() const noexcept { return m_value; }
     constexpr bool isUninitialized() const noexcept { return m_value == s_uninitializedValue; }

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -51,6 +51,19 @@ namespace edm {
     template <typename ADAPTER>
     constexpr explicit ESGetToken(ADAPTER&& iAdapter) : ESGetToken(iAdapter.template consumes<ESProduct, ESRecord>()) {}
 
+    template <typename ADAPTER>
+    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ADAPTER&& iAdapter) noexcept {
+      ESGetToken<ESProduct, ESRecord> temp(std::forward<ADAPTER>(iAdapter));
+      return (*this = std::move(temp));
+    }
+
+    //protect against templated version being a better match
+    constexpr ESGetToken(ESGetToken<ESProduct, ESRecord>& iOther)
+        : ESGetToken(const_cast<const ESGetToken<ESProduct, ESRecord>&>(iOther)) {}
+    constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord>& iOther) noexcept {
+      return (*this = const_cast<ESGetToken<ESProduct, ESRecord> const&>(iOther));
+    }
+
     constexpr unsigned int transitionID() const noexcept { return m_transitionID; }
     constexpr bool isInitialized() const noexcept { return transitionID() != std::numeric_limits<unsigned int>::max(); }
     constexpr ESTokenIndex index() const noexcept { return m_index; }

--- a/FWCore/Utilities/interface/ESGetToken.h
+++ b/FWCore/Utilities/interface/ESGetToken.h
@@ -48,6 +48,9 @@ namespace edm {
     constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord>&&) noexcept = default;
     constexpr ESGetToken<ESProduct, ESRecord>& operator=(ESGetToken<ESProduct, ESRecord> const&) noexcept = default;
 
+    template <typename ADAPTER>
+    constexpr explicit ESGetToken(ADAPTER&& iAdapter) : ESGetToken(iAdapter.template consumes<ESProduct, ESRecord>()) {}
+
     constexpr unsigned int transitionID() const noexcept { return m_transitionID; }
     constexpr bool isInitialized() const noexcept { return transitionID() != std::numeric_limits<unsigned int>::max(); }
     constexpr ESTokenIndex index() const noexcept { return m_index; }

--- a/FWCore/Utilities/test/EDGetToken_t.cpp
+++ b/FWCore/Utilities/test/EDGetToken_t.cpp
@@ -25,7 +25,7 @@ int main() {
     abort();
   }
 
-  edm::EDGetTokenT<int> token2 = edm::TestEDGetToken::makeTokenT<int>(11);
+  edm::EDGetTokenT<int> token2 = edm::TestEDGetToken::makeTokenT<int>(11U);
   if (token2.isUninitialized() || !(token2.index() == 11)) {
     std::cout << "EDGetTokenT 1 argument constructor failed 2" << std::endl;
     abort();


### PR DESCRIPTION
#### PR description:

Made it possible to deduce the template parameters of the `edm::EDGetTokenT` and the `edm::ESGetToken` when specifying consumes. 

#### PR validation:

The code compiles and all framework units pass.