### PR TITLE
Small fixes for tauReco at miniAOD

### DIFF
--- a/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
+++ b/RecoTauTag/RecoTau/src/AntiElectronIDMVA6.cc
@@ -784,7 +784,7 @@ TauVars AntiElectronIDMVA6<TauType, ElectronType>::getTauVarsTypeSpecific(const 
       if (patLeadCandiate != nullptr) {
         tauVars.leadPFChargedHadrHoP = patLeadCandiate->caloFraction() * patLeadCandiate->energy() *
                                        patLeadCandiate->hcalFraction() / patLeadCandiate->p();
-        tauVars.leadPFChargedHadrHoP = patLeadCandiate->caloFraction() * patLeadCandiate->energy() *
+        tauVars.leadPFChargedHadrEoP = patLeadCandiate->caloFraction() * patLeadCandiate->energy() *
                                        (1. - patLeadCandiate->hcalFraction()) / patLeadCandiate->p();
       }
     }


### PR DESCRIPTION
#### PR description:

This PR contains small fixes for tauReco@MiniAOD:
* Fix of a typo in a variable name in the anti-e MVA discriminant code; this bug have not affected any present workflow as it is related only to taus reconstructed at MiniAOD;
* Extension of example configuration of tauReco@MiniAOD to run it on real data.

Changes introduced by this PR do not affect any existing workflow.

#### PR validation:

The extended configuration run successfully on data and MC.
