### PR TITLE
Use ideal pixel bad components and remove obsolete pixel tags for Phase-2 simulation

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -81,7 +81,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '112X_mcRun4_realistic_v1'
+    'phase2_realistic'         : '112X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Currently the phase 2 pixel bad component record (`SiPixelQualityFromDbRcd`) uses a tag intended for 2018 MC simulation. This "works" on a technical level only by accident but does not specify any sort of physically sensible list of bad components. This PR updates the pixel bad component record to use a payload that models an ideal detector with no bad components. In addition, several obsolete pixel tags have been removed. Please refer to the [presentation at the 13 August 2020 AlCaDB meeting](https://indico.cern.ch/event/950215/#31-issue-with-pixel-bad-compon) for further details.

The GT diff can be found below.

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun4_realistic_v1/112X_mcRun4_realistic_v2

#### PR validation:

Please see the [presentation at the 13 August 2020 AlCaDB meeting](https://indico.cern.ch/event/950215/#31-issue-with-pixel-bad-compon) for details. In addition, a technical test was performed:

`runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 11_1_X.
