### PR TITLE
[Do not Merge] testing new aarch64 container

### DIFF
--- a/PhysicsTools/PythonAnalysis/test/BuildFile.xml
+++ b/PhysicsTools/PythonAnalysis/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <!-- To make sure we rebuild this package when python_tools package updated -->
+
 <use name="python_tools"/>
 
 <test name="testPandas" command="testPandas.py"/>


### PR DESCRIPTION
Please do not merge.

One unit test is failing for aarch64 due to CERN CA ROOT certificate https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_aarch64_gcc820/CMSSW_11_2_X_2020-08-24-2300/unitTestLogs/PhysicsTools/PythonAnalysis#/417-417

There is now docker image now available with correct CERN CA ROOT certificates.