### PR TITLE
Support phase-2 IT tags in pixel Payload Inspector

### DIFF
--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -430,7 +430,6 @@ namespace PixelRegions {
 
   private:
     const TrackerTopology* m_trackerTopo;
-    const bool m_isPhase1;
     bool m_isTrackerTopologySet;
     SiPixelPI::phase m_Phase;
     std::map<PixelId, std::shared_ptr<TH1F>> m_theMap;

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -35,21 +35,25 @@ namespace PixelRegions {
     // FPix plus
     Rp1l = 2211, Rp1u = 2212, Rp2l = 2221, Rp2u = 2222, Rp3l = 2231, Rp3u = 2232,   // phase1-only
     // Phase-2 endcaps
-    Ph2D1 = 3010, Ph2D2 = 3020, Ph2D3 = 3030, Ph2D4 = 3040,  Ph2D5 = 3050,  Ph2D6 = 3060, // phase-2 only
-    Ph2D7 = 3070, Ph2D8 = 3080, Ph2D9 = 3090, Ph2D10 = 3100, Ph2D11 = 3110, Ph2D12 = 3120,
+    Ph2EmR1 = 3101, Ph2EmR2 = 3102, Ph2EmR3 = 3103, Ph2EmR4 = 3104,  // phase-2 EPix
+    Ph2EpR1 = 3201, Ph2EpR2 = 3202, Ph2EpR3 = 3203, Ph2EpR4 = 3204,
+    Ph2FmR1 = 4101, Ph2FmR2 = 4102, Ph2FmR3 = 4103, Ph2FmR4 = 4104, Ph2FmR5 = 4105, //phase-2 FPix
+    Ph2FpR1 = 4201, Ph2FpR2 = 4202, Ph2FpR3 = 4203, Ph2FpR4 = 4204, Ph2FpR5 = 4205,
     End = 99999
   };
 
   const std::vector<PixelId> PixelIDs = {
     // BPix
     PixelId::L1, PixelId::L2, PixelId::L3, PixelId::L4,
-    // FPix minus
+    // Phase-1 FPix minus
     PixelId::Rm1l, PixelId::Rm1u, PixelId::Rm2l, PixelId::Rm2u, PixelId::Rm3l, PixelId::Rm3u, // phase-1 only
-    // FPix plus
+    // Phase-1 FPix plus
     PixelId::Rp1l, PixelId::Rp1u, PixelId::Rp2l, PixelId::Rp2u, PixelId::Rp3l, PixelId::Rp3u, // phase-1 only
     // Phase-2 endcaps
-    PixelId::Ph2D1, PixelId::Ph2D2, PixelId::Ph2D3, PixelId::Ph2D4,  PixelId::Ph2D5,  PixelId::Ph2D6, // phase-2 only
-    PixelId::Ph2D7, PixelId::Ph2D8, PixelId::Ph2D9, PixelId::Ph2D10, PixelId::Ph2D11, PixelId::Ph2D12,
+    PixelId::Ph2EmR1, PixelId::Ph2EmR2, PixelId::Ph2EmR3, PixelId::Ph2EmR4, // phase-2 EPix
+    PixelId::Ph2EpR1, PixelId::Ph2EpR2, PixelId::Ph2EpR3, PixelId::Ph2EpR4,
+    PixelId::Ph2FmR1, PixelId::Ph2FmR2, PixelId::Ph2FmR3, PixelId::Ph2FmR4, PixelId::Ph2FmR5, // phase-2 FPix
+    PixelId::Ph2FpR1, PixelId::Ph2FpR2, PixelId::Ph2FpR3, PixelId::Ph2FpR4, PixelId::Ph2FpR5,
     PixelId::End
   };
 
@@ -71,19 +75,48 @@ namespace PixelRegions {
                                              "FPIX(+) Disk 2 outer ring",  //14
                                              "FPIX(+) Disk 3 inner ring",  //15
                                              "FPIX(+) Disk 3 outer ring",  //16
-                                             "FPIX Disk 1",                //17
-                                             "FPIX Disk 2",                //18
-                                             "FPIX Disk 3",                //19
-                                             "FPIX Disk 4",                //20
-                                             "FPIX Disk 5",                //21
-                                             "FPIX Disk 6",                //22
-                                             "FPIX Disk 7",                //23
-                                             "FPIX Disk 8",                //24
-                                             "FPIX Disk 9",                //25
-                                             "FPIX Disk 10",               //26
-                                             "FPIX Disk 11",               //27
-                                             "FPIX Disk 12",               //28
-                                             "END"};                       //29
+                                             "EPix(-) Ring 1",             //17
+                                             "EPix(-) Ring 2",             //18
+                                             "EPix(-) Ring 3",             //19
+                                             "EPix(-) Ring 4",             //20
+                                             "EPix(+) Ring 1",             //21
+                                             "EPix(+) Ring 2",             //22
+                                             "EPix(+) Ring 3",             //23
+                                             "EPix(+) Ring 4",             //24
+                                             "FPix(-) Ring 1",             //25
+                                             "FPix(-) Ring 2",             //26
+                                             "FPix(-) Ring 3",             //27
+                                             "FPix(-) Ring 4",             //28
+                                             "FPix(-) Ring 5",             //29
+                                             "FPix(+) Ring 1",             //30
+                                             "FPix(+) Ring 2",             //31
+                                             "FPix(+) Ring 3",             //32
+                                             "FPix(+) Ring 4",             //33
+                                             "FPix(+) Ring 5",             //34
+                                             "END"};                       //35
+
+  //============================================================================
+  [[maybe_unused]] static const std::vector<std::string> getIDLabels(const SiPixelPI::phase& ph, bool isBarrel) {
+    std::vector<std::string> out;
+    for (const auto& label : IDlabels) {
+      if (isBarrel) {
+        if (label.find("Barrel") != std::string::npos) {
+          out.push_back(label);
+        }
+      } else {
+        if (ph == SiPixelPI::phase::two) {
+          if (label.find("Ring") != std::string::npos) {
+            out.push_back(label);
+          }
+        } else {
+          if (label.find("ring") != std::string::npos) {
+            out.push_back(label);
+          }
+        }
+      }
+    }
+    return out;
+  }
 
   //============================================================================
   static const PixelId calculateBPixID(const unsigned int layer) {
@@ -100,10 +133,17 @@ namespace PixelRegions {
     // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
     using namespace SiPixelPI;
     unsigned int prefix(2000);
+    unsigned int disk_(0);  // if that's phase-2 set the disk n. to zero
     if (ph > phase::one) {
-      prefix += 1000;
+      if (disk < 9) {
+        prefix += 1000;  // if that's EPix id starts with 3k
+      } else {
+        prefix += 2000;  // if that's FPix id starts with 4k
+      }
+    } else {
+      disk_ = disk;  // if that's not phase-2 set the disk to real disk n.
     }
-    PixelId fpixRing = static_cast<PixelId>(prefix + 100 * side + 10 * disk + ring);
+    PixelId fpixRing = static_cast<PixelId>(prefix + 100 * side + 10 * disk_ + ring);
     return fpixRing;
   }
 
@@ -130,8 +170,9 @@ namespace PixelRegions {
           ring = SiPixelPI::ring(detid, *trackTopo, true);  // 1 (lower), 2 (upper)
           break;
         case phase::two:
-          ring = 0;  // we only fill disks in phase2
-          side = 0;
+          // I know, that's funny but go look at:
+          // https://github.com/cms-sw/cmssw/blob/master/Geometry/TrackerNumberingBuilder/README.md
+          ring = trackTopo->pxfBlade(detId);
           break;
         default:
           throw cms::Exception("LogicalError") << " there is not such phase as " << ph;
@@ -227,9 +268,9 @@ namespace PixelRegions {
                  const float xmax) {
       using namespace SiPixelPI;
       for (const auto& pixelId : PixelIDs | boost::adaptors::indexed(0)) {
-        if (m_Phase == phase::two &&          // if that's phase-2
-            pixelId.value() > PixelId::L4 &&  // if it's end-cap
-            pixelId.value() < PixelId::Ph2D1  // it's a phase-1 ring
+        if (m_Phase == phase::two &&            // if that's phase-2
+            pixelId.value() > PixelId::L4 &&    // if it's end-cap
+            pixelId.value() < PixelId::Ph2EmR1  // it's a phase-1 ring
         ) {
           continue;
         }
@@ -264,7 +305,12 @@ namespace PixelRegions {
 
     //============================================================================
     void draw(TCanvas& canv, bool isBarrel, const char* option = "bar2", bool isPhase1Comparison = false) {
+      using namespace SiPixelPI;
       if (isBarrel) {
+        if (canv.GetListOfPrimitives()->GetSize() == 0) {
+          // divide only if it was not already divided
+          canv.Divide(2, 2);
+        }
         for (int j = 1; j <= 4; j++) {
           if (!m_isLog) {
             canv.cd(j);
@@ -285,10 +331,23 @@ namespace PixelRegions {
           }
         }
       } else {  // forward
-        for (int j = 1; j <= 12; j++) {
+        // pattern where to insert the plots in the canvas
+        // clang-format off
+        const std::array<int, 18> phase2Pattern = {{1,  2,  3,  4, /**/
+                                                    6,  7,  8,  9, /**/
+                                                    11, 12, 13, 14, 15,
+                                                    16, 17, 18, 19, 20}};
+        // clang-format on
+
+        if (canv.GetListOfPrimitives()->GetSize() == 0) {
+          canv.Divide(m_Phase == phase::two ? 5 : 4, m_Phase == phase::two ? 4 : 3);
+        }
+        const int maxPads = (m_Phase == phase::two) ? 18 : 12;
+        for (int j = 1; j <= maxPads; j++) {
           unsigned int mapIndex = m_Phase == 2 ? j + 15 : j + 3;
           if (!m_isLog) {
-            canv.cd(j);
+            canv.cd((m_Phase == phase::two) ? phase2Pattern[j - 1] : j);
+            //canv.cd(j);
           } else {
             canv.cd(j)->SetLogy();
           }
@@ -354,7 +413,8 @@ namespace PixelRegions {
       if (it != m_theMap.end()) {
         return it->second;
       } else {
-        throw cms::Exception("PixelRegionContainer") << "No histogram is available for PixelId" << theId << "\n";
+        throw cms::Exception("LogicError")
+            << "PixelRegionContainer::getHistoFromMap(): No histogram is available for PixelId: " << theId << "\n";
       }
     }
 

--- a/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
+++ b/CondCore/SiPixelPlugins/interface/PixelRegionContainers.h
@@ -24,62 +24,66 @@ namespace PixelRegions {
   // "PixelId"
   // BPix: 1000*(subdetId=1) + 100*(layer=1,2,3,4)
   // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
+  // Phase-2 FPix: 1000*(subdetId=3) + 10*(disk=1...12)
 
+  // clang-format off
   enum PixelId {
-    L1 = 1100,  // BPix
-    L2 = 1200,
-    L3 = 1300,
-    L4 = 1400,
-    Rm1l = 2111,  // FPix minus
-    Rm1u = 2112,
-    Rm2l = 2121,
-    Rm2u = 2122,
-    Rm3l = 2131,
-    Rm3u = 2132,
-    Rp1l = 2211,  // FPix plus
-    Rp1u = 2212,
-    Rp2l = 2221,
-    Rp2u = 2222,
-    Rp3l = 2231,
-    Rp3u = 2232,
+    // BPix
+    L1 = 1100, L2 = 1200, L3 = 1300, L4 = 1400, // common to phase1 and phase2
+    // FPix minus
+    Rm1l = 2111, Rm1u = 2112, Rm2l = 2121, Rm2u = 2122, Rm3l = 2131, Rm3u = 2132,   // phase1-only
+    // FPix plus
+    Rp1l = 2211, Rp1u = 2212, Rp2l = 2221, Rp2u = 2222, Rp3l = 2231, Rp3u = 2232,   // phase1-only
+    // Phase-2 endcaps
+    Ph2D1 = 3010, Ph2D2 = 3020, Ph2D3 = 3030, Ph2D4 = 3040,  Ph2D5 = 3050,  Ph2D6 = 3060, // phase-2 only
+    Ph2D7 = 3070, Ph2D8 = 3080, Ph2D9 = 3090, Ph2D10 = 3100, Ph2D11 = 3110, Ph2D12 = 3120,
     End = 99999
   };
 
-  const std::vector<PixelId> PixelIDs = {PixelId::L1,  // BPix
-                                         PixelId::L2,
-                                         PixelId::L3,
-                                         PixelId::L4,
-                                         PixelId::Rm1l,  // FPix minus
-                                         PixelId::Rm1u,
-                                         PixelId::Rm2l,
-                                         PixelId::Rm2u,
-                                         PixelId::Rm3l,
-                                         PixelId::Rm3u,
-                                         PixelId::Rp1l,  // FPix plus
-                                         PixelId::Rp1u,
-                                         PixelId::Rp2l,
-                                         PixelId::Rp2u,
-                                         PixelId::Rp3l,
-                                         PixelId::Rp3u,
-                                         PixelId::End};
+  const std::vector<PixelId> PixelIDs = {
+    // BPix
+    PixelId::L1, PixelId::L2, PixelId::L3, PixelId::L4,
+    // FPix minus
+    PixelId::Rm1l, PixelId::Rm1u, PixelId::Rm2l, PixelId::Rm2u, PixelId::Rm3l, PixelId::Rm3u, // phase-1 only
+    // FPix plus
+    PixelId::Rp1l, PixelId::Rp1u, PixelId::Rp2l, PixelId::Rp2u, PixelId::Rp3l, PixelId::Rp3u, // phase-1 only
+    // Phase-2 endcaps
+    PixelId::Ph2D1, PixelId::Ph2D2, PixelId::Ph2D3, PixelId::Ph2D4,  PixelId::Ph2D5,  PixelId::Ph2D6, // phase-2 only
+    PixelId::Ph2D7, PixelId::Ph2D8, PixelId::Ph2D9, PixelId::Ph2D10, PixelId::Ph2D11, PixelId::Ph2D12,
+    PixelId::End
+  };
 
-  const std::vector<std::string> IDlabels = {"Barrel Pixel L1",
-                                             "Barrel Pixel L2",
-                                             "Barrel Pixel L3",
-                                             "Barrel Pixel L4",
-                                             "FPIX(-) Disk 1 inner ring",
-                                             "FPIX(-) Disk 1 outer ring",
-                                             "FPIX(-) Disk 2 inner ring",
-                                             "FPIX(-) Disk 2 outer ring",
-                                             "FPIX(-) Disk 3 inner ring",
-                                             "FPIX(-) Disk 3 outer ring",
-                                             "FPIX(+) Disk 1 inner ring",
-                                             "FPIX(+) Disk 1 outer ring",
-                                             "FPIX(+) Disk 2 inner ring",
-                                             "FPIX(+) Disk 2 outer ring",
-                                             "FPIX(+) Disk 3 inner ring",
-                                             "FPIX(+) Disk 3 outer ring",
-                                             "END"};
+  // clang-format on
+
+  const std::vector<std::string> IDlabels = {"Barrel Pixel L1",            //1
+                                             "Barrel Pixel L2",            //2
+                                             "Barrel Pixel L3",            //3
+                                             "Barrel Pixel L4",            //4
+                                             "FPIX(-) Disk 1 inner ring",  //5
+                                             "FPIX(-) Disk 1 outer ring",  //6
+                                             "FPIX(-) Disk 2 inner ring",  //7
+                                             "FPIX(-) Disk 2 outer ring",  //8
+                                             "FPIX(-) Disk 3 inner ring",  //9
+                                             "FPIX(-) Disk 3 outer ring",  //10
+                                             "FPIX(+) Disk 1 inner ring",  //11
+                                             "FPIX(+) Disk 1 outer ring",  //12
+                                             "FPIX(+) Disk 2 inner ring",  //13
+                                             "FPIX(+) Disk 2 outer ring",  //14
+                                             "FPIX(+) Disk 3 inner ring",  //15
+                                             "FPIX(+) Disk 3 outer ring",  //16
+                                             "FPIX Disk 1",                //17
+                                             "FPIX Disk 2",                //18
+                                             "FPIX Disk 3",                //19
+                                             "FPIX Disk 4",                //20
+                                             "FPIX Disk 5",                //21
+                                             "FPIX Disk 6",                //22
+                                             "FPIX Disk 7",                //23
+                                             "FPIX Disk 8",                //24
+                                             "FPIX Disk 9",                //25
+                                             "FPIX Disk 10",               //26
+                                             "FPIX Disk 11",               //27
+                                             "FPIX Disk 12",               //28
+                                             "END"};                       //29
 
   //============================================================================
   static const PixelId calculateBPixID(const unsigned int layer) {
@@ -89,52 +93,83 @@ namespace PixelRegions {
   }
 
   //============================================================================
-  static const PixelId calculateFPixID(const unsigned int side, const unsigned int disk, const unsigned int ring) {
+  static const PixelId calculateFPixID(const SiPixelPI::phase& ph,
+                                       const unsigned int side,
+                                       const unsigned int disk,
+                                       const unsigned int ring) {
     // FPix: 1000*(subdetId=2) + 100*(side=1,2) + 10*(disk=1,2,3) + 1*(ring=1,2)
-    PixelId fpixRing = static_cast<PixelId>(2000 + 100 * side + 10 * disk + ring);
+    using namespace SiPixelPI;
+    unsigned int prefix(2000);
+    if (ph > phase::one) {
+      prefix += 1000;
+    }
+    PixelId fpixRing = static_cast<PixelId>(prefix + 100 * side + 10 * disk + ring);
     return fpixRing;
   }
 
   //============================================================================
-  static const PixelId detIdToPixelId(const unsigned int detid, const TrackerTopology* trackTopo, const bool phase1) {
+  static const PixelId detIdToPixelId(const unsigned int detid,
+                                      const TrackerTopology* trackTopo,
+                                      const SiPixelPI::phase& ph) {
+    using namespace SiPixelPI;
     DetId detId = DetId(detid);
     unsigned int subid = detId.subdetId();
     unsigned int pixid = 0;
     if (subid == PixelSubdetector::PixelBarrel) {
-      PixelBarrelName bpix(detId, trackTopo, phase1);
-      int layer = bpix.layerName();
+      int layer = trackTopo->pxbLayer(detId);  // 1, 2, 3, 4
       pixid = calculateBPixID(layer);
     } else if (subid == PixelSubdetector::PixelEndcap) {
-      PixelEndcapName fpix(detId, trackTopo, phase1);
       int side = trackTopo->pxfSide(detId);  // 1 (-z), 2 for (+z)
-      int disk = fpix.diskName();            //trackTopo->pxfDisk(detId); // 1, 2, 3
-      // This works only in case of the Phase-1 detector
-      //int ring = fpix.ringName();          // 1 (lower), 2 (upper)
-      int ring = SiPixelPI::ring(detid, *trackTopo, phase1);  // 1 (lower), 2 (upper)
-      pixid = calculateFPixID(side, disk, ring);
+      int disk = trackTopo->pxfDisk(detId);  // 1, 2, 3
+      int ring(0);
+      switch (ph) {
+        case phase::zero:
+          ring = SiPixelPI::ring(detid, *trackTopo, false);  // 1 (lower), 2 (upper)
+          break;
+        case phase::one:
+          ring = SiPixelPI::ring(detid, *trackTopo, true);  // 1 (lower), 2 (upper)
+          break;
+        case phase::two:
+          ring = 0;  // we only fill disks in phase2
+          side = 0;
+          break;
+        default:
+          throw cms::Exception("LogicalError") << " there is not such phase as " << ph;
+      }
+      pixid = calculateFPixID(ph, side, disk, ring);
     }
     PixelId pixID = static_cast<PixelId>(pixid);
     return pixID;
   }
 
   //============================================================================
-  const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
-                                           const TrackerTopology* trackTopo,
-                                           const bool phase1) {
+  [[maybe_unused]] static const std::vector<uint32_t> attachedDets(const PixelRegions::PixelId theId,
+                                                                   const TrackerTopology* trackTopo,
+                                                                   const SiPixelPI::phase& ph) {
+    using namespace SiPixelPI;
     std::vector<uint32_t> out = {};
     edm::FileInPath m_fp;
-    if (phase1) {
-      // phase-1 skimmed geometry from release
-      m_fp = edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt");
-    } else {
-      // phase-0 skimmed geometry from release
-      m_fp = edm::FileInPath("CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt");
+
+    switch (ph) {
+      case phase::zero:
+        // phase-1 skimmed geometry from release
+        m_fp = edm::FileInPath("CalibTracker/SiPixelESProducers/data/PixelSkimmedGeometry.txt");
+        break;
+      case phase::one:
+        // phase-0 skimmed geometry from release
+        m_fp = edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseI/PixelSkimmedGeometry_phase1.txt");
+        break;
+      case phase::two:
+        m_fp = edm::FileInPath("SLHCUpgradeSimulations/Geometry/data/PhaseII/Tilted/PixelSkimmedGeometryT14.txt");
+        break;
+      default:
+        throw cms::Exception("LogicalError") << " there is not such phase as " << ph;
     }
 
     SiPixelDetInfoFileReader pxlreader(m_fp.fullPath());
     const std::vector<uint32_t>& pxldetids = pxlreader.getAllDetIds();
     for (const auto& d : pxldetids) {
-      auto ID = detIdToPixelId(d, trackTopo, phase1);
+      auto ID = detIdToPixelId(d, trackTopo, ph);
       if (ID == theId) {
         out.push_back(d);
       }
@@ -161,8 +196,8 @@ namespace PixelRegions {
   /--------------------------------------------------------------------*/
   class PixelRegionContainers {
   public:
-    PixelRegionContainers(const TrackerTopology* t_topo, const bool isPhase1)
-        : m_trackerTopo(t_topo), m_isPhase1(isPhase1) {
+    PixelRegionContainers(const TrackerTopology* t_topo, const SiPixelPI::phase& ph)
+        : m_trackerTopo(t_topo), m_Phase(ph) {
       // set log scale by default to false
       m_isLog = false;
       if (m_trackerTopo) {
@@ -190,7 +225,15 @@ namespace PixelRegions {
                  const int nbins,
                  const float xmin,
                  const float xmax) {
+      using namespace SiPixelPI;
       for (const auto& pixelId : PixelIDs | boost::adaptors::indexed(0)) {
+        if (m_Phase == phase::two &&          // if that's phase-2
+            pixelId.value() > PixelId::L4 &&  // if it's end-cap
+            pixelId.value() < PixelId::Ph2D1  // it's a phase-1 ring
+        ) {
+          continue;
+        }
+
         m_theMap[pixelId.value()] = std::make_shared<TH1F>((title_label + itoa(pixelId.value())).c_str(),
                                                            Form("%s %s;%s;%s",
                                                                 (IDlabels.at(pixelId.index())).c_str(),
@@ -209,12 +252,13 @@ namespace PixelRegions {
       assert(m_trackerTopo);
 
       // convert from detid to pixelid
-      PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid, m_trackerTopo, m_isPhase1);
+      PixelRegions::PixelId myId = PixelRegions::detIdToPixelId(detid, m_trackerTopo, m_Phase);
       if (m_theMap.find(myId) != m_theMap.end()) {
         m_theMap[myId]->Fill(value);
       } else {
         edm::LogError("PixelRegionContainers")
-            << detid << " :=> " << myId << " is not a recongnized PixelId enumerator!" << std::endl;
+            << detid << " :=> " << myId << " is not a recongnized PixelId enumerator! \n"
+            << m_trackerTopo->print(detid);
       }
     }
 
@@ -227,7 +271,7 @@ namespace PixelRegions {
           } else {
             canv.cd(j)->SetLogy();
           }
-          if ((j == 4) && !m_isPhase1 && !isPhase1Comparison) {
+          if ((j == 4) && (m_Phase < 1) && !isPhase1Comparison) {
             m_theMap.at(PixelIDs[j - 1])->Draw("AXIS");
             TLatex t2;
             t2.SetTextAlign(22);
@@ -242,13 +286,14 @@ namespace PixelRegions {
         }
       } else {  // forward
         for (int j = 1; j <= 12; j++) {
+          unsigned int mapIndex = m_Phase == 2 ? j + 15 : j + 3;
           if (!m_isLog) {
             canv.cd(j);
           } else {
             canv.cd(j)->SetLogy();
           }
-          if ((j % 6 == 5 || j % 6 == 0) && !m_isPhase1 && !isPhase1Comparison) {
-            m_theMap.at(PixelIDs[j + 3])->Draw("AXIS");
+          if ((j % 6 == 5 || j % 6 == 0) && (m_Phase < 1) && !isPhase1Comparison) {
+            m_theMap.at(PixelIDs[mapIndex])->Draw("AXIS");
             TLatex t2;
             t2.SetTextAlign(22);
             t2.SetTextSize(0.1);
@@ -257,7 +302,7 @@ namespace PixelRegions {
             t2.SetTextColor(kBlack);
             t2.DrawLatexNDC(0.5, 0.5, "Not in Phase-0!");
           } else {
-            m_theMap.at(PixelIDs[j + 3])->Draw(option);
+            m_theMap.at(PixelIDs[mapIndex])->Draw(option);
           }
         }
       }
@@ -327,7 +372,7 @@ namespace PixelRegions {
     const TrackerTopology* m_trackerTopo;
     const bool m_isPhase1;
     bool m_isTrackerTopologySet;
-
+    SiPixelPI::phase m_Phase;
     std::map<PixelId, std::shared_ptr<TH1F>> m_theMap;
     int m_nbins;
     float m_xim, m_xmax;

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -1393,6 +1393,9 @@ namespace gainCalibHelper {
 
       TCanvas canvas("Comparison", "Comparison", 1600, 800);
 
+      SiPixelPI::PhaseInfo f_phaseInfo(f_GainsMap_.size());
+      SiPixelPI::PhaseInfo l_phaseInfo(l_GainsMap_.size());
+
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> FirstGains_spectraByRegion;
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> LastGains_spectraByRegion;
       std::shared_ptr<TH1F> summaryFirst;
@@ -1453,16 +1456,11 @@ namespace gainCalibHelper {
                                            0,
                                            LastGains_spectraByRegion.size());
 
-      const char* path_toTopologyXML = (f_GainsMap_.size() == SiPixelPI::phase0size)
-                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
-      TrackerTopology f_tTopo =
-          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+      // deal with first IOV
+      const char* path_toTopologyXML = f_phaseInfo.pathToTopoXML();
 
-      bool isPhase0(false);
-      if (f_GainsMap_.size() == SiPixelPI::phase0size) {
-        isPhase0 = true;
-      }
+      auto f_tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       // -------------------------------------------------------------------
       // loop on the first Gains Map
@@ -1476,21 +1474,17 @@ namespace gainCalibHelper {
         SiPixelPI::topolInfo t_info_fromXML;
         t_info_fromXML.init();
         DetId detid(it.first);
-        t_info_fromXML.fillGeometryInfo(detid, f_tTopo, isPhase0);
+        t_info_fromXML.fillGeometryInfo(detid, f_tTopo, f_phaseInfo.phase());
 
         SiPixelPI::regions thePart = t_info_fromXML.filterThePartition();
         FirstGains_spectraByRegion[thePart]->Fill(it.second);
       }  // ends loop on the vector of error transforms
 
-      path_toTopologyXML = (l_GainsMap_.size() == SiPixelPI::phase0size)
-                               ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                               : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
-      TrackerTopology l_tTopo =
-          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
+      // deal with last IOV
+      path_toTopologyXML = l_phaseInfo.pathToTopoXML();
 
-      if (l_GainsMap_.size() == SiPixelPI::phase0size) {
-        isPhase0 = true;
-      }
+      auto l_tTopo =
+          StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
       // -------------------------------------------------------------------
       // loop on the second Gains Map
@@ -1504,7 +1498,7 @@ namespace gainCalibHelper {
         SiPixelPI::topolInfo t_info_fromXML;
         t_info_fromXML.init();
         DetId detid(it.first);
-        t_info_fromXML.fillGeometryInfo(detid, l_tTopo, isPhase0);
+        t_info_fromXML.fillGeometryInfo(detid, l_tTopo, l_phaseInfo.phase());
 
         SiPixelPI::regions thePart = t_info_fromXML.filterThePartition();
         LastGains_spectraByRegion[thePart]->Fill(it.second);

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -376,7 +376,6 @@ namespace gainCalibHelper {
         return false;
       }
 
-      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
       SiPixelPI::PhaseInfo phaseInfo(detids.size());
@@ -546,7 +545,6 @@ namespace gainCalibHelper {
         return false;
       }
 
-      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
       SiPixelPI::PhaseInfo l_phaseInfo(l_detids.size());

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -481,8 +481,8 @@ namespace gainCalibHelper {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -491,7 +491,7 @@ namespace gainCalibHelper {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -604,8 +604,8 @@ namespace gainCalibHelper {
       std::unique_ptr<TLegend> legend;
       if (this->m_plotAnnotations.ntags == 2) {
         legend = std::make_unique<TLegend>(0.36, 0.86, 0.94, 0.92);
-        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + tagname2 + "}").c_str(), "F");
-        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + tagname1 + "}").c_str(), "F");
+        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + l_tagname + "}").c_str(), "F");
+        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + f_tagname + "}").c_str(), "F");
         legend->SetTextSize(0.024);
       } else {
         legend = std::make_unique<TLegend>(0.58, 0.80, 0.90, 0.92);
@@ -1373,8 +1373,8 @@ namespace gainCalibHelper {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -1383,7 +1383,7 @@ namespace gainCalibHelper {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1579,8 +1579,8 @@ namespace gainCalibHelper {
       legend.SetHeader("#mu_{H} value comparison", "C");  // option "C" allows to center the header
       std::string l_tagOrHash, f_tagOrHash;
       if (this->m_plotAnnotations.ntags == 2) {
-        l_tagOrHash = tagname2;
-        f_tagOrHash = tagname1;
+        l_tagOrHash = l_tagname;
+        f_tagOrHash = f_tagname;
       } else {
         l_tagOrHash = std::get<1>(lastiov);
         f_tagOrHash = std::get<1>(firstiov);

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -36,9 +36,51 @@
 
 namespace SiPixelPI {
 
+  enum phase { zero = 0, one = 1, two = 2 };
+
   // size of the phase-0 pixel detID list
   static const unsigned int phase0size = 1440;
   static const unsigned int phase1size = 1856;
+
+  //============================================================================
+  // struct to store info useful to construct topology based on the detid list
+  struct PhaseInfo {
+    PhaseInfo(unsigned int size) : m_detsize(size) {}
+    virtual ~PhaseInfo() { edm::LogInfo("PhaseInfo") << "PhaseInfo::~PhaseInfo()\n"; }
+    const SiPixelPI::phase phase() const {
+      if (m_detsize == phase0size)
+        return phase::zero;
+      else if (m_detsize == phase1size)
+        return phase::one;
+      else if (m_detsize > phase1size)
+        return phase::two;
+      else {
+        throw cms::Exception("LogicError") << "this detId list size: " << m_detsize << "should not exist!";
+      }
+    }
+
+    const char* pathToTopoXML() {
+      if (m_detsize == phase0size)
+        return "Geometry/TrackerCommonData/data/trackerParameters.xml";
+      else if (m_detsize == phase1size)
+        return "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      else if (m_detsize > phase1size)
+        return "Geometry/TrackerCommonData/data/PhaseII/trackerParameters.xml";
+      else {
+        throw cms::Exception("LogicError") << "this detId list size: " << m_detsize << "should not exist!";
+      }
+    }
+
+    const bool isPhase1Comparison(const PhaseInfo& theOtherPhase) const {
+      if (phase() == phase::one || theOtherPhase.phase() == phase::one)
+        return true;
+      else
+        return false;
+    }
+
+  private:
+    size_t m_detsize;
+  };
 
   //============================================================================
   std::pair<unsigned int, unsigned int> unpack(cond::Time_t since) {

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -78,6 +78,15 @@ namespace SiPixelPI {
         return false;
     }
 
+    const bool isComparedWithPhase2(const PhaseInfo& theOtherPhase) const {
+      if ((phase() == phase::two && theOtherPhase.phase() != phase::two) ||
+          (phase() != phase::two && theOtherPhase.phase() == phase::two)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
   private:
     size_t m_detsize;
   };

--- a/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h
@@ -41,11 +41,30 @@ namespace SiPixelPI {
   // size of the phase-0 pixel detID list
   static const unsigned int phase0size = 1440;
   static const unsigned int phase1size = 1856;
+  static const unsigned int phase2size = 3892;
 
   //============================================================================
   // struct to store info useful to construct topology based on the detid list
   struct PhaseInfo {
+    // construct with det size
     PhaseInfo(unsigned int size) : m_detsize(size) {}
+    // construct passing the phase
+    PhaseInfo(const phase& thePhase) {
+      switch (thePhase) {
+        case phase::zero:
+          m_detsize = phase0size;
+          break;
+        case phase::one:
+          m_detsize = phase1size;
+          break;
+        case phase::two:
+          m_detsize = phase2size;
+          break;
+        default:
+          m_detsize = 99999;
+          edm::LogError("PhaseInfo") << "undefined phase: " << thePhase;
+      }
+    }
     virtual ~PhaseInfo() { edm::LogInfo("PhaseInfo") << "PhaseInfo::~PhaseInfo()\n"; }
     const SiPixelPI::phase phase() const {
       if (m_detsize == phase0size)

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -123,18 +123,26 @@ namespace {
                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonSingleTag<gainCalibHelper::gainCalibPI::t_gain,
-                                                                         SiPixelGainCalibrationForHLT>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
+                                                                    SiPixelGainCalibrationForHLT,
+                                                                    cond::payloadInspector::MULTI_IOV,
+                                                                    1>;
   using SiPixelGainCalibForHLTPedestalByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonSingleTag<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                         SiPixelGainCalibrationForHLT>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                    SiPixelGainCalibrationForHLT,
+                                                                    cond::payloadInspector::MULTI_IOV,
+                                                                    1>;
 
   using SiPixelGainCalibForHLTGainByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                                       SiPixelGainCalibrationForHLT>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
+                                                                    SiPixelGainCalibrationForHLT,
+                                                                    cond::payloadInspector::SINGLE_IOV,
+                                                                    2>;
   using SiPixelGainCalibForHLTPedestalByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       SiPixelGainCalibrationForHLT>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                    SiPixelGainCalibrationForHLT,
+                                                                    cond::payloadInspector::SINGLE_IOV,
+                                                                    2>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -125,19 +125,26 @@ namespace {
                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonSingleTag<gainCalibHelper::gainCalibPI::t_gain,
-                                                                         SiPixelGainCalibrationOffline>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
+                                                                    SiPixelGainCalibrationOffline,
+                                                                    cond::payloadInspector::MULTI_IOV,
+                                                                    1>;
   using SiPixelGainCalibOfflinePedestalByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonSingleTag<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                         SiPixelGainCalibrationOffline>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                    SiPixelGainCalibrationOffline,
+                                                                    cond::payloadInspector::MULTI_IOV,
+                                                                    1>;
 
   using SiPixelGainCalibOfflineGainByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                                       SiPixelGainCalibrationOffline>;
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
+                                                                    SiPixelGainCalibrationOffline,
+                                                                    cond::payloadInspector::SINGLE_IOV,
+                                                                    2>;
   using SiPixelGainCalibOfflinePedestalByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       SiPixelGainCalibrationOffline>;
-
+      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                                    SiPixelGainCalibrationOffline,
+                                                                    cond::payloadInspector::SINGLE_IOV,
+                                                                    2>;
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -244,8 +244,8 @@ namespace {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -254,7 +254,7 @@ namespace {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -338,8 +338,8 @@ namespace {
       std::unique_ptr<TLegend> legend;
       if (this->m_plotAnnotations.ntags == 2) {
         legend = std::make_unique<TLegend>(0.36, 0.86, 0.94, 0.92);
-        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + tagname2 + "}").c_str(), "F");
-        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + tagname1 + "}").c_str(), "F");
+        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + l_tagname + "}").c_str(), "F");
+        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + f_tagname + "}").c_str(), "F");
         legend->SetTextSize(0.024);
       } else {
         legend = std::make_unique<TLegend>(0.58, 0.80, 0.90, 0.92);
@@ -537,8 +537,8 @@ namespace {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -547,7 +547,7 @@ namespace {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -715,8 +715,8 @@ namespace {
       legend.SetHeader("#mu_{H} value comparison", "C");  // option "C" allows to center the header
       std::string l_tagOrHash, f_tagOrHash;
       if (this->m_plotAnnotations.ntags == 2) {
-        l_tagOrHash = tagname2;
-        f_tagOrHash = tagname1;
+        l_tagOrHash = l_tagname;
+        f_tagOrHash = f_tagname;
       } else {
         l_tagOrHash = std::get<1>(lastiov);
         f_tagOrHash = std::get<1>(firstiov);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelLorentzAngle_PayloadInspector.cc
@@ -533,6 +533,7 @@ namespace {
   /************************************************
    Summary Comparison per region of SiPixelLorentzAngle between 2 IOVs
   *************************************************/
+  template <cond::payloadInspector::IOVMultiplicity nIOVs, int ntags>
   class SiPixelLorentzAngleByRegionComparisonBase : public cond::payloadInspector::PlotImage<SiPixelLorentzAngle> {
   public:
     SiPixelLorentzAngleByRegionComparisonBase()
@@ -562,15 +563,6 @@ namespace {
       SiPixelPI::PhaseInfo f_phaseInfo(f_LAMap_.size());
 
       TCanvas canvas("Comparison", "Comparison", 1600, 800);
-      /*
-      if (f_LAMap_.size() > SiPixelPI::phase1size || l_LAMap_.size() > SiPixelPI::phase1size) {
-        SiPixelPI::displayNotSupported(canvas, std::max(f_LAMap_.size(), l_LAMap_.size()));
-        std::string fileName(this->m_imageFileName);
-        canvas.SaveAs(fileName.c_str());
-        return false;
-      }
-      */
-
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> FirstLA_spectraByRegion;
       std::map<SiPixelPI::regions, std::shared_ptr<TH1F>> LastLA_spectraByRegion;
       std::shared_ptr<TH1F> summaryFirst;
@@ -607,13 +599,8 @@ namespace {
       // deal with first IOV
       const char *path_toTopologyXML = f_phaseInfo.pathToTopoXML();
 
-      TrackerTopology f_tTopo =
+      auto f_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
-
-      bool isPhase0(false);
-      if (f_LAMap_.size() == SiPixelPI::phase0size) {
-        isPhase0 = true;
-      }
 
       // -------------------------------------------------------------------
       // loop on the first LA Map
@@ -628,7 +615,7 @@ namespace {
         SiPixelPI::topolInfo t_info_fromXML;
         t_info_fromXML.init();
         DetId detid(it.first);
-        t_info_fromXML.fillGeometryInfo(detid, f_tTopo, isPhase0);
+        t_info_fromXML.fillGeometryInfo(detid, f_tTopo, f_phaseInfo.phase());
 
         SiPixelPI::regions thePart = t_info_fromXML.filterThePartition();
         if (thePart != SiPixelPI::NUM_OF_REGIONS) {
@@ -639,12 +626,8 @@ namespace {
       // deal with last IOV
       path_toTopologyXML = l_phaseInfo.pathToTopoXML();
 
-      TrackerTopology l_tTopo =
+      auto l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
-
-      if (l_LAMap_.size() == SiPixelPI::phase0size) {
-        isPhase0 = true;
-      }
 
       // -------------------------------------------------------------------
       // loop on the second LA Map
@@ -659,7 +642,7 @@ namespace {
         SiPixelPI::topolInfo t_info_fromXML;
         t_info_fromXML.init();
         DetId detid(it.first);
-        t_info_fromXML.fillGeometryInfo(detid, l_tTopo, isPhase0);
+        t_info_fromXML.fillGeometryInfo(detid, l_tTopo, l_phaseInfo.phase());
 
         SiPixelPI::regions thePart = t_info_fromXML.filterThePartition();
         if (thePart != SiPixelPI::NUM_OF_REGIONS) {

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -311,8 +311,8 @@ namespace {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -321,7 +321,7 @@ namespace {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -421,8 +421,8 @@ namespace {
       std::unique_ptr<TLegend> legend;
       if (this->m_plotAnnotations.ntags == 2) {
         legend = std::make_unique<TLegend>(0.36, 0.86, 0.94, 0.92);
-        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + tagname2 + "}").c_str(), "F");
-        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + tagname1 + "}").c_str(), "F");
+        legend->AddEntry(l_myPlots.getHistoFromMap(colorTag).get(), ("#color[2]{" + l_tagname + "}").c_str(), "F");
+        legend->AddEntry(f_myPlots.getHistoFromMap(colorTag).get(), ("#color[4]{" + f_tagname + "}").c_str(), "F");
         legend->SetTextSize(0.024);
       } else {
         legend = std::make_unique<TLegend>(0.58, 0.80, 0.90, 0.92);

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -225,7 +225,6 @@ namespace {
         return false;
       }
 
-      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
       SiPixelPI::PhaseInfo phaseInfo(Map_.size());
@@ -362,7 +361,6 @@ namespace {
         return false;
       }
 
-      canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
       SiPixelPI::PhaseInfo l_phaseInfo(l_Map_.size());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelVCal_PayloadInspector.cc
@@ -228,13 +228,13 @@ namespace {
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
-      const char *path_toTopologyXML = (Map_.size() == SiPixelPI::phase0size)
-                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      SiPixelPI::PhaseInfo phaseInfo(Map_.size());
+      const char *path_toTopologyXML = phaseInfo.pathToTopoXML();
+
       TrackerTopology tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, (Map_.size() == SiPixelPI::phase1size));
+      auto myPlots = PixelRegions::PixelRegionContainers(&tTopo, phaseInfo.phase());
       myPlots.bookAll((myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value" : "SiPixel VCal offset value",
                       (myType == SiPixelVCalPI::t_slope) ? "SiPixel VCal slope value [ADC/VCal units]"
                                                          : "SiPixel VCal offset value [ADC]",
@@ -365,16 +365,17 @@ namespace {
       canvas.Divide(isBarrel ? 2 : 4, isBarrel ? 2 : 3);
       canvas.cd();
 
+      SiPixelPI::PhaseInfo l_phaseInfo(l_Map_.size());
+      SiPixelPI::PhaseInfo f_phaseInfo(f_Map_.size());
+
       // deal with last IOV
 
-      const char *path_toTopologyXML = (l_Map_.size() == SiPixelPI::phase0size)
-                                           ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                                           : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      const char *path_toTopologyXML = l_phaseInfo.pathToTopoXML();
 
       auto l_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto l_myPlots = PixelRegions::PixelRegionContainers(&l_tTopo, (l_Map_.size() == SiPixelPI::phase1size));
+      auto l_myPlots = PixelRegions::PixelRegionContainers(&l_tTopo, l_phaseInfo.phase());
       l_myPlots.bookAll(
           fmt::sprintf("SiPixel VCal %s,last", (myType == SiPixelVCalPI::t_slope ? "slope" : "offset")),
           fmt::sprintf("SiPixel VCal %s", (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]")),
@@ -392,14 +393,12 @@ namespace {
 
       // deal with first IOV
 
-      path_toTopologyXML = (f_Map_.size() == SiPixelPI::phase0size)
-                               ? "Geometry/TrackerCommonData/data/trackerParameters.xml"
-                               : "Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml";
+      path_toTopologyXML = f_phaseInfo.pathToTopoXML();
 
       auto f_tTopo =
           StandaloneTrackerTopology::fromTrackerParametersXMLFile(edm::FileInPath(path_toTopologyXML).fullPath());
 
-      auto f_myPlots = PixelRegions::PixelRegionContainers(&f_tTopo, (f_Map_.size() == SiPixelPI::phase1size));
+      auto f_myPlots = PixelRegions::PixelRegionContainers(&f_tTopo, f_phaseInfo.phase());
       f_myPlots.bookAll(
           fmt::sprintf("SiPixel VCal %s,first", (myType == SiPixelVCalPI::t_slope ? "slope" : "offset")),
           fmt::sprintf("SiPixel VCal %s", (myType == SiPixelVCalPI::t_slope ? " slope [ADC/VCal]" : " offset [ADC]")),

--- a/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
+++ b/CondCore/SiPixelPlugins/test/testSiPixelPayloadInspector.cpp
@@ -56,6 +56,13 @@ int main(int argc, char** argv) {
   histo5.process(connectionString, PI::mk_input(tag, end, end));
   edm::LogPrint("testSiPixelPayloadInspector") << histo5.data() << std::endl;
 
+  std::string f_tagPhase2 = "SiPixelLorentzAngle_phase2_T15_v5_mc";
+  std::string l_tagPhase2 = "SiPixelLorentzAngle_phase2_T19_v1_mc";
+
+  SiPixelLorentzAngleValuesBarrelCompareTwoTags histoPhase2;
+  histoPhase2.process(connectionString, PI::mk_input(f_tagPhase2, 1, 1, l_tagPhase2, 1, 1));
+  edm::LogPrint("testSiPixelPayloadInspector") << histoPhase2.data() << std::endl;
+
   // 2 tags comparisons
 
   std::string tag2 = "SiPixelLorentzAngle_2016_ultralegacymc_v2";


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to support the visualization of conditions for the phase-2 Inner Tracker with the Pixel Payload Inspector. The class `PixelRegionContainers` is modified in order to allow the display of conditions for the Phase-2 Pixel. In order to do that an auxiliary struct `PhaseInfo` is introduced and used where necessary. Usages of that class outside of `CondCore/SiPixelPlugins` (namely in ` Alignment/OfflineValidation`) are adjusted accordingly.
I profit of this PR to migrate to the new class templates introduced in #29622 where not yet done.

#### PR validation:

Relies on the existing unit tests.
Example of plot obtainable with Phase-2 LA tags:

![B55E4E1E-EE68-104E-9738-85EB6CB036B7](https://user-images.githubusercontent.com/5082376/91426346-b1739a00-e85c-11ea-8345-4279a510a1e6.png)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, and no backport is needed.
cc: @tvami