### PR TITLE
NanoAOD: add flag to keep all PS weights

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -450,9 +450,8 @@ public:
     const std::vector<unsigned int>& psWeightIDs = weightChoice->psWeightIDs;
 
     auto weights = genProd.weights();
-    double w0 = weights.at(1);
-    double originalXWGTUP = weights.at(1);
-    ;
+    double w0 = (weights.size() > 1) ? weights.at(1) : 1.;
+    double originalXWGTUP = (weights.size() > 1) ? weights.at(1) : 1.;
 
     std::vector<double> wScale, wPDF, wPS;
     for (auto id : scaleWeightIDs)

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -930,7 +930,8 @@ public:
           }
         } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
                    line.find("fsr") != std::string::npos) {
-          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos || line.find("Def") != std::string::npos) {
+          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos ||
+              line.find("Def") != std::string::npos) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           }
         }

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -398,8 +398,8 @@ public:
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
       if (keepAllPSWeights_) {
-        for (std::size_t i = 2; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i]) / nominal;
+        for (std::size_t i = 0; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i + 2]) / nominal;
         }
         psWeightDocStr = "All PS weights (w_var / w_nominal)";
       } else {
@@ -507,8 +507,8 @@ public:
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
       if (keepAllPSWeights_) {
-        for (std::size_t i = 2; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i]) / nominal;
+        for (std::size_t i = 0; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i + 2]) / nominal;
         }
         psWeightDocStr = "All PS weights (w_var / w_nominal)";
       } else {
@@ -930,7 +930,7 @@ public:
           }
         } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
                    line.find("fsr") != std::string::npos) {
-          if (keepAllPSWeights_ || line.find("Def") != std::string::npos) {
+          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos || line.find("Def") != std::string::npos) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           }
         }

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -15,6 +15,7 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),
     lheWeightPrecision = cms.int32(14),
-    maxPdfWeights = cms.uint32(150), 
+    maxPdfWeights = cms.uint32(150),
+    keepAllPSWeights = cms.bool(False),
     debug = cms.untracked.bool(False),
 )

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -467,6 +467,13 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('z', 'z', 20, -20, 20, 'Z position of other primary vertices, excluding the main PV'),
             )
         ),
+        PSWeight = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('', '', 20, 0, 2, 'All PS weights (w_var / w_nominal)'),
+                Count1D('_size', 46, -0.5, 45.5, 'Number of PS weights'),
+            )
+        ),
         PV = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(

--- a/PhysicsTools/NanoAOD/python/nanogen_cff.py
+++ b/PhysicsTools/NanoAOD/python/nanogen_cff.py
@@ -68,6 +68,7 @@ NANOAODGENoutput = cms.OutputModule("NanoAODOutputModule",
 def nanoGenCommonCustomize(process):
     process.lheInfoTable.storeLHEParticles = True
     process.lheInfoTable.precision = 14
+    process.genWeightsTable.keepAllPSWeights = True
     process.genJetFlavourAssociation.jets = process.genJetTable.src
     process.genJetFlavourTable.src = process.genJetTable.src
     process.genJetAK8FlavourAssociation.jets = process.genJetAK8Table.src


### PR DESCRIPTION
#### PR description:

- Add a flag (default false) to keep all the available PS weights instead of the regular 4 (ISR/FSR x up/down), as asked by JME for their custom ntuple production. If set to true, the whole PS weight array is kept, apart from the first two entries (these correspond to either `[XWGTUP * PSweight * match_eff, XWGTUP * PSweight]` or `[PSweight * match_eff, PSweight]`, so they'll be equal to 1 most of the time after normalizing the weights by the second entry, see https://github.com/cms-nanoAOD/cmssw/pull/506). 

- The flag is set to true for the nanoGEN format

- Add the PS weights to nanoDQM

- Fix the PS weight normalization in the case where the weights are parsed according to the lumi header (see https://github.com/cms-nanoAOD/cmssw/pull/441): the PS weights should be normalized by the `Baseline` weight (assumed to be the first PS weight seen).

- Add a protection for the case of empty weight arrays - fixes https://github.com/cms-nanoAOD/cmssw/issues/538

Note: was originally https://github.com/cms-nanoAOD/cmssw/pull/542
FYI  @camclean @alefisico

#### PR validation:

Tested in 106X: produced nanoAOD files for TTToSemiLeptonic (2016 and 2018) and for one of the parameter scan files mentioned in https://github.com/cms-nanoAOD/cmssw/pull/441 [1].

[1] /store/mc/RunIIAutumn18MiniAOD/SMS-TChiWZ_ZToLL_mZMin-0p1_mC1-325to1000_TuneCP2_13TeV-madgraphMLM-pythia8/MINIAODSIM/GridpackScan_102X_upgrade2018_realistic_v15-v1/70000/FFE78E85-6F7A-9441-8963-980A38403D1F.root