### PR TITLE
Make DTTTrigSyncFromDB able to process multiple DTT0 instances

### DIFF
--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cfi.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cfi.py
@@ -27,7 +27,8 @@ dtVDriftMeanTimerCalibration = cms.EDAnalyzer("DTVDriftCalibration",
         # Switch on/off the TO correction from pulses
         doT0Correction = cms.bool(True),
         debug = cms.untracked.bool(False),
-        tTrigLabel = cms.string('')
+        tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
     ),
     # Choose to calculate vDrift and t0 or just fill the TMax histograms
     findVDriftAndT0 = cms.untracked.bool(False),

--- a/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cosmics_cfi.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftMeanTimerCalibration_cosmics_cfi.py
@@ -27,7 +27,8 @@ dtVDriftMeanTimerCalibration = cms.EDAnalyzer("DTVDriftCalibration",
         # Switch on/off the TO correction from pulses
         doT0Correction = cms.bool(True),
         debug = cms.untracked.bool(False),
-        tTrigLabel = cms.string('cosmics')
+        tTrigLabel = cms.string('cosmics'),
+        t0Label = cms.string('')
     ),
     # Choose to calculate vDrift and t0 or just fill the TMax histograms
     findVDriftAndT0 = cms.untracked.bool(False),

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
@@ -36,7 +36,11 @@ DTTTrigSyncFromDB::DTTTrigSyncFromDB(const ParameterSet& config)
       theWirePropCorrType(config.getParameter<int>("wirePropCorrType")),
       // spacing of BX in ns
       theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)),
-      thetTrigLabel(config.getParameter<string>("tTrigLabel")) {}
+      thetTrigLabel(config.getParameter<string>("tTrigLabel")),
+      thet0Label("") {
+  if (config.exists("t0Label")) 
+    thet0Label = config.getParameter<string>("t0Label");
+}
 
 DTTTrigSyncFromDB::~DTTTrigSyncFromDB() {}
 
@@ -44,7 +48,7 @@ void DTTTrigSyncFromDB::setES(const EventSetup& setup) {
   if (doT0Correction) {
     // Get the map of t0 from pulses from the Setup
     ESHandle<DTT0> t0Handle;
-    setup.get<DTT0Rcd>().get(t0Handle);
+    setup.get<DTT0Rcd>().get(thet0Label, t0Handle);
     tZeroMap = &*t0Handle;
     if (debug) {
       cout << "[DTTTrigSyncFromDB] t0 version: " << tZeroMap->version() << endl;

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
@@ -38,7 +38,7 @@ DTTTrigSyncFromDB::DTTTrigSyncFromDB(const ParameterSet& config)
       theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)),
       thetTrigLabel(config.getParameter<string>("tTrigLabel")),
       thet0Label("") {
-  if (config.exists("t0Label")) 
+  if (config.exists("t0Label"))
     thet0Label = config.getParameter<string>("t0Label");
 }
 

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.cc
@@ -37,10 +37,7 @@ DTTTrigSyncFromDB::DTTTrigSyncFromDB(const ParameterSet& config)
       // spacing of BX in ns
       theBXspace(config.getUntrackedParameter<double>("bxSpace", 25.)),
       thetTrigLabel(config.getParameter<string>("tTrigLabel")),
-      thet0Label("") {
-  if (config.exists("t0Label"))
-    thet0Label = config.getParameter<string>("t0Label");
-}
+      thet0Label(config.getParameter<string>("t0Label")) {}
 
 DTTTrigSyncFromDB::~DTTTrigSyncFromDB() {}
 

--- a/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
+++ b/CalibMuon/DTDigiSync/src/DTTTrigSyncFromDB.h
@@ -103,5 +103,6 @@ private:
   double theBXspace;
 
   std::string thetTrigLabel;
+  std::string thet0Label;
 };
 #endif

--- a/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
+++ b/DQM/DTMonitorModule/python/dtTriggerSynchTask_cfi.py
@@ -21,7 +21,8 @@ dtTriggerSynchMonitor = DQMEDAnalyzer('DTLocalTriggerSynchTask',
             doWirePropCorrection = cms.bool(False),
             doT0Correction = cms.bool(False),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('')
+            tTrigLabel = cms.string(''),
+            t0Label = cms.string('')
     ),
     tTrigMode = cms.string('DTTTrigSyncFromDB')
 )

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -186,7 +186,7 @@ def customiseFor31295(process):
 
     return process
 
-def customiseForDtT0Label(process):
+def customiseFor31263(process):
     """Add the t0Label parameter (with default value) to DTTTrigSyncFromDB in HLT"""
 
     if hasattr(process,'hltDt1DRecHits'):
@@ -209,6 +209,6 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
     process = customiseFor31295(process)
-    process = customiseForDtT0Label(process)
+    process = customiseFor31263(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -186,11 +186,29 @@ def customiseFor31295(process):
 
     return process
 
+def customiseForDtT0Label(process):
+    """Add the t0Label parameter (with default value) to DTTTrigSyncFromDB in HLT"""
+
+    if hasattr(process,'hltDt1DRecHits'):
+        process.hltDt1DRecHits.recAlgoConfig.tTrigModeConfig.t0Label = cms.string("")
+
+    if hasattr(process,'hltDt4DSegments'):
+        process.hltDt4DSegments.Reco4DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label = cms.string("")
+        process.hltDt4DSegments.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label = cms.string("")
+
+    if hasattr(process,'hltDt4DSegmentsMeanTimer'):
+        process.hltDt4DSegmentsMeanTimer.Reco4DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label = cms.string("")
+        process.hltDt4DSegmentsMeanTimer.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label = cms.string("")
+
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
     process = customiseFor31295(process)
+    process = customiseForDtT0Label(process)
 
     return process

--- a/L1Trigger/DTTriggerPhase2/python/CalibratedDigis_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/CalibratedDigis_cfi.py
@@ -17,6 +17,7 @@ CalibratedDigis = cms.EDProducer("CalibratedDigis",
         doT0Correction = cms.bool(True),
         debug = cms.untracked.bool(False),
         tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
         ),
                                  tTrigMode = cms.string('DTTTrigSyncFromDB'),
                                  timeOffset = cms.int32(0),

--- a/L1Trigger/DTTriggerPhase2/python/CalibratedDigishlt_cfi.py
+++ b/L1Trigger/DTTriggerPhase2/python/CalibratedDigishlt_cfi.py
@@ -17,6 +17,7 @@ CalibratedDigis = cms.EDProducer("CalibratedDigis",
         doT0Correction = cms.bool(True),
         debug = cms.untracked.bool(False),
         tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
         ),
                                  tTrigMode = cms.string('DTTTrigSyncFromDB'),
                                  timeOffset = cms.int32(0),

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftAlgo_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftAlgo_CosmicData_cfi.py
@@ -27,7 +27,8 @@ DTLinearDriftAlgo_CosmicData = cms.PSet(
             # Switch on/off the T0 correction from pulses
             doT0Correction = cms.bool(True),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('cosmics')
+            tTrigLabel = cms.string('cosmics'),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(420.0)
     ),

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftAlgo_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftAlgo_cfi.py
@@ -24,7 +24,8 @@ DTLinearDriftAlgo = cms.PSet(
             # Switch on/off the TOF correction from pulses
             doT0Correction = cms.bool(True),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('')
+            tTrigLabel = cms.string(''),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(415.0)
     ),

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_CosmicData_cfi.py
@@ -19,7 +19,8 @@ DTLinearDriftFromDBAlgo_CosmicData = cms.PSet(
             # Switch on/off the TOF correction from pulses
             doT0Correction = cms.bool(True),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('cosmics')
+            tTrigLabel = cms.string('cosmics'),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(420.0),
         # Forcing Step 2 to go back to digi time 

--- a/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTLinearDriftFromDBAlgo_cfi.py
@@ -19,7 +19,8 @@ DTLinearDriftFromDBAlgo = cms.PSet(
             # Switch on/off the TOF correction from pulses
             doT0Correction = cms.bool(True),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('')
+            tTrigLabel = cms.string(''),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(420.0),
         # Forcing Step 2 to go back to digi time 

--- a/RecoLocalMuon/DTRecHit/python/DTNoDriftAlgo_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTNoDriftAlgo_CosmicData_cfi.py
@@ -27,7 +27,8 @@ DTNoDriftAlgo_CosmicData = cms.PSet(
             doWirePropCorrection = cms.bool(False),
             doT0Correction = cms.bool(False),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('cosmics')
+            tTrigLabel = cms.string('cosmics'),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(3500.0)
     ),

--- a/RecoLocalMuon/DTRecHit/python/DTParametrizedDriftAlgo_cfi.py
+++ b/RecoLocalMuon/DTRecHit/python/DTParametrizedDriftAlgo_cfi.py
@@ -20,7 +20,8 @@ DTParametrizedDriftAlgo = cms.PSet(
             # Switch on/off the TOF correction from pulses
             doT0Correction = cms.bool(True),
             debug = cms.untracked.bool(False),
-            tTrigLabel = cms.string('')
+            tTrigLabel = cms.string(''),
+            t0Label = cms.string('')
         ),
         maxTime = cms.double(415.0)
     ),

--- a/RecoLocalMuon/DTSegment/python/DTAnalyzerDetailed_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTAnalyzerDetailed_cfi.py
@@ -17,7 +17,9 @@ DTAnalyzerDetailed = cms.EDAnalyzer("DTAnalyzerDetailed",
         wirePropCorrType = cms.int32(0),
         doWirePropCorrection = cms.bool(False),
         doT0Correction = cms.bool(True),
-        debug = cms.untracked.bool(False)
+        debug = cms.untracked.bool(False),
+        tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
     ),
     recHits1DLabel = cms.string('dt1DRecHits')
 )

--- a/RecoLocalMuon/DTSegment/python/DTSegAnalyzer_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTSegAnalyzer_cfi.py
@@ -17,7 +17,9 @@ DTSegAnalyzer = cms.EDAnalyzer("DTSegAnalyzer",
         wirePropCorrType = cms.int32(0),
         doWirePropCorrection = cms.bool(False),
         doT0Correction = cms.bool(True),
-        debug = cms.untracked.bool(False)
+        debug = cms.untracked.bool(False),
+        tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
     ),
     recHits1DLabel = cms.string('dt1DRecHits')
 )

--- a/RecoLocalMuon/DTSegment/test/DTSegAnalyzer_cfi.py
+++ b/RecoLocalMuon/DTSegment/test/DTSegAnalyzer_cfi.py
@@ -17,7 +17,9 @@ DTSegAnalyzer = cms.EDAnalyzer("DTSegAnalyzer",
         wirePropCorrType = cms.int32(0),
         doWirePropCorrection = cms.bool(False),
         doT0Correction = cms.bool(True),
-        debug = cms.untracked.bool(False)
+        debug = cms.untracked.bool(False),
+        tTrigLabel = cms.string(''),
+        t0Label = cms.string('')
     ),
     recHits1DLabel = cms.string('dt1DRecHits')
 )


### PR DESCRIPTION
#### PR description:

This PR extends the `DTTTrigSyncFromDB` class (and its relative configuration) to make it able to process different instances of `DTT0` conditions. The feature is needed to reconstruct, in parallel, DT segments out of digis from the phase-1 and -phase-2 DT readout chains of the DT slice-test demonstrator. Examples of results obtained after implementing this change are documented in [this talk](https://indico.cern.ch/event/942907/#31-slice-test-plots-for-approv).

At present, this feature is exploited only in private analysis workflows of DT slice-test data, therefore no changes are expected for standard workflows.

#### PR validation:

Beyond the set of tests recommended [here](http://cms-sw.github.io/PRWorkflow):
- performance results out of the analysis of DT slice-test data (linked above) were obtained based on this modification;
- 100 events were produced out of the 1321.0 runTheMatrix.py workflow to test that the standalone muon reconstruction efficiency is unchanged.
