### PR TITLE
[RFC] Make BeamSpotToCUDA constructible, and avoid building CUDADataFormats/BeamSpot when CUDA is not available according to cuda-gcc-support

### DIFF
--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,8 +1,10 @@
-<use name="rootcore"/>
-<use name="CUDADataFormats/Common"/>
-<use name="DataFormats/Common"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
+<iftool name="cuda-gcc-support">
+  <use name="rootcore"/>
+  <use name="CUDADataFormats/Common"/>
+  <use name="DataFormats/Common"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 
-<export>
+  <export>
     <lib name="1"/>
-</export>
+  </export>
+</iftool>

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -39,10 +39,12 @@
 <library file="OfflineToTransientBeamSpotESProducer.cc" name="OfflineToTransientBeamSpotESProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
-<library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
-  <use name="cuda"/>
-  <use name="CUDADataFormats/BeamSpot"/>
-  <use name="HeterogeneousCore/CUDACore"/>
-  <use name="HeterogeneousCore/CUDAServices"/>
-  <flags EDM_PLUGIN="1"/>
-</library>
+<iftool name="cuda-gcc-support">
+  <library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+    <use name="cuda"/>
+    <use name="CUDADataFormats/BeamSpot"/>
+    <use name="HeterogeneousCore/CUDACore"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -39,12 +39,13 @@
 <library file="OfflineToTransientBeamSpotESProducer.cc" name="OfflineToTransientBeamSpotESProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
-<iftool name="cuda-gcc-support">
-  <library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+<library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+  <iftool name="cuda-gcc-support">
     <use name="cuda"/>
     <use name="CUDADataFormats/BeamSpot"/>
     <use name="HeterogeneousCore/CUDACore"/>
     <use name="HeterogeneousCore/CUDAServices"/>
-    <flags EDM_PLUGIN="1"/>
-  </library>
-</iftool>
+    <flags CXXFLAGS="-DCMS_CUDA_AVAILABLE"/>
+  </iftool>
+  <flags EDM_PLUGIN="1"/>
+</library>


### PR DESCRIPTION
#### PR description:

Attempt to fix a build failure in gcc10, and after that to make workflows to run.

#### PR validation:

Building `CUDADataFormats/BeamSpot` succeeds (i.e. gets skipped) on gcc10.