### PR TITLE
Warn about bit number above trigger collections sizes only once per event/bx

### DIFF
--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -898,7 +898,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
         }  // require bit in range
 	else if (!alreadyReported) {
           alreadyReported = true;
-          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= prescaleFactorsAlgoTrig.size() " << std::endl;
+          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= prescaleFactorsAlgoTrig.size() in bx " << iBxInEvent << std::endl;
         }
       }  //if algo bit is set true
     }    //loop over alg bits
@@ -928,7 +928,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
           isMasked = (triggerMaskAlgoTrig.at(iBit) == 0);
         else if (!alreadyReported) {
           alreadyReported = true;
-          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= triggerMaskAlgoTrig.size() " << std::endl;
+          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= triggerMaskAlgoTrig.size() in bx " << iBxInEvent << std::endl;
         }
 
         bool passMask = (bitValue && !isMasked);

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -874,6 +874,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
     int inBxInEvent = totalBxInEvent / 2 + iBxInEvent;
 
     bool temp_algPrescaledOr = false;
+    bool alreadyReported = false;
     for (unsigned int iBit = 0; iBit < numberPhysTriggers; ++iBit) {
       bool bitValue = m_uGtAlgBlk.getAlgoDecisionInitial(iBit);
       if (bitValue) {
@@ -895,7 +896,8 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
             temp_algPrescaledOr = true;
           }
         }  // require bit in range
-        else {
+	else if (!alreadyReported) {
+          alreadyReported = true;
           edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= prescaleFactorsAlgoTrig.size() " << std::endl;
         }
       }  //if algo bit is set true
@@ -915,6 +917,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
 
   if (!algorithmTriggersUnmasked) {
     bool temp_algFinalOr = false;
+    bool alreadyReported = false;
     for (unsigned int iBit = 0; iBit < numberPhysTriggers; ++iBit) {
       bool bitValue = m_uGtAlgBlk.getAlgoDecisionInterm(iBit);
 
@@ -923,7 +926,8 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
         bool isMasked = false;
         if (iBit < triggerMaskAlgoTrig.size())
           isMasked = (triggerMaskAlgoTrig.at(iBit) == 0);
-        else {
+        else if (!alreadyReported) {
+          alreadyReported = true;
           edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= triggerMaskAlgoTrig.size() " << std::endl;
         }
 

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -896,9 +896,10 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
             temp_algPrescaledOr = true;
           }
         }  // require bit in range
-	else if (!alreadyReported) {
+        else if (!alreadyReported) {
           alreadyReported = true;
-          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= prescaleFactorsAlgoTrig.size() in bx " << iBxInEvent << std::endl;
+          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= prescaleFactorsAlgoTrig.size() in bx " << iBxInEvent
+                                       << std::endl;
         }
       }  //if algo bit is set true
     }    //loop over alg bits
@@ -928,7 +929,8 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
           isMasked = (triggerMaskAlgoTrig.at(iBit) == 0);
         else if (!alreadyReported) {
           alreadyReported = true;
-          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= triggerMaskAlgoTrig.size() in bx " << iBxInEvent << std::endl;
+          edm::LogWarning("L1TGlobal") << "\nWarning: algoBit >= triggerMaskAlgoTrig.size() in bx " << iBxInEvent
+                                       << std::endl;
         }
 
         bool passMask = (bitValue && !isMasked);


### PR DESCRIPTION
#### PR description:

Logs in a few test outputs are now flooded by warning messages from L1TGlobalProducer. This makes difficult to find other warnings and debug possible other issues in the code. 

For example, in wf 136.731 the MessageLogger Summary says:
```
MessageLogger Summary

 type     category        sev    module        subroutine        count    total
 ---- -------------------- -- ---------------- ----------------  -----    -----
    1 Configuration        -w HLTHighLevel:ALC                       2        2
    2 L1TGlobal            -w L1TGlobalProduce                   10868    10868
    3 HLTConfigProvider    -e DQMPFCandidateAn                       2        2
    4 HLTConfigProvider    -e METAnalyzer:pfMe                       2        2
    5 HLTConfigProvider    -e METAnalyzer:pfPu                       2        2
    6 TimeReport           -e AfterModEndJob                         1*       1
    7 hltPrescaleTable     -e PATTriggerProduc                       1        1
    8 fileAction           -s file_close                             1        1
    9 fileAction           -s file_open                              2        2

* Some occurrences of this message were suppressed in all logs, due to limits.

 type    category    Examples: run/evt        run/evt          run/evt
 ---- -------------------- ---------------- ---------------- ----------------
    1 Configuration        274199/39389360  274199/38626099  
    2 L1TGlobal            274199/39389360  274199/39389360  274199/39733340
    3 HLTConfigProvider    Run: 274199      Run: 274199      
    4 HLTConfigProvider    Run: 274199      Run: 274199      
    5 HLTConfigProvider    Run: 274199      Run: 274199      
    6 TimeReport           EndJob                            
    7 hltPrescaleTable     274199/39389360                   
    8 fileAction           PostGlobalEndRun                  
    9 fileAction           pre-events       pre-events       

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
Warning             10870               10870
Error                   8                   8
System                  3                   3
```

Those warnings are repeated for every BX in the event and for every bit number above the vector dimension thresholds. Since there is no information on the bit number itself, having that message repeated multiple time is completely useless.

One possibility to reduce the number of those logWarnings is to have them only printed once per event (this is needed, because different events my have different trigger menus) and per bx, and **not** for every single bit in a given bx. This is what is implemented in this PR. (Actually, I don't think that repeating the same warning at every bx can have any usefulness, but I did not want to hit thread safety issues in doing it).

With this PR, the MessageLogger Summary for the same  wf 136.731 becomes:

```
MessageLogger Summary

 type     category        sev    module        subroutine        count    total
 ---- -------------------- -- ---------------- ----------------  -----    -----
    1 Configuration        -w HLTHighLevel:ALC                       2        2
    2 L1TGlobal            -w L1TGlobalProduce                    1000     1000
    3 HLTConfigProvider    -e DQMPFCandidateAn                       2        2
    4 HLTConfigProvider    -e METAnalyzer:pfMe                       2        2
    5 HLTConfigProvider    -e METAnalyzer:pfPu                       2        2
    6 hltPrescaleTable     -e PATTriggerProduc                       1        1
    7 fileAction           -s file_close                             1        1
    8 fileAction           -s file_open                              2        2

 type    category    Examples: run/evt        run/evt          run/evt
 ---- -------------------- ---------------- ---------------- ----------------
    1 Configuration        274199/39389360  274199/38626099  
    2 L1TGlobal            274199/39389360  274199/39389360  274199/39733340
    3 HLTConfigProvider    Run: 274199      Run: 274199      
    4 HLTConfigProvider    Run: 274199      Run: 274199      
    5 HLTConfigProvider    Run: 274199      Run: 274199      
    6 hltPrescaleTable     274199/39389360                   
    7 fileAction           PostGlobalEndRun                  
    8 fileAction           pre-events       pre-events       

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
Warning              1002                1002
Error                   7                   7
System                  3                   3
```

The outputs are not yet fully cleaned, but with a factor 10 reduction of the repeatedly identical messages the logs already become much better readable and inspectable for other messages.

To the attention of @cms-sw/l1-l2

#### PR validation:

It compiles and actually cleans up (a bit) the logs, without removing information from the warning message