### PR TITLE
Fix crashing PixelOnlyGPU workflows (add missing CUDAServices)

### DIFF
--- a/Configuration/StandardSequences/python/Services_cff.py
+++ b/Configuration/StandardSequences/python/Services_cff.py
@@ -11,3 +11,11 @@ from IOMC.RandomEngine.IOMC_cff import *
 #an "intermediate layer" remains, just in case somebody is using it...
 # from Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff import *
 from DQMServices.Core.DQMStore_cfg import *
+
+# Add CUDAServices when using gpu Modifier is enabled
+from Configuration.ProcessModifiers.gpu_cff import gpu
+def _addCUDAServices(theProcess):
+     theProcess.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
+
+modifyConfigurationStandardSequencesServicesAddCUDAServices_ = gpu.makeProcessModifier( _addCUDAServices )
+


### PR DESCRIPTION
#### PR description:

This PR fixes the crash of workflows 136.885502,136.888502,10824.502,10842.502,11634.502,11650.502 as reported in https://github.com/cms-sw/cmssw/pull/31130#issuecomment-681815102 .
This fix loads `HeterogeneousCore.CUDAServices.CUDAService_cfi` in `RecoVertex/BeamSpotProducer/python/BeamSpot_cff.py` through the `gpu` Modifier.

#### PR validation:

`runTheMatrix.py -l 136.885502` works