### PR TITLE
Fix unused variable warning

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -8,7 +8,6 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
 namespace {
-  const edm::EDGetTokenT<edm::ValueMap<float>> empty_token;
   const edm::InputTag empty_tag("");
   template <typename T, typename U, typename V>
   inline void make_consumes(const T& tag, edm::EDGetTokenT<U>& tok, V& sume) {


### PR DESCRIPTION
#### PR description:

Remove unused variable warning in clang IBs
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_2_CLANG_X_2020-08-30-2300/RecoEgamma/EgammaTools
The file was not touched since 2019 and I still don't know why it didn't show until now

#### PR validation:

builds without warning using clang IBs