### PR TITLE
SimDataFormats/ValidationFormats - move G4 dependency out of data format 

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="SimDataFormats/ValidationFormats"/>
 <use name="SimG4CMS/Calo"/>
 <use name="SimG4CMS/EcalTestBeam"/>
 <use name="SimG4CMS/FP420"/>

--- a/SimDataFormats/ValidationFormats/BuildFile.xml
+++ b/SimDataFormats/ValidationFormats/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/Math"/>
 <use name="clhep"/>
-<use name="geant4core"/>
 <use name="expat"/>
 <export>
   <lib name="1"/>

--- a/SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h
+++ b/SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h
@@ -3,7 +3,6 @@
 
 #include <vector>
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "G4VPhysicalVolume.hh"
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingStep.h"
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingDetector.h"
 
@@ -14,14 +13,13 @@ private:
   enum { kSteps = 600, kDetectors = 30 };
 
 public:
-  MaterialAccountingTrack(void) : m_total(), m_current_volume(nullptr), m_detector(), m_steps(), m_detectors() {
+  MaterialAccountingTrack(void) : m_total(), m_detector(), m_steps(), m_detectors() {
     m_steps.reserve(kSteps);
     m_detectors.reserve(kDetectors);
   }
 
   void reset(void) {
     m_total.clear();
-    m_current_volume = nullptr;
     m_steps.clear();
     m_steps.reserve(kSteps);
     m_steps.push_back(m_total);
@@ -35,8 +33,8 @@ public:
     m_steps.push_back(step);
   }
 
-  void enterDetector(const G4VPhysicalVolume* volume, const GlobalPoint& position, double cosTheta);
-  void leaveDetector(const G4VPhysicalVolume* volume, double cosTheta);
+  void enterDetector(const GlobalPoint& position, double cosTheta);
+  void leaveDetector(double cosTheta);
 
   const MaterialAccountingStep& summary() const { return m_total; }
 
@@ -50,7 +48,6 @@ public:
 
 private:
   MaterialAccountingStep m_total;             // cache position along track (length and material)
-  const G4VPhysicalVolume* m_current_volume;  // keep track of current G4 volume
   MaterialAccountingDetector m_detector;      // keep track of current detector
   std::vector<MaterialAccountingStep> m_steps;
   std::vector<MaterialAccountingDetector> m_detectors;

--- a/SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h
+++ b/SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h
@@ -47,8 +47,8 @@ public:
   std::vector<MaterialAccountingStep>& steps() { return m_steps; }
 
 private:
-  MaterialAccountingStep m_total;             // cache position along track (length and material)
-  MaterialAccountingDetector m_detector;      // keep track of current detector
+  MaterialAccountingStep m_total;         // cache position along track (length and material)
+  MaterialAccountingDetector m_detector;  // keep track of current detector
   std::vector<MaterialAccountingStep> m_steps;
   std::vector<MaterialAccountingDetector> m_detectors;
 };

--- a/SimDataFormats/ValidationFormats/src/MaterialAccountingTrack.cc
+++ b/SimDataFormats/ValidationFormats/src/MaterialAccountingTrack.cc
@@ -1,44 +1,18 @@
 #include <iostream>
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "G4VPhysicalVolume.hh"
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h"
 
-void MaterialAccountingTrack::enterDetector(const G4VPhysicalVolume* volume,
-                                            const GlobalPoint& position,
+void MaterialAccountingTrack::enterDetector(const GlobalPoint& position,
                                             double cosTheta) {
-  if (m_current_volume != nullptr) {
-    // error: entering a volume while inside an other (or the same) one !
-    if (m_current_volume != volume)
-      std::cerr << "MaterialAccountingTrack::leaveDetector(...): ERROR: entering volume (" << volume
-                << ") while inside volume (" << m_current_volume << ")" << std::endl;
-    else
-      std::cerr << "MaterialAccountingTrack::leaveDetector(...): ERROR: entering volume (" << volume << ") twice"
-                << std::endl;
-    m_detector.clear();
-    return;
-  }
 
-  m_current_volume = volume;
   m_detector.m_position = position;
   m_detector.m_curvilinearIn = m_total.length();
   m_detector.m_cosThetaIn = cosTheta;
 }
 
-void MaterialAccountingTrack::leaveDetector(const G4VPhysicalVolume* volume, double cosTheta) {
-  if (m_current_volume != volume) {
-    // error: leaving the wrong (or no) volume !
-    if (m_current_volume)
-      std::cerr << "MaterialAccountingTrack::leaveDetector(...): ERROR: leaving volume (" << volume
-                << ") while inside volume (" << m_current_volume << ")" << std::endl;
-    else
-      std::cerr << "MaterialAccountingTrack::leaveDetector(...): ERROR: leaving volume (" << volume
-                << ") while not inside any volume" << std::endl;
-    m_detector.clear();
-    return;
-  }
+void MaterialAccountingTrack::leaveDetector(double cosTheta) {
 
-  m_current_volume = nullptr;
   m_detector.m_curvilinearOut = m_total.length();
   m_detector.m_cosThetaOut = cosTheta;
   m_detectors.push_back(m_detector);

--- a/SimDataFormats/ValidationFormats/src/MaterialAccountingTrack.cc
+++ b/SimDataFormats/ValidationFormats/src/MaterialAccountingTrack.cc
@@ -3,16 +3,13 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h"
 
-void MaterialAccountingTrack::enterDetector(const GlobalPoint& position,
-                                            double cosTheta) {
-
+void MaterialAccountingTrack::enterDetector(const GlobalPoint& position, double cosTheta) {
   m_detector.m_position = position;
   m_detector.m_curvilinearIn = m_total.length();
   m_detector.m_cosThetaIn = cosTheta;
 }
 
 void MaterialAccountingTrack::leaveDetector(double cosTheta) {
-
   m_detector.m_curvilinearOut = m_total.length();
   m_detector.m_cosThetaOut = cosTheta;
   m_detectors.push_back(m_detector);

--- a/SimDataFormats/ValidationFormats/src/classes_def.xml
+++ b/SimDataFormats/ValidationFormats/src/classes_def.xml
@@ -170,7 +170,6 @@
   
   <class name="MaterialAccountingTrack" ClassVersion="10">
    <version ClassVersion="10" checksum="3618055651"/>
-    <field name="m_current_volume"  transient="true"/>
     <field name="m_detector"        transient="true"/>
   </class>
   <class name="std::vector<MaterialAccountingTrack>"/>

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -284,8 +284,9 @@ void TrackingMaterialProducer::update(const G4Step* step) {
 
   // update track accounting
   if (enter_sensitive) {
-    if ( m_track_volume != nullptr ) {
-      edm::LogWarning("TrackingMaterialProducer") << "Entering volume " << sensitive << "while inside volume " << m_track_volume << ". Something is inconsistent";
+    if (m_track_volume != nullptr) {
+      edm::LogWarning("TrackingMaterialProducer") << "Entering volume " << sensitive << "while inside volume "
+                                                  << m_track_volume << ". Something is inconsistent";
       m_track.reset();
     }
     m_track_volume = sensitive;
@@ -293,13 +294,12 @@ void TrackingMaterialProducer::update(const G4Step* step) {
   }
   m_track.step(MaterialAccountingStep(length, radiationLengths, energyLoss, globalPositionIn, globalPositionOut));
   if (leave_sensitive) {
-    if ( m_track_volume != sensitive ) {
-      edm::LogWarning("TrackingMaterialProducer") << "Leaving volume " << sensitive << "while inside volume " << m_track_volume << ". Something is inconsistent";
+    if (m_track_volume != sensitive) {
+      edm::LogWarning("TrackingMaterialProducer") << "Leaving volume " << sensitive << "while inside volume "
+                                                  << m_track_volume << ". Something is inconsistent";
       m_track.reset();
-    }
-    else 
+    } else
       m_track.leaveDetector(cosThetaPost);
-    
   }
   if (sensitive)
     LogInfo("TrackingMaterialProducer") << "Track was near sensitive     volume " << sensitive->GetName() << std::endl;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -84,6 +84,7 @@ TrackingMaterialProducer::TrackingMaterialProducer(const edm::ParameterSet& iPSe
   m_txtOutFile = config.getUntrackedParameter<std::string>("txtOutFile");
   m_hgcalzfront = config.getParameter<double>("hgcalzfront");
   m_tracks = nullptr;
+  m_track_volume = nullptr;
 
   produces<std::vector<MaterialAccountingTrack> >();
   output_file_ = new TFile("radLen_vs_eta_fromProducer.root", "RECREATE");
@@ -140,6 +141,7 @@ void TrackingMaterialProducer::update(const BeginOfEvent* event) {
 //-------------------------------------------------------------------------
 void TrackingMaterialProducer::update(const BeginOfTrack* event) {
   m_track.reset();
+  m_track_volume = nullptr;
 
   // prevent secondary tracks from propagating
   G4Track* track = const_cast<G4Track*>((*event)());
@@ -281,12 +283,24 @@ void TrackingMaterialProducer::update(const G4Step* step) {
   }
 
   // update track accounting
-  if (enter_sensitive)
-    m_track.enterDetector(sensitive, position, cosThetaPre);
+  if (enter_sensitive) {
+    if ( m_track_volume != nullptr ) {
+      edm::LogWarning("TrackingMaterialProducer") << "Entering volume " << sensitive << "while inside volume " << m_track_volume << ". Something is inconsistent";
+      m_track.reset();
+    }
+    m_track_volume = sensitive;
+    m_track.enterDetector(position, cosThetaPre);
+  }
   m_track.step(MaterialAccountingStep(length, radiationLengths, energyLoss, globalPositionIn, globalPositionOut));
-  if (leave_sensitive)
-    m_track.leaveDetector(sensitive, cosThetaPost);
-
+  if (leave_sensitive) {
+    if ( m_track_volume != sensitive ) {
+      edm::LogWarning("TrackingMaterialProducer") << "Leaving volume " << sensitive << "while inside volume " << m_track_volume << ". Something is inconsistent";
+      m_track.reset();
+    }
+    else 
+      m_track.leaveDetector(cosThetaPost);
+    
+  }
   if (sensitive)
     LogInfo("TrackingMaterialProducer") << "Track was near sensitive     volume " << sensitive->GetName() << std::endl;
   else

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
@@ -60,7 +60,7 @@ private:
   std::string m_txtOutFile;
   double m_hgcalzfront;
   MaterialAccountingTrack m_track;
-  const G4VPhysicalVolume *m_track_volume;
+  const G4VPhysicalVolume* m_track_volume;
   std::vector<MaterialAccountingTrack>* m_tracks;
   TFile* output_file_;
   TProfile* radLen_vs_eta_;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.h
@@ -60,6 +60,7 @@ private:
   std::string m_txtOutFile;
   double m_hgcalzfront;
   MaterialAccountingTrack m_track;
+  const G4VPhysicalVolume *m_track_volume;
   std::vector<MaterialAccountingTrack>* m_tracks;
   TFile* output_file_;
   TProfile* radLen_vs_eta_;


### PR DESCRIPTION
Moved into TrackingMaterialProducer which already depends on G4.