### PR TITLE
add missing includes to CondFormats/GeometryObjects

### DIFF
--- a/CondFormats/GeometryObjects/BuildFile.xml
+++ b/CondFormats/GeometryObjects/BuildFile.xml
@@ -1,5 +1,9 @@
 <use name="DataFormats/DetId"/>
 <use name="CondFormats/Serialization"/>
+<use name="CondFormats/External"/>
+<use name="DetectorDescription/DDCMS"/>
+<use name="FWCore/Utilities"/>
+<use name="Geometry/VeryForwardGeometryBuilder"/>
 <use name="boost_serialization"/>
 <use name="dd4hep"/>
 <export>


### PR DESCRIPTION
#31240 broke the modules IB last night due to missing build file dependencies. This adds them.
