### PR TITLE
drop type specs in RecoEcal

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/correctedHybridSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedHybridSuperClusters_cfi.py
@@ -31,5 +31,6 @@ correctedHybridSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
 )
 
 
-uncleanedOnlyCorrectedHybridSuperClusters =correctedHybridSuperClusters.clone()
-uncleanedOnlyCorrectedHybridSuperClusters.rawSuperClusterProducer = cms.InputTag("hybridSuperClusters","uncleanOnlyHybridSuperClusters")
+uncleanedOnlyCorrectedHybridSuperClusters =correctedHybridSuperClusters.clone(
+    rawSuperClusterProducer = "hybridSuperClusters:uncleanOnlyHybridSuperClusters"
+)

--- a/RecoEcal/EgammaClusterProducers/python/correctedMulti5x5SuperClustersWithPreshower_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedMulti5x5SuperClustersWithPreshower_cfi.py
@@ -34,5 +34,6 @@ correctedMulti5x5SuperClustersWithPreshower = cms.EDProducer("EgammaSCCorrection
 )
 
 
-uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower = correctedMulti5x5SuperClustersWithPreshower.clone()
-uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.rawSuperClusterProducer = cms.InputTag("uncleanedOnlyMulti5x5SuperClustersWithPreshower")
+uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower = correctedMulti5x5SuperClustersWithPreshower.clone(
+    rawSuperClusterProducer = "uncleanedOnlyMulti5x5SuperClustersWithPreshower"
+)

--- a/RecoEcal/EgammaClusterProducers/python/dynamicHybridSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/dynamicHybridSuperClusters_cfi.py
@@ -3,22 +3,22 @@ import FWCore.ParameterSet.Config as cms
 import RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi
 
 dynamicHybridSuperClusters = RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi.cleanedHybridSuperClusters.clone(
-    shapeAssociation = cms.string('dynamicHybridShapeAssoc'),
-    dynamicPhiRoad = cms.bool(True),
-    basicclusterCollection = cms.string(''),
-    dynamicEThresh = cms.bool(True),
+    shapeAssociation       = 'dynamicHybridShapeAssoc',
+    dynamicPhiRoad         = True,
+    basicclusterCollection = '',
+    dynamicEThresh         = True,
     bremRecoveryPset = cms.PSet(
-    barrel = cms.PSet(
-    cryVec = cms.vint32(17, 15, 13, 12, 11,
-                        10, 9, 8, 7, 6),
-    cryMin = cms.int32(5),
-    etVec = cms.vdouble(5.0, 10.0, 15.0, 20.0, 30.0,
-                        40.0, 45.0, 135.0, 195.0, 225.0)
-    ),
-    endcap = cms.PSet(
-    a = cms.double(47.85),
-    c = cms.double(0.1201),
-    b = cms.double(108.8)
+       barrel = cms.PSet(
+         cryVec = cms.vint32(17, 15, 13, 12, 11,
+                             10, 9, 8, 7, 6),
+         cryMin = cms.int32(5),
+         etVec = cms.vdouble(5.0, 10.0, 15.0, 20.0, 30.0,
+                             40.0, 45.0, 135.0, 195.0, 225.0)
+       ),
+       endcap = cms.PSet(
+         a = cms.double(47.85),
+         c = cms.double(0.1201),
+         b = cms.double(108.8)
+       )
     )
-     )
-    )
+)

--- a/RecoEcal/EgammaClusterProducers/python/hybridClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/hybridClusteringSequence_cff.py
@@ -9,9 +9,10 @@ from RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.correctedHybridSuperClusters_cfi import *
 # hybrid clustering sequence
 #uncleanedHybridSuperClusters = RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi.hybridSuperClusters.clone()
-uncleanedHybridSuperClusters = cleanedHybridSuperClusters.clone()
-uncleanedHybridSuperClusters.RecHitSeverityToBeExcluded = cms.vstring()
-uncleanedHybridSuperClusters.excludeFlagged = False
+uncleanedHybridSuperClusters = cleanedHybridSuperClusters.clone(
+    RecHitSeverityToBeExcluded = [],
+    excludeFlagged             = False
+)
 
 from RecoEcal.EgammaClusterProducers.unifiedSCCollection_cfi import *
 

--- a/RecoEcal/EgammaClusterProducers/python/multi5x5BasicClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/multi5x5BasicClusters_cfi.py
@@ -37,5 +37,6 @@ multi5x5BasicClustersCleaned = cms.EDProducer("Multi5x5ClusterProducer",
 
 # with no cleaning
 
-multi5x5BasicClustersUncleaned = multi5x5BasicClustersCleaned.clone()
-multi5x5BasicClustersUncleaned.RecHitFlagToBeExcluded= cms.vstring()
+multi5x5BasicClustersUncleaned = multi5x5BasicClustersCleaned.clone(
+    RecHitFlagToBeExcluded = []
+)

--- a/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClustersWithPreshower_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClustersWithPreshower_cfi.py
@@ -18,6 +18,6 @@ multi5x5SuperClustersWithPreshower = cms.EDProducer("PreshowerPhiClusterProducer
                                                     endcapSClusterProducer = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapSuperClusters")
                                                     )
 
-uncleanedOnlyMulti5x5SuperClustersWithPreshower = multi5x5SuperClustersWithPreshower.clone()
-
-uncleanedOnlyMulti5x5SuperClustersWithPreshower.endcapSClusterProducer = cms.InputTag("multi5x5SuperClusters","uncleanOnlyMulti5x5EndcapSuperClusters")
+uncleanedOnlyMulti5x5SuperClustersWithPreshower = multi5x5SuperClustersWithPreshower.clone(
+    endcapSClusterProducer = "multi5x5SuperClusters:uncleanOnlyMulti5x5EndcapSuperClusters"
+)

--- a/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
@@ -7,10 +7,10 @@ multi5x5SuperClustersCleaned = cms.EDProducer("Multi5x5SuperClusterProducer",
     barrelSuperclusterCollection = cms.string('multi5x5BarrelSuperClusters'),
     endcapEtaSearchRoad = cms.double(0.14),
     barrelClusterTag = cms.InputTag('multi5x5BasicClusters',
-									'multi5x5BarrelBasicClustersCleaned'),
+				    'multi5x5BarrelBasicClustersCleaned'),
     dynamicPhiRoad = cms.bool(False),
     endcapClusterTag= cms.InputTag('multi5x5BasicClustersCleaned',
-								   'multi5x5EndcapBasicClusters'),
+				   'multi5x5EndcapBasicClusters'),
     barrelPhiSearchRoad = cms.double(0.8),
     endcapPhiSearchRoad = cms.double(0.6),
     seedTransverseEnergyThreshold = cms.double(1.0),
@@ -39,10 +39,9 @@ multi5x5SuperClustersCleaned = cms.EDProducer("Multi5x5SuperClusterProducer",
 )
 
 
-multi5x5SuperClustersUncleaned = multi5x5SuperClustersCleaned.clone()
-multi5x5SuperClustersUncleaned.endcapClusterProducer = cms.string('multi5x5BasicClustersUncleaned')
-multi5x5SuperClustersUncleaned.endcapClusterProducer = cms.string('multi5x5BasicClustersUncleaned')
-
+multi5x5SuperClustersUncleaned = multi5x5SuperClustersCleaned.clone(
+    endcapClusterProducer = cms.string('multi5x5BasicClustersUncleaned')
+)
 
 multi5x5SuperClusters=cms.EDProducer("UnifiedSCCollectionProducer",
             # input collections:

--- a/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
@@ -40,7 +40,8 @@ multi5x5SuperClustersCleaned = cms.EDProducer("Multi5x5SuperClusterProducer",
 
 
 multi5x5SuperClustersUncleaned = multi5x5SuperClustersCleaned.clone(
-    endcapClusterProducer = cms.string('multi5x5BasicClustersUncleaned')
+    barrelClusterTag = 'multi5x5BasicClustersUncleaned:multi5x5BarrelBasicClustersCleaned',
+    endcapClusterTag = 'multi5x5BasicClustersUncleaned:multi5x5EndcapBasicClusters'
 )
 
 multi5x5SuperClusters=cms.EDProducer("UnifiedSCCollectionProducer",

--- a/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/multi5x5SuperClusters_cfi.py
@@ -6,8 +6,8 @@ import FWCore.ParameterSet.Config as cms
 multi5x5SuperClustersCleaned = cms.EDProducer("Multi5x5SuperClusterProducer",
     barrelSuperclusterCollection = cms.string('multi5x5BarrelSuperClusters'),
     endcapEtaSearchRoad = cms.double(0.14),
-    barrelClusterTag = cms.InputTag('multi5x5BasicClusters',
-				    'multi5x5BarrelBasicClustersCleaned'),
+    barrelClusterTag = cms.InputTag('multi5x5BasicClustersCleaned',
+				    'multi5x5BarrelBasicClusters'),
     dynamicPhiRoad = cms.bool(False),
     endcapClusterTag= cms.InputTag('multi5x5BasicClustersCleaned',
 				   'multi5x5EndcapBasicClusters'),
@@ -40,7 +40,7 @@ multi5x5SuperClustersCleaned = cms.EDProducer("Multi5x5SuperClusterProducer",
 
 
 multi5x5SuperClustersUncleaned = multi5x5SuperClustersCleaned.clone(
-    barrelClusterTag = 'multi5x5BasicClustersUncleaned:multi5x5BarrelBasicClustersCleaned',
+    barrelClusterTag = 'multi5x5BasicClustersUncleaned:multi5x5BarrelBasicClusters',
     endcapClusterTag = 'multi5x5BasicClustersUncleaned:multi5x5EndcapBasicClusters'
 )
 

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterOOTECAL_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterOOTECAL_cff.py
@@ -1,21 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 from RecoEcal.EgammaClusterProducers.particleFlowSuperClusterECAL_cfi import *
 
-particleFlowSuperClusterOOTECAL = particleFlowSuperClusterECAL.clone()
-particleFlowSuperClusterOOTECAL.PFClusters = cms.InputTag("particleFlowClusterOOTECAL")
-particleFlowSuperClusterOOTECAL.ESAssociation = cms.InputTag("particleFlowClusterOOTECAL")
-particleFlowSuperClusterOOTECAL.PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterOOTECALBarrel")
-particleFlowSuperClusterOOTECAL.PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterOOTECALBarrel")
-particleFlowSuperClusterOOTECAL.PFBasicClusterCollectionEndcap = cms.string("particleFlowBasicClusterOOTECALEndcap")
-particleFlowSuperClusterOOTECAL.PFSuperClusterCollectionEndcap = cms.string("particleFlowSuperClusterOOTECALEndcap")
-particleFlowSuperClusterOOTECAL.PFBasicClusterCollectionPreshower = cms.string("particleFlowBasicClusterOOTECALPreshower")
-particleFlowSuperClusterOOTECAL.PFSuperClusterCollectionEndcapWithPreshower = cms.string("particleFlowSuperClusterOOTECALEndcapWithPreshower")
-
-## modification for Algo
-particleFlowSuperClusterOOTECAL.isOOTCollection = cms.bool(True)
-particleFlowSuperClusterOOTECAL.barrelRecHits = cms.InputTag("ecalRecHit","EcalRecHitsEB")
-particleFlowSuperClusterOOTECAL.endcapRecHits = cms.InputTag("ecalRecHit","EcalRecHitsEE")
-
+particleFlowSuperClusterOOTECAL = particleFlowSuperClusterECAL.clone(
+    PFClusters                     = "particleFlowClusterOOTECAL",
+    ESAssociation                  = "particleFlowClusterOOTECAL",
+    PFBasicClusterCollectionBarrel = "particleFlowBasicClusterOOTECALBarrel",
+    PFSuperClusterCollectionBarrel = "particleFlowSuperClusterOOTECALBarrel",
+    PFBasicClusterCollectionEndcap = "particleFlowBasicClusterOOTECALEndcap",
+    PFSuperClusterCollectionEndcap = "particleFlowSuperClusterOOTECALEndcap",
+    PFBasicClusterCollectionPreshower = "particleFlowBasicClusterOOTECALPreshower",
+    PFSuperClusterCollectionEndcapWithPreshower = "particleFlowSuperClusterOOTECALEndcapWithPreshower",
+    ## modification for Algo
+    isOOTCollection                = True,
+    barrelRecHits                  = "ecalRecHit:EcalRecHitsEB",
+    endcapRecHits                  = "ecalRecHit:EcalRecHitsEE"
+)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 
 run2_miniAOD_80XLegacy.toModify(

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -28,7 +28,6 @@ phase2_hgcal.toModify(
 particleFlowSuperClusterHGCalFromMultiCl = particleFlowSuperClusterHGCal.clone()
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
-    #PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
     PFClusters = 'particleFlowClusterHGCalFromMultiCl'
 )
 _phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusteringTask.copy()

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusteringSequence_cff.py
@@ -15,20 +15,21 @@ particleFlowSuperClusterHGCal = particleFlowSuperClusterECAL.clone()
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCal,
-    PFClusters = cms.InputTag('particleFlowClusterHGCal'),
-    useRegression = cms.bool(False), #no HGCal regression yet
-    use_preshower = cms.bool(False),
-    PFBasicClusterCollectionEndcap = cms.string(""),
-    PFSuperClusterCollectionEndcap = cms.string(""),
-    PFSuperClusterCollectionEndcapWithPreshower = cms.string(""),
-    thresh_PFClusterEndcap = cms.double(1.5e-1), # 150 MeV threshold
-    dropUnseedable = cms.bool(True),
+    PFClusters                     = 'particleFlowClusterHGCal',
+    useRegression                  = False, #no HGCal regression yet
+    use_preshower                  = False,
+    PFBasicClusterCollectionEndcap = "",
+    PFSuperClusterCollectionEndcap = "",
+    PFSuperClusterCollectionEndcapWithPreshower = "",
+    thresh_PFClusterEndcap         = 1.5e-1, # 150 MeV threshold
+    dropUnseedable                 = True,
 )
 
 particleFlowSuperClusterHGCalFromMultiCl = particleFlowSuperClusterHGCal.clone()
 phase2_hgcal.toModify(
     particleFlowSuperClusterHGCalFromMultiCl,
-    PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
+    #PFClusters = cms.InputTag('particleFlowClusterHGCalFromMultiCl')
+    PFClusters = 'particleFlowClusterHGCalFromMultiCl'
 )
 _phase2_hgcal_particleFlowSuperClusteringTask = particleFlowSuperClusteringTask.copy()
 _phase2_hgcal_particleFlowSuperClusteringTask.add(particleFlowSuperClusterHGCal)

--- a/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
+++ b/RecoEcal/EgammaClusterProducers/python/reducedRecHitsSequence_cff.py
@@ -3,72 +3,72 @@ import FWCore.ParameterSet.Config as cms
 import RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi
 
 interestingEcalDetIdEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("hybridSuperClusters","hybridBarrelBasicClusters"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "hybridSuperClusters:hybridBarrelBasicClusters",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 interestingEcalDetIdEBU = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("hybridSuperClusters","uncleanOnlyHybridBarrelBasicClusters"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "hybridSuperClusters:uncleanOnlyHybridBarrelBasicClusters",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 interestingEcalDetIdEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("multi5x5SuperClusters","multi5x5EndcapBasicClusters"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "multi5x5SuperClusters:multi5x5EndcapBasicClusters",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )
 
 interestingEcalDetIdPFEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterECAL","particleFlowBasicClusterECALBarrel"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "particleFlowSuperClusterECAL:particleFlowBasicClusterECALBarrel",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 interestingEcalDetIdPFEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterECAL","particleFlowBasicClusterECALEndcap"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "particleFlowSuperClusterECAL:particleFlowBasicClusterECALEndcap",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )
 
 interestingEcalDetIdPFES = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterECAL","particleFlowBasicClusterECALPreshower"),
-    recHitsLabel = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
-    severityLevel = cms.int32(-1),
-    keepNextToDead = cms.bool(False),
-    keepNextToBoundary = cms.bool(False)    
+    basicClustersLabel = "particleFlowSuperClusterECAL:particleFlowBasicClusterECALPreshower",
+    recHitsLabel       = "ecalPreshowerRecHit:EcalRecHitsES",
+    severityLevel      = -1,
+    keepNextToDead     = False,
+    keepNextToBoundary = False    
     )
 
 interestingEcalDetIdOOTPFEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterOOTECAL","particleFlowBasicClusterOOTECALBarrel"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "particleFlowSuperClusterOOTECAL:particleFlowBasicClusterOOTECALBarrel",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 interestingEcalDetIdOOTPFEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterOOTECAL","particleFlowBasicClusterOOTECALEndcap"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "particleFlowSuperClusterOOTECAL:particleFlowBasicClusterOOTECALEndcap",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )
 
 interestingEcalDetIdOOTPFES = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowSuperClusterOOTECAL","particleFlowBasicClusterOOTECALPreshower"),
-    recHitsLabel = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
-    severityLevel = cms.int32(-1),
-    keepNextToDead = cms.bool(False),
-    keepNextToBoundary = cms.bool(False)    
+    basicClustersLabel = "particleFlowSuperClusterOOTECAL:particleFlowBasicClusterOOTECALPreshower",
+    recHitsLabel       = "ecalPreshowerRecHit:EcalRecHitsES",
+    severityLevel      = -1,
+    keepNextToDead     = False,
+    keepNextToBoundary = False    
     )
 
 interestingEcalDetIdRefinedEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowEGamma","EBEEClusters"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "particleFlowEGamma:EBEEClusters",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 interestingEcalDetIdRefinedEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowEGamma","EBEEClusters"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "particleFlowEGamma:EBEEClusters",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )
 
 interestingEcalDetIdRefinedES = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("particleFlowEGamma","ESClusters"),
-    recHitsLabel = cms.InputTag("ecalPreshowerRecHit","EcalRecHitsES"),
-    severityLevel = cms.int32(-1),
-    keepNextToDead = cms.bool(False),
-    keepNextToBoundary = cms.bool(False)    
+    basicClustersLabel = "particleFlowEGamma:ESClusters",
+    recHitsLabel       = "ecalPreshowerRecHit:EcalRecHitsES",
+    severityLevel      = -1,
+    keepNextToDead     = False,
+    keepNextToBoundary = False    
     )
     
 # rechits associated to high pt tracks for HSCP


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#30700](https://github.com/cms-sw/cmssw/pull/30700), [PR#30827](https://github.com/cms-sw/cmssw/pull/30827), [PR#30947](https://github.com/cms-sw/cmssw/pull/30947),[PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243))

In this PR, total 10 files updated. 
- RecoEcal/{EgammaClusterProducers} 10 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).