### PR TITLE
Small enhancements to geometry DB payload validation scripts

### DIFF
--- a/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
+++ b/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
@@ -18,6 +18,16 @@
 using Graph = DDCompactView::Graph;
 using adjl_iterator = Graph::const_adj_iterator;
 
+// For output of values to four decimal places, round negative values
+// equivalent to 0 within the precision to 0 to prevent printing "-0".
+template <class valType>
+static constexpr valType roundNeg0(valType value) {
+  if (value < 0. && value > -5.0e-5)
+    return (0.0);
+  else
+    return (value);
+}
+
 GeometryInfoDump::GeometryInfoDump() {}
 
 GeometryInfoDump::~GeometryInfoDump() {}
@@ -52,18 +62,18 @@ void GeometryInfoDump::dumpInfo(
         size_t s = snprintf(buf,
                             256,
                             ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
-                            epv.translation().x(),
-                            epv.translation().y(),
-                            epv.translation().z(),
-                            x.X(),
-                            y.X(),
-                            z.X(),
-                            x.Y(),
-                            y.Y(),
-                            z.Y(),
-                            x.Z(),
-                            y.Z(),
-                            z.Z());
+                            roundNeg0(epv.translation().x()),
+                            roundNeg0(epv.translation().y()),
+                            roundNeg0(epv.translation().z()),
+                            roundNeg0(x.X()),
+                            roundNeg0(y.X()),
+                            roundNeg0(z.X()),
+                            roundNeg0(x.Y()),
+                            roundNeg0(y.Y()),
+                            roundNeg0(z.Y()),
+                            roundNeg0(x.Z()),
+                            roundNeg0(y.Z()),
+                            roundNeg0(z.Z()));
         assert(s < 256);
         dump << buf;
       }

--- a/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
+++ b/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
@@ -7,6 +7,7 @@
 #include "DetectorDescription/Core/interface/DDExpandedNode.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
+#include "DataFormats/Math/interface/Rounding.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <cassert>
@@ -17,6 +18,7 @@
 
 using Graph = DDCompactView::Graph;
 using adjl_iterator = Graph::const_adj_iterator;
+using namespace cms_rounding;
 
 GeometryInfoDump::GeometryInfoDump() {}
 
@@ -48,13 +50,16 @@ void GeometryInfoDump::dumpInfo(
       dump << " - " << epv.geoHistory();
       DD3Vector x, y, z;
       epv.rotation().GetComponents(x, y, z);
+      x = roundVecIfNear0(x, 1.e-5);
+      y = roundVecIfNear0(y, 1.e-5);
+      z = roundVecIfNear0(z, 1.e-5);
       if (dumpPosInfo) {
         size_t s = snprintf(buf,
                             256,
                             ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
-                            epv.translation().x(),
-                            epv.translation().y(),
-                            epv.translation().z(),
+                            roundIfNear0(epv.translation().x()),
+                            roundIfNear0(epv.translation().y()),
+                            roundIfNear0(epv.translation().z()),
                             x.X(),
                             y.X(),
                             z.X(),

--- a/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
+++ b/DetectorDescription/OfflineDBLoader/src/GeometryInfoDump.cc
@@ -7,7 +7,6 @@
 #include "DetectorDescription/Core/interface/DDExpandedNode.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
-#include "DataFormats/Math/interface/Rounding.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include <cassert>
@@ -18,7 +17,16 @@
 
 using Graph = DDCompactView::Graph;
 using adjl_iterator = Graph::const_adj_iterator;
-using namespace cms_rounding;
+
+// For output of values to four decimal places, round negative values
+// equivalent to 0 within the precision to 0 to prevent printing "-0".
+template <class valType>
+static constexpr valType roundNeg0(valType value) {
+  if (value < 0. && value > -5.0e-5)
+    return (0.0);
+  else
+    return (value);
+}
 
 GeometryInfoDump::GeometryInfoDump() {}
 
@@ -50,25 +58,22 @@ void GeometryInfoDump::dumpInfo(
       dump << " - " << epv.geoHistory();
       DD3Vector x, y, z;
       epv.rotation().GetComponents(x, y, z);
-      x = roundVecIfNear0(x, 1.e-5);
-      y = roundVecIfNear0(y, 1.e-5);
-      z = roundVecIfNear0(z, 1.e-5);
       if (dumpPosInfo) {
         size_t s = snprintf(buf,
                             256,
                             ",%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f,%12.4f",
-                            roundIfNear0(epv.translation().x()),
-                            roundIfNear0(epv.translation().y()),
-                            roundIfNear0(epv.translation().z()),
-                            x.X(),
-                            y.X(),
-                            z.X(),
-                            x.Y(),
-                            y.Y(),
-                            z.Y(),
-                            x.Z(),
-                            y.Z(),
-                            z.Z());
+                            roundNeg0(epv.translation().x()),
+                            roundNeg0(epv.translation().y()),
+                            roundNeg0(epv.translation().z()),
+                            roundNeg0(x.X()),
+                            roundNeg0(y.X()),
+                            roundNeg0(z.X()),
+                            roundNeg0(x.Y()),
+                            roundNeg0(y.Y()),
+                            roundNeg0(z.Y()),
+                            roundNeg0(x.Z()),
+                            roundNeg0(y.Z()),
+                            roundNeg0(z.Z()));
         assert(s < 256);
         dump << buf;
       }

--- a/Geometry/CSCGeometry/test/testCSCGeometry_cfg.py
+++ b/Geometry/CSCGeometry/test/testCSCGeometry_cfg.py
@@ -8,7 +8,7 @@ process = cms.Process("CSCGeometryAnalyzer")
 # ====================
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
-process.load("Geometry.MuonCommonData.muonEndcapIdealGeometryXML_cfi")
+process.load('Configuration.Geometry.GeometryExtended_cff')
 
 # Fake alignment is/should be ideal geometry
 # ==========================================

--- a/Geometry/CSCGeometry/test/testCSCGeometry_cfg.py
+++ b/Geometry/CSCGeometry/test/testCSCGeometry_cfg.py
@@ -2,30 +2,28 @@
 
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("CSCGeometryAnalyzer")
+process = cms.Process('CSCGeometryAnalyzer')
 
 # Endcap Muon geometry
 # ====================
-process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
-process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load('Configuration.Geometry.GeometryExtended_cff')
 
 # Fake alignment is/should be ideal geometry
 # ==========================================
-process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
-process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource")
+process.load('Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi')
+process.preferFakeAlign = cms.ESPrefer('FakeAlignmentSource')
 
 # flags for modelling of CSC layer & strip geometry
 # =================================================
-process.load("Geometry.CSCGeometry.cscGeometry_cfi")
+process.load('Geometry.CSCGeometry.cscGeometry_cfi')
 
-process.source = cms.Source("EmptySource")
+process.source = cms.Source('EmptySource')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.MessageLogger.debugModules.append('CSCGeometryESModule')
 process.MessageLogger.categories.append('CSCGeometry')
 process.MessageLogger.categories.append('CSCGeometryBuilder')
@@ -36,6 +34,6 @@ process.MessageLogger.cout = cms.untracked.PSet(
    CSCGeometryBuilder = cms.untracked.PSet( limit = cms.untracked.int32(-1) )
 )
 
-process.producer = cms.EDAnalyzer("CSCGeometryAnalyzer")
+process.producer = cms.EDAnalyzer('CSCGeometryAnalyzer')
 
 process.p1 = cms.Path(process.producer)

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -47,8 +47,7 @@ DTGeometryAnalyzer::DTGeometryAnalyzer(const edm::ParameterSet& iConfig)
     : dashedLineWidth_(104),
       dashedLine_(string(dashedLineWidth_, '-')),
       myName_("DTGeometryAnalyzer"),
-      tolerance_(iConfig.getUntrackedParameter<double>("tolerance", 1.e-23))
-{}
+      tolerance_(iConfig.getUntrackedParameter<double>("tolerance", 1.e-23)) {}
 
 DTGeometryAnalyzer::~DTGeometryAnalyzer() {}
 

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -9,6 +9,8 @@
 #include <FWCore/Framework/interface/one/EDAnalyzer.h>
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Math/interface/Rounding.h"
 
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
 
@@ -22,6 +24,7 @@
 #include <vector>
 
 using namespace std;
+using namespace cms_rounding;
 
 class DTGeometryAnalyzer : public edm::one::EDAnalyzer<> {
 public:
@@ -37,16 +40,26 @@ private:
   const int dashedLineWidth_;
   const string dashedLine_;
   const string myName_;
+  bool tinyDifferences_;
 };
 
 DTGeometryAnalyzer::DTGeometryAnalyzer(const edm::ParameterSet& iConfig)
-    : dashedLineWidth_(104), dashedLine_(string(dashedLineWidth_, '-')), myName_("DTGeometryAnalyzer") {}
+    : dashedLineWidth_(104),
+      dashedLine_(string(dashedLineWidth_, '-')),
+      myName_("DTGeometryAnalyzer"),
+      tinyDifferences_(iConfig.getUntrackedParameter<bool>("tinyDifferences", true))
+// Set tinyDifferences to True to show values as small as |1.e-23|;
+// otherwise values <|1.e-7| will be rounded to 0.
+{}
 
 DTGeometryAnalyzer::~DTGeometryAnalyzer() {}
 
 void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ESHandle<DTGeometry> pDD;
   iSetup.get<MuonGeometryRecord>().get(pDD);
+  double tolerance = 1.e-7;
+  if (tinyDifferences_)
+    tolerance = 1.e-23;
 
   cout << myName() << ": Analyzer..." << endl;
   cout << "start " << dashedLine_ << endl;
@@ -83,7 +96,7 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     cout << "Layer " << det->id() << " SL " << det->superLayer()->id() << " chamber " << det->chamber()->id()
          << " Topology W/H/L: " << topo.cellWidth() << "/" << topo.cellHeight() << "/" << topo.cellLenght()
          << " first/last/# wire " << topo.firstChannel() << "/" << topo.lastChannel() << "/" << topo.channels()
-         << " Position " << surf.position() << " normVect " << surf.normalVector()
+         << " Position " << surf.position() << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance)
          << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
          << surf.bounds().length() << endl;
   }
@@ -93,8 +106,9 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
   for (auto det : pDD->superLayers()) {
     const BoundPlane& surf = det->surface();
     cout << "SuperLayer " << det->id() << " chamber " << det->chamber()->id() << " Position " << surf.position()
-         << " normVect " << surf.normalVector() << " bounds W/H/L: " << surf.bounds().width() << "/"
-         << surf.bounds().thickness() << "/" << surf.bounds().length() << endl;
+         << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance)
+         << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
+         << surf.bounds().length() << endl;
   }
 
   // check chamber
@@ -103,9 +117,9 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     //cout << "Chamber " << (*det)->geographicalId().det() << endl;
     const BoundPlane& surf = det->surface();
     //cout << "surf " << &surf <<  endl;
-    cout << "Chamber " << det->id() << " Position " << surf.position() << " normVect " << surf.normalVector()
-         << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
-         << surf.bounds().length() << endl;
+    cout << "Chamber " << det->id() << " Position " << surf.position() << " normVect "
+         << roundVecIfNear0(surf.normalVector(), tolerance) << " bounds W/H/L: " << surf.bounds().width() << "/"
+         << surf.bounds().thickness() << "/" << surf.bounds().length() << endl;
   }
   cout << "END " << dashedLine_ << endl;
 

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -56,7 +56,7 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
   iSetup.get<MuonGeometryRecord>().get(pDD);
   double tolerance = 1.e-7;
   if (tinyDifferences_)
-    tolerance = 1.e-25;
+    tolerance = 1.e-23;
 
   cout << myName() << ": Analyzer..." << endl;
   cout << "start " << dashedLine_ << endl;

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -47,7 +47,10 @@ DTGeometryAnalyzer::DTGeometryAnalyzer(const edm::ParameterSet& iConfig)
     : dashedLineWidth_(104),
       dashedLine_(string(dashedLineWidth_, '-')),
       myName_("DTGeometryAnalyzer"),
-      tinyDifferences_(iConfig.getUntrackedParameter<bool>("tinyDifferences", true)) {}
+      tinyDifferences_(iConfig.getUntrackedParameter<bool>("tinyDifferences", true))
+// Set tinyDifferences to True to show values as small as |1.e-23|;
+// otherwise values <|1.e-7| will be rounded to 0.
+{}
 
 DTGeometryAnalyzer::~DTGeometryAnalyzer() {}
 

--- a/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
+++ b/Geometry/DTGeometry/test/DTGeometryAnalyzer.cc
@@ -5,17 +5,17 @@
 
 #include <memory>
 
-#include <FWCore/Framework/interface/Frameworkfwd.h>
-#include <FWCore/Framework/interface/one/EDAnalyzer.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Math/interface/Rounding.h"
 
-#include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
-#include <Geometry/DTGeometry/interface/DTGeometry.h>
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <iostream>
 #include <string>
@@ -40,16 +40,14 @@ private:
   const int dashedLineWidth_;
   const string dashedLine_;
   const string myName_;
-  bool tinyDifferences_;
+  double tolerance_;
 };
 
 DTGeometryAnalyzer::DTGeometryAnalyzer(const edm::ParameterSet& iConfig)
     : dashedLineWidth_(104),
       dashedLine_(string(dashedLineWidth_, '-')),
       myName_("DTGeometryAnalyzer"),
-      tinyDifferences_(iConfig.getUntrackedParameter<bool>("tinyDifferences", true))
-// Set tinyDifferences to True to show values as small as |1.e-23|;
-// otherwise values <|1.e-7| will be rounded to 0.
+      tolerance_(iConfig.getUntrackedParameter<double>("tolerance", 1.e-23))
 {}
 
 DTGeometryAnalyzer::~DTGeometryAnalyzer() {}
@@ -57,9 +55,6 @@ DTGeometryAnalyzer::~DTGeometryAnalyzer() {}
 void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ESHandle<DTGeometry> pDD;
   iSetup.get<MuonGeometryRecord>().get(pDD);
-  double tolerance = 1.e-7;
-  if (tinyDifferences_)
-    tolerance = 1.e-23;
 
   cout << myName() << ": Analyzer..." << endl;
   cout << "start " << dashedLine_ << endl;
@@ -96,7 +91,7 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     cout << "Layer " << det->id() << " SL " << det->superLayer()->id() << " chamber " << det->chamber()->id()
          << " Topology W/H/L: " << topo.cellWidth() << "/" << topo.cellHeight() << "/" << topo.cellLenght()
          << " first/last/# wire " << topo.firstChannel() << "/" << topo.lastChannel() << "/" << topo.channels()
-         << " Position " << surf.position() << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance)
+         << " Position " << surf.position() << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance_)
          << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
          << surf.bounds().length() << endl;
   }
@@ -106,7 +101,7 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
   for (auto det : pDD->superLayers()) {
     const BoundPlane& surf = det->surface();
     cout << "SuperLayer " << det->id() << " chamber " << det->chamber()->id() << " Position " << surf.position()
-         << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance)
+         << " normVect " << roundVecIfNear0(surf.normalVector(), tolerance_)
          << " bounds W/H/L: " << surf.bounds().width() << "/" << surf.bounds().thickness() << "/"
          << surf.bounds().length() << endl;
   }
@@ -118,7 +113,7 @@ void DTGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     const BoundPlane& surf = det->surface();
     //cout << "surf " << &surf <<  endl;
     cout << "Chamber " << det->id() << " Position " << surf.position() << " normVect "
-         << roundVecIfNear0(surf.normalVector(), tolerance) << " bounds W/H/L: " << surf.bounds().width() << "/"
+         << roundVecIfNear0(surf.normalVector(), tolerance_) << " bounds W/H/L: " << surf.bounds().width() << "/"
          << surf.bounds().thickness() << "/" << surf.bounds().length() << endl;
   }
   cout << "END " << dashedLine_ << endl;

--- a/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py
@@ -23,7 +23,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
-                              tinyDifferences = cms.untracked.bool(True)
+                              tolerance = cms.untracked.double(1.0e-23)
                              )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py
@@ -22,6 +22,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 
-process.prod = cms.EDAnalyzer("DTGeometryAnalyzer")
+process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
+                              tinyDifferences = cms.untracked.bool(True)
+                             )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py
@@ -46,7 +46,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
-                              tinyDifferences = cms.untracked.bool(True)
+                              tolerance = cms.untracked.double(1.0e-23)
                              )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py
@@ -45,6 +45,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("EmptySource")
 
-process.prod = cms.EDAnalyzer("DTGeometryAnalyzer")
+process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
+                              tinyDifferences = cms.untracked.bool(True)
+                             )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/DTGeometry/test/testDTGeometry_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometry_cfg.py
@@ -19,7 +19,9 @@ process.source = cms.Source("EmptySource")
 
 process.out = cms.OutputModule("AsciiOutputModule")
 
-process.prod = cms.EDAnalyzer("DTGeometryAnalyzer")
+process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
+                              tinyDifferences = cms.untracked.bool(True)
+                             )
 
 process.p1 = cms.Path(process.prod)
 

--- a/Geometry/DTGeometry/test/testDTGeometry_cfg.py
+++ b/Geometry/DTGeometry/test/testDTGeometry_cfg.py
@@ -20,7 +20,7 @@ process.source = cms.Source("EmptySource")
 process.out = cms.OutputModule("AsciiOutputModule")
 
 process.prod = cms.EDAnalyzer("DTGeometryAnalyzer",
-                              tinyDifferences = cms.untracked.bool(True)
+                              tolerance = cms.untracked.double(1.0e-23)
                              )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -82,8 +82,7 @@ static const double density_units = 6.24151e+18;
 ModuleInfo::ModuleInfo(const edm::ParameterSet& ps)
     : fromDDD_(ps.getParameter<bool>("fromDDD")),
       printDDD_(ps.getUntrackedParameter<bool>("printDDD", true)),
-      tolerance_(ps.getUntrackedParameter<double>("tolerance", 1.e-23))
-{}
+      tolerance_(ps.getUntrackedParameter<double>("tolerance", 1.e-23)) {}
 
 ModuleInfo::~ModuleInfo() {}
 

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -74,7 +74,7 @@ public:
 private:
   bool fromDDD_;
   bool printDDD_;
-  bool tinyDifferences_;
+  double tolerance_;
 };
 
 static const double density_units = 6.24151e+18;
@@ -82,9 +82,7 @@ static const double density_units = 6.24151e+18;
 ModuleInfo::ModuleInfo(const edm::ParameterSet& ps)
     : fromDDD_(ps.getParameter<bool>("fromDDD")),
       printDDD_(ps.getUntrackedParameter<bool>("printDDD", true)),
-      tinyDifferences_(ps.getUntrackedParameter<bool>("tinyDifferences", true))
-// Set tinyDifferences to True to show values as small as |1.e-23|;
-// otherwise values <|1.e-7| will be rounded to 0.
+      tolerance_(ps.getUntrackedParameter<double>("tolerance", 1.e-23))
 {}
 
 ModuleInfo::~ModuleInfo() {}
@@ -99,13 +97,7 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   std::ofstream TECOutput("TECLayout_CMSSW.dat", std::ios::out);
   // Numbering Scheme
   std::ofstream NumberingOutput("ModuleNumbering.dat", std::ios::out);
-  //
 
-  double tolerance = 1.e-7;
-  if (tinyDifferences_)
-    tolerance = 1.e-23;
-
-  //
   // get the GeometricDet
   //
   edm::ESHandle<GeometricDet> rDD;
@@ -484,12 +476,12 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         } else {
           out_module = tTopo->tecModule(id);
         }
-        double out_x = roundIfNear0(module->translation().X(), tolerance);
-        double out_y = roundIfNear0(module->translation().Y(), tolerance);
+        double out_x = roundIfNear0(module->translation().X(), tolerance_);
+        double out_y = roundIfNear0(module->translation().Y(), tolerance_);
         double out_z = module->translation().Z();
         double out_r = sqrt(module->translation().X() * module->translation().X() +
                             module->translation().Y() * module->translation().Y());
-        double out_phi_rad = roundIfNear0(atan2(module->translation().Y(), module->translation().X()), tolerance);
+        double out_phi_rad = roundIfNear0(atan2(module->translation().Y(), module->translation().X()), tolerance_);
         TECOutput << out_side << " " << out_disk << " " << out_sector << " " << out_petal << " " << out_ring << " "
                   << out_module << " " << out_sensor << " " << out_x << " " << out_y << " " << out_z << " " << out_r
                   << " " << out_phi_rad << std::endl;
@@ -537,12 +529,12 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     // active area versors (rotation matrix)
     DD3Vector x, y, z;
     module->rotation().GetComponents(x, y, z);
-    x = roundVecIfNear0(x, tolerance);
-    y = roundVecIfNear0(y, tolerance);
-    z = roundVecIfNear0(z, tolerance);
-    xGlobal = roundVecIfNear0(xGlobal, tolerance);
-    yGlobal = roundVecIfNear0(yGlobal, tolerance);
-    zGlobal = roundVecIfNear0(zGlobal, tolerance);
+    x = roundVecIfNear0(x, tolerance_);
+    y = roundVecIfNear0(y, tolerance_);
+    z = roundVecIfNear0(z, tolerance_);
+    xGlobal = roundVecIfNear0(xGlobal, tolerance_);
+    yGlobal = roundVecIfNear0(yGlobal, tolerance_);
+    zGlobal = roundVecIfNear0(zGlobal, tolerance_);
     Output << "\tActive Area Rotation Matrix" << std::endl;
     Output << "\t z = n = (" << std::fixed << std::setprecision(4) << z.X() << "," << std::fixed << std::setprecision(4)
            << z.Y() << "," << std::fixed << std::setprecision(4) << z.Z() << ")" << std::endl

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -38,6 +38,7 @@
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/GeometrySurface/interface/BoundSurface.h"
+#include "DataFormats/Math/interface/Rounding.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/TrackerNumberingBuilder/interface/CmsTrackerDebugNavigator.h"
@@ -59,6 +60,8 @@
 #include <cmath>
 #include <bitset>
 
+using namespace cms_rounding;
+
 class ModuleInfo : public edm::one::EDAnalyzer<> {
 public:
   explicit ModuleInfo(const edm::ParameterSet&);
@@ -71,14 +74,15 @@ public:
 private:
   bool fromDDD_;
   bool printDDD_;
+  bool tinyDifferences_;
 };
 
 static const double density_units = 6.24151e+18;
 
-ModuleInfo::ModuleInfo(const edm::ParameterSet& ps) {
-  fromDDD_ = ps.getParameter<bool>("fromDDD");
-  printDDD_ = ps.getUntrackedParameter<bool>("printDDD", true);
-}
+ModuleInfo::ModuleInfo(const edm::ParameterSet& ps)
+    : fromDDD_(ps.getParameter<bool>("fromDDD")),
+      printDDD_(ps.getUntrackedParameter<bool>("printDDD", true)),
+      tinyDifferences_(ps.getUntrackedParameter<bool>("tinyDifferences", true)) {}
 
 ModuleInfo::~ModuleInfo() {}
 
@@ -93,6 +97,10 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   // Numbering Scheme
   std::ofstream NumberingOutput("ModuleNumbering.dat", std::ios::out);
   //
+
+  double tolerance = 1.e-7;
+  if (tinyDifferences_)
+    tolerance = 1.e-25;
 
   //
   // get the GeometricDet
@@ -473,12 +481,12 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         } else {
           out_module = tTopo->tecModule(id);
         }
-        double out_x = module->translation().X();
-        double out_y = module->translation().Y();
+        double out_x = roundIfNear0(module->translation().X(), tolerance);
+        double out_y = roundIfNear0(module->translation().Y(), tolerance);
         double out_z = module->translation().Z();
         double out_r = sqrt(module->translation().X() * module->translation().X() +
                             module->translation().Y() * module->translation().Y());
-        double out_phi_rad = atan2(module->translation().Y(), module->translation().X());
+        double out_phi_rad = roundIfNear0(atan2(module->translation().Y(), module->translation().X()), tolerance);
         TECOutput << out_side << " " << out_disk << " " << out_sector << " " << out_petal << " " << out_ring << " "
                   << out_module << " " << out_sensor << " " << out_x << " " << out_y << " " << out_z << " " << out_r
                   << " " << out_phi_rad << std::endl;
@@ -526,6 +534,12 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     // active area versors (rotation matrix)
     DD3Vector x, y, z;
     module->rotation().GetComponents(x, y, z);
+    x = roundVecIfNear0(x, tolerance);
+    y = roundVecIfNear0(y, tolerance);
+    z = roundVecIfNear0(z, tolerance);
+    xGlobal = roundVecIfNear0(xGlobal, tolerance);
+    yGlobal = roundVecIfNear0(yGlobal, tolerance);
+    zGlobal = roundVecIfNear0(zGlobal, tolerance);
     Output << "\tActive Area Rotation Matrix" << std::endl;
     Output << "\t z = n = (" << std::fixed << std::setprecision(4) << z.X() << "," << std::fixed << std::setprecision(4)
            << z.Y() << "," << std::fixed << std::setprecision(4) << z.Z() << ")" << std::endl

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -100,7 +100,7 @@ void ModuleInfo::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
   double tolerance = 1.e-7;
   if (tinyDifferences_)
-    tolerance = 1.e-25;
+    tolerance = 1.e-23;
 
   //
   // get the GeometricDet

--- a/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
+++ b/Geometry/TrackerGeometryBuilder/test/ModuleInfo.cc
@@ -82,7 +82,10 @@ static const double density_units = 6.24151e+18;
 ModuleInfo::ModuleInfo(const edm::ParameterSet& ps)
     : fromDDD_(ps.getParameter<bool>("fromDDD")),
       printDDD_(ps.getUntrackedParameter<bool>("printDDD", true)),
-      tinyDifferences_(ps.getUntrackedParameter<bool>("tinyDifferences", true)) {}
+      tinyDifferences_(ps.getUntrackedParameter<bool>("tinyDifferences", true))
+// Set tinyDifferences to True to show values as small as |1.e-23|;
+// otherwise values <|1.e-7| will be rounded to 0.
+{}
 
 ModuleInfo::~ModuleInfo() {}
 

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py
@@ -26,7 +26,8 @@ process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource")
 process.out = cms.OutputModule("AsciiOutputModule")
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
-    fromDDD = cms.bool(False)
+    fromDDD = cms.bool(False),
+    tinyDifferences = cms.untracked.bool(True)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py
@@ -27,7 +27,7 @@ process.out = cms.OutputModule("AsciiOutputModule")
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(False),
-    tinyDifferences = cms.untracked.bool(True)
+    tolerance = cms.untracked.double(1.0e-23)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py
@@ -41,7 +41,8 @@ process.MessageLogger.cout = cms.untracked.PSet(
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(True),
-    printDDD = cms.untracked.bool(False)
+    printDDD = cms.untracked.bool(False),
+    tinyDifferences = cms.untracked.bool(True)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py
@@ -42,7 +42,7 @@ process.MessageLogger.cout = cms.untracked.PSet(
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(True),
     printDDD = cms.untracked.bool(False),
-    tinyDifferences = cms.untracked.bool(True)
+    tolerance = cms.untracked.double(1.0e-23)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoFromDDDNoPrintDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoFromDDDNoPrintDDD_cfg.py
@@ -28,7 +28,8 @@ process.maxEvents = cms.untracked.PSet(
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(True),
-    printDDD = cms.untracked.bool(False)
+    printDDD = cms.untracked.bool(False),
+    tinyDifferences = cms.untracked.bool(True)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoFromDDDNoPrintDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoFromDDDNoPrintDDD_cfg.py
@@ -29,7 +29,7 @@ process.maxEvents = cms.untracked.PSet(
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(True),
     printDDD = cms.untracked.bool(False),
-    tinyDifferences = cms.untracked.bool(True)
+    tolerance = cms.untracked.double(1.0e-23)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py
@@ -47,7 +47,7 @@ process.out = cms.OutputModule("AsciiOutputModule")
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
     fromDDD = cms.bool(False),
-    tinyDifferences = cms.untracked.bool(True)
+    tolerance = cms.untracked.double(1.0e-23)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py
@@ -46,7 +46,8 @@ process.preferFakeAlign = cms.ESPrefer("FakeAlignmentSource")
 process.out = cms.OutputModule("AsciiOutputModule")
 
 process.prod = cms.EDAnalyzer("ModuleInfo",
-    fromDDD = cms.bool(False)
+    fromDDD = cms.bool(False),
+    tinyDifferences = cms.untracked.bool(True)
 )
 
 process.p1 = cms.Path(process.prod)

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -3,7 +3,13 @@
 cmsenv
 
 echo " START Geometry Validation"
-set loctag = ''
+
+# $1 is the Global Tag
+# $2 is the scenario
+# $3 is "round" to round values in comparisons  to 0 if < |1.e7|.
+# Omit this option to show differences down to |1.e-23|.
+
+set roundFlag = ''
 if ($#argv == 0) then
     set gtag="auto:run1_mc"
     set geometry="GeometryExtended"
@@ -16,10 +22,12 @@ else if ($#argv == 2) then
 else if ($#argv == 3) then 
     set gtag=`echo ${1}`
     set geometry=`echo ${2}`
-    set loctag = `echo ${3}`
+    set roundFlag = `echo ${3}`
 endif
 echo GlobalTag = ${gtag}
 echo geometry = ${geometry}
+echo roundFlag = ${roundFlag}
+
 #global tag gtag is assumed to be of the form GeometryWORD such as GeometryExtended or GeometryIdeal
 #as of 3.4.X loaded objects in the DB, these correspond to condlabels Extended, Ideal, etc...
 # Run 2 Extended condlabel corresponds to GeometryExtended2015 scenario. 
@@ -106,10 +114,14 @@ mkdir tkddd
 cp myfile.db tkdblocal
 
 cd tkdb
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -120,10 +132,14 @@ else
 endif
 
 cd ../tkdblocal
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoLocalDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -134,10 +150,14 @@ else
 endif
 
 cd ../tkddd
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
 sed -i "{s/GeometryExtended/${geometry}/}" trackerModuleInfoDDD_cfg.py >>  ../GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDDD_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -168,10 +188,14 @@ echo "End Tracker RECO geometry validation" | tee -a GeometryValidation.log
 
 echo "Start DT RECO geometry validation" | tee -a GeometryValidation.log
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py .  
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py .  
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
-sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
+sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometryFromDB_cfg.py > outDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from DB run ok" | tee -a GeometryValidation.log
@@ -180,10 +204,14 @@ else
     exit
 endif
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py .  
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py .  
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometryFromLocalDB_cfg.py > outLocalDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from Local DB run ok" | tee -a GeometryValidation.log
@@ -192,10 +220,14 @@ else
     exit
 endif
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometry_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometry_cfg.py .
 sed -i "{s/GeometryExtended/${geometry}/}" testDTGeometry_cfg.py >>  GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometry_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometry_cfg.py >> GeometryValidation.log 
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometry_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometry_cfg.py > outDDD_DT.log
 if ( -s outDDD_DT.log ) then
     echo "DT test from DDD run ok" | tee -a GeometryValidation.log

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -3,7 +3,13 @@
 cmsenv
 
 echo " START Geometry Validation"
-set loctag = ''
+
+# $1 is the Global Tag
+# $2 is the scenario
+# $3 is "round" to round values in comparisons  to 0 if < |1.e7|.
+# Omit this option to show differences down to |1.e-23|.
+
+set roundFlag = ''
 if ($#argv == 0) then
     set gtag="auto:run1_mc"
     set geometry="GeometryExtended"
@@ -16,10 +22,12 @@ else if ($#argv == 2) then
 else if ($#argv == 3) then 
     set gtag=`echo ${1}`
     set geometry=`echo ${2}`
-    set loctag = `echo ${3}`
+    set roundFlag = `echo ${3}`
 endif
 echo GlobalTag = ${gtag}
 echo geometry = ${geometry}
+echo roundFlag = ${roundFlag}
+
 #global tag gtag is assumed to be of the form GeometryWORD such as GeometryExtended or GeometryIdeal
 #as of 3.4.X loaded objects in the DB, these correspond to condlabels Extended, Ideal, etc...
 # Run 2 Extended condlabel corresponds to GeometryExtended2015 scenario. 
@@ -106,11 +114,14 @@ mkdir tkddd
 cp myfile.db tkdblocal
 
 cd tkdb
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
-sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDB_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -121,11 +132,14 @@ else
 endif
 
 cd ../tkdblocal
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoLocalDB_cfg.py .
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
-sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoLocalDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -136,11 +150,14 @@ else
 endif
 
 cd ../tkddd
+# cp $CMSSW_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInfoDDD_cfg.py .
 sed -i "{s/GeometryExtended/${geometry}/}" trackerModuleInfoDDD_cfg.py >>  ../GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
-sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
+endif
 cmsRun trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDDD_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -171,11 +188,14 @@ echo "End Tracker RECO geometry validation" | tee -a GeometryValidation.log
 
 echo "Start DT RECO geometry validation" | tee -a GeometryValidation.log
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py .  
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py .  
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
-sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometryFromDB_cfg.py > outDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from DB run ok" | tee -a GeometryValidation.log
@@ -184,11 +204,14 @@ else
     exit
 endif
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py .  
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cfg.py .  
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
-sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometryFromLocalDB_cfg.py > outLocalDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from Local DB run ok" | tee -a GeometryValidation.log
@@ -197,11 +220,14 @@ else
     exit
 endif
 
+# cp $CMSSW_BASE/src/Geometry/DTGeometry/test/testDTGeometry_cfg.py .
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometry_cfg.py .
 sed -i "{s/GeometryExtended/${geometry}/}" testDTGeometry_cfg.py >>  GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometry_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometry_cfg.py >> GeometryValidation.log 
-sed -i '/tinyDifferences/s/True/False/' testDTGeometry_cfg.py >> GeometryValidation.log
+if ( "${roundFlag}" == round ) then                                                               
+  sed -i '/tinyDifferences/s/True/False/' testDTGeometry_cfg.py >> GeometryValidation.log
+endif
 cmsRun testDTGeometry_cfg.py > outDDD_DT.log
 if ( -s outDDD_DT.log ) then
     echo "DT test from DDD run ok" | tee -a GeometryValidation.log

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -28,6 +28,9 @@ echo GlobalTag = ${gtag}
 echo geometry = ${geometry}
 echo roundFlag = ${roundFlag}
 
+set tolerance = '1.0e-7'
+# If rounding enabled, tolerance for numerical comparisons. Absolute values less than this are set to 0.
+
 #global tag gtag is assumed to be of the form GeometryWORD such as GeometryExtended or GeometryIdeal
 #as of 3.4.X loaded objects in the DB, these correspond to condlabels Extended, Ideal, etc...
 # Run 2 Extended condlabel corresponds to GeometryExtended2015 scenario. 
@@ -120,7 +123,7 @@ sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDB_cfg.py >> ../Geome
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDB_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" trackerModuleInfoDB_cfg.py >> GeometryValidation.log
 endif
 cmsRun trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDB_cfg.py ../
@@ -138,7 +141,7 @@ sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
 endif
 cmsRun trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoLocalDB_cfg.py ../
@@ -156,7 +159,7 @@ sed -i "{s/GeometryExtended/${geometry}/}" trackerModuleInfoDDD_cfg.py >>  ../Ge
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
 endif
 cmsRun trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDDD_cfg.py ../
@@ -194,7 +197,7 @@ sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromDB_cfg.py >> Geometr
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 endif
 cmsRun testDTGeometryFromDB_cfg.py > outDB_DT.log
 if ( -s outDB_DT.log ) then
@@ -210,7 +213,7 @@ sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromLocalDB_cfg.py >> Ge
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
 endif
 cmsRun testDTGeometryFromLocalDB_cfg.py > outLocalDB_DT.log
 if ( -s outDB_DT.log ) then
@@ -226,7 +229,7 @@ sed -i "{s/GeometryExtended/${geometry}/}" testDTGeometry_cfg.py >>  GeometryVal
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometry_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometry_cfg.py >> GeometryValidation.log 
 if ( "${roundFlag}" == round ) then                                                               
-  sed -i '/tinyDifferences/s/True/False/' testDTGeometry_cfg.py >> GeometryValidation.log
+  sed -i "/tolerance/s/1.0e-23/${tolerance}/" testDTGeometry_cfg.py >> GeometryValidation.log
 endif
 cmsRun testDTGeometry_cfg.py > outDDD_DT.log
 if ( -s outDDD_DT.log ) then

--- a/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
+++ b/Validation/Geometry/test/dddvsdb/runDDDvsDBGeometryValidation.sh
@@ -110,6 +110,7 @@ cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInf
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log 
+sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDB_cfg.py >> GeometryValidation.log
 cmsRun trackerModuleInfoDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -124,6 +125,7 @@ cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInf
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log 
+sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoLocalDB_cfg.py >> GeometryValidation.log
 cmsRun trackerModuleInfoLocalDB_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoLocalDB_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -138,6 +140,7 @@ cp $CMSSW_RELEASE_BASE/src/Geometry/TrackerGeometryBuilder/test/trackerModuleInf
 sed -i "{s/GeometryExtended/${geometry}/}" trackerModuleInfoDDD_cfg.py >>  ../GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log 
+sed -i '/tinyDifferences/s/True/False/' trackerModuleInfoDDD_cfg.py >> GeometryValidation.log
 cmsRun trackerModuleInfoDDD_cfg.py >> ../GeometryValidation.log
 mv trackerModuleInfoDDD_cfg.py ../
 if ( -s ModuleInfo.log ) then
@@ -171,7 +174,8 @@ echo "Start DT RECO geometry validation" | tee -a GeometryValidation.log
 cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromDB_cfg.py .  
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
-sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log 
+sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromDB_cfg.py >> GeometryValidation.log
+sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromDB_cfg.py >> GeometryValidation.log
 cmsRun testDTGeometryFromDB_cfg.py > outDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from DB run ok" | tee -a GeometryValidation.log
@@ -184,6 +188,7 @@ cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometryFromLocalDB_cf
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
 sed -i "/FrontierConditions_GlobalTag_cff/ a\process.XMLFromDBSource.label = cms.string('${condlabel}')" testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log 
+sed -i '/tinyDifferences/s/True/False/' testDTGeometryFromLocalDB_cfg.py >> GeometryValidation.log
 cmsRun testDTGeometryFromLocalDB_cfg.py > outLocalDB_DT.log
 if ( -s outDB_DT.log ) then
     echo "DT test from Local DB run ok" | tee -a GeometryValidation.log
@@ -196,6 +201,7 @@ cp $CMSSW_RELEASE_BASE/src/Geometry/DTGeometry/test/testDTGeometry_cfg.py .
 sed -i "{s/GeometryExtended/${geometry}/}" testDTGeometry_cfg.py >>  GeometryValidation.log
 sed -i "{/process.GlobalTag.globaltag/d}" testDTGeometry_cfg.py >> GeometryValidation.log
 sed -i "/FrontierConditions_GlobalTag_cff/ a\from Configuration.AlCa.GlobalTag import GlobalTag\nprocess.GlobalTag = GlobalTag(process.GlobalTag, '${gtag}', '')" testDTGeometry_cfg.py >> GeometryValidation.log 
+sed -i '/tinyDifferences/s/True/False/' testDTGeometry_cfg.py >> GeometryValidation.log
 cmsRun testDTGeometry_cfg.py > outDDD_DT.log
 if ( -s outDDD_DT.log ) then
     echo "DT test from DDD run ok" | tee -a GeometryValidation.log


### PR DESCRIPTION
`runDDDvsDBGeometryValidation.sh` compares new geometry DB payloads with the geometry XML files and the payloads in the Conditions DB. It will show differences down to the level of |1.e-23|. This PR adds the option to reduce the precision of comparison to |1.e-7| to allow focusing on big differences without being overwhelmed with tiny numerical fluctuations.
Also, values in simulation geometry that are shown to four decimal places are rounded to zero if they are < |5.e-5| to avoid showing differences between 0.0000 and -0.0000, which are not very helpful.

These scripts are for expert use and have no effect on production workflows.

No backport is needed.
