### PR TITLE
fixed the problem related to concurrent lumis with the AlcaBeamMonitor code

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -1,7 +1,7 @@
 /*
  * \file AlcaBeamMonitor.cc
  * \author Lorenzo Uplegger/FNAL
- *
+ * modified by Simone Gennai INFN/Bicocca
  */
 
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -48,6 +48,8 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
 
   thePVFitter_ = new PVFitter(parameters_, consumesCollector());
 
+  processedLumis_.clear();
+
   varNamesV_.push_back("x");
   varNamesV_.push_back("y");
   varNamesV_.push_back("z");
@@ -72,45 +74,34 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
-
+  
+  
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
          itM++) {
-      if (itM->first == "run") {
-        histosMap_[*itV][itM->first][itM->second] = nullptr;
-      } else {
-        positionsMap_[*itV][itM->first][itM->second] = 3 * numberOfValuesToSave_;  //value, error, ok
-        ++numberOfValuesToSave_;
-      }
+        histosMap_[*itV][itM->first][itM->second] = nullptr;     
     }
   }
-
-  //  beamSpotsMap_["BF"] = map<LuminosityBlockNumber_t,BeamSpot>();//For each lumi the beamfitter will have a result
-  //  beamSpotsMap_["PV"] = map<LuminosityBlockNumber_t,BeamSpot>();//For each lumi the PVfitter will have a result
-  //  beamSpotsMap_["DB"] = map<LuminosityBlockNumber_t,BeamSpot>();//For each lumi we take the values that are stored in the database, already collapsed then
-  //  beamSpotsMap_["SC"] = map<LuminosityBlockNumber_t,BeamSpot>();//For each lumi we take the beamspot value in the file that is the same as the scaler for the alca reco stream
-  //  beamSpotsMap_["BF"] = 0;//For each lumi the beamfitter will have a result
-  //  beamSpotsMap_["PV"] = 0;//For each lumi the PVfitter will have a result
-  //  beamSpotsMap_["DB"] = 0;//For each lumi we take the values that are stored in the database, already collapsed then
-  //  beamSpotsMap_["SC"] = 0;//For each lumi we take the beamspot value in the file that is the same as the scaler for the alca reco stream
 }
-
+      
 AlcaBeamMonitor::~AlcaBeamMonitor() {
-  if (theBeamFitter_ != nullptr) {
+  //if (theBeamFitter_ != nullptr) {
     delete theBeamFitter_;
-  }
+ // }
 
-  if (thePVFitter_ != nullptr) {
+ // if (thePVFitter_ != nullptr) {
     delete thePVFitter_;
-  }
+ // }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const& iRun, edm::EventSetup const& iSetup) {
   string name;
   string title;
-  ibooker.setCurrentFolder(monitorName_ + "Debug");
+  int firstLumi = 1;
+  int lastLumi = 3000;
   for (HistosContainer::iterator itM = histosMap_.begin(); itM != histosMap_.end(); itM++) {
+    ibooker.setCurrentFolder(monitorName_ + "Debug");
     for (map<string, MonitorElement*>::iterator itMM = itM->second["run"].begin(); itMM != itM->second["run"].end();
          itMM++) {
       name = string("h") + itM->first + itMM->first;
@@ -171,21 +162,51 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         itMM->second->setAxisTitle("Entries", 2);
       }
     }
-  }
-  ibooker.setCurrentFolder(monitorName_ + "Service");
-  {
-    auto scope = DQMStore::IBooker::UseLumiScope(ibooker);
-    theValuesContainer_ = ibooker.bookProfile("hHistoLumiValues",
-                                              "Histo Lumi Values",
-                                              3 * numberOfValuesToSave_,
-                                              0.,
-                                              3 * numberOfValuesToSave_,
-                                              100.,
-                                              -100.,
-                                              9000.,
-                                              " ");
-  }
 
+  //Making histos per Lumi
+  // x,y,z,sigmaX,sigmaY,sigmaZ
+     for (map<string, map<string, MonitorElement*> >::iterator itMM = itM->second.begin(); itMM != itM->second.end();
+         itMM++) {
+      if (itMM->first != "run") {
+        for (map<string, MonitorElement*>::iterator itMMM = itMM->second.begin(); itMMM != itMM->second.end();
+             itMMM++) {
+          name = string("h") + itM->first + itMMM->first;
+          title = itM->first + "_{0} " + itMMM->first;
+          if (itMM->first == "lumi") {      
+            ibooker.setCurrentFolder(monitorName_ + "Debug");    
+            itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
+            itMMM->second->setEfficiencyFlag();
+          } else if (itMM->first == "validation" && itMMM->first == "Lumibased Scalers-DataBase fit") {
+            ibooker.setCurrentFolder(monitorName_ + "Validation");
+            itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
+            itMMM->second->setEfficiencyFlag();
+          } else if (itMM->first == "validation" && itMMM->first != "Lumibased Scalers-DataBase fit" &&
+                     (itM->first == "x" || itM->first == "y" || itM->first == "z")) {
+            ibooker.setCurrentFolder(monitorName_ + "Validation");
+            itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
+            itMMM->second->setEfficiencyFlag();
+          } else if (itMM->first == "validation" &&
+                     (itM->first == "sigmaX" || itM->first == "sigmaY" || itM->first == "sigmaZ")) {
+            ibooker.setCurrentFolder(monitorName_ + "Validation");
+            itMMM->second = nullptr;
+          } else {
+            LogInfo("AlcaBeamMonitorClient") << "Unrecognized category " << itMM->first;
+            // assert(0);
+          }
+          if (itMMM->second != nullptr) {
+            if (itMMM->first.find('-') != string::npos) {
+              itMMM->second->setAxisTitle(string("#Delta ") + itM->first + "_{0} (cm)", 2);
+            } else {
+              itMMM->second->setAxisTitle(itM->first + "_{0} (cm)", 2);
+            }
+            itMMM->second->setAxisTitle("Lumisection", 1);
+          }
+        }
+      }
+    }
+  
+ }
+ 
   // create and cd into new folder
   ibooker.setCurrentFolder(monitorName_ + "Validation");
   //Book histograms
@@ -199,20 +220,19 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitor::dqmBeginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
   vertices_.clear();
-  theValuesContainer_->Reset();
   beamSpotsMap_.clear();
-
+  processedLumis_.push_back(iLumi.id().luminosityBlock());
   //Read BeamSpot from DB
   ESHandle<BeamSpotObjects> bsDBHandle;
   try {
     iSetup.get<BeamSpotObjectsRcd>().get(bsDBHandle);
   } catch (cms::Exception& exception) {
     LogInfo("AlcaBeamMonitor") << exception.what();
-    return;
+    return nullptr;
   }
   if (bsDBHandle.isValid()) {  // check the product
     const BeamSpotObjects* spotDB = bsDBHandle.product();
@@ -247,6 +267,7 @@ void AlcaBeamMonitor::dqmBeginLuminosityBlock(const LuminosityBlock& iLumi, cons
   } else {
     LogInfo("AlcaBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
   }
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -279,8 +300,8 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
     try {
       iEvent.getByToken(scalerLabel_, recoBeamSpotHandle);
     } catch (cms::Exception& exception) {
-      LogInfo("AlcaBeamMonitor") << exception.what();
-      return;
+      LogInfo("AlcaBeamMonitor") << exception.what();  
+      return;    
     }
     beamSpotsMap_["SC"] = *recoBeamSpotHandle;
     if (beamSpotsMap_["SC"].BeamWidthX() != 0) {
@@ -292,7 +313,9 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void AlcaBeamMonitor::dqmEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+  //int nLumis = numberOfProcessedLumis_;
+
   if (theBeamFitter_->runPVandTrkFitter()) {
     beamSpotsMap_["BF"] = theBeamFitter_->getBeamSpot();
   }
@@ -310,7 +333,6 @@ void AlcaBeamMonitor::dqmEndLuminosityBlock(const LuminosityBlock& iLumi, const 
   map<std::string, pair<double, double> > resultsMap;
   vector<pair<double, double> > vertexResults;
   MonitorElement* histo = nullptr;
-  int position = 0;
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     resultsMap.clear();
     for (BeamSpotContainer::iterator itBS = beamSpotsMap_.begin(); itBS != beamSpotsMap_.end(); itBS++) {
@@ -354,32 +376,11 @@ void AlcaBeamMonitor::dqmEndLuminosityBlock(const LuminosityBlock& iLumi, const 
         }
       }
     }
-    /*
-  histoByCategoryNames_.insert( pair<string,string>("run",        "Coordinate"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex fit-DataBase"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex fit-BeamFit"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex fit-Scalers"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex-DataBase"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex-BeamFit"));
-  histoByCategoryNames_.insert( pair<string,string>("run",        "PrimaryVertex-Scalers"));
-
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased BeamSpotFit"));  
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased PrimaryVertex"));
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased DataBase"));     
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased Scalers"));      
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased PrimaryVertex-DataBase fit"));
-  histoByCategoryNames_.insert( pair<string,string>("lumi",       "Lumibased PrimaryVertex-Scalers fit"));
-  histoByCategoryNames_.insert( pair<string,string>("validation", "Lumibased Scalers-DataBase fit"));
-  histoByCategoryNames_.insert( pair<string,string>("validation", "Lumibased PrimaryVertex-DataBase"));
-  histoByCategoryNames_.insert( pair<string,string>("validation", "Lumibased PrimaryVertex-Scalers"));
-*/
+ 
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
-         itM++) {
-      if (itM->first == "run" && (histo = histosMap_[*itV][itM->first][itM->second]) == nullptr) {
+         itM++) {     
+       if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr) 
         continue;
-      } else if (itM->first != "run") {
-        position = positionsMap_[*itV][itM->first][itM->second];
-      }
       if (itM->second == "Coordinate") {
         if (beamSpotsMap_.find("DB") != beamSpotsMap_.end()) {
           histo->Fill(resultsMap["DB"].first);
@@ -414,98 +415,68 @@ void AlcaBeamMonitor::dqmEndLuminosityBlock(const LuminosityBlock& iLumi, const 
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
-            histo->Fill(itPV->first - resultsMap["SC"].first);
+            histo->Fill(itPV->first - resultsMap["SC"].first);            
           }
         }
       } else if (itM->second == "Lumibased BeamSpotFit") {
-        if (resultsMap.find("BF") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["BF"].first);       //Value
-          theValuesContainer_->Fill(position + 1, resultsMap["BF"].second);  //Error
-          theValuesContainer_->Fill(position + 2, 1);                        //ok
+        if (resultsMap.find("BF") != resultsMap.end()) {          
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["BF"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["BF"].second);
         }
       } else if (itM->second == "Lumibased PrimaryVertex") {
         if (resultsMap.find("PV") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["PV"].first);       //Value
-          theValuesContainer_->Fill(position + 1, resultsMap["PV"].second);  //Error
-          theValuesContainer_->Fill(position + 2, 1);                        //ok
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["PV"].second);          
         }
       } else if (itM->second == "Lumibased DataBase") {
         if (resultsMap.find("DB") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["DB"].first);       //Value
-          theValuesContainer_->Fill(position + 1, resultsMap["DB"].second);  //Error
-          theValuesContainer_->Fill(position + 2, 1);                        //ok
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["DB"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["DB"].second);           
         }
       } else if (itM->second == "Lumibased Scalers") {
         if (resultsMap.find("SC") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["SC"].first);       //Value
-          theValuesContainer_->Fill(position + 1, resultsMap["SC"].second);  //Error
-          theValuesContainer_->Fill(position + 2, 1);                        //ok
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);                        
         }
       } else if (itM->second == "Lumibased PrimaryVertex-DataBase fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["PV"].first - resultsMap["DB"].first);  //Value
-          theValuesContainer_->Fill(
-              position + 1,
-              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));  //Error
-          theValuesContainer_->Fill(position + 2, 1);                                                   //ok
+           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["DB"].first);
+           histo->setBinError(iLumi.id().luminosityBlock(), std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));                                               //ok
         }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["PV"].first - resultsMap["SC"].first);  //Value
-          theValuesContainer_->Fill(
-              position + 1,
-              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));  //Error
-          theValuesContainer_->Fill(position + 2, 1);                                                   //ok
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["SC"].first);   
+          histo->setBinError(iLumi.id().luminosityBlock(), std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));       
         }
       } else if (itM->second == "Lumibased Scalers-DataBase fit") {
         if (resultsMap.find("SC") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
-          theValuesContainer_->Fill(position, resultsMap["SC"].first - resultsMap["DB"].first);  //Value
-          theValuesContainer_->Fill(
-              position + 1,
-              std::sqrt(std::pow(resultsMap["SC"].second, 2) + std::pow(resultsMap["DB"].second, 2)));  //Error
-          theValuesContainer_->Fill(position + 2, 1);                                                   //ok
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first - resultsMap["DB"].first);  
+          histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow(resultsMap["SC"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
         }
       } else if (itM->second == "Lumibased PrimaryVertex-DataBase") {
         if (resultsMap.find("DB") != resultsMap.end() && !vertexResults.empty()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
-            theValuesContainer_->Fill(position, (*itPV).first - resultsMap["DB"].first);  //Value
+            histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["DB"].first);
+            //We need to evaluate the error            
+            histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["DB"].second,2)));
+          //this was the original code ...
+          //theValuesContainer_->Fill(position + 1,
+                                    //theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error
+            
           }
-          /*
-          double error = 0;
-	  if(vertexResults.size() != 0){
-	    for(vector<pair<double,double> >::iterator itPV=vertexResults.begin(); itPV!=vertexResults.end(); itPV++){
-              error += std::pow((*itPV).first-resultsMap["DB"].first-theValuesContainer_->getTProfile()->GetBinContent(position+1),2.);
-            }
-	    error = std::sqrt(error)/vertexResults.size();
-	  }
-//          theValuesContainer_->Fill(position+1,std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["DB"].second,2)));//Error	  
-          theValuesContainer_->Fill(position+1,error);//Error	  
-*/
-          theValuesContainer_->Fill(position + 1,
-                                    theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error
-          theValuesContainer_->Fill(position + 2, 1);                                                //ok
-        }
+       }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers") {
         if (resultsMap.find("SC") != resultsMap.end() && !vertexResults.empty()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
-            theValuesContainer_->Fill(position, (*itPV).first - resultsMap["SC"].first);  //Value
+                 histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["SC"].first);
+            //We need to evaluate the error            
+            histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["SC"].second,2)));
+          //this was the original code ...
+          //theValuesContainer_->Fill(position + 1,
+                                    //theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error            
           }
-          /*
-          double error = 0;
-	  if(vertexResults.size() != 0){
-	    for(vector<pair<double,double> >::iterator itPV=vertexResults.begin(); itPV!=vertexResults.end(); itPV++){
-              error += std::pow((*itPV).first-resultsMap["SC"].first-theValuesContainer_->getTProfile()->GetBinContent(position+1),2.);
-            }
-	    error = std::sqrt(error)/vertexResults.size();
-	  }
-//          theValuesContainer_->Fill(position+1,std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["SC"].second,2)));//Error	  
-          theValuesContainer_->Fill(position+1,error);//Error	  
-*/
-          theValuesContainer_->Fill(position + 1,
-                                    theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error
-          theValuesContainer_->Fill(position + 2, 1);                                                //ok
         }
       }
       //      else if(itM->second == "Lumibased Scalers-DataBase"){
@@ -522,4 +493,89 @@ void AlcaBeamMonitor::dqmEndLuminosityBlock(const LuminosityBlock& iLumi, const 
   }
 }
 
+void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
+  const double bigNumber = 1000000.;
+  std::sort(processedLumis_.begin(), processedLumis_.end());
+  int firstLumi = *processedLumis_.begin();
+  int lastLumi = *(--processedLumis_.end());
+  
+  for (HistosContainer::iterator itH = histosMap_.begin(); itH != histosMap_.end(); itH++) {
+    for (map<string, map<string, MonitorElement*> >::iterator itHH = itH->second.begin(); itHH != itH->second.end();
+         itHH++) {
+      double min = bigNumber;
+      double max = -bigNumber;
+      double minDelta = bigNumber;
+      double maxDelta = -bigNumber;
+      //      double minDeltaProf = bigNumber;
+      //      double maxDeltaProf = -bigNumber;
+      if (itHH->first != "run") {
+        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
+             itHHH++) {
+          if (itHHH->second != nullptr) {                       
+            for (int bin = 1; bin <= itHHH->second->getTH1()->GetNbinsX(); bin++) {
+              if (itHHH->second->getTH1()->GetBinError(bin) != 0 || itHHH->second->getTH1()->GetBinContent(bin) != 0) {
+                if (itHHH->first == "Lumibased BeamSpotFit" || itHHH->first == "Lumibased PrimaryVertex" ||
+                    itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Scalers") {
+                  if (min > itHHH->second->getTH1()->GetBinContent(bin)) {
+                    min = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                  if (max < itHHH->second->getTH1()->GetBinContent(bin)) {
+                    max = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                } else if (itHHH->first == "Lumibased PrimaryVertex-DataBase fit" ||
+                           itHHH->first == "Lumibased PrimaryVertex-Scalers fit" ||
+                           itHHH->first == "Lumibased Scalers-DataBase fit" ||
+                           itHHH->first == "Lumibased PrimaryVertex-DataBase" ||
+                           itHHH->first == "Lumibased PrimaryVertex-Scalers") {
+                  if (minDelta > itHHH->second->getTH1()->GetBinContent(bin)) {
+                    minDelta = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                  if (maxDelta < itHHH->second->getTH1()->GetBinContent(bin)) {
+                    maxDelta = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                } else {
+                  LogInfo("AlcaBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
+                                                   << " that I can't recognize in this loop!";
+                  // assert(0);
+                }
+              }
+            }            
+          }
+        }
+        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
+             itHHH++) {
+          if (itHHH->second != nullptr) {
+            if (itHHH->first == "Lumibased BeamSpotFit" || itHHH->first == "Lumibased PrimaryVertex" ||
+                itHHH->first == "Lumibased DataBase" || itHHH->first == "Lumibased Scalers") {
+              if ((max == -bigNumber && min == bigNumber) || max - min == 0) {
+                itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
+                itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);
+              } else {
+                itHHH->second->getTH1()->SetMinimum(min - 0.1 * (max - min));
+                itHHH->second->getTH1()->SetMaximum(max + 0.1 * (max - min));
+              }
+            } else if (itHHH->first == "Lumibased PrimaryVertex-DataBase fit" ||
+                       itHHH->first == "Lumibased PrimaryVertex-Scalers fit" ||
+                       itHHH->first == "Lumibased Scalers-DataBase fit" ||
+                       itHHH->first == "Lumibased PrimaryVertex-DataBase" ||
+                       itHHH->first == "Lumibased PrimaryVertex-Scalers") {
+              if ((maxDelta == -bigNumber && minDelta == bigNumber) || maxDelta - minDelta == 0) {
+                itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
+                itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);
+              } else {
+                itHHH->second->getTH1()->SetMinimum(minDelta - 2 * (maxDelta - minDelta));
+                itHHH->second->getTH1()->SetMaximum(maxDelta + 2 * (maxDelta - minDelta));
+              }
+            } else {
+              LogInfo("AlcaBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
+                                               << " that I can't recognize in this loop!";
+            }
+            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi-0.5,lastLumi+0.5);
+          }
+        }
+      }
+    }
+  }
+ 
+}
 DEFINE_FWK_MODULE(AlcaBeamMonitor);

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -74,11 +74,11 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
-    
+
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
          itM++) {
-      histosMap_[*itV][itM->first][itM->second] = nullptr;     
+      histosMap_[*itV][itM->first][itM->second] = nullptr;
     }
   }
 }
@@ -198,7 +198,7 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         }
       }
     }
- }
+  }
 
   // create and cd into new folder
   ibooker.setCurrentFolder(monitorName_ + "Validation");
@@ -213,8 +213,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi, 
-                                                                    const EventSetup& iSetup) const {
+std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi,
+                                                                     const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
   vertices_.clear();
@@ -308,7 +308,6 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
-
   if (theBeamFitter_->runPVandTrkFitter()) {
     beamSpotsMap_["BF"] = theBeamFitter_->getBeamSpot();
   }
@@ -412,14 +411,14 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
           }
         }
       } else if (itM->second == "Lumibased BeamSpotFit") {
-        if (resultsMap.find("BF") != resultsMap.end()) {          
+        if (resultsMap.find("BF") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["BF"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["BF"].second);
         }
       } else if (itM->second == "Lumibased PrimaryVertex") {
         if (resultsMap.find("PV") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["PV"].second);         
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["PV"].second);
         }
       } else if (itM->second == "Lumibased DataBase") {
         if (resultsMap.find("DB") != resultsMap.end()) {
@@ -429,18 +428,18 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
       } else if (itM->second == "Lumibased Scalers") {
         if (resultsMap.find("SC") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);                       
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);
         }
       } else if (itM->second == "Lumibased PrimaryVertex-DataBase fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
-           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["DB"].first);
-           histo->setBinError(iLumi.id().luminosityBlock(), 
-                              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["DB"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(),
+                             std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
         }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["SC"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), 
+          histo->setBinError(iLumi.id().luminosityBlock(),
                              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));
         }
       } else if (itM->second == "Lumibased Scalers-DataBase fit") {
@@ -455,7 +454,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
                itPV++) {
             histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["DB"].first);
             histo->setBinError(iLumi.id().luminosityBlock(),
-                               std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["DB"].second,2)));
+                               std::sqrt(std::pow((*itPV).second, 2) + std::pow(resultsMap["DB"].second, 2)));
           }
         }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers") {
@@ -464,7 +463,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
                itPV++) {
             histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["SC"].first);
             histo->setBinError(iLumi.id().luminosityBlock(),
-                               std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["SC"].second,2)));
+                               std::sqrt(std::pow((*itPV).second, 2) + std::pow(resultsMap["SC"].second, 2)));
           }
         }
       }
@@ -528,7 +527,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
                   // assert(0);
                 }
               }
-            }        
+            }
           }
         }
         for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
@@ -559,7 +558,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
               LogInfo("AlcaBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
                                                << " that I can't recognize in this loop!";
             }
-            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5,lastLumi + 0.5);
+            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
           }
         }
       }

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -12,15 +12,17 @@
 #include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 //#include "DataFormats/Scalers/interface/BeamSpotOnline.h"
-#include "DataFormats/Common/interface/View.h"
+#include "DQM/BeamMonitor/plugins/AlcaBeamMonitor.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
 #include "RecoVertex/BeamSpotProducer/interface/PVFitter.h"
-#include "DQM/BeamMonitor/plugins/AlcaBeamMonitor.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include <memory>
+
 #include <numeric>
 
 using namespace std;
@@ -40,13 +42,13 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   if (!monitorName_.empty())
     monitorName_ = monitorName_ + "/";
 
-  theBeamFitter_ = std::unique_ptr<BeamFitter>(new BeamFitter(parameters_, consumesCollector()));
+  theBeamFitter_ = std::make_unique<BeamFitter>(parameters_, consumesCollector());
   theBeamFitter_->resetTrkVector();
   theBeamFitter_->resetLSRange();
   theBeamFitter_->resetRefTime();
   theBeamFitter_->resetPVFitter();
 
-  thePVFitter_ = std::unique_ptr<PVFitter>(new PVFitter(parameters_, consumesCollector()));
+  thePVFitter_ = std::make_unique<PVFitter>(parameters_, consumesCollector());
 
   processedLumis_.clear();
 

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -74,24 +74,18 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased Scalers-DataBase fit"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-DataBase"));
   histoByCategoryNames_.insert(pair<string, string>("validation", "Lumibased PrimaryVertex-Scalers"));
-  
-  
+    
   for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
          itM++) {
-        histosMap_[*itV][itM->first][itM->second] = nullptr;     
+      histosMap_[*itV][itM->first][itM->second] = nullptr;     
     }
   }
 }
-      
-AlcaBeamMonitor::~AlcaBeamMonitor() {
-  //if (theBeamFitter_ != nullptr) {
-    delete theBeamFitter_;
- // }
 
- // if (thePVFitter_ != nullptr) {
-    delete thePVFitter_;
- // }
+AlcaBeamMonitor::~AlcaBeamMonitor() {
+  delete theBeamFitter_;
+  delete thePVFitter_;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -163,17 +157,17 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
       }
     }
 
-  //Making histos per Lumi
-  // x,y,z,sigmaX,sigmaY,sigmaZ
-     for (map<string, map<string, MonitorElement*> >::iterator itMM = itM->second.begin(); itMM != itM->second.end();
+    //Making histos per Lumi
+    // x,y,z,sigmaX,sigmaY,sigmaZ
+    for (map<string, map<string, MonitorElement*> >::iterator itMM = itM->second.begin(); itMM != itM->second.end();
          itMM++) {
       if (itMM->first != "run") {
         for (map<string, MonitorElement*>::iterator itMMM = itMM->second.begin(); itMMM != itMM->second.end();
              itMMM++) {
           name = string("h") + itM->first + itMMM->first;
           title = itM->first + "_{0} " + itMMM->first;
-          if (itMM->first == "lumi") {      
-            ibooker.setCurrentFolder(monitorName_ + "Debug");    
+          if (itMM->first == "lumi") {
+            ibooker.setCurrentFolder(monitorName_ + "Debug");
             itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
             itMMM->second->setEfficiencyFlag();
           } else if (itMM->first == "validation" && itMMM->first == "Lumibased Scalers-DataBase fit") {
@@ -204,9 +198,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
         }
       }
     }
-  
  }
- 
+
   // create and cd into new folder
   ibooker.setCurrentFolder(monitorName_ + "Validation");
   //Book histograms
@@ -220,7 +213,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) const {
+std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi, 
+                                                                    const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
   vertices_.clear();
@@ -300,8 +294,8 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
     try {
       iEvent.getByToken(scalerLabel_, recoBeamSpotHandle);
     } catch (cms::Exception& exception) {
-      LogInfo("AlcaBeamMonitor") << exception.what();  
-      return;    
+      LogInfo("AlcaBeamMonitor") << exception.what();
+      return;
     }
     beamSpotsMap_["SC"] = *recoBeamSpotHandle;
     if (beamSpotsMap_["SC"].BeamWidthX() != 0) {
@@ -314,7 +308,6 @@ void AlcaBeamMonitor::analyze(const Event& iEvent, const EventSetup& iSetup) {
 
 //----------------------------------------------------------------------------------------------------------------------
 void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
-  //int nLumis = numberOfProcessedLumis_;
 
   if (theBeamFitter_->runPVandTrkFitter()) {
     beamSpotsMap_["BF"] = theBeamFitter_->getBeamSpot();
@@ -376,10 +369,10 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
         }
       }
     }
- 
+
     for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
-         itM++) {     
-       if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr) 
+         itM++) {
+      if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr)
         continue;
       if (itM->second == "Coordinate") {
         if (beamSpotsMap_.find("DB") != beamSpotsMap_.end()) {
@@ -415,7 +408,7 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
-            histo->Fill(itPV->first - resultsMap["SC"].first);            
+            histo->Fill(itPV->first - resultsMap["SC"].first);
           }
         }
       } else if (itM->second == "Lumibased BeamSpotFit") {
@@ -426,56 +419,52 @@ void AlcaBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, con
       } else if (itM->second == "Lumibased PrimaryVertex") {
         if (resultsMap.find("PV") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["PV"].second);          
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["PV"].second);         
         }
       } else if (itM->second == "Lumibased DataBase") {
         if (resultsMap.find("DB") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["DB"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["DB"].second);           
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["DB"].second);
         }
       } else if (itM->second == "Lumibased Scalers") {
         if (resultsMap.find("SC") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first);
-          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);                        
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["SC"].second);                       
         }
       } else if (itM->second == "Lumibased PrimaryVertex-DataBase fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
            histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["DB"].first);
-           histo->setBinError(iLumi.id().luminosityBlock(), std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));                                               //ok
+           histo->setBinError(iLumi.id().luminosityBlock(), 
+                              std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
         }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers fit") {
         if (resultsMap.find("PV") != resultsMap.end() && resultsMap.find("SC") != resultsMap.end()) {
-          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["SC"].first);   
-          histo->setBinError(iLumi.id().luminosityBlock(), std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));       
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["PV"].first - resultsMap["SC"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), 
+                             std::sqrt(std::pow(resultsMap["PV"].second, 2) + std::pow(resultsMap["SC"].second, 2)));
         }
       } else if (itM->second == "Lumibased Scalers-DataBase fit") {
         if (resultsMap.find("SC") != resultsMap.end() && resultsMap.find("DB") != resultsMap.end()) {
-          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first - resultsMap["DB"].first);  
-          histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow(resultsMap["SC"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["SC"].first - resultsMap["DB"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(),
+                             std::sqrt(std::pow(resultsMap["SC"].second, 2) + std::pow(resultsMap["DB"].second, 2)));
         }
       } else if (itM->second == "Lumibased PrimaryVertex-DataBase") {
         if (resultsMap.find("DB") != resultsMap.end() && !vertexResults.empty()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
             histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["DB"].first);
-            //We need to evaluate the error            
-            histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["DB"].second,2)));
-          //this was the original code ...
-          //theValuesContainer_->Fill(position + 1,
-                                    //theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error
-            
+            histo->setBinError(iLumi.id().luminosityBlock(),
+                               std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["DB"].second,2)));
           }
-       }
+        }
       } else if (itM->second == "Lumibased PrimaryVertex-Scalers") {
         if (resultsMap.find("SC") != resultsMap.end() && !vertexResults.empty()) {
           for (vector<pair<double, double> >::iterator itPV = vertexResults.begin(); itPV != vertexResults.end();
                itPV++) {
-                 histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["SC"].first);
-            //We need to evaluate the error            
-            histo->setBinError(iLumi.id().luminosityBlock(),std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["SC"].second,2)));
-          //this was the original code ...
-          //theValuesContainer_->Fill(position + 1,
-                                    //theValuesContainer_->getTProfile()->GetBinError(position + 1));  //Error            
+            histo->setBinContent(iLumi.id().luminosityBlock(), (*itPV).first - resultsMap["SC"].first);
+            histo->setBinError(iLumi.id().luminosityBlock(),
+                               std::sqrt(std::pow((*itPV).second,2)+std::pow(resultsMap["SC"].second,2)));
           }
         }
       }
@@ -498,7 +487,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
   std::sort(processedLumis_.begin(), processedLumis_.end());
   int firstLumi = *processedLumis_.begin();
   int lastLumi = *(--processedLumis_.end());
-  
+
   for (HistosContainer::iterator itH = histosMap_.begin(); itH != histosMap_.end(); itH++) {
     for (map<string, map<string, MonitorElement*> >::iterator itHH = itH->second.begin(); itHH != itH->second.end();
          itHH++) {
@@ -511,7 +500,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
       if (itHH->first != "run") {
         for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
              itHHH++) {
-          if (itHHH->second != nullptr) {                       
+          if (itHHH->second != nullptr) {
             for (int bin = 1; bin <= itHHH->second->getTH1()->GetNbinsX(); bin++) {
               if (itHHH->second->getTH1()->GetBinError(bin) != 0 || itHHH->second->getTH1()->GetBinContent(bin) != 0) {
                 if (itHHH->first == "Lumibased BeamSpotFit" || itHHH->first == "Lumibased PrimaryVertex" ||
@@ -539,7 +528,7 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
                   // assert(0);
                 }
               }
-            }            
+            }        
           }
         }
         for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
@@ -570,12 +559,11 @@ void AlcaBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
               LogInfo("AlcaBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
                                                << " that I can't recognize in this loop!";
             }
-            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi-0.5,lastLumi+0.5);
+            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5,lastLumi + 0.5);
           }
         }
       }
     }
   }
- 
 }
 DEFINE_FWK_MODULE(AlcaBeamMonitor);

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -40,13 +40,13 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
   if (!monitorName_.empty())
     monitorName_ = monitorName_ + "/";
 
-  theBeamFitter_ = new BeamFitter(parameters_, consumesCollector());
+  theBeamFitter_ = std::unique_ptr<BeamFitter>(new BeamFitter(parameters_, consumesCollector()));
   theBeamFitter_->resetTrkVector();
   theBeamFitter_->resetLSRange();
   theBeamFitter_->resetRefTime();
   theBeamFitter_->resetPVFitter();
 
-  thePVFitter_ = new PVFitter(parameters_, consumesCollector());
+  thePVFitter_ = std::unique_ptr<PVFitter>(new PVFitter(parameters_, consumesCollector()));
 
   processedLumis_.clear();
 
@@ -81,11 +81,6 @@ AlcaBeamMonitor::AlcaBeamMonitor(const ParameterSet& ps)
       histosMap_[*itV][itM->first][itM->second] = nullptr;
     }
   }
-}
-
-AlcaBeamMonitor::~AlcaBeamMonitor() {
-  delete theBeamFitter_;
-  delete thePVFitter_;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -213,8 +208,8 @@ void AlcaBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker, edm::Run const&
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-std::shared_ptr<NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi,
-                                                                     const EventSetup& iSetup) const {
+std::shared_ptr<alcabeammonitor::NoCache> AlcaBeamMonitor::globalBeginLuminosityBlock(const LuminosityBlock& iLumi,
+                                                                                      const EventSetup& iSetup) const {
   // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
 
   vertices_.clear();

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -4,7 +4,7 @@
 /** \class AlcaBeamMonitor
  * *
  *  \author  Lorenzo Uplegger/FNAL
- *   
+ *   modified by Simone Gennai INFN/Bicocca
  */
 // C++
 #include <map>
@@ -24,7 +24,9 @@
 class BeamFitter;
 class PVFitter;
 
-class AlcaBeamMonitor : public DQMOneLumiEDAnalyzer<> {
+struct NoCache {};
+
+class AlcaBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<NoCache>> {
 public:
   AlcaBeamMonitor(const edm::ParameterSet&);
   ~AlcaBeamMonitor() override;
@@ -32,9 +34,10 @@ public:
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  void dqmBeginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
-  void dqmEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
-
+  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
+  
 private:
   //Typedefs
   //                BF,BS...
@@ -56,19 +59,21 @@ private:
   int numberOfValuesToSave_;
   BeamFitter* theBeamFitter_;
   PVFitter* thePVFitter_;
+  mutable int numberOfProcessedLumis_;
+  mutable std::vector<int> processedLumis_;
 
   // MonitorElements:
   MonitorElement* hD0Phi0_;
   MonitorElement* hDxyBS_;
-  MonitorElement* theValuesContainer_;
+  //mutable MonitorElement* theValuesContainer_;
 
   //Containers
-  BeamSpotContainer beamSpotsMap_;
+  mutable BeamSpotContainer beamSpotsMap_;
   HistosContainer histosMap_;
   PositionContainer positionsMap_;
   std::vector<std::string> varNamesV_;                            //x,y,z,sigmax(y,z)
   std::multimap<std::string, std::string> histoByCategoryNames_;  //run, lumi
-  std::vector<reco::VertexCollection> vertices_;
+  mutable std::vector<reco::VertexCollection> vertices_;
 };
 
 #endif

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -24,18 +24,19 @@
 class BeamFitter;
 class PVFitter;
 
-struct NoCache {};
+namespace alcabeammonitor {
+  struct NoCache {};
+}  // namespace alcabeammonitor
 
-class AlcaBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<NoCache>> {
+class AlcaBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<alcabeammonitor::NoCache>> {
 public:
   AlcaBeamMonitor(const edm::ParameterSet&);
-  ~AlcaBeamMonitor() override;
 
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
-                                                      const edm::EventSetup& iSetup) const override;
+  std::shared_ptr<alcabeammonitor::NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
+                                                                       const edm::EventSetup& iSetup) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
 
@@ -58,8 +59,8 @@ private:
 
   //Service variables
   int numberOfValuesToSave_;
-  BeamFitter* theBeamFitter_;
-  PVFitter* thePVFitter_;
+  std::unique_ptr<BeamFitter> theBeamFitter_;
+  std::unique_ptr<PVFitter> thePVFitter_;
   mutable int numberOfProcessedLumis_;
   mutable std::vector<int> processedLumis_;
 

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -34,7 +34,7 @@ public:
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi, 
+  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
                                                       const edm::EventSetup& iSetup) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;

--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.h
@@ -34,18 +34,19 @@ public:
 protected:
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) const override;
+  std::shared_ptr<NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi, 
+                                                      const edm::EventSetup& iSetup) const override;
   void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
-  
+
 private:
   //Typedefs
   //                BF,BS...
   typedef std::map<std::string, reco::BeamSpot> BeamSpotContainer;
   //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name
-  typedef std::map<std::string, std::map<std::string, std::map<std::string, MonitorElement*> > > HistosContainer;
+  typedef std::map<std::string, std::map<std::string, std::map<std::string, MonitorElement*>>> HistosContainer;
   //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name
-  typedef std::map<std::string, std::map<std::string, std::map<std::string, int> > > PositionContainer;
+  typedef std::map<std::string, std::map<std::string, std::map<std::string, int>>> PositionContainer;
 
   //Parameters
   edm::ParameterSet parameters_;

--- a/DQM/BeamMonitor/test/Alca_BeamMonitor_file.py
+++ b/DQM/BeamMonitor/test/Alca_BeamMonitor_file.py
@@ -4,10 +4,37 @@ process = cms.Process("DQM")
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-'/store/relval/CMSSW_3_8_0/MinimumBias/ALCARECO/GR_R_38X_V7_RelVal_col_10_bs_TkAlMinBias-v1/0007/90B6F8D6-4E96-DF11-B3A9-0018F3D0970A.root',
-'/store/relval/CMSSW_3_8_0/MinimumBias/ALCARECO/GR_R_38X_V7_RelVal_col_10_bs_TkAlMinBias-v1/0007/8A6CDD40-C995-DF11-B6D5-0018F3D096AA.root'
+         #"file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/07CBA04E-BEA0-AE4B-A9F1-3C6DF122B40E.root",
+         #"file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0869AF69-CD0D-6F45-B1C7-FC1BF3AC7A01.root",
+                    "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0874B9E6-DAA6-3148-8A8A-4A323D682591.root",
+#                                                                   "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0E38963B-7E4A-9447-A56F-7E87903E2ED4.root",
+                    "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0E497339-C393-ED4A-8FA6-E372183A841F.root",
+                    "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0F68686E-FE48-7F42-AF13-6F9F058D7BB6.root",
+        "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0874B9E6-DAA6-3148-8A8A-4A323D682591.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0E38963B-7E4A-9447-A56F-7E87903E2ED4.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0E497339-C393-ED4A-8FA6-E372183A841F.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/0F68686E-FE48-7F42-AF13-6F9F058D7BB6.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/11F4A099-8675-D248-B648-B39C866557DD.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/120196ED-8F8F-A044-8037-3B7416D9B273.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/1386E376-340A-964E-ADFC-F30D662B4DD8.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/159017AF-F91B-FC48-88FC-0BEF7C3C36F1.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/15A187C2-B285-B54D-9BDF-DB34CCCA9480.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/1789D57E-0D78-A342-BCDD-F3DC1193AF77.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/17F827A5-F84D-6D40-AB10-A1B11EA74CAC.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/1985F374-DBC9-5F4F-A52D-93FBB031FA5F.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/19DE7ADA-C714-9141-946B-311861E05DCE.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/1C7884AD-B58B-F441-959A-3EFC70EBECB0.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/1D4C6C74-E523-E84B-916F-5E9509837053.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/213103A9-2731-F740-B718-189C9D94750F.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/23A6C766-D39F-5F44-B017-D0CD2B42C398.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/26005441-0069-B24E-B040-91F00D129557.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/28CF7DC0-A45E-0248-938F-764FC31853B1.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/29B394F7-6729-3E44-9846-EBB63B2C4B88.root",
+                                                                     "file:/eos/cms/store/data/Run2018D/JetHT/RAW-RECO/JetHTJetPlusHOFilter-12Nov2019_UL2018_rsb-v1/120000/2B9B72F2-06F4-A043-9BDE-5B9C6C454705.root",
+                                                                                                                         
+    
     )
-#    , duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
+    #    , duplicateCheckMode = cms.untracked.string('noDuplicateCheck')
 )
 
 # initialize MessageLogger
@@ -20,55 +47,48 @@ process.MessageLogger.cout = cms.untracked.PSet(
        limit = cms.untracked.int32(0)
     ),
     AlcaBeamMonitor = cms.untracked.PSet(
-        #reportEvery = cms.untracked.int32(100) # every 1000th only
+        reportEvery = cms.untracked.int32(1), # every 1000th only
 	limit = cms.untracked.int32(0)
     )
 )
 #process.MessageLogger.statistics.append('cout')
-
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(2000)
 )
 
-process.load("DQMServices.Core.DQM_cfg")
-process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 process.load("DQM.BeamMonitor.AlcaBeamMonitor_cff")
+
+
 process.load("CondCore.DBCommon.CondDBSetup_cfi")
-
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
-                                        process.CondDBSetup,
-                                        toGet = cms.VPSet(cms.PSet(
-    								   record = cms.string('BeamSpotObjectsRcd'),			        
-#    								   tag = cms.string('BeamSpotObjects_2009_LumiBased_v16_offline') 
-    								   tag = cms.string('BeamSpotObject_ByLumi') 
-    								  )
-						         ),								        
-                                         #connect = cms.string('frontier://cmsfrontier.cern.ch:8000/Frontier/CMS_COND_31X_BEAMSPOT')
-                                         connect = cms.string('sqlite_file:step4.db')
-                                         #connect = cms.string('oracle://cms_orcoff_prod/CMS_COND_31X_BEAMSPOT')
-                                         #connect = cms.string('frontier://PromptProd/CMS_COND_31X_BEAMSPOT')
-                                        )
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+# you may need to set manually the GT in the line below
+#process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
 
 
+# DQM Live Environment
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = 'BeamMonitor'
+process.dqmSaver.tag           = 'BeamMonitor'
 
-process.DQMStore.verbose = 0
-process.DQM.collectorHost = 'cmslpc08.fnal.gov'
-process.DQM.collectorPort = 9190
-process.dqmSaver.dirName = '.'
-process.dqmSaver.convention = 'Offline'
-process.dqmSaver.workflow = '/DQM/TkAlCalibration/ALCARECO'
-process.dqmEnv.subSystemFolder = 'AlcaBeamMonitor'
-process.dqmSaver.saveByRun = 1
-#process.dqmSaver.saveAtJobEnd = True
+process.dqmEnvPixelLess = process.dqmEnv.clone()
+process.dqmEnvPixelLess.subSystemFolder = 'BeamMonitor_PixelLess'
+
+
 
 #import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
 #process.offlineBeamSpotForDQM = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 
 # # summary
 process.options = cms.untracked.PSet(
-    wantSummary = cms.untracked.bool(True)
+    wantSummary = cms.untracked.bool(True),
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32 (4),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2)
+
     )
 
-process.pp = cms.Path(process.AlcaBeamMonitor+process.dqmSaver)
+process.pp = cms.Path(process.alcaBeamMonitor+process.dqmSaver)
 process.schedule = cms.Schedule(process.pp)


### PR DESCRIPTION
#### PR description:

This code fixes the problem related to concurrent lumi sections, using a DQMOneEDAnalyzer.
I have also restructured the way the per lumi plots are made and now the client code (AlcaBeamMonitorClient.*) is basically useless. I kept it for not breaking the harvesting configuration. It can be run harmlessly, though.

I have modified the way some errors are defined, I kept commented the old code for reference.

I have checked if the results are compatible with the old code and while doing it I found out the old code is bugged.
Instead of properly reporting the values per lumi in the histograms the values are the incremental avarage of all the previously analyzed lumisection. It affected only the per lumi plots which as far as I understood they were not so much used (that's why maybe nobody noticed it).

#### PR validation:
I have run the test/AlcaBeam_monitor_file.py to produce the histograms and I have checked they are compatible with the values from the beam spot producers

