### PR TITLE
fix es consumes in dd4hep/TrackerParametersESProducer

### DIFF
--- a/Geometry/TrackerGeometryBuilder/plugins/dd4hep/TrackerParametersESProducer.cc
+++ b/Geometry/TrackerGeometryBuilder/plugins/dd4hep/TrackerParametersESProducer.cc
@@ -31,12 +31,15 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   ReturnType produce(const PTrackerParametersRcd&);
+
+private:
+  edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> geomToken_;
 };
 
 TrackerParametersESProducer::TrackerParametersESProducer(const edm::ParameterSet&) {
   edm::LogInfo("TRACKER") << "TrackerParametersESProducer::TrackerParametersESProducer";
 
-  setWhatProduced(this);
+  setWhatProduced(this).setConsumes(geomToken_);
 }
 
 TrackerParametersESProducer::~TrackerParametersESProducer() {}
@@ -49,8 +52,7 @@ void TrackerParametersESProducer::fillDescriptions(edm::ConfigurationDescription
 TrackerParametersESProducer::ReturnType TrackerParametersESProducer::produce(const PTrackerParametersRcd& iRecord) {
   edm::LogInfo("TrackerParametersESProducer")
       << "TrackerParametersESProducer::produce(const PTrackerParametersRcd& iRecord)" << std::endl;
-  edm::ESTransientHandle<cms::DDCompactView> cpv;
-  iRecord.getRecord<IdealGeometryRecord>().get(cpv);
+  edm::ESTransientHandle<cms::DDCompactView> cpv = iRecord.getTransientHandle(geomToken_);
 
   auto ptp = std::make_unique<PTrackerParameters>();
   TrackerParametersFromDD builder;


### PR DESCRIPTION
#### PR description:

Addresses https://github.com/cms-sw/cmssw/pull/27926#discussion_r475960872.
Added ES consumes as done for `Geometry/TrackerGeometryBuilder/plugins/TrackerParametersESModule.cc` in https://github.com/cms-sw/cmssw/pull/28228

#### PR validation:

It compiles. Cannot be tested further because of https://github.com/cms-sw/cmssw/pull/27926#discussion_r476240843

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed