### PR TITLE
remove vertex type from PFCandidate (addresses #30895)

### DIFF
--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -71,18 +71,6 @@ namespace reco {
       GAMMA_TO_GAMMACONV
     };
 
-    enum PFVertexType {
-      kCandVertex = 0,
-      kTrkVertex = 1,
-      kComMuonVertex = 2,
-      kSAMuonVertex = 3,
-      kTrkMuonVertex = 4,
-      kGSFVertex = 5,
-      kTPFMSMuonVertex = 6,
-      kPickyMuonVertex = 7,
-      kDYTMuonVertex = 8
-    };
-
     /// default constructor
     PFCandidate();
 
@@ -386,30 +374,6 @@ namespace reco {
 
     friend std::ostream& operator<<(std::ostream& out, const PFCandidate& c);
 
-    //Tips on setting the vertex efficiently
-    //There are two choices: a) use the vertex_ data member, or b) point to the vertex
-    //of one of the refs stored by this class. The PFVertexType enum gives the current list
-    //of possible references. For these references, use the setVeretxSource method and NOT
-    //the setVertex method. If none of the available refs have the vertex that you want for this
-    //PFCandidate, use the setVertex method. If you find that you are using frequently two store a
-    // vertex that is the same as one of the refs in this class, you should just extend the enum
-    // and modify the vertex() method accordingly.
-    void setVertexSource(PFVertexType vt) {
-      vertexType_ = vt;
-      if (vertexType_ != kCandVertex)
-        LeafCandidate::setVertex(Point(0., 0., 0.));
-    }
-
-    void setVertex(const math::XYZPoint& p) override {
-      LeafCandidate::setVertex(p);
-      vertexType_ = kCandVertex;
-    }
-
-    const Point& vertex() const override;
-    double vx() const override { return vertex().x(); }
-    double vy() const override { return vertex().y(); }
-    double vz() const override { return vertex().z(); }
-
     /// do we have a valid time information
     bool isTimeValid() const { return timeError_ >= 0.f; }
     /// \return the timing
@@ -482,8 +446,6 @@ namespace reco {
 
     /// uncertainty on 3-momentum
     float deltaP_;
-
-    PFVertexType vertexType_;
 
     // mva for isolated electrons
     float mva_Isolated_;

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -34,7 +34,6 @@ PFCandidate::PFCandidate()
       ps2Energy_(0.),
       flags_(0),
       deltaP_(0.),
-      vertexType_(kCandVertex),
       mva_Isolated_(bigMva_),
       mva_e_pi_(bigMva_),
       mva_e_mu_(bigMva_),
@@ -73,7 +72,6 @@ PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType pa
       ps2Energy_(0.),
       flags_(0),
       deltaP_(0.),
-      vertexType_(kCandVertex),
       mva_Isolated_(bigMva_),
       mva_e_pi_(bigMva_),
       mva_e_mu_(bigMva_),
@@ -129,7 +127,6 @@ PFCandidate::PFCandidate(PFCandidate const& iOther)
       ps2Energy_(iOther.ps2Energy_),
       flags_(iOther.flags_),
       deltaP_(iOther.deltaP_),
-      vertexType_(iOther.vertexType_),
       mva_Isolated_(iOther.mva_Isolated_),
       mva_e_pi_(iOther.mva_e_pi_),
       mva_e_mu_(iOther.mva_e_mu_),
@@ -173,7 +170,6 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   ps2Energy_ = iOther.ps2Energy_;
   flags_ = iOther.flags_;
   deltaP_ = iOther.deltaP_;
-  vertexType_ = iOther.vertexType_;
   mva_Isolated_ = iOther.mva_Isolated_;
   mva_e_pi_ = iOther.mva_e_pi_;
   mva_e_mu_ = iOther.mva_e_mu_;
@@ -597,40 +593,6 @@ void PFCandidate::setPFEGammaExtraRef(const reco::PFCandidateEGammaExtraRef& iRe
   //std::cout << " before storeRefInfo " << kRefPFEGammaExtraMask << " " <<  kRefPFEGammaExtraBit << " " <<  iRef.isNonnull() << " " <<  iRef.key() <<  " " << std::endl;
   storeRefInfo(
       kRefPFEGammaExtraMask, kRefPFEGammaExtraBit, iRef.isNonnull(), iRef.refCore(), iRef.key(), iRef.productGetter());
-}
-
-const math::XYZPoint& PFCandidate::vertex() const {
-  switch (vertexType_) {
-    case kCandVertex:
-      return LeafCandidate::vertex();
-      break;
-    case kTrkVertex:
-      return trackRef()->vertex();
-      break;
-    case kComMuonVertex:
-      return muonRef()->combinedMuon()->vertex();
-      break;
-    case kSAMuonVertex:
-      return muonRef()->standAloneMuon()->vertex();
-      break;
-    case kTrkMuonVertex:
-      return muonRef()->track()->vertex();
-      break;
-    case kTPFMSMuonVertex:
-      return muonRef()->tpfmsTrack()->vertex();
-      break;
-    case kPickyMuonVertex:
-      return muonRef()->pickyTrack()->vertex();
-      break;
-    case kDYTMuonVertex:
-      return muonRef()->dytTrack()->vertex();
-      break;
-
-    case kGSFVertex:
-      return gsfTrackRef()->vertex();
-      break;
-  }
-  return LeafCandidate::vertex();
 }
 
 const PFCandidate::ElementsInBlocks& PFCandidate::elementsInBlocks() const {

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="19">
+   <class name="reco::PFCandidate" ClassVersion="20">
+    <version ClassVersion="20" checksum="1260609994"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
     <version ClassVersion="17" checksum="3126170233"/>
@@ -52,7 +53,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="15">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
+   <version ClassVersion="16" checksum="1266825707"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
    <version ClassVersion="13" checksum="1855164250"/>
@@ -67,7 +69,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="15">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
+   <version ClassVersion="16" checksum="278254000"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>
    <version ClassVersion="13" checksum="1734488695"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -314,7 +314,8 @@
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="15">
+  <class name="pat::PFParticle"  ClassVersion="16">
+   <version ClassVersion="16" checksum="4013624954"/>
    <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>
    <version ClassVersion="13" checksum="223824921"/>

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -3160,7 +3160,7 @@ unsigned PFAlgo::reconstructTrack(const reco::PFBlockElement& elt, bool allowLoo
                                       << ", phi=" << momentum.phi();
   pfCandidates_->push_back(PFCandidate(charge, momentum, particleType));
   //Set vertex and stuff like this
-  pfCandidates_->back().setVertexSource(PFCandidate::kTrkVertex);
+  pfCandidates_->back().setVertex(trackRef->vertex());
   pfCandidates_->back().setTrackRef(trackRef);
   pfCandidates_->back().setPositionAtECALEntrance(eltTrack->positionAtECALEntrance());
   if (muonRef.isNonnull())

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1488,12 +1488,14 @@ PFEGammaAlgo::EgammaObjects PFEGammaAlgo::fillPFCandidates(const std::list<PFEGa
       cand.setCharge(RO.primaryKFs[0]->trackRef()->charge());
       xtra.setKfTrackRef(RO.primaryKFs[0]->trackRef());
       cand.setTrackRef(RO.primaryKFs[0]->trackRef());
+      cand.setVertex(RO.primaryKFs[0]->trackRef()->vertex());
       cand.addElementInBlock(_currentblock, RO.primaryKFs[0]->index());
     }
     if (!RO.primaryGSFs.empty()) {
       cand.setCharge(RO.primaryGSFs[0]->GsftrackRef()->chargeMode());
       xtra.setGsfTrackRef(RO.primaryGSFs[0]->GsftrackRef());
       cand.setGsfTrackRef(RO.primaryGSFs[0]->GsftrackRef());
+      cand.setVertex(RO.primaryGSFs[0]->GsftrackRef()->vertex());
       cand.addElementInBlock(_currentblock, RO.primaryGSFs[0]->index());
     }
     if (RO.parentSC) {

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -1,13 +1,14 @@
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonCocktails.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "DataFormats/MuonReco/interface/MuonCocktails.h"
 #include <iostream>
+#include <memory>
 
 using namespace std;
 using namespace reco;
@@ -633,27 +634,27 @@ void PFMuonAlgo::postClean(reco::PFCandidateCollection* cands) {
   if (pfCosmicsMuonCleanedCandidates_.get())
     pfCosmicsMuonCleanedCandidates_->clear();
   else
-    pfCosmicsMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
+    pfCosmicsMuonCleanedCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   if (pfCleanedTrackerAndGlobalMuonCandidates_.get())
     pfCleanedTrackerAndGlobalMuonCandidates_->clear();
   else
-    pfCleanedTrackerAndGlobalMuonCandidates_.reset(new reco::PFCandidateCollection);
+    pfCleanedTrackerAndGlobalMuonCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   if (pfFakeMuonCleanedCandidates_.get())
     pfFakeMuonCleanedCandidates_->clear();
   else
-    pfFakeMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
+    pfFakeMuonCleanedCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   if (pfPunchThroughMuonCleanedCandidates_.get())
     pfPunchThroughMuonCleanedCandidates_->clear();
   else
-    pfPunchThroughMuonCleanedCandidates_.reset(new reco::PFCandidateCollection);
+    pfPunchThroughMuonCleanedCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   if (pfPunchThroughHadronCleanedCandidates_.get())
     pfPunchThroughHadronCleanedCandidates_->clear();
   else
-    pfPunchThroughHadronCleanedCandidates_.reset(new reco::PFCandidateCollection);
+    pfPunchThroughHadronCleanedCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   pfPunchThroughHadronCleanedCandidates_->clear();
 
@@ -720,7 +721,7 @@ void PFMuonAlgo::addMissingMuons(edm::Handle<reco::MuonCollection> muons, reco::
   if (pfAddedMuonCandidates_.get())
     pfAddedMuonCandidates_->clear();
   else
-    pfAddedMuonCandidates_.reset(new reco::PFCandidateCollection);
+    pfAddedMuonCandidates_ = std::make_unique<reco::PFCandidateCollection>();
 
   for (unsigned imu = 0; imu < muons->size(); ++imu) {
     reco::MuonRef muonRef(muons, imu);

--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -600,16 +600,7 @@ void PFMuonAlgo::changeTrack(reco::PFCandidate& candidate, const MuonTrackTypePa
   candidate.setParticleType(reco::PFCandidate::mu);
   //    candidate.setTrackRef( bestTrack );
   candidate.setMuonTrackType(trackType);
-  if (trackType == reco::Muon::InnerTrack)
-    candidate.setVertexSource(PFCandidate::kTrkMuonVertex);
-  else if (trackType == reco::Muon::CombinedTrack)
-    candidate.setVertexSource(PFCandidate::kComMuonVertex);
-  else if (trackType == reco::Muon::TPFMS)
-    candidate.setVertexSource(PFCandidate::kTPFMSMuonVertex);
-  else if (trackType == reco::Muon::Picky)
-    candidate.setVertexSource(PFCandidate::kPickyMuonVertex);
-  else if (trackType == reco::Muon::DYT)
-    candidate.setVertexSource(PFCandidate::kDYTMuonVertex);
+  candidate.setVertex(bestTrack->vertex());
 }
 
 reco::Muon::MuonTrackTypePair PFMuonAlgo::getTrackWithSmallestError(


### PR DESCRIPTION
this commit addressed the GitHub issue https://github.com/cms-sw/cmssw/issues/30895 :

- set vertex position of PFCandidate in PFAlgo, PFEGammaAlgo, and PFMuonAlgo
- remove vertex related member-functions from PFCandidate class (use the member-fuctions defined in the LeafCandidate base-class instead)
- updated ClassDefs in classes_def.xml files accordingly

#### PR description:

This PR adresses the GitHub issue https://github.com/cms-sw/cmssw/issues/30895 .

No changes are expected in the output, except (maybe) for PFCandidates of type electron.
This is because the enum value PFCandidate::kGSFVertex was not used before, causing the function PFCandidate::vertex() to never return the vertex associated with the gsfTrackRef(), which I believe is a (minor) bug. In this PR, the vertex of PFCandidates of type electron is set to the vertex assocciated with the gsfTrackRef() in PFEGammaAlgo, which I believe is the intended behaviour.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
