### PR TITLE
drop type specs in RecoEgamma

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/electronEDIsolationDeposits_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/electronEDIsolationDeposits_cff.py
@@ -2,21 +2,21 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.electronPFIsolationDeposits_cff import *
 
-elEDIsoDepositCharged=elPFIsoDepositCharged.clone()
-elEDIsoDepositCharged.src="ecalDrivenGsfElectrons"
-
-elEDIsoDepositChargedAll=elPFIsoDepositChargedAll.clone()
-elEDIsoDepositChargedAll.src="ecalDrivenGsfElectrons"
-
-elEDIsoDepositGamma=elPFIsoDepositGamma.clone()
-elEDIsoDepositGamma.src="ecalDrivenGsfElectrons"
-
-elEDIsoDepositNeutral=elPFIsoDepositNeutral.clone()
-elEDIsoDepositNeutral.src="ecalDrivenGsfElectrons"
-
-elEDIsoDepositPU=elPFIsoDepositPU.clone()
-elEDIsoDepositPU.src="ecalDrivenGsfElectrons"
-
+elEDIsoDepositCharged=elPFIsoDepositCharged.clone(
+    src="ecalDrivenGsfElectrons"
+)
+elEDIsoDepositChargedAll=elPFIsoDepositChargedAll.clone(
+    src="ecalDrivenGsfElectrons"
+)
+elEDIsoDepositGamma=elPFIsoDepositGamma.clone(
+    src="ecalDrivenGsfElectrons"
+)
+elEDIsoDepositNeutral=elPFIsoDepositNeutral.clone(
+    src="ecalDrivenGsfElectrons"
+)
+elEDIsoDepositPU=elPFIsoDepositPU.clone(
+    src="ecalDrivenGsfElectrons"
+)
 electronEDIsolationDepositsTask = cms.Task(
     elEDIsoDepositCharged,
     elEDIsoDepositChargedAll,

--- a/RecoEgamma/EgammaElectronProducers/python/electronEDIsolationValues_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/electronEDIsolationValues_cff.py
@@ -2,35 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.EgammaElectronProducers.electronPFIsolationValues_cff import *
 
-elEDIsoValueCharged03 = elPFIsoValueCharged03.clone()
-elEDIsoValueCharged03.deposits[0].src ='elEDIsoDepositCharged'
+elEDIsoValueCharged03 = elPFIsoValueCharged03.clone(deposits = {0: dict(src ='elEDIsoDepositCharged')} )
 
-elEDIsoValueChargedAll03 = elPFIsoValueChargedAll03.clone()
-elEDIsoValueChargedAll03.deposits[0].src='elEDIsoDepositChargedAll'
+elEDIsoValueChargedAll03 = elPFIsoValueChargedAll03.clone(deposits = {0: dict(src='elEDIsoDepositChargedAll')} )
 
-elEDIsoValueGamma03 = elPFIsoValueGamma03.clone()
-elEDIsoValueGamma03.deposits[0].src='elEDIsoDepositGamma'
+elEDIsoValueGamma03 = elPFIsoValueGamma03.clone(deposits = {0: dict(src='elEDIsoDepositGamma')} )
 
-elEDIsoValueNeutral03 = elPFIsoValueNeutral03.clone()
-elEDIsoValueNeutral03.deposits[0].src='elEDIsoDepositNeutral'
+elEDIsoValueNeutral03 = elPFIsoValueNeutral03.clone(deposits = {0: dict(src='elEDIsoDepositNeutral')} )
 
-elEDIsoValuePU03  = elPFIsoValuePU03.clone()
-elEDIsoValuePU03.deposits[0].src = 'elEDIsoDepositPU'
+elEDIsoValuePU03  = elPFIsoValuePU03.clone(deposits = {0: dict(src = 'elEDIsoDepositPU')} )
 
-elEDIsoValueCharged04 = elPFIsoValueCharged04.clone()
-elEDIsoValueCharged04.deposits[0].src ='elEDIsoDepositCharged'
+elEDIsoValueCharged04 = elPFIsoValueCharged04.clone(deposits = {0: dict(src ='elEDIsoDepositCharged')} )
 
-elEDIsoValueChargedAll04 = elPFIsoValueChargedAll04.clone()
-elEDIsoValueChargedAll04.deposits[0].src='elEDIsoDepositChargedAll'
+elEDIsoValueChargedAll04 = elPFIsoValueChargedAll04.clone(deposits = {0: dict(src='elEDIsoDepositChargedAll')} )
 
-elEDIsoValueGamma04 = elPFIsoValueGamma04.clone()
-elEDIsoValueGamma04.deposits[0].src='elEDIsoDepositGamma'
+elEDIsoValueGamma04 = elPFIsoValueGamma04.clone(deposits = {0: dict(src='elEDIsoDepositGamma')} )
 
-elEDIsoValueNeutral04 = elPFIsoValueNeutral04.clone()
-elEDIsoValueNeutral04.deposits[0].src='elEDIsoDepositNeutral'
+elEDIsoValueNeutral04 = elPFIsoValueNeutral04.clone(deposits = {0: dict(src='elEDIsoDepositNeutral')} )
 
-elEDIsoValuePU04  = elPFIsoValuePU04.clone()
-elEDIsoValuePU04.deposits[0].src = 'elEDIsoDepositPU'
+elEDIsoValuePU04  = elPFIsoValuePU04.clone(deposits = {0: dict(src = 'elEDIsoDepositPU')} )
 
 electronEDIsolationValuesTask = cms.Task(
     elEDIsoValueCharged03,

--- a/RecoEgamma/EgammaElectronProducers/python/electronPFIsolationValues_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/electronPFIsolationValues_cff.py
@@ -71,24 +71,11 @@ elPFIsoValuePU03 = cms.EDProducer("PFCandIsolatorFromDeposits",
    )
 )
 
-elPFIsoValueCharged04 = elPFIsoValueCharged03.clone()
-elPFIsoValueCharged04.deposits[0].deltaR = 0.4
-
-
-elPFIsoValueChargedAll04 = elPFIsoValueChargedAll03.clone()
-elPFIsoValueChargedAll04.deposits[0].deltaR = 0.4
-
-elPFIsoValueGamma04 = elPFIsoValueGamma03.clone()
-elPFIsoValueGamma04.deposits[0].deltaR = 0.4
-
-
-elPFIsoValueNeutral04 = elPFIsoValueNeutral03.clone()
-elPFIsoValueNeutral04.deposits[0].deltaR = 0.4
-
-elPFIsoValuePU04 = elPFIsoValuePU03.clone()
-elPFIsoValuePU04.deposits[0].deltaR = 0.4
-
-
+elPFIsoValueCharged04 = elPFIsoValueCharged03.clone(deposits = {0: dict(deltaR = 0.4)} )
+elPFIsoValueChargedAll04 = elPFIsoValueChargedAll03.clone(deposits = {0: dict(deltaR = 0.4)} )
+elPFIsoValueGamma04 = elPFIsoValueGamma03.clone(deposits = {0: dict(deltaR = 0.4)} )
+elPFIsoValueNeutral04 = elPFIsoValueNeutral03.clone(deposits = {0: dict(deltaR = 0.4)} )
+elPFIsoValuePU04 = elPFIsoValuePU03.clone(deposits ={0: dict(deltaR = 0.4)} )
 
 electronPFIsolationValuesTask = cms.Task(
     elPFIsoValueCharged03,

--- a/RecoEgamma/EgammaElectronProducers/python/electronPFIsolationValues_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/electronPFIsolationValues_cff.py
@@ -72,21 +72,21 @@ elPFIsoValuePU03 = cms.EDProducer("PFCandIsolatorFromDeposits",
 )
 
 elPFIsoValueCharged04 = elPFIsoValueCharged03.clone()
-elPFIsoValueCharged04.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueCharged04.deposits[0].deltaR = 0.4
 
 
 elPFIsoValueChargedAll04 = elPFIsoValueChargedAll03.clone()
-elPFIsoValueChargedAll04.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueChargedAll04.deposits[0].deltaR = 0.4
 
 elPFIsoValueGamma04 = elPFIsoValueGamma03.clone()
-elPFIsoValueGamma04.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueGamma04.deposits[0].deltaR = 0.4
 
 
 elPFIsoValueNeutral04 = elPFIsoValueNeutral03.clone()
-elPFIsoValueNeutral04.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueNeutral04.deposits[0].deltaR = 0.4
 
 elPFIsoValuePU04 = elPFIsoValuePU03.clone()
-elPFIsoValuePU04.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValuePU04.deposits[0].deltaR = 0.4
 
 
 

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSeeds_cfi.py
@@ -34,13 +34,14 @@ lowPtGsfElectronSeeds = cms.EDProducer(
 
 # Modifiers for FastSim
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-lowPtGsfElectronSeedsTmp = lowPtGsfElectronSeeds.clone(tracks = cms.InputTag("generalTracksBeforeMixing"))
+lowPtGsfElectronSeedsTmp = lowPtGsfElectronSeeds.clone(tracks = "generalTracksBeforeMixing")
 import FastSimulation.Tracking.ElectronSeedTrackRefFix_cfi
-_fastSim_lowPtGsfElectronSeeds = FastSimulation.Tracking.ElectronSeedTrackRefFix_cfi.fixedTrackerDrivenElectronSeeds.clone()
-_fastSim_lowPtGsfElectronSeeds.seedCollection = cms.InputTag("lowPtGsfElectronSeedsTmp","")
-_fastSim_lowPtGsfElectronSeeds.idCollection = cms.VInputTag("lowPtGsfElectronSeedsTmp","lowPtGsfElectronSeedsTmp:HCAL")
-_fastSim_lowPtGsfElectronSeeds.PreIdLabel = cms.vstring("","HCAL")
-_fastSim_lowPtGsfElectronSeeds.PreGsfLabel = cms.string("")
+_fastSim_lowPtGsfElectronSeeds = FastSimulation.Tracking.ElectronSeedTrackRefFix_cfi.fixedTrackerDrivenElectronSeeds.clone(
+    seedCollection = "lowPtGsfElectronSeedsTmp:",
+    idCollection   = ["lowPtGsfElectronSeedsTmp","lowPtGsfElectronSeedsTmp:HCAL"],
+    PreIdLabel     = ["","HCAL"],
+    PreGsfLabel    = ""
+)
 fastSim.toReplaceWith(lowPtGsfElectronSeeds,_fastSim_lowPtGsfElectronSeeds)
 
 # Modifiers for BParking

--- a/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSequence_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/lowPtGsfElectronSequence_cff.py
@@ -5,11 +5,11 @@ from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 # PFRecTracks from generalTracks
 from RecoParticleFlow.PFTracking.pfTrack_cfi import *
-lowPtGsfElePfTracks = pfTrack.clone()
-lowPtGsfElePfTracks.TkColList = ['generalTracks']
-lowPtGsfElePfTracks.GsfTracksInEvents = False
-lowPtGsfElePfTracks.GsfTrackModuleLabel = ''
-
+lowPtGsfElePfTracks = pfTrack.clone(
+    TkColList           = ['generalTracks'],
+    GsfTracksInEvents   = False,
+    GsfTrackModuleLabel = ''
+)
 fastSim.toModify(lowPtGsfElePfTracks,TkColList = ['generalTracksBeforeMixing'])
 
 # Low pT ElectronSeeds
@@ -17,41 +17,44 @@ from RecoEgamma.EgammaElectronProducers.lowPtGsfElectronSeeds_cfi import *
 
 # Electron track candidates
 from TrackingTools.GsfTracking.CkfElectronCandidateMaker_cff import *
-lowPtGsfEleTrajectoryFilter = TrajectoryFilterForElectrons.clone()
-lowPtGsfEleTrajectoryFilter.minPt = 0.
-lowPtGsfEleTrajectoryFilter.minimumNumberOfHits = 3
-lowPtGsfEleTrajectoryBuilder = TrajectoryBuilderForElectrons.clone()
-lowPtGsfEleTrajectoryBuilder.trajectoryFilter.refToPSet_ = 'lowPtGsfEleTrajectoryFilter'
-lowPtGsfEleCkfTrackCandidates = electronCkfTrackCandidates.clone()
-lowPtGsfEleCkfTrackCandidates.TrajectoryBuilderPSet.refToPSet_ = 'lowPtGsfEleTrajectoryBuilder'
-lowPtGsfEleCkfTrackCandidates.src = 'lowPtGsfElectronSeeds'
-
+lowPtGsfEleTrajectoryFilter = TrajectoryFilterForElectrons.clone(
+    minPt = 0.,
+    minimumNumberOfHits = 3
+)
+lowPtGsfEleTrajectoryBuilder = TrajectoryBuilderForElectrons.clone(
+    trajectoryFilter = dict(refToPSet_ = 'lowPtGsfEleTrajectoryFilter')
+)
+lowPtGsfEleCkfTrackCandidates = electronCkfTrackCandidates.clone(
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'lowPtGsfEleTrajectoryBuilder'),
+    src = 'lowPtGsfElectronSeeds'
+)
 import FastSimulation.Tracking.electronCkfTrackCandidates_cff
-fastLowPtGsfTkfTrackCandidates = FastSimulation.Tracking.electronCkfTrackCandidates_cff.electronCkfTrackCandidates.clone(src = cms.InputTag("lowPtGsfElectronSeeds"))
+fastLowPtGsfTkfTrackCandidates = FastSimulation.Tracking.electronCkfTrackCandidates_cff.electronCkfTrackCandidates.clone(src = "lowPtGsfElectronSeeds")
 
 # GsfTracks
 from TrackingTools.GsfTracking.GsfElectronGsfFit_cff import *
-lowPtGsfEleFittingSmoother = GsfElectronFittingSmoother.clone()
-lowPtGsfEleFittingSmoother.ComponentName = 'lowPtGsfEleFittingSmoother'
-lowPtGsfEleFittingSmoother.MinNumberOfHits = 2
+lowPtGsfEleFittingSmoother = GsfElectronFittingSmoother.clone(
+    ComponentName = 'lowPtGsfEleFittingSmoother',
+    MinNumberOfHits = 2
+)
 from TrackingTools.GsfTracking.GsfElectronGsfFit_cff import * 
-lowPtGsfEleGsfTracks = electronGsfTracks.clone()
-lowPtGsfEleGsfTracks.Fitter = 'lowPtGsfEleFittingSmoother'
-lowPtGsfEleGsfTracks.src = 'lowPtGsfEleCkfTrackCandidates'
-
-fastSim.toModify(lowPtGsfEleGsfTracks,src = cms.InputTag("fastLowPtGsfTkfTrackCandidates"))
+lowPtGsfEleGsfTracks = electronGsfTracks.clone(
+    Fitter = 'lowPtGsfEleFittingSmoother',
+    src = 'lowPtGsfEleCkfTrackCandidates'
+)
+fastSim.toModify(lowPtGsfEleGsfTracks,src = "fastLowPtGsfTkfTrackCandidates")
 
 # GSFTrack to track association
 from RecoEgamma.EgammaElectronProducers.lowPtGsfToTrackLinks_cfi import lowPtGsfToTrackLinks
 
 # GsfPFRecTracks
 from RecoParticleFlow.PFTracking.pfTrackElec_cfi import *
-lowPtGsfElePfGsfTracks = pfTrackElec.clone()
-lowPtGsfElePfGsfTracks.GsfTrackModuleLabel = 'lowPtGsfEleGsfTracks'
-lowPtGsfElePfGsfTracks.PFRecTrackLabel = 'lowPtGsfElePfTracks'
-lowPtGsfElePfGsfTracks.applyGsfTrackCleaning = False
-lowPtGsfElePfGsfTracks.useFifthStepForTrackerDrivenGsf = True
-
+lowPtGsfElePfGsfTracks = pfTrackElec.clone(
+    GsfTrackModuleLabel   = 'lowPtGsfEleGsfTracks',
+    PFRecTrackLabel       = 'lowPtGsfElePfTracks',
+    applyGsfTrackCleaning = False,
+    useFifthStepForTrackerDrivenGsf = True
+)
 # SuperCluster generator and matching to GSF tracks
 # Below relies on the following default configurations:
 # RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py

--- a/RecoEgamma/EgammaElectronProducers/python/uncleanedOnlyElectronSequence_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/uncleanedOnlyElectronSequence_cff.py
@@ -8,13 +8,13 @@
 
 from RecoEgamma.EgammaElectronProducers.ecalDrivenElectronSeeds_cff import *
 uncleanedOnlyElectronSeeds = ecalDrivenElectronSeeds.clone(
-    barrelSuperClusters = cms.InputTag("uncleanedOnlyCorrectedHybridSuperClusters"),
-    endcapSuperClusters = cms.InputTag("uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower")
+    barrelSuperClusters = "uncleanedOnlyCorrectedHybridSuperClusters",
+    endcapSuperClusters = "uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower"
     )
 
 from TrackingTools.GsfTracking.CkfElectronCandidateMaker_cff import *
 uncleanedOnlyElectronCkfTrackCandidates = electronCkfTrackCandidates.clone(
-    src = cms.InputTag("uncleanedOnlyElectronSeeds")
+    src = "uncleanedOnlyElectronSeeds"
     )
 
 from TrackingTools.GsfTracking.GsfElectronGsfFit_cff import *
@@ -30,24 +30,24 @@ uncleanedOnlyTracking = cms.Sequence(uncleanedOnlyTrackingTask)
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackCandidates_cfi import *
 uncleanedOnlyConversionTrackCandidates = conversionTrackCandidates.clone(
-    scHybridBarrelProducer = cms.InputTag("uncleanedOnlyCorrectedHybridSuperClusters"),
-    bcBarrelCollection  = cms.InputTag("hybridSuperClusters","uncleanOnlyHybridSuperClusters"),
-    scIslandEndcapProducer  = cms.InputTag("uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower"),
-    bcEndcapCollection  = cms.InputTag("multi5x5SuperClusters","uncleanOnlyMulti5x5EndcapBasicClusters")
+    scHybridBarrelProducer  = "uncleanedOnlyCorrectedHybridSuperClusters",
+    bcBarrelCollection      = "hybridSuperClusters:uncleanOnlyHybridSuperClusters",
+    scIslandEndcapProducer  = "uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower",
+    bcEndcapCollection      = "multi5x5SuperClusters:uncleanOnlyMulti5x5EndcapBasicClusters"
     )
 
 from RecoEgamma.EgammaPhotonProducers.ckfOutInTracksFromConversions_cfi import *
 uncleanedOnlyCkfOutInTracksFromConversions = ckfOutInTracksFromConversions.clone(
-    src = cms.InputTag("uncleanedOnlyConversionTrackCandidates","outInTracksFromConversions"),
-    producer = cms.string('uncleanedOnlyConversionTrackCandidates'),
-    ComponentName = cms.string('uncleanedOnlyCkfOutInTracksFromConversions')
+    src           = "uncleanedOnlyConversionTrackCandidates:outInTracksFromConversions",
+    producer      = 'uncleanedOnlyConversionTrackCandidates',
+    ComponentName = 'uncleanedOnlyCkfOutInTracksFromConversions'
     )
 
 from RecoEgamma.EgammaPhotonProducers.ckfInOutTracksFromConversions_cfi import *
 uncleanedOnlyCkfInOutTracksFromConversions = ckfInOutTracksFromConversions.clone(
-    src = cms.InputTag("uncleanedOnlyConversionTrackCandidates","inOutTracksFromConversions"),
-    producer = cms.string('uncleanedOnlyConversionTrackCandidates'),
-    ComponentName = cms.string('uncleanedOnlyCkfInOutTracksFromConversions')
+    src           = "uncleanedOnlyConversionTrackCandidates:inOutTracksFromConversions",
+    producer      = 'uncleanedOnlyConversionTrackCandidates',
+    ComponentName = 'uncleanedOnlyCkfInOutTracksFromConversions'
     )
 
 uncleanedOnlyCkfTracksFromConversionsTask = cms.Task(uncleanedOnlyConversionTrackCandidates,uncleanedOnlyCkfOutInTracksFromConversions,uncleanedOnlyCkfInOutTracksFromConversions)
@@ -58,17 +58,17 @@ uncleanedOnlyGeneralConversionTrackProducer = generalConversionTrackProducer.clo
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyInOutConversionTrackProducer = inOutConversionTrackProducer.clone(
-    TrackProducer = cms.string('uncleanedOnlyCkfInOutTracksFromConversions')
+    TrackProducer = 'uncleanedOnlyCkfInOutTracksFromConversions'
     )
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyOutInConversionTrackProducer = outInConversionTrackProducer.clone(
-    TrackProducer = cms.string('uncleanedOnlyCkfOutInTracksFromConversions')
+    TrackProducer = 'uncleanedOnlyCkfOutInTracksFromConversions'
     )
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyGsfConversionTrackProducer = gsfConversionTrackProducer.clone(
-    TrackProducer = cms.string('uncleanedOnlyElectronGsfTracks')
+    TrackProducer = 'uncleanedOnlyElectronGsfTracks'
     )
 
 uncleanedOnlyConversionTrackProducersTask  = cms.Task(uncleanedOnlyGeneralConversionTrackProducer,uncleanedOnlyInOutConversionTrackProducer,uncleanedOnlyOutInConversionTrackProducer,uncleanedOnlyGsfConversionTrackProducer)
@@ -76,20 +76,20 @@ uncleanedOnlyConversionTrackProducers  = cms.Sequence(uncleanedOnlyConversionTra
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyInOutOutInConversionTrackMerger = inOutOutInConversionTrackMerger.clone(
-    TrackProducer2 = cms.InputTag('uncleanedOnlyOutInConversionTrackProducer'),
-    TrackProducer1 = cms.InputTag('uncleanedOnlyInOutConversionTrackProducer')
+    TrackProducer2 = 'uncleanedOnlyOutInConversionTrackProducer',
+    TrackProducer1 = 'uncleanedOnlyInOutConversionTrackProducer'
     )
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyGeneralInOutOutInConversionTrackMerger = generalInOutOutInConversionTrackMerger.clone(
-    TrackProducer2 = cms.InputTag('uncleanedOnlyGeneralConversionTrackProducer'),
-    TrackProducer1 = cms.InputTag('uncleanedOnlyInOutOutInConversionTrackMerger')
+    TrackProducer2 = 'uncleanedOnlyGeneralConversionTrackProducer',
+    TrackProducer1 = 'uncleanedOnlyInOutOutInConversionTrackMerger'
     )
 
 from RecoEgamma.EgammaPhotonProducers.conversionTrackSequence_cff import *
 uncleanedOnlyGsfGeneralInOutOutInConversionTrackMerger = gsfGeneralInOutOutInConversionTrackMerger.clone(
-    TrackProducer2 = cms.InputTag('uncleanedOnlyGsfConversionTrackProducer'),
-    TrackProducer1 = cms.InputTag('uncleanedOnlyGeneralInOutOutInConversionTrackMerger')
+    TrackProducer2 = 'uncleanedOnlyGsfConversionTrackProducer',
+    TrackProducer1 = 'uncleanedOnlyGeneralInOutOutInConversionTrackMerger'
     )
 
 uncleanedOnlyConversionTrackMergersTask = cms.Task(uncleanedOnlyInOutOutInConversionTrackMerger,uncleanedOnlyGeneralInOutOutInConversionTrackMerger,uncleanedOnlyGsfGeneralInOutOutInConversionTrackMerger)
@@ -97,11 +97,11 @@ uncleanedOnlyConversionTrackMergers = cms.Sequence(uncleanedOnlyConversionTrackM
 
 from RecoEgamma.EgammaPhotonProducers.allConversions_cfi import *
 uncleanedOnlyAllConversions = allConversions.clone(
-    scBarrelProducer = cms.InputTag("uncleanedOnlyCorrectedHybridSuperClusters"),
-    bcBarrelCollection  = cms.InputTag("hybridSuperClusters","uncleanOnlyHybridSuperClusters"),
-    scEndcapProducer = cms.InputTag("uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower"),
-    bcEndcapCollection = cms.InputTag("multi5x5SuperClusters","uncleanOnlyMulti5x5EndcapBasicClusters"),
-    src = cms.InputTag("uncleanedOnlyGsfGeneralInOutOutInConversionTrackMerger")
+    scBarrelProducer    = "uncleanedOnlyCorrectedHybridSuperClusters",
+    bcBarrelCollection  = "hybridSuperClusters:uncleanOnlyHybridSuperClusters",
+    scEndcapProducer    = "uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower",
+    bcEndcapCollection  = "multi5x5SuperClusters:uncleanOnlyMulti5x5EndcapBasicClusters",
+    src                 = "uncleanedOnlyGsfGeneralInOutOutInConversionTrackMerger"
     )
 
 uncleanedOnlyConversionsTask = cms.Task(uncleanedOnlyCkfTracksFromConversionsTask,uncleanedOnlyConversionTrackProducersTask,uncleanedOnlyConversionTrackMergersTask,uncleanedOnlyAllConversions)
@@ -112,19 +112,19 @@ uncleanedOnlyConversions = cms.Sequence(uncleanedOnlyConversionsTask)
 
 from RecoParticleFlow.PFTracking.pfTrack_cfi import *
 uncleanedOnlyPfTrack = pfTrack.clone(
-    GsfTrackModuleLabel = cms.InputTag("uncleanedOnlyElectronGsfTracks")
+    GsfTrackModuleLabel = "uncleanedOnlyElectronGsfTracks"
     )
 
 from RecoParticleFlow.PFTracking.pfConversions_cfi import *
 uncleanedOnlyPfConversions = pfConversions.clone(
-    conversionCollection = cms.InputTag("allConversions")
+    conversionCollection = "allConversions"
     )
 
 from RecoParticleFlow.PFTracking.pfTrackElec_cfi import *
 uncleanedOnlyPfTrackElec = pfTrackElec.clone(
-    PFConversions = cms.InputTag("uncleanedOnlyPfConversions"),
-    GsfTrackModuleLabel = cms.InputTag("uncleanedOnlyElectronGsfTracks"),
-    PFRecTrackLabel = cms.InputTag("uncleanedOnlyPfTrack")
+    PFConversions       = "uncleanedOnlyPfConversions",
+    GsfTrackModuleLabel = "uncleanedOnlyElectronGsfTracks",
+    PFRecTrackLabel     = "uncleanedOnlyPfTrack"
     )
 
 uncleanedOnlyPfTrackingTask = cms.Task(uncleanedOnlyPfTrack,uncleanedOnlyPfConversions,uncleanedOnlyPfTrackElec)
@@ -137,15 +137,15 @@ uncleanedOnlyPfTracking = cms.Sequence(uncleanedOnlyPfTrackingTask)
 from RecoEgamma.EgammaElectronProducers.ecalDrivenGsfElectronCores_cfi import ecalDrivenGsfElectronCores
 from RecoEgamma.EgammaElectronProducers.ecalDrivenGsfElectronCoresFromMultiCl_cff import ecalDrivenGsfElectronCoresFromMultiCl
 uncleanedOnlyGsfElectronCores = ecalDrivenGsfElectronCores.clone(
-    gsfTracks = cms.InputTag("uncleanedOnlyElectronGsfTracks"),
-    gsfPfRecTracks = cms.InputTag("uncleanedOnlyPfTrackElec")
+    gsfTracks      = "uncleanedOnlyElectronGsfTracks",
+    gsfPfRecTracks = "uncleanedOnlyPfTrackElec"
     )
 
 from RecoEgamma.EgammaElectronProducers.gsfElectrons_cfi import *
 uncleanedOnlyGsfElectrons = ecalDrivenGsfElectrons.clone(
-    gsfPfRecTracksTag = cms.InputTag("uncleanedOnlyPfTrackElec"),
-    gsfElectronCoresTag = cms.InputTag("uncleanedOnlyGsfElectronCores"),
-    seedsTag = cms.InputTag("uncleanedOnlyElectronSeeds")
+    gsfPfRecTracksTag   = "uncleanedOnlyPfTrackElec",
+    gsfElectronCoresTag = "uncleanedOnlyGsfElectronCores",
+    seedsTag            = "uncleanedOnlyElectronSeeds"
     )
 
 uncleanedOnlyElectronsTask = cms.Task(uncleanedOnlyGsfElectronCores,uncleanedOnlyGsfElectrons)

--- a/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/egmPhotonIsolationPUPPI_cff.py
@@ -32,7 +32,8 @@ egmPhotonIsolationAODPUPPI = cms.EDProducer( "CITKPFIsolationSumProducerForPUPPI
 			  isolationConeDefinitions = IsoConeDefinitions
 )
 
-egmPhotonIsolationMiniAODPUPPI = egmPhotonIsolationAODPUPPI.clone()
-egmPhotonIsolationMiniAODPUPPI.srcForIsolationCone = cms.InputTag("packedPFCandidates")
-egmPhotonIsolationMiniAODPUPPI.srcToIsolate = cms.InputTag("slimmedPhotons")
-egmPhotonIsolationMiniAODPUPPI.puppiValueMap = cms.InputTag('')
+egmPhotonIsolationMiniAODPUPPI = egmPhotonIsolationAODPUPPI.clone(
+    srcForIsolationCone = "packedPFCandidates",
+    srcToIsolate        = "slimmedPhotons",
+    puppiValueMap       = ''
+)

--- a/RecoEgamma/EgammaIsolationAlgos/python/electronTrackIsolations_cfi.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/electronTrackIsolations_cfi.py
@@ -28,8 +28,8 @@ trkIsol04CfgV1 = cms.PSet(
 
 #V2, used by HEEP ID in 2016
 trkIsol03CfgV2 = cms.PSet(
-    barrelCuts=_defaultCuts.clone(algosToReject = cms.vstring()),
-    endcapCuts=_defaultCuts.clone(algosToReject = cms.vstring(),maxDZ=0.5)
+    barrelCuts=_defaultCuts.clone(algosToReject = []),
+    endcapCuts=_defaultCuts.clone(algosToReject = [],maxDZ=0.5)
 )
 trkIsol04CfgV2 = cms.PSet(
     barrelCuts=trkIsol03CfgV2.barrelCuts.clone(maxDR=0.4),

--- a/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/interestingEgammaIsoDetIdsSequence_cff.py
@@ -5,112 +5,121 @@ from RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff import *
 
 
 import RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff
-interestingGedEleIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff.interestingEleIsoDetId.clone()
-interestingGedEleIsoDetIdEB.recHitsLabel = 'ecalRecHit:EcalRecHitsEB'
-interestingGedEleIsoDetIdEB.emObjectLabel = 'gedGsfElectrons'
-interestingGedEleIsoDetIdEB.etCandCut = 0.0
-interestingGedEleIsoDetIdEB.energyCut = 0.095
-interestingGedEleIsoDetIdEB.etCut = 0.0
-interestingGedEleIsoDetIdEB.outerRadius = 0.6
-interestingGedEleIsoDetIdEB.innerRadius = 0.0
+interestingGedEleIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff.interestingEleIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEB',
+    emObjectLabel = 'gedGsfElectrons',
+    etCandCut     = 0.0,
+    energyCut     = 0.095,
+    etCut         = 0.0,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff
-interestingGedEleIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff.interestingEleIsoDetId.clone()
-interestingGedEleIsoDetIdEE.recHitsLabel = 'ecalRecHit:EcalRecHitsEE'
-interestingGedEleIsoDetIdEE.emObjectLabel = 'gedGsfElectrons'
-interestingGedEleIsoDetIdEE.etCandCut = 0.0
-interestingGedEleIsoDetIdEE.energyCut = 0.0
-interestingGedEleIsoDetIdEE.etCut = 0.110
-interestingGedEleIsoDetIdEE.outerRadius = 0.6
-interestingGedEleIsoDetIdEE.innerRadius = 0.0
+interestingGedEleIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingEleIsoDetIdModule_cff.interestingEleIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEE',
+    emObjectLabel = 'gedGsfElectrons',
+    etCandCut     = 0.0,
+    energyCut     = 0.0,
+    etCut         = 0.110,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff
-interestingGedGamIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone()
-interestingGedGamIsoDetIdEB.recHitsLabel = 'ecalRecHit:EcalRecHitsEB'
-interestingGedGamIsoDetIdEB.emObjectLabel = 'gedPhotons'
-interestingGedGamIsoDetIdEB.etCandCut = 0.0
-interestingGedGamIsoDetIdEB.energyCut = 0.095
-interestingGedGamIsoDetIdEB.etCut = 0.0
-interestingGedGamIsoDetIdEB.outerRadius = 0.6
-interestingGedGamIsoDetIdEB.innerRadius = 0.0
+interestingGedGamIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEB',
+    emObjectLabel = 'gedPhotons',
+    etCandCut     = 0.0,
+    energyCut     = 0.095,
+    etCut         = 0.0,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff
-interestingGedGamIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone()
-interestingGedGamIsoDetIdEE.recHitsLabel = 'ecalRecHit:EcalRecHitsEE'
-interestingGedGamIsoDetIdEE.emObjectLabel = 'gedPhotons'
-interestingGedGamIsoDetIdEE.etCandCut = 0.0
-interestingGedGamIsoDetIdEE.energyCut = 0.0
-interestingGedGamIsoDetIdEE.etCut = 0.110
-interestingGedGamIsoDetIdEE.outerRadius = 0.6
-interestingGedGamIsoDetIdEE.innerRadius = 0.0
-
+interestingGedGamIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEE',
+    emObjectLabel = 'gedPhotons',
+    etCandCut     = 0.0,
+    energyCut     = 0.0,
+    etCut         = 0.110,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 ## OOT photons 
 interestingOotGamIsoDetIdEB = interestingGedGamIsoDetIdEB.clone(emObjectLabel = 'ootPhotons')
 interestingOotGamIsoDetIdEE = interestingGedGamIsoDetIdEE.clone(emObjectLabel = 'ootPhotons')
 
 import RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff
-interestingGamIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone()
-interestingGamIsoDetIdEB.recHitsLabel = 'ecalRecHit:EcalRecHitsEB'
-interestingGamIsoDetIdEB.emObjectLabel = 'photons'
-interestingGamIsoDetIdEB.etCandCut = 0.0
-interestingGamIsoDetIdEB.energyCut = 0.095
-interestingGamIsoDetIdEB.etCut = 0.0
-interestingGamIsoDetIdEB.outerRadius = 0.6
-interestingGamIsoDetIdEB.innerRadius = 0.0
+interestingGamIsoDetIdEB = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEB',
+    emObjectLabel = 'photons',
+    etCandCut     = 0.0,
+    energyCut     = 0.095,
+    etCut         = 0.0,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff
-interestingGamIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone()
-interestingGamIsoDetIdEE.recHitsLabel = 'ecalRecHit:EcalRecHitsEE'
-interestingGamIsoDetIdEE.emObjectLabel = 'photons'
-interestingGamIsoDetIdEE.etCandCut = 0.0
-interestingGamIsoDetIdEE.energyCut = 0.0
-interestingGamIsoDetIdEE.etCut = 0.110
-interestingGamIsoDetIdEE.outerRadius = 0.6
-interestingGamIsoDetIdEE.innerRadius = 0.0
+interestingGamIsoDetIdEE = RecoEgamma.EgammaIsolationAlgos.interestingGamIsoDetIdModule_cff.interestingGamIsoDetId.clone(
+    recHitsLabel  = 'ecalRecHit:EcalRecHitsEE',
+    emObjectLabel = 'photons',
+    etCandCut     = 0.0,
+    energyCut     = 0.0,
+    etCut         = 0.110,
+    outerRadius   = 0.6,
+    innerRadius   = 0.0
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingGedEgammaIsoHCALDetId_cfi
-interestingGedEgammaIsoHCALDetId = RecoEgamma.EgammaIsolationAlgos.interestingGedEgammaIsoHCALDetId_cfi.interestingGedEgammaIsoHCALDetId.clone()
 interestingEgammaIsoHCALSel = cms.PSet(
-  maxDIEta=cms.int32(5),
-  maxDIPhi=cms.int32(5),
-  minEnergyHB = cms.double(0.8),
-  minEnergyHEDepth1 = cms.double(0.1),
-  minEnergyHEDefault = cms.double(0.2),
+    maxDIEta           = cms.int32(5),
+    maxDIPhi           = cms.int32(5),
+    minEnergyHB        = cms.double(0.8),
+    minEnergyHEDepth1  = cms.double(0.1),
+    minEnergyHEDefault = cms.double(0.2),
 )
-interestingGedEgammaIsoHCALDetId.recHitsLabel=cms.InputTag("hbhereco")
-interestingGedEgammaIsoHCALDetId.elesLabel=cms.InputTag("gedGsfElectrons")
-interestingGedEgammaIsoHCALDetId.phosLabel=cms.InputTag("gedPhotons")
-interestingGedEgammaIsoHCALDetId.superClustersLabel=cms.InputTag("particleFlowEGamma")
-interestingGedEgammaIsoHCALDetId.minSCEt=cms.double(20)
-interestingGedEgammaIsoHCALDetId.minEleEt=cms.double(20)
-interestingGedEgammaIsoHCALDetId.minPhoEt=cms.double(20)
-interestingGedEgammaIsoHCALDetId.hitSelection=interestingEgammaIsoHCALSel
+interestingGedEgammaIsoHCALDetId = RecoEgamma.EgammaIsolationAlgos.interestingGedEgammaIsoHCALDetId_cfi.interestingGedEgammaIsoHCALDetId.clone(
+    recHitsLabel       = "hbhereco",
+    elesLabel          = "gedGsfElectrons",
+    phosLabel          = "gedPhotons",
+    superClustersLabel = "particleFlowEGamma",
+    minSCEt            = 20,
+    minEleEt           = 20,
+    minPhoEt           = 20,
+    hitSelection       = interestingEgammaIsoHCALSel
+)
 
 ## OOT Photons
-interestingOotEgammaIsoHCALDetId = interestingGedEgammaIsoHCALDetId.clone()
-interestingOotEgammaIsoHCALDetId.phosLabel=cms.InputTag("ootPhotons")
-interestingOotEgammaIsoHCALDetId.elesLabel=cms.InputTag("")
-interestingOotEgammaIsoHCALDetId.superClustersLabel=cms.InputTag("")
+interestingOotEgammaIsoHCALDetId = interestingGedEgammaIsoHCALDetId.clone(
+    phosLabel          = "ootPhotons",
+    elesLabel          = "",
+    superClustersLabel = ""
+)
 
 import RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff
-interestingGedEgammaIsoESDetId = RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff.interestingEgammaIsoESDetId.clone()
-interestingGedEgammaIsoESDetId.eeClusToESMapLabel=cms.InputTag("particleFlowClusterECALRemade")
-interestingGedEgammaIsoESDetId.ecalPFClustersLabel=cms.InputTag("particleFlowClusterECALRemade")
-interestingGedEgammaIsoESDetId.elesLabel=cms.InputTag("gedGsfElectrons")
-interestingGedEgammaIsoESDetId.phosLabel=cms.InputTag("gedPhotons")
-interestingGedEgammaIsoESDetId.superClustersLabel=cms.InputTag("particleFlowEGamma")
-interestingGedEgammaIsoESDetId.minSCEt=cms.double(500)
-interestingGedEgammaIsoESDetId.minEleEt=cms.double(20)
-interestingGedEgammaIsoESDetId.minPhoEt=cms.double(20)
-interestingGedEgammaIsoESDetId.maxDR=cms.double(0.4)
+interestingGedEgammaIsoESDetId = RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoESDetIdModule_cff.interestingEgammaIsoESDetId.clone(
+    eeClusToESMapLabel = "particleFlowClusterECALRemade",
+    ecalPFClustersLabel= "particleFlowClusterECALRemade",
+    elesLabel          = "gedGsfElectrons",
+    phosLabel          = "gedPhotons",
+    superClustersLabel = "particleFlowEGamma",
+    minSCEt            = 500,
+    minEleEt           = 20,
+    minPhoEt           = 20,
+    maxDR              = 0.4
+)
 
 ## OOT Photons
-interestingOotEgammaIsoESDetId = interestingGedEgammaIsoESDetId.clone()
-interestingOotEgammaIsoESDetId.eeClusToESMapLabel=cms.InputTag("particleFlowClusterOOTECAL")
-interestingOotEgammaIsoESDetId.ecalPFClustersLabel=cms.InputTag("particleFlowClusterOOTECAL")
-interestingOotEgammaIsoESDetId.phosLabel=cms.InputTag("ootPhotons")
-interestingOotEgammaIsoESDetId.elesLabel=cms.InputTag("")
-interestingOotEgammaIsoESDetId.superClustersLabel=cms.InputTag("")
+interestingOotEgammaIsoESDetId = interestingGedEgammaIsoESDetId.clone(
+    eeClusToESMapLabel = "particleFlowClusterOOTECAL",
+    ecalPFClustersLabel= "particleFlowClusterOOTECAL",
+    phosLabel          = "ootPhotons",
+    elesLabel          = "",
+    superClustersLabel = ""
+)
 
 interestingEgammaIsoDetIdsTask = cms.Task(
     interestingGedEleIsoDetIdEB ,

--- a/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
+++ b/RecoEgamma/EgammaIsolationAlgos/python/pfClusterIsolation_cfi.py
@@ -24,10 +24,10 @@ photonEcalPFClusterIsolationProducer = cms.EDProducer('PhotonEcalPFClusterIsolat
                                                       energyEndcap = cms.double(0)
                                                       )
 
-ootPhotonEcalPFClusterIsolationProducer = photonEcalPFClusterIsolationProducer.clone()
-ootPhotonEcalPFClusterIsolationProducer.candidateProducer = cms.InputTag('ootPhotonsTmp')
-ootPhotonEcalPFClusterIsolationProducer.pfClusterProducer = cms.InputTag('particleFlowClusterOOTECAL')
-
+ootPhotonEcalPFClusterIsolationProducer = photonEcalPFClusterIsolationProducer.clone(
+    candidateProducer = 'ootPhotonsTmp',
+    pfClusterProducer = 'particleFlowClusterOOTECAL'
+)
 electronHcalPFClusterIsolationProducer = cms.EDProducer('ElectronHcalPFClusterIsolationProducer',
                                                         candidateProducer = cms.InputTag('gedGsfElectronsTmp'),
                                                         pfClusterProducerHCAL = cms.InputTag('particleFlowClusterHCAL'),
@@ -54,9 +54,9 @@ photonHcalPFClusterIsolationProducer = cms.EDProducer('PhotonHcalPFClusterIsolat
                                                       energyEndcap = cms.double(0)
                                                       )
 
-ootPhotonHcalPFClusterIsolationProducer = photonHcalPFClusterIsolationProducer.clone()
-ootPhotonHcalPFClusterIsolationProducer.candidateProducer = cms.InputTag('ootPhotonsTmp')
-
+ootPhotonHcalPFClusterIsolationProducer = photonHcalPFClusterIsolationProducer.clone(
+    candidateProducer = 'ootPhotonsTmp'
+)
 pfClusterIsolationTask = cms.Task(
     electronEcalPFClusterIsolationProducer ,
     photonEcalPFClusterIsolationProducer ,

--- a/RecoEgamma/EgammaPhotonProducers/python/KFFittingSmootherForInOut_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFFittingSmootherForInOut_cfi.py
@@ -4,10 +4,10 @@ from RecoEgamma.EgammaPhotonProducers.KFTrajectoryFitterForInOut_cfi import *
 from RecoEgamma.EgammaPhotonProducers.KFTrajectorySmootherForInOut_cfi import *
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 # KFFittingSmootherESProducer
-KFFittingSmootherForInOut = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
-KFFittingSmootherForInOut.ComponentName = 'KFFittingSmootherForInOut'
-KFFittingSmootherForInOut.Fitter = 'KFFitterForInOut'
-KFFittingSmootherForInOut.Smoother = 'KFSmootherForInOut'
-KFFittingSmootherForInOut.EstimateCut = -1
-KFFittingSmootherForInOut.MinNumberOfHits = 3
-
+KFFittingSmootherForInOut = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName   = 'KFFittingSmootherForInOut',
+    Fitter          = 'KFFitterForInOut',
+    Smoother        = 'KFSmootherForInOut',
+    EstimateCut     = -1,
+    MinNumberOfHits = 3
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/KFFittingSmootherForOutIn_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFFittingSmootherForOutIn_cfi.py
@@ -4,10 +4,10 @@ from RecoEgamma.EgammaPhotonProducers.KFTrajectoryFitterForOutIn_cfi import *
 from RecoEgamma.EgammaPhotonProducers.KFTrajectorySmootherForOutIn_cfi import *
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 # KFFittingSmootherESProducer
-KFFittingSmootherForOutIn = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
-KFFittingSmootherForOutIn.ComponentName = 'KFFittingSmootherForOutIn'
-KFFittingSmootherForOutIn.Fitter = 'KFFitterForOutIn'
-KFFittingSmootherForOutIn.Smoother = 'KFSmootherForOutIn'
-KFFittingSmootherForOutIn.EstimateCut = -1
-KFFittingSmootherForOutIn.MinNumberOfHits = 3
-
+KFFittingSmootherForOutIn = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName   = 'KFFittingSmootherForOutIn',
+    Fitter          = 'KFFitterForOutIn',
+    Smoother        = 'KFSmootherForOutIn',
+    EstimateCut     = -1,
+    MinNumberOfHits = 3
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/KFTrajectoryFitterForInOut_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFTrajectoryFitterForInOut_cfi.py
@@ -4,9 +4,9 @@ from RecoEgamma.EgammaPhotonProducers.propAlongMomentumWithMaterialForElectrons_
 from RecoEgamma.EgammaPhotonProducers.chi2EstimatorForInOutFit_cfi import *
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 #KFTrajectoryFitterESProducer
-KFTrajectoryFitterForInOut = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone()
-KFTrajectoryFitterForInOut.ComponentName = 'KFFitterForInOut'
-KFTrajectoryFitterForInOut.Propagator = 'alongMomElePropagator'
-KFTrajectoryFitterForInOut.Estimator = 'Chi2ForInOut'
-KFTrajectoryFitterForInOut.minHits = 3
-
+KFTrajectoryFitterForInOut = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterForInOut',
+    Propagator    = 'alongMomElePropagator',
+    Estimator     = 'Chi2ForInOut',
+    minHits       = 3
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/KFTrajectoryFitterForOutIn_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFTrajectoryFitterForOutIn_cfi.py
@@ -4,9 +4,9 @@ from RecoEgamma.EgammaPhotonProducers.propAlongMomentumWithMaterialForElectrons_
 from RecoEgamma.EgammaPhotonProducers.chi2EstimatorForOutInFit_cfi import *
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 #KFTrajectoryFitterESProducer
-KFTrajectoryFitterForOutIn = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone()
-KFTrajectoryFitterForOutIn.ComponentName = 'KFFitterForOutIn'
-KFTrajectoryFitterForOutIn.Propagator = 'alongMomElePropagator'
-KFTrajectoryFitterForOutIn.Estimator = 'Chi2ForOutIn'
-KFTrajectoryFitterForOutIn.minHits = 3
-
+KFTrajectoryFitterForOutIn = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterForOutIn',
+    Propagator    = 'alongMomElePropagator',
+    Estimator     = 'Chi2ForOutIn',
+    minHits       = 3
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/KFTrajectorySmootherForInOut_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFTrajectorySmootherForInOut_cfi.py
@@ -4,8 +4,8 @@ from RecoEgamma.EgammaPhotonProducers.propOppoMomentumWithMaterialForElectrons_c
 from RecoEgamma.EgammaPhotonProducers.chi2EstimatorForInOutFit_cfi import *
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 # KFTrajectorySmootherESProducer
-KFTrajectorySmootherForInOut = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone()
-KFTrajectorySmootherForInOut.ComponentName = 'KFSmootherForInOut'
-KFTrajectorySmootherForInOut.Propagator = 'oppositeToMomElePropagator'
-KFTrajectorySmootherForInOut.Estimator = 'Chi2ForInOut'
-
+KFTrajectorySmootherForInOut = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherForInOut',
+    Propagator    = 'oppositeToMomElePropagator',
+    Estimator     = 'Chi2ForInOut'
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/KFTrajectorySmootherForOutIn_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/KFTrajectorySmootherForOutIn_cfi.py
@@ -4,8 +4,8 @@ from RecoEgamma.EgammaPhotonProducers.propOppoMomentumWithMaterialForElectrons_c
 from RecoEgamma.EgammaPhotonProducers.chi2EstimatorForOutInFit_cfi import *
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 # KFTrajectorySmootherESProducer
-KFTrajectorySmootherForOutIn = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone()
-KFTrajectorySmootherForOutIn.ComponentName = 'KFSmootherForOutIn'
-KFTrajectorySmootherForOutIn.Propagator = 'oppositeToMomElePropagator'
-KFTrajectorySmootherForOutIn.Estimator = 'Chi2ForOutIn'
-
+KFTrajectorySmootherForOutIn = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherForOutIn',
+    Propagator    = 'oppositeToMomElePropagator',
+    Estimator     = 'Chi2ForOutIn'
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/allConversionSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/allConversionSequence_cff.py
@@ -7,11 +7,11 @@ from RecoEgamma.EgammaPhotonProducers.allConversions_cfi import *
 allConversionTask = cms.Task(allConversions)
 allConversionSequence = cms.Sequence(allConversionTask)
 
-allConversionsOldEG = allConversions.clone()
-allConversionsOldEG.scBarrelProducer = cms.InputTag("correctedHybridSuperClusters")
-allConversionsOldEG.bcBarrelCollection = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
-allConversionsOldEG.scEndcapProducer = cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
-allConversionsOldEG.bcEndcapCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
-
+allConversionsOldEG = allConversions.clone(
+    scBarrelProducer   = "correctedHybridSuperClusters",
+    bcBarrelCollection = "hybridSuperClusters:hybridBarrelBasicClusters",
+    scEndcapProducer   = "correctedMulti5x5SuperClustersWithPreshower",
+    bcEndcapCollection = "multi5x5SuperClusters:multi5x5EndcapBasicClusters"
+)
 allConversionOldEGSequence = cms.Sequence(allConversionsOldEG)
 

--- a/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForInOutFit_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForInOutFit_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-Chi2MeasurementEstimatorForInOut = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-Chi2MeasurementEstimatorForInOut.ComponentName = 'Chi2ForInOut'
-Chi2MeasurementEstimatorForInOut.MaxChi2 = 100.
-Chi2MeasurementEstimatorForInOut.nSigma = 3.
-Chi2MeasurementEstimatorForInOut.MaxDisplacement = 100
-Chi2MeasurementEstimatorForInOut.MaxSagitta=-1
+Chi2MeasurementEstimatorForInOut = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName   = 'Chi2ForInOut',
+    MaxChi2         = 100.,
+    nSigma          = 3.,
+    MaxDisplacement = 100,
+    MaxSagitta      = -1
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForOutInFit_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/chi2EstimatorForOutInFit_cfi.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-Chi2MeasurementEstimatorForOutIn = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-Chi2MeasurementEstimatorForOutIn.ComponentName = 'Chi2ForOutIn'
-Chi2MeasurementEstimatorForOutIn.MaxChi2 = 500.
-Chi2MeasurementEstimatorForOutIn.nSigma = 3.
-Chi2MeasurementEstimatorForOutIn.MaxDisplacement = 100
-Chi2MeasurementEstimatorForOutIn.MaxSagitta = -1. 
-
+Chi2MeasurementEstimatorForOutIn = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName   = 'Chi2ForOutIn',
+    MaxChi2         = 500.,
+    nSigma          = 3.,
+    MaxDisplacement = 100,
+    MaxSagitta      = -1. 
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionOpenTrackSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionOpenTrackSequence_cff.py
@@ -4,15 +4,12 @@ import RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi
 
 #producer from lowPt electronTracksOpen
 gsfTracksOpenConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-   TrackProducer = cms.string('lowPtGsfEleGsfTracks'),
-   setIsGsfTrackOpen = cms.bool(True),
-   setArbitratedMergedEcalGeneral  = cms.bool(False),
-   setArbitratedEcalSeeded  = cms.bool(False),
-   setArbitratedMerged  = cms.bool(False),
-   filterOnConvTrackHyp = cms.bool(False),
+   TrackProducer                  = 'lowPtGsfEleGsfTracks',
+   setIsGsfTrackOpen              = True,
+   setArbitratedMergedEcalGeneral = False,
+   setArbitratedEcalSeeded        = False,
+   setArbitratedMerged            = False,
+   filterOnConvTrackHyp           = False,
 )
 
-
 conversionOpenTrackTask = cms.Task(gsfTracksOpenConversionTrackProducer)
-
-

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionSequence_cff.py
@@ -11,11 +11,12 @@ from RecoEgamma.EgammaPhotonProducers.conversions_cfi import *
 conversionTask = cms.Task(conversions)
 conversionSequence = cms.Sequence(conversionTask)
 
-oldegConversions = conversions.clone()
-oldegConversions.scHybridBarrelProducer = cms.InputTag("correctedHybridSuperClusters")
-oldegConversions.bcBarrelCollection = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
-oldegConversions.scIslandEndcapProducer = cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
-oldegConversions.bcEndcapCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
-oldegConversions.conversionIOTrackProducer = cms.string('ckfInOutTracksFromOldEGConversions')
-oldegConversions.conversionOITrackProducer = cms.string('ckfOutInTracksFromOldEGConversions')
+oldegConversions = conversions.clone(
+    scHybridBarrelProducer    = "correctedHybridSuperClusters",
+    bcBarrelCollection        = "hybridSuperClusters:hybridBarrelBasicClusters",
+    scIslandEndcapProducer    = "correctedMulti5x5SuperClustersWithPreshower",
+    bcEndcapCollection        = "multi5x5SuperClusters:multi5x5EndcapBasicClusters",
+    conversionIOTrackProducer = 'ckfInOutTracksFromOldEGConversions',
+    conversionOITrackProducer = 'ckfOutInTracksFromOldEGConversions'
+)
 oldegConversionSequence = cms.Sequence(oldegConversions)

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackMerger_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackMerger_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 conversionTrackMerger = cms.EDProducer("ConversionTrackMerger",
     # minimum shared fraction to be called duplicate
     ShareFrac = cms.double(0.19),
-    TrackProducer1 = cms.string(''),
-    TrackProducer2 = cms.string(''),
+    TrackProducer1 = cms.InputTag(''),
+    TrackProducer2 = cms.InputTag(''),
     allowFirstHitShare = cms.bool(True),
     checkCharge = cms.bool(True),
     minProb = cms.double(1e-6),

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequenceForReReco_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequenceForReReco_cff.py
@@ -14,37 +14,37 @@ ckfTracksFromConversionsReRecoTask = cms.Task(conversionTrackCandidates,
 
 #producer from general tracks collection, set tracker only and merged arbitrated flag
 generalConversionTrackProducerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('generalTracks'),
-    setTrackerOnly = cms.bool(True),
-    useTrajectory = cms.bool(False),
+    TrackProducer  = 'generalTracks',
+    setTrackerOnly = True,
+    useTrajectory  = False,
 )
 
 #producer from conversionStep tracks collection, set tracker only, merged arbitrated, merged arbitrated ecal/general flags
 conversionStepConversionTrackProducerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('conversionStepTracks'),
-    setTrackerOnly = cms.bool(True),
-    setArbitratedMergedEcalGeneral = cms.bool(True),
-    useTrajectory = cms.bool(False),
+    TrackProducer  = 'conversionStepTracks',
+    setTrackerOnly = True,
+    setArbitratedMergedEcalGeneral = True,
+    useTrajectory  = False,
 )
 
 #producer from inout ecal seeded tracks, set arbitratedecalseeded and mergedarbitrated flags
 inOutConversionTrackProducerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('ckfInOutTracksFromConversions'),
-    setArbitratedEcalSeeded = cms.bool(True),
-    useTrajectory = cms.bool(False), 
+    TrackProducer = 'ckfInOutTracksFromConversions',
+    setArbitratedEcalSeeded = True,
+    useTrajectory = False,
 )
 
 #producer from outin ecal seeded tracks, set arbitratedecalseeded and mergedarbitrated flags
 outInConversionTrackProducerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('ckfOutInTracksFromConversions'),
-    setArbitratedEcalSeeded = cms.bool(True),
-    useTrajectory = cms.bool(False),
+    TrackProducer = 'ckfOutInTracksFromConversions',
+    setArbitratedEcalSeeded = True,
+    useTrajectory = False,
 )
 
 #producer from gsf tracks, set only mergedarbitrated flag (default behaviour)
 gsfConversionTrackProducerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('electronGsfTracks'),
-    useTrajectory = cms.bool(False),
+    TrackProducer = 'electronGsfTracks',
+    useTrajectory = False,
 )
 
 conversionTrackProducersReRecoTask = cms.Task(generalConversionTrackProducerReReco,
@@ -55,30 +55,30 @@ conversionTrackProducersReRecoTask = cms.Task(generalConversionTrackProducerReRe
 
 #merge generalTracks and conversionStepTracks collections, with arbitration by nhits then chi^2/ndof for ecalseededarbitrated, mergedarbitratedecalgeneral and mergedarbitrated flags
 generalConversionStepConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.string('generalConversionTrackProducerReReco'),
-    TrackProducer2 = cms.string('conversionStepConversionTrackProducerReReco'),
+    TrackProducer1 = 'generalConversionTrackProducerReReco',
+    TrackProducer2 = 'conversionStepConversionTrackProducerReReco',
     #prefer collection settings:
     #-1: propagate output/flag from both input collections
     # 0: propagate output/flag from neither input collection
     # 1: arbitrate output/flag (remove duplicates by shared hits), give precedence to first input collection
     # 2: arbitrate output/flag (remove duplicates by shared hits), give precedence to second input collection
     # 3: arbitrate output/flag (remove duplicates by shared hits), arbitration first by number of hits, second by chisq/ndof  
-    arbitratedMergedPreferCollection = cms.int32(3),
-    arbitratedMergedEcalGeneralPreferCollection = cms.int32(3),        
+    arbitratedMergedPreferCollection = 3,
+    arbitratedMergedEcalGeneralPreferCollection = 3,
 )
 
 #merge two ecal-seeded collections, with arbitration by nhits then chi^2/ndof for both ecalseededarbitrated and mergedarbitrated flags
 inOutOutInConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.string('inOutConversionTrackProducerReReco'),
-    TrackProducer2 = cms.string('outInConversionTrackProducerReReco'),
+    TrackProducer1 = 'inOutConversionTrackProducerReReco',
+    TrackProducer2 = 'outInConversionTrackProducerReReco',
     #prefer collection settings:
     #-1: propagate output/flag from both input collections
     # 0: propagate output/flag from neither input collection
     # 1: arbitrate output/flag (remove duplicates by shared hits), give precedence to first input collection
     # 2: arbitrate output/flag (remove duplicates by shared hits), give precedence to second input collection
     # 3: arbitrate output/flag (remove duplicates by shared hits), arbitration first by number of hits, second by chisq/ndof  
-    arbitratedEcalSeededPreferCollection = cms.int32(3),    
-    arbitratedMergedPreferCollection = cms.int32(3),
+    arbitratedEcalSeededPreferCollection = 3,    
+    arbitratedMergedPreferCollection = 3,
 )
 
 #merge ecalseeded collections with collection from general tracks
@@ -86,18 +86,18 @@ inOutOutInConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.convers
 #ecalseeded flag is forwarded from the ecal seeded collection
 #arbitratedmerged flag is set based on shared hit matching, arbitration by nhits then chi^2/ndof
 generalInOutOutInConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.string('inOutOutInConversionTrackMergerReReco'),
-    TrackProducer2 = cms.string('generalConversionStepConversionTrackMergerReReco'),
-    arbitratedMergedPreferCollection = cms.int32(3),
+    TrackProducer1 = 'inOutOutInConversionTrackMergerReReco',
+    TrackProducer2 = 'generalConversionStepConversionTrackMergerReReco',
+    arbitratedMergedPreferCollection = 3,
 )
 
 #merge the result of the above with the collection from gsf tracks
 #trackeronly and mergedecal flags are forwarded
 #arbitratedmerged flag set based on overlap removal by shared hits, with precedence given to gsf tracks
 gsfGeneralInOutOutInConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.string('generalInOutOutInConversionTrackMergerReReco'),
-    TrackProducer2 = cms.string('gsfConversionTrackProducerReReco'),
-    arbitratedMergedPreferCollection = cms.int32(2),
+    TrackProducer1 = 'generalInOutOutInConversionTrackMergerReReco',
+    TrackProducer2 = 'gsfConversionTrackProducerReReco',
+    arbitratedMergedPreferCollection = 2,
 )
 
 #final output collection contains combination of generaltracks, ecal seeded tracks and gsf tracks, with overlaps removed by shared hits
@@ -118,9 +118,9 @@ conversionTrackSequenceForReReco = cms.Sequence(conversionTrackTaskForReReco)
 #merge the general tracks with the collection from gsf tracks
 #arbitratedmerged flag set based on overlap removal by shared hits, with precedence given to gsf tracks
 gsfGeneralConversionTrackMergerReReco = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.string('generalConversionTrackProducerReReco'),
-    TrackProducer2 = cms.string('gsfConversionTrackProducerReReco'),
-    arbitratedMergedPreferCollection = cms.int32(2),
+    TrackProducer1 = 'generalConversionTrackProducerReReco',
+    TrackProducer2 = 'gsfConversionTrackProducerReReco',
+    arbitratedMergedPreferCollection = 2,
 )
 
 #conversionTrackSequenceNoEcalSeeded = cms.Sequence(generalConversionTrackProducer*gsfConversionTrackProducer*gsfGeneralConversionTrackMerger)

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequence_cff.py
@@ -12,29 +12,29 @@ from RecoEgamma.EgammaPhotonProducers.ckfInOutTracksFromConversions_cfi import *
 ckfTracksFromConversionsTask = cms.Task(conversionTrackCandidates,ckfOutInTracksFromConversions,ckfInOutTracksFromConversions)
 ckfTracksFromConversions = cms.Sequence(ckfTracksFromConversionsTask)
 
-oldegConversionTrackCandidates = conversionTrackCandidates.clone()
-oldegConversionTrackCandidates.scHybridBarrelProducer = cms.InputTag("correctedHybridSuperClusters")
-oldegConversionTrackCandidates.bcBarrelCollection = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters")
-oldegConversionTrackCandidates.scIslandEndcapProducer = cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
-oldegConversionTrackCandidates.bcEndcapCollection = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters")
-
-ckfOutInTracksFromOldEGConversions = ckfOutInTracksFromConversions.clone()
-ckfOutInTracksFromOldEGConversions.src = cms.InputTag('oldegConversionTrackCandidates','outInTracksFromConversions')
-ckfOutInTracksFromOldEGConversions.producer = cms.string('oldegConversionTrackCandidates')
-ckfOutInTracksFromOldEGConversions.ComponentName = cms.string('ckfOutInTracksFromOldEGConversions')
-
-ckfInOutTracksFromOldEGConversions = ckfInOutTracksFromConversions.clone()
-ckfInOutTracksFromOldEGConversions.src = cms.InputTag('oldegConversionTrackCandidates','inOutTracksFromConversions')
-ckfInOutTracksFromOldEGConversions.producer = cms.string('oldegConversionTrackCandidates')
-ckfInOutTracksFromOldEGConversions.ComponentName = cms.string('ckfInOutTracksFromOldEGConversions')
-
+oldegConversionTrackCandidates = conversionTrackCandidates.clone(
+    scHybridBarrelProducer = "correctedHybridSuperClusters",
+    bcBarrelCollection     = "hybridSuperClusters:hybridBarrelBasicClusters",
+    scIslandEndcapProducer = "correctedMulti5x5SuperClustersWithPreshower",
+    bcEndcapCollection     = "multi5x5SuperClusters:multi5x5EndcapBasicClusters"
+)
+ckfOutInTracksFromOldEGConversions = ckfOutInTracksFromConversions.clone(
+    src           = 'oldegConversionTrackCandidates:outInTracksFromConversions',
+    producer      = 'oldegConversionTrackCandidates',
+    ComponentName = 'ckfOutInTracksFromOldEGConversions'
+)
+ckfInOutTracksFromOldEGConversions = ckfInOutTracksFromConversions.clone(
+    src           = 'oldegConversionTrackCandidates:inOutTracksFromConversions',
+    producer      = 'oldegConversionTrackCandidates',
+    ComponentName = 'ckfInOutTracksFromOldEGConversions'
+)
 ckfTracksFromOldEGConversionsTask = cms.Task(oldegConversionTrackCandidates,ckfOutInTracksFromOldEGConversions,ckfInOutTracksFromOldEGConversions)
 ckfTracksFromOldEGConversions = cms.Sequence(ckfTracksFromOldEGConversionsTask)
 #producer from general tracks collection, set tracker only, merged arbitrated, merged arbitrated ecal/general flags
 generalConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('generalTracks'),
-    setTrackerOnly = cms.bool(True),
-    setArbitratedMergedEcalGeneral = cms.bool(True),
+    TrackProducer  = 'generalTracks',
+    setTrackerOnly = True,
+    setArbitratedMergedEcalGeneral = True,
 )
 
 #fastSim
@@ -47,76 +47,77 @@ generalConversionTrackProducerTmp = generalConversionTrackProducer.clone(
 # then we need to fix the track references, so that they point to the final track collection, after mixing
 import FastSimulation.Tracking.ConversionTrackRefFix_cfi
 _fastSim_conversionTrackRefFix = FastSimulation.Tracking.ConversionTrackRefFix_cfi.fixedConversionTracks.clone(
-                 src = cms.InputTag("generalConversionTrackProducerTmp"))
+                 src = "generalConversionTrackProducerTmp")
 fastSim.toReplaceWith(generalConversionTrackProducer,
                       _fastSim_conversionTrackRefFix)
 
 
 #producer from conversionStep tracks collection, set tracker only, merged arbitrated, merged arbitrated ecal/general flags
 conversionStepConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('conversionStepTracks'),
-    setTrackerOnly = cms.bool(True),
-    setArbitratedMergedEcalGeneral = cms.bool(True),
+    TrackProducer  = 'conversionStepTracks',
+    setTrackerOnly = True,
+    setArbitratedMergedEcalGeneral = True,
 )
 
 
 #producer from inout ecal seeded tracks, set arbitratedecalseeded, mergedarbitratedecalgeneral and mergedarbitrated flags
 inOutConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('ckfInOutTracksFromConversions'),
-    setArbitratedEcalSeeded = cms.bool(True),
-    setArbitratedMergedEcalGeneral = cms.bool(True),    
+    TrackProducer           = 'ckfInOutTracksFromConversions',
+    setArbitratedEcalSeeded = True,
+    setArbitratedMergedEcalGeneral = True,
 )
 
 #producer from outin ecal seeded tracks, set arbitratedecalseeded, mergedarbitratedecalgeneral and mergedarbitrated flags
 outInConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('ckfOutInTracksFromConversions'),
-    setArbitratedEcalSeeded = cms.bool(True),
-    setArbitratedMergedEcalGeneral = cms.bool(True),    
+    TrackProducer           = 'ckfOutInTracksFromConversions',
+    setArbitratedEcalSeeded = True,
+    setArbitratedMergedEcalGeneral = True,
 )
 
 #producer from gsf tracks, set only mergedarbitrated flag (default behaviour)
 gsfConversionTrackProducer = RecoEgamma.EgammaPhotonProducers.conversionTrackProducer_cfi.conversionTrackProducer.clone(
-    TrackProducer = cms.string('electronGsfTracks'),
-    filterOnConvTrackHyp = cms.bool(False),
+    TrackProducer        = 'electronGsfTracks',
+    filterOnConvTrackHyp = False,
 )
 
 conversionTrackProducersTask = cms.Task(generalConversionTrackProducer,conversionStepConversionTrackProducer,inOutConversionTrackProducer,outInConversionTrackProducer,gsfConversionTrackProducer)
 conversionTrackProducers = cms.Sequence(conversionTrackProducersTask)
 
-inOutOldEGConversionTrackProducer = inOutConversionTrackProducer.clone()
-inOutOldEGConversionTrackProducer.TrackProducer = cms.string('ckfInOutTracksFromOldEGConversions')
-outInOldEGConversionTrackProducer = outInConversionTrackProducer.clone()
-outInOldEGConversionTrackProducer.TrackProducer = cms.string('ckfOutInTracksFromOldEGConversions')
-
+inOutOldEGConversionTrackProducer = inOutConversionTrackProducer.clone(
+    TrackProducer = 'ckfInOutTracksFromOldEGConversions'
+)
+outInOldEGConversionTrackProducer = outInConversionTrackProducer.clone(
+    TrackProducer = 'ckfOutInTracksFromOldEGConversions'
+)
 oldegConversionTrackProducersTask = cms.Task(inOutOldEGConversionTrackProducer,outInOldEGConversionTrackProducer)
 oldegConversionTrackProducers = cms.Sequence(oldegConversionTrackProducersTask)
 #merge generalTracks and conversionStepTracks collections, with arbitration by nhits then chi^2/ndof for ecalseededarbitrated, mergedarbitratedecalgeneral and mergedarbitrated flags
 generalConversionStepConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.InputTag('generalConversionTrackProducer'),
-    TrackProducer2 = cms.InputTag('conversionStepConversionTrackProducer'),
+    TrackProducer1 = 'generalConversionTrackProducer',
+    TrackProducer2 = 'conversionStepConversionTrackProducer',
     #prefer collection settings:
     #-1: propagate output/flag from both input collections
     # 0: propagate output/flag from neither input collection
     # 1: arbitrate output/flag (remove duplicates by shared hits), give precedence to first input collection
     # 2: arbitrate output/flag (remove duplicates by shared hits), give precedence to second input collection
     # 3: arbitrate output/flag (remove duplicates by shared hits), arbitration first by number of hits, second by chisq/ndof  
-    arbitratedMergedPreferCollection = cms.int32(3),
-    arbitratedMergedEcalGeneralPreferCollection = cms.int32(3),        
+    arbitratedMergedPreferCollection            = 3,
+    arbitratedMergedEcalGeneralPreferCollection = 3,        
 )
 
 #merge two ecal-seeded collections, with arbitration by nhits then chi^2/ndof for ecalseededarbitrated, mergedarbitratedecalgeneral and mergedarbitrated flags
 inOutOutInConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.InputTag('inOutConversionTrackProducer'),
-    TrackProducer2 = cms.InputTag('outInConversionTrackProducer'),
+    TrackProducer1 = 'inOutConversionTrackProducer',
+    TrackProducer2 = 'outInConversionTrackProducer',
     #prefer collection settings:
     #-1: propagate output/flag from both input collections
     # 0: propagate output/flag from neither input collection
     # 1: arbitrate output/flag (remove duplicates by shared hits), give precedence to first input collection
     # 2: arbitrate output/flag (remove duplicates by shared hits), give precedence to second input collection
     # 3: arbitrate output/flag (remove duplicates by shared hits), arbitration first by number of hits, second by chisq/ndof  
-    arbitratedEcalSeededPreferCollection = cms.int32(3),    
-    arbitratedMergedPreferCollection = cms.int32(3),
-    arbitratedMergedEcalGeneralPreferCollection = cms.int32(3),        
+    arbitratedEcalSeededPreferCollection        = 3,    
+    arbitratedMergedPreferCollection            = 3,
+    arbitratedMergedEcalGeneralPreferCollection = 3,        
 )
 
 #merge ecalseeded collections with collection from general tracks
@@ -125,19 +126,19 @@ inOutOutInConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTra
 #arbitratedmerged flag is set based on shared hit matching, arbitration by nhits then chi^2/ndof
 #arbitratedmergedecalgeneral flag is set based on shared hit matching, precedence given to generalTracks
 generalInOutOutInConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.InputTag('inOutOutInConversionTrackMerger'),
-    TrackProducer2 = cms.InputTag('generalConversionStepConversionTrackMerger'),
-    arbitratedMergedPreferCollection = cms.int32(3),
-    arbitratedMergedEcalGeneralPreferCollection = cms.int32(2),        
+    TrackProducer1 = 'inOutOutInConversionTrackMerger',
+    TrackProducer2 = 'generalConversionStepConversionTrackMerger',
+    arbitratedMergedPreferCollection            = 3,
+    arbitratedMergedEcalGeneralPreferCollection = 2,        
 )
 
 #merge the result of the above with the collection from gsf tracks
 #trackeronly, arbitratedmergedecalgeneral, and mergedecal flags are forwarded
 #arbitratedmerged flag set based on overlap removal by shared hits, with precedence given to gsf tracks
 gsfGeneralInOutOutInConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.InputTag('generalInOutOutInConversionTrackMerger'),
-    TrackProducer2 = cms.InputTag('gsfConversionTrackProducer'),
-    arbitratedMergedPreferCollection = cms.int32(2),
+    TrackProducer1 = 'generalInOutOutInConversionTrackMerger',
+    TrackProducer2 = 'gsfConversionTrackProducer',
+    arbitratedMergedPreferCollection = 2,
 )
 
 #final output collection contains combination of generaltracks, ecal seeded tracks and gsf tracks, with overlaps removed by shared hits
@@ -148,16 +149,16 @@ gsfGeneralInOutOutInConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.con
 conversionTrackMergersTask = cms.Task(inOutOutInConversionTrackMerger,generalConversionStepConversionTrackMerger,generalInOutOutInConversionTrackMerger,gsfGeneralInOutOutInConversionTrackMerger)
 conversionTrackMergers = cms.Sequence(conversionTrackMergersTask)
 
-inOutOutInOldEGConversionTrackMerger = inOutOutInConversionTrackMerger.clone()
-inOutOutInOldEGConversionTrackMerger.TrackProducer1 = cms.InputTag('inOutOldEGConversionTrackProducer')
-inOutOutInOldEGConversionTrackMerger.TrackProducer2 = cms.InputTag('outInOldEGConversionTrackProducer')
-
-generalInOutOutInOldEGConversionTrackMerger = generalInOutOutInConversionTrackMerger.clone()
-generalInOutOutInOldEGConversionTrackMerger.TrackProducer1 = cms.InputTag('inOutOutInOldEGConversionTrackMerger')
-
-gsfGeneralInOutOutInOldEGConversionTrackMerger = gsfGeneralInOutOutInConversionTrackMerger.clone()
-gsfGeneralInOutOutInOldEGConversionTrackMerger.TrackProducer1 = cms.InputTag('generalInOutOutInOldEGConversionTrackMerger')
-
+inOutOutInOldEGConversionTrackMerger = inOutOutInConversionTrackMerger.clone(
+    TrackProducer1 = 'inOutOldEGConversionTrackProducer',
+    TrackProducer2 = 'outInOldEGConversionTrackProducer'
+)
+generalInOutOutInOldEGConversionTrackMerger = generalInOutOutInConversionTrackMerger.clone(
+    TrackProducer1 = 'inOutOutInOldEGConversionTrackMerger'
+)
+gsfGeneralInOutOutInOldEGConversionTrackMerger = gsfGeneralInOutOutInConversionTrackMerger.clone(
+    TrackProducer1 = 'generalInOutOutInOldEGConversionTrackMerger'
+)
 oldegConversionTrackMergersTask = cms.Task(inOutOutInOldEGConversionTrackMerger,generalInOutOutInOldEGConversionTrackMerger,gsfGeneralInOutOutInOldEGConversionTrackMerger)
 oldegConversionTrackMergers = cms.Sequence(oldegConversionTrackMergersTask)
 
@@ -167,9 +168,9 @@ conversionTrackSequence = cms.Sequence(conversionTrackTask)
 #merge the general tracks with the collection from gsf tracks
 #arbitratedmerged flag set based on overlap removal by shared hits, with precedence given to gsf tracks
 gsfGeneralConversionTrackMerger = RecoEgamma.EgammaPhotonProducers.conversionTrackMerger_cfi.conversionTrackMerger.clone(
-    TrackProducer1 = cms.InputTag('generalConversionTrackProducer'),
-    TrackProducer2 = cms.InputTag('gsfConversionTrackProducer'),
-    arbitratedMergedPreferCollection = cms.int32(2),
+    TrackProducer1 = 'generalConversionTrackProducer',
+    TrackProducer2 = 'gsfConversionTrackProducer',
+    arbitratedMergedPreferCollection = 2,
 )
 
 #special sequence for fastsim which skips the ecal-seeded and conversionStep tracks for now

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTracks_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTracks_cff.py
@@ -12,22 +12,22 @@ ckfTracksFromConversionsTask = cms.Task(conversionTrackCandidates,
                                         ckfInOutTracksFromConversions)
 ckfTracksFromConversions = cms.Sequence(ckfTracksFromConversionsTask)
 
-mustacheConversionTrackCandidates = conversionTrackCandidates.clone()
-mustacheConversionTrackCandidates.scHybridBarrelProducer = cms.InputTag('particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel')
-mustacheConversionTrackCandidates.bcBarrelCollection = cms.InputTag('particleFlowSuperClusterECAL:particleFlowBasicClusterECALBarrel')
-mustacheConversionTrackCandidates.scIslandEndcapProducer = cms.InputTag('particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower')
-mustacheConversionTrackCandidates.bcEndcapCollection = cms.InputTag('particleFlowSuperClusterECAL:particleFlowBasicClusterECALEndcap')
-
-ckfOutInTracksFromMustacheConversions = ckfOutInTracksFromConversions.clone()
-ckfOutInTracksFromMustacheConversions.src = cms.InputTag('mustacheConversionTrackCandidates','outInTracksFromConversions')
-ckfOutInTracksFromMustacheConversions.producer = cms.string('mustacheConversionTrackCandidates')
-ckfOutInTracksFromMustacheConversions.ComponentName = cms.string('ckfOutInTracksFromMustacheConversions')
-
-ckfInOutTracksFromMustacheConversions = ckfInOutTracksFromConversions.clone()
-ckfInOutTracksFromMustacheConversions.src = cms.InputTag('mustacheConversionTrackCandidates','inOutTracksFromConversions')
-ckfInOutTracksFromMustacheConversions.producer = cms.string('mustacheConversionTrackCandidates')
-ckfInOutTracksFromMustacheConversions.ComponentName = cms.string('ckfInOutTracksFromMustacheConversions')
-
+mustacheConversionTrackCandidates = conversionTrackCandidates.clone(
+    scHybridBarrelProducer = 'particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel',
+    bcBarrelCollection     = 'particleFlowSuperClusterECAL:particleFlowBasicClusterECALBarrel',
+    scIslandEndcapProducer = 'particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower',
+    bcEndcapCollection     = 'particleFlowSuperClusterECAL:particleFlowBasicClusterECALEndcap'
+)
+ckfOutInTracksFromMustacheConversions = ckfOutInTracksFromConversions.clone(
+    src           = 'mustacheConversionTrackCandidates:outInTracksFromConversions',
+    producer      = 'mustacheConversionTrackCandidates',
+    ComponentName = 'ckfOutInTracksFromMustacheConversions',
+)
+ckfInOutTracksFromMustacheConversions = ckfInOutTracksFromConversions.clone(
+    src           = 'mustacheConversionTrackCandidates:inOutTracksFromConversions',
+    producer      = 'mustacheConversionTrackCandidates',
+    ComponentName = 'ckfInOutTracksFromMustacheConversions',
+)
 ckfTracksFromMustacheConversionsTask = cms.Task(mustacheConversionTrackCandidates,
                                                 ckfOutInTracksFromMustacheConversions,
                                                 ckfInOutTracksFromMustacheConversions)

--- a/RecoEgamma/EgammaPhotonProducers/python/egammaForCoreTracking_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/egammaForCoreTracking_cff.py
@@ -7,9 +7,9 @@ from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import par
 #cant use the regression as requires #vertices and we cant use tracking info
 #also require it to be above 20 GeV as we only want E/gammas Et>20 and H/E <0.2
 particleFlowSuperClusterECALForTrk = _particleFlowSuperClusterECAL.clone(
-     useRegression = cms.bool(False),
+     useRegression = False,
      regressionConfig = cms.PSet(),
-     thresh_SCEt = cms.double(20.0)
+     thresh_SCEt = 20.0
 )
 
 egammasForTrk = cms.EDProducer( "EgammaHLTRecoEcalCandidateProducers",

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotonSequence_cff.py
@@ -9,30 +9,32 @@ from RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi import *
 
 import RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi 
 
-gedPhotonsTmp = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone()
-gedPhotonsTmp.photonProducer = cms.InputTag("gedPhotonCore")
-gedPhotonsTmp.candidateP4type = cms.string("fromEcalEnergy")
+gedPhotonsTmp = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone(
+    photonProducer         = "gedPhotonCore",
+    candidateP4type        = "fromEcalEnergy",
+    outputPhotonCollection = "",
+    reconstructionStep     = "tmp"
+)
 del gedPhotonsTmp.regressionConfig
-gedPhotonsTmp.outputPhotonCollection = cms.string("")
-gedPhotonsTmp.reconstructionStep = cms.string("tmp")
+
 gedPhotonTaskTmp = cms.Task(gedPhotonCore, gedPhotonsTmp)
 gedPhotonSequenceTmp = cms.Sequence(gedPhotonTaskTmp)
 
-gedPhotons = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone()
-gedPhotons.photonProducer = cms.InputTag("gedPhotonsTmp")
-gedPhotons.outputPhotonCollection = cms.string("")
-gedPhotons.reconstructionStep = cms.string("final")
-gedPhotons.pfECALClusIsolation = cms.InputTag("photonEcalPFClusterIsolationProducer")
-gedPhotons.pfHCALClusIsolation = cms.InputTag("photonHcalPFClusterIsolationProducer")
-gedPhotons.pfIsolCfg = cms.PSet(
-    chargedHadronIso = cms.InputTag("photonIDValueMaps","phoChargedIsolation"),
-    neutralHadronIso = cms.InputTag("photonIDValueMaps","phoNeutralHadronIsolation"),
-    photonIso = cms.InputTag("photonIDValueMaps","phoPhotonIsolation"),
-    chargedHadronWorstVtxIso = cms.InputTag("photonIDValueMaps","phoWorstChargedIsolation"),
-    chargedHadronWorstVtxGeomVetoIso = cms.InputTag("photonIDValueMaps","phoWorstChargedIsolationConeVeto"),
-    chargedHadronPFPVIso = cms.InputTag("egmPhotonIsolationCITK:h+-DR030-"),
+gedPhotons = RecoEgamma.EgammaPhotonProducers.gedPhotons_cfi.gedPhotons.clone(
+    photonProducer         = "gedPhotonsTmp",
+    outputPhotonCollection = "",
+    reconstructionStep     = "final",
+    pfECALClusIsolation    = cms.InputTag("photonEcalPFClusterIsolationProducer"),
+    pfHCALClusIsolation    = cms.InputTag("photonHcalPFClusterIsolationProducer"),
+    pfIsolCfg = cms.PSet(
+	chargedHadronIso = cms.InputTag("photonIDValueMaps","phoChargedIsolation"),
+	neutralHadronIso = cms.InputTag("photonIDValueMaps","phoNeutralHadronIsolation"),
+	photonIso        = cms.InputTag("photonIDValueMaps","phoPhotonIsolation"),
+	chargedHadronWorstVtxIso = cms.InputTag("photonIDValueMaps","phoWorstChargedIsolation"),
+	chargedHadronWorstVtxGeomVetoIso = cms.InputTag("photonIDValueMaps","phoWorstChargedIsolationConeVeto"),
+	chargedHadronPFPVIso     = cms.InputTag("egmPhotonIsolationCITK:h+-DR030-"),
     )
-    
+)
 gedPhotonTask    = cms.Task(gedPhotons)
 gedPhotonSequence    = cms.Sequence(gedPhotonTask)
 

--- a/RecoEgamma/EgammaPhotonProducers/python/gsfTracksOpenConversionSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gsfTracksOpenConversionSequence_cff.py
@@ -4,9 +4,10 @@ import FWCore.ParameterSet.Config as cms
 # Tracker only conversion producer
 from RecoEgamma.EgammaPhotonProducers.allConversions_cfi import *
 
-gsfTracksOpenConversions = allConversions.clone()
-gsfTracksOpenConversions.src =  cms.InputTag("gsfTracksOpenConversionTrackProducer")
-gsfTracksOpenConversions.AlgorithmName =  cms.string('trackerOnly')
-gsfTracksOpenConversions.rCut = cms.double(1.5)
-gsfTracksOpenConversions.convertedPhotonCollection = cms.string('gsfTracksOpenConversions')
+gsfTracksOpenConversions = allConversions.clone(
+    src           = "gsfTracksOpenConversionTrackProducer",
+    AlgorithmName = 'trackerOnly',
+    rCut          = 1.5,
+    convertedPhotonCollection = 'gsfTracksOpenConversions'
+)
 gsfTracksOpenConversionSequence = cms.Sequence(gsfTracksOpenConversions)

--- a/RecoEgamma/EgammaPhotonProducers/python/looseChi2Estimator_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/looseChi2Estimator_cfi.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-chi2CutForConversionTrajectoryBuilder = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-chi2CutForConversionTrajectoryBuilder.ComponentName = 'eleLooseChi2'
-chi2CutForConversionTrajectoryBuilder.MaxChi2 = 100000.
-chi2CutForConversionTrajectoryBuilder.nSigma = 3.
-chi2CutForConversionTrajectoryBuilder.MaxDisplacement = 100.
-chi2CutForConversionTrajectoryBuilder.MaxSagitta = -1
+chi2CutForConversionTrajectoryBuilder = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName   = 'eleLooseChi2',
+    MaxChi2         = 100000.,
+    nSigma          = 3.,
+    MaxDisplacement = 100.,
+    MaxSagitta      = -1
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/ootPhotonCore_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/ootPhotonCore_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 from RecoEgamma.EgammaPhotonProducers.photonCore_cfi import *
 
-ootPhotonCore = photonCore.clone()
-ootPhotonCore.scHybridBarrelProducer = cms.InputTag("particleFlowSuperClusterOOTECAL:particleFlowSuperClusterOOTECALBarrel")
-ootPhotonCore.scIslandEndcapProducer = cms.InputTag("particleFlowSuperClusterOOTECAL:particleFlowSuperClusterOOTECALEndcapWithPreshower")
-ootPhotonCore.conversionProducer = cms.InputTag("conversions")
+ootPhotonCore = photonCore.clone(
+    scHybridBarrelProducer = "particleFlowSuperClusterOOTECAL:particleFlowSuperClusterOOTECALBarrel",
+    scIslandEndcapProducer = "particleFlowSuperClusterOOTECAL:particleFlowSuperClusterOOTECALEndcapWithPreshower",
+    conversionProducer     = "conversions"
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/propAlongMomentumWithMaterialForElectrons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/propAlongMomentumWithMaterialForElectrons_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.MaterialEffects.MaterialPropagator_cfi
 #PropagatorWithMaterialESProducer 
-alongMomElePropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone()
-alongMomElePropagator.Mass = 0.000511
-alongMomElePropagator.ComponentName = 'alongMomElePropagator'
-
+alongMomElePropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'alongMomElePropagator'
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/propOppoMomentumWithMaterialForElectrons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/propOppoMomentumWithMaterialForElectrons_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
 #PropagatorWithMaterialESProducer 
-oppositeToMomElePropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone()
-oppositeToMomElePropagator.Mass = 0.000511
-oppositeToMomElePropagator.ComponentName = 'oppositeToMomElePropagator'
-
+oppositeToMomElePropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'oppositeToMomElePropagator'
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryBuilderForConversions_cfi.py
@@ -6,15 +6,16 @@ from RecoEgamma.EgammaPhotonProducers.propOppoMomentumWithMaterialForElectrons_c
 #TrajectoryBuilder
 from RecoTracker.CkfPattern.CkfTrajectoryBuilder_cff import *
 import RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi
-TrajectoryBuilderForConversions = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.CkfTrajectoryBuilder.clone()
-TrajectoryBuilderForConversions.estimator = 'eleLooseChi2'
-TrajectoryBuilderForConversions.TTRHBuilder = 'WithTrackAngle'
-TrajectoryBuilderForConversions.updator = 'KFUpdator'
-TrajectoryBuilderForConversions.propagatorAlong = 'alongMomElePropagator'
-TrajectoryBuilderForConversions.propagatorOpposite = 'oppositeToMomElePropagator'
-TrajectoryBuilderForConversions.trajectoryFilter.refToPSet_ = 'TrajectoryFilterForConversions'
-TrajectoryBuilderForConversions.maxCand = 5
-TrajectoryBuilderForConversions.lostHitPenalty = 30.
-TrajectoryBuilderForConversions.intermediateCleaning = True
-TrajectoryBuilderForConversions.alwaysUseInvalidHits = True
-TrajectoryBuilderForConversions.seedAs5DHit  = False
+TrajectoryBuilderForConversions = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.CkfTrajectoryBuilder.clone(
+    estimator            = 'eleLooseChi2',
+    TTRHBuilder          = 'WithTrackAngle',
+    updator              = 'KFUpdator',
+    propagatorAlong      = 'alongMomElePropagator',
+    propagatorOpposite   = 'oppositeToMomElePropagator',
+    trajectoryFilter     = dict(refToPSet_ = 'TrajectoryFilterForConversions'),
+    maxCand              = 5,
+    lostHitPenalty       = 30.,
+    intermediateCleaning = True,
+    alwaysUseInvalidHits = True,
+    seedAs5DHit          = False
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/trajectoryCleanerBySharedHitsForConversions_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/trajectoryCleanerBySharedHitsForConversions_cfi.py
@@ -2,8 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import *
 import  TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi
-TrajectoryCleanerBySharedHitsForConversions = TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi.trajectoryCleanerBySharedHits.clone()
-TrajectoryCleanerBySharedHitsForConversions.ComponentName = 'TrajectoryCleanerBySharedHitsForConversions'
-TrajectoryCleanerBySharedHitsForConversions.fractionShared = cms.double(0.5)
-
-
+TrajectoryCleanerBySharedHitsForConversions = TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi.trajectoryCleanerBySharedHits.clone(
+    ComponentName  = 'TrajectoryCleanerBySharedHitsForConversions',
+    fractionShared = 0.5
+)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -18,8 +18,8 @@ from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_
 run2_miniAOD_94XFall17.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017Nov17)
 
 calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
-    recHitCollectionEB = cms.InputTag('reducedEgamma','reducedEBRecHits'),
-    recHitCollectionEE = cms.InputTag('reducedEgamma','reducedEERecHits')
+    recHitCollectionEB = 'reducedEgamma:reducedEBRecHits',
+    recHitCollectionEE = 'reducedEgamma:reducedEERecHits'
     )
 
 ecalTrkCombinationRegression = cms.PSet(

--- a/RecoEgamma/EgammaTools/python/slimmedEgammaFromMultiCl_cff.py
+++ b/RecoEgamma/EgammaTools/python/slimmedEgammaFromMultiCl_cff.py
@@ -7,35 +7,35 @@ from PhysicsTools.PatAlgos.slimming.slimmedElectrons_cfi import slimmedElectrons
 from RecoLocalCalo.HGCalRecProducers.hgcalRecHitMapProducer_cfi import hgcalRecHitMapProducer
 
 hgcElectronID = hgcalElectronIDValueMap.clone(
-    electrons = cms.InputTag("cleanedEcalDrivenGsfElectronsFromMultiCl"),
+    electrons = "cleanedEcalDrivenGsfElectronsFromMultiCl",
 )
 patElectronsFromMultiCl = PATElectronProducer.clone(
-    electronSource = cms.InputTag("cleanedEcalDrivenGsfElectronsFromMultiCl"),
-    beamLineSrc    = cms.InputTag("offlineBeamSpot"),
-    pvSrc          = cms.InputTag("offlinePrimaryVertices"),
-    addElectronID  = cms.bool(False),
-    addGenMatch    = cms.bool(False),
-    addMVAVariables= cms.bool(False),
-    embedGenMatch              = cms.bool(False),
-    embedGsfElectronCore       = cms.bool(True),
-    embedGsfTrack              = cms.bool(True),
-    embedSuperCluster          = cms.bool(True),
-    embedPflowSuperCluster     = cms.bool(False),
-    embedSeedCluster           = cms.bool(True),
-    embedBasicClusters         = cms.bool(False),
-    embedPreshowerClusters     = cms.bool(False),
-    embedPflowBasicClusters    = cms.bool(False),
-    embedPflowPreshowerClusters= cms.bool(False),
-    embedPFCandidate           = cms.bool(False),
-    embedTrack                 = cms.bool(True),
-    embedRecHits               = cms.bool(False),
-    embedHighLevelSelection    = cms.bool(True),
+    electronSource             = "cleanedEcalDrivenGsfElectronsFromMultiCl",
+    beamLineSrc                = "offlineBeamSpot",
+    pvSrc                      = "offlinePrimaryVertices",
+    addElectronID              = False,
+    addGenMatch                = False,
+    addMVAVariables            = False,
+    embedGenMatch              = False,
+    embedGsfElectronCore       = True,
+    embedGsfTrack              = True,
+    embedSuperCluster          = True,
+    embedPflowSuperCluster     = False,
+    embedSeedCluster           = True,
+    embedBasicClusters         = False,
+    embedPreshowerClusters     = False,
+    embedPflowBasicClusters    = False,
+    embedPflowPreshowerClusters= False,
+    embedPFCandidate           = False,
+    embedTrack                 = True,
+    embedRecHits               = False,
+    embedHighLevelSelection    = True,
     userData = cms.PSet(
         userClasses = cms.PSet( src = cms.VInputTag('')),
-        userFloats = cms.PSet( src = cms.VInputTag(
+        userFloats  = cms.PSet( src = cms.VInputTag(
             [cms.InputTag("hgcElectronID", key) for key in hgcElectronID.variables]
         )),
-        userInts = cms.PSet( src = cms.VInputTag('')),
+        userInts  = cms.PSet( src = cms.VInputTag('')),
         userCands = cms.PSet( src = cms.VInputTag('')),
         userFunctions = cms.vstring(),
         userFunctionLabels = cms.vstring()
@@ -46,10 +46,10 @@ selectedPatElectronsFromMultiCl = cms.EDFilter("PATElectronSelector",
     cut = cms.string("!isEB && pt >= 10."),
 )
 slimmedElectronsFromMultiCl = slimmedElectrons.clone(
-    src = cms.InputTag("selectedPatElectronsFromMultiCl"),
-    linkToPackedPFCandidates = cms.bool(False),
-    saveNonZSClusterShapes = cms.string("0"),
-    modifyElectrons = cms.bool(False),
+    src = "selectedPatElectronsFromMultiCl",
+    linkToPackedPFCandidates = False,
+    saveNonZSClusterShapes   = "0",
+    modifyElectrons          = False,
 )
 
 slimmedElectronsFromMultiClTask = cms.Task(
@@ -66,26 +66,27 @@ from PhysicsTools.PatAlgos.PATPhotonProducer_cfi import PATPhotonProducer
 from PhysicsTools.PatAlgos.slimming.slimmedPhotons_cfi import slimmedPhotons
 
 hgcPhotonID = hgcalPhotonIDValueMap.clone()
+
 patPhotonsFromMultiCl = PATPhotonProducer.clone(
-    photonSource = cms.InputTag("photonsFromMultiCl"),
-    electronSource = cms.InputTag("ecalDrivenGsfElectronsFromMultiCl"),
-    beamLineSrc = cms.InputTag("offlineBeamSpot"),
-    addPhotonID = cms.bool(False),
-    addGenMatch = cms.bool(False),
-    embedSuperCluster      = cms.bool(True),
-    embedSeedCluster       = cms.bool(True),
-    embedBasicClusters     = cms.bool(False),
-    embedPreshowerClusters = cms.bool(False),
-    embedRecHits           = cms.bool(False),
-    saveRegressionData     = cms.bool(False),
-    embedGenMatch          = cms.bool(False),
+    photonSource           = "photonsFromMultiCl",
+    electronSource         = "ecalDrivenGsfElectronsFromMultiCl",
+    beamLineSrc            = "offlineBeamSpot",
+    addPhotonID            = False,
+    addGenMatch            = False,
+    embedSuperCluster      = True,
+    embedSeedCluster       = True,
+    embedBasicClusters     = False,
+    embedPreshowerClusters = False,
+    embedRecHits           = False,
+    saveRegressionData     = False,
+    embedGenMatch          = False,
     isolationValues = cms.PSet(),
     userData = cms.PSet(
         userClasses = cms.PSet( src = cms.VInputTag('')),
-        userFloats = cms.PSet( src = cms.VInputTag(
+        userFloats  = cms.PSet( src = cms.VInputTag(
             [cms.InputTag("hgcPhotonID", key) for key in hgcPhotonID.variables]
         )),
-        userInts = cms.PSet( src = cms.VInputTag('')),
+        userInts  = cms.PSet( src = cms.VInputTag('')),
         userCands = cms.PSet( src = cms.VInputTag('')),
         userFunctions = cms.vstring(),
         userFunctionLabels = cms.vstring()
@@ -96,10 +97,10 @@ selectedPatPhotonsFromMultiCl = cms.EDFilter("PATPhotonSelector",
     cut = cms.string("!isEB && pt >= 15."),
 )
 slimmedPhotonsFromMultiCl = slimmedPhotons.clone(
-    src = cms.InputTag("selectedPatPhotonsFromMultiCl"),
-    linkToPackedPFCandidates = cms.bool(False),
-    saveNonZSClusterShapes = cms.string("0"),
-    modifyPhotons = cms.bool(False),
+    src = "selectedPatPhotonsFromMultiCl",
+    linkToPackedPFCandidates = False,
+    saveNonZSClusterShapes   = "0",
+    modifyPhotons            = False,
 )
 
 slimmedPhotonsFromMultiClTask = cms.Task(

--- a/RecoEgamma/ElectronIdentification/python/electronIdSequence_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/electronIdSequence_cff.py
@@ -2,25 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoEgamma.ElectronIdentification.electronIdCutBasedExt_cfi import *
 
-eidRobustLoose = eidCutBasedExt.clone()
-eidRobustLoose.electronIDType = 'robust'
-eidRobustLoose.electronQuality = 'loose'
-
-eidRobustTight = eidCutBasedExt.clone()
-eidRobustTight.electronIDType = 'robust'
-eidRobustTight.electronQuality = 'tight'
-
-eidRobustHighEnergy = eidCutBasedExt.clone()
-eidRobustHighEnergy.electronIDType = 'robust'
-eidRobustHighEnergy.electronQuality = 'highenergy'
-
-eidLoose = eidCutBasedExt.clone()
-eidLoose.electronIDType = 'classbased'
-eidLoose.electronQuality = 'loose'
-
-eidTight = eidCutBasedExt.clone()
-eidTight.electronIDType = 'classbased'
-eidTight.electronQuality = 'tight'
-
+eidRobustLoose = eidCutBasedExt.clone(
+    electronIDType  = 'robust',
+    electronQuality = 'loose'
+)
+eidRobustTight = eidCutBasedExt.clone(
+    electronIDType  = 'robust',
+    electronQuality = 'tight'
+)
+eidRobustHighEnergy = eidCutBasedExt.clone(
+    electronIDType  = 'robust',
+    electronQuality = 'highenergy'
+)
+eidLoose = eidCutBasedExt.clone(
+    electronIDType  = 'classbased',
+    electronQuality = 'loose'
+)
+eidTight = eidCutBasedExt.clone(
+    electronIDType  = 'classbased',
+    electronQuality = 'tight'
+)
 eIdTask = cms.Task(eidRobustLoose,eidRobustTight,eidRobustHighEnergy,eidLoose,eidTight)
 eIdSequence = cms.Sequence(eIdTask)

--- a/RecoEgamma/PhotonIdentification/python/photonId_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/photonId_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # Producer for Hybrid BasicClusters and SuperClusters
 from RecoEgamma.PhotonIdentification.photonId_cfi import *
 # photonID sequence
-PhotonIDProdGED = PhotonIDProd.clone(photonProducer = cms.string('gedPhotons'))
+PhotonIDProdGED = PhotonIDProd.clone(photonProducer = 'gedPhotons')
 photonIDTask = cms.Task(PhotonIDProd)
 photonIDSequence = cms.Sequence(photonIDTask)
 photonIDTaskGED = cms.Task(PhotonIDProdGED)


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#30700](https://github.com/cms-sw/cmssw/pull/30700), [PR#30827](https://github.com/cms-sw/cmssw/pull/30827), [PR#30947](https://github.com/cms-sw/cmssw/pull/30947),[PR#31162](https://github.com/cms-sw/cmssw/pull/31162),)

In this PR, total 36 files updated. 
- RecoEgamma/{EgammaPhotonProducers} 23 files 
- RecoEgamma/{EgammaElectronProducers} 5 files 
- RecoEgamma/{EgammaIsolationAlgos} 4 files 
- RecoEgamma/{EgammaTools} 2 files 
- RecoEgamma/{ElectronIdentification} 1 file 
- RecoEgamma/{PhotonIdentification} 1 file 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).
