### PR TITLE
Cleanups in PhysicsTools and OnlineDB

### DIFF
--- a/OnlineDB/EcalCondDB/interface/IRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/IRunIOV.h
@@ -12,6 +12,8 @@ class IIOV;
 
 class IRunIOV {
  public:
+  virtual ~IRunIOV() {}
+
   virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const noexcept(false) =0;
 
   virtual void fetchWithin(std::vector<IIOV>* fillVec, const run_t beginRun, const run_t endRun, ITag* tag) const noexcept(false) =0;

--- a/OnlineDB/EcalCondDB/interface/IRunIOV.h
+++ b/OnlineDB/EcalCondDB/interface/IRunIOV.h
@@ -11,13 +11,13 @@ typedef int run_t;
 class IIOV;
 
 class IRunIOV {
- public:
+public:
   virtual ~IRunIOV() {}
 
-  virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const noexcept(false) =0;
+  virtual void fetchAt(IIOV* fillIOV, const run_t run, ITag* tag) const noexcept(false) = 0;
 
-  virtual void fetchWithin(std::vector<IIOV>* fillVec, const run_t beginRun, const run_t endRun, ITag* tag) const noexcept(false) =0;
-  
+  virtual void fetchWithin(std::vector<IIOV>* fillVec, const run_t beginRun, const run_t endRun, ITag* tag) const
+      noexcept(false) = 0;
 };
 
 #endif

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_electron.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_electron.C
@@ -10,50 +10,44 @@ This example creates a histogram of Electron Pt, using Electrons with Pt above 3
 #include "TCanvas.h"
 #include "TLegend.h"
 
-
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "PhysicsTools/SelectorUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h"
 #endif
 
 #include <iostream>
-#include <cmath>      //necessary for absolute function fabs()
+#include <cmath>  //necessary for absolute function fabs()
 
 using namespace std;
 
-void sk_fwlitecuts()
-{
-  ElectronVPlusJetsIDSelectionFunctor muId( ElectronVPlusJetsIDSelectionFunctor::SUMMER08 );
+void sk_fwlitecuts() {
+  ElectronVPlusJetsIDSelectionFunctor muId(ElectronVPlusJetsIDSelectionFunctor::SUMMER08);
 
-
-  TFile  * file = new TFile("PATLayer1_Output.fromAOD_full.root");
-  TH1D * hist_ePt = new TH1D("hist_ePt", "Electron p_{T}", 20, 0, 100 );
+  TFile* file = new TFile("PATLayer1_Output.fromAOD_full.root");
+  TH1D* hist_ePt = new TH1D("hist_ePt", "Electron p_{T}", 20, 0, 100);
   fwlite::Event ev(file);
 
   //loop through each event
-  for( ev.toBegin();
-         ! ev.atEnd();
-         ++ev) {
+  for (ev.toBegin(); !ev.atEnd(); ++ev) {
     fwlite::Handle<std::vector<pat::Electron> > h_mu;
-    h_mu.getByLabel(ev,"cleanLayer1Electrons");
-    if (!h_mu.isValid() ) continue;
-    vector<pat::Electron> const & electrons = *h_mu;
+    h_mu.getByLabel(ev, "cleanLayer1Electrons");
+    if (!h_mu.isValid())
+      continue;
+    vector<pat::Electron> const& electrons = *h_mu;
 
-   //loop through each Electron
-   vector<pat::Electron>::const_iterator iter;
-   for ( iter = electrons.begin(); iter != electrons.end() ; ++iter) {
-   
-     if ( (iter->pt() > 30 ) && ( fabs(iter->eta() ) < 2.1)  ) {
-       cout << "Passed kin" << endl;
-       if ( muId( *iter ) ) {
-	 cout << "Passed ID" << endl;
-	 hist_ePt->Fill( iter->pt() );
-       }
-     }
-       
+    //loop through each Electron
+    vector<pat::Electron>::const_iterator iter;
+    for (iter = electrons.begin(); iter != electrons.end(); ++iter) {
+      if ((iter->pt() > 30) && (fabs(iter->eta()) < 2.1)) {
+        cout << "Passed kin" << endl;
+        if (muId(*iter)) {
+          cout << "Passed ID" << endl;
+          hist_ePt->Fill(iter->pt());
+        }
+      }
 
-   }   //end Electron loop   
-   }   //end event loop
+    }  //end Electron loop
+  }    //end event loop
 
-   hist_ePt->Draw();   
+  hist_ePt->Draw();
 }

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_electron.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_electron.C
@@ -13,7 +13,7 @@ This example creates a histogram of Electron Pt, using Electrons with Pt above 3
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Electron.h"
-#include "PhysicsTools/PatUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h"
+#include "PhysicsTools/SelectorUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h"
 #endif
 
 #include <iostream>

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_jet.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_jet.C
@@ -10,50 +10,44 @@ This example creates a histogram of Jet Pt, using Jets with Pt above 30 and ETA 
 #include "TCanvas.h"
 #include "TLegend.h"
 
-
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"
 #endif
 
 #include <iostream>
-#include <cmath>      //necessary for absolute function fabs()
+#include <cmath>  //necessary for absolute function fabs()
 
 using namespace std;
 
-void sk_fwlitecuts()
-{
-  JetIDSelectionFunctor jetId( JetIDSelectionFunctor::CRAFT08, JetIDSelectionFunctor::TIGHT );
+void sk_fwlitecuts() {
+  JetIDSelectionFunctor jetId(JetIDSelectionFunctor::CRAFT08, JetIDSelectionFunctor::TIGHT);
 
-
-  TFile  * file = new TFile("PATLayer1_Output.fromAOD_full.root");
-  TH1D * hist_jetPt = new TH1D("hist_jetPt", "Jet p_{T}", 20, 0, 100 );
+  TFile* file = new TFile("PATLayer1_Output.fromAOD_full.root");
+  TH1D* hist_jetPt = new TH1D("hist_jetPt", "Jet p_{T}", 20, 0, 100);
   fwlite::Event ev(file);
 
   //loop through each event
-  for( ev.toBegin();
-         ! ev.atEnd();
-         ++ev) {
+  for (ev.toBegin(); !ev.atEnd(); ++ev) {
     fwlite::Handle<std::vector<pat::Jet> > h_mu;
-    h_mu.getByLabel(ev,"cleanLayer1Jets");
-    if (!h_mu.isValid() ) continue;
-    vector<pat::Jet> const & jets = *h_mu;
+    h_mu.getByLabel(ev, "cleanLayer1Jets");
+    if (!h_mu.isValid())
+      continue;
+    vector<pat::Jet> const& jets = *h_mu;
 
-   //loop through each Jet
-   vector<pat::Jet>::const_iterator iter;
-   for ( iter = jets.begin(); iter != jets.end() ; ++iter) {
-   
-     if ( (iter->pt() > 30 ) && ( fabs(iter->eta() ) < 2.1)  ) {
-       cout << "Passed kin" << endl;
-       if ( jetId( *iter ) ) {
-	 cout << "Passed ID" << endl;
-	 hist_jetPt->Fill( iter->pt() );
-       }
-     }
-       
+    //loop through each Jet
+    vector<pat::Jet>::const_iterator iter;
+    for (iter = jets.begin(); iter != jets.end(); ++iter) {
+      if ((iter->pt() > 30) && (fabs(iter->eta()) < 2.1)) {
+        cout << "Passed kin" << endl;
+        if (jetId(*iter)) {
+          cout << "Passed ID" << endl;
+          hist_jetPt->Fill(iter->pt());
+        }
+      }
 
-   }   //end Jet loop   
-   }   //end event loop
+    }  //end Jet loop
+  }    //end event loop
 
-   hist_jetPt->Draw();   
+  hist_jetPt->Draw();
 }

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_jet.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_jet.C
@@ -13,7 +13,7 @@ This example creates a histogram of Jet Pt, using Jets with Pt above 30 and ETA 
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Jet.h"
-#include "PhysicsTools/PatUtils/interface/JetIDSelectionFunctor.h"
+#include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"
 #endif
 
 #include <iostream>

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_muon.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_muon.C
@@ -10,50 +10,44 @@ This example creates a histogram of Muon Pt, using Muons with Pt above 30 and ET
 #include "TCanvas.h"
 #include "TLegend.h"
 
-
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h"
 #endif
 
 #include <iostream>
-#include <cmath>      //necessary for absolute function fabs()
+#include <cmath>  //necessary for absolute function fabs()
 
 using namespace std;
 
-void sk_fwlitecuts()
-{
-  MuonVPlusJetsIDSelectionFunctor muId( MuonVPlusJetsIDSelectionFunctor::SUMMER08 );
+void sk_fwlitecuts() {
+  MuonVPlusJetsIDSelectionFunctor muId(MuonVPlusJetsIDSelectionFunctor::SUMMER08);
 
-
-  TFile  * file = new TFile("PATLayer1_Output.fromAOD_full.root");
-  TH1D * hist_muPt = new TH1D("hist_muPt", "Muon p_{T}", 20, 0, 100 );
+  TFile* file = new TFile("PATLayer1_Output.fromAOD_full.root");
+  TH1D* hist_muPt = new TH1D("hist_muPt", "Muon p_{T}", 20, 0, 100);
   fwlite::Event ev(file);
 
   //loop through each event
-  for( ev.toBegin();
-         ! ev.atEnd();
-         ++ev) {
+  for (ev.toBegin(); !ev.atEnd(); ++ev) {
     fwlite::Handle<std::vector<pat::Muon> > h_mu;
-    h_mu.getByLabel(ev,"cleanLayer1Muons");
-    if (!h_mu.isValid() ) continue;
-    vector<pat::Muon> const & muons = *h_mu;
+    h_mu.getByLabel(ev, "cleanLayer1Muons");
+    if (!h_mu.isValid())
+      continue;
+    vector<pat::Muon> const& muons = *h_mu;
 
-   //loop through each Muon
-   vector<pat::Muon>::const_iterator iter;
-   for ( iter = muons.begin(); iter != muons.end() ; ++iter) {
-   
-     if ( (iter->pt() > 30 ) && ( fabs(iter->eta() ) < 2.1)  ) {
-       cout << "Passed kin" << endl;
-       if ( muId( *iter ) ) {
-	 cout << "Passed ID" << endl;
-	 hist_muPt->Fill( iter->pt() );
-       }
-     }
-       
+    //loop through each Muon
+    vector<pat::Muon>::const_iterator iter;
+    for (iter = muons.begin(); iter != muons.end(); ++iter) {
+      if ((iter->pt() > 30) && (fabs(iter->eta()) < 2.1)) {
+        cout << "Passed kin" << endl;
+        if (muId(*iter)) {
+          cout << "Passed ID" << endl;
+          hist_muPt->Fill(iter->pt());
+        }
+      }
 
-   }   //end Muon loop   
-   }   //end event loop
+    }  //end Muon loop
+  }    //end event loop
 
-   hist_muPt->Draw();   
+  hist_muPt->Draw();
 }

--- a/PhysicsTools/PatAlgos/test/fwlite/testSelection_muon.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/testSelection_muon.C
@@ -13,7 +13,7 @@ This example creates a histogram of Muon Pt, using Muons with Pt above 30 and ET
 
 #if !defined(__CINT__) && !defined(__MAKECINT__)
 #include "DataFormats/PatCandidates/interface/Muon.h"
-#include "PhysicsTools/PatUtils/interface/MuonVPlusJetsIDSelectionFunctor.h"
+#include "PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h"
 #endif
 
 #include <iostream>

--- a/PhysicsTools/PatUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h
+++ b/PhysicsTools/PatUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h
@@ -1,3 +1,0 @@
-#warning "This has moved to PhysicsTools/SelectorUtils"
-#include "PhysicsTools/SelectorUtils/interface/ElectronVPlusJetsIDSelectionFunctor.h"
-

--- a/PhysicsTools/PatUtils/interface/JetIDSelectionFunctor.h
+++ b/PhysicsTools/PatUtils/interface/JetIDSelectionFunctor.h
@@ -1,2 +1,0 @@
-#warning "This has moved to PhysicsTools/SelectorUtils"
-#include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"

--- a/PhysicsTools/PatUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
+++ b/PhysicsTools/PatUtils/interface/MuonVPlusJetsIDSelectionFunctor.h
@@ -1,3 +1,0 @@
-#warning "This has moved to PhysicsTools/SelectorUtils"
-#include "PhysicsTools/SelectorUtils/interface/MuonVPlusJetsIDSelectionFunctor.h"
-


### PR DESCRIPTION
Finish old migration and remove long-ago-moved headers in PhyscisTools
Add virtual destructor to a presumably unused class in OnlineDB.
Both identified as warnings in the modules IB.