### PR TITLE
CCLUT generator macro; LUTs in half-strip format (CCLUT-7)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -21,7 +21,7 @@ public:
   enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
   enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
   // temporary to facilitate CCLUT-EMTF/OMTF integration studies
-  enum LCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
+  enum LCTPatternMasks { kRun3SlopeMask = 0x1f, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum LCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
 

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -1,5 +1,5 @@
-#ifndef CSCCommonTrigger_CSCConstants_h
-#define CSCCommonTrigger_CSCConstants_h
+#ifndef L1Trigger_CSCCommonTrigger_CSCConstants_h
+#define L1Trigger_CSCCommonTrigger_CSCConstants_h
 
 /**
  * \class CSCConstants
@@ -53,6 +53,7 @@ public:
     CLCT_PATTERN_WIDTH = 11,
     // Max number of wires participating in a pattern
     MAX_WIRES_IN_PATTERN = 14,
+    NUM_COMPARATOR_CODES = 4096
   };
 
   enum Digis_Info { MAX_DIGIS_PER_ALCT = 10, MAX_DIGIS_PER_CLCT = 8 };

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -101,6 +101,7 @@ protected:
   // unique pointers to the luts
   std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutpos_;
   std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutslope_;
+  std::array<std::unique_ptr<CSCComparatorCodeLUT>, 5> lutpatconv_;
 
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
@@ -157,15 +158,12 @@ protected:
   int calculateComparatorCode(const std::array<std::array<int, 3>, 6>& halfStripPattern) const;
 
   // sets the 1/4 and 1/8 strip bits given a floating point position offset
-  void calculatePositionCC(float offset, uint16_t& halfstrip, bool& quartstrip, bool& eightstrip) const;
-
-  // converts the floating point slope into integer slope
-  int calculateSlopeCC(float slope, int nBits) const;
+  void assignPositionCC(const unsigned offset, uint16_t& halfstrip, bool& quartstrip, bool& eightstrip) const;
 
   // runs the CCLUT procedure
   void runCCLUT(CSCCLCTDigi& digi) const;
 
-  unsigned convertSlopeToRun2Pattern(unsigned slope, unsigned bend) const;
+  unsigned convertSlopeToRun2Pattern(const unsigned slope) const;
   //--------------------------- Member variables -----------------------------
 
   /* best pattern Id for a given half-strip */
@@ -221,10 +219,6 @@ protected:
   /** VK: whether to readout only the earliest two LCTs in readout window */
   bool readout_earliest_2;
 
-  // Use the new patterns according to the comparator code format
-  unsigned int nbits_position_cc_;
-  unsigned int nbits_slope_cc_;
-
   /** Default values of configuration parameters. */
   static const unsigned int def_fifo_tbins, def_fifo_pretrig;
   static const unsigned int def_hit_persist, def_drift_delay;
@@ -235,6 +229,7 @@ protected:
 
   std::vector<std::string> positionLUTFiles_;
   std::vector<std::string> slopeLUTFiles_;
+  std::vector<std::string> patternConversionLUTFiles_;
 
   /* quality control */
   std::unique_ptr<LCTQualityControl> qualityControl_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
@@ -11,7 +11,8 @@
 class CSCPatternBank {
 public:
   // typedef used for both ALCT and CLCT
-  typedef std::vector<std::vector<std::vector<int> > > LCTPatterns;
+  typedef std::vector<std::vector<int> > LCTPattern;
+  typedef std::vector<LCTPattern> LCTPatterns;
 
   /** Pre-defined ALCT patterns. */
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -29,11 +29,11 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
     savePreTriggers = cms.bool(False),
 
     positionLUTFiles = cms.vstring(
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat0_ideal_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat1_ideal_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat2_ideal_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat3_ideal_v1.txt",
-        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat4_ideal_v1.txt"
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePosOffsetLUT_pat4_v1.txt"
     ),
 
     slopeLUTFiles = cms.vstring(
@@ -42,6 +42,14 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat2_v1.txt",
         "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat3_v1.txt",
         "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodeSlopeLUT_pat4_v1.txt"
+    ),
+
+    patternConversionLUTFiles = cms.vstring(
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat0_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat1_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat2_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat3_v1.txt",
+        "L1Trigger/CSCTriggerPrimitives/data/CSCComparatorCodePatternConversionLUT_pat4_v1.txt"
     ),
 
     # Parameters common for all boards
@@ -181,8 +189,6 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         useRun3Patterns = cms.bool(False),
 
         useComparatorCodes = cms.bool(False),
-        nBitsPositionCC = cms.uint32(10),
-        nBitsSlopeCC = cms.uint32(4)
     ),
 
     # Parameters for CLCT processors: SLHC studies
@@ -224,9 +230,6 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         useRun3Patterns = cms.bool(False),
 
         useComparatorCodes = cms.bool(False),
-
-        nBitsPositionCC = cms.uint32(10),
-        nBitsSlopeCC = cms.uint32(4)
     ),
 
     tmbParam = cms.PSet(

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -1313,7 +1313,6 @@ void CSCCathodeLCTProcessor::assignPositionCC(const unsigned offset,
                                               uint16_t& halfstrip,
                                               bool& quartstrip,
                                               bool& eightstrip) const {
-
   /*
     | Value | Half-Strip Offset  | Delta Half-Strip  | Quarter-Strip Bit  | Eighth-Strip Bit |
     |-------|--------------------|-------------------|--------------------|------------------|
@@ -1334,12 +1333,16 @@ void CSCCathodeLCTProcessor::assignPositionCC(const unsigned offset,
     |   14  |   7/4              |   1               |   1                |   1              |
     |   15  |   2                |   2               |   0                |   0              |
    */
-  if (offset <= 2) halfstrip -= 2;
-  else if (offset > 2 and offset <= 6) halfstrip--;
-  else if (offset > 10 and offset <= 14) halfstrip += 1;
-  else if (offset == 15) halfstrip += 2;
+  if (offset <= 2)
+    halfstrip -= 2;
+  else if (offset > 2 and offset <= 6)
+    halfstrip--;
+  else if (offset > 10 and offset <= 14)
+    halfstrip += 1;
+  else if (offset == 15)
+    halfstrip += 2;
 
-  quartstrip = std::bitset<4>(offset+1)[1];
+  quartstrip = std::bitset<4>(offset + 1)[1];
   eightstrip = !std::bitset<4>(offset)[0];
 }
 
@@ -1442,14 +1445,7 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
 
 unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(const unsigned slope) const {
   // interesting: the "right-bending" patterns have a negative slope
-  const unsigned slopeList[32] = {2, 2, 2,
-                                  4, 4, 4,
-                                  6, 6, 6, 6,
-                                  8, 8, 8, 8,
-                                  10, 10, 10, 10,
-                                  9, 9, 9, 9,
-                                  7, 7, 7, 7,
-                                  5, 5, 5,
-                                  3, 3, 3};
+  const unsigned slopeList[32] = {2,  2,  2, 4, 4, 4, 6, 6, 6, 6, 8, 8, 8, 8, 10, 10,
+                                  10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3,  3};
   return slopeList[slope];
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <bitset>
 
 // Default values of configuration parameters.
 const unsigned int CSCCathodeLCTProcessor::def_fifo_tbins = 12;
@@ -63,10 +64,6 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
     pid_thresh_pretrig = 0;
   }
 
-  nbits_position_cc_ = clctParams_.getParameter<unsigned int>("nBitsPositionCC");
-
-  nbits_slope_cc_ = clctParams_.getParameter<unsigned int>("nBitsSlopeCC");
-
   // Check and print configuration parameters.
   checkConfigParameters();
   if ((infoV > 0) && !config_dumped) {
@@ -93,10 +90,12 @@ CSCCathodeLCTProcessor::CSCCathodeLCTProcessor(unsigned endcap,
   if (use_comparator_codes_) {
     positionLUTFiles_ = conf.getParameter<std::vector<std::string>>("positionLUTFiles");
     slopeLUTFiles_ = conf.getParameter<std::vector<std::string>>("slopeLUTFiles");
+    patternConversionLUTFiles_ = conf.getParameter<std::vector<std::string>>("patternConversionLUTFiles");
 
     for (int i = 0; i < 5; ++i) {
       lutpos_[i] = std::make_unique<CSCComparatorCodeLUT>(positionLUTFiles_[i]);
       lutslope_[i] = std::make_unique<CSCComparatorCodeLUT>(slopeLUTFiles_[i]);
+      lutpatconv_[i] = std::make_unique<CSCComparatorCodeLUT>(patternConversionLUTFiles_[i]);
     }
   }
 
@@ -1310,49 +1309,38 @@ int CSCCathodeLCTProcessor::calculateComparatorCode(const std::array<std::array<
   return id;
 }
 
-void CSCCathodeLCTProcessor::calculatePositionCC(float offset,
-                                                 uint16_t& halfstrip,
-                                                 bool& quartstrip,
-                                                 bool& eightstrip) const {
-  // offset is too small, no bits are are set!
-  if (std::abs(offset) < 0.125)
-    return;
+void CSCCathodeLCTProcessor::assignPositionCC(const unsigned offset,
+                                              uint16_t& halfstrip,
+                                              bool& quartstrip,
+                                              bool& eightstrip) const {
 
-  const float fhalfstrip = halfstrip + offset;
-  halfstrip = int(std::floor(fhalfstrip));
+  /*
+    | Value | Half-Strip Offset  | Delta Half-Strip  | Quarter-Strip Bit  | Eighth-Strip Bit |
+    |-------|--------------------|-------------------|--------------------|------------------|
+    |   0   |   -7/4             |   -2              |   0                |   1              |
+    |   1   |   -3/2             |   -2              |   1                |   0              |
+    |   2   |   -5/4             |   -2              |   1                |   1              |
+    |   3   |   -1               |   -1              |   0                |   0              |
+    |   4   |   -3/4             |   -1              |   0                |   1              |
+    |   5   |   -1/2             |   -1              |   1                |   0              |
+    |   6   |   -1/4             |   -1              |   1                |   1              |
+    |   7   |   0                |   0               |   0                |   0              |
+    |   8   |   1/4              |   0               |   0                |   1              |
+    |   9   |   1/2              |   0               |   1                |   0              |
+    |   10  |   3/4              |   0               |   1                |   1              |
+    |   11  |   1                |   1               |   0                |   0              |
+    |   12  |   5/4              |   1               |   0                |   1              |
+    |   13  |   3/2              |   1               |   1                |   0              |
+    |   14  |   7/4              |   1               |   1                |   1              |
+    |   15  |   2                |   2               |   0                |   0              |
+   */
+  if (offset <= 2) halfstrip -= 2;
+  else if (offset > 2 and offset <= 6) halfstrip--;
+  else if (offset > 10 and offset <= 14) halfstrip += 1;
+  else if (offset == 15) halfstrip += 2;
 
-  const float delta(std::abs(fhalfstrip - halfstrip));
-  if (delta >= 0.125 and delta < 0.375) {
-    quartstrip = false;
-    eightstrip = true;
-  } else if (delta >= 0.375 and delta < 0.625) {
-    quartstrip = true;
-    eightstrip = false;
-  } else if (delta >= 0.625 and delta < 0.875) {
-    quartstrip = true;
-    eightstrip = true;
-  }
-}
-
-int CSCCathodeLCTProcessor::calculateSlopeCC(float slope, int nBits) const {
-  int returnValue;
-  double minSlope = 0;
-  double maxSlope = 2.0;
-  int range = pow(2, nBits);
-  double deltaSlope = (maxSlope - minSlope) / range;
-
-  // in what follows we use the absolute value
-
-  // max value is 15
-  if (std::abs(slope) >= 1) {
-    returnValue = pow(2, nBits) - 1;
-  }
-  // discretize the slope between 0 and 15
-  else {
-    returnValue = std::min(std::floor(std::abs(slope) / deltaSlope), pow(2, nBits) - 1);
-  }
-
-  return returnValue;
+  quartstrip = std::bitset<4>(offset+1)[1];
+  eightstrip = !std::bitset<4>(offset)[0];
 }
 
 void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
@@ -1406,21 +1394,22 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   // set the Run-3 pattern
   digi.setRun3Pattern(pattern);
 
-  // position offset is in strips -> *2 to get to half-strips!
-  const float positionCC(2 * lutpos_[pattern]->lookup(comparatorCode));
-  const float slopeCC(lutslope_[pattern]->lookup(comparatorCode));
+  // look-up the unsigned values
+  const unsigned positionCC(lutpos_[pattern]->lookup(comparatorCode));
+  const unsigned slopeCC(lutslope_[pattern]->lookup(comparatorCode));
+  unsigned run2PatternCC(lutpatconv_[pattern]->lookup(comparatorCode));
 
-  // if the slope is negative, set bending to 1
-  if (slopeCC < 0)
-    digi.setBend(1);
-  else
+  // if the slope is negative, set bending to 0
+  if (slopeCC < 16)
     digi.setBend(0);
+  else
+    digi.setBend(1);
 
   // calculate the new position
   uint16_t halfstrip = digi.getKeyStrip();
   bool quartstrip = false;
   bool eightstrip = false;
-  calculatePositionCC(positionCC, halfstrip, quartstrip, eightstrip);
+  assignPositionCC(positionCC, halfstrip, quartstrip, eightstrip);
 
   // store the new 1/2, 1/4 and 1/8 strip positions
   digi.setStrip(halfstrip - digi.getCFEB() * 32);
@@ -1428,12 +1417,13 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   digi.setEightStrip(eightstrip);
 
   // store the bending angle value in the pattern data member
-  const unsigned slope(calculateSlopeCC(slopeCC, nbits_slope_cc_));
-  digi.setSlope(slope);
+  digi.setSlope(slopeCC);
 
   // set the quasi Run-2 pattern - to accommodate integration with EMTF/OMTF
-  const unsigned run2Pattern(convertSlopeToRun2Pattern(slope, digi.getBend()));
-  digi.setPattern(run2Pattern);
+  if (run2PatternCC == 0) {
+    run2PatternCC = convertSlopeToRun2Pattern(slopeCC);
+  }
+  digi.setPattern(run2PatternCC);
 
   // now print out the new CLCT for debugging
   if (infoV > 2) {
@@ -1450,12 +1440,16 @@ void CSCCathodeLCTProcessor::runCCLUT(CSCCLCTDigi& digi) const {
   }
 }
 
-unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(unsigned slope, unsigned bend) const {
-  const int pslopeList[16] = {10, 10, 8, 8, 8, 8, 6, 6, 6, 6, 4, 4, 4, 2, 2, 2};
-  const int nslopeList[16] = {10, 10, 9, 9, 9, 9, 7, 7, 7, 7, 5, 5, 5, 3, 3, 3};
-  if (bend == 0) {
-    return pslopeList[slope];
-  } else {
-    return nslopeList[slope];
-  }
+unsigned CSCCathodeLCTProcessor::convertSlopeToRun2Pattern(const unsigned slope) const {
+  // interesting: the "right-bending" patterns have a negative slope
+  const unsigned slopeList[32] = {2, 2, 2,
+                                  4, 4, 4,
+                                  6, 6, 6, 6,
+                                  8, 8, 8, 8,
+                                  10, 10, 10, 10,
+                                  9, 9, 9, 9,
+                                  7, 7, 7, 7,
+                                  5, 5, 5,
+                                  3, 3, 3};
+  return slopeList[slope];
 }

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCPatternBank.cc
@@ -48,16 +48,17 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
         {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, 11},
     },
-    // pid=2: right-bending (large)
+    // pid=2: left-bending (large)
     {
-        {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1},
-        {0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0},
-        {0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
-        {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0},
-        {0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0},
-        {1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11},
+        //      0  1  2  3  4  5  6  7  8  9  A
+        /*L1*/ {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1},
+        /*L2*/ {0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0},
+        /*L3*/ {0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0},
+        /*L4*/ {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0},
+        /*L5*/ {0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0},
+        /*L6*/ {1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11},
     },
-    // pid=3: left-bending (large)
+    // pid=3: right-bending (large)
     {
         {1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0},
@@ -66,7 +67,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0},
         {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 11},
     },
-    // pid=4: right-bending (medium)
+    // pid=4: left-bending (medium)
     {
         {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0},
         {0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0},
@@ -75,7 +76,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0},
         {0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 9},
     },
-    // pid=5: left-bending (medium)
+    // pid=5: right-bending (medium)
     {
         {0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0},
@@ -84,7 +85,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0},
         {0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 9},
     },
-    // pid=6: right-bending (medium)
+    // pid=6: left-bending (medium)
     {
         {0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0},
         {0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0},
@@ -93,7 +94,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0},
         {0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 7},
     },
-    // pid=7: left-bending (medium)
+    // pid=7: right-bending (medium)
     {
         {0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0},
@@ -102,7 +103,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0},
         {0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 1, 7},
     },
-    // pid=8: right-bending (small)
+    // pid=8: left-bending (small)
     {
         {0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0},
         {0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0},
@@ -111,7 +112,7 @@ const CSCPatternBank::LCTPatterns CSCPatternBank::clct_pattern_legacy_ = {
         {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0},
         {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 5},
     },
-    // pid=9: left-bending (small)
+    // pid=9: right-bending (small)
     {
         {0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0},
         {0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0},

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
@@ -222,16 +222,19 @@ void LCTQualityControl::checkMultiplicityBX(const std::vector<CSCCorrelatedLCTDi
 }
 
 int LCTQualityControl::getSlopePhase1(int pattern) const {
-  int slopeList[CSCConstants::NUM_CLCT_PATTERNS] = {0, 0, 8, -8, 6, -6, 4, -4, 2, -2, 0};
+  // PID 2 is actually a left-bending pattern with a negative slope
+  // PID 3 is actually a right-bending pattern with a positive slope
+  int slopeList[CSCConstants::NUM_CLCT_PATTERNS] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
   return slopeList[pattern];
 }
 
 std::pair<int, int> LCTQualityControl::get_csc_clct_min_max_slope(bool isRun3, bool runCCLUT) const {
   int min_slope, max_slope;
   // Run-3 case with CCLUT
+  // 5-bit number (includes the L/R bending)
   if (runCCLUT) {
     min_slope = 0;
-    max_slope = 15;
+    max_slope = 31;
   }
   // Run-1 or Run-2 case
   // Run-3 case without CCLUT

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
@@ -124,7 +124,8 @@ int CSCPattern::recoverPatternCCCombination(
   return 0;
 }
 
-int convertToLegacyPattern(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH], unsigned N_LAYER_REQUIREMENT);
+int convertToLegacyPattern(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH],
+                           unsigned N_LAYER_REQUIREMENT);
 void getErrors(const vector<float>& x, const vector<float>& y, float& sigmaM, float& sigmaB);
 void writeHeaderPosOffsetLUT(ofstream& file);
 void writeHeaderSlopeLUT(ofstream& file);
@@ -410,7 +411,9 @@ int CCLUTLinearFitWriter(unsigned N_LAYER_REQUIREMENT = 3) {
 
 /// helpers
 
-int searchForHits(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH], int delta, unsigned N_LAYER_REQUIREMENT) {
+int searchForHits(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH],
+                  int delta,
+                  unsigned N_LAYER_REQUIREMENT) {
   unsigned returnValue = 0;
   unsigned maxlayers = 0;
   for (unsigned iPat = 2; iPat < CSCPatternBank::clct_pattern_legacy_.size(); iPat++) {
@@ -447,7 +450,8 @@ int searchForHits(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CL
 }
 
 // function to convert
-int convertToLegacyPattern(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH], unsigned N_LAYER_REQUIREMENT) {
+int convertToLegacyPattern(const int code_hits[CSCConstants::NUM_LAYERS][CSCConstants::CLCT_PATTERN_WIDTH],
+                           unsigned N_LAYER_REQUIREMENT) {
   int returnValue = searchForHits(code_hits, 0, N_LAYER_REQUIREMENT);
   // try the search on a half-strip to the left
   if (!returnValue)

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
@@ -255,7 +255,7 @@ int CCLUTLinearFitWriter() {
 
     // pattern conversions
     ofstream outpatternconv;
-    outpatternconv.open(outdir + "CSCPatternConversionLUT_pat" + patt->getName() + "_v1.txt");
+    outpatternconv.open(outdir + "CSCComparatorCodePatternConversionLUT_pat" + patt->getName() + "_v1.txt");
 
     // iterate through each possible comparator code
     for (unsigned code = 0; code < CSCConstants::NUM_COMPARATOR_CODES; code++) {

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/README.md
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/README.md
@@ -1,11 +1,14 @@
 The macro CCLUTLinearFitWriter.cpp produces look-up tables for the Run-3 CSC trigger.
 
-* 10 LUTs will be created for CMSSW (5 for position offset, 5 for slope). 5 LUTs will be created for the Verilog firmware. These  files are similar to the ones found here: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives. 5 additional LUTs will be created that convert the Run-3 comparator code & pattern ID to a Run-1/2 pattern ID.
+* 10 LUTs will be created for CMSSW (5 for position offset, 5 for slope). 5 LUTs will be created for the Verilog firmware. These  files are similar to the ones found here: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives. 5 additional LUTs will be created that convert the Run-3 comparator code & pattern ID to a Run-1/2 pattern ID. The LUTs used in the simulation require at least 3 layers. For reference the macro also produces fits with at least four layers.
 
 <PRE>
-mkdir output
-mkdir figures
-root -l -q -b CCLUTLinearFitWriter.cpp++
+mkdir output_3layers
+mkdir output_4layers
+mkdir figures_3layers
+mkdir figures_4layers
+root -l -q -b CCLUTLinearFitWriter.cpp++(3)
+root -l -q -b CCLUTLinearFitWriter.cpp++(4)
 </PRE>
 
 * Convention for 4-bit position offset word:

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/README.md
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/README.md
@@ -1,0 +1,30 @@
+The macro CCLUTLinearFitWriter.cpp produces look-up tables for the Run-3 CSC trigger.
+
+* 10 LUTs will be created for CMSSW (5 for position offset, 5 for slope). 5 LUTs will be created for the Verilog firmware. These  files are similar to the ones found here: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives. 5 additional LUTs will be created that convert the Run-3 comparator code & pattern ID to a Run-1/2 pattern ID.
+
+<PRE>
+mkdir output
+mkdir figures
+root -l -q -b CCLUTLinearFitWriter.cpp++
+</PRE>
+
+* Convention for 4-bit position offset word:
+
+| Value | Half-Strip Offset  | Delta Half-Strip  | Quarter-Strip Bit  | Eighth-Strip Bit |
+|-------|--------------------|-------------------|--------------------|------------------|
+|   0   |   -7/4             |   -2              |   0                |   1              |
+|   1   |   -3/2             |   -2              |   1                |   0              |
+|   2   |   -5/4             |   -2              |   1                |   1              |
+|   3   |   -1               |   -1              |   0                |   0              |
+|   4   |   -3/4             |   -1              |   0                |   1              |
+|   5   |   -1/2             |   -1              |   1                |   0              |
+|   6   |   -1/4             |   -1              |   1                |   1              |
+|   7   |   0                |   0               |   0                |   0              |
+|   8   |   1/4              |   0               |   0                |   1              |
+|   9   |   1/2              |   0               |   1                |   0              |
+|   10  |   3/4              |   0               |   1                |   1              |
+|   11  |   1                |   1               |   0                |   0              |
+|   12  |   5/4              |   1               |   0                |   1              |
+|   13  |   3/2              |   1               |   1                |   0              |
+|   14  |   7/4              |   1               |   1                |   1              |
+|   15  |   2                |   2               |   0                |   0              |


### PR DESCRIPTION
#### PR description:

Macro that generates the look-up tables for the Run-3 CSC trigger in https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives (both for CMSSW simulation and firmware). The script performs a linear fit to 5 (patterns) x 3942 (valid comparator codes) possible combinations of >= 3 hits in a CSC. The patterns are those in `CSCPatternBank::clct_pattern_run3_`. Fit results (plots can be found in [DN-19-059, Sec.4.2](https://gitlab.cern.ch/tdr/notes/DN-19-059/blob/master/temp/DN-19-059_temp.pdf)) are used in the CLCT processor to correct the key half-strip, and assign the 1/4-strip bit, 1/8-strip bit and the 5-bit CLCT bending angle. See also: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/2.

There are 6 types of LUTs:
```
* CSCComparatorCodePatternConversionLUT_pat*_v1.txt: converts (Run-3 pattern, Comparator Code) -> Run-1/2 pattern
* CSCComparatorCodePosOffsetLUT_pat*_float_v1.txt:   Key half-strip position offset in floating point
* CSCComparatorCodePosOffsetLUT_pat*_v1.txt:         4-bit key half-strip position offset  
* CSCComparatorCodeSlopeLUT_pat*_float_v1.txt:       floating point slope
* CSCComparatorCodeSlopeLUT_pat*_v1.txt:             5-bit slope
* rom_pat*.mem:                                      memory files for CSC OTMB firmware
```

The CCLUT procedures in the CLCT processor have been updated to use the new LUTs.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 