### PR TITLE
fixed typo for recHitEE_

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/EGMSeedGainProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/EGMSeedGainProducer.cc
@@ -74,7 +74,7 @@ void EGMSeedGainProducer<T>::produce(edm::StreamID streamID, edm::Event& iEvent,
   edm::Handle<EcalRecHitCollection> recHitsEB;
   iEvent.getByToken(recHitsEB_, recHitsEB);
   edm::Handle<EcalRecHitCollection> recHitsEE;
-  iEvent.getByToken(recHitsEB_, recHitsEE);
+  iEvent.getByToken(recHitsEE_, recHitsEE);
 
   unsigned nSrc = src->size();
   std::vector<int> gainSeed(nSrc, 12);


### PR DESCRIPTION
#### PR description:

Providing a fix for a gainSeed issue with the EGM producer in nanoAOD corresponding to https://github.com/cms-nanoAOD/cmssw/issues/534

A typo was causing the issue. The correction was to change recHitsEB_ ---> recHitsEE_.
