### PR TITLE
Use ideal pixel bad components and remove obsolete pixel tags for Phase-2 simulation (backport)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -79,7 +79,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '110X_mcRun4_realistic_v3'
+    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Currently the phase 2 pixel bad component record (SiPixelQualityFromDbRcd) uses a tag intended for 2018 MC simulation. This "works" on a technical level only by accident but does not specify any sort of physically sensible list of bad components. This PR updates the pixel bad component record to use a payload that models an ideal detector with no bad components. In addition, several obsolete pixel tags have been removed. Please refer to the [presentation at the 13 August 2020 AlCaDB meeting ](https://indico.cern.ch/event/950215/#31-issue-with-pixel-bad-compon) for further details.

Note: the previous GT (110X_mcRun4_realistic_v3) differed from what was ran in the MC samples. See [request and discussion in AlCaDB HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4334/1/1/2.html).

The GT diff with the GT used to run the MC samples (111X_mcRun4_realistic_T15_v1) can be found below as well as the GT diff with the previous GT in autoCond.py.

#### Phase 2 realistic
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun4_realistic_T15_v1/111X_mcRun4_realistic_T15_v2
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun4_realistic_v3/111X_mcRun4_realistic_T15_v2

#### PR validation:

Please see the [presentation at the 13 August 2020 AlCaDB meeting ](https://indico.cern.ch/event/950215/#31-issue-with-pixel-bad-compon) for details. In addition, a technical test was performed:

runTheMatrix.py -l limited --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of [#31316](https://github.com/cms-sw/cmssw/pull/31316) for the needs of TSG (see [discussion in AlCaDB HN](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4334/1/1/2.html)).
