### PR TITLE
change typedef for pfParticle_iterator to avoid naming conflict

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFSimParticleFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSimParticleFwd.h
@@ -21,7 +21,7 @@ namespace reco {
   typedef edm::RefVector<PFSimParticleCollection> PFSimParticleRefVector;
 
   /// iterator over a vector of references to PFSimParticle objects
-  typedef PFSimParticleRefVector::iterator pfParticle_iterator;
+  typedef PFSimParticleRefVector::iterator pfSimParticle_iterator;
 }  // namespace reco
 
 #endif


### PR DESCRIPTION
pfParticle_iterator is present in both PFParticleFwd and PFSimParticleFwd. I'm adding Sim to this one which follows the same convention as for the other fwd declarations in these files. These typedefs are not used in cmssw.