### PR TITLE
Data vs emulator plots for CSC trigger primitives in Offline DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TdeCSCTPG.h
@@ -1,0 +1,72 @@
+#ifndef DQM_L1TMonitor_L1TdeCSCTPG_h
+#define DQM_L1TMonitor_L1TdeCSCTPG_h
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+
+class L1TdeCSCTPG : public DQMEDAnalyzer {
+public:
+  L1TdeCSCTPG(const edm::ParameterSet& ps);
+  ~L1TdeCSCTPG() override;
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, const edm::Run&, const edm::EventSetup&) override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  edm::EDGetTokenT<CSCALCTDigiCollection> dataALCT_token_;
+  edm::EDGetTokenT<CSCALCTDigiCollection> emulALCT_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> dataCLCT_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> emulCLCT_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> dataLCT_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> emulLCT_token_;
+  std::string monitorDir_;
+  bool verbose_;
+
+  // ALCT
+  MonitorElement* alct_quality_emul_[10];
+  MonitorElement* alct_wiregroup_emul_[10];
+  MonitorElement* alct_bx_emul_[10];
+  // ALCT
+  MonitorElement* alct_quality_data_[10];
+  MonitorElement* alct_wiregroup_data_[10];
+  MonitorElement* alct_bx_data_[10];
+
+  // CLCT
+  MonitorElement* clct_pattern_emul_[10];
+  MonitorElement* clct_quality_emul_[10];
+  MonitorElement* clct_halfstrip_emul_[10];
+  MonitorElement* clct_bend_emul_[10];
+  MonitorElement* clct_bx_emul_[10];
+  // CLCT
+  MonitorElement* clct_pattern_data_[10];
+  MonitorElement* clct_quality_data_[10];
+  MonitorElement* clct_halfstrip_data_[10];
+  MonitorElement* clct_bend_data_[10];
+  MonitorElement* clct_bx_data_[10];
+
+  // LCT
+  MonitorElement* lct_pattern_emul_[10];
+  MonitorElement* lct_quality_emul_[10];
+  MonitorElement* lct_wiregroup_emul_[10];
+  MonitorElement* lct_halfstrip_emul_[10];
+  MonitorElement* lct_bend_emul_[10];
+  MonitorElement* lct_bx_emul_[10];
+  // LCT
+  MonitorElement* lct_pattern_data_[10];
+  MonitorElement* lct_quality_data_[10];
+  MonitorElement* lct_wiregroup_data_[10];
+  MonitorElement* lct_halfstrip_data_[10];
+  MonitorElement* lct_bend_data_[10];
+  MonitorElement* lct_bx_data_[10];
+};
+
+#endif

--- a/DQM/L1TMonitor/plugins/SealModule.cc
+++ b/DQM/L1TMonitor/plugins/SealModule.cc
@@ -1,81 +1,81 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
-#include <DQM/L1TMonitor/interface/L1TFED.h>
+#include "DQM/L1TMonitor/interface/L1TFED.h"
 DEFINE_FWK_MODULE(L1TFED);
 
-#include <DQM/L1TMonitor/interface/L1TCSCTPG.h>
+#include "DQM/L1TMonitor/interface/L1TCSCTPG.h"
 DEFINE_FWK_MODULE(L1TCSCTPG);
 
-#include <DQM/L1TMonitor/interface/L1TCSCTF.h>
+#include "DQM/L1TMonitor/interface/L1TCSCTF.h"
 DEFINE_FWK_MODULE(L1TCSCTF);
 
-#include <DQM/L1TMonitor/interface/L1TDTTPG.h>
+#include "DQM/L1TMonitor/interface/L1TDTTPG.h"
 DEFINE_FWK_MODULE(L1TDTTPG);
 
-#include <DQM/L1TMonitor/interface/L1TDTTF.h>
+#include "DQM/L1TMonitor/interface/L1TDTTF.h"
 DEFINE_FWK_MODULE(L1TDTTF);
 
-#include <DQM/L1TMonitor/interface/L1TRPCTPG.h>
+#include "DQM/L1TMonitor/interface/L1TRPCTPG.h"
 DEFINE_FWK_MODULE(L1TRPCTPG);
 
-#include <DQM/L1TMonitor/interface/L1TRPCTF.h>
+#include "DQM/L1TMonitor/interface/L1TRPCTF.h"
 DEFINE_FWK_MODULE(L1TRPCTF);
 
-#include <DQM/L1TMonitor/interface/L1TGMT.h>
+#include "DQM/L1TMonitor/interface/L1TGMT.h"
 DEFINE_FWK_MODULE(L1TGMT);
 
-#include <DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h>
+#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer1);
 
-#include <DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h>
+#include "DQM/L1TMonitor/interface/L1TStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TStage2CaloLayer2);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGMT.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGMT.h"
 DEFINE_FWK_MODULE(L1TStage2uGMT);
 
-#include <DQM/L1TMonitor/interface/L1TObjectsTiming.h>
+#include "DQM/L1TMonitor/interface/L1TObjectsTiming.h"
 DEFINE_FWK_MODULE(L1TObjectsTiming);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h"
 DEFINE_FWK_MODULE(L1TStage2uGMTMuon);
 
-#include <DQM/L1TMonitor/interface/L1TStage2MuonComp.h>
+#include "DQM/L1TMonitor/interface/L1TStage2MuonComp.h"
 DEFINE_FWK_MODULE(L1TStage2MuonComp);
 
-#include <DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h>
+#include "DQM/L1TMonitor/interface/L1TStage2RegionalMuonCandComp.h"
 DEFINE_FWK_MODULE(L1TStage2RegionalMuonCandComp);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGT.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGT.h"
 DEFINE_FWK_MODULE(L1TStage2uGT);
 
-#include <DQM/L1TMonitor/interface/L1TStage2uGTTiming.h>
+#include "DQM/L1TMonitor/interface/L1TStage2uGTTiming.h"
 DEFINE_FWK_MODULE(L1TStage2uGTTiming);
 
-#include <DQM/L1TMonitor/interface/L1TStage2BMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2BMTF.h"
 DEFINE_FWK_MODULE(L1TStage2BMTF);
 
-#include <DQM/L1TMonitor/interface/L1TStage2OMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2OMTF.h"
 DEFINE_FWK_MODULE(L1TStage2OMTF);
 
-#include <DQM/L1TMonitor/interface/L1TStage2EMTF.h>
+#include "DQM/L1TMonitor/interface/L1TStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TStage2EMTF);
 
-#include <DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h>
+#include "DQM/L1TMonitor/interface/L1TMP7ZeroSupp.h"
 DEFINE_FWK_MODULE(L1TMP7ZeroSupp);
 
-#include <DQM/L1TMonitor/interface/L1TGCT.h>
+#include "DQM/L1TMonitor/interface/L1TGCT.h"
 DEFINE_FWK_MODULE(L1TGCT);
 
-#include <DQM/L1TMonitor/interface/L1TRCT.h>
+#include "DQM/L1TMonitor/interface/L1TRCT.h"
 DEFINE_FWK_MODULE(L1TRCT);
 
 #include "DQM/L1TMonitor/interface/L1TPUM.h"
 DEFINE_FWK_MODULE(L1TPUM);
 
-#include <DQM/L1TMonitor/interface/L1TGT.h>
+#include "DQM/L1TMonitor/interface/L1TGT.h"
 DEFINE_FWK_MODULE(L1TGT);
 
-#include <DQM/L1TMonitor/interface/L1TCompare.h>
+#include "DQM/L1TMonitor/interface/L1TCompare.h"
 DEFINE_FWK_MODULE(L1TCompare);
 
 #include "DQM/L1TMonitor/interface/BxTiming.h"
@@ -92,13 +92,16 @@ DEFINE_FWK_MODULE(L1TdeGCT);
 #include "DQM/L1TMonitor/interface/L1TdeRCT.h"
 DEFINE_FWK_MODULE(L1TdeRCT);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer1.h"
 DEFINE_FWK_MODULE(L1TdeStage2CaloLayer1);
+
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
+DEFINE_FWK_MODULE(L1TdeCSCTPG);
 
 #include "DQM/L1TMonitor/interface/L1TdeCSCTF.h"
 DEFINE_FWK_MODULE(L1TdeCSCTF);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2EMTF.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2EMTF.h"
 DEFINE_FWK_MODULE(L1TdeStage2EMTF);
 
 //#include "DQM/L1TMonitor/interface/L1GtHwValidation.h"
@@ -125,5 +128,5 @@ DEFINE_FWK_MODULE(L1TStage2uGTCaloLayer2Comp);
 #include "DQM/L1TMonitor/interface/L1TdeStage2CaloLayer2.h"
 DEFINE_FWK_MODULE(L1TdeStage2CaloLayer2);
 
-#include <DQM/L1TMonitor/interface/L1TdeStage2uGT.h>
+#include "DQM/L1TMonitor/interface/L1TdeStage2uGT.h"
 DEFINE_FWK_MODULE(L1TdeStage2uGT);

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -46,6 +46,8 @@ l1TdeRCTfromRCT = l1TdeRCT.clone()
 l1TdeRCTfromRCT.rctSourceData = 'rctDigis'
 l1TdeRCTfromRCT.HistFolder = cms.untracked.string('L1TEMU/L1TdeRCT_FromRCT')
 
+from DQM.L1TMonitor.L1TdeCSCTPG_cfi import *
+
 from DQM.L1TMonitor.L1TdeCSCTF_cfi import *
 
 from DQM.L1TMonitor.L1GtHwValidation_cff import *
@@ -67,7 +69,7 @@ from L1Trigger.L1TCalorimeter.caloStage1LegacyFormatDigis_cfi import *
 
 ############################################################
 
-# GMT unpack from Fed813 in legacy stage1 parallel running                                                               
+# GMT unpack from Fed813 in legacy stage1 parallel running
 from EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi import *
 l1GtUnpack.DaqGtInputTag = 'rawDataCollector'
 
@@ -78,9 +80,10 @@ l1TdeRCTSeq = cms.Sequence(
                     )
 
 l1ExpertDataVsEmulator = cms.Sequence(
-                                l1TdeGCT + 
-                                l1TdeCSCTF + 
-                                l1GtHwValidation + 
+                                l1TdeGCT +
+    l1tdeCSCTPG +
+                                l1TdeCSCTF +
+                                l1GtHwValidation +
                                 l1TdeRCTRun1
                                 )
 
@@ -116,7 +119,7 @@ l1ExpertDataVsEmulatorStage1 = cms.Sequence(
 
 l1EmulatorMonitorStage1 = cms.Sequence(
     #caloStage1Digis*
-    #caloStage1LegacyFormatDigis*    
+    #caloStage1LegacyFormatDigis*
     l1demonstage1+
     l1ExpertDataVsEmulatorStage1
     )

--- a/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
+++ b/DQM/L1TMonitor/python/L1TdeCSCTPG_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
+l1tdeCSCTPG = DQMEDAnalyzer(
+    "L1TdeCSCTPG",
+    dataALCT = cms.InputTag("muonCSCDigis","MuonCSCALCTDigi"),
+    emulALCT = cms.InputTag("valCscTriggerPrimitiveDigis"),
+    dataCLCT = cms.InputTag("muonCSCDigis","MuonCSCCLCTDigi"),
+    emulCLCT = cms.InputTag("valCscTriggerPrimitiveDigis"),
+    dataLCT = cms.InputTag("muonCSCDigis","MuonCSCCorrelatedLCTDigi"),
+    emulLCT = cms.InputTag("valCscTriggerPrimitiveDigis", "MPCSORTED"),
+    monitorDir = cms.string("L1TEMU/L1TdeCSCTPG"),
+    verbose = cms.bool(False),
+)

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -2,15 +2,15 @@
 
 #include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
 
-L1TdeCSCTPG::L1TdeCSCTPG(const edm::ParameterSet& ps) :
-  dataALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("dataALCT"))),
-  emulALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("emulALCT"))),
-  dataCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataCLCT"))),
-  emulCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulCLCT"))),
-  dataLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataLCT"))),
-  emulLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulLCT"))),
-  monitorDir_(ps.getParameter<std::string>("monitorDir")),
-  verbose_(ps.getParameter<bool>("verbose")) {}
+L1TdeCSCTPG::L1TdeCSCTPG(const edm::ParameterSet& ps)
+    : dataALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("dataALCT"))),
+      emulALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("emulALCT"))),
+      dataCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataCLCT"))),
+      emulCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulCLCT"))),
+      dataLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataLCT"))),
+      emulLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulLCT"))),
+      monitorDir_(ps.getParameter<std::string>("monitorDir")),
+      verbose_(ps.getParameter<bool>("verbose")) {}
 
 L1TdeCSCTPG::~L1TdeCSCTPG() {}
 

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -1,0 +1,145 @@
+#include <string>
+
+#include "DQM/L1TMonitor/interface/L1TdeCSCTPG.h"
+
+L1TdeCSCTPG::L1TdeCSCTPG(const edm::ParameterSet& ps) :
+  dataALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("dataALCT"))),
+  emulALCT_token_(consumes<CSCALCTDigiCollection>(ps.getParameter<edm::InputTag>("emulALCT"))),
+  dataCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataCLCT"))),
+  emulCLCT_token_(consumes<CSCCLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulCLCT"))),
+  dataLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("dataLCT"))),
+  emulLCT_token_(consumes<CSCCorrelatedLCTDigiCollection>(ps.getParameter<edm::InputTag>("emulLCT"))),
+  monitorDir_(ps.getParameter<std::string>("monitorDir")),
+  verbose_(ps.getParameter<bool>("verbose")) {}
+
+L1TdeCSCTPG::~L1TdeCSCTPG() {}
+
+void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const edm::EventSetup&) {
+  ibooker.setCurrentFolder(monitorDir_);
+
+  for (unsigned iType = 0; iType < 10; iType++) {
+    alct_quality_emul_[iType] = ibooker.book1D("CSC ALCT quality", "CSC ALCT quality", 16, 0.5, 16.5);
+    alct_wiregroup_emul_[iType] = ibooker.book1D("CSC ALCT wire group", "CSC ALCT wire group", 116, -0.5, 115.5);
+    alct_bx_emul_[iType] = ibooker.book1D("CSC ALCT bx", "CSC ALCT bx", 20, -0.5, 19.5);
+
+    alct_quality_data_[iType] = ibooker.book1D("CSC ALCT quality", "CSC ALCT quality", 16, 0.5, 16.5);
+    alct_wiregroup_data_[iType] = ibooker.book1D("CSC ALCT wire group", "CSC ALCT wire group", 116, -0.5, 115.5);
+    alct_bx_data_[iType] = ibooker.book1D("CSC ALCT bx", "CSC ALCT bx", 20, -0.5, 19.5);
+
+    clct_pattern_emul_[iType] = ibooker.book1D("CSC CLCT hit pattern", "CSC CLCT hit pattern", 16, -0.5, 15.5);
+    clct_quality_emul_[iType] = ibooker.book1D("CSC CLCT quality", "CSC CLCT quality", 16, 0.5, 16.5);
+    clct_halfstrip_emul_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 160, -0.5, 159.5);
+    clct_bend_emul_[iType] = ibooker.book1D("CSC CLCT bend", "CSC CLCT bend", 3, 0.5, 2.5);
+    clct_bx_emul_[iType] = ibooker.book1D("CSC CLCT bx", "CSC CLCT bx", 20, -0.5, 19.5);
+
+    clct_pattern_data_[iType] = ibooker.book1D("CSC CLCT hit pattern", "CSC CLCT hit pattern", 16, -0.5, 15.5);
+    clct_quality_data_[iType] = ibooker.book1D("CSC CLCT quality", "CSC CLCT quality", 16, 0.5, 16.5);
+    clct_halfstrip_data_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 160, -0.5, 159.5);
+    clct_bend_data_[iType] = ibooker.book1D("CSC CLCT bend", "CSC CLCT bend", 3, 0.5, 2.5);
+    clct_bx_data_[iType] = ibooker.book1D("CSC CLCT bx", "CSC CLCT bx", 20, -0.5, 19.5);
+
+    lct_pattern_emul_[iType] = ibooker.book1D("CSC LCT hit pattern", "CSC LCT hit pattern", 16, -0.5, 15.5);
+    lct_quality_emul_[iType] = ibooker.book1D("CSC LCT quality", "CSC LCT quality", 16, 0.5, 16.5);
+    lct_wiregroup_emul_[iType] = ibooker.book1D("CSC LCT wire group", "CSC LCT wire group", 116, -0.5, 115.5);
+    lct_halfstrip_emul_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 160, -0.5, 159.5);
+    lct_bend_emul_[iType] = ibooker.book1D("CSC LCT bend", "CSC LCT bend", 3, 0.5, 2.5);
+    lct_bx_emul_[iType] = ibooker.book1D("CSC LCT bx", "CSC LCT bx", 20, -0.5, 19.5);
+
+    lct_pattern_data_[iType] = ibooker.book1D("CSC LCT hit pattern", "CSC LCT hit pattern", 16, -0.5, 15.5);
+    lct_quality_data_[iType] = ibooker.book1D("CSC LCT quality", "CSC LCT quality", 16, 0.5, 16.5);
+    lct_wiregroup_data_[iType] = ibooker.book1D("CSC LCT wire group", "CSC LCT wire group", 116, -0.5, 115.5);
+    lct_halfstrip_data_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 160, -0.5, 159.5);
+    lct_bend_data_[iType] = ibooker.book1D("CSC LCT bend", "CSC LCT bend", 3, 0.5, 2.5);
+    lct_bx_data_[iType] = ibooker.book1D("CSC LCT bx", "CSC LCT bx", 20, -0.5, 19.5);
+  }
+}
+
+void L1TdeCSCTPG::analyze(const edm::Event& e, const edm::EventSetup& c) {
+  if (verbose_)
+    edm::LogInfo("L1TdeCSCTPG") << "L1TdeCSCTPG: analyzing collections" << std::endl;
+
+  // handles
+  edm::Handle<CSCALCTDigiCollection> dataALCTs;
+  edm::Handle<CSCALCTDigiCollection> emulALCTs;
+  edm::Handle<CSCCLCTDigiCollection> dataCLCTs;
+  edm::Handle<CSCCLCTDigiCollection> emulCLCTs;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> dataLCTs;
+  edm::Handle<CSCCorrelatedLCTDigiCollection> emulLCTs;
+
+  e.getByToken(dataALCT_token_, dataALCTs);
+  e.getByToken(emulALCT_token_, emulALCTs);
+  e.getByToken(dataCLCT_token_, dataCLCTs);
+  e.getByToken(emulCLCT_token_, emulCLCTs);
+  e.getByToken(dataLCT_token_, dataLCTs);
+  e.getByToken(emulLCT_token_, emulLCTs);
+
+  for (auto it = dataALCTs->begin(); it != dataALCTs->end(); it++) {
+    auto range = dataALCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto alct = range.first; alct != range.second; alct++) {
+      alct_quality_data_[type]->Fill(alct->getQuality());
+      alct_wiregroup_data_[type]->Fill(alct->getKeyWG());
+      alct_bx_data_[type]->Fill(alct->getBX());
+    }
+  }
+
+  for (auto it = emulALCTs->begin(); it != emulALCTs->end(); it++) {
+    auto range = emulALCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto alct = range.first; alct != range.second; alct++) {
+      alct_quality_emul_[type]->Fill(alct->getQuality());
+      alct_wiregroup_emul_[type]->Fill(alct->getKeyWG());
+      alct_bx_emul_[type]->Fill(alct->getBX());
+    }
+  }
+
+  for (auto it = dataCLCTs->begin(); it != dataCLCTs->end(); it++) {
+    auto range = dataCLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto clct = range.first; clct != range.second; clct++) {
+      clct_pattern_data_[type]->Fill(clct->getPattern());
+      clct_quality_data_[type]->Fill(clct->getQuality());
+      clct_halfstrip_data_[type]->Fill(clct->getKeyStrip());
+      clct_bend_data_[type]->Fill(clct->getBend());
+      clct_bx_data_[type]->Fill(clct->getBX());
+    }
+  }
+
+  for (auto it = emulCLCTs->begin(); it != emulCLCTs->end(); it++) {
+    auto range = emulCLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto clct = range.first; clct != range.second; clct++) {
+      clct_pattern_emul_[type]->Fill(clct->getPattern());
+      clct_quality_emul_[type]->Fill(clct->getQuality());
+      clct_halfstrip_emul_[type]->Fill(clct->getKeyStrip());
+      clct_bend_emul_[type]->Fill(clct->getBend());
+      clct_bx_emul_[type]->Fill(clct->getBX());
+    }
+  }
+
+  for (auto it = dataLCTs->begin(); it != dataLCTs->end(); it++) {
+    auto range = dataLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto lct = range.first; lct != range.second; lct++) {
+      lct_pattern_data_[type]->Fill(lct->getCLCTPattern());
+      lct_quality_data_[type]->Fill(lct->getQuality());
+      lct_wiregroup_data_[type]->Fill(lct->getKeyWG());
+      lct_halfstrip_data_[type]->Fill(lct->getStrip());
+      lct_bend_data_[type]->Fill(lct->getBend());
+      lct_bx_data_[type]->Fill(lct->getBX());
+    }
+  }
+
+  for (auto it = emulLCTs->begin(); it != emulLCTs->end(); it++) {
+    auto range = emulLCTs->get((*it).first);
+    const int type = ((*it).first).iChamberType() - 1;
+    for (auto lct = range.first; lct != range.second; lct++) {
+      lct_pattern_emul_[type]->Fill(lct->getCLCTPattern());
+      lct_quality_emul_[type]->Fill(lct->getQuality());
+      lct_wiregroup_emul_[type]->Fill(lct->getKeyWG());
+      lct_halfstrip_emul_[type]->Fill(lct->getStrip());
+      lct_bend_emul_[type]->Fill(lct->getBend());
+      lct_bx_emul_[type]->Fill(lct->getBX());
+    }
+  }
+}

--- a/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTPG.cc
@@ -28,27 +28,27 @@ void L1TdeCSCTPG::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, co
 
     clct_pattern_emul_[iType] = ibooker.book1D("CSC CLCT hit pattern", "CSC CLCT hit pattern", 16, -0.5, 15.5);
     clct_quality_emul_[iType] = ibooker.book1D("CSC CLCT quality", "CSC CLCT quality", 16, 0.5, 16.5);
-    clct_halfstrip_emul_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 160, -0.5, 159.5);
+    clct_halfstrip_emul_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 224, -0.5, 223.5);
     clct_bend_emul_[iType] = ibooker.book1D("CSC CLCT bend", "CSC CLCT bend", 3, 0.5, 2.5);
     clct_bx_emul_[iType] = ibooker.book1D("CSC CLCT bx", "CSC CLCT bx", 20, -0.5, 19.5);
 
     clct_pattern_data_[iType] = ibooker.book1D("CSC CLCT hit pattern", "CSC CLCT hit pattern", 16, -0.5, 15.5);
     clct_quality_data_[iType] = ibooker.book1D("CSC CLCT quality", "CSC CLCT quality", 16, 0.5, 16.5);
-    clct_halfstrip_data_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 160, -0.5, 159.5);
+    clct_halfstrip_data_[iType] = ibooker.book1D("CSC CLCT halfstrip", "CSC CLCT strip", 224, -0.5, 223.5);
     clct_bend_data_[iType] = ibooker.book1D("CSC CLCT bend", "CSC CLCT bend", 3, 0.5, 2.5);
     clct_bx_data_[iType] = ibooker.book1D("CSC CLCT bx", "CSC CLCT bx", 20, -0.5, 19.5);
 
     lct_pattern_emul_[iType] = ibooker.book1D("CSC LCT hit pattern", "CSC LCT hit pattern", 16, -0.5, 15.5);
     lct_quality_emul_[iType] = ibooker.book1D("CSC LCT quality", "CSC LCT quality", 16, 0.5, 16.5);
     lct_wiregroup_emul_[iType] = ibooker.book1D("CSC LCT wire group", "CSC LCT wire group", 116, -0.5, 115.5);
-    lct_halfstrip_emul_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 160, -0.5, 159.5);
+    lct_halfstrip_emul_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 224, -0.5, 223.5);
     lct_bend_emul_[iType] = ibooker.book1D("CSC LCT bend", "CSC LCT bend", 3, 0.5, 2.5);
     lct_bx_emul_[iType] = ibooker.book1D("CSC LCT bx", "CSC LCT bx", 20, -0.5, 19.5);
 
     lct_pattern_data_[iType] = ibooker.book1D("CSC LCT hit pattern", "CSC LCT hit pattern", 16, -0.5, 15.5);
     lct_quality_data_[iType] = ibooker.book1D("CSC LCT quality", "CSC LCT quality", 16, 0.5, 16.5);
     lct_wiregroup_data_[iType] = ibooker.book1D("CSC LCT wire group", "CSC LCT wire group", 116, -0.5, 115.5);
-    lct_halfstrip_data_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 160, -0.5, 159.5);
+    lct_halfstrip_data_[iType] = ibooker.book1D("CSC LCT halfstrip", "CSC LCT strip", 224, -0.5, 223.5);
     lct_bend_data_[iType] = ibooker.book1D("CSC LCT bend", "CSC LCT bend", 3, 0.5, 2.5);
     lct_bx_data_[iType] = ibooker.book1D("CSC LCT bx", "CSC LCT bx", 20, -0.5, 19.5);
   }

--- a/DQM/L1TMonitorClient/interface/L1TCSCTPGClient.h
+++ b/DQM/L1TMonitorClient/interface/L1TCSCTPGClient.h
@@ -1,0 +1,34 @@
+#ifndef DQM_L1TMONITORCLIENT_L1TCSCTPGCLIENT_H
+#define DQM_L1TMONITORCLIENT_L1TCSCTPGCLIENT_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+
+#include <string>
+
+class L1TCSCTPGClient : public DQMEDHarvester {
+public:
+  /// Constructor
+  L1TCSCTPGClient(const edm::ParameterSet &ps);
+
+  /// Destructor
+  ~L1TCSCTPGClient() override;
+
+protected:
+  void dqmEndLuminosityBlock(DQMStore::IBooker &,
+                             DQMStore::IGetter &,
+                             edm::LuminosityBlock const &,
+                             edm::EventSetup const &) override;       //performed in the endLumi
+  void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) override;  //performed in the endJob
+
+private:
+  void processHistograms(DQMStore::IGetter &);
+
+  std::string monitorDir_;
+};
+
+#endif

--- a/DQM/L1TMonitorClient/python/L1TCSCTPGClient_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TCSCTPGClient_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+
+l1tCSCTPGClient = DQMEDHarvester("L1TCSCTPGClient",
+    monitorDir = cms.string('L1TEMU/L1TdeCSCTPG'),
+)

--- a/DQM/L1TMonitorClient/python/L1TMonitorClient_cff.py
+++ b/DQM/L1TMonitorClient/python/L1TMonitorClient_cff.py
@@ -4,16 +4,16 @@ import FWCore.ParameterSet.Config as cms
 #
 # used by DQM GUI: DQM/Integration/python/test/l1t_dqm_sourceclient-*_cfg.py
 #
-# standard RawToDigi sequence must be run before the L1T module, labels 
+# standard RawToDigi sequence must be run before the L1T module, labels
 # from the standard sequence are used as default for the L1 DQM modules
 # any configuration change in the unpacking must be done in l1t_dqm_sourceclient-*_cfg.py
 #
 # see CVS for previous authors
 #
 # V.M. Ghete 2011-05-26 revised version of L1 Trigger client DQM
-#                       
+#
 
-# DQM quality tests 
+# DQM quality tests
 from DQM.L1TMonitorClient.L1TriggerQualityTests_cff import *
 
 #
@@ -27,38 +27,38 @@ from DQM.L1TMonitorClient.L1TriggerQualityTests_cff import *
 # ECAL TPG client DQM module
 # not run in L1T - do we need it? FIXME
 
-# HCAL TPG DQM module 
+# HCAL TPG DQM module
 # not run in L1T - do we need it? FIXME
 
 # RCT DQM client module - not available
 #from DQM.L1TMonitorClient.L1TRCTClient_cfi import *
 
-# GCT DQM client module 
+# GCT DQM client module
 from DQM.L1TMonitorClient.L1TGCTClient_cfi import *
 from DQM.L1TMonitorClient.L1TStage1Layer2Client_cfi import *
 
-# DTTPG DQM module 
+# DTTPG DQM module
 # not run in L1T - do we need it? FIXME
 
-# DTTF DQM client module 
+# DTTF DQM client module
 from DQM.L1TMonitorClient.L1TDTTFClient_cfi import *
 
-# CSCTPG DQM module 
-# not run in L1T - do we need it? FIXME
+# CSCTPG DQM module
+from DQM.L1TMonitorClient.L1TCSCTPGClient_cfi import *
 
-# CSCTF DQM client module 
-from DQM.L1TMonitorClient.L1TCSCTFClient_cfi import * 
+# CSCTF DQM client module
+from DQM.L1TMonitorClient.L1TCSCTFClient_cfi import *
 
 # RPC DQM client module - non-standard name of the module
 from DQM.L1TMonitorClient.L1TRPCTFClient_cfi import *
 
-# GMT DQM module 
+# GMT DQM module
 from DQM.L1TMonitorClient.L1TGMTClient_cfi import *
 
-# GT DQM client module - not available 
+# GT DQM client module - not available
 #from DQM.L1TMonitorClient.L1TGTClient_cfi import *
 
-# L1Extra DQM client module - not available 
+# L1Extra DQM client module - not available
 
 # L1 rates DQM client module
 # L1 synchronization DQM client module
@@ -66,7 +66,7 @@ from DQM.L1TMonitorClient.L1TGMTClient_cfi import *
 from DQM.L1TMonitorClient.L1TOccupancyClient_cff import *
 from DQM.L1TMonitorClient.L1TTestsSummary_cff import *
 
-# L1 event info DQM client 
+# L1 event info DQM client
 from DQM.L1TMonitorClient.L1TEventInfoClient_cfi import *
 
 #
@@ -80,14 +80,15 @@ l1tsClient.dqmFolder = cms.untracked.string("L1T/L1Scalers_SM")
 
 
 #
-# define sequences 
+# define sequences
 #
 
 # L1T monitor client sequence (system clients and quality tests)
 l1TriggerClients = cms.Sequence(
                         l1tGctClient +
                         l1tDttfClient +
-                        l1tCsctfClient + 
+                        l1tCSCTPGClient +
+                        l1tCsctfClient +
                         l1tRpctfClient +
                         l1tGmtClient +
                         l1tOccupancyClient +
@@ -98,7 +99,8 @@ l1TriggerClients = cms.Sequence(
 l1TriggerStage1Clients = cms.Sequence(
                         l1tStage1Layer2Client +
                         l1tDttfClient +
-                        l1tCsctfClient + 
+                        l1tCSCTPGClient +
+                        l1tCsctfClient +
                         l1tRpctfClient +
                         l1tGmtClient +
                         l1tOccupancyClient +
@@ -118,11 +120,9 @@ l1tMonitorStage1Client = cms.Sequence(
                         )
 
 
-# sequence for L1 Trigger DQM client modules on EndPath 
+# sequence for L1 Trigger DQM client modules on EndPath
 # FIXME clarify why needed on EndPath
 
 l1tMonitorClientEndPathSeq = cms.Sequence(
                                 l1tsClient
                                 )
-
-

--- a/DQM/L1TMonitorClient/src/L1TCSCTPGClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TCSCTPGClient.cc
@@ -1,0 +1,28 @@
+#include "DQM/L1TMonitorClient/interface/L1TCSCTPGClient.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "TRandom.h"
+using namespace edm;
+using namespace std;
+
+L1TCSCTPGClient::L1TCSCTPGClient(const edm::ParameterSet &ps) { monitorDir_ = ps.getParameter<string>("monitorDir"); }
+
+L1TCSCTPGClient::~L1TCSCTPGClient() {}
+
+void L1TCSCTPGClient::dqmEndLuminosityBlock(DQMStore::IBooker &,
+                                            DQMStore::IGetter &igetter,
+                                            const edm::LuminosityBlock &lumiSeg,
+                                            const edm::EventSetup &c) {}
+
+//--------------------------------------------------------
+void L1TCSCTPGClient::dqmEndJob(DQMStore::IBooker &ibooker, DQMStore::IGetter &igetter) {
+  ibooker.setCurrentFolder(monitorDir_);
+}
+
+//--------------------------------------------------------
+void L1TCSCTPGClient::processHistograms(DQMStore::IGetter &igetter) {}


### PR DESCRIPTION
#### PR description:

We're making substantial changes to the CSC local trigger in Run-3 (new patterns, new algorithms). We expect that frequent data vs emulator comparisons will be necessary. I added a class `L1TdeCSCTPG` that dumps ALCT/CLCT/LCT key properties (half-strip, wire-group, BX etc.) into DQM MonitorElements for both unpacked stubs and re-emulated stubs. The histograms for data and emulator should be overlaid to compare, but I don't think the DQM does that by default. I may need to amend the PR with an extra module to take care of this.
 
#### PR validation:

Tested with WF 23634.0.
 
23634.0_TTbar_14TeV+2026D51+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Aug 27 11:05:48 2020-date Thu Aug 27 10:21:22 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

May need to be backported to CMSSW_11_1_X to run in upcoming MWGRs.

@jfernan2 @tahuang1991 