### PR TITLE
DD4hep: TrackerGeometryBuilder Track FilteredView info

### DIFF
--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.cc
@@ -150,6 +150,22 @@ void CmsTrackerLevelBuilder<FilteredView>::build(FilteredView& fv,
   while (doLayers) {
     buildComponent(fv, tracker, attribute);
     doLayers = fv.nextSibling();  // go to next layer
+    if constexpr (std::is_same_v<FilteredView, DDFilteredView>) {
+
+      edm::LogVerbatim("TrackerGeometryBuilder")
+        << "CmsTrackerLevelbuilder<DDFilteredView>::build" << fv.geoHistory();
+
+    } else if constexpr (std::is_same_v<FilteredView, cms::DDFilteredView>) {
+
+        edm::LogVerbatim("TrackerGeometryBuilder")
+          << "CmsTrackerLevelbuilder<cms::DDFilteredView>::build";
+        std::vector<const cms::Node*> hst = fv.geoHistory();
+        std::string path;
+        for(auto nd = hst.rbegin(); nd!= hst.rend(); ++nd){
+          path += "/" + std::string((*nd)->GetName());
+        }
+        edm::LogVerbatim("TrackerGeometryBuilder") << path;
+    }
   }
 
   fv.parent();

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLevelBuilder.cc
@@ -151,20 +151,16 @@ void CmsTrackerLevelBuilder<FilteredView>::build(FilteredView& fv,
     buildComponent(fv, tracker, attribute);
     doLayers = fv.nextSibling();  // go to next layer
     if constexpr (std::is_same_v<FilteredView, DDFilteredView>) {
-
-      edm::LogVerbatim("TrackerGeometryBuilder")
-        << "CmsTrackerLevelbuilder<DDFilteredView>::build" << fv.geoHistory();
+      edm::LogVerbatim("TrackerGeometryBuilder") << "CmsTrackerLevelbuilder<DDFilteredView>::build" << fv.geoHistory();
 
     } else if constexpr (std::is_same_v<FilteredView, cms::DDFilteredView>) {
-
-        edm::LogVerbatim("TrackerGeometryBuilder")
-          << "CmsTrackerLevelbuilder<cms::DDFilteredView>::build";
-        std::vector<const cms::Node*> hst = fv.geoHistory();
-        std::string path;
-        for(auto nd = hst.rbegin(); nd!= hst.rend(); ++nd){
-          path += "/" + std::string((*nd)->GetName());
-        }
-        edm::LogVerbatim("TrackerGeometryBuilder") << path;
+      edm::LogVerbatim("TrackerGeometryBuilder") << "CmsTrackerLevelbuilder<cms::DDFilteredView>::build";
+      std::vector<const cms::Node*> hst = fv.geoHistory();
+      std::string path;
+      for (auto nd = hst.rbegin(); nd != hst.rend(); ++nd) {
+        path += "/" + std::string((*nd)->GetName());
+      }
+      edm::LogVerbatim("TrackerGeometryBuilder") << path;
     }
   }
 

--- a/SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step3_cfg.py
+++ b/SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step3_cfg.py
@@ -24,6 +24,8 @@ process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
 process.load('DQMOffline.Configuration.DQMOfflineMC_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+process.MessageLogger.categories.append("TrackerGeometryBuilder");
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10),
     output = cms.optional.untracked.allowed(cms.int32,cms.PSet)

--- a/SimG4Core/Configuration/test/ddd_ZMM_Run3_Step3_cfg.py
+++ b/SimG4Core/Configuration/test/ddd_ZMM_Run3_Step3_cfg.py
@@ -24,6 +24,8 @@ process.load('DQMServices.Core.DQMStoreNonLegacy_cff')
 process.load('DQMOffline.Configuration.DQMOfflineMC_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+process.MessageLogger.categories.append("TrackerGeometryBuilder");
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10),
     output = cms.optional.untracked.allowed(cms.int32,cms.PSet)


### PR DESCRIPTION
#### PR description:

Progress on https://github.com/cms-sw/cmssw/issues/31143, please see: https://github.com/cms-sw/cmssw/issues/31143#issuecomment-675687549


#### PR validation:

```
$ cmsRun SimG4Core/Configuration/test/ddd_ZMM_Run3_Step1_cfg.py
$ cmsRun SimG4Core/Configuration/test/ddd_ZMM_Run3_Step2_cfg.py
$ cmsRun SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step3_cfg.py # Still breaking but producing better logs
```

@ianna `dd4hep::FilteredView::nextSibling()` and `dd::FilteredView::nextSibling()` are taking us to different nodes. Is that the expected behavior?