### PR TITLE
[PY3] Remove release check condition to fix unit test

### DIFF
--- a/CondCore/BeamSpotPlugins/test/BuildFile.xml
+++ b/CondCore/BeamSpotPlugins/test/BuildFile.xml
@@ -1,7 +1,4 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <bin file="testBeamSpotPayloadInspector.cpp" name="testBeamSpotPayloadInspector">
- <ifrelease name="_PY3_">
-    <flags SETENV="PYTHONHOME=$(PYTHON_BASE)"/>
- </ifrelease>
 </bin>


### PR DESCRIPTION
#### PR description:

Removing the PY3 release condition made the unit test start working. 
Found it by  chance removing conditions from the the BuildFile

#### PR validation:

The test https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_2_PY3_X_2020-08-26-2300/unitTestLogs/CondCore/BeamSpotPlugins#/
is running under the PY3 IB after the change
