### PR TITLE
add missed dependencies to Pythia8Hadonizer plugins

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
@@ -2,6 +2,16 @@
 <library file="Pythia8Hadronizer.cc,Py8toJetInput.cc,*Hook*.cc,LHA*.cc" name="GeneratorInterfacePythia8Filters">
   <use name="GeneratorInterface/PartonShowerVeto"/>
   <use name="GeneratorInterface/ExternalDecays"/>
+  <use name="FWCore/Concurrency"/>
+  <use name="FWCore/MessageLogger"/>
+  <use name="FWCore/ParameterSet"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="FWCore/Utilities"/>
+  <use name="GeneratorInterface/Core"/>
+  <use name="GeneratorInterface/Pythia8Interface"/>
+  <use name="hepmc"/>
+  <use name="pythia8"/>
+  <use name="SimDataFormats/GeneratorProducts"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 


### PR DESCRIPTION
Believed to cause unit test failures in the modules IB (missing dictionaries due to missing dependencies)