### PR TITLE
Solution for decay products of Long-lived exotic particles in FastSim 

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -141,4 +141,9 @@ namespace fastsim {
   };
 }  // namespace fastsim
 
+inline bool isExotic(int pdgid_) {
+  unsigned int pdgid = std::abs(pdgid_);
+  return (pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) || pdgid == 17 || pdgid == 34 || pdgid == 37;
+}
+
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -123,6 +123,10 @@ namespace fastsim {
         genParticleIterator_;  //!< Iterator to keep track on which GenParticles where already considered.
     const HepMC::GenEvent::particle_const_iterator genParticleEnd_;  //!< The last particle of the GenEvent.
     int genParticleIndex_;  //!< Index of particle in the GenEvent (if it is a GenParticle)
+
+    HepMC::GenEvent::particle_const_iterator relativesIterator_; // iterator to loop over particle relatives
+    const HepMC::GenEvent::particle_const_iterator relativesIteratorEnd_; // last relative
+
     const HepPDT::ParticleDataTable* const
         particleDataTable_;         //!< Necessary to get information like lifetime and charge of a particle if unknown.
     const double beamPipeRadius2_;  //!< (Radius of the beampipe)^2

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -110,6 +110,7 @@ namespace fastsim {
             \return Index of that simTrack.
         */
     unsigned addSimTrack(const Particle* particle);
+    void exoticRelativesChecker(const HepMC::GenVertex* originVertex, int& hasExoticAssociation, int ngendepth);
 
     //! Returns next particle from the GenEvent that has to be propagated.
     /*!

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -142,8 +142,11 @@ namespace fastsim {
 }  // namespace fastsim
 
 inline bool isExotic(int pdgid_) {
-  unsigned int pdgid = std::abs(pdgid_);
-  return (pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) || pdgid == 17 || pdgid == 34 || pdgid == 37;
+unsigned int pdgid = std::abs(pdgid_);
+return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) || // SUSY, R-hadron, and technicolor particles
+pdgid == 17 || // 4th generation lepton
+pdgid == 34 || // W-prime
+pdgid == 37); // charged Higgs
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -123,10 +123,6 @@ namespace fastsim {
         genParticleIterator_;  //!< Iterator to keep track on which GenParticles where already considered.
     const HepMC::GenEvent::particle_const_iterator genParticleEnd_;  //!< The last particle of the GenEvent.
     int genParticleIndex_;  //!< Index of particle in the GenEvent (if it is a GenParticle)
-
-    HepMC::GenEvent::particle_const_iterator relativesIterator_; // iterator to loop over particle relatives
-    const HepMC::GenEvent::particle_const_iterator relativesIteratorEnd_; // last relative
-
     const HepPDT::ParticleDataTable* const
         particleDataTable_;         //!< Necessary to get information like lifetime and charge of a particle if unknown.
     const double beamPipeRadius2_;  //!< (Radius of the beampipe)^2

--- a/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
+++ b/FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h
@@ -142,11 +142,11 @@ namespace fastsim {
 }  // namespace fastsim
 
 inline bool isExotic(int pdgid_) {
-unsigned int pdgid = std::abs(pdgid_);
-return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) || // SUSY, R-hadron, and technicolor particles
-pdgid == 17 || // 4th generation lepton
-pdgid == 34 || // W-prime
-pdgid == 37); // charged Higgs
+  unsigned int pdgid = std::abs(pdgid_);
+  return ((pdgid >= 1000000 && pdgid < 4000000 && pdgid != 3000022) ||  // SUSY, R-hadron, and technicolor particles
+          pdgid == 17 ||                                                // 4th generation lepton
+          pdgid == 34 ||                                                // W-prime
+          pdgid == 37);                                                 // charged Higgs
 }
 
 #endif

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -33,6 +33,7 @@ void fastsim::Decayer::decay(const Particle& particle,
 
   // inspired by method Pythia8Hadronizer::residualDecay() in GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
   int pid = particle.pdgId();
+  if (abs(pid)>1000000) return;/////for now, just taking preset decays for exotic particles
   pythia_->event.reset();
 
   // create a pythia particle which has the same properties as the FastSim particle

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -1,5 +1,6 @@
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/Decayer.h"
 #include "FastSimulation/SimplifiedGeometryPropagator/interface/Particle.h"
+#include "FastSimulation/SimplifiedGeometryPropagator/interface/ParticleManager.h"
 #include "FWCore/ServiceRegistry/interface/RandomEngineSentry.h"
 #include "GeneratorInterface/Pythia8Interface/interface/P8RndmEngine.h"
 
@@ -35,14 +36,11 @@ void fastsim::Decayer::decay(const Particle& particle,
   int pid = particle.pdgId();
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
-  int abspid = std::abs(pid);
-  if ((abspid >= 1000000 && abspid < 4000000 && abspid != 3000022) || abspid == 17 || abspid == 34 || abspid == 37) {
-    std::cout << "not decaying due to pdgid=" << pid << std::endl;
+
+  if (isExotic(pid)) {
     return;
   }
-  abspid = std::abs(particle.getMotherPdgId());
-  if ((abspid >= 1000000 && abspid < 4000000 && abspid != 3000022) || abspid == 17 || abspid == 34 || abspid == 37) {
-    std::cout << "not decaying " << pid << " due to mother=" << particle.getMotherPdgId() << std::endl;
+  if (isExotic(particle.getMotherPdgId())) {
     return;
   }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -37,7 +37,7 @@ void fastsim::Decayer::decay(const Particle& particle,
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
 
-if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
+  if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
     return;
 }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -33,7 +33,11 @@ void fastsim::Decayer::decay(const Particle& particle,
 
   // inspired by method Pythia8Hadronizer::residualDecay() in GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
   int pid = particle.pdgId();
-  if (abs(pid)>1000000) return;/////for now, just taking preset decays for exotic particles
+  // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
+  // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard. 
+  if (abs(pid)>1000000) { return; }
+  if (abs(particle.getMotherPdgId())>1000000) { return; }
+
   pythia_->event.reset();
 
   // create a pythia particle which has the same properties as the FastSim particle

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -39,7 +39,7 @@ void fastsim::Decayer::decay(const Particle& particle,
 
   if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
     return;
-}
+  }
 
   pythia_->event.reset();
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -34,9 +34,13 @@ void fastsim::Decayer::decay(const Particle& particle,
   // inspired by method Pythia8Hadronizer::residualDecay() in GeneratorInterface/Pythia8Interface/src/Py8GunBase.cc
   int pid = particle.pdgId();
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
-  // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard. 
-  if (abs(pid)>1000000) { return; }
-  if (abs(particle.getMotherPdgId())>1000000) { return; }
+  // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
+  if (abs(pid) > 1000000) {
+    return;
+  }
+  if (abs(particle.getMotherPdgId()) > 1000000) {
+    return;
+  }
 
   pythia_->event.reset();
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -37,7 +37,7 @@ void fastsim::Decayer::decay(const Particle& particle,
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
 
-if (isExotic(pid) || isExotic(particle.getMotherPdgId())){
+if (isExotic(pid) || isExotic(particle.getMotherPdgId())) {
     return;
 }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -35,10 +35,10 @@ void fastsim::Decayer::decay(const Particle& particle,
   int pid = particle.pdgId();
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
-  if (abs(pid) > 1000000) {
+  if (std::abs(pid) > 1000000) {
     return;
   }
-  if (abs(particle.getMotherPdgId()) > 1000000) {
+  if (std::abs(particle.getMotherPdgId()) > 1000000) {
     return;
   }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -35,10 +35,14 @@ void fastsim::Decayer::decay(const Particle& particle,
   int pid = particle.pdgId();
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
-  if (std::abs(pid) > 1000000) {
+  int abspid = std::abs(pid);
+  if ((abspid >= 1000000 && abspid < 4000000 && abspid != 3000022) || abspid == 17 || abspid == 34 || abspid == 37) {
+    std::cout << "not decaying due to pdgid=" << pid << std::endl;
     return;
   }
-  if (std::abs(particle.getMotherPdgId()) > 1000000) {
+  abspid = std::abs(particle.getMotherPdgId());
+  if ((abspid >= 1000000 && abspid < 4000000 && abspid != 3000022) || abspid == 17 || abspid == 34 || abspid == 37) {
+    std::cout << "not decaying " << pid << " due to mother=" << particle.getMotherPdgId() << std::endl;
     return;
   }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/Decayer.cc
@@ -37,12 +37,9 @@ void fastsim::Decayer::decay(const Particle& particle,
   // snip decay products of exotic particles or their children. These decay products are preserved from the event record.
   // limitation: if exotic incurs heavy energy loss during propagation, the saved decay products could be too hard.
 
-  if (isExotic(pid)) {
+if (isExotic(pid) || isExotic(particle.getMotherPdgId())){
     return;
-  }
-  if (isExotic(particle.getMotherPdgId())) {
-    return;
-  }
+}
 
   pythia_->event.reset();
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -214,7 +214,19 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
 
     // particle must be produced within the beampipe
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
-      continue;
+      std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = productionVertex->particles_in_const_begin();
+      std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = productionVertex->particles_in_const_end();
+      bool hasExoticAssociation = false;
+      for ( ; relativesIterator_ != relativesIteratorEnd_ ; ++relativesIterator_ ) 
+	{
+	  const HepMC::GenParticle & genRelative = **relativesIterator_;
+	  if (abs(genRelative.pdg_id())>1000000)
+	    {
+	      hasExoticAssociation = true;
+	      break;
+	    }
+	}
+      if (!hasExoticAssociation) {continue;}
     }
 
     // particle must not decay before it reaches the beam pipe

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -211,9 +211,11 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (!productionVertex) {
       continue;
     }
+    if (std::abs(particle.pdg_id())<10 || std::abs(particle.pdg_id())==21) {
+      continue;
+    }
 
-    // previously: particle must be produced within the beampipe
-    // now: particles which do not descend from exotics must be produced within the beampipe
+    // particles which do not descend from exotics must be produced within the beampipe
     int exoticRelativeId = 0;
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -211,10 +211,9 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (!productionVertex) {
       continue;
     }
-    if (std::abs(particle.pdg_id())<10 || std::abs(particle.pdg_id())==21) {
+    if (std::abs(particle.pdg_id()) < 10 || std::abs(particle.pdg_id()) == 21) {
       continue;
     }
-
     // particles which do not descend from exotics must be produced within the beampipe
     int exoticRelativeId = 0;
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -281,10 +281,7 @@ if (!isExotic(exoticRelativeId))
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  int relpid = std::abs(exoticRelativeId_);
-  bool relIsExotic = isExotic(relpid);
-
-  if (ngendepth > 99 || exoticRelativeId_ == -1 || relIsExotic)
+   if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_))) 
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -219,7 +219,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-    if (!isExotic(exoticRelativeId)){
+      if (!isExotic(exoticRelativeId)) {
         continue;
       }
     }
@@ -281,7 +281,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-   if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_))) 
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_))) 
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -212,23 +212,43 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
       continue;
     }
 
-    // particle must be produced within the beampipe
-    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) {
-      std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = productionVertex->particles_in_const_begin();
-      std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = productionVertex->particles_in_const_end();
-      bool hasExoticAssociation = false;
-      for ( ; relativesIterator_ != relativesIteratorEnd_ ; ++relativesIterator_ ) 
-	{
-	  const HepMC::GenParticle & genRelative = **relativesIterator_;
-	  if (abs(genRelative.pdg_id())>1000000)
-	    {
-	      hasExoticAssociation = true;
-	      break;
-	    }
-	}
-      if (!hasExoticAssociation) {continue;}
-    }
+    // previously: particle must be produced within the beampipe
+    // now: particles which do not descend from exotics must be produced within the beampipe
+    int exoticRelativeId = 0;
+    if(productionVertex->position().perp2()*lengthUnitConversionFactor2_ > beamPipeRadius2_)//
+      {
+	std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = productionVertex->particles_in_const_begin();
+	std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = productionVertex->particles_in_const_end();
+	bool hasExoticAssociation = false;
+	for ( ; relativesIterator_ != relativesIteratorEnd_ ; ++relativesIterator_ ) 
+	  {
+	    const HepMC::GenParticle & genRelative = **relativesIterator_;
+	    if (abs(genRelative.pdg_id())>1000000)
+	      {
+		exoticRelativeId = genRelative.pdg_id();
+		hasExoticAssociation = true;
+		break;
+	      }
+	    const HepMC::GenVertex * relVertex = genRelative.production_vertex();
+	    if(!relVertex) continue;
 
+	    std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIterator_ = relVertex->particles_in_const_begin();
+	    std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIteratorEnd_ = relVertex->particles_in_const_end();
+	    for ( ; relatives2ndGenIterator_ != relatives2ndGenIteratorEnd_ ; ++relatives2ndGenIterator_ ) 
+	      {
+		const HepMC::GenParticle & genRelative2ndGen = **relatives2ndGenIterator_;
+		if (abs(genRelative2ndGen.pdg_id())>1000000)
+		  {
+		    exoticRelativeId = genRelative2ndGen.pdg_id();
+		    hasExoticAssociation = true;
+		    break;
+		  }
+	      }
+	    if(hasExoticAssociation) break;
+	  }
+	if (!hasExoticAssociation) {continue;}
+      }
+    
     // particle must not decay before it reaches the beam pipe
     if (endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_) {
       continue;
@@ -246,6 +266,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
                                              particle.momentum().z() * momentumUnitConversionFactor_,
                                              particle.momentum().e() * momentumUnitConversionFactor_)));
     newParticle->setGenParticleIndex(genParticleIndex_);
+    if (abs(exoticRelativeId)>1000000) {newParticle->setMotherPdgId(exoticRelativeId);}
 
     // try to get the life time of the particle from the genEvent
     if (endVertex) {

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -218,7 +218,9 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-      bool hasExoticAssociation = bool(std::abs(exoticRelativeId) > 1000000);
+      int relpid = std::abs(exoticRelativeId);
+      bool hasExoticAssociation =
+          (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
       if (!hasExoticAssociation) {
         continue;
       }
@@ -281,20 +283,28 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  if (ngendepth > 3 || exoticRelativeId_ == -1 || std::abs(exoticRelativeId_) > 1000000)
+  int relpid = std::abs(exoticRelativeId_);
+  bool relIsExotic =
+      (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || relIsExotic)
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();
   std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = originVertex->particles_in_const_end();
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
-    if (std::abs(genRelative.pdg_id()) > 1000000) {
+    relpid = std::abs(genRelative.pdg_id());
+    relIsExotic =
+        (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
+    if (relIsExotic) {
       exoticRelativeId_ = genRelative.pdg_id();
-      if (ngendepth == 4)
+      if (ngendepth == 100)
         exoticRelativeId_ = -1;
       return;
     }
     const HepMC::GenVertex* vertex_ = genRelative.production_vertex();
+    if (!vertex_)
+      return;
     exoticRelativesChecker(vertex_, exoticRelativeId_, ngendepth);
   }
   return;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -254,7 +254,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
           for (; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_; ++relatives3rdGenIterator_) {
             const HepMC::GenParticle& genRelative3rdGen = **relatives3rdGenIterator_;
             if (std::abs(genRelative3rdGen.pdg_id()) > 1000000) {
-              exoticRelativeId = 0;  
+              exoticRelativeId = 0;
               hasExoticAssociation = true;
               break;
             }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -224,7 +224,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
       bool hasExoticAssociation = false;
       for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
         const HepMC::GenParticle& genRelative = **relativesIterator_;
-        if (abs(genRelative.pdg_id()) > 1000000) {
+        if (std::abs(genRelative.pdg_id()) > 1000000) {
           exoticRelativeId = genRelative.pdg_id();
           hasExoticAssociation = true;
           break;
@@ -239,7 +239,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
             relVertex->particles_in_const_end();
         for (; relatives2ndGenIterator_ != relatives2ndGenIteratorEnd_; ++relatives2ndGenIterator_) {
           const HepMC::GenParticle& genRelative2ndGen = **relatives2ndGenIterator_;
-          if (abs(genRelative2ndGen.pdg_id()) > 1000000) {
+          if (std::abs(genRelative2ndGen.pdg_id()) > 1000000) {
             exoticRelativeId = genRelative2ndGen.pdg_id();
             hasExoticAssociation = true;
             break;
@@ -253,7 +253,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
               relVertex2->particles_in_const_end();
           for (; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_; ++relatives3rdGenIterator_) {
             const HepMC::GenParticle& genRelative3rdGen = **relatives3rdGenIterator_;
-            if (abs(genRelative3rdGen.pdg_id()) > 1000000) {
+            if (std::abs(genRelative3rdGen.pdg_id()) > 1000000) {
               //the current particle, if non-stable, will have its decay products remade by fastsim
               exoticRelativeId = 0;  
               hasExoticAssociation = true;
@@ -288,7 +288,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
                                              particle.momentum().z() * momentumUnitConversionFactor_,
                                              particle.momentum().e() * momentumUnitConversionFactor_)));
     newParticle->setGenParticleIndex(genParticleIndex_);
-    if (abs(exoticRelativeId) > 1000000) {
+    if (std::abs(exoticRelativeId) > 1000000) {
       newParticle->setMotherPdgId(exoticRelativeId);
     }
 

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -219,8 +219,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-      bool hasExoticAssociation = isExotic(exoticRelativeId);
-      if (!hasExoticAssociation) {
+if (!isExotic(exoticRelativeId))
         continue;
       }
     }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -219,9 +219,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-      int relpid = std::abs(exoticRelativeId);
-      bool hasExoticAssociation =
-          (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
+      bool hasExoticAssociation = isExotic(exoticRelativeId);
       if (!hasExoticAssociation) {
         continue;
       }
@@ -244,7 +242,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
                                              particle.momentum().z() * momentumUnitConversionFactor_,
                                              particle.momentum().e() * momentumUnitConversionFactor_)));
     newParticle->setGenParticleIndex(genParticleIndex_);
-    if (std::abs(exoticRelativeId) > 1000000) {
+    if (isExotic(exoticRelativeId)) {
       newParticle->setMotherPdgId(exoticRelativeId);
     }
 
@@ -285,8 +283,8 @@ void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* or
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
   int relpid = std::abs(exoticRelativeId_);
-  bool relIsExotic =
-      (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
+  bool relIsExotic = isExotic(relpid);
+
   if (ngendepth > 99 || exoticRelativeId_ == -1 || relIsExotic)
     return;
   ngendepth += 1;
@@ -295,8 +293,7 @@ void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* or
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
     relpid = std::abs(genRelative.pdg_id());
-    relIsExotic =
-        (relpid >= 1000000 && relpid < 4000000 && relpid != 3000022) || relpid == 17 || relpid == 34 || relpid == 37;
+    relIsExotic = isExotic(relpid);
     if (relIsExotic) {
       exoticRelativeId_ = genRelative.pdg_id();
       if (ngendepth == 100)

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -281,7 +281,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
 void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* originVertex,
                                                       int& exoticRelativeId_,
                                                       int ngendepth = 0) {
-  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_))) 
+  if (ngendepth > 99 || exoticRelativeId_ == -1 || isExotic(std::abs(exoticRelativeId_)))
     return;
   ngendepth += 1;
   std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = originVertex->particles_in_const_begin();

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -254,8 +254,8 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
           for (; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_; ++relatives3rdGenIterator_) {
             const HepMC::GenParticle& genRelative3rdGen = **relatives3rdGenIterator_;
             if (abs(genRelative3rdGen.pdg_id()) > 1000000) {
-              exoticRelativeId =
-                  0;  //the current particle, if non-stable, will have its decay products remade by fastsim
+              //the current particle, if non-stable, will have its decay products remade by fastsim
+              exoticRelativeId = 0;  
               hasExoticAssociation = true;
               break;
             }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -254,7 +254,6 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
           for (; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_; ++relatives3rdGenIterator_) {
             const HepMC::GenParticle& genRelative3rdGen = **relatives3rdGenIterator_;
             if (std::abs(genRelative3rdGen.pdg_id()) > 1000000) {
-              //the current particle, if non-stable, will have its decay products remade by fastsim
               exoticRelativeId = 0;  
               hasExoticAssociation = true;
               break;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -243,6 +243,21 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
 		    hasExoticAssociation = true;
 		    break;
 		  }
+		const HepMC::GenVertex * relVertex2 = genRelative2ndGen.production_vertex();
+		if(!relVertex2) continue;
+		std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIterator_ = relVertex2->particles_in_const_begin();
+		std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIteratorEnd_ = relVertex2->particles_in_const_end();
+		for ( ; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_ ; ++relatives3rdGenIterator_ ) 
+		  {
+		    const HepMC::GenParticle & genRelative3rdGen = **relatives3rdGenIterator_;
+		    if (abs(genRelative3rdGen.pdg_id())>1000000)
+		      {
+			exoticRelativeId = 0;//the current particle, if non-stable, will have its decay products remade by fastsim
+			hasExoticAssociation = true;
+			break;
+		      }
+		  }
+		if(hasExoticAssociation) break;
 	      }
 	    if(hasExoticAssociation) break;
 	  }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -219,7 +219,7 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
     {
       exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-if (!isExotic(exoticRelativeId))
+    if (!isExotic(exoticRelativeId)){
         continue;
       }
     }

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -288,9 +288,7 @@ void fastsim::ParticleManager::exoticRelativesChecker(const HepMC::GenVertex* or
   std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = originVertex->particles_in_const_end();
   for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
     const HepMC::GenParticle& genRelative = **relativesIterator_;
-    relpid = std::abs(genRelative.pdg_id());
-    relIsExotic = isExotic(relpid);
-    if (relIsExotic) {
+    if (isExotic(std::abs(genRelative.pdg_id()))) {
       exoticRelativeId_ = genRelative.pdg_id();
       if (ngendepth == 100)
         exoticRelativeId_ = -1;

--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -215,55 +215,62 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
     // previously: particle must be produced within the beampipe
     // now: particles which do not descend from exotics must be produced within the beampipe
     int exoticRelativeId = 0;
-    if(productionVertex->position().perp2()*lengthUnitConversionFactor2_ > beamPipeRadius2_)//
-      {
-	std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ = productionVertex->particles_in_const_begin();
-	std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ = productionVertex->particles_in_const_end();
-	bool hasExoticAssociation = false;
-	for ( ; relativesIterator_ != relativesIteratorEnd_ ; ++relativesIterator_ ) 
-	  {
-	    const HepMC::GenParticle & genRelative = **relativesIterator_;
-	    if (abs(genRelative.pdg_id())>1000000)
-	      {
-		exoticRelativeId = genRelative.pdg_id();
-		hasExoticAssociation = true;
-		break;
-	      }
-	    const HepMC::GenVertex * relVertex = genRelative.production_vertex();
-	    if(!relVertex) continue;
+    if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
+    {
+      std::vector<HepMC::GenParticle*>::const_iterator relativesIterator_ =
+          productionVertex->particles_in_const_begin();
+      std::vector<HepMC::GenParticle*>::const_iterator relativesIteratorEnd_ =
+          productionVertex->particles_in_const_end();
+      bool hasExoticAssociation = false;
+      for (; relativesIterator_ != relativesIteratorEnd_; ++relativesIterator_) {
+        const HepMC::GenParticle& genRelative = **relativesIterator_;
+        if (abs(genRelative.pdg_id()) > 1000000) {
+          exoticRelativeId = genRelative.pdg_id();
+          hasExoticAssociation = true;
+          break;
+        }
+        const HepMC::GenVertex* relVertex = genRelative.production_vertex();
+        if (!relVertex)
+          continue;
 
-	    std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIterator_ = relVertex->particles_in_const_begin();
-	    std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIteratorEnd_ = relVertex->particles_in_const_end();
-	    for ( ; relatives2ndGenIterator_ != relatives2ndGenIteratorEnd_ ; ++relatives2ndGenIterator_ ) 
-	      {
-		const HepMC::GenParticle & genRelative2ndGen = **relatives2ndGenIterator_;
-		if (abs(genRelative2ndGen.pdg_id())>1000000)
-		  {
-		    exoticRelativeId = genRelative2ndGen.pdg_id();
-		    hasExoticAssociation = true;
-		    break;
-		  }
-		const HepMC::GenVertex * relVertex2 = genRelative2ndGen.production_vertex();
-		if(!relVertex2) continue;
-		std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIterator_ = relVertex2->particles_in_const_begin();
-		std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIteratorEnd_ = relVertex2->particles_in_const_end();
-		for ( ; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_ ; ++relatives3rdGenIterator_ ) 
-		  {
-		    const HepMC::GenParticle & genRelative3rdGen = **relatives3rdGenIterator_;
-		    if (abs(genRelative3rdGen.pdg_id())>1000000)
-		      {
-			exoticRelativeId = 0;//the current particle, if non-stable, will have its decay products remade by fastsim
-			hasExoticAssociation = true;
-			break;
-		      }
-		  }
-		if(hasExoticAssociation) break;
-	      }
-	    if(hasExoticAssociation) break;
-	  }
-	if (!hasExoticAssociation) {continue;}
+        std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIterator_ =
+            relVertex->particles_in_const_begin();
+        std::vector<HepMC::GenParticle*>::const_iterator relatives2ndGenIteratorEnd_ =
+            relVertex->particles_in_const_end();
+        for (; relatives2ndGenIterator_ != relatives2ndGenIteratorEnd_; ++relatives2ndGenIterator_) {
+          const HepMC::GenParticle& genRelative2ndGen = **relatives2ndGenIterator_;
+          if (abs(genRelative2ndGen.pdg_id()) > 1000000) {
+            exoticRelativeId = genRelative2ndGen.pdg_id();
+            hasExoticAssociation = true;
+            break;
+          }
+          const HepMC::GenVertex* relVertex2 = genRelative2ndGen.production_vertex();
+          if (!relVertex2)
+            continue;
+          std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIterator_ =
+              relVertex2->particles_in_const_begin();
+          std::vector<HepMC::GenParticle*>::const_iterator relatives3rdGenIteratorEnd_ =
+              relVertex2->particles_in_const_end();
+          for (; relatives3rdGenIterator_ != relatives3rdGenIteratorEnd_; ++relatives3rdGenIterator_) {
+            const HepMC::GenParticle& genRelative3rdGen = **relatives3rdGenIterator_;
+            if (abs(genRelative3rdGen.pdg_id()) > 1000000) {
+              exoticRelativeId =
+                  0;  //the current particle, if non-stable, will have its decay products remade by fastsim
+              hasExoticAssociation = true;
+              break;
+            }
+          }
+          if (hasExoticAssociation)
+            break;
+        }
+        if (hasExoticAssociation)
+          break;
       }
-    
+      if (!hasExoticAssociation) {
+        continue;
+      }
+    }
+
     // particle must not decay before it reaches the beam pipe
     if (endVertex && endVertex->position().perp2() * lengthUnitConversionFactor2_ < beamPipeRadius2_) {
       continue;
@@ -281,7 +288,9 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle() {
                                              particle.momentum().z() * momentumUnitConversionFactor_,
                                              particle.momentum().e() * momentumUnitConversionFactor_)));
     newParticle->setGenParticleIndex(genParticleIndex_);
-    if (abs(exoticRelativeId)>1000000) {newParticle->setMotherPdgId(exoticRelativeId);}
+    if (abs(exoticRelativeId) > 1000000) {
+      newParticle->setMotherPdgId(exoticRelativeId);
+    }
 
     // try to get the life time of the particle from the genEvent
     if (endVertex) {


### PR DESCRIPTION
#### PR description:
Note: The proposed changes to the code have no effect on SM physics by construction, nor on existing prompt BSM models. The changes impact events where an exotic particle (pdgId>1000000) has a displaced decay with dxy>~3cm. 

Problem: 
BAU, some decay products of  long-lived (LL) particles are not simulated by FastSim.

Explanation
FastSim decays displaced particles (dxy(origin, PV)>xy(beam pipe)) "one by one" by creating an empty Pythia event, loading in the one particle, and using pythia8::next() to decay. However, some exotic particles cannot be decayed "on their own", for example, LL top squarks - in reality, these would form R-hadrons, but we don't always generate those. In such cases, FastSim just gives up and no decay products are produced.

Proposed solution:
Let’s make it default to take pre-set decay products of exotics. This will be the same as what's done for FullSim by default. 
Another option would be to compel anyone requesting such models to work with realistic particles, say, R-hadrons in place of LL squarks. But, this would reduce FastSim's flexibility. 

#### PR validation:

Validation has been performed by comparing equivalent FastSim and FullSim recipes. These validation studies were presented 
https://indico.cern.ch/event/949596/contributions/3993708/attachments/2093307/3517762/FastSimAugust2020Update.pdf

#### 
These changes should also be backported to previous releases 9_4_X, 10_2_X, and 10_6_X.

backport 9_4_X #31575
fix backport 9_4_X #31596
backport 10_2_X #31597
backport 10_6_X #31598
