### PR TITLE
Run3-gem52 Make dd4hep algorithms for muon involving rotation matrix to use double

### DIFF
--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -44,13 +44,13 @@ static long algorithm(dd4hep::Detector& /* description */,
   // Now position child in mother *n* times
   double phi = startAngle;
   int copyNo = startCopyNo;
+  double thetax = 90.0_deg;
+  double thetay = invert == 0 ? 0.0 : 180.0_deg;
   for (int ii = 0; ii < n; ii++) {
     double phiz = phi;
     if (phiz >= 2._pi)
       phiz -= 2._pi;
-    double thetax = 90.0_deg;
     double phix = invert == 0 ? (90.0_deg + phiz) : (-90.0_deg + phiz);
-    double thetay = invert == 0 ? 0.0 : 180.0_deg;
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Creating a rotation " << convertRadToDeg(thetax) << ", "
                                  << convertRadToDeg(phix) << ", " << convertRadToDeg(thetay) << ", 0, "

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -15,11 +15,11 @@ static long algorithm(dd4hep::Detector& /* description */,
   cms::DDAlgoArguments args(ctxt, e);
 
   // Header section of original DDGEMAngular.h
-  float startAngle = args.value<float>("startAngle");
-  float stepAngle = args.value<float>("stepAngle");
+  double startAngle = args.value<double>("startAngle");
+  double stepAngle = args.value<double>("stepAngle");
   int invert = args.value<int>("invert");
-  float rPos = args.value<float>("rPosition");
-  float zoffset = args.value<float>("zoffset");
+  double rPos = args.value<double>("rPosition");
+  double zoffset = args.value<double>("zoffset");
   int n = args.value<int>("n");
   int startCopyNo = args.value<int>("startCopyNo");
   int incrCopyNo = args.value<int>("incrCopyNo");
@@ -42,16 +42,16 @@ static long algorithm(dd4hep::Detector& /* description */,
 #endif
 
   // Now position child in mother *n* times
-  float phi = startAngle;
+  double phi = startAngle;
   int copyNo = startCopyNo;
   for (int ii = 0; ii < n; ii++) {
-    float phitmp = phi;
+    double phitmp = phi;
     if (phitmp >= 2._pi)
       phitmp -= 2._pi;
-    float thetax = 90.0_deg;
-    float phix = invert == 0 ? (90.0_deg + phitmp) : (-90.0_deg + phitmp);
-    float thetay = invert == 0 ? 0.0 : 180.0_deg;
-    float phiz = phitmp;
+    double thetax = 90.0_deg;
+    double phix = invert == 0 ? (90.0_deg + phitmp) : (-90.0_deg + phitmp);
+    double thetay = invert == 0 ? 0.0 : 180.0_deg;
+    double phiz = phitmp;
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Creating a rotation " << convertRadToDeg(thetax) << ", "
                                  << convertRadToDeg(phix) << ", " << convertRadToDeg(thetay) << ", 0, "

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -15,8 +15,8 @@ static long algorithm(dd4hep::Detector& /* description */,
   cms::DDAlgoArguments args(ctxt, e);
 
   // Header section of original DDGEMAngular.h
-  double startAngle = args.value<double>("startAngle");
-  double stepAngle = args.value<double>("stepAngle");
+  float startAngle = args.value<float>("startAngle");
+  float stepAngle = args.value<float>("stepAngle");
   int invert = args.value<int>("invert");
   double rPos = args.value<double>("rPosition");
   double zoffset = args.value<double>("zoffset");
@@ -45,20 +45,19 @@ static long algorithm(dd4hep::Detector& /* description */,
   double phi = startAngle;
   int copyNo = startCopyNo;
   for (int ii = 0; ii < n; ii++) {
-    double phitmp = phi;
-    if (phitmp >= 2._pi)
-      phitmp -= 2._pi;
+    double phiz = phi;
+    if (phiz >= 2._pi)
+      phiz -= 2._pi;
     double thetax = 90.0_deg;
-    double phix = invert == 0 ? (90.0_deg + phitmp) : (-90.0_deg + phitmp);
+    double phix = invert == 0 ? (90.0_deg + phiz) : (-90.0_deg + phiz);
     double thetay = invert == 0 ? 0.0 : 180.0_deg;
-    double phiz = phitmp;
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("MuonGeom") << "DDGEMAngular: Creating a rotation " << convertRadToDeg(thetax) << ", "
                                  << convertRadToDeg(phix) << ", " << convertRadToDeg(thetay) << ", 0, "
                                  << convertRadToDeg(thetax) << ", " << convertRadToDeg(phiz);
 #endif
     dd4hep::Rotation3D rotation = cms::makeRotation3D(thetax, phix, thetay, 0., thetax, phiz);
-    dd4hep::Position tran(rPos * cos(phitmp), rPos * sin(phitmp), zoffset);
+    dd4hep::Position tran(rPos * cos(phiz), rPos * sin(phiz), zoffset);
     parent.placeVolume(child, copyNo, dd4hep::Transform3D(rotation, tran));
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("MuonGeom") << "DDGEMAngular: " << child.name() << " number " << copyNo << " positioned in "

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -18,9 +18,9 @@ static long algorithm(Detector& /* description */,
   int n = args.value<int>("n");
   int startCopyNo = args.find("startCopyNo") ? args.value<int>("startCopyNo") : 1;
   int incrCopyNo = args.find("incrCopyNo") ? args.value<int>("incrCopyNo") : 1;
-  float startAngle = args.value<float>("startAngle");
-  float stepAngle = args.value<float>("stepAngle");
-  float zoffset = args.value<float>("zoffset");
+  double startAngle = args.value<double>("startAngle");
+  double stepAngle = args.value<double>("stepAngle");
+  double zoffset = args.value<double>("zoffset");
   string rotns = args.value<string>("RotNameSpace");
   Volume mother = ns.volume(args.parentName());
   string childName = args.value<string>("ChildName");
@@ -34,11 +34,11 @@ static long algorithm(Detector& /* description */,
   LogDebug("DDAlgorithm") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace "
                           << ns.name();
 
-  float phi = startAngle;
+  double phi = startAngle;
   int copyNo = startCopyNo;
 
   for (int i = 0; i < n; ++i) {
-    float phitmp = phi;
+    double phitmp = phi;
     if (phitmp >= 2._pi)
       phitmp -= 2._pi;
     Rotation3D rotation = makeRotation3D(90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -24,8 +24,11 @@ static long algorithm(dd4hep::Detector& /* description */,
   childName = ns.prepend(childName);
   dd4hep::Volume child = ns.volume(childName);
 
-  edm::LogVerbatim("MuonGeom") << "debug: Parameters for positioning:: n " << n << " Start, Step " << convertRadToDeg(startAngle) << ", " << convertRadToDeg(stepAngle) << ", zoffset " << zoffset << ", RotNameSpace " << rotns;
-  edm::LogVerbatim("MuonGeom") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace " << ns.name();
+  edm::LogVerbatim("MuonGeom") << "debug: Parameters for positioning:: n " << n << " Start, Step "
+                               << convertRadToDeg(startAngle) << ", " << convertRadToDeg(stepAngle) << ", zoffset "
+                               << zoffset << ", RotNameSpace " << rotns;
+  edm::LogVerbatim("MuonGeom") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace "
+                               << ns.name();
 
   double phi = startAngle;
   int copyNo = startCopyNo;
@@ -42,7 +45,8 @@ static long algorithm(dd4hep::Detector& /* description */,
     }
     dd4hep::Position tran(0., 0., zoffset);
     mother.placeVolume(child, copyNo, dd4hep::Transform3D(rotation, tran));
-    edm::LogVerbatim("MuonGeom") << "test " << child.name() << " number " << copyNo << " positioned in " << mother.name() << " at " << tran << " with " << rotstr << ": " << rotation;
+    edm::LogVerbatim("MuonGeom") << "test " << child.name() << " number " << copyNo << " positioned in "
+                                 << mother.name() << " at " << tran << " with " << rotstr << ": " << rotation;
     phi += stepAngle;
     copyNo += incrCopyNo;
   }

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -3,36 +3,29 @@
 #include "DetectorDescription/DDCMS/interface/DDPlugins.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace std;
-using namespace dd4hep;
-using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */,
+static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& context,
                       xml_h element,
-                      SensitiveDetector& /* sens */) {
+                      dd4hep::SensitiveDetector& /* sens */) {
   cms::DDNamespace ns(context, element, true);
-  DDAlgoArguments args(context, element);
+  cms::DDAlgoArguments args(context, element);
 
   int n = args.value<int>("n");
   int startCopyNo = args.find("startCopyNo") ? args.value<int>("startCopyNo") : 1;
   int incrCopyNo = args.find("incrCopyNo") ? args.value<int>("incrCopyNo") : 1;
-  double startAngle = args.value<double>("startAngle");
-  double stepAngle = args.value<double>("stepAngle");
-  double zoffset = args.value<double>("zoffset");
-  string rotns = args.value<string>("RotNameSpace");
-  Volume mother = ns.volume(args.parentName());
-  string childName = args.value<string>("ChildName");
+  float startAngle = args.value<float>("startAngle");
+  float stepAngle = args.value<float>("stepAngle");
+  float zoffset = args.value<float>("zoffset");
+  std::string rotns = args.value<std::string>("RotNameSpace");
+  dd4hep::Volume mother = ns.volume(args.parentName());
+  std::string childName = args.value<std::string>("ChildName");
   childName = ns.prepend(childName);
-  Volume child = ns.volume(childName);
+  dd4hep::Volume child = ns.volume(childName);
 
-  LogDebug("DDAlgorithm") << "debug: Parameters for positioning:: n " << n << " Start, Step "
-                          << convertRadToDeg(startAngle) << " " << convertRadToDeg(stepAngle) << " "
-                          << ", zoffset " << zoffset << " "
-                          << ", RotNameSpace " << rotns.c_str();
-  LogDebug("DDAlgorithm") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace "
-                          << ns.name();
+  edm::LogVerbatim("MuonGeom") << "debug: Parameters for positioning:: n " << n << " Start, Step " << convertRadToDeg(startAngle) << ", " << convertRadToDeg(stepAngle) << ", zoffset " << zoffset << ", RotNameSpace " << rotns;
+  edm::LogVerbatim("MuonGeom") << "debug: Parent " << mother.name() << "\tChild " << child.name() << " NameSpace " << ns.name();
 
   double phi = startAngle;
   int copyNo = startCopyNo;
@@ -41,16 +34,15 @@ static long algorithm(Detector& /* description */,
     double phitmp = phi;
     if (phitmp >= 2._pi)
       phitmp -= 2._pi;
-    Rotation3D rotation = makeRotation3D(90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);
-    string rotstr = ns.nsName(child.name()) + std::to_string(phitmp * 10.);
+    dd4hep::Rotation3D rotation = cms::makeRotation3D(90._deg, phitmp, 90._deg, 90._deg + phitmp, 0., 0.);
+    std::string rotstr = ns.nsName(child.name()) + std::to_string(phitmp * 10.);
     auto irot = context.rotations.find(ns.prepend(rotstr));
     if (irot != context.rotations.end()) {
       rotation = ns.rotation(ns.prepend(rotstr));
     }
-    Position tran(0., 0., zoffset);
-    mother.placeVolume(child, copyNo, Transform3D(rotation, tran));
-    LogDebug("DDAlgorithm") << "test " << child.name() << " number " << copyNo << " positioned in " << mother.name()
-                            << " at " << tran << " with " << rotstr << ": " << rotation;
+    dd4hep::Position tran(0., 0., zoffset);
+    mother.placeVolume(child, copyNo, dd4hep::Transform3D(rotation, tran));
+    edm::LogVerbatim("MuonGeom") << "test " << child.name() << " number " << copyNo << " positioned in " << mother.name() << " at " << tran << " with " << rotstr << ": " << rotation;
     phi += stepAngle;
     copyNo += incrCopyNo;
   }


### PR DESCRIPTION
#### PR description:

Make dd4hep algorithms for muon involving rotation matrix to use double

#### PR validation:

Avoids overlaps in Geant4 geometry

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special