### PR TITLE
PythiaTauDecayHook: filter for tau to electron or muon decays

### DIFF
--- a/GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h
+++ b/GeneratorInterface/Pythia8Interface/interface/BiasedTauDecayer.h
@@ -22,7 +22,8 @@ public:
 private:
   Pythia8::TauDecays decayer;
   bool filter_;
-  bool eMuDecays_;
+  bool eDecays_;
+  bool muDecays_;
   std::vector<int> idProdSave;
   std::vector<double> mProdSave;
   std::vector<Pythia8::Vec4> pProdSave;

--- a/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
+++ b/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
@@ -8,8 +8,10 @@ using namespace Pythia8;
 // leptonic decays
 //
 
-BiasedTauDecayer::BiasedTauDecayer(
-    const Info* infoPtr, Settings* settingsPtr, ParticleData* particleDataPtr, Rndm* rndmPtr) {
+BiasedTauDecayer::BiasedTauDecayer(const Info* infoPtr,
+                                   Settings* settingsPtr,
+                                   ParticleData* particleDataPtr,
+                                   Rndm* rndmPtr) {
   decayer = TauDecays();
   decayer.init();
   filter_ = settingsPtr->flag("BiasedTauDecayer:filter");
@@ -50,8 +52,7 @@ bool BiasedTauDecayer::decay(
       i2 = decay[iDec].daughter2();
       for (int i = i1; i < i2 + 1; ++i) {
         if (decay[i].isLepton() && decay[i].isCharged()) {
-          if ((eDecays_  && abs(decay[i].id())==11) ||
-              (muDecays_ && abs(decay[i].id())==13)) {
+          if ((eDecays_ && abs(decay[i].id()) == 11) || (muDecays_ && abs(decay[i].id()) == 13)) {
             hasLepton = true;
             break;
           }
@@ -64,8 +65,7 @@ bool BiasedTauDecayer::decay(
       i2 = decay[iDecSis].daughter2();
       for (int i = i1; i < i2 + 1; ++i) {
         if (decay[i].isLepton() && decay[i].isCharged()) {
-          if ((eDecays_  && abs(decay[i].id())==11) ||
-              (muDecays_ && abs(decay[i].id())==13)) {
+          if ((eDecays_ && abs(decay[i].id()) == 11) || (muDecays_ && abs(decay[i].id()) == 13)) {
             hasLepton = true;
             break;
           }

--- a/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
+++ b/GeneratorInterface/Pythia8Interface/src/BiasedTauDecayer.cc
@@ -13,7 +13,8 @@ BiasedTauDecayer::BiasedTauDecayer(
   decayer = TauDecays();
   decayer.init();
   filter_ = settingsPtr->flag("BiasedTauDecayer:filter");
-  eMuDecays_ = settingsPtr->flag("BiasedTauDecayer:eMuDecays");
+  eDecays_ = settingsPtr->flag("BiasedTauDecayer:eDecays");
+  muDecays_ = settingsPtr->flag("BiasedTauDecayer:muDecays");
 }
 
 bool BiasedTauDecayer::decay(
@@ -37,7 +38,7 @@ bool BiasedTauDecayer::decay(
   bool notDecayed = event[iDecSis].status() > 0 ? true : false;
   if (notDecayed) {
     // bias for leptonic decays
-    bool hasLepton = (eMuDecays_) ? false : true;
+    bool hasLepton = (eDecays_ || muDecays_) ? false : true;
     Event decay;
     int i1 = -1;
     int i2 = -1;
@@ -49,8 +50,11 @@ bool BiasedTauDecayer::decay(
       i2 = decay[iDec].daughter2();
       for (int i = i1; i < i2 + 1; ++i) {
         if (decay[i].isLepton() && decay[i].isCharged()) {
-          hasLepton = true;
-          break;
+          if ((eDecays_  && abs(decay[i].id())==11) ||
+              (muDecays_ && abs(decay[i].id())==13)) {
+            hasLepton = true;
+            break;
+          }
         }
       }
       if (hasLepton)
@@ -60,8 +64,11 @@ bool BiasedTauDecayer::decay(
       i2 = decay[iDecSis].daughter2();
       for (int i = i1; i < i2 + 1; ++i) {
         if (decay[i].isLepton() && decay[i].isCharged()) {
-          hasLepton = true;
-          break;
+          if ((eDecays_  && abs(decay[i].id())==11) ||
+              (muDecays_ && abs(decay[i].id())==13)) {
+            hasLepton = true;
+            break;
+          }
         }
       }
     }

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -84,7 +84,8 @@ namespace gen {
 
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("BiasedTauDecayer:filter", false);
-    fMasterGen->settings.addFlag("BiasedTauDecayer:eMuDecays", true);
+    fMasterGen->settings.addFlag("BiasedTauDecayer:eDecays", true);
+    fMasterGen->settings.addFlag("BiasedTauDecayer:muDecays", true);
 
     //add settings for resonance decay filter
     fMasterGen->settings.addFlag("ResonanceDecayFilter:filter", false);

--- a/GeneratorInterface/Pythia8Interface/test/ZToTauTau_photos_13TeV_rivet_cfg.py
+++ b/GeneratorInterface/Pythia8Interface/test/ZToTauTau_photos_13TeV_rivet_cfg.py
@@ -1,0 +1,113 @@
+import FWCore.ParameterSet.Config as cms
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing ('python')
+options.register('outFilename', 'particleLevel.root',  VarParsing.multiplicity.singleton, VarParsing.varType.string, "Output file name")
+options.register('photos', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "ME corrections")
+options.register('lepton', 13, VarParsing.multiplicity.singleton, VarParsing.varType.int, "Lepton ID for Z decays")
+options.register('cutoff', 0.00011, VarParsing.multiplicity.singleton, VarParsing.varType.float, "IR cutoff")
+options.register('taufilter', 'off', VarParsing.multiplicity.singleton, VarParsing.varType.string, "Filter tau -> leptons")
+options.setDefault('maxEvents', 100)
+options.parseArguments()
+print(options)
+
+process = cms.Process("PROD")
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = int(options.maxEvents/100)
+
+from IOMC.RandomEngine.RandomServiceHelper import RandomNumberServiceHelper
+randSvc = RandomNumberServiceHelper(process.RandomNumberGeneratorService)
+randSvc.populate()
+
+# set input to process
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.maxEvents) )
+
+process.source = cms.Source("EmptySource")
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+
+process.generator = cms.EDFilter("Pythia8GeneratorFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'WeakSingleBoson:ffbar2gmZ = on',
+            'PhaseSpace:mHatMin = 50.',
+            '23:onMode = off', 
+            '23:onIfAny = 15',
+            'ParticleDecays:allowPhotonRadiation = on',
+            'TimeShower:QEDshowerByL = off',
+            ),
+		parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'processParameters')
+    ),
+	ExternalDecays = cms.PSet(
+        Photospp = cms.untracked.PSet(
+            parameterSets = cms.vstring("setExponentiation", "setInfraredCutOff", "setMeCorrectionWtForW", "setMeCorrectionWtForZ", "setMomentumConservationThreshold", "setPairEmission", "setPhotonEmission", "setStopAtCriticalError", "suppressAll", "forceBremForDecay"),
+            setExponentiation = cms.bool(True),
+            setMeCorrectionWtForW = cms.bool(True),
+            setMeCorrectionWtForZ = cms.bool(True),
+            setInfraredCutOff = cms.double(0.00011),
+            setMomentumConservationThreshold = cms.double(0.1),
+            setPairEmission = cms.bool(True),
+            setPhotonEmission = cms.bool(True),
+            setStopAtCriticalError = cms.bool(False),
+            # Use Photos only for W/Z decays
+            suppressAll = cms.bool(True),
+            forceBremForDecay = cms.PSet(
+                parameterSets = cms.vstring("Z", "Wp", "Wm"),
+                Z = cms.vint32(0, 23),
+                Wp = cms.vint32(0, 24),
+                Wm = cms.vint32(0, -24),
+            ),
+        ),
+        parameterSets = cms.vstring("Photospp")
+    )
+)
+
+if options.taufilter != 'off':
+    process.generator.PythiaParameters.processParameters.append('BiasedTauDecayer:filter = on')
+    if options.taufilter == 'el':
+        process.generator.PythiaParameters.processParameters.append('BiasedTauDecayer:eDecays = on')
+        process.generator.PythiaParameters.processParameters.append('BiasedTauDecayer:muDecays = off')
+    if options.taufilter == 'mu':
+        process.generator.PythiaParameters.processParameters.append('BiasedTauDecayer:eDecays = off')
+        process.generator.PythiaParameters.processParameters.append('BiasedTauDecayer:muDecays = on')
+
+
+## configure process options
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    wantSummary      = cms.untracked.bool(True)
+)
+
+process.genParticles = cms.EDProducer("GenParticleProducer",
+    saveBarCodes = cms.untracked.bool(True),
+    src = cms.InputTag("generator:unsmeared"),
+    abortOnUnknownPDGCode = cms.untracked.bool(False)
+)
+process.printTree1 = cms.EDAnalyzer("ParticleListDrawer",
+    src = cms.InputTag("genParticles"),
+    maxEventsToPrint  = cms.untracked.int32(10)
+)
+
+process.load("GeneratorInterface.RivetInterface.rivetAnalyzer_cfi")
+process.rivetAnalyzer.AnalysisNames = cms.vstring('PDG_TAUS', 'MC_ELECTRONS', 'MC_MUONS', 'MC_TAUS')
+process.rivetAnalyzer.useLHEweights = False
+# process.rivetAnalyzer.OutputFile = 'out.yoda'
+process.rivetAnalyzer.OutputFile = 'z-taufilter-%s.yoda' % options.taufilter
+
+# process.path = cms.Path(process.externalLHEProducer*process.generator*process.rivetAnalyzer)
+process.path = cms.Path(process.generator*process.rivetAnalyzer)
+


### PR DESCRIPTION
#### PR description:

Add options in BiasedTauDecayer for filtering tau->electron or muon decays only.

Attention: BiasedTauDecayer seems to be incompatible with Pythia 8.3, it crashes with 11_2 in these unchanged lines:
```cpp
decayer = TauDecays();
decayer.init();
```
@smrenna @bendavid 

However, the code changes are minimal, and the goal would be to backport this as soon as possible to 10_6 so that it can be included in the next UL production release.

#### PR validation:

Validation plots done in 11_1_3:
![image](https://user-images.githubusercontent.com/1311783/91740111-21628700-ebb3-11ea-84f4-47a3d8a16e5f.png) ![image](https://user-images.githubusercontent.com/1311783/91740127-26273b00-ebb3-11ea-9f83-1b1ff10b097a.png) ![image](https://user-images.githubusercontent.com/1311783/91740172-32ab9380-ebb3-11ea-8371-b60c53c696c9.png)
![image](https://user-images.githubusercontent.com/1311783/91740186-37704780-ebb3-11ea-98b1-1a6a773a040b.png) ![image](https://user-images.githubusercontent.com/1311783/91740215-4525cd00-ebb3-11ea-9c84-e5656e81f5be.png)


