### PR TITLE
Removed unused GCC11Compatibility.h

### DIFF
--- a/FWCore/Utilities/interface/GCC11Compatibility.h
+++ b/FWCore/Utilities/interface/GCC11Compatibility.h
@@ -1,4 +1,0 @@
-#ifndef FWCORE_GCC11COMPATIBILITY_H
-#define FWCORE_GCC11COMPATIBILITY_H
-#warning "GCC11Compatibility.h should be replaced with Visibility.h or Likely.h"
-#endif  // FWCORE_GCC11COMPATIBILITY_H


### PR DESCRIPTION
#### PR description:

GCC11Compatibility.h has been deprecated for quite some time and no code in CMSSW is using it anymore.

This was showing up as a warning in the CXXMODULES build since it is being included in the modules declaration.

#### PR validation:

Did a `git grep GCC11Compatibility.h` and had no hits.