### PR TITLE
Initial Changes for Incoporating GEM GE0 into the Reco Pipeline

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C11M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11M9_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+
+Phase2C11M9 = cms.ModifierChain(Phase2C11, phase2_GE0)

--- a/Configuration/Eras/python/Modifier_phase2_GE0_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_GE0_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+
+phase2_GE0 =  cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -43,6 +43,7 @@ class Eras (object):
                  'Phase2C10_dd4hep',
                  'Phase2C11_dd4hep',
                  'Phase2C12_dd4hep',
+                 'Phase2C11M9',
         ]
 
         internalUseMods = ['run2_common', 'run2_25ns_specific',
@@ -55,7 +56,8 @@ class Eras (object):
                            'phase1Pixel', 'run3_GEM', 'run2_GEM_2017',
                            'run2_CSC_2018',
                            'phase2_common', 'phase2_tracker',
-                           'phase2_hgcal', 'phase2_muon', 'phase2_timing', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11', 'phase2_hgcalV12',
+                           'phase2_muon', 'phase2_GEM', 'phase2_GE0',
+                           'phase2_hgcal', 'phase2_timing', 'phase2_hfnose', 'phase2_hgcalV10', 'phase2_hgcalV11', 'phase2_hgcalV12',
                            'phase2_timing_layer', 'phase2_hcal', 'phase2_ecal',
                            'phase2_trigger',
                            'trackingLowPU', 'trackingPhase1', 'ctpps_2016', 'ctpps_2017', 'ctpps_2018', 'ctpps_2021', 'trackingPhase2PU140','highBetaStar_2018',

--- a/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
+++ b/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
@@ -97,7 +97,9 @@ public:
 };
 
 inline int GEMOfflineDQMBase::getMaxVFAT(const int station) {
-  if (station == 1)
+  if (station == 0)
+    return GEMeMap::maxVFatGE0_;
+  else if (station == 1)
     return GEMeMap::maxVFatGE11_;
   else if (station == 2)
     return GEMeMap::maxVFatGE21_;

--- a/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
+++ b/DQMOffline/Muon/interface/GEMOfflineDQMBase.h
@@ -97,11 +97,11 @@ public:
 };
 
 inline int GEMOfflineDQMBase::getMaxVFAT(const int station) {
-  if (station == 0)
+  if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE0)
     return GEMeMap::maxVFatGE0_;
-  else if (station == 1)
+  else if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE11)
     return GEMeMap::maxVFatGE11_;
-  else if (station == 2)
+  else if (GEMSubDetId::station(station) == GEMSubDetId::Station::GE21)
     return GEMeMap::maxVFatGE21_;
   else
     return -1;

--- a/L1Trigger/L1TGEM/python/me0TriggerDigis_cff.py
+++ b/L1Trigger/L1TGEM/python/me0TriggerDigis_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 
 from L1Trigger.L1TGEM.simMuonME0PadDigis_cfi import *
 from L1Trigger.L1TGEM.me0TriggerDigis_cfi import *
@@ -6,3 +7,6 @@ from L1Trigger.L1TGEM.me0TriggerPseudoDigis_cff import *
 
 me0TriggerRealDigiTask = cms.Task(simMuonME0PadDigis, me0TriggerDigis)
 me0TriggerAllDigiTask = cms.Task(me0TriggerRealDigiTask, me0TriggerPseudoDigiTask)
+
+## in scenarios with GE0, remove the pseudo digis
+phase2_GE0.toReplaceWith(me0TriggerAllDigiTask, me0TriggerAllDigiTask.copyAndExclude([me0TriggerPseudoDigiTask]))

--- a/L1Trigger/L1TMuon/python/simDigis_cff.py
+++ b/L1Trigger/L1TMuon/python/simDigis_cff.py
@@ -104,6 +104,10 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 from L1Trigger.L1TGEM.me0TriggerDigis_cff import *
 _phase2_SimL1TMuonTask = SimL1TMuonTask.copy()
 _phase2_SimL1TMuonTask.add(me0TriggerAllDigiTask)
+_phase2_GE0_SimL1TMuonTask = SimL1TMuonTask.copyAndExclude([me0TriggerAllDigiTask])
 
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 (stage2L1Trigger & phase2_muon).toReplaceWith( SimL1TMuonTask, _phase2_SimL1TMuonTask )
+
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+(stage2L1Trigger & phase2_GE0).toReplaceWith( SimL1TMuonTask, _phase2_GE0_SimL1TMuonTask )

--- a/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
+++ b/RecoLocalMuon/Configuration/python/RecoLocalMuon_cff.py
@@ -54,9 +54,13 @@ _run3_muonlocalrecoTask.add(gemLocalRecoTask)
 _phase2_muonlocalrecoTask = _run3_muonlocalrecoTask.copy()
 _phase2_muonlocalrecoTask.add(me0LocalRecoTask)
 
+_phase2_ge0_muonlocalrecoTask = _phase2_muonlocalrecoTask.copyAndExclude([me0LocalRecoTask])
+
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith( muonlocalrecoTask , _run2_GEM_2017_muonlocalrecoTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonlocalrecoTask , _run3_muonlocalrecoTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonlocalrecoTask , _phase2_muonlocalrecoTask )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toReplaceWith( muonlocalrecoTask , _phase2_ge0_muonlocalrecoTask )

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -92,6 +92,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( muons1stStep, TrackAssociatorParameters = dict(useGEM = True ) )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = True ) )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( muons1stStep, TrackAssociatorParameters = dict(useME0 = False ) )
 
 muonEcalDetIds = cms.EDProducer("InterestingEcalDetIdProducer",
                                 inputCollection = cms.InputTag("muons1stStep")

--- a/RecoMuon/MuonSeedGenerator/python/ancientMuonSeed_cfi.py
+++ b/RecoMuon/MuonSeedGenerator/python/ancientMuonSeed_cfi.py
@@ -26,3 +26,6 @@ ancientMuonSeed = cms.EDProducer("MuonSeedGenerator",
 # phase2 ME0
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(ancientMuonSeed, EnableME0Measurement = True)
+# phase2 GE0
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify(ancientMuonSeed, EnableME0Measurement = False)

--- a/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cfi.py
+++ b/RecoMuon/StandAloneMuonProducer/python/standAloneMuons_cfi.py
@@ -119,3 +119,9 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( standAloneMuons, STATrajBuilderParameters = dict(
     FilterParameters = _enableME0Measurement,
     BWFilterParameters = _enableME0Measurement ) )
+
+_disableME0Measurement = dict( EnableME0Measurement = False )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( standAloneMuons, STATrajBuilderParameters = dict(
+    FilterParameters = _disableME0Measurement,
+    BWFilterParameters = _disableME0Measurement ) )

--- a/RecoMuon/TrackingTools/python/MuonServiceProxy_cff.py
+++ b/RecoMuon/TrackingTools/python/MuonServiceProxy_cff.py
@@ -55,3 +55,7 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify(MuonServiceProxy,
     ServiceParameters = dict(ME0Layers = True)
 )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify(MuonServiceProxy,
+    ServiceParameters = dict(ME0Layers = False)
+)

--- a/SimGeneral/MixingModule/python/mixObjects_cfi.py
+++ b/SimGeneral/MixingModule/python/mixObjects_cfi.py
@@ -262,6 +262,21 @@ phase2_muon.toModify( theMixObjects,
         pcrossingFrames = theMixObjects.mixSH.pcrossingFrames + [ 'MuonME0Hits' ]
     )
 )
+
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( theMixObjects,
+    mixSH = dict(
+        input = list(filter(lambda x: type(x) == type(cms.InputTag("","")) and x != cms.InputTag("g4SimHits","MuonME0Hits"), theMixObjects.mixSH.input)),
+        subdets = list(filter(lambda x: x != 'MuonME0Hits', theMixObjects.mixSH.subdets)),
+        crossingFrames = list(filter(lambda x: x != 'MuonME0Hits', theMixObjects.mixSH.crossingFrames))
+    )
+)
+(premix_stage1 & phase2_GE0).toModify(theMixObjects,
+    mixSH = dict(
+        pcrossingFrames = list(filter(lambda x: x != 'MuonME0Hits', theMixObjects.mixSH.pcrossingFrames))
+    )
+)
+
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify( theMixObjects,
     mixCH = dict(

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -64,5 +64,10 @@ from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( trackingParticles, simHitCollections = dict(
         muon = trackingParticles.simHitCollections.muon+[cms.InputTag("g4SimHits","MuonME0Hits")]))
 
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( trackingParticles, simHitCollections = dict(
+        muon = list(filter(lambda x: x != cms.InputTag("g4SimHits","MuonME0Hits"),
+                           trackingParticles.simHitCollections.muon))))
+
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify( trackingParticles, simHitCollections = dict( tracker = []) )

--- a/SimMuon/Configuration/python/SimMuon_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_cff.py
@@ -24,10 +24,15 @@ _run3_muonDigiTask.add(muonGEMDigiTask)
 _phase2_muonDigiTask = _run3_muonDigiTask.copy()
 _phase2_muonDigiTask.add(muonME0DigiTask)
 
+# while GE0 is in development, just turn off ME0 tasks
+_phase2_ge0 = _phase2_muonDigiTask.copyAndExclude([muonME0DigiTask])
+
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith( muonDigiTask, _run3_muonDigiTask )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( muonDigiTask, _run3_muonDigiTask )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( muonDigiTask, _phase2_muonDigiTask )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toReplaceWith( muonDigiTask, _phase2_ge0 )
 

--- a/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
+++ b/SimMuon/GEMDigitizer/python/muonME0Digi_cff.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 
 from SimMuon.GEMDigitizer.muonME0Digis_cfi import *
 from SimMuon.GEMDigitizer.muonME0PseudoDigis_cfi import *
@@ -9,4 +10,8 @@ muonME0RealDigi = cms.Task(simMuonME0Digis)
 muonME0PseudoDigi = cms.Task(simMuonME0PseudoDigis, simMuonME0PseudoReDigis)
 
 muonME0DigiTask = cms.Task(muonME0RealDigi, muonME0PseudoDigi)
+
+## in scenarios with GE0, remove the pseudo digis
+phase2_GE0.toReplaceWith(muonME0DigiTask, muonME0DigiTask.copyAndExclude([muonME0PseudoDigi]))
+
 muonME0Digi = cms.Sequence(muonME0DigiTask)

--- a/TrackingTools/TrackAssociator/python/DetIdAssociatorESProducer_cff.py
+++ b/TrackingTools/TrackAssociator/python/DetIdAssociatorESProducer_cff.py
@@ -51,6 +51,8 @@ run3_GEM.toModify( muonDetIdAssociator, includeGEM = True )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( muonDetIdAssociator, includeME0 = True )
 phase2_muon.toModify( hcalDetIdAssociator, hcalRegion = 1 )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( muonDetIdAssociator, includeME0 = False )
 
 preshowerDetIdAssociator = cms.ESProducer("DetIdAssociatorESProducer",
     ComponentName = cms.string('PreshowerDetIdAssociator'),

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -229,6 +229,8 @@ _phase2_globalValidation = _run3_globalValidation.copy()
 _phase2_globalValidation += trackerphase2ValidationSource
 _phase2_globalValidation += me0SimValid
 
+_phase2_ge0_globalValidation = _run3_globalValidation.copy()
+_phase2_ge0_globalValidation += trackerphase2ValidationSource
 
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith( globalValidation, _run3_globalValidation )
@@ -236,6 +238,9 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( globalValidation, _run3_globalValidation )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( globalValidation, _phase2_globalValidation )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toReplaceWith( globalValidation, _phase2_ge0_globalValidation )
+phase2_GE0.toReplaceWith( globalPrevalidationMuons, globalPrevalidationMuons.copyAndExclude([me0SimValid]) )
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(globalValidation, globalValidation.copyAndExclude([pfTauRunDQMValidation]))
 from Configuration.Eras.Modifier_phase2_timing_layer_cff import phase2_timing_layer

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -129,9 +129,15 @@ _phase2_postValidation += MuonME0DigisPostProcessors
 _phase2_postValidation += MuonME0SegPostProcessors
 _phase2_postValidation += trackerphase2ValidationHarvesting
 
+_phase2_ge0_postValidation = _run3_postValidation.copy()
+_phase2_ge0_postValidation += hgcalPostProcessor
+_phase2_ge0_postValidation += trackerphase2ValidationHarvesting
+
 from Configuration.Eras.Modifier_run2_GEM_2017_cff import run2_GEM_2017
 run2_GEM_2017.toReplaceWith( postValidation, _run3_postValidation )
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( postValidation, _run3_postValidation )
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( postValidation, _phase2_postValidation )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+(phase2_GE0 & phase2_hgcal).toReplaceWith( postValidation, _phase2_ge0_postValidation )

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -141,3 +141,4 @@ from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toReplaceWith( postValidation, _phase2_postValidation )
 from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
 (phase2_GE0 & phase2_hgcal).toReplaceWith( postValidation, _phase2_ge0_postValidation )
+phase2_GE0.toReplaceWith( postValidation_muons, postValidation_muons.copyAndExclude([MuonME0DigisPostProcessors, MuonME0SegPostProcessors]) )

--- a/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
+++ b/Validation/RecoMuon/python/MuonTrackValidator_cfi.py
@@ -54,6 +54,8 @@ from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toModify( muonTrackValidator, useGEMs = cms.bool(True) )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toModify( muonTrackValidator, useME0 = cms.bool(True) )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toModify( muonTrackValidator, useME0 = cms.bool(False) )
 
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 premix_stage2.toModify(muonTrackValidator,

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -257,7 +257,13 @@ _phase2_muonValidation = recoMuonValidation_reduced_seq.copy()
 _phase2_muonValidation += gemMuonValidation
 _phase2_muonValidation += me0MuonValidation
 
+#_phase2_ge0_muonValidation = recoMuonValidation.copy()          #For full validation
+_phase2_ge0_muonValidation = recoMuonValidation_reduced_seq.copy()
+_phase2_ge0_muonValidation += gemMuonValidation
+
 from Configuration.Eras.Modifier_run3_GEM_cff import run3_GEM
 run3_GEM.toReplaceWith( recoMuonValidation, _run3_muonValidation )
 from Configuration.Eras.Modifier_phase2_muon_cff import phase2_muon
 phase2_muon.toReplaceWith( recoMuonValidation, _phase2_muonValidation )
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+phase2_GE0.toReplaceWith( recoMuonValidation, _phase2_ge0_muonValidation )


### PR DESCRIPTION
#### PR description:

Modifications to allow the GE0 test geometry (which will eventually replace ME0, putting it in with the other GEM stations) to run step1/2 of the TenMu workflow.

Introduces a temporary phase2_GE0 process modifier which switches off ME0. For now, just enough to run step1 and 2 (and RAW2DIGI works). Once GE0 is fully working, we will remove ME0 from the codebase, and then the modifier won't be necessary.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

Tested on upgrade workflow 24821.0 replacing the D54 geometry with the Geometry/GEMGeometry/test/GeometryExtended2026GE0Test_cff.py geometry and adding the phase2_GE0 procModifier to the cmsDriver.py line. Station 0 SimDigis are created.

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
