### PR TITLE
TagAndProbe package - avoid ODR violation / remove header that is not needed

### DIFF
--- a/PhysicsTools/TagAndProbe/interface/ColinsSoperVariables.h
+++ b/PhysicsTools/TagAndProbe/interface/ColinsSoperVariables.h
@@ -7,7 +7,7 @@
 
 // calculate the Colins-Soper variables;
 // everything is in the lab frame
-void calCSVariables(TLorentzVector mu, TLorentzVector mubar, double *res, bool swap) {
+inline void calCSVariables(TLorentzVector mu, TLorentzVector mubar, double *res, bool swap) {
   // convention. beam direction is on the positive Z direction.
   // beam contains quark flux.
   TLorentzVector Pbeam(0, 0, CM_ENERGY / 2.0, CM_ENERGY / 2.0);

--- a/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
+++ b/PhysicsTools/TagAndProbe/src/BaseTreeFiller.cc
@@ -2,8 +2,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
-#include "PhysicsTools/TagAndProbe/interface/ColinsSoperVariables.h"
-
 #include <TList.h>
 #include <TObjString.h>
 


### PR DESCRIPTION
as pointed out in modules build.