### PR TITLE
Turn on dual slope ToT in phase-2 pixels digitizer and clusterizer and update CPE payloads to match

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -69,14 +69,16 @@ allTags["GenError"] = {
     'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T17' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T20' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
     'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T17' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T20' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 ##

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1014,7 +1014,6 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D64',                   # N.B.: Geometry with square 50x50 um2 pixels in the Inner Tracker.
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T22',
-        'ProcessModifier': 'phase2_PixelCPEGeneric',  # Pixel Template reconstruction is temporarily inactive (will update once conditions are availalble).
         'Era' : 'Phase2C11',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/PixelThresholdClusterizer.cc
@@ -317,14 +317,14 @@ int PixelThresholdClusterizer::calibrate(int adc, int col, int row) {
       electrons = int(adc * gain);
     } else {
       if (adc < thePhase2KinkADC) {
-        electrons = int((adc - 0.5) * gain);
+        electrons = int((adc + 0.5) * gain);
       } else {
         const int dualslopeparam = (thePhase2ReadoutMode < 10 ? thePhase2ReadoutMode : 10);
         const int dualslope = int(dualslopeparam <= 1 ? 1. : pow(2, dualslopeparam - 1));
-        adc -= (thePhase2KinkADC - 1);
+        adc -= thePhase2KinkADC;
         adc *= dualslope;
-        adc += (thePhase2KinkADC - 1);
-        electrons = int((adc - 0.5 * dualslope) * gain);
+        adc += thePhase2KinkADC;
+        electrons = int((adc + 0.5 * dualslope) * gain);
       }
       electrons += int(thePhase2DigiBaseline);
     }

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -34,10 +34,10 @@ phase2_tracker.toModify(siPixelClusters, # FIXME
   src = 'simSiPixelDigis:Pixel',
   MissCalibrate = False,
   Phase2Calibration = True,
-  Phase2ReadoutMode = -1, # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
-  Phase2DigiBaseline = 1200.,
+  Phase2ReadoutMode = 3, # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
+  Phase2DigiBaseline = 1000.,
   Phase2KinkADC = 8,
-  ElectronPerADCGain = 600. # it can be changed to something else (e.g. 135e) if needed
+  ElectronPerADCGain = 1500. # it can be changed to something else (e.g. 135e) if needed
 )
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 (premix_stage2 & phase2_tracker).toModify(siPixelClusters,

--- a/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
+++ b/RecoLocalTracker/SiPixelClusterizer/python/SiPixelClusterizer_cfi.py
@@ -30,14 +30,15 @@ run3_common.toModify(siPixelClusters,
 
 # Need these until phase2 pixel templates are used
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
+from SimTracker.SiPhase2Digitizer.phase2TrackerDigitizer_cfi import PixelDigitizerAlgorithmCommon
 phase2_tracker.toModify(siPixelClusters, # FIXME
   src = 'simSiPixelDigis:Pixel',
   MissCalibrate = False,
   Phase2Calibration = True,
-  Phase2ReadoutMode = 3, # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
-  Phase2DigiBaseline = 1000.,
+  Phase2ReadoutMode = PixelDigitizerAlgorithmCommon.Phase2ReadoutMode.value(), # Flag to decide Readout Mode : linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4 ...) with threshold subtraction
+  Phase2DigiBaseline = PixelDigitizerAlgorithmCommon.ThresholdInElectrons_Barrel.value(), #Same for barrel and endcap
   Phase2KinkADC = 8,
-  ElectronPerADCGain = 1500. # it can be changed to something else (e.g. 135e) if needed
+  ElectronPerADCGain = PixelDigitizerAlgorithmCommon.ElectronPerAdc.value()
 )
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 (premix_stage2 & phase2_tracker).toModify(siPixelClusters,

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -2,17 +2,17 @@
 import FWCore.ParameterSet.Config as cms
 
 PixelDigitizerAlgorithmCommon = cms.PSet(
-    ElectronPerAdc = cms.double(600.0),
+    ElectronPerAdc = cms.double(1500.0),
     ReadoutNoiseInElec = cms.double(0.0),
-    ThresholdInElectrons_Barrel = cms.double(1200.0),
-    ThresholdInElectrons_Endcap = cms.double(1200.0),
+    ThresholdInElectrons_Barrel = cms.double(1000.0),
+    ThresholdInElectrons_Endcap = cms.double(1000.0),
     AddThresholdSmearing = cms.bool(False),
     ThresholdSmearing_Barrel = cms.double(0.0),
     ThresholdSmearing_Endcap = cms.double(0.0),
     HIPThresholdInElectrons_Barrel = cms.double(1.0e10), # very high value to avoid Over threshold bit
     HIPThresholdInElectrons_Endcap = cms.double(1.0e10), # very high value to avoid Over threshold bit
     NoiseInElectrons = cms.double(0.0),
-    Phase2ReadoutMode = cms.int32(-1), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
+    Phase2ReadoutMode = cms.int32(3), # Flag to decide Readout Mode :Digital(0) or Analog (linear TDR (-1), dual slope with slope parameters (+1,+2,+3,+4) with threshold subtraction
     AdcFullScale = cms.int32(15),
     TofUpperCut = cms.double(12.5),
     TofLowerCut = cms.double(-12.5),


### PR DESCRIPTION
This pull request turns on the 'dual-slope' configuration of the phase 2 pixel electronics simulation, and changes the Q/ToT settings from 600e to 1500e and the threshhold from 1200e to 1000e. 

To match these changes GenErrors and Templates were made for the T21 and T22 geometries, and these are being activated as well. The 'generic reco only' configuration of the T22 geoemtry is turned off as well now that the necessary payloads exist. 

The performance of these new payloads in local reconstruction were tested and look good.

Tracking validation was also run with the new changes using 100 TTbar events without pileup for both the T21 and T22 geometries (workflows 29034 and 29434). They show only minor differences as expected. 

These tests are summarized in slides [here](https://indico.cern.ch/event/934808/contributions/3996590/attachments/2094091/3519320/phase2_dual_slope_payloads_and_testing.pdf). 

@mmusich @tsusa @emiglior @cmantill @mtosi @tvami @pmaksim1 @JanFSchulte @jalimena @perrotta @slava77 