### PR TITLE
Draw the cluster position in Fireworks

### DIFF
--- a/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloClusterProxyBuilder.cc
@@ -142,7 +142,7 @@ void FWCaloClusterProxyBuilder::build(const reco::CaloCluster &iData,
           continue;
       }
 
-      // seed
+      // seed and cluster position
       if (iData.seed().rawId() == it->first.rawId()) {
         TEveStraightLineSet *marker = new TEveStraightLineSet;
         marker->SetLineWidth(1);
@@ -159,6 +159,18 @@ void FWCaloClusterProxyBuilder::build(const reco::CaloCluster &iData,
         marker->AddLine(center[0], center[1], center[2] - crossScale, center[0], center[1], center[2] + crossScale);
 
         oItemHolder.AddElement(marker);
+
+        TEveStraightLineSet *position_marker = new TEveStraightLineSet;
+        position_marker->SetLineWidth(2);
+        position_marker->SetLineColor(kOrange);
+        auto const &pos = iData.position();
+        const float position_crossScale = crossScale * 0.5;
+        position_marker->AddLine(
+            pos.x() - position_crossScale, pos.y(), pos.z(), pos.x() + position_crossScale, pos.y(), pos.z());
+        position_marker->AddLine(
+            pos.x(), pos.y() - position_crossScale, pos.z(), pos.x(), pos.y() + position_crossScale, pos.z());
+
+        oItemHolder.AddElement(position_marker);
       }
 
       const float energy =


### PR DESCRIPTION
#### PR description:

This PR will draw the position of the LayerClusters in HGCAL using an arrow as a marker. It replicates what was already implemented for the seed position. This addition could be useful to visually compare the two quantities.

#### PR validation:

Validated using a private, local, build of Fireworks/cmsShow

