### PR TITLE
Move SiPhase2OuterTrackerLorentzAngleRcd to GlobalTag

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -81,7 +81,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '110X_mcRun4_realistic_v3'
+    'phase2_realistic'         : '112X_mcRun4_realistic_v1'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -80,24 +80,28 @@ allTags["Template"] = {
 }
 
 ##
-## Outer Tracker records
+## Outer Tracker records (to be filled if necessary)
 ##
 
 '''
-tempConnectionString="frontier://FrontierPrep/CMS_CONDITIONS"
-
 allTags["OTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 
 allTags["SimOTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_T15_v0' ,TrackerSimLARecord,tempConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 '''
 ##

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -85,23 +85,23 @@ allTags["Template"] = {
 
 '''
 allTags["OTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngle_v0_mc' ,TrackerLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 
 allTags["SimOTLA"] = {
-    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
-    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,ConnectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T15' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T17' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T19' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T20' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T21' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T22' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
+    'T23' : ( ','.join( [ 'SiPhase2OuterTrackerLorentzAngleSim_v0_mc' ,TrackerSimLARecord,connectionString, "", "2020-07-19 17:00:00.000"] ), ),  #uH = 0.07/T
 }
 '''
 ##

--- a/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D49XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D50_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D50_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D50XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D51_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D51_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D51XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D53_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D53XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D54_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D54_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D54XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D56_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D56_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D56XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D57_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D57_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D57XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D58_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D58_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D58XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D59_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D59_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D59XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D60_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D61_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D61_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D61XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D62_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D62_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D62XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D63_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D63_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D63XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D64_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D64_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D64XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/GeometryExtended2026D65_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D65_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2026D65XML_cfi import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
-from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -142,7 +142,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -177,7 +176,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -212,7 +210,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -247,7 +244,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -283,7 +279,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -319,7 +314,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -354,7 +348,6 @@ trackerDict = {
         ],
         "sim" : [
             'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
-            'from SLHCUpgradeSimulations.Geometry.fakePhase2OuterTrackerConditions_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',


### PR DESCRIPTION
#### PR description:

Now that https://github.com/cms-sw/cmssw/pull/31095 is merged in a pre-release (`CMSSW_11_2_0_pre5`), the corresponding conditions for the reco and sim outer tracker Lorentz Angle `SiPhase2OuterTrackerLorentzAngleRcd` and `SiPhase2OuterTrackerLorentzAngleSimRcd` can be supplied directly from the Global Tag `ESSource`, in lieu of a separate `ESProducer`.
As the conditions are the same for all the currently supported Phase-2 Tracker Geometries, the new tags are included in the physical autoCond base GT for the key `auto:phase2_realistic`. If in future the values for different geometries need to diverge, these can be changed individually for each symbolic Global Tag in `autoCondPhase2`.
The Global Tag is at the moment a GT candidate, but can be changed to full-fledged GT if the AlCa/DB team can supply one, the difference in terms of tags is available [here](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun4_realistic_Candidate_2020_08_27_12_26_21/110X_mcRun4_realistic_v3). 
No physics changes are expected.
#### PR validation:

This branch passes the unit tests `scramv1 b runtests` as well as 
```python
runTheMatrix.py --what upgrade -l 23206.0,23606.0,24406.0,24806.0,26606.0,27006.0,27406.0,27806.0,28206.0,28606.0,29006.0
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.

attn: @trtomei 
