### PR TITLE
Remove L1Trigger dependency from DataFormats

### DIFF
--- a/DataFormats/L1TMuon/interface/CSCConstants.h
+++ b/DataFormats/L1TMuon/interface/CSCConstants.h
@@ -1,5 +1,5 @@
-#ifndef CSCCommonTrigger_CSCConstants_h
-#define CSCCommonTrigger_CSCConstants_h
+#ifndef DataFormats_L1TMuon_CSCConstants_h
+#define DataFormats_L1TMuon_CSCConstants_h
 
 /**
  * \class CSCConstants

--- a/DataFormats/L1TMuon/interface/EMTFHit.h
+++ b/DataFormats/L1TMuon/interface/EMTFHit.h
@@ -16,10 +16,7 @@
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
 #include "DataFormats/GEMDigi/interface/GEMPadDigiCluster.h"
 #include "DataFormats/L1TMuon/interface/CPPFDigi.h"
-
-// Included *only* for TrigerPrimitive::subsystem_type enum...
-// surely there's a better way/place for such common definitions
-#include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 namespace l1t {
 
@@ -267,12 +264,11 @@ namespace l1t {
     int ALCT_quality() const { return alct_quality; }
     int CLCT_quality() const { return clct_quality; }
 
-    // See L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
-    bool Is_DT() const { return subsystem == l1tmu::TriggerPrimitive::kDT; }
-    bool Is_CSC() const { return subsystem == l1tmu::TriggerPrimitive::kCSC; }
-    bool Is_RPC() const { return subsystem == l1tmu::TriggerPrimitive::kRPC; }
-    bool Is_GEM() const { return subsystem == l1tmu::TriggerPrimitive::kGEM; }
-    bool Is_ME0() const { return subsystem == l1tmu::TriggerPrimitive::kME0; }
+    bool Is_DT() const { return subsystem == l1tmu::kDT; }
+    bool Is_CSC() const { return subsystem == l1tmu::kCSC; }
+    bool Is_RPC() const { return subsystem == l1tmu::kRPC; }
+    bool Is_GEM() const { return subsystem == l1tmu::kGEM; }
+    bool Is_ME0() const { return subsystem == l1tmu::kME0; }
 
   private:
     //CSCDetId csc_DetId;

--- a/DataFormats/L1TMuon/interface/L1TMuonSubsystems.h
+++ b/DataFormats/L1TMuon/interface/L1TMuonSubsystems.h
@@ -1,0 +1,8 @@
+#ifndef DataFormats_L1TMuon_L1TMuonSubsystems_hh
+#define DataFormats_L1TMuon_L1TMuonSubsystems_hh
+
+namespace L1TMuon {
+    enum subsystem_type { kDT, kCSC, kRPC, kGEM, kME0, kNSubsystems };
+}
+
+#endif

--- a/DataFormats/L1TMuon/interface/L1TMuonSubsystems.h
+++ b/DataFormats/L1TMuon/interface/L1TMuonSubsystems.h
@@ -2,7 +2,7 @@
 #define DataFormats_L1TMuon_L1TMuonSubsystems_hh
 
 namespace L1TMuon {
-    enum subsystem_type { kDT, kCSC, kRPC, kGEM, kME0, kNSubsystems };
+  enum subsystem_type { kDT, kCSC, kRPC, kGEM, kME0, kNSubsystems };
 }
 
 #endif

--- a/DataFormats/L1TMuon/src/EMTFHit.cc
+++ b/DataFormats/L1TMuon/src/EMTFHit.cc
@@ -1,5 +1,5 @@
 #include "DataFormats/L1TMuon/interface/EMTFHit.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 namespace l1t {
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/EMTFUnpackerTools.cc
@@ -1,5 +1,5 @@
-
 #include "EMTFUnpackerTools.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 namespace l1t {
   namespace stage2 {
@@ -18,7 +18,7 @@ namespace l1t {
         _hit.set_sync_err(_ME.SE());
         _hit.set_bx(_ME.TBIN() - 3);
         _hit.set_bc0(_ME.BC0());
-        _hit.set_subsystem(l1tmu::TriggerPrimitive::kCSC);
+        _hit.set_subsystem(l1tmu::kCSC);
         // _hit.set_layer();
 
         _hit.set_ring(L1TMuonEndCap::calc_ring(_hit.Station(), _hit.CSC_ID(), _hit.Strip()));
@@ -43,7 +43,7 @@ namespace l1t {
         _hit.set_bx(_RPC.TBIN() - 3);
         _hit.set_valid(_RPC.VP());
         _hit.set_bc0(_RPC.BC0());
-        _hit.set_subsystem(l1tmu::TriggerPrimitive::kRPC);
+        _hit.set_subsystem(l1tmu::kRPC);
 
         _hit.SetRPCDetId(_hit.CreateRPCDetId());
         // // Not yet implemented - AWB 15.03.17
@@ -77,7 +77,7 @@ namespace l1t {
         _hit.set_bx(_GEM.TBIN() - 3);
         _hit.set_valid(_GEM.VP());
         _hit.set_bc0(_GEM.BC0());
-        _hit.set_subsystem(l1tmu::TriggerPrimitive::kGEM);
+        _hit.set_subsystem(l1tmu::kGEM);
 
         _hit.set_ring(1);  // GEM only on ring 1
         // TODO: FIXME correct for GEM, should match CSC chamber, but GEM have 2 chambers (layers in a superchamber) per CSC chamber - JS 13.07.20

--- a/EventFilter/L1TRawToDigi/src/OmtfCscPacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfCscPacker.cc
@@ -2,7 +2,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfCscDataWord64.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 namespace omtf {
 

--- a/EventFilter/L1TRawToDigi/src/OmtfCscUnpacker.cc
+++ b/EventFilter/L1TRawToDigi/src/OmtfCscUnpacker.cc
@@ -4,7 +4,7 @@
 
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 #include "DataFormats/L1TMuon/interface/OMTF/OmtfCscDataWord64.h"
 

--- a/L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h
@@ -9,7 +9,7 @@
  * This was factored out of the Sector Receiver since it is used in
  * parts of the trigger primitive generator (I think).
  */
-#include <L1Trigger/CSCCommonTrigger/interface/CSCConstants.h>
+#include <DataFormats/L1TMuon/interface/CSCConstants.h>
 
 class CSCPatternLUT {
 public:

--- a/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverLUT.cc
@@ -4,7 +4,7 @@
 #include <L1Trigger/CSCCommonTrigger/interface/CSCFrontRearLUT.h>
 #include <DataFormats/L1CSCTrackFinder/interface/CSCBitWidths.h>
 #include <DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h>
-#include <L1Trigger/CSCCommonTrigger/interface/CSCConstants.h>
+#include <DataFormats/L1TMuon/interface/CSCConstants.h>
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include <Geometry/CSCGeometry/interface/CSCLayerGeometry.h>

--- a/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverMiniLUT.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCSectorReceiverMiniLUT.cc
@@ -2,7 +2,7 @@
 #include <L1Trigger/CSCCommonTrigger/interface/CSCFrontRearLUT.h>
 #include <DataFormats/L1CSCTrackFinder/interface/CSCBitWidths.h>
 #include <DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h>
-#include <L1Trigger/CSCCommonTrigger/interface/CSCConstants.h>
+#include <DataFormats/L1TMuon/interface/CSCConstants.h>
 
 #include <Geometry/CSCGeometry/interface/CSCLayerGeometry.h>
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"

--- a/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
@@ -4,7 +4,7 @@
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 #include <DataFormats/MuonDetId/interface/CSCTriggerNumbering.h>
 #include <DataFormats/L1CSCTrackFinder/interface/CSCBitWidths.h>
-#include <L1Trigger/CSCCommonTrigger/interface/CSCConstants.h>
+#include <DataFormats/L1TMuon/interface/CSCConstants.h>
 #include <DataFormats/MuonDetId/interface/DTChamberId.h>
 
 #include <L1Trigger/CSCTrackFinder/src/CSCTFDTReceiverLUT.h>

--- a/L1Trigger/CSCTrackFinder/src/CSCTFMuonSorter.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFMuonSorter.cc
@@ -1,5 +1,5 @@
 #include <L1Trigger/CSCTrackFinder/interface/CSCTFMuonSorter.h>
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 CSCTFMuonSorter::CSCTFMuonSorter(const edm::ParameterSet& pset) {

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -6,7 +6,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboardLUT.h"
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboardLUTGenerator.h"

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCPatternBank.h
@@ -1,7 +1,7 @@
 #ifndef L1Trigger_CSCTriggerPrimitives_CSCPatternBank_h
 #define L1Trigger_CSCTriggerPrimitives_CSCPatternBank_h
 
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include <vector>
 
 //

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboardLUT.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCUpgradeMotherboardLUT.h
@@ -1,7 +1,7 @@
 #ifndef L1Trigger_CSCTriggerPrimitives_CSCUpgradeMotherboardLUT_h
 #define L1Trigger_CSCTriggerPrimitives_CSCUpgradeMotherboardLUT_h
 
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
 

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTContainer.h
@@ -10,7 +10,7 @@
  */
 
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 #include <vector>
 #include <algorithm>

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesReader.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesReader.h
@@ -20,7 +20,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMuonPortCard.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/CSCTriggerPrimitives/interface/CSCMuonPortCard.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include <algorithm>
 
 CSCMuonPortCard::CSCMuonPortCard() {}

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -56,7 +56,6 @@ namespace L1TMuon {
 
   class TriggerPrimitive {
   public:
-
     // define the data we save locally from each subsystem type
     // variables in these structs keep their colloquial meaning
     // within a subsystem

--- a/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
+++ b/L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h
@@ -23,6 +23,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 // DT digi types
 class DTChamberId;
@@ -55,8 +56,6 @@ namespace L1TMuon {
 
   class TriggerPrimitive {
   public:
-    // define the subsystems that we have available
-    enum subsystem_type { kDT, kCSC, kRPC, kGEM, kME0, kNSubsystems };
 
     // define the data we save locally from each subsystem type
     // variables in these structs keep their colloquial meaning

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -27,19 +27,19 @@ GeometryTranslator::~GeometryTranslator() {}
 
 double GeometryTranslator::calculateGlobalEta(const TriggerPrimitive& tp) const {
   switch (tp.subsystem()) {
-    case TriggerPrimitive::kDT:
+    case L1TMuon::kDT:
       return calcDTSpecificEta(tp);
       break;
-    case TriggerPrimitive::kCSC:
+    case L1TMuon::kCSC:
       return calcCSCSpecificEta(tp);
       break;
-    case TriggerPrimitive::kRPC:
+    case L1TMuon::kRPC:
       return calcRPCSpecificEta(tp);
       break;
-    case TriggerPrimitive::kGEM:
+    case L1TMuon::kGEM:
       return calcGEMSpecificEta(tp);
       break;
-    case TriggerPrimitive::kME0:
+    case L1TMuon::kME0:
       return calcME0SpecificEta(tp);
       break;
     default:
@@ -50,19 +50,19 @@ double GeometryTranslator::calculateGlobalEta(const TriggerPrimitive& tp) const 
 
 double GeometryTranslator::calculateGlobalPhi(const TriggerPrimitive& tp) const {
   switch (tp.subsystem()) {
-    case TriggerPrimitive::kDT:
+    case L1TMuon::kDT:
       return calcDTSpecificPhi(tp);
       break;
-    case TriggerPrimitive::kCSC:
+    case L1TMuon::kCSC:
       return calcCSCSpecificPhi(tp);
       break;
-    case TriggerPrimitive::kRPC:
+    case L1TMuon::kRPC:
       return calcRPCSpecificPhi(tp);
       break;
-    case TriggerPrimitive::kGEM:
+    case L1TMuon::kGEM:
       return calcGEMSpecificPhi(tp);
       break;
-    case TriggerPrimitive::kME0:
+    case L1TMuon::kME0:
       return calcME0SpecificPhi(tp);
       break;
     default:
@@ -73,19 +73,19 @@ double GeometryTranslator::calculateGlobalPhi(const TriggerPrimitive& tp) const 
 
 double GeometryTranslator::calculateBendAngle(const TriggerPrimitive& tp) const {
   switch (tp.subsystem()) {
-    case TriggerPrimitive::kDT:
+    case L1TMuon::kDT:
       return calcDTSpecificBend(tp);
       break;
-    case TriggerPrimitive::kCSC:
+    case L1TMuon::kCSC:
       return calcCSCSpecificBend(tp);
       break;
-    case TriggerPrimitive::kRPC:
+    case L1TMuon::kRPC:
       return calcRPCSpecificBend(tp);
       break;
-    case TriggerPrimitive::kGEM:
+    case L1TMuon::kGEM:
       return calcGEMSpecificBend(tp);
       break;
-    case TriggerPrimitive::kME0:
+    case L1TMuon::kME0:
       return calcME0SpecificBend(tp);
       break;
     default:
@@ -96,19 +96,19 @@ double GeometryTranslator::calculateBendAngle(const TriggerPrimitive& tp) const 
 
 GlobalPoint GeometryTranslator::getGlobalPoint(const TriggerPrimitive& tp) const {
   switch (tp.subsystem()) {
-    case TriggerPrimitive::kDT:
+    case L1TMuon::kDT:
       return calcDTSpecificPoint(tp);
       break;
-    case TriggerPrimitive::kCSC:
+    case L1TMuon::kCSC:
       return getCSCSpecificPoint(tp);
       break;
-    case TriggerPrimitive::kRPC:
+    case L1TMuon::kRPC:
       return getRPCSpecificPoint(tp);
       break;
-    case TriggerPrimitive::kGEM:
+    case L1TMuon::kGEM:
       return getGEMSpecificPoint(tp);
       break;
-    case TriggerPrimitive::kME0:
+    case L1TMuon::kME0:
       return getME0SpecificPoint(tp);
       break;
     default:

--- a/L1Trigger/L1TMuon/src/GeometryTranslator.cc
+++ b/L1Trigger/L1TMuon/src/GeometryTranslator.cc
@@ -12,7 +12,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "L1Trigger/DTUtilities/interface/DTTrigGeom.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h"
 
 #include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h"

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -30,7 +30,7 @@ namespace {
 TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const L1MuDTChambPhDigi& digi_phi,
                                    const int segment_number)
-    : _id(detid), _subsystem(TriggerPrimitive::kDT) {
+    : _id(detid), _subsystem(L1TMuon::kDT) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -57,7 +57,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
 TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const L1MuDTChambThDigi& digi_th,
                                    const int theta_bti_group)
-    : _id(detid), _subsystem(TriggerPrimitive::kDT) {
+    : _id(detid), _subsystem(L1TMuon::kDT) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -85,7 +85,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
                                    const L1MuDTChambPhDigi& digi_phi,
                                    const L1MuDTChambThDigi& digi_th,
                                    const int theta_bti_group)
-    : _id(detid), _subsystem(TriggerPrimitive::kDT) {
+    : _id(detid), _subsystem(L1TMuon::kDT) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -112,7 +112,7 @@ TriggerPrimitive::TriggerPrimitive(const DTChamberId& detid,
 // _____________________________________________________________________________
 // Constructor from CSC data
 TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid, const CSCCorrelatedLCTDigi& digi)
-    : _id(detid), _subsystem(TriggerPrimitive::kCSC) {
+    : _id(detid), _subsystem(L1TMuon::kCSC) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -144,7 +144,7 @@ TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid, const CSCCorrelatedLCT
 // _____________________________________________________________________________
 // Constructors from RPC data
 TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCDigi& digi)
-    : _id(detid), _subsystem(TriggerPrimitive::kRPC) {
+    : _id(detid), _subsystem(L1TMuon::kRPC) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -166,7 +166,7 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCDigi& digi)
 }
 
 TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCRecHit& rechit)
-    : _id(detid), _subsystem(TriggerPrimitive::kRPC) {
+    : _id(detid), _subsystem(L1TMuon::kRPC) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -190,7 +190,7 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCRecHit& rechi
 // _____________________________________________________________________________
 // Constructor from CPPF data
 TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const l1t::CPPFDigi& digi)
-    : _id(detid), _subsystem(TriggerPrimitive::kRPC) {
+    : _id(detid), _subsystem(L1TMuon::kRPC) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -215,7 +215,7 @@ TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const l1t::CPPFDigi& d
 // _____________________________________________________________________________
 // Constructor from GEM data
 TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid, const GEMPadDigiCluster& digi)
-    : _id(detid), _subsystem(TriggerPrimitive::kGEM) {
+    : _id(detid), _subsystem(L1TMuon::kGEM) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;
@@ -230,7 +230,7 @@ TriggerPrimitive::TriggerPrimitive(const GEMDetId& detid, const GEMPadDigiCluste
 // _____________________________________________________________________________
 // Constructor from ME0 data
 TriggerPrimitive::TriggerPrimitive(const ME0DetId& detid, const ME0TriggerDigi& digi)
-    : _id(detid), _subsystem(TriggerPrimitive::kME0) {
+    : _id(detid), _subsystem(L1TMuon::kME0) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;

--- a/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
+++ b/L1Trigger/L1TMuon/src/MuonTriggerPrimitive.cc
@@ -143,8 +143,7 @@ TriggerPrimitive::TriggerPrimitive(const CSCDetId& detid, const CSCCorrelatedLCT
 
 // _____________________________________________________________________________
 // Constructors from RPC data
-TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCDigi& digi)
-    : _id(detid), _subsystem(L1TMuon::kRPC) {
+TriggerPrimitive::TriggerPrimitive(const RPCDetId& detid, const RPCDigi& digi) : _id(detid), _subsystem(L1TMuon::kRPC) {
   calculateGlobalSector(detid, _globalsector, _subsector);
   _eta = 0.;
   _phi = 0.;

--- a/L1Trigger/L1TMuonEndCap/src/AngleCalculation.cc
+++ b/L1Trigger/L1TMuonEndCap/src/AngleCalculation.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/AngleCalculation.h"
-
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 #include "helper.h"  // to_hex, to_binary
 
 namespace {
@@ -386,7 +386,7 @@ void AngleCalculation::calculate_angles(EMTFTrack& track, const int izone) const
     // CSC chamber, so the FR bit assignment is the same as for CSCs - AWB 06.06.17
 
     // GEMs are in front of the CSCs
-    if (subsystem == TriggerPrimitive::kGEM)
+    if (subsystem == L1TMuon::kGEM)
       return true;
 
     bool result = false;

--- a/L1Trigger/L1TMuonEndCap/src/DebugTools.cc
+++ b/L1Trigger/L1TMuonEndCap/src/DebugTools.cc
@@ -1,10 +1,10 @@
 #include "L1Trigger/L1TMuonEndCap/interface/DebugTools.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 namespace emtf {
 
   void dump_fw_raw_input(const l1t::EMTFHitCollection& out_hits, const l1t::EMTFTrackCollection& out_tracks) {
     // from interface/Common.h
-    typedef L1TMuon::TriggerPrimitive TriggerPrimitive;
     constexpr int MIN_ENDCAP = 1;
     constexpr int MAX_ENDCAP = 2;
     constexpr int MIN_TRIGSECTOR = 1;
@@ -30,7 +30,7 @@ namespace emtf {
 
         for (int ibx = -3 - 5; (ibx < +3 + 5 + 5) && !empty_sector; ++ibx) {
           for (const auto& h : out_hits) {
-            if (h.Subsystem() == TriggerPrimitive::kCSC) {
+            if (h.Subsystem() == L1TMuon::kCSC) {
               if (h.Sector_idx() != es)
                 continue;
               if (h.BX() != ibx)
@@ -48,7 +48,7 @@ namespace emtf {
                         << valid << " " << h.Quality() << " " << h.Pattern() << " " << wire << " " << chamber << " "
                         << h.Bend() << " " << strip << std::endl;
 
-            } else if (h.Subsystem() == TriggerPrimitive::kRPC) {
+            } else if (h.Subsystem() == L1TMuon::kRPC) {
               if (h.Sector_idx() != es)
                 continue;
               if (h.BX() + 6 != ibx)

--- a/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
+++ b/L1Trigger/L1TMuonEndCap/src/EMTFSubsystemCollector.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/EMTFSubsystemCollector.h"
-
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
@@ -360,7 +360,7 @@ void EMTFSubsystemCollector::cluster_rpc(const TriggerPrimitiveCollection& muon_
   // Define operator to select RPC digis
   struct {
     typedef TriggerPrimitive value_type;
-    bool operator()(const value_type& x) const { return (x.subsystem() == TriggerPrimitive::kRPC); }
+    bool operator()(const value_type& x) const { return (x.subsystem() == L1TMuon::kRPC); }
   } rpc_digi_select;
 
   // Define operator to sort the RPC digis prior to clustering.

--- a/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PatternRecognition.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/PatternRecognition.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 #include "helper.h"  // to_hex, to_binary
 
@@ -192,7 +193,7 @@ void PatternRecognition::process(const std::deque<EMTFHitCollection>& extended_c
   if (verbose_ > 0) {  // debug
     for (const auto& conv_hits : extended_conv_hits) {
       for (const auto& conv_hit : conv_hits) {
-        if (conv_hit.Subsystem() == TriggerPrimitive::kCSC) {
+        if (conv_hit.Subsystem() == L1TMuon::kCSC) {
           std::cout << "CSC hit st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
                     << " ph: " << conv_hit.Phi_fp() << " th: " << conv_hit.Theta_fp() << " strip: " << conv_hit.Strip()
                     << " wire: " << conv_hit.Wire() << " cpat: " << conv_hit.Pattern()
@@ -204,7 +205,7 @@ void PatternRecognition::process(const std::deque<EMTFHitCollection>& extended_c
 
     for (const auto& conv_hits : extended_conv_hits) {
       for (const auto& conv_hit : conv_hits) {
-        if (conv_hit.Subsystem() == TriggerPrimitive::kRPC) {
+        if (conv_hit.Subsystem() == L1TMuon::kRPC) {
           std::cout << "RPC hit st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
                     << " ph>>2: " << (conv_hit.Phi_fp() >> 2) << " th>>2: " << (conv_hit.Theta_fp() >> 2)
                     << " strip: " << conv_hit.Strip() << " roll: " << conv_hit.Roll() << " cpat: " << conv_hit.Pattern()
@@ -215,7 +216,7 @@ void PatternRecognition::process(const std::deque<EMTFHitCollection>& extended_c
 
     for (const auto& conv_hits : extended_conv_hits) {
       for (const auto& conv_hit : conv_hits) {
-        if (conv_hit.Subsystem() == TriggerPrimitive::kGEM) {
+        if (conv_hit.Subsystem() == L1TMuon::kGEM) {
           std::cout << "GEM hit st: " << conv_hit.PC_station() << " ch: " << conv_hit.PC_chamber()
                     << " ph: " << conv_hit.Phi_fp() << " th: " << conv_hit.Theta_fp() << " strip: " << conv_hit.Strip()
                     << " roll: " << conv_hit.Roll() << " cpat: " << conv_hit.Pattern() << " bx: " << conv_hit.BX()
@@ -284,10 +285,10 @@ bool PatternRecognition::is_zone_empty(int zone,
       emtf_assert(conv_hits_it->PC_segment() <=
                   4);  // With 2 unique LCTs per chamber, 4 possible strip/wire combinations
 
-      if (conv_hits_it->Subsystem() == TriggerPrimitive::kRPC)
+      if (conv_hits_it->Subsystem() == L1TMuon::kRPC)
         continue;  // Don't use RPC hits for pattern formation
 
-      if (conv_hits_it->Subsystem() == TriggerPrimitive::kGEM)
+      if (conv_hits_it->Subsystem() == L1TMuon::kGEM)
         continue;  // Don't use GEM hits for pattern formation
 
       if (conv_hits_it->Zone_code() & (1 << izone)) {  // hit belongs to this zone
@@ -321,10 +322,10 @@ void PatternRecognition::make_zone_image(int zone,
     EMTFHitCollection::const_iterator conv_hits_end = ext_conv_hits_it->end();
 
     for (; conv_hits_it != conv_hits_end; ++conv_hits_it) {
-      if (conv_hits_it->Subsystem() == TriggerPrimitive::kRPC)
+      if (conv_hits_it->Subsystem() == L1TMuon::kRPC)
         continue;  // Don't use RPC hits for pattern formation
 
-      if (conv_hits_it->Subsystem() == TriggerPrimitive::kGEM)
+      if (conv_hits_it->Subsystem() == L1TMuon::kGEM)
         continue;  // Don't use GEM hits for pattern formation
 
       if (conv_hits_it->Zone_code() & (1 << izone)) {  // hit belongs to this zone

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveConversion.cc
@@ -1,5 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/PrimitiveConversion.h"
-
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 #include "L1Trigger/L1TMuonEndCap/interface/SectorProcessorLUT.h"
 
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"  // for special treatments for iRPC
@@ -65,15 +65,15 @@ void PrimitiveConversion::process(const std::map<int, TriggerPrimitiveCollection
 
     for (; tp_it != tp_end; ++tp_it) {
       EMTFHit conv_hit;
-      if (tp_it->subsystem() == TriggerPrimitive::kCSC) {
+      if (tp_it->subsystem() == L1TMuon::kCSC) {
         convert_csc(pc_sector, pc_station, pc_chamber, pc_segment, *tp_it, conv_hit);
-      } else if (tp_it->subsystem() == TriggerPrimitive::kRPC) {
+      } else if (tp_it->subsystem() == L1TMuon::kRPC) {
         convert_rpc(pc_sector, pc_station, pc_chamber, pc_segment, *tp_it, conv_hit);
-      } else if (tp_it->subsystem() == TriggerPrimitive::kGEM) {
+      } else if (tp_it->subsystem() == L1TMuon::kGEM) {
         convert_gem(pc_sector, 0, selected, pc_segment, *tp_it, conv_hit);  // pc_station and pc_chamber are meaningless
-      } else if (tp_it->subsystem() == TriggerPrimitive::kME0) {
+      } else if (tp_it->subsystem() == L1TMuon::kME0) {
         convert_me0(pc_sector, 0, selected, pc_segment, *tp_it, conv_hit);  // pc_station and pc_chamber are meaningless
-      } else if (tp_it->subsystem() == TriggerPrimitive::kDT) {
+      } else if (tp_it->subsystem() == L1TMuon::kDT) {
         convert_dt(pc_sector, 0, selected, pc_segment, *tp_it, conv_hit);  // pc_station and pc_chamber are meaningless
       } else {
         emtf_assert(false && "Incorrect subsystem type");
@@ -127,7 +127,7 @@ void PrimitiveConversion::convert_csc(int pc_sector,
   conv_hit.SetCSCDetId(tp_detId);
 
   conv_hit.set_bx(tp_bx + bxShiftCSC_);
-  conv_hit.set_subsystem(TriggerPrimitive::kCSC);
+  conv_hit.set_subsystem(L1TMuon::kCSC);
   conv_hit.set_endcap((tp_endcap == 2) ? -1 : tp_endcap);
   conv_hit.set_station(tp_station);
   conv_hit.set_ring(tp_ring);
@@ -503,7 +503,7 @@ void PrimitiveConversion::convert_rpc(int pc_sector,
   conv_hit.SetRPCDetId(tp_detId);
 
   conv_hit.set_bx(tp_bx + bxShiftRPC_);
-  conv_hit.set_subsystem(TriggerPrimitive::kRPC);
+  conv_hit.set_subsystem(L1TMuon::kRPC);
   conv_hit.set_endcap((tp_endcap == 2) ? -1 : tp_endcap);
   conv_hit.set_station(tp_station);
   conv_hit.set_ring(tp_ring);
@@ -746,7 +746,7 @@ void PrimitiveConversion::convert_gem(int pc_sector,
   conv_hit.SetGEMDetId(tp_detId);
 
   conv_hit.set_bx(tp_bx + bxShiftGEM_);
-  conv_hit.set_subsystem(TriggerPrimitive::kGEM);
+  conv_hit.set_subsystem(L1TMuon::kGEM);
   conv_hit.set_endcap((tp_endcap == 2) ? -1 : tp_endcap);
   conv_hit.set_station(tp_station);
   conv_hit.set_ring(tp_ring);
@@ -916,7 +916,7 @@ void PrimitiveConversion::convert_me0(int pc_sector,
   conv_hit.SetME0DetId(tp_detId);
 
   conv_hit.set_bx(tp_bx + bxShiftME0_);
-  conv_hit.set_subsystem(TriggerPrimitive::kME0);
+  conv_hit.set_subsystem(L1TMuon::kME0);
   conv_hit.set_endcap((tp_endcap == 2) ? -1 : tp_endcap);
   conv_hit.set_station(tp_station);
   conv_hit.set_ring(tp_ring);
@@ -1045,7 +1045,7 @@ void PrimitiveConversion::convert_dt(int pc_sector,
   conv_hit.SetDTDetId(tp_detId);
 
   conv_hit.set_bx(tp_bx);
-  conv_hit.set_subsystem(TriggerPrimitive::kDT);
+  conv_hit.set_subsystem(L1TMuon::kDT);
   conv_hit.set_endcap((tp_endcap == 2) ? -1 : tp_endcap);
   conv_hit.set_station(tp_station);
   conv_hit.set_ring(1);         // set to ring 1?
@@ -1134,7 +1134,7 @@ int PrimitiveConversion::get_zone_code(const EMTFHit& conv_hit, int th) const {
   // bnd1 is the lower boundary, bnd2 the upper boundary
   int zone_code = 0;
 
-  bool is_csc = (conv_hit.Subsystem() == TriggerPrimitive::kCSC);
+  bool is_csc = (conv_hit.Subsystem() == L1TMuon::kCSC);
   bool is_me13 = (is_csc && conv_hit.Station() == 1 && conv_hit.Ring() == 3);
 
   if (th >= 127)

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveMatching.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveMatching.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/PrimitiveMatching.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 #include "helper.h"  // to_hex, to_binary, merge_sort3
 
@@ -409,7 +410,7 @@ void PrimitiveMatching::process_single_zone_station(int zone,
           bool operator()(const value_type& lhs, const value_type& rhs) const {
             // If different types, prefer CSC over RPC; else prefer the closer hit in dPhi
             if (lhs.second->Subsystem() != rhs.second->Subsystem())
-              return (lhs.second->Subsystem() == TriggerPrimitive::kCSC);
+              return (lhs.second->Subsystem() == L1TMuon::kCSC);
             else
               return lhs.first <= rhs.first;
           }
@@ -436,7 +437,7 @@ void PrimitiveMatching::insert_hits(hit_ptr_t conv_hit_ptr,
   EMTFHitCollection::const_iterator conv_hits_it = conv_hits.begin();
   EMTFHitCollection::const_iterator conv_hits_end = conv_hits.end();
 
-  const bool is_csc_me11 = (conv_hit_ptr->Subsystem() == TriggerPrimitive::kCSC) && (conv_hit_ptr->Station() == 1) &&
+  const bool is_csc_me11 = (conv_hit_ptr->Subsystem() == L1TMuon::kCSC) && (conv_hit_ptr->Station() == 1) &&
                            (conv_hit_ptr->Ring() == 1 || conv_hit_ptr->Ring() == 4);
 
   // Find all possible duplicated hits, insert them

--- a/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
+++ b/L1Trigger/L1TMuonEndCap/src/PrimitiveSelection.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/L1TMuonEndCap/interface/PrimitiveSelection.h"
+#include "DataFormats/L1TMuon/interface/L1TMuonSubsystems.h"
 
 #include "helper.h"  // merge_map_into_map
 
@@ -585,7 +586,7 @@ void PrimitiveSelection::merge_no_truncate(const std::map<int, TriggerPrimitiveC
 int PrimitiveSelection::select_csc(const TriggerPrimitive& muon_primitive) const {
   int selected = -1;
 
-  if (muon_primitive.subsystem() == TriggerPrimitive::kCSC) {
+  if (muon_primitive.subsystem() == L1TMuon::kCSC) {
     const CSCDetId& tp_detId = muon_primitive.detId<CSCDetId>();
     const CSCData& tp_data = muon_primitive.getCSCData();
 
@@ -744,7 +745,7 @@ int PrimitiveSelection::get_index_csc(
 int PrimitiveSelection::select_rpc(const TriggerPrimitive& muon_primitive) const {
   int selected = -1;
 
-  if (muon_primitive.subsystem() == TriggerPrimitive::kRPC) {
+  if (muon_primitive.subsystem() == L1TMuon::kRPC) {
     const RPCDetId& tp_detId = muon_primitive.detId<RPCDetId>();
     const RPCData& tp_data = muon_primitive.getRPCData();
 
@@ -896,7 +897,7 @@ int PrimitiveSelection::get_index_rpc(
 int PrimitiveSelection::select_gem(const TriggerPrimitive& muon_primitive) const {
   int selected = -1;
 
-  if (muon_primitive.subsystem() == TriggerPrimitive::kGEM) {
+  if (muon_primitive.subsystem() == L1TMuon::kGEM) {
     const GEMDetId& tp_detId = muon_primitive.detId<GEMDetId>();
     const GEMData& tp_data = muon_primitive.getGEMData();
 
@@ -995,7 +996,7 @@ int PrimitiveSelection::get_index_gem(
 int PrimitiveSelection::select_me0(const TriggerPrimitive& muon_primitive) const {
   int selected = -1;
 
-  if (muon_primitive.subsystem() == TriggerPrimitive::kME0) {
+  if (muon_primitive.subsystem() == L1TMuon::kME0) {
     const ME0DetId& tp_detId = muon_primitive.detId<ME0DetId>();
     const ME0Data& tp_data = muon_primitive.getME0Data();
 
@@ -1133,7 +1134,7 @@ int PrimitiveSelection::get_index_me0(
 int PrimitiveSelection::select_dt(const TriggerPrimitive& muon_primitive) const {
   int selected = -1;
 
-  if (muon_primitive.subsystem() == TriggerPrimitive::kDT) {
+  if (muon_primitive.subsystem() == L1TMuon::kDT) {
     const DTChamberId& tp_detId = muon_primitive.detId<DTChamberId>();
     const DTData& tp_data = muon_primitive.getDTData();
 

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeAngleLUT.cc
@@ -29,7 +29,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
 //#include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 #include "L1Trigger/L1TMuon/interface/GeometryTranslator.h"
 #include "L1Trigger/L1TMuon/interface/MuonTriggerPrimitive.h"

--- a/L1Trigger/L1TMuonEndCap/test/tools/MakeCoordLUT.cc
+++ b/L1Trigger/L1TMuonEndCap/test/tools/MakeCoordLUT.cc
@@ -19,7 +19,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/CSCTriggerNumbering.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCChamber.h"
@@ -27,7 +27,7 @@
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
-//#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+//#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 //#include "L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h"
 //#include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
 

--- a/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
+++ b/L1Trigger/L1TMuonOverlap/src/AngleConverter.cc
@@ -5,7 +5,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Transition.h"
 
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "L1Trigger/CSCCommonTrigger/interface/CSCPatternLUT.h"
 
 #include "L1Trigger/DTUtilities/interface/DTTrigGeom.h"

--- a/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
+++ b/L1Trigger/L1TMuonOverlap/src/OMTFinputMaker.cc
@@ -12,7 +12,7 @@
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFinput.h"
 #include "L1Trigger/L1TMuonOverlap/interface/OMTFConfiguration.h"
 #include "L1Trigger/L1TMuonOverlap/interface/AngleConverter.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 ///////////////////////////////////////

--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -1,5 +1,5 @@
 #include "Validation/MuonCSCDigis/interface/CSCStubMatcher.h"
-#include "L1Trigger/CSCCommonTrigger/interface/CSCConstants.h"
+#include "DataFormats/L1TMuon/interface/CSCConstants.h"
 #include <algorithm>
 
 using namespace std;


### PR DESCRIPTION
Move enums into DataFormats/L1TMuon to avoid L1Trigger dependencies there and to avoid a circular dependency.