### PR TITLE
Build CUDA host code if CUDA libraries are available

### DIFF
--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,8 +1,10 @@
-<use name="rootcore"/>
-<use name="CUDADataFormats/Common"/>
-<use name="DataFormats/Common"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
+<iftool name="cuda"/>
+  <use name="rootcore"/>
+  <use name="CUDADataFormats/Common"/>
+  <use name="DataFormats/Common"/>
+  <use name="HeterogeneousCore/CUDAUtilities"/>
 
-<export>
+  <export>
     <lib name="1"/>
-</export>
+  </export>
+</iftool>

--- a/CUDADataFormats/BeamSpot/BuildFile.xml
+++ b/CUDADataFormats/BeamSpot/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda"/>
+<iftool name="cuda">
   <use name="rootcore"/>
   <use name="CUDADataFormats/Common"/>
   <use name="DataFormats/Common"/>

--- a/CUDADataFormats/Common/BuildFile.xml
+++ b/CUDADataFormats/Common/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <use name="HeterogeneousCore/CUDAUtilities"/>
   <export>
     <lib name="1"/>

--- a/HeterogeneousCore/CUDACore/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <use name="FWCore/Concurrency"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>

--- a/HeterogeneousCore/CUDAServices/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/ParameterSet"/>

--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <use name="cuda"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
@@ -11,6 +11,7 @@
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/CUDAServices"/>
+
   <library file="*.cc" name="HeterogeneousCoreCUDAServicesPlugins">
     <flags EDM_PLUGIN="1"/>
   </library>

--- a/HeterogeneousCore/CUDAServices/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/test/BuildFile.xml
@@ -1,8 +1,7 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <bin file="testCUDAService.cpp test_main.cpp" name="testCUDAService">
-    <use name="HeterogeneousCore/CUDAServices"/>
-    <use name="cuda"/>
     <use name="catch2"/>
+    <use name="cuda"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
   </bin>
-
 </iftool>

--- a/HeterogeneousCore/CUDAUtilities/BuildFile.xml
+++ b/HeterogeneousCore/CUDAUtilities/BuildFile.xml
@@ -1,4 +1,4 @@
-<iftool name="cuda-gcc-support">
+<iftool name="cuda">
   <use name="cuda"/>
   <use name="eigen"/>
   <use name="FWCore/Utilities"/>

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -39,10 +39,12 @@
 <library file="OfflineToTransientBeamSpotESProducer.cc" name="OfflineToTransientBeamSpotESProducer">
   <flags EDM_PLUGIN="1"/>
 </library>
-<library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
-  <use name="cuda"/>
-  <use name="CUDADataFormats/BeamSpot"/>
-  <use name="HeterogeneousCore/CUDACore"/>
-  <use name="HeterogeneousCore/CUDAServices"/>
-  <flags EDM_PLUGIN="1"/>
-</library>
+<iftool name="cuda">
+  <library file="BeamSpotToCUDA.cc" name="BeamSpotToCUDA">
+    <use name="cuda"/>
+    <use name="CUDADataFormats/BeamSpot"/>
+    <use name="HeterogeneousCore/CUDACore"/>
+    <use name="HeterogeneousCore/CUDAServices"/>
+    <flags EDM_PLUGIN="1"/>
+  </library>
+</iftool>


### PR DESCRIPTION
#### PR description:

Relax the condition for building CUDA host code to check only for the availability of the CUDA libraries, without requiring the possibility to compile CUDA device code.
This makes them available - for example - in GCC 10 builds.

#### PR validation:

The affected packages now build with GCC 10, and the `CUDAService` can be loaded:
```bash
$ echo $SCRAM_ARCH 
slc7_amd64_gcc820

$ cmsRun HeterogeneousCore/CUDAServices/test/testCUDAService.py 
%MSG-w CUDAService:  (NoModuleName) 02-Sep-2020 16:25:51 CEST pre-events
Failed to initialize the CUDA runtime.
Disabling the CUDAService.
%MSG
```