### PR TITLE
break circular dependencies reported by IB system

### DIFF
--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -20,7 +20,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h"
 #include "CondFormats/HcalObjects/interface/HcalL1TriggerObjects.h"
 #include "CondFormats/HcalObjects/interface/HcalL1TriggerObject.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -8,7 +8,6 @@
 #include "DataFormats/HcalDigi/interface/HcalQIESample.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "EventFilter/HcalRawToDigi/interface/HcalTTPUnpacker.h"
-#include "EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h"
 
 //#define DebugLog
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -10,7 +10,6 @@
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h"
-#include "RecoLocalCalo/HGCalRecProducers/interface/HGCalClusteringAlgoBase.h"
 
 #include "CommonTools/RecoAlgos/interface/KDTreeLinkerAlgo.h"
 

--- a/TrackingTools/KalmanUpdators/src/MRHChi2MeasurementEstimator.cc
+++ b/TrackingTools/KalmanUpdators/src/MRHChi2MeasurementEstimator.cc
@@ -1,5 +1,4 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
-#include "RecoTracker/SiTrackerMRHTools/interface/SiTrackerMultiRecHitUpdator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "TrackingTools/KalmanUpdators/interface/MRHChi2MeasurementEstimator.h"
 #include "TrackingTools/PatternTools/interface/MeasurementExtractor.h"


### PR DESCRIPTION
looks like these were simply extract #includes that could be removed.