### PR TITLE
Fix deg to rad conversion in L1TkMuonProducer ("ManTra" version) for HLT TDR [11_2_X]

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h
@@ -84,8 +84,6 @@ private:
                                     const std::vector<int>& matches);
 
   // converters
-  double deg_to_rad(double x) { return (x * angle_units::degPerRad); }
-
   double eta_to_theta(double x) {
     //  give theta in rad
     return (2. * atan(exp(-1. * x)));
@@ -97,14 +95,6 @@ private:
       x -= M_PI;
     while (x < -0.5 * M_PI)
       x += M_PI;
-    return x;
-  }
-
-  double to_mpi_pi(double x) {
-    while (x >= M_PI)
-      x -= 2. * M_PI;
-    while (x < -M_PI)
-      x += 2. * M_PI;
     return x;
   }
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
@@ -82,7 +82,7 @@ public:
   static std::vector<double> prepare_corr_bounds(std::string fname, std::string hname);
 
   // converters
-  static double deg_to_rad(double x) { return (x * angle_units::degPerRad); }
+  static double deg_to_rad(double x) { return (x / angle_units::degPerRad); }
 
   static double eta_to_theta(double x) {
     //  give theta in rad

--- a/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h
@@ -82,8 +82,6 @@ public:
   static std::vector<double> prepare_corr_bounds(std::string fname, std::string hname);
 
   // converters
-  static double deg_to_rad(double x) { return (x / angle_units::degPerRad); }
-
   static double eta_to_theta(double x) {
     //  give theta in rad
     return (2. * atan(exp(-1. * x)));
@@ -95,14 +93,6 @@ public:
       x -= M_PI;
     while (x < -0.5 * M_PI)
       x += M_PI;
-    return x;
-  }
-
-  static double to_mpi_pi(double x) {
-    while (x >= M_PI)
-      x -= 2. * M_PI;
-    while (x < -M_PI)
-      x += 2. * M_PI;
     return x;
   }
 

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -10,10 +10,10 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 #include "DataFormats/L1TCorrelator/interface/TkMuon.h"
@@ -638,7 +638,7 @@ std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const EM
     result[imu].pt = mu.Pt();
     result[imu].eta = mu.Eta();
     result[imu].theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(mu.Eta()));
-    result[imu].phi = L1TkMuMantra::deg_to_rad(mu.Phi_glob());
+    result[imu].phi = angle_units::operators::convertDegToRad(mu.Phi_glob());
     result[imu].charge = mu.Charge();
   }
   return result;

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuCorrDynamicWindows.cc
@@ -1,4 +1,6 @@
 #include "L1Trigger/L1TTrackMatch/interface/L1TkMuCorrDynamicWindows.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/angle_units.h"
 
 // ROOT includes
 #include "TH1.h"
@@ -189,10 +191,10 @@ std::vector<int> L1TkMuCorrDynamicWindows::find_match(const EMTFTrackCollection&
 
       // putting everything in rad
       float emtf_theta = to_mpio2_pio2(eta_to_theta(l1muit->Eta()));
-      float emtf_phi = deg_to_rad(l1muit->Phi_glob());
+      float emtf_phi = angle_units::operators::convertDegToRad(l1muit->Phi_glob());
 
       float dtheta = std::abs(emtf_theta - trk_theta);
-      float dphi = to_mpi_pi(emtf_phi - trk_phi);
+      float dphi = reco::deltaPhi(emtf_phi, trk_phi);
       float adphi = std::abs(dphi);
 
       double sf_l;
@@ -288,10 +290,10 @@ std::vector<int> L1TkMuCorrDynamicWindows::find_match_stub(const EMTFHitCollecti
         continue;
 
       float emtf_theta = to_mpio2_pio2(eta_to_theta(l1muit->Eta_sim()));
-      float emtf_phi = deg_to_rad(l1muit->Phi_sim());
+      float emtf_phi = angle_units::operators::convertDegToRad(l1muit->Phi_sim());
 
       float dtheta = std::abs(emtf_theta - trk_theta);
-      float dphi = to_mpi_pi(emtf_phi - trk_phi);
+      float dphi = reco::deltaPhi(emtf_phi, trk_phi);
       float adphi = std::abs(dphi);
 
       double sf_l;

--- a/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkMuMantra.cc
@@ -1,5 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
 #include "TH2.h"
 #include "TFile.h"
 
@@ -125,7 +127,7 @@ std::vector<int> L1TkMuMantra::find_match(const std::vector<track_df>& tracks, c
       if (trk.nstubs < min_nstubs)
         continue;  // require trk.nstubs >= min_nstubs
 
-      double dphi_charge = to_mpi_pi((trk.phi - mu.phi) * trk.charge);
+      double dphi_charge = reco::deltaPhi(trk.phi, mu.phi) * trk.charge;
       // sign from theta, to avoid division by 0
       double dtheta_endc = (mu.theta - trk.theta) * sign(mu.theta);
       if (sign(mu.theta) != sign(trk.theta)) {


### PR DESCRIPTION
#### PR description:

An inefficiency was reported for the L1TkMu object in recently produced samples (including  `/DYToLL_M-50_TuneCP5_14TeV-pythia8/Phase2HLTTDRSummer20ReRECOMiniAOD-NoPU_pilot_111X_mcRun4_realistic_T15_v1-v1/FEVT`) for the HLT TDR. Per @l-cadamuro 's suggestion I changed the `deg_to_rad` function back to the definition in https://github.com/cms-l1t-offline/cmssw/blob/l1t-phase2-v2.37.2/L1Trigger/L1TTrackMatch/interface/L1TkMuMantra.h#L85. 
#### PR validation:

Tested the TP, DynamicWindows and ManTra versions on 2900 events in `/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/FEVT/NoPU_pilot_111X_mcRun4_realistic_T15_v1-v1/100000/FE80A42E-0B59-FD45-A1E5-56A34EFA3DB9.root`. Tested the ManTra version again after the fix on the same sample. Efficiency plots can be found here: https://its.cern.ch/jira/browse/CMSLITDPG-908. This largely fixes the issue, though a substantial drop can be seen near |eta|~1.6. 

ManTra before fix:
- pt https://its.cern.ch/jira/secure/attachment/249235/Screen%20Shot%202020-09-02%20at%203.44.31%20PM.png
- |eta|: https://its.cern.ch/jira/secure/attachment/249236/Screen%20Shot%202020-09-02%20at%203.46.16%20PM.png
- phi: https://its.cern.ch/jira/secure/attachment/249234/Screen%20Shot%202020-09-02%20at%203.43.36%20PM.png

ManTra after fix:
- pt: https://its.cern.ch/jira/secure/attachment/249239/Screen%20Shot%202020-09-02%20at%209.36.18%20PM.png
- |eta|: https://its.cern.ch/jira/secure/attachment/249240/Screen%20Shot%202020-09-02%20at%209.36.56%20PM.png
- phi: https://its.cern.ch/jira/secure/attachment/249241/Screen%20Shot%202020-09-02%20at%209.37.29%20PM.png


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

May need to be backported to 11_1_X

FYI @l-cadamuro @rekovic @BenjaminRS 
