### PR TITLE
L1T EG Phase2 Track match and EG validation code

### DIFF
--- a/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
@@ -26,11 +26,11 @@ from L1Trigger.L1CaloTrigger.ntuple_cfi import *
 
 
 l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEE)
-# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEB)
-# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_TTTracks)
-# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleElMathHGC)
-# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleBARREL)
-# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleElBARREL)
+l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEB)
+l1CaloTriggerNtuplizer.Ntuples.append(ntuple_TTTracks)
+l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleEllEE)
+l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleEllEB)
+
 #
 
 l1CaloTriggerNtuples = cms.Sequence(l1CaloTriggerNtuplizer)

--- a/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cfi import *
+
+l1CaloTriggerNtuplizer = hgcalTriggerNtuplizer.clone()
+
+ntuple_multiclusters_hmvdr = ntuple_multiclusters.clone()
+ntuple_multiclusters_hmvdr.Prefix = cms.untracked.string('HMvDR')
+
+l1CaloTriggerNtuplizer.Ntuples = cms.VPSet(ntuple_event,
+                                           ntuple_gen,
+                                           ntuple_triggercells,
+                                           ntuple_multiclusters_hmvdr)
+
+# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_genjet)
+# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_gentau)
+# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_digis)
+# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_multiclusters)
+# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_towers)
+
+
+from L1Trigger.L1CaloTrigger.ntuple_cfi import *
+
+
+
+
+
+l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEE)
+# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEB)
+# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_TTTracks)
+# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleElMathHGC)
+# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleBARREL)
+# l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleElBARREL)
+#
+
+l1CaloTriggerNtuples = cms.Sequence(l1CaloTriggerNtuplizer)
+
+
+# from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
+# from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_V9
+# modifyHgcalTriggerNtuplesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_ntuples_V9)
+#

--- a/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/L1TCaloTriggerNtuples_cff.py
@@ -12,18 +12,7 @@ l1CaloTriggerNtuplizer.Ntuples = cms.VPSet(ntuple_event,
                                            ntuple_triggercells,
                                            ntuple_multiclusters_hmvdr)
 
-# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_genjet)
-# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_gentau)
-# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_digis)
-# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_multiclusters)
-# l1CaloTriggerNtuplizer.Ntuples.remove(ntuple_towers)
-
-
 from L1Trigger.L1CaloTrigger.ntuple_cfi import *
-
-
-
-
 
 l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEE)
 l1CaloTriggerNtuplizer.Ntuples.append(ntuple_egammaEB)
@@ -31,12 +20,5 @@ l1CaloTriggerNtuplizer.Ntuples.append(ntuple_TTTracks)
 l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleEllEE)
 l1CaloTriggerNtuplizer.Ntuples.append(ntuple_tkEleEllEB)
 
-#
-
 l1CaloTriggerNtuples = cms.Sequence(l1CaloTriggerNtuplizer)
 
-
-# from Configuration.Eras.Modifier_phase2_hgcalV9_cff import phase2_hgcalV9
-# from L1Trigger.L1THGCalUtilities.customNtuples import custom_ntuples_V9
-# modifyHgcalTriggerNtuplesWithV9Geometry_ = phase2_hgcalV9.makeProcessModifier(custom_ntuples_V9)
-#

--- a/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
@@ -2,5 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 # from L1Trigger.L1CaloTrigger.l1EGammaCrystalsProducer_cfi import *
 from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
+from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
 
-l1EgammaStaProducers = cms.Sequence(l1EGammaEEProducer)
+l1EgammaStaProducers = cms.Sequence(l1EGammaEEProducer+L1EGammaClusterEmuProducer)
+
+l1EgammaStaProducersEE = cms.Sequence(l1EGammaEEProducer)
+l1EgammaStaProducersEB = cms.Sequence(L1EGammaClusterEmuProducer)

--- a/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+# from L1Trigger.L1CaloTrigger.l1EGammaCrystalsProducer_cfi import *
+from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
+
+l1EgammaStaProducers = cms.Sequence(l1EGammaEEProducer)

--- a/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
+++ b/L1Trigger/L1CaloTrigger/python/l1EgammaStaProducers_cff.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# from L1Trigger.L1CaloTrigger.l1EGammaCrystalsProducer_cfi import *
 from L1Trigger.L1CaloTrigger.l1EGammaEEProducer_cfi import *
 from L1Trigger.L1CaloTrigger.L1EGammaCrystalsEmulatorProducer_cfi import *
 

--- a/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
@@ -6,14 +6,50 @@ ntuple_egammaEE = cms.PSet(
     BranchNamePrefix = cms.untracked.string("egammaEE")
 )
 
+ntuple_egammaEB = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleEgamma'),
+    Egamma = cms.InputTag("L1EGammaClusterEmuProducer","L1EGammaCollectionBXVEmulator"),
+    BranchNamePrefix = cms.untracked.string("egammaEB")
+)
+
 ntuple_TTTracks = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTrackTrigger'),
     TTTracks = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
     BranchNamePrefix = cms.untracked.string("l1Trk")
 )
 
-ntuple_tkEle = cms.PSet(
+ntuple_tkEleEE = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
-    TkElectrons = cms.InputTag("L1TkElectrons","EG"),
-    BranchNamePrefix = cms.untracked.string("tkEle")
+    TkElectrons = cms.InputTag("L1TkElectronsHGC","EG"),
+    BranchNamePrefix = cms.untracked.string("tkEleEE")
+)
+
+ntuple_tkEleEB = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkElectronsCrystal","EG"),
+    BranchNamePrefix = cms.untracked.string("tkEleEB")
+)
+
+ntuple_tkEleEllEE = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkElectronsEllipticMatchHGC","EG"),
+    BranchNamePrefix = cms.untracked.string("tkEleEllEE")
+)
+
+ntuple_tkEleEllEB = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkElectronsEllipticMatchCrystal","EG"),
+    BranchNamePrefix = cms.untracked.string("tkEleEllEB")
+)
+
+ntuple_tkIsoEleEE = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkIsoElectronsHGC","EG"),
+    BranchNamePrefix = cms.untracked.string("tkIsoEleEE")
+)
+
+ntuple_tkIsoEleEB = cms.PSet(
+    NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
+    TkElectrons = cms.InputTag("L1TkIsoElectronsCrystal","EG"),
+    BranchNamePrefix = cms.untracked.string("tkIsoEleEB")
 )

--- a/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
@@ -1,16 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
 ntuple_egammaEE = cms.PSet(
-    NtupleName = cms.string('L1TriggerNtupleEgammaEE'),
-    EgammaEE = cms.InputTag('l1EGammaEEProducer:L1EGammaCollectionBXVWithCuts')
+    NtupleName = cms.string('L1TriggerNtupleEgamma'),
+    Egamma = cms.InputTag('l1EGammaEEProducer:L1EGammaCollectionBXVWithCuts'),
+    BranchNamePrefix = cms.untracked.string("egammaEE")
 )
 
 ntuple_TTTracks = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTrackTrigger'),
-    TTTracks = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
+    TTTracks = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
+    BranchNamePrefix = cms.untracked.string("l1Trk")
 )
 
 ntuple_tkEle = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
-    TkElectrons = cms.InputTag("L1TkElectrons","EG")
+    TkElectrons = cms.InputTag("L1TkElectrons","EG"),
+    BranchNamePrefix = cms.untracked.string("tkEle")
 )

--- a/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
+++ b/L1Trigger/L1CaloTrigger/python/ntuple_cfi.py
@@ -8,7 +8,7 @@ ntuple_egammaEE = cms.PSet(
 
 ntuple_egammaEB = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleEgamma'),
-    Egamma = cms.InputTag("L1EGammaClusterEmuProducer","L1EGammaCollectionBXVEmulator"),
+    Egamma = cms.InputTag("L1EGammaClusterEmuProducer"),
     BranchNamePrefix = cms.untracked.string("egammaEB")
 )
 
@@ -33,13 +33,13 @@ ntuple_tkEleEB = cms.PSet(
 ntuple_tkEleEllEE = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
     TkElectrons = cms.InputTag("L1TkElectronsEllipticMatchHGC","EG"),
-    BranchNamePrefix = cms.untracked.string("tkEleEllEE")
+    BranchNamePrefix = cms.untracked.string("tkEleEE")
 )
 
 ntuple_tkEleEllEB = cms.PSet(
     NtupleName = cms.string('L1TriggerNtupleTkElectrons'),
     TkElectrons = cms.InputTag("L1TkElectronsEllipticMatchCrystal","EG"),
-    BranchNamePrefix = cms.untracked.string("tkEleEllEB")
+    BranchNamePrefix = cms.untracked.string("tkEleEB")
 )
 
 ntuple_tkIsoEleEE = cms.PSet(

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -1,0 +1,24 @@
+<library   name="L1TriggerL1CaloTriggerPlugins_test_ntuples" file="ntuples/*.cc">
+  <use   name="L1Trigger/L1THGCal"/>
+  <use   name="L1Trigger/L1THGCalUtilities"/>
+  <use   name="CommonTools/BaseParticlePropagator"/>
+  <use   name="MagneticField/Engine"/>
+  <use   name="MagneticField/Records"/>
+  <use   name="L1Trigger/Phase2L1ParticleFlow"/>
+  <use   name="L1Trigger/L1TTrackMatch"/>
+  <use   name="Geometry/TrackerGeometryBuilder"/>
+
+  <!-- <use   name="CommonTools/UtilAlgos"/>
+  <use   name="SimDataFormats/CaloTest"/>
+  <use   name="DataFormats/JetReco"/>
+  <use   name="Geometry/HcalTowerAlgo"/>
+  <use   name="SimDataFormats/PileupSummaryInfo"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
+  <use   name="TrackPropagation/RungeKutta"/>
+  <use   name="FastSimulation/Event"/>
+  <use   name="FastSimulation/CaloGeometryTools"/>
+  <use   name="MagneticField/Engine"/>
+  <use   name="MagneticField/Records"/> -->
+  <use name="heppdt"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/L1Trigger/L1CaloTrigger/test/BuildFile.xml
+++ b/L1Trigger/L1CaloTrigger/test/BuildFile.xml
@@ -7,18 +7,6 @@
   <use   name="L1Trigger/Phase2L1ParticleFlow"/>
   <use   name="L1Trigger/L1TTrackMatch"/>
   <use   name="Geometry/TrackerGeometryBuilder"/>
-
-  <!-- <use   name="CommonTools/UtilAlgos"/>
-  <use   name="SimDataFormats/CaloTest"/>
-  <use   name="DataFormats/JetReco"/>
-  <use   name="Geometry/HcalTowerAlgo"/>
-  <use   name="SimDataFormats/PileupSummaryInfo"/>
-  <use   name="SimDataFormats/GeneratorProducts"/>
-  <use   name="TrackPropagation/RungeKutta"/>
-  <use   name="FastSimulation/Event"/>
-  <use   name="FastSimulation/CaloGeometryTools"/>
-  <use   name="MagneticField/Engine"/>
-  <use   name="MagneticField/Records"/> -->
   <use name="heppdt"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
@@ -1,0 +1,20 @@
+#include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
+
+
+
+class L1TCaloTriggerNtupleBase : public HGCalTriggerNtupleBase
+{
+
+  public:
+    L1TCaloTriggerNtupleBase(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf),
+                                                              branch_name_prefix_(conf.getUntrackedParameter<std::string>("BranchNamePrefix", "")) {}
+    ~L1TCaloTriggerNtupleBase() override{};
+
+    char const* branch_name_w_prefix(const std::string name) const {
+      return (branch_name_prefix_ + "_" + name).c_str();
+    }
+
+  private:
+    std::string branch_name_prefix_;
+
+};

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
@@ -7,7 +7,7 @@ public:
         branch_name_prefix_(conf.getUntrackedParameter<std::string>("BranchNamePrefix", "")) {}
   ~L1TCaloTriggerNtupleBase() override{};
 
-  char const* branch_name_w_prefix(const std::string name) const { return (branch_name_prefix_ + "_" + name).c_str(); }
+  std::string branch_name_w_prefix(const std::string name) const { return branch_name_prefix_ + "_" + name; }
 
 private:
   std::string branch_name_prefix_;

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TCaloTriggerNtupleBase.h
@@ -1,20 +1,14 @@
 #include "L1Trigger/L1THGCalUtilities/interface/HGCalTriggerNtupleBase.h"
 
+class L1TCaloTriggerNtupleBase : public HGCalTriggerNtupleBase {
+public:
+  L1TCaloTriggerNtupleBase(const edm::ParameterSet& conf)
+      : HGCalTriggerNtupleBase(conf),
+        branch_name_prefix_(conf.getUntrackedParameter<std::string>("BranchNamePrefix", "")) {}
+  ~L1TCaloTriggerNtupleBase() override{};
 
+  char const* branch_name_w_prefix(const std::string name) const { return (branch_name_prefix_ + "_" + name).c_str(); }
 
-class L1TCaloTriggerNtupleBase : public HGCalTriggerNtupleBase
-{
-
-  public:
-    L1TCaloTriggerNtupleBase(const edm::ParameterSet& conf) : HGCalTriggerNtupleBase(conf),
-                                                              branch_name_prefix_(conf.getUntrackedParameter<std::string>("BranchNamePrefix", "")) {}
-    ~L1TCaloTriggerNtupleBase() override{};
-
-    char const* branch_name_w_prefix(const std::string name) const {
-      return (branch_name_prefix_ + "_" + name).c_str();
-    }
-
-  private:
-    std::string branch_name_prefix_;
-
+private:
+  std::string branch_name_prefix_;
 };

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
@@ -1,0 +1,91 @@
+#include "DataFormats/L1Trigger/interface/EGamma.h"
+#include "L1TCaloTriggerNtupleBase.h"
+
+
+class L1TriggerNtupleEgamma : public L1TCaloTriggerNtupleBase
+{
+
+  public:
+    L1TriggerNtupleEgamma(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleEgamma() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+
+  private:
+    void clear() final;
+
+    edm::EDGetToken egamma_token_;
+
+    int egamma_n_ ;
+    std::vector<float> egamma_pt_;
+    std::vector<float> egamma_energy_;
+    std::vector<float> egamma_eta_;
+    std::vector<float> egamma_phi_;
+    std::vector<float> egamma_hwQual_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+                  L1TriggerNtupleEgamma,
+                  "L1TriggerNtupleEgamma" );
+
+
+L1TriggerNtupleEgamma::
+L1TriggerNtupleEgamma(const edm::ParameterSet& conf):L1TCaloTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleEgamma::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  egamma_token_ = collector.consumes<l1t::EGammaBxCollection>(conf.getParameter<edm::InputTag>("Egamma"));
+
+  tree.Branch(branch_name_w_prefix("n"),     &egamma_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("_pt"),     &egamma_pt_);
+  tree.Branch(branch_name_w_prefix("_energy"), &egamma_energy_);
+  tree.Branch(branch_name_w_prefix("_eta"),    &egamma_eta_);
+  tree.Branch(branch_name_w_prefix("_phi"),    &egamma_phi_);
+  tree.Branch(branch_name_w_prefix("_hwQual"), &egamma_hwQual_);
+
+}
+
+
+
+void
+L1TriggerNtupleEgamma::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+
+  // retrieve towers
+  edm::Handle<l1t::EGammaBxCollection> egamma_h;
+  e.getByToken(egamma_token_, egamma_h);
+  const l1t::EGammaBxCollection& egamma_collection = *egamma_h;
+
+
+  // triggerTools_.eventSetup(es);
+
+  clear();
+  for(auto egee_itr=egamma_collection.begin(0); egee_itr!=egamma_collection.end(0); egee_itr++) {
+    egamma_n_++;
+    // physical values
+    egamma_pt_.emplace_back(egee_itr->pt());
+    egamma_energy_.emplace_back(egee_itr->energy());
+    egamma_eta_.emplace_back(egee_itr->eta());
+    egamma_phi_.emplace_back(egee_itr->phi());
+    egamma_hwQual_.emplace_back(egee_itr->hwQual());
+  }
+}
+
+
+void
+L1TriggerNtupleEgamma::
+clear()
+{
+  egamma_n_ = 0;
+  egamma_pt_.clear();
+  egamma_energy_.clear();
+  egamma_eta_.clear();
+  egamma_phi_.clear();
+  egamma_hwQual_.clear();
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
@@ -1,72 +1,51 @@
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "L1TCaloTriggerNtupleBase.h"
 
+class L1TriggerNtupleEgamma : public L1TCaloTriggerNtupleBase {
+public:
+  L1TriggerNtupleEgamma(const edm::ParameterSet& conf);
+  ~L1TriggerNtupleEgamma() override{};
+  void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+  void fill(const edm::Event& e, const edm::EventSetup& es) final;
 
-class L1TriggerNtupleEgamma : public L1TCaloTriggerNtupleBase
-{
+private:
+  void clear() final;
 
-  public:
-    L1TriggerNtupleEgamma(const edm::ParameterSet& conf);
-    ~L1TriggerNtupleEgamma() override{};
-    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  edm::EDGetToken egamma_token_;
 
-  private:
-    void clear() final;
-
-    edm::EDGetToken egamma_token_;
-
-    int egamma_n_ ;
-    std::vector<float> egamma_pt_;
-    std::vector<float> egamma_energy_;
-    std::vector<float> egamma_eta_;
-    std::vector<float> egamma_phi_;
-    std::vector<float> egamma_hwQual_;
-
+  int egamma_n_;
+  std::vector<float> egamma_pt_;
+  std::vector<float> egamma_energy_;
+  std::vector<float> egamma_eta_;
+  std::vector<float> egamma_phi_;
+  std::vector<float> egamma_hwQual_;
 };
 
-DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
-                  L1TriggerNtupleEgamma,
-                  "L1TriggerNtupleEgamma" );
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, L1TriggerNtupleEgamma, "L1TriggerNtupleEgamma");
 
+L1TriggerNtupleEgamma::L1TriggerNtupleEgamma(const edm::ParameterSet& conf) : L1TCaloTriggerNtupleBase(conf) {}
 
-L1TriggerNtupleEgamma::
-L1TriggerNtupleEgamma(const edm::ParameterSet& conf):L1TCaloTriggerNtupleBase(conf)
-{
-}
-
-void
-L1TriggerNtupleEgamma::
-initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
-{
+void L1TriggerNtupleEgamma::initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector) {
   egamma_token_ = collector.consumes<l1t::EGammaBxCollection>(conf.getParameter<edm::InputTag>("Egamma"));
 
-  tree.Branch(branch_name_w_prefix("n"),     &egamma_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"),     &egamma_pt_);
+  tree.Branch(branch_name_w_prefix("n"), &egamma_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("pt"), &egamma_pt_);
   tree.Branch(branch_name_w_prefix("energy"), &egamma_energy_);
-  tree.Branch(branch_name_w_prefix("eta"),    &egamma_eta_);
-  tree.Branch(branch_name_w_prefix("phi"),    &egamma_phi_);
+  tree.Branch(branch_name_w_prefix("eta"), &egamma_eta_);
+  tree.Branch(branch_name_w_prefix("phi"), &egamma_phi_);
   tree.Branch(branch_name_w_prefix("hwQual"), &egamma_hwQual_);
-
 }
 
-
-
-void
-L1TriggerNtupleEgamma::
-fill(const edm::Event& e, const edm::EventSetup& es)
-{
-
+void L1TriggerNtupleEgamma::fill(const edm::Event& e, const edm::EventSetup& es) {
   // retrieve towers
   edm::Handle<l1t::EGammaBxCollection> egamma_h;
   e.getByToken(egamma_token_, egamma_h);
   const l1t::EGammaBxCollection& egamma_collection = *egamma_h;
 
-
   // triggerTools_.eventSetup(es);
 
   clear();
-  for(auto egee_itr=egamma_collection.begin(0); egee_itr!=egamma_collection.end(0); egee_itr++) {
+  for (auto egee_itr = egamma_collection.begin(0); egee_itr != egamma_collection.end(0); egee_itr++) {
     egamma_n_++;
     // physical values
     egamma_pt_.emplace_back(egee_itr->pt());
@@ -77,11 +56,7 @@ fill(const edm::Event& e, const edm::EventSetup& es)
   }
 }
 
-
-void
-L1TriggerNtupleEgamma::
-clear()
-{
+void L1TriggerNtupleEgamma::clear() {
   egamma_n_ = 0;
   egamma_pt_.clear();
   egamma_energy_.clear();

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
@@ -28,12 +28,12 @@ L1TriggerNtupleEgamma::L1TriggerNtupleEgamma(const edm::ParameterSet& conf) : L1
 void L1TriggerNtupleEgamma::initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector) {
   egamma_token_ = collector.consumes<l1t::EGammaBxCollection>(conf.getParameter<edm::InputTag>("Egamma"));
 
-  tree.Branch(branch_name_w_prefix("n"), &egamma_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"), &egamma_pt_);
-  tree.Branch(branch_name_w_prefix("energy"), &egamma_energy_);
-  tree.Branch(branch_name_w_prefix("eta"), &egamma_eta_);
-  tree.Branch(branch_name_w_prefix("phi"), &egamma_phi_);
-  tree.Branch(branch_name_w_prefix("hwQual"), &egamma_hwQual_);
+  tree.Branch(branch_name_w_prefix("n").c_str(), &egamma_n_, branch_name_w_prefix("n/I").c_str());
+  tree.Branch(branch_name_w_prefix("pt").c_str(), &egamma_pt_);
+  tree.Branch(branch_name_w_prefix("energy").c_str(), &egamma_energy_);
+  tree.Branch(branch_name_w_prefix("eta").c_str(), &egamma_eta_);
+  tree.Branch(branch_name_w_prefix("phi").c_str(), &egamma_phi_);
+  tree.Branch(branch_name_w_prefix("hwQual").c_str(), &egamma_hwQual_);
 }
 
 void L1TriggerNtupleEgamma::fill(const edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
@@ -42,11 +42,11 @@ initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& 
   egamma_token_ = collector.consumes<l1t::EGammaBxCollection>(conf.getParameter<edm::InputTag>("Egamma"));
 
   tree.Branch(branch_name_w_prefix("n"),     &egamma_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("_pt"),     &egamma_pt_);
-  tree.Branch(branch_name_w_prefix("_energy"), &egamma_energy_);
-  tree.Branch(branch_name_w_prefix("_eta"),    &egamma_eta_);
-  tree.Branch(branch_name_w_prefix("_phi"),    &egamma_phi_);
-  tree.Branch(branch_name_w_prefix("_hwQual"), &egamma_hwQual_);
+  tree.Branch(branch_name_w_prefix("pt"),     &egamma_pt_);
+  tree.Branch(branch_name_w_prefix("energy"), &egamma_energy_);
+  tree.Branch(branch_name_w_prefix("eta"),    &egamma_eta_);
+  tree.Branch(branch_name_w_prefix("phi"),    &egamma_phi_);
+  tree.Branch(branch_name_w_prefix("hwQual"), &egamma_hwQual_);
 
 }
 

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleEgamma.cc
@@ -42,8 +42,6 @@ void L1TriggerNtupleEgamma::fill(const edm::Event& e, const edm::EventSetup& es)
   e.getByToken(egamma_token_, egamma_h);
   const l1t::EGammaBxCollection& egamma_collection = *egamma_h;
 
-  // triggerTools_.eventSetup(es);
-
   clear();
   for (auto egee_itr = egamma_collection.begin(0); egee_itr != egamma_collection.end(0); egee_itr++) {
     egamma_n_++;

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -34,13 +34,13 @@ void L1TriggerNtupleTkElectrons::initialize(TTree& tree,
                                             edm::ConsumesCollector&& collector) {
   tkEle_token_ = collector.consumes<l1t::TkElectronCollection>(conf.getParameter<edm::InputTag>("TkElectrons"));
 
-  tree.Branch(branch_name_w_prefix("n"), &tkEle_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"), &tkEle_pt_);
-  tree.Branch(branch_name_w_prefix("energy"), &tkEle_energy_);
-  tree.Branch(branch_name_w_prefix("eta"), &tkEle_eta_);
-  tree.Branch(branch_name_w_prefix("phi"), &tkEle_phi_);
-  tree.Branch(branch_name_w_prefix("hwQual"), &tkEle_hwQual_);
-  tree.Branch(branch_name_w_prefix("tkIso"), &tkEle_tkIso_);
+  tree.Branch(branch_name_w_prefix("n").c_str(), &tkEle_n_, branch_name_w_prefix("n/I").c_str());
+  tree.Branch(branch_name_w_prefix("pt").c_str(), &tkEle_pt_);
+  tree.Branch(branch_name_w_prefix("energy").c_str(), &tkEle_energy_);
+  tree.Branch(branch_name_w_prefix("eta").c_str(), &tkEle_eta_);
+  tree.Branch(branch_name_w_prefix("phi").c_str(), &tkEle_phi_);
+  tree.Branch(branch_name_w_prefix("hwQual").c_str(), &tkEle_hwQual_);
+  tree.Branch(branch_name_w_prefix("tkIso").c_str(), &tkEle_tkIso_);
 }
 
 void L1TriggerNtupleTkElectrons::fill(const edm::Event& e, const edm::EventSetup& es) {

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -3,72 +3,55 @@
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
 
-class L1TriggerNtupleTkElectrons : public L1TCaloTriggerNtupleBase
-{
+class L1TriggerNtupleTkElectrons : public L1TCaloTriggerNtupleBase {
+public:
+  L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf);
+  ~L1TriggerNtupleTkElectrons() override{};
+  void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+  void fill(const edm::Event& e, const edm::EventSetup& es) final;
 
-  public:
-    L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf);
-    ~L1TriggerNtupleTkElectrons() override{};
-    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+private:
+  void clear() final;
 
-  private:
-    void clear() final;
+  edm::EDGetToken tkEle_token_;
 
-    edm::EDGetToken tkEle_token_;
-
-    int                tkEle_n_ ;
-    std::vector<float> tkEle_pt_;
-    std::vector<float> tkEle_energy_;
-    std::vector<float> tkEle_eta_;
-    std::vector<float> tkEle_phi_;
-    std::vector<float> tkEle_hwQual_;
-    std::vector<float> tkEle_tkIso_;
-
+  int tkEle_n_;
+  std::vector<float> tkEle_pt_;
+  std::vector<float> tkEle_energy_;
+  std::vector<float> tkEle_eta_;
+  std::vector<float> tkEle_phi_;
+  std::vector<float> tkEle_hwQual_;
+  std::vector<float> tkEle_tkIso_;
 };
 
-DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
-    L1TriggerNtupleTkElectrons,
-    "L1TriggerNtupleTkElectrons" );
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, L1TriggerNtupleTkElectrons, "L1TriggerNtupleTkElectrons");
 
+L1TriggerNtupleTkElectrons::L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf)
+    : L1TCaloTriggerNtupleBase(conf) {}
 
-L1TriggerNtupleTkElectrons::
-L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf) : L1TCaloTriggerNtupleBase(conf)
-{
-}
-
-void
-L1TriggerNtupleTkElectrons::
-initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
-{
+void L1TriggerNtupleTkElectrons::initialize(TTree& tree,
+                                            const edm::ParameterSet& conf,
+                                            edm::ConsumesCollector&& collector) {
   tkEle_token_ = collector.consumes<l1t::TkElectronCollection>(conf.getParameter<edm::InputTag>("TkElectrons"));
 
-  tree.Branch(branch_name_w_prefix("n"),      &tkEle_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"),     &tkEle_pt_);
+  tree.Branch(branch_name_w_prefix("n"), &tkEle_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("pt"), &tkEle_pt_);
   tree.Branch(branch_name_w_prefix("energy"), &tkEle_energy_);
-  tree.Branch(branch_name_w_prefix("eta"),    &tkEle_eta_);
-  tree.Branch(branch_name_w_prefix("phi"),    &tkEle_phi_);
+  tree.Branch(branch_name_w_prefix("eta"), &tkEle_eta_);
+  tree.Branch(branch_name_w_prefix("phi"), &tkEle_phi_);
   tree.Branch(branch_name_w_prefix("hwQual"), &tkEle_hwQual_);
   tree.Branch(branch_name_w_prefix("tkIso"), &tkEle_tkIso_);
-
 }
 
-
-
-void
-L1TriggerNtupleTkElectrons::
-fill(const edm::Event& e, const edm::EventSetup& es)
-{
-
+void L1TriggerNtupleTkElectrons::fill(const edm::Event& e, const edm::EventSetup& es) {
   // retrieve towers
   edm::Handle<l1t::TkElectronCollection> tkEle_h;
   e.getByToken(tkEle_token_, tkEle_h);
   const l1t::TkElectronCollection& tkEle_collection = *tkEle_h;
 
-
   // triggerTools_.eventSetup(es);
   clear();
-  for(auto tkele_itr: tkEle_collection) {
+  for (auto tkele_itr : tkEle_collection) {
     tkEle_n_++;
     tkEle_pt_.emplace_back(tkele_itr.pt());
     tkEle_energy_.emplace_back(tkele_itr.energy());
@@ -79,11 +62,7 @@ fill(const edm::Event& e, const edm::EventSetup& es)
   }
 }
 
-
-void
-L1TriggerNtupleTkElectrons::
-clear()
-{
+void L1TriggerNtupleTkElectrons::clear() {
   tkEle_n_ = 0;
   tkEle_pt_.clear();
   tkEle_energy_.clear();

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -1,0 +1,94 @@
+#include "L1TCaloTriggerNtupleBase.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+
+class L1TriggerNtupleTkElectrons : public L1TCaloTriggerNtupleBase
+{
+
+  public:
+    L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleTkElectrons() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+
+  private:
+    void clear() final;
+
+    edm::EDGetToken tkEle_token_;
+
+    int                tkEle_n_ ;
+    std::vector<float> tkEle_pt_;
+    std::vector<float> tkEle_energy_;
+    std::vector<float> tkEle_eta_;
+    std::vector<float> tkEle_phi_;
+    std::vector<float> tkEle_hwQual_;
+    std::vector<float> tkEle_tkIso_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+    L1TriggerNtupleTkElectrons,
+    "L1TriggerNtupleTkElectrons" );
+
+
+L1TriggerNtupleTkElectrons::
+L1TriggerNtupleTkElectrons(const edm::ParameterSet& conf) : L1TCaloTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleTkElectrons::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  tkEle_token_ = collector.consumes<l1t::TkElectronCollection>(conf.getParameter<edm::InputTag>("TkElectrons"));
+
+  tree.Branch(branch_name_w_prefix("n"),      &tkEle_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("pt"),     &tkEle_pt_);
+  tree.Branch(branch_name_w_prefix("energy"), &tkEle_energy_);
+  tree.Branch(branch_name_w_prefix("eta"),    &tkEle_eta_);
+  tree.Branch(branch_name_w_prefix("phi"),    &tkEle_phi_);
+  tree.Branch(branch_name_w_prefix("hwQual"), &tkEle_hwQual_);
+  tree.Branch(branch_name_w_prefix("tkIso"), &tkEle_tkIso_);
+
+}
+
+
+
+void
+L1TriggerNtupleTkElectrons::
+fill(const edm::Event& e, const edm::EventSetup& es)
+{
+
+  // retrieve towers
+  edm::Handle<l1t::TkElectronCollection> tkEle_h;
+  e.getByToken(tkEle_token_, tkEle_h);
+  const l1t::TkElectronCollection& tkEle_collection = *tkEle_h;
+
+
+  // triggerTools_.eventSetup(es);
+  clear();
+  for(auto tkele_itr: tkEle_collection) {
+    tkEle_n_++;
+    tkEle_pt_.emplace_back(tkele_itr.pt());
+    tkEle_energy_.emplace_back(tkele_itr.energy());
+    tkEle_eta_.emplace_back(tkele_itr.eta());
+    tkEle_phi_.emplace_back(tkele_itr.phi());
+    tkEle_hwQual_.emplace_back(tkele_itr.EGRef()->hwQual());
+    tkEle_tkIso_.emplace_back(tkele_itr.trkIsol());
+  }
+}
+
+
+void
+L1TriggerNtupleTkElectrons::
+clear()
+{
+  tkEle_n_ = 0;
+  tkEle_pt_.clear();
+  tkEle_energy_.clear();
+  tkEle_eta_.clear();
+  tkEle_phi_.clear();
+  tkEle_hwQual_.clear();
+  tkEle_tkIso_.clear();
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTkElectrons.cc
@@ -49,7 +49,6 @@ void L1TriggerNtupleTkElectrons::fill(const edm::Event& e, const edm::EventSetup
   e.getByToken(tkEle_token_, tkEle_h);
   const l1t::TkElectronCollection& tkEle_collection = *tkEle_h;
 
-  // triggerTools_.eventSetup(es);
   clear();
   for (auto tkele_itr : tkEle_collection) {
     tkEle_n_++;

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -19,103 +19,89 @@
 
 #include "L1TCaloTriggerNtupleBase.h"
 
-
 class L1TriggerNtupleTrackTrigger : public L1TCaloTriggerNtupleBase {
+public:
+  L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf);
+  ~L1TriggerNtupleTrackTrigger() override{};
+  void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+  void fill(const edm::Event& e, const edm::EventSetup& es) final;
+  typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
 
-  public:
-    L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf);
-    ~L1TriggerNtupleTrackTrigger() override{};
-    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
-    void fill(const edm::Event& e, const edm::EventSetup& es) final;
-    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+private:
+  void clear() final;
+  // HGCalTriggerTools triggerTools_;
+  std::pair<float, float> propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                          const math::XYZTLorentzVector& iVtx,
+                                          double iCharge,
+                                          double iBField);
 
-  private:
-    void clear() final;
-    // HGCalTriggerTools triggerTools_;
-    std::pair<float,float> propagateToCalo(const math::XYZTLorentzVector& iMom,
-                                           const math::XYZTLorentzVector& iVtx,
-                                           double iCharge,
-                                           double iBField);
+  edm::EDGetToken track_token_;
 
-    edm::EDGetToken track_token_;
+  int l1track_n_;
+  std::vector<float> l1track_pt_;
+  std::vector<float> l1track_pt2stubs_;
 
-    int l1track_n_ ;
-    std::vector<float> l1track_pt_;
-    std::vector<float> l1track_pt2stubs_;
+  // std::vector<float> l1track_energy_;
+  std::vector<float> l1track_eta_;
+  std::vector<float> l1track_phi_;
+  std::vector<float> l1track_curv_;
+  std::vector<float> l1track_chi2_;
+  std::vector<float> l1track_chi2Red_;
+  std::vector<int> l1track_nStubs_;
+  std::vector<float> l1track_z0_;
+  std::vector<int> l1track_charge_;
+  std::vector<float> l1track_caloeta_;
+  std::vector<float> l1track_calophi_;
 
-    // std::vector<float> l1track_energy_;
-    std::vector<float> l1track_eta_;
-    std::vector<float> l1track_phi_;
-    std::vector<float> l1track_curv_;
-    std::vector<float> l1track_chi2_;
-    std::vector<float> l1track_chi2Red_;
-    std::vector<int> l1track_nStubs_;
-    std::vector<float> l1track_z0_;
-    std::vector<int> l1track_charge_;
-    std::vector<float> l1track_caloeta_;
-    std::vector<float> l1track_calophi_;
-
-    edm::ESWatcher<IdealMagneticFieldRecord> magfield_watcher_;
-    HGCalTriggerTools triggerTools_;
-
+  edm::ESWatcher<IdealMagneticFieldRecord> magfield_watcher_;
+  HGCalTriggerTools triggerTools_;
 };
 
-DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
-    L1TriggerNtupleTrackTrigger,
-    "L1TriggerNtupleTrackTrigger" );
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory, L1TriggerNtupleTrackTrigger, "L1TriggerNtupleTrackTrigger");
 
+L1TriggerNtupleTrackTrigger::L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf)
+    : L1TCaloTriggerNtupleBase(conf) {}
 
-L1TriggerNtupleTrackTrigger::
-L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf):L1TCaloTriggerNtupleBase(conf)
-{
-}
+void L1TriggerNtupleTrackTrigger::initialize(TTree& tree,
+                                             const edm::ParameterSet& conf,
+                                             edm::ConsumesCollector&& collector) {
+  track_token_ =
+      collector.consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf.getParameter<edm::InputTag>("TTTracks"));
 
-void
-L1TriggerNtupleTrackTrigger::
-initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
-{
-  track_token_ = collector.consumes<std::vector<TTTrack< Ref_Phase2TrackerDigi_> > >(conf.getParameter<edm::InputTag>("TTTracks"));
-
-  tree.Branch(branch_name_w_prefix("n"),       &l1track_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"),      &l1track_pt_);
-  tree.Branch(branch_name_w_prefix("pt2stubs"),      &l1track_pt2stubs_);
+  tree.Branch(branch_name_w_prefix("n"), &l1track_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("pt"), &l1track_pt_);
+  tree.Branch(branch_name_w_prefix("pt2stubs"), &l1track_pt2stubs_);
 
   // tree.Branch("l1track_energy", &l1track_energy_);
-  tree.Branch(branch_name_w_prefix("eta"),     &l1track_eta_);
-  tree.Branch(branch_name_w_prefix("phi"),     &l1track_phi_);
-  tree.Branch(branch_name_w_prefix("curv"),    &l1track_curv_);
-  tree.Branch(branch_name_w_prefix("chi2"),    &l1track_chi2_);
-  tree.Branch(branch_name_w_prefix("chi2Red"),    &l1track_chi2Red_);
-  tree.Branch(branch_name_w_prefix("nStubs"),  &l1track_nStubs_);
-  tree.Branch(branch_name_w_prefix("z0"),      &l1track_z0_);
-  tree.Branch(branch_name_w_prefix("charge"),  &l1track_charge_);
+  tree.Branch(branch_name_w_prefix("eta"), &l1track_eta_);
+  tree.Branch(branch_name_w_prefix("phi"), &l1track_phi_);
+  tree.Branch(branch_name_w_prefix("curv"), &l1track_curv_);
+  tree.Branch(branch_name_w_prefix("chi2"), &l1track_chi2_);
+  tree.Branch(branch_name_w_prefix("chi2Red"), &l1track_chi2Red_);
+  tree.Branch(branch_name_w_prefix("nStubs"), &l1track_nStubs_);
+  tree.Branch(branch_name_w_prefix("z0"), &l1track_z0_);
+  tree.Branch(branch_name_w_prefix("charge"), &l1track_charge_);
   tree.Branch(branch_name_w_prefix("caloeta"), &l1track_caloeta_);
   tree.Branch(branch_name_w_prefix("calophi"), &l1track_calophi_);
-
 }
 
-
-
-void
-L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& es) {
-
+void L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& es) {
   // the L1Tracks
-  edm::Handle<std::vector< L1TTTrackType >> l1TTTrackHandle;
+  edm::Handle<std::vector<L1TTTrackType>> l1TTTrackHandle;
   ev.getByToken(track_token_, l1TTTrackHandle);
 
   float fBz = 0;
-  if(magfield_watcher_.check(es)) {
+  if (magfield_watcher_.check(es)) {
     edm::ESHandle<MagneticField> magfield;
     es.get<IdealMagneticFieldRecord>().get(magfield);
     // aField_ = &(*magfield);
-    fBz = magfield->inTesla(GlobalPoint(0,0,0)).z();
+    fBz = magfield->inTesla(GlobalPoint(0, 0, 0)).z();
   }
 
   // geometry needed to call pTFrom2Stubs
   edm::ESHandle<TrackerGeometry> geomHandle;
   es.get<TrackerDigiGeometryRecord>().get("idealForDigi", geomHandle);
   const TrackerGeometry* tGeom = geomHandle.product();
-
 
   triggerTools_.eventSetup(es);
 
@@ -134,16 +120,15 @@ L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& e
     l1track_nStubs_.emplace_back(trackIter->getStubRefs().size());
     // FIXME: need to be configuratble?
     // int nParam_ = 4;
-    float z0   = trackIter->POCA().z(); //cm
+    float z0 = trackIter->POCA().z();  //cm
     int charge = trackIter->rInv() > 0 ? +1 : -1;
 
-    reco::Candidate::PolarLorentzVector p4p(trackIter->momentum().perp(),
-                                            trackIter->momentum().eta(),
-                                            trackIter->momentum().phi(), 0); // no mass ?
+    reco::Candidate::PolarLorentzVector p4p(
+        trackIter->momentum().perp(), trackIter->momentum().eta(), trackIter->momentum().phi(), 0);  // no mass ?
     reco::Particle::LorentzVector p4(p4p.X(), p4p.Y(), p4p.Z(), p4p.E());
-    reco::Particle::Point vtx(0.,0.,z0);
+    reco::Particle::Point vtx(0., 0., z0);
 
-    auto caloetaphi = propagateToCalo(p4, math::XYZTLorentzVector(0.,0.,z0,0.), charge, fBz);
+    auto caloetaphi = propagateToCalo(p4, math::XYZTLorentzVector(0., 0., z0, 0.), charge, fBz);
 
     l1track_z0_.emplace_back(z0);
     l1track_charge_.emplace_back(charge);
@@ -152,9 +137,7 @@ L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& e
   }
 }
 
-
-void
-L1TriggerNtupleTrackTrigger::clear() {
+void L1TriggerNtupleTrackTrigger::clear() {
   l1track_n_ = 0;
   l1track_pt_.clear();
   l1track_pt2stubs_.clear();
@@ -169,24 +152,21 @@ L1TriggerNtupleTrackTrigger::clear() {
   l1track_charge_.clear();
   l1track_caloeta_.clear();
   l1track_calophi_.clear();
-
 }
-
-
-
 
 // #include "FastSimulation/Particle/interface/RawParticle.h"
 
-std::pair<float,float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math::XYZTLorentzVector& iMom,
-                                                                    const math::XYZTLorentzVector& iVtx,
-                                                                    double iCharge,
-                                                                    double iBField) {
-    BaseParticlePropagator prop = BaseParticlePropagator(RawParticle(iMom,iVtx,iCharge),0.,0.,iBField);
-    prop.setPropagationConditions(129.0 , triggerTools_.getLayerZ(1) , false);
-    prop.propagate();
-    double ecalShowerDepth = reco::PFCluster::getDepthCorrection(prop.particle().momentum().E(),false,false);
-    math::XYZVector point = math::XYZVector(prop.particle().vertex())+math::XYZTLorentzVector(prop.particle().momentum()).Vect().Unit()*ecalShowerDepth;
-    // math::XYZVector point  = particle.vertex();
-    // math::XYZVector point = math::XYZVector(particle.vertex())+math::XYZTLorentzVector(particle.momentum()).Vect().Unit()*ecalShowerDepth;
-    return std::make_pair(point.eta(), point.phi());
+std::pair<float, float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                                                     const math::XYZTLorentzVector& iVtx,
+                                                                     double iCharge,
+                                                                     double iBField) {
+  BaseParticlePropagator prop = BaseParticlePropagator(RawParticle(iMom, iVtx, iCharge), 0., 0., iBField);
+  prop.setPropagationConditions(129.0, triggerTools_.getLayerZ(1), false);
+  prop.propagate();
+  double ecalShowerDepth = reco::PFCluster::getDepthCorrection(prop.particle().momentum().E(), false, false);
+  math::XYZVector point = math::XYZVector(prop.particle().vertex()) +
+                          math::XYZTLorentzVector(prop.particle().momentum()).Vect().Unit() * ecalShowerDepth;
+  // math::XYZVector point  = particle.vertex();
+  // math::XYZVector point = math::XYZVector(particle.vertex())+math::XYZTLorentzVector(particle.momentum()).Vect().Unit()*ecalShowerDepth;
+  return std::make_pair(point.eta(), point.phi());
 }

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -68,21 +68,21 @@ void L1TriggerNtupleTrackTrigger::initialize(TTree& tree,
   track_token_ =
       collector.consumes<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>(conf.getParameter<edm::InputTag>("TTTracks"));
 
-  tree.Branch(branch_name_w_prefix("n"), &l1track_n_, branch_name_w_prefix("n/I"));
-  tree.Branch(branch_name_w_prefix("pt"), &l1track_pt_);
-  tree.Branch(branch_name_w_prefix("pt2stubs"), &l1track_pt2stubs_);
+  tree.Branch(branch_name_w_prefix("n").c_str(), &l1track_n_, branch_name_w_prefix("n/I").c_str());
+  tree.Branch(branch_name_w_prefix("pt").c_str(), &l1track_pt_);
+  tree.Branch(branch_name_w_prefix("pt2stubs").c_str(), &l1track_pt2stubs_);
 
   // tree.Branch("l1track_energy", &l1track_energy_);
-  tree.Branch(branch_name_w_prefix("eta"), &l1track_eta_);
-  tree.Branch(branch_name_w_prefix("phi"), &l1track_phi_);
-  tree.Branch(branch_name_w_prefix("curv"), &l1track_curv_);
-  tree.Branch(branch_name_w_prefix("chi2"), &l1track_chi2_);
-  tree.Branch(branch_name_w_prefix("chi2Red"), &l1track_chi2Red_);
-  tree.Branch(branch_name_w_prefix("nStubs"), &l1track_nStubs_);
-  tree.Branch(branch_name_w_prefix("z0"), &l1track_z0_);
-  tree.Branch(branch_name_w_prefix("charge"), &l1track_charge_);
-  tree.Branch(branch_name_w_prefix("caloeta"), &l1track_caloeta_);
-  tree.Branch(branch_name_w_prefix("calophi"), &l1track_calophi_);
+  tree.Branch(branch_name_w_prefix("eta").c_str(), &l1track_eta_);
+  tree.Branch(branch_name_w_prefix("phi").c_str(), &l1track_phi_);
+  tree.Branch(branch_name_w_prefix("curv").c_str(), &l1track_curv_);
+  tree.Branch(branch_name_w_prefix("chi2").c_str(), &l1track_chi2_);
+  tree.Branch(branch_name_w_prefix("chi2Red").c_str(), &l1track_chi2Red_);
+  tree.Branch(branch_name_w_prefix("nStubs").c_str(), &l1track_nStubs_);
+  tree.Branch(branch_name_w_prefix("z0").c_str(), &l1track_z0_);
+  tree.Branch(branch_name_w_prefix("charge").c_str(), &l1track_charge_);
+  tree.Branch(branch_name_w_prefix("caloeta").c_str(), &l1track_caloeta_);
+  tree.Branch(branch_name_w_prefix("calophi").c_str(), &l1track_calophi_);
 }
 
 void L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& es) {

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -1,0 +1,192 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+#include "L1Trigger/L1TTrackMatch/interface/pTFrom2Stubs.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "L1TCaloTriggerNtupleBase.h"
+
+
+class L1TriggerNtupleTrackTrigger : public L1TCaloTriggerNtupleBase {
+
+  public:
+    L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf);
+    ~L1TriggerNtupleTrackTrigger() override{};
+    void initialize(TTree&, const edm::ParameterSet&, edm::ConsumesCollector&&) final;
+    void fill(const edm::Event& e, const edm::EventSetup& es) final;
+    typedef TTTrack< Ref_Phase2TrackerDigi_ >  L1TTTrackType;
+
+  private:
+    void clear() final;
+    // HGCalTriggerTools triggerTools_;
+    std::pair<float,float> propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                           const math::XYZTLorentzVector& iVtx,
+                                           double iCharge,
+                                           double iBField);
+
+    edm::EDGetToken track_token_;
+
+    int l1track_n_ ;
+    std::vector<float> l1track_pt_;
+    std::vector<float> l1track_pt2stubs_;
+
+    // std::vector<float> l1track_energy_;
+    std::vector<float> l1track_eta_;
+    std::vector<float> l1track_phi_;
+    std::vector<float> l1track_curv_;
+    std::vector<float> l1track_chi2_;
+    std::vector<float> l1track_chi2Red_;
+    std::vector<int> l1track_nStubs_;
+    std::vector<float> l1track_z0_;
+    std::vector<int> l1track_charge_;
+    std::vector<float> l1track_caloeta_;
+    std::vector<float> l1track_calophi_;
+
+    edm::ESWatcher<IdealMagneticFieldRecord> magfield_watcher_;
+    HGCalTriggerTools triggerTools_;
+
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerNtupleFactory,
+    L1TriggerNtupleTrackTrigger,
+    "L1TriggerNtupleTrackTrigger" );
+
+
+L1TriggerNtupleTrackTrigger::
+L1TriggerNtupleTrackTrigger(const edm::ParameterSet& conf):L1TCaloTriggerNtupleBase(conf)
+{
+}
+
+void
+L1TriggerNtupleTrackTrigger::
+initialize(TTree& tree, const edm::ParameterSet& conf, edm::ConsumesCollector&& collector)
+{
+  track_token_ = collector.consumes<std::vector<TTTrack< Ref_Phase2TrackerDigi_> > >(conf.getParameter<edm::InputTag>("TTTracks"));
+
+  tree.Branch(branch_name_w_prefix("n"),       &l1track_n_, branch_name_w_prefix("n/I"));
+  tree.Branch(branch_name_w_prefix("pt"),      &l1track_pt_);
+  tree.Branch(branch_name_w_prefix("pt2stubs"),      &l1track_pt2stubs_);
+
+  // tree.Branch("l1track_energy", &l1track_energy_);
+  tree.Branch(branch_name_w_prefix("eta"),     &l1track_eta_);
+  tree.Branch(branch_name_w_prefix("phi"),     &l1track_phi_);
+  tree.Branch(branch_name_w_prefix("curv"),    &l1track_curv_);
+  tree.Branch(branch_name_w_prefix("chi2"),    &l1track_chi2_);
+  tree.Branch(branch_name_w_prefix("chi2Red"),    &l1track_chi2Red_);
+  tree.Branch(branch_name_w_prefix("nStubs"),  &l1track_nStubs_);
+  tree.Branch(branch_name_w_prefix("z0"),      &l1track_z0_);
+  tree.Branch(branch_name_w_prefix("charge"),  &l1track_charge_);
+  tree.Branch(branch_name_w_prefix("caloeta"), &l1track_caloeta_);
+  tree.Branch(branch_name_w_prefix("calophi"), &l1track_calophi_);
+
+}
+
+
+
+void
+L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSetup& es) {
+
+  // the L1Tracks
+  edm::Handle<std::vector< L1TTTrackType >> l1TTTrackHandle;
+  ev.getByToken(track_token_, l1TTTrackHandle);
+
+  float fBz = 0;
+  if(magfield_watcher_.check(es)) {
+    edm::ESHandle<MagneticField> magfield;
+    es.get<IdealMagneticFieldRecord>().get(magfield);
+    // aField_ = &(*magfield);
+    fBz = magfield->inTesla(GlobalPoint(0,0,0)).z();
+  }
+
+  // geometry needed to call pTFrom2Stubs
+  edm::ESHandle<TrackerGeometry> geomHandle;
+  es.get<TrackerDigiGeometryRecord>().get("idealForDigi", geomHandle);
+  const TrackerGeometry* tGeom = geomHandle.product();
+
+
+  triggerTools_.eventSetup(es);
+
+  clear();
+  for (auto trackIter = l1TTTrackHandle->begin(); trackIter != l1TTTrackHandle->end(); ++trackIter) {
+    l1track_n_++;
+    l1track_pt_.emplace_back(trackIter->momentum().perp());
+    l1track_pt2stubs_.emplace_back(pTFrom2Stubs::pTFrom2(trackIter, tGeom));
+
+    // l1track_energy_.emplace_back(trackIter->energy());
+    l1track_eta_.emplace_back(trackIter->momentum().eta());
+    l1track_phi_.emplace_back(trackIter->momentum().phi());
+    l1track_curv_.emplace_back(trackIter->rInv());
+    l1track_chi2_.emplace_back(trackIter->chi2());
+    l1track_chi2Red_.emplace_back(trackIter->chi2Red());
+    l1track_nStubs_.emplace_back(trackIter->getStubRefs().size());
+    // FIXME: need to be configuratble?
+    // int nParam_ = 4;
+    float z0   = trackIter->POCA().z(); //cm
+    int charge = trackIter->rInv() > 0 ? +1 : -1;
+
+    reco::Candidate::PolarLorentzVector p4p(trackIter->momentum().perp(),
+                                            trackIter->momentum().eta(),
+                                            trackIter->momentum().phi(), 0); // no mass ?
+    reco::Particle::LorentzVector p4(p4p.X(), p4p.Y(), p4p.Z(), p4p.E());
+    reco::Particle::Point vtx(0.,0.,z0);
+
+    auto caloetaphi = propagateToCalo(p4, math::XYZTLorentzVector(0.,0.,z0,0.), charge, fBz);
+
+    l1track_z0_.emplace_back(z0);
+    l1track_charge_.emplace_back(charge);
+    l1track_caloeta_.emplace_back(caloetaphi.first);
+    l1track_calophi_.emplace_back(caloetaphi.second);
+  }
+}
+
+
+void
+L1TriggerNtupleTrackTrigger::clear() {
+  l1track_n_ = 0;
+  l1track_pt_.clear();
+  l1track_pt2stubs_.clear();
+  // l1track_energy_.clear();
+  l1track_eta_.clear();
+  l1track_phi_.clear();
+  l1track_curv_.clear();
+  l1track_chi2_.clear();
+  l1track_chi2Red_.clear();
+  l1track_nStubs_.clear();
+  l1track_z0_.clear();
+  l1track_charge_.clear();
+  l1track_caloeta_.clear();
+  l1track_calophi_.clear();
+
+}
+
+
+
+
+// #include "FastSimulation/Particle/interface/RawParticle.h"
+
+std::pair<float,float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math::XYZTLorentzVector& iMom,
+                                                                    const math::XYZTLorentzVector& iVtx,
+                                                                    double iCharge,
+                                                                    double iBField) {
+    BaseParticlePropagator prop = BaseParticlePropagator(RawParticle(iMom,iVtx,iCharge),0.,0.,iBField);
+    prop.setPropagationConditions(129.0 , triggerTools_.getLayerZ(1) , false);
+    prop.propagate();
+    double ecalShowerDepth = reco::PFCluster::getDepthCorrection(prop.particle().momentum().E(),false,false);
+    math::XYZVector point = math::XYZVector(prop.particle().vertex())+math::XYZTLorentzVector(prop.particle().momentum()).Vect().Unit()*ecalShowerDepth;
+    // math::XYZVector point  = particle.vertex();
+    // math::XYZVector point = math::XYZVector(particle.vertex())+math::XYZTLorentzVector(particle.momentum()).Vect().Unit()*ecalShowerDepth;
+    return std::make_pair(point.eta(), point.phi());
+}

--- a/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
+++ b/L1Trigger/L1CaloTrigger/test/ntuples/L1TriggerNtupleTrackTrigger.cc
@@ -29,7 +29,6 @@ public:
 
 private:
   void clear() final;
-  // HGCalTriggerTools triggerTools_;
   std::pair<float, float> propagateToCalo(const math::XYZTLorentzVector& iMom,
                                           const math::XYZTLorentzVector& iVtx,
                                           double iCharge,
@@ -40,8 +39,6 @@ private:
   int l1track_n_;
   std::vector<float> l1track_pt_;
   std::vector<float> l1track_pt2stubs_;
-
-  // std::vector<float> l1track_energy_;
   std::vector<float> l1track_eta_;
   std::vector<float> l1track_phi_;
   std::vector<float> l1track_curv_;
@@ -71,8 +68,6 @@ void L1TriggerNtupleTrackTrigger::initialize(TTree& tree,
   tree.Branch(branch_name_w_prefix("n").c_str(), &l1track_n_, branch_name_w_prefix("n/I").c_str());
   tree.Branch(branch_name_w_prefix("pt").c_str(), &l1track_pt_);
   tree.Branch(branch_name_w_prefix("pt2stubs").c_str(), &l1track_pt2stubs_);
-
-  // tree.Branch("l1track_energy", &l1track_energy_);
   tree.Branch(branch_name_w_prefix("eta").c_str(), &l1track_eta_);
   tree.Branch(branch_name_w_prefix("phi").c_str(), &l1track_phi_);
   tree.Branch(branch_name_w_prefix("curv").c_str(), &l1track_curv_);
@@ -94,7 +89,6 @@ void L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSet
   if (magfield_watcher_.check(es)) {
     edm::ESHandle<MagneticField> magfield;
     es.get<IdealMagneticFieldRecord>().get(magfield);
-    // aField_ = &(*magfield);
     fBz = magfield->inTesla(GlobalPoint(0, 0, 0)).z();
   }
 
@@ -110,16 +104,12 @@ void L1TriggerNtupleTrackTrigger::fill(const edm::Event& ev, const edm::EventSet
     l1track_n_++;
     l1track_pt_.emplace_back(trackIter->momentum().perp());
     l1track_pt2stubs_.emplace_back(pTFrom2Stubs::pTFrom2(trackIter, tGeom));
-
-    // l1track_energy_.emplace_back(trackIter->energy());
     l1track_eta_.emplace_back(trackIter->momentum().eta());
     l1track_phi_.emplace_back(trackIter->momentum().phi());
     l1track_curv_.emplace_back(trackIter->rInv());
     l1track_chi2_.emplace_back(trackIter->chi2());
     l1track_chi2Red_.emplace_back(trackIter->chi2Red());
     l1track_nStubs_.emplace_back(trackIter->getStubRefs().size());
-    // FIXME: need to be configuratble?
-    // int nParam_ = 4;
     float z0 = trackIter->POCA().z();  //cm
     int charge = trackIter->rInv() > 0 ? +1 : -1;
 
@@ -141,7 +131,6 @@ void L1TriggerNtupleTrackTrigger::clear() {
   l1track_n_ = 0;
   l1track_pt_.clear();
   l1track_pt2stubs_.clear();
-  // l1track_energy_.clear();
   l1track_eta_.clear();
   l1track_phi_.clear();
   l1track_curv_.clear();
@@ -154,8 +143,6 @@ void L1TriggerNtupleTrackTrigger::clear() {
   l1track_calophi_.clear();
 }
 
-// #include "FastSimulation/Particle/interface/RawParticle.h"
-
 std::pair<float, float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math::XYZTLorentzVector& iMom,
                                                                      const math::XYZTLorentzVector& iVtx,
                                                                      double iCharge,
@@ -166,7 +153,5 @@ std::pair<float, float> L1TriggerNtupleTrackTrigger::propagateToCalo(const math:
   double ecalShowerDepth = reco::PFCluster::getDepthCorrection(prop.particle().momentum().E(), false, false);
   math::XYZVector point = math::XYZVector(prop.particle().vertex()) +
                           math::XYZTLorentzVector(prop.particle().momentum()).Vect().Unit() * ecalShowerDepth;
-  // math::XYZVector point  = particle.vertex();
-  // math::XYZVector point = math::XYZVector(particle.vertex())+math::XYZTLorentzVector(particle.momentum()).Vect().Unit()*ecalShowerDepth;
   return std::make_pair(point.eta(), point.phi());
 }

--- a/L1Trigger/L1CaloTrigger/test/runL1TP2EgammaNtuples_D49geom.py
+++ b/L1Trigger/L1CaloTrigger/test/runL1TP2EgammaNtuples_D49geom.py
@@ -1,0 +1,139 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.StandardSequences.Eras import eras
+process = cms.Process('DIGI',eras.Phase2C9)
+
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+############################################################
+# L1 tracking
+############################################################
+
+# remake stubs ?
+process.load('L1Trigger.TrackTrigger.TrackTrigger_cff')
+from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
+process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
+process.load("L1Trigger.TrackFindingTracklet.Tracklet_cfi")
+process.load("RecoVertex.BeamSpotProducer.BeamSpot_cfi")
+
+# process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
+# process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
+
+
+process.TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag(
+    cms.InputTag('TTTracksFromTrackletEmulation', 'Level1TTTracks'))
+
+# emulation
+process.TTTracksEmulationWithTruth = cms.Path(
+    process.offlineBeamSpot *
+    process.TTTracksFromTrackletEmulation *
+    process.TrackTriggerAssociatorTracks)
+# L1TRK_PROC.asciiFileName = cms.untracked.string("evlist.txt")
+
+
+
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(200)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring('file:/data/cerminar/Phase2HLTTDRWinter20DIGI/SingleElectron_PT2to200/GEN-SIM-DIGI-RAW/PU200_110X_mcRun4_realistic_v3_ext2-v2/F32C5A21-F0E9-9149-B04A-883CC704E820.root'),
+       # fileNames = cms.untracked.vstring('/store/mc/PhaseIIMTDTDRAutumn18DR/SinglePion_FlatPt-2to100/FEVT/PU200_103X_upgrade2023_realistic_v2-v1/70000/FFA969EE-22E0-E447-86AA-46A6CBF6407D.root'),
+       inputCommands=cms.untracked.vstring(
+           'keep *',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_CSC_HLT',
+           'drop l1tEMTFHit2016Extras_simEmtfDigis_RPC_HLT',
+           'drop l1tEMTFHit2016s_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016Extras_simEmtfDigis__HLT',
+           'drop l1tEMTFTrack2016s_simEmtfDigis__HLT',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLBarrel_RECO',
+           'drop FTLClusteredmNewDetSetVector_mtdClusters_FTLEndcap_RECO',
+           'drop MTDTrackingRecHitedmNewDetSetVector_mtdTrackingRecHits__RECO',
+           'drop BTLDetIdBTLSampleFTLDataFrameTsSorted_mix_FTLBarrel_HLT',
+           'drop ETLDetIdETLSampleFTLDataFrameTsSorted_mix_FTLEndcap_HLT',
+           )
+       )
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("ntuple.root")
+    )
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+
+# load HGCAL TPG simulation
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+
+# To add truth-matched calo cells and downstream objects
+# process.load('L1Trigger.L1THGCalUtilities.caloTruthCells_cff')
+# process.hgcalTriggerPrimitives += process.caloTruthCells
+# process.load('L1Trigger.L1THGCalUtilities.caloTruthCellsNtuples_cff')
+
+process.hgcl1tpg_step = cms.Path(process.hgcalTriggerPrimitives)
+
+# load Standalone EG producers
+process.load('L1Trigger.L1CaloTrigger.l1EgammaStaProducers_cff')
+process.l1EgammaStaProducers_step = cms.Path(process.l1EgammaStaProducers)
+
+# load track matching modules
+process.load('L1Trigger.L1TTrackMatch.L1TkEgammaObjects_cff')
+process.l1EgammaTrackMatchProducers_step = cms.Path(process.l1TkElectronTrackEllipticProducers)
+
+# load ntuplizer
+process.load('L1Trigger.L1CaloTrigger.L1TCaloTriggerNtuples_cff')
+process.ntuple_step = cms.Path(process.l1CaloTriggerNtuples)
+
+# customization from Giovanni
+# process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters.threshold_histo_multicluster = 0.5
+# process.hgcalBackEndLayer2Producer.ProcessorParameters.C3d_parameters.histoMax_C3d_seeding_parameters.binSumsHisto = cms.vuint32(
+#          3,  3,  3,  3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+#     )
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.TTTracksEmulationWithTruth,
+    process.hgcl1tpg_step,
+    process.l1EgammaTrackMatchProducers_step,
+    process.l1EgammaStaProducers_step,
+    process.ntuple_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -13,10 +13,16 @@ namespace L1TkElectronTrackMatchAlgo {
                double& dph,
                double& dr,
                double& deta);
+  void doMatchClusterET(BXVector<l1t::EGamma>::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta);
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta);
 
   double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
   double deltaPhi(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
+  double deltaPhiClusterET(BXVector<l1t::EGamma>::const_iterator egIter, const edm::Ptr<L1TTTrackType>& pTrk);
   double deltaEta(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
   GlobalPoint calorimeterPosition(double phi, double eta, double e);
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -14,10 +14,10 @@ namespace L1TkElectronTrackMatchAlgo {
                double& dr,
                double& deta);
   void doMatchClusterET(BXVector<l1t::EGamma>::const_iterator egIter,
-               const edm::Ptr<L1TTTrackType>& pTrk,
-               double& dph,
-               double& dr,
-               double& deta);
+                        const edm::Ptr<L1TTTrackType>& pTrk,
+                        double& dph,
+                        double& dr,
+                        double& deta);
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta);
 
   double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -89,7 +89,7 @@ private:
 
   float trkQualityChi2_;
   bool useTwoStubsPT_;
-  bool useClusterET_;  // use cluster et to extrapolate tracks  
+  bool useClusterET_;  // use cluster et to extrapolate tracks
   float trkQualityPtMin_;
   std::vector<double> dPhiCutoff_;
   std::vector<double> dRCutoff_;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -89,6 +89,7 @@ private:
 
   float trkQualityChi2_;
   bool useTwoStubsPT_;
+  bool useClusterET_;  // use cluster et to extrapolate tracks  
   float trkQualityPtMin_;
   std::vector<double> dPhiCutoff_;
   std::vector<double> dRCutoff_;
@@ -132,6 +133,7 @@ L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iC
   trkQualityChi2_ = (float)iConfig.getParameter<double>("TrackChi2");
   trkQualityPtMin_ = (float)iConfig.getParameter<double>("TrackMinPt");
   useTwoStubsPT_ = iConfig.getParameter<bool>("useTwoStubsPT");
+  useClusterET_ = iConfig.getParameter<bool>("useClusterET");
   dPhiCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaPhi");
   dRCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaR");
   dEtaCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaEta");
@@ -203,7 +205,10 @@ void L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetu
         double dPhi = 99.;
         double dR = 99.;
         double dEta = 99.;
-        L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta);
+        if (useClusterET_)
+          L1TkElectronTrackMatchAlgo::doMatchClusterET(egIter, L1TrackPtr, dPhi, dR, dEta);
+        else
+          L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta);
         if (dR < drmin && selectMatchedTrack(dR, dPhi, dEta, trkPt, eta_ele)) {
           drmin = dR;
           itrack = itr;

--- a/L1Trigger/L1TTrackMatch/python/L1TkEgammaObjects_cff.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkEgammaObjects_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from L1Trigger.L1TTrackMatch.L1TkElectronTrackProducer_cfi import *
+
+l1TkElectronTrackEllipticProducers = cms.Sequence(L1TkElectronsEllipticMatchCrystal+L1TkElectronsEllipticMatchHGC)
+l1TkElectronTrackEllipticProducersEB = cms.Sequence(L1TkElectronsEllipticMatchCrystal)
+l1TkElectronTrackEllipticProducersEE = cms.Sequence(L1TkElectronsEllipticMatchHGC)
+
+# from L1Trigger.L1TTrackMatch.L1TkEmParticleProducer_cfi import *

--- a/L1Trigger/L1TTrackMatch/python/L1TkEgammaObjects_cff.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkEgammaObjects_cff.py
@@ -6,4 +6,3 @@ l1TkElectronTrackEllipticProducers = cms.Sequence(L1TkElectronsEllipticMatchCrys
 l1TkElectronTrackEllipticProducersEB = cms.Sequence(L1TkElectronsEllipticMatchCrystal)
 l1TkElectronTrackEllipticProducersEE = cms.Sequence(L1TkElectronsEllipticMatchHGC)
 
-# from L1Trigger.L1TTrackMatch.L1TkEmParticleProducer_cfi import *

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -11,14 +11,14 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     # Quality cuts on Track and Track L1EG matching criteria
     TrackChi2           = cms.double(1e10), # minimum Chi2 to select tracks
     TrackMinPt          = cms.double(10.0), # minimum Pt to select tracks
-	useTwoStubsPT       = cms.bool( False ),
+    useTwoStubsPT       = cms.bool( False ),
+    useClusterET       = cms.bool( False ),
     TrackEGammaMatchType = cms.string("PtDependentCut"),
     TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0), # functional Delta Phi cut parameters to match Track with L1EG objects
     TrackEGammaDeltaR   = cms.vdouble(0.08, 0.0, 0.0), # functional Delta R cut parameters to match Track with L1EG objects
-    # Delta Eta cutoff to match Track with L1EG objects
-    # are considered. (unused in default configuration)
-    TrackEGammaDeltaEta = cms.vdouble(1e10, 0.0, 0.0), 
-	  RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
+    TrackEGammaDeltaEta = cms.vdouble(1e10, 0.0, 0.0), # Delta Eta cutoff to match Track with L1EG objects
+                                                       # are considered. (unused in default configuration)
+    RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
 						# else absolute.
     # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
     # the isolation is below RelIsoCut are written into
@@ -79,10 +79,10 @@ L1TkElectronsHGC=L1TkElectrons.clone(
 
 
 L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
-#     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
-    TrackEGammaMatchType = cms.string("EllipticalCut"),
-    TrackEGammaDeltaEta = cms.vdouble(0.0075, 0.0075,1e10),
-    maxChi2IsoTracks = cms.double(100),
+    # L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
+    TrackEGammaMatchType = cms.string("EllipticalCut")
+    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10)
+    maxChi2IsoTracks = cms.double(100)
     minNStubsIsoTracks = cms.int32(4)
 )
 

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -6,7 +6,7 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     L1EGammaInputTag = cms.InputTag("simCaloStage2Digis",""),
     # Only the L1EG objects that have ET > ETmin in GeV
     # are considered. ETmin < 0 means that no cut is applied.
-    ETmin = cms.double( -1.0 ),             
+    ETmin = cms.double( -1.0 ),
     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
     # Quality cuts on Track and Track L1EG matching criteria
     TrackChi2           = cms.double(1e10), # minimum Chi2 to select tracks
@@ -25,7 +25,7 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     # the output collection. When RelIsoCut < 0, no cut is applied.
 		# When RelativeIsolation = False, IsoCut is in GeV.
     # Determination of the isolation w.r.t. L1Tracks :
-    IsoCut = cms.double( -0.10 ), 		
+    IsoCut = cms.double( -0.10 ),
     PTMINTRA = cms.double( 2. ),	# in GeV
 	  DRmin = cms.double( 0.03),
 	  DRmax = cms.double( 0.2 ),
@@ -80,10 +80,10 @@ L1TkElectronsHGC=L1TkElectrons.clone(
 
 L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
     # L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
-    TrackEGammaMatchType = cms.string("EllipticalCut")
-    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10)
-    maxChi2IsoTracks = cms.double(100)
-    minNStubsIsoTracks = cms.int32(4)
+    TrackEGammaMatchType = cms.string("EllipticalCut"),
+    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10),
+    maxChi2IsoTracks = cms.double(100),
+    minNStubsIsoTracks = cms.int32(4),
 )
 
 

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -64,7 +64,6 @@ L1TkElectronsLooseCrystal = L1TkElectronsCrystal.clone(
 )
 
 L1TkElectronsEllipticMatchCrystal = L1TkElectronsCrystal.clone(
-#     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
     TrackEGammaMatchType = cms.string("EllipticalCut"),
     TrackEGammaDeltaEta = cms.vdouble(0.015, 0.025,1e10)
 )
@@ -79,7 +78,6 @@ L1TkElectronsHGC=L1TkElectrons.clone(
 
 
 L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
-    # L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
     TrackEGammaMatchType = cms.string("EllipticalCut"),
     TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10),
     maxChi2IsoTracks = cms.double(100),

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -33,10 +33,10 @@ namespace L1TkElectronTrackMatchAlgo {
   }
   // ------------ match EGamma and Track
   void doMatchClusterET(l1t::EGammaBxCollection::const_iterator egIter,
-               const edm::Ptr<L1TTTrackType>& pTrk,
-               double& dph,
-               double& dr,
-               double& deta) {
+                        const edm::Ptr<L1TTTrackType>& pTrk,
+                        double& dph,
+                        double& dr,
+                        double& deta) {
     GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
     dph = L1TkElectronTrackMatchAlgo::deltaPhiClusterET(egIter, pTrk);
     dr = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
@@ -66,10 +66,10 @@ namespace L1TkElectronTrackMatchAlgo {
     double et = egIter->et();
     double pt = pTrk->momentum().perp();
     double curv = pTrk->rInv();
-        
+
     double dphi_curv = (asin(er * curv * pt / (2.0 * et)));
     double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
-        
+
     double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
     return dphi;
   }

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -32,6 +32,17 @@ namespace L1TkElectronTrackMatchAlgo {
     deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
   }
   // ------------ match EGamma and Track
+  void doMatchClusterET(l1t::EGammaBxCollection::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta) {
+    GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    dph = L1TkElectronTrackMatchAlgo::deltaPhiClusterET(egIter, pTrk);
+    dr = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
+  }
+  // ------------ match EGamma and Track
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta) {
     dph = L1TkElectronTrackMatchAlgo::deltaPhi(epos, pTrk);
     dr = L1TkElectronTrackMatchAlgo::deltaR(epos, pTrk);
@@ -45,6 +56,20 @@ namespace L1TkElectronTrackMatchAlgo {
     double dphi_curv = (asin(er * curv / (2.0)));
     double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
 
+    double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
+    return dphi;
+  }
+  // --------------- use cluster et to extrapolate tracks
+  double deltaPhiClusterET(l1t::EGammaBxCollection::const_iterator egIter, const edm::Ptr<L1TTTrackType>& pTrk) {
+    GlobalPoint epos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    double er = epos.perp();
+    double et = egIter->et();
+    double pt = pTrk->momentum().perp();
+    double curv = pTrk->rInv();
+        
+    double dphi_curv = (asin(er * curv * pt / (2.0 * et)));
+    double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
+        
     double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
     return dphi;
   }
@@ -62,7 +87,7 @@ namespace L1TkElectronTrackMatchAlgo {
     double ez = epos.z();
     double z0 = pTrk->POCA().z();
     double theta = 0.0;
-    if (ez >= 0)
+    if (ez - z0 >= 0)
       theta = atan(er / fabs(ez - z0));
     else
       theta = M_PI - atan(er / fabs(ez - z0));


### PR DESCRIPTION
#### PR description:

The PR addresses a minor problem in the matching of L1 tracks & EG standalone objects (see [Jack Li talk @ EG L1 P2 meeting ](https://indico.cern.ch/event/933640/contributions/3923081/attachments/2066176/3467521/EgammaMeeting_30Jun.pdf) for details).

The net effect of the fix is to increase the efficiency for central electrons at no expenses in rate (see attached plots).
The new code also allows (optionally) to use a different (more efficient) strategy for the matching using the cluster pT in the track extrapolation. The code is however deactivated for now pending FW demonstration.

The PR also integrates some validation code (ntuples) not consumed in any production workflow.

#### PR validation:

![canvas(168)](https://user-images.githubusercontent.com/4802196/91179907-6ab06380-e6e7-11ea-8f22-8e7312260a10.png)

![canvas(169)](https://user-images.githubusercontent.com/4802196/91179887-608e6500-e6e7-11ea-950c-2f63bf299754.png)

