### PR TITLE
Fix for era modifiers used to rerun anti-e MVA tauID for NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/taus_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_cff.py
@@ -156,7 +156,9 @@ for era in [run2_nanoAOD_94XMiniAODv1,]:
 run2_miniAOD_80XLegacy.toModify(tauTable,
                                 variables = _variables80X
 )
-(~run2_miniAOD_80XLegacy).toModify(tauTable.variables,
+for era in [run2_nanoAOD_92X, run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2, \
+            run2_nanoAOD_94X2016, run2_nanoAOD_102Xv1, run2_nanoAOD_106Xv1]:
+    era.toModify(tauTable.variables,
                  rawAntiEle2018 = Var("tauID('againstElectronMVA6Raw2018')", float, doc= "Anti-electron MVA discriminator V6 raw output discriminator (2018)", precision=10),
                  rawAntiEleCat2018 = Var("tauID('againstElectronMVA6category2018')", int, doc="Anti-electron MVA discriminator V6 category (2018)"),
                  idAntiEle2018 = _tauId5WPMask("againstElectron%sMVA62018", doc= "Anti-electron MVA discriminator V6 (2018)"),

--- a/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
+++ b/PhysicsTools/NanoAOD/python/taus_updatedMVAIds_cff.py
@@ -296,7 +296,9 @@ _patTauDiscriminationByElectronRejection2015Seq = cms.Sequence(
     +patTauDiscriminationByElectronRejectionMVA62015
 )
 patTauDiscriminationByElectronRejectionSeq = _patTauDiscriminationByElectronRejection2015Seq.copy()
-(~run2_miniAOD_80XLegacy).toReplaceWith(patTauDiscriminationByElectronRejectionSeq,
+for era in [run2_nanoAOD_92X,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,\
+            run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1]:
+    era.toReplaceWith(patTauDiscriminationByElectronRejectionSeq,
                       _patTauDiscriminationByElectronRejection2018Seq)
 
 
@@ -412,7 +414,9 @@ _tauIDSourcesWithAntiE2015 = cms.PSet(
     _antiETauIDSources2015
 )
 slimmedTausUpdated.tauIDSources=_tauIDSourcesWithAntiE2015
-(~run2_miniAOD_80XLegacy).toModify(slimmedTausUpdated,
+for era in [run2_nanoAOD_92X,run2_nanoAOD_94XMiniAODv1,run2_nanoAOD_94XMiniAODv2,\
+            run2_nanoAOD_94X2016,run2_nanoAOD_102Xv1,run2_nanoAOD_106Xv1]:
+    era.toModify(slimmedTausUpdated,
                  tauIDSources = _tauIDSourcesWithAntiE2018
     )
 


### PR DESCRIPTION
#### PR description:

This PR fixes way in which era modifiers are used to switch between different versions of anti-e MVA tauID for NanoAOD. Namely, with setup updated in this PR the tau ID with the most recent (2018) training is rerun as a part of nanoAOD sequences for (explicitly listed) past nanoAOD eras, while the tauID with an old (2015) training is read from input miniAOD. For other (new) eras, conversely: the tauID with the old training is rerun, while the one with the new training is read from input miniAOD.

This PR reverts changes introduced in https://github.com/cms-sw/cmssw/commit/064713f34928edf6f161753f55266e8f5c698389 and follows discussion in https://github.com/cms-sw/cmssw/pull/31065#issuecomment-682090565

#### PR validation:

Tested with relevant nanoAOD workflows.
