### PR TITLE
Add partition number in GEM trigger primitives

### DIFF
--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -17,6 +17,8 @@
 class GEMPadDigi {
 public:
   enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
+  // Newer GE2/1 geometries will have 16 eta partitions
+  // instead of the usual 8.
   enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
   explicit GEMPadDigi(uint16_t pad,
@@ -37,9 +39,6 @@ public:
   int16_t bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
-  // Newer GE2/1 geometries will have 16! eta partitions
-  // instead of the usual 8.
-  void setNPartitions(unsigned nPart) { part_ = nPart; }
   unsigned nPartitions() const { return part_; }
   void print() const;
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigi.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigi.h
@@ -17,8 +17,12 @@
 class GEMPadDigi {
 public:
   enum InValid { ME0InValid = 255, GE11InValid = 255, GE21InValid = 511 };
+  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
-  explicit GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
+  explicit GEMPadDigi(uint16_t pad,
+                      int16_t bx,
+                      enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                      unsigned nPart = NumberPartitions::GE11);
   GEMPadDigi();
 
   bool operator==(const GEMPadDigi& digi) const;
@@ -33,12 +37,18 @@ public:
   int16_t bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
+  // Newer GE2/1 geometries will have 16! eta partitions
+  // instead of the usual 8.
+  void setNPartitions(unsigned nPart) { part_ = nPart; }
+  unsigned nPartitions() const { return part_; }
   void print() const;
 
 private:
   uint16_t pad_;
   int16_t bx_;
   GEMSubDetId::Station station_;
+  // number of eta partitions
+  unsigned part_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigi& digi);

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -19,6 +19,8 @@
 class GEMPadDigiCluster {
 public:
   enum InValid { GE11InValid = 255, GE21InValid = 511 };
+  // Newer GE2/1 geometries will have 16 eta partitions
+  // instead of the usual 8.
   enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
   explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
@@ -38,9 +40,6 @@ public:
   int bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
-  // Newer GE2/1 geometries will have 16! eta partitions
-  // instead of the usual 8.
-  void setNPartitions(unsigned nPart) { part_ = nPart; }
   unsigned nPartitions() const { return part_; }
   void print() const;
 

--- a/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
+++ b/DataFormats/GEMDigi/interface/GEMPadDigiCluster.h
@@ -19,10 +19,12 @@
 class GEMPadDigiCluster {
 public:
   enum InValid { GE11InValid = 255, GE21InValid = 511 };
+  enum NumberPartitions { ME0 = 8, GE11 = 8, GE21 = 8, GE21SplitStrip = 16 };
 
   explicit GEMPadDigiCluster(std::vector<uint16_t> pads,
                              int16_t bx,
-                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11);
+                             enum GEMSubDetId::Station station = GEMSubDetId::Station::GE11,
+                             unsigned nPart = NumberPartitions::GE11);
   GEMPadDigiCluster();
 
   bool operator==(const GEMPadDigiCluster& digi) const;
@@ -36,12 +38,18 @@ public:
   int bx() const { return bx_; }
   GEMSubDetId::Station station() const { return station_; }
 
+  // Newer GE2/1 geometries will have 16! eta partitions
+  // instead of the usual 8.
+  void setNPartitions(unsigned nPart) { part_ = nPart; }
+  unsigned nPartitions() const { return part_; }
   void print() const;
 
 private:
   std::vector<uint16_t> v_;
   int32_t bx_;
   GEMSubDetId::Station station_;
+  // number of eta partitions
+  unsigned part_;
 };
 
 std::ostream& operator<<(std::ostream& o, const GEMPadDigiCluster& digi);

--- a/DataFormats/GEMDigi/src/GEMPadDigi.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigi.cc
@@ -1,10 +1,11 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigi.h"
 #include <iostream>
 
-GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station)
-    : pad_(pad), bx_(bx), station_(station) {}
+GEMPadDigi::GEMPadDigi(uint16_t pad, int16_t bx, enum GEMSubDetId::Station station, unsigned nPart)
+    : pad_(pad), bx_(bx), station_(station), part_(nPart) {}
 
-GEMPadDigi::GEMPadDigi() : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
+GEMPadDigi::GEMPadDigi()
+    : pad_(GE11InValid), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
 // Comparison
 bool GEMPadDigi::operator==(const GEMPadDigi& digi) const {

--- a/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
+++ b/DataFormats/GEMDigi/src/GEMPadDigiCluster.cc
@@ -1,10 +1,14 @@
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include <iostream>
 
-GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads, int16_t bx, enum GEMSubDetId::Station station)
-    : v_(pads), bx_(bx), station_(station) {}
+GEMPadDigiCluster::GEMPadDigiCluster(std::vector<uint16_t> pads,
+                                     int16_t bx,
+                                     enum GEMSubDetId::Station station,
+                                     unsigned nPart)
+    : v_(pads), bx_(bx), station_(station), part_(nPart) {}
 
-GEMPadDigiCluster::GEMPadDigiCluster() : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11) {}
+GEMPadDigiCluster::GEMPadDigiCluster()
+    : v_(std::vector<uint16_t>()), bx_(-99), station_(GEMSubDetId::Station::GE11), part_(NumberPartitions::GE11) {}
 
 // Comparison
 bool GEMPadDigiCluster::operator==(const GEMPadDigiCluster& digi) const {

--- a/DataFormats/GEMDigi/src/classes_def.xml
+++ b/DataFormats/GEMDigi/src/classes_def.xml
@@ -10,10 +10,11 @@
 <class name="MuonDigiCollection<GEMDetId,GEMDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigi" ClassVersion="13">
+<class name="GEMPadDigi" ClassVersion="14">
  <version ClassVersion="11" checksum="426510066"/>
  <version ClassVersion="12" checksum="3838591655"/>
  <version ClassVersion="13" checksum="2944221332"/>
+ <version ClassVersion="14" checksum="1418399352"/>
 </class>
 <class name="std::vector<GEMPadDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigi> >"/>
@@ -21,9 +22,10 @@
 <class name="MuonDigiCollection<GEMDetId,GEMPadDigi>"/>
 <class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMPadDigi> >" splitLevel="0"/>
 
-<class name="GEMPadDigiCluster" ClassVersion="11">
+<class name="GEMPadDigiCluster" ClassVersion="12">
  <version ClassVersion="10" checksum="2569340006"/>
  <version ClassVersion="11" checksum="3372991553"/>
+ <version ClassVersion="12" checksum="533478463"/>
 </class>
 <class name="std::vector<GEMPadDigiCluster>"/>
 <class name="std::map<GEMDetId,std::vector<GEMPadDigiCluster> >"/>
@@ -47,8 +49,8 @@
 <class name="std::vector<GEMVfatStatusDigi>"/>
 <class name="std::map<GEMDetId,std::vector<GEMVfatStatusDigi> >"/>
 <class name="std::pair<GEMDetId,std::vector<GEMVfatStatusDigi> >"/>
-<class name="MuonDigiCollection<GEMDetId,GEMVfatStatusDigi>"/> 
-<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVfatStatusDigi> >" splitLevel="0"/> 
+<class name="MuonDigiCollection<GEMDetId,GEMVfatStatusDigi>"/>
+<class name="edm::Wrapper<MuonDigiCollection<GEMDetId,GEMVfatStatusDigi> >" splitLevel="0"/>
 
 <class name="gem::GEBdata" ClassVersion="3">
   <version ClassVersion="3" checksum="3127786112"/>

--- a/Geometry/GEMGeometry/interface/GEMGeometry.h
+++ b/Geometry/GEMGeometry/interface/GEMGeometry.h
@@ -109,6 +109,10 @@ public:
   /// Add a GEMEtaPartition  to the Geometry
   void add(const GEMEtaPartition* etaPartition);
 
+  bool hasME0() const;
+  bool hasGE11() const;
+  bool hasGE21() const;
+
 private:
   DetContainer theEtaPartitions;
   DetContainer theDets;

--- a/Geometry/GEMGeometry/src/GEMGeometry.cc
+++ b/Geometry/GEMGeometry/src/GEMGeometry.cc
@@ -107,3 +107,9 @@ void GEMGeometry::add(const GEMChamber* chamber) {
   theDetIds.emplace_back(chamber->geographicalId());
   theMap.insert(std::make_pair((chamber->geographicalId()).rawId(), chamber));
 }
+
+bool GEMGeometry::hasME0() const { return station(1, 0) != nullptr and station(-1, 0) != nullptr; }
+
+bool GEMGeometry::hasGE11() const { return station(1, 1) != nullptr and station(-1, 1) != nullptr; }
+
+bool GEMGeometry::hasGE21() const { return station(1, 2) != nullptr and station(-1, 2) != nullptr; }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -45,6 +45,10 @@ void CSCGEMMotherboard::retrieveGEMPads(const GEMPadDigiCollection* gemPads, uns
       GEMDetId roll_id(roll->id());
       auto pads_in_det = gemPads->get(roll_id);
       for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
+        // ignore 16-partition GE2/1 pads
+        if (roll->isGE21() and pad->nPartitions() == GEMPadDigi::GE21SplitStrip)
+          continue;
+
         // ignore invalid pads
         if (!pad->isValid())
           continue;
@@ -63,6 +67,11 @@ void CSCGEMMotherboard::retrieveGEMCoPads() {
   coPads_.clear();
   for (const auto& copad : gemCoPadV) {
     GEMDetId detId(theRegion, 1, theStation, 0, theChamber, 0);
+
+    // ignore 16-partition GE2/1 pads
+    if (detId.isGE21() and copad.first().nPartitions() == GEMPadDigi::GE21SplitStrip)
+      continue;
+
     // only consider matches with same BX
     coPads_[CSCConstants::LCT_CENTRAL_BX + copad.bx(1)].emplace_back(detId.rawId(), copad);
   }

--- a/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/GEMCoPadProcessor.cc
@@ -59,6 +59,10 @@ std::vector<GEMCoPadDigi> GEMCoPadProcessor::run(const GEMPadDigiCollection* in_
       // now let's correlate the pads in two layers of this partition
       const auto& pads_range = (*det_range).second;
       for (auto p = pads_range.first; p != pads_range.second; ++p) {
+        // ignore 16-partition GE2/1 pads
+        if (id.isGE21() and p->nPartitions() == GEMPadDigi::GE21SplitStrip)
+          continue;
+
         // only consider valid pads
         if (!p->isValid())
           continue;
@@ -99,6 +103,10 @@ void GEMCoPadProcessor::declusterize(const GEMPadDigiClusterCollection* in_clust
     const GEMDetId& id = (*detUnitIt).first;
     const auto& range = (*detUnitIt).second;
     for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+      // ignore 16-partition GE2/1 pads
+      if (id.isGE21() and digiIt->nPartitions() == GEMPadDigiCluster::GE21SplitStrip)
+        continue;
+
       // only consider valid clusters
       if (!digiIt->isValid())
         continue;

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -192,6 +192,12 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
     if (part->isME0())
       continue;
 
+    // number of eta partitions
+    auto nPart = GEMPadDigiCluster::NumberPartitions::GE11;
+    if (part->isGE21()) {
+      nPart = GEMPadDigiCluster::NumberPartitions::GE21;
+    }
+
     GEMPadDigiClusters all_pad_clusters;
 
     auto pads = det_pads.get(part->id());
@@ -211,7 +217,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
           cl.push_back((*d).pad());
         } else {
           // put the current cluster in the proto collection
-          GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem());
+          GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem(), nPart);
 
           // check if the output cluster is valid
           checkValid(pad_cluster, part->id());
@@ -228,7 +234,7 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
     // put the last cluster in the proto collection
     if (pads.first != pads.second) {
-      GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem());
+      GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem(), nPart);
 
       // check if the output cluster is valid
       checkValid(pad_cluster, part->id());

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -192,12 +192,6 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
     if (part->isME0())
       continue;
 
-    // number of eta partitions
-    auto nPart = GEMPadDigiCluster::NumberPartitions::GE11;
-    if (part->isGE21()) {
-      nPart = GEMPadDigiCluster::NumberPartitions::GE21;
-    }
-
     GEMPadDigiClusters all_pad_clusters;
 
     auto pads = det_pads.get(part->id());

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -192,6 +192,12 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
     if (part->isME0())
       continue;
 
+    // number of eta partitions
+    auto nPart = GEMPadDigiCluster::NumberPartitions::GE11;
+    if (part->isGE21()) {
+      nPart = GEMPadDigiCluster::NumberPartitions::GE21;
+    }
+
     GEMPadDigiClusters all_pad_clusters;
 
     auto pads = det_pads.get(part->id());

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiClusterProducer.cc
@@ -192,12 +192,6 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
     if (part->isME0())
       continue;
 
-    // number of eta partitions
-    auto nPart = GEMPadDigiCluster::NumberPartitions::GE11;
-    if (part->isGE21()) {
-      nPart = GEMPadDigiCluster::NumberPartitions::GE21;
-    }
-
     GEMPadDigiClusters all_pad_clusters;
 
     auto pads = det_pads.get(part->id());
@@ -207,6 +201,9 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
     for (auto d = pads.first; d != pads.second; ++d) {
       // check if the input pad is valid
       checkValid(*d, part->id());
+
+      // number of eta partitions
+      unsigned nPart = d->nPartitions();
 
       if (cl.empty()) {
         cl.push_back((*d).pad());
@@ -234,6 +231,9 @@ void GEMPadDigiClusterProducer::buildClusters(const GEMPadDigiCollection& det_pa
 
     // put the last cluster in the proto collection
     if (pads.first != pads.second) {
+      // number of eta partitions
+      unsigned nPart = (pads.first)->nPartitions();
+
       GEMPadDigiCluster pad_cluster(cl, startBX, part->subsystem(), nPart);
 
       // check if the output cluster is valid

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -71,8 +71,10 @@ void GEMPadDigiProducer::beginRun(const edm::Run& run, const edm::EventSetup& ev
   edm::ESHandle<GEMGeometry> hGeom = eventSetup.getHandle(geom_token_);
   geometry_ = &*hGeom;
   // check the number of parititions
-  use16GE21_ = (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() ==
-                GEMPadDigi::NumberPartitions::GE21SplitStrip);
+  if (geometry_->hasGE21()) {
+    use16GE21_ = (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() ==
+                  GEMPadDigi::NumberPartitions::GE21SplitStrip);
+  }
 }
 
 void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) {
@@ -152,6 +154,14 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 }
 
 void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
+  // check that GE2/1 has 16-eta partitions
+  if (geometry_->hasGE21()) {
+    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() !=
+        GEMPadDigi::NumberPartitions::GE21SplitStrip) {
+      edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (16 partition) appears corrupted";
+    }
+  }
+
   for (const auto& p : geometry_->etaPartitions()) {
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE1/1

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -185,7 +185,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::Station::GE21, GEMPadDigi::NumberPartitions::GE21SplitStrip);
+      GEMPadDigi pad_digi(d.first, d.second, p->subsystem(), GEMPadDigi::NumberPartitions::GE21SplitStrip);
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -185,7 +185,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, p->subsystem(), GEMPadDigi::NumberPartitions::GE21SplitStrip);
+      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::Station::GE21, GEMPadDigi::NumberPartitions::GE21SplitStrip);
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -92,6 +92,27 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 }
 
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
+  // check that ME0 has 8-eta partitions
+  if (geometry_->hasME0()) {
+    if (geometry_->station(1, 0)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::ME0) {
+      edm::LogError("GEMPadDigiProducer") << "ME0 geometry appears corrupted";
+    }
+  }
+
+  // check that GE1/1 has 8-eta partitions
+  if (geometry_->hasGE11()) {
+    if (geometry_->station(1, 1)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE11) {
+      edm::LogError("GEMPadDigiProducer") << "GE1/1 geometry appears corrupted";
+    }
+  }
+
+  // check that GE2/1 has 8-eta partitions
+  if (geometry_->hasGE21()) {
+    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
+      edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (8 partition) appears corrupted";
+    }
+  }
+
   for (const auto& p : geometry_->etaPartitions()) {
     // when using the GE2/1 geometry with 16 eta partitions
     // ->ignore GE2/1

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -50,7 +50,6 @@ private:
 
 GEMPadDigiProducer::GEMPadDigiProducer(const edm::ParameterSet& ps) : geometry_(nullptr) {
   digis_ = ps.getParameter<edm::InputTag>("InputCollection");
-  use16GE21_ = ps.getParameter<bool>("use16GE21");
 
   digi_token_ = consumes<GEMDigiCollection>(digis_);
   geom_token_ = esConsumes<GEMGeometry, MuonGeometryRecord, edm::Transition::BeginRun>();
@@ -64,8 +63,6 @@ GEMPadDigiProducer::~GEMPadDigiProducer() {}
 void GEMPadDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("InputCollection", edm::InputTag("simMuonGEMDigis"));
-  // GE2/1 geometry with 16 eta partitions
-  desc.add<bool>("use16GE21", false);
 
   descriptions.add("simMuonGEMPadDigisDef", desc);
 }
@@ -73,6 +70,9 @@ void GEMPadDigiProducer::fillDescriptions(edm::ConfigurationDescriptions& descri
 void GEMPadDigiProducer::beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) {
   edm::ESHandle<GEMGeometry> hGeom = eventSetup.getHandle(geom_token_);
   geometry_ = &*hGeom;
+  // check the number of parititions
+  use16GE21_ = (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() ==
+                GEMPadDigi::NumberPartitions::GE21SplitStrip);
 }
 
 void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetup) {
@@ -98,8 +98,8 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
     if (use16GE21_ and p->isGE21())
       continue;
 
-    // set of <pad, bx> pairs, sorted first by pad then by bx
-    std::set<std::pair<int, int> > proto_pads;
+    // set of <pad, bx, part> pairs, sorted first by pad then by bx
+    std::set<std::tuple<int, int, enum GEMPadDigi::NumberPartitions> > proto_pads;
 
     // walk over digis in this partition,
     // and stuff them into a set of unique pads (equivalent of OR operation)
@@ -107,17 +107,23 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
     for (auto d = digis.first; d != digis.second; ++d) {
       unsigned pad_num = static_cast<int>(p->padOfStrip(d->strip()));
 
+      auto nPart = GEMPadDigi::NumberPartitions::GE11;
+      if (p->isME0()) {
+        nPart = GEMPadDigi::NumberPartitions::ME0;
+      } else if (p->isGE21()) {
+        nPart = GEMPadDigi::NumberPartitions::GE21;
+      }
       // check that the input digi is valid
       if ((p->isGE11() and pad_num == GEMPadDigi::GE11InValid) or
           (p->isGE21() and pad_num == GEMPadDigi::GE21InValid) or (p->isME0() and pad_num == GEMPadDigi::ME0InValid)) {
         edm::LogWarning("GEMPadDigiProducer") << "Invalid " << pad_num << " from  " << *d << " in " << p->id();
       }
-      proto_pads.emplace(pad_num, d->bx());
+      proto_pads.emplace(pad_num, d->bx(), nPart);
     }
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, p->subsystem());
+      GEMPadDigi pad_digi(std::get<0>(d), std::get<1>(d), GEMSubDetId::station(p->id().station()), std::get<2>(d));
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }
@@ -158,7 +164,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, p->subsystem());
+      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::Station::GE21, GEMPadDigi::NumberPartitions::GE21SplitStrip);
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -99,13 +99,13 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
       continue;
 
     // set of <pad, bx, part> pairs, sorted first by pad then by bx
-    std::set<std::tuple<int, int, enum GEMPadDigi::NumberPartitions> > proto_pads;
+    std::set<std::tuple<int, int, unsigned> > proto_pads;
 
     // walk over digis in this partition,
     // and stuff them into a set of unique pads (equivalent of OR operation)
     auto digis = det_digis.get(p->id());
     for (auto d = digis.first; d != digis.second; ++d) {
-      unsigned pad_num = static_cast<int>(p->padOfStrip(d->strip()));
+      unsigned pad_num = static_cast<unsigned>(p->padOfStrip(d->strip()));
 
       auto nPart = GEMPadDigi::NumberPartitions::GE11;
       if (p->isME0()) {
@@ -123,7 +123,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(std::get<0>(d), std::get<1>(d), GEMSubDetId::station(p->id().station()), std::get<2>(d));
+      GEMPadDigi pad_digi(std::get<0>(d), std::get<1>(d), p->subsystem(), std::get<2>(d));
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }
@@ -164,7 +164,7 @@ void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEM
 
     // fill the output collections
     for (const auto& d : proto_pads) {
-      GEMPadDigi pad_digi(d.first, d.second, GEMSubDetId::Station::GE21, GEMPadDigi::NumberPartitions::GE21SplitStrip);
+      GEMPadDigi pad_digi(d.first, d.second, p->subsystem(), GEMPadDigi::NumberPartitions::GE21SplitStrip);
       checkValid(pad_digi, p->id());
       out_pads.insertDigi(p->id(), pad_digi);
     }

--- a/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
+++ b/L1Trigger/L1TGEM/plugins/GEMPadDigiProducer.cc
@@ -96,21 +96,21 @@ void GEMPadDigiProducer::produce(edm::Event& e, const edm::EventSetup& eventSetu
 void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
   // check that ME0 has 8-eta partitions
   if (geometry_->hasME0()) {
-    if (geometry_->station(1, 0)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::ME0) {
+    if (geometry_->chamber(GEMDetId(1, 1, 0, 1, 1, 0))->nEtaPartitions() != GEMPadDigi::NumberPartitions::ME0) {
       edm::LogError("GEMPadDigiProducer") << "ME0 geometry appears corrupted";
     }
   }
 
   // check that GE1/1 has 8-eta partitions
   if (geometry_->hasGE11()) {
-    if (geometry_->station(1, 1)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE11) {
+    if (geometry_->chamber(GEMDetId(1, 1, 1, 1, 1, 0))->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE11) {
       edm::LogError("GEMPadDigiProducer") << "GE1/1 geometry appears corrupted";
     }
   }
 
   // check that GE2/1 has 8-eta partitions
   if (geometry_->hasGE21()) {
-    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
+    if (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() != GEMPadDigi::NumberPartitions::GE21) {
       edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (8 partition) appears corrupted";
     }
   }
@@ -156,7 +156,7 @@ void GEMPadDigiProducer::buildPads(const GEMDigiCollection& det_digis, GEMPadDig
 void GEMPadDigiProducer::buildPads16GE21(const GEMDigiCollection& det_digis, GEMPadDigiCollection& out_pads) const {
   // check that GE2/1 has 16-eta partitions
   if (geometry_->hasGE21()) {
-    if (geometry_->station(1, 2)->superChamber(1)->chamber(1)->nEtaPartitions() !=
+    if (geometry_->chamber(GEMDetId(1, 1, 2, 1, 1, 0))->nEtaPartitions() !=
         GEMPadDigi::NumberPartitions::GE21SplitStrip) {
       edm::LogError("GEMPadDigiProducer") << "GE2/1 geometry (16 partition) appears corrupted";
     }

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiClusterValidation.cc
@@ -143,6 +143,10 @@ void GEMPadDigiClusterValidation::analyze(const edm::Event& event, const edm::Ev
     ME3IdsKey key3(region_id, station_id, layer_id);
 
     for (auto digi = range.first; digi != range.second; ++digi) {
+      // ignore 16-partition GE2/1 pads
+      if (gemid.isGE21() and digi->nPartitions() == GEMPadDigiCluster::GE21SplitStrip)
+        continue;
+
       const auto& padsVec = digi->pads();
       if (padsVec.empty()) {
         edm::LogError(kLogCategory_) << "Pads missing for digi from GEM ID = " << gemid;

--- a/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/plugins/GEMPadDigiValidation.cc
@@ -144,6 +144,10 @@ void GEMPadDigiValidation::analyze(const edm::Event& event, const edm::EventSetu
     ME3IdsKey key3(region_id, station_id, layer_id);
 
     for (auto digi = range.first; digi != range.second; ++digi) {
+      // ignore 16-partition GE2/1 pads
+      if (gemid.isGE21() and digi->nPartitions() == GEMPadDigi::GE21SplitStrip)
+        continue;
+
       Int_t pad = digi->pad();
       Int_t bx = digi->bx();
 

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -135,6 +135,7 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
     const auto& digis_in_det = digis.get(p_id);
 
     for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
+
       // check that the digi is within BX range
       if (d->bx() < minBXDigi_ || d->bx() > maxBXDigi_)
         continue;

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -135,6 +135,7 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
     const auto& digis_in_det = digis.get(p_id);
 
     for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
+
       // check that the digi is within BX range
       if (d->bx() < minBXDigi_ || d->bx() > maxBXDigi_)
         continue;
@@ -165,6 +166,11 @@ void GEMDigiMatcher::matchPadsToSimTrack(const GEMPadDigiCollection& pads) {
     const auto& pads_in_det = pads.get(p_id);
 
     for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
+
+      // ignore 16-partition GE2/1 pads
+      if (p_id.isGE21() and pad->nPartitions() == GEMPadDigi::GE21SplitStrip)
+        continue;
+
       // check that the pad BX is within the range
       if (pad->bx() < minBXPad_ || pad->bx() > maxBXPad_)
         continue;
@@ -196,6 +202,10 @@ void GEMDigiMatcher::matchClustersToSimTrack(const GEMPadDigiClusterCollection& 
 
     for (auto cluster = clusters_in_det.first; cluster != clusters_in_det.second; ++cluster) {
       bool isMatched;
+
+      // ignore 16-partition GE2/1 pads
+      if (p_id.isGE21() and cluster->nPartitions() == GEMPadDigiCluster::GE21SplitStrip)
+        continue;
 
       // check that the cluster BX is within the range
       if (cluster->bx() < minBXCluster_ || cluster->bx() > maxBXCluster_)

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -135,7 +135,6 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
     const auto& digis_in_det = digis.get(p_id);
 
     for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
-
       // check that the digi is within BX range
       if (d->bx() < minBXDigi_ || d->bx() > maxBXDigi_)
         continue;

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -135,7 +135,6 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
     const auto& digis_in_det = digis.get(p_id);
 
     for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
-
       // check that the digi is within BX range
       if (d->bx() < minBXDigi_ || d->bx() > maxBXDigi_)
         continue;
@@ -166,7 +165,6 @@ void GEMDigiMatcher::matchPadsToSimTrack(const GEMPadDigiCollection& pads) {
     const auto& pads_in_det = pads.get(p_id);
 
     for (auto pad = pads_in_det.first; pad != pads_in_det.second; ++pad) {
-
       // ignore 16-partition GE2/1 pads
       if (p_id.isGE21() and pad->nPartitions() == GEMPadDigi::GE21SplitStrip)
         continue;


### PR DESCRIPTION
#### PR description:

The new GE2/1 geometry has 16 eta partitions (each strip split in 2), instead of 8 eta partitions. To prevent a miscommunication between GE2/1 TPs and the GEM-CSC local trigger, the EMTF, or the GEM packer/unpacker, I added a member `part_` in the `GEMPadDigi` and `GEMPadDigiCluster`. This was requested by EMTF folks. This way it should be relatively easy to check which geometry you are dealing with by calling `nPartitions()`. (Retry of #30998.) 16-partition  GE2/1 pads are currently rejected in the GEM-CSC trigger and GEM validation.

This PR is to be followed with an update of the EMTF to reject 16-partition GE2/1 pads temporarily until algorithms or validation modules are updated. 

See also #https://github.com/cms-sw/cmssw/pull/31264.
 
#### PR validation:

Tested with WF 23234.0

```
23234.0_TTbar_14TeV+2026D49+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Aug 27 12:06:19 2020-date Thu Aug 27 11:33:38 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed
```
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A 

@watson-ij @bsunanda @jshlee @jiafulow @eyigitba