### PR TITLE
[CondCore/SiPixelPlugins] Support Ratios and Diff for Pixel Gains

### DIFF
--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -1204,8 +1204,8 @@ namespace gainCalibHelper {
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
       auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
-      std::string tagname2 = "";
+      auto f_tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string l_tagname = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
 
@@ -1214,7 +1214,7 @@ namespace gainCalibHelper {
 
       if (this->m_plotAnnotations.ntags == 2) {
         auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        l_tagname = cond::payloadInspector::PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1282,7 +1282,7 @@ namespace gainCalibHelper {
           fmt::sprintf("#scale[1.2]{SiPixelGainCalibration%s Ratio}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
       if (this->m_plotAnnotations.ntags == 2) {
         latex.DrawLatexNDC(
-            .41, .91, ("#splitline{#font[12]{" + tagname1 + "}}{ / #font[12]{" + tagname2 + "}}").c_str());
+            .41, .91, ("#splitline{#font[12]{" + f_tagname + "}}{ / #font[12]{" + l_tagname + "}}").c_str());
       } else {
         latex.DrawLatexNDC(.41, .91, (firstIOVsince + " / " + lastIOVsince).c_str());
       }
@@ -1297,7 +1297,7 @@ namespace gainCalibHelper {
           fmt::sprintf("#scale[1.2]{SiPixelGainCalibration%s Diff}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
       if (this->m_plotAnnotations.ntags == 2) {
         latex2.DrawLatexNDC(
-            .41, .91, ("#splitline{#font[12]{" + tagname1 + "}}{ - #font[12]{" + tagname2 + "}}").c_str());
+            .41, .91, ("#splitline{#font[12]{" + f_tagname + "}}{ - #font[12]{" + l_tagname + "}}").c_str());
       } else {
         latex2.DrawLatexNDC(.41, .91, (firstIOVsince + " - " + lastIOVsince).c_str());
       }

--- a/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
+++ b/CondCore/SiPixelPlugins/interface/SiPixelGainCalibHelper.h
@@ -5,6 +5,7 @@
 #include "CondCore/Utilities/interface/PayloadInspector.h"
 #include "CondCore/CondDB/interface/Time.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 #include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
 #include "CondCore/SiPixelPlugins/interface/SiPixelPayloadInspectorHelper.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
@@ -40,14 +41,18 @@ namespace gainCalibHelper {
     //===========================================================================
     // helper method to fill the ratio and diff distributions
     template <typename PayloadType>
-    static void fillDiffAndRatio(const std::shared_ptr<PayloadType>& payload_A,
-                                 const std::shared_ptr<PayloadType>& payload_B,
-                                 std::array<std::shared_ptr<TH1F>, 2> arr,
-                                 const gainCalibPI::type& theType) {
+    static std::array<std::shared_ptr<TH1F>, 2> fillDiffAndRatio(const std::shared_ptr<PayloadType>& payload_A,
+                                                                 const std::shared_ptr<PayloadType>& payload_B,
+                                                                 const gainCalibPI::type& theType) {
+      std::array<std::shared_ptr<TH1F>, 2> arr;
+
       std::vector<uint32_t> detids_A;
       payload_A->getDetIds(detids_A);
       std::vector<uint32_t> detids_B;
       payload_B->getDetIds(detids_B);
+
+      std::vector<float> v_ratios;
+      std::vector<float> v_diffs;
 
       if (detids_A != detids_B) {
         edm::LogError("fillDiffAndRatio") << "the list of DetIds for the two payloads are not equal"
@@ -55,7 +60,6 @@ namespace gainCalibHelper {
       }
 
       assert(detids_A == detids_B);
-
       for (const auto& d : detids_A) {
         auto range = payload_A->getRange(d);
         int numberOfRowsToAverageOver = payload_A->getNumberOfRowsToAverageOver();
@@ -65,31 +69,25 @@ namespace gainCalibHelper {
         int nrows = std::max((payload_A->getNumberOfRowsToAverageOver() * nRocsInRow),
                              nRowsForHLT);  // dirty trick to make it work for the HLT payload
 
-        auto rangeAndCol_A = payload_A->getRangeAndNCols(d);
-        auto rangeAndCol_B = payload_B->getRangeAndNCols(d);
-        bool isDeadColumn;
-        bool isNoisyColumn;
+        auto rAndCol_A = payload_A->getRangeAndNCols(d);
+        auto rAndCol_B = payload_B->getRangeAndNCols(d);
+        bool isDeadCol, isNoisyCol;
 
         float ratio(-.1), diff(-1.);
-
         for (int col = 0; col < ncols; col++) {
           for (int row = 0; row < nrows; row++) {
             switch (theType) {
               case gainCalibPI::t_gain: {
-                auto gainA = payload_A->getGain(
-                    col, row, rangeAndCol_A.first, rangeAndCol_A.second, isDeadColumn, isNoisyColumn);
-                auto gainB = payload_B->getGain(
-                    col, row, rangeAndCol_B.first, rangeAndCol_B.second, isDeadColumn, isNoisyColumn);
-                ratio = gainA / gainB;
+                auto gainA = payload_A->getGain(col, row, rAndCol_A.first, rAndCol_A.second, isDeadCol, isNoisyCol);
+                auto gainB = payload_B->getGain(col, row, rAndCol_B.first, rAndCol_B.second, isDeadCol, isNoisyCol);
+                ratio = gainB != 0 ? (gainA / gainB) : -1.;  // if the ratio does not make sense the default is -1
                 diff = gainA - gainB;
                 break;
               }
               case gainCalibPI::t_pedestal: {
-                auto pedA =
-                    payload_A->getPed(col, row, rangeAndCol_A.first, rangeAndCol_A.second, isDeadColumn, isNoisyColumn);
-                auto pedB =
-                    payload_B->getPed(col, row, rangeAndCol_B.first, rangeAndCol_B.second, isDeadColumn, isNoisyColumn);
-                ratio = pedA / pedB;
+                auto pedA = payload_A->getPed(col, row, rAndCol_A.first, rAndCol_A.second, isDeadCol, isNoisyCol);
+                auto pedB = payload_B->getPed(col, row, rAndCol_B.first, rAndCol_B.second, isDeadCol, isNoisyCol);
+                ratio = pedB != 0 ? (pedA / pedB) : -1.;  // if the ratio does not make sense the default is -1
                 diff = pedA - pedB;
                 break;
               }
@@ -97,11 +95,31 @@ namespace gainCalibHelper {
                 edm::LogError("gainCalibPI::fillTheHisto") << "Unrecognized type " << theType << std::endl;
                 break;
             }
-            arr[0]->Fill(ratio);
-            arr[1]->Fill(diff);
+            // fill the containers
+            v_diffs.push_back(diff);
+            v_ratios.push_back(ratio);
           }  // loop on rows
         }    // loop on cols
       }      // loop on detids
+
+      std::sort(v_diffs.begin(), v_diffs.end());
+      std::sort(v_ratios.begin(), v_ratios.end());
+
+      double minDiff = v_diffs.front();
+      double maxDiff = v_diffs.back();
+      double minRatio = v_ratios.front();
+      double maxRatio = v_ratios.back();
+
+      arr[0] = std::make_shared<TH1F>("h_Ratio", "", 50, minRatio - 1., maxRatio + 1.);
+      arr[1] = std::make_shared<TH1F>("h_Diff", "", 50, minDiff - 1., maxDiff + 1.);
+
+      for (const auto& r : v_ratios) {
+        arr[0]->Fill(r);
+      }
+      for (const auto& d : v_diffs) {
+        arr[1]->Fill(d);
+      }
+      return arr;
     }
 
     //============================================================================
@@ -1106,16 +1124,16 @@ namespace gainCalibHelper {
       legend.Draw("same");
 
       TPaveStats* st1 = (TPaveStats*)hfirst->FindObject("stats");
-      st1->SetTextSize(0.022);
+      st1->SetTextSize(0.021);
       st1->SetLineColor(kRed);
       st1->SetTextColor(kRed);
-      SiPixelPI::adjustStats(st1, 0.13, 0.84, 0.31, 0.94);
+      SiPixelPI::adjustStats(st1, 0.13, 0.86, 0.31, 0.94);
 
       TPaveStats* st2 = (TPaveStats*)hlast->FindObject("stats");
-      st2->SetTextSize(0.022);
+      st2->SetTextSize(0.021);
       st2->SetLineColor(kBlue);
       st2->SetTextColor(kBlue);
-      SiPixelPI::adjustStats(st2, 0.13, 0.73, 0.31, 0.83);
+      SiPixelPI::adjustStats(st2, 0.13, 0.77, 0.31, 0.85);
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
@@ -1208,92 +1226,49 @@ namespace gainCalibHelper {
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
 
-      float diffHigh(-9999.);
-      float diffLow(-9999.);
-      float maxRatio(-9999.);
-      float minRatio(-9999.);
-
-      float f_gHi = first_payload->getGainHigh();
-      float f_gLo = first_payload->getGainLow();
-      float f_pHi = first_payload->getPedHigh();
-      float f_pLo = first_payload->getPedLow();
-
-      float l_gHi = last_payload->getGainHigh();
-      float l_gLo = last_payload->getGainLow();
-      float l_pHi = last_payload->getPedHigh();
-      float l_pLo = last_payload->getPedLow();
-
-      switch (myType) {
-        case gainCalibPI::t_gain:
-          diffHigh = f_gHi - l_gHi;
-          diffLow = f_gLo - l_gLo;
-          maxRatio = l_gHi != 0 ? f_gHi / l_gHi : 0.;
-          minRatio = l_gLo != 0 ? f_gLo / l_gLo : 0.;
-          break;
-        case gainCalibPI::t_pedestal:
-          diffHigh = f_pHi - l_pHi;
-          diffLow = f_pLo - l_pLo;
-          maxRatio = l_pHi != 0 ? f_pHi / l_pHi : 0.;
-          minRatio = l_pLo != 0 ? f_pLo / l_pLo : 0.;
-          break;
-        default:
-          edm::LogError(label_) << "Unrecognized type " << myType << std::endl;
-          break;
-      }
-
-      auto span = std::abs(maxRatio - minRatio);
-
       TCanvas canvas("Canv", "Canv", 1300, 800);
       canvas.Divide(2, 1);
       canvas.cd();
-      auto hratio = std::make_shared<TH1F>("h_Ratio",
-                                           Form("SiPixel Gain Calibration %s - %s;per %s %s ratio;# %ss",
-                                                (isForHLT_ ? "ForHLT" : "Offline"),
-                                                TypeName[myType],
-                                                (isForHLT_ ? "Column" : "Pixel"),
-                                                TypeName[myType],
-                                                (isForHLT_ ? "column" : "pixel")),
-                                           50,
-                                           minRatio - span / 4.,
-                                           maxRatio + span / 4.);
-
-      auto hdiff = std::make_shared<TH1F>("h_Diff",
-                                          Form("SiPixel Gain Calibration %s - %s;per %s %s difference;# %ss",
-                                               (isForHLT_ ? "ForHLT" : "Offline"),
-                                               TypeName[myType],
-                                               (isForHLT_ ? "Column" : "Pixel"),
-                                               TypeName[myType],
-                                               (isForHLT_ ? "column" : "pixel")),
-                                          50,
-                                          (diffHigh < diffLow) ? diffHigh : diffLow,
-                                          (diffHigh < diffLow) ? diffLow : diffHigh);
 
       SiPixelPI::adjustCanvasMargins(canvas.cd(1), 0.05, 0.12, 0.12, 0.04);
       SiPixelPI::adjustCanvasMargins(canvas.cd(2), 0.05, 0.12, 0.12, 0.04);
       canvas.Modified();
 
-      std::array<std::shared_ptr<TH1F>, 2> array = {{hratio, hdiff}};
-      gainCalibPI::fillDiffAndRatio(first_payload, last_payload, array, myType);
+      auto array = gainCalibPI::fillDiffAndRatio(first_payload, last_payload, myType);
+
+      array[0]->SetTitle(Form("SiPixel Gain Calibration %s - %s;per %s %s ratio;# %ss",
+                              (isForHLT_ ? "ForHLT" : "Offline"),
+                              TypeName[myType],
+                              (isForHLT_ ? "Column" : "Pixel"),
+                              TypeName[myType],
+                              (isForHLT_ ? "column" : "pixel")));
+
+      array[1]->SetTitle(Form("SiPixel Gain Calibration %s - %s;per %s %s difference;# %ss",
+                              (isForHLT_ ? "ForHLT" : "Offline"),
+                              TypeName[myType],
+                              (isForHLT_ ? "Column" : "Pixel"),
+                              TypeName[myType],
+                              (isForHLT_ ? "column" : "pixel")));
 
       canvas.cd(1)->SetLogy();
-      hratio->SetTitle("");
-      hratio->SetLineColor(kBlack);
-      hratio->SetFillColor(kRed);
-      hratio->SetBarWidth(0.90);
-      hratio->SetMaximum(hratio->GetMaximum() * 10);
-      hratio->Draw("bar");
-      SiPixelPI::makeNicePlotStyle(hratio.get());
-      hratio->SetStats(true);
+      array[0]->SetTitle("");
+      array[0]->SetLineColor(kBlack);
+      array[0]->SetFillColor(kRed);
+      array[0]->SetBarWidth(0.90);
+      array[0]->SetMaximum(array[0]->GetMaximum() * 10);
+      array[0]->Draw("bar");
+      SiPixelPI::makeNicePlotStyle(array[0].get());
+      array[0]->SetStats(true);
 
       canvas.cd(2)->SetLogy();
-      hdiff->SetTitle("");
-      hdiff->SetLineColor(kBlack);
-      hdiff->SetFillColor(kBlue);
-      hdiff->SetBarWidth(0.90);
-      hdiff->SetMaximum(hdiff->GetMaximum() * 10);
-      hdiff->Draw("bar");
-      SiPixelPI::makeNicePlotStyle(hdiff.get());
-      hdiff->SetStats(true);
+      array[1]->SetTitle("");
+      array[1]->SetLineColor(kBlack);
+      array[1]->SetFillColor(kBlue);
+      array[1]->SetBarWidth(0.90);
+      array[1]->SetMaximum(array[1]->GetMaximum() * 10);
+      array[1]->Draw("bar");
+      SiPixelPI::makeNicePlotStyle(array[1].get());
+      array[1]->SetStats(true);
 
       canvas.Update();
 
@@ -1304,7 +1279,7 @@ namespace gainCalibHelper {
       latex.DrawLatexNDC(
           .41,
           .94,
-          fmt::sprintf("#scale[1.2]{SiPixel %s Gain Calibration Ratio}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
+          fmt::sprintf("#scale[1.2]{SiPixelGainCalibration%s Ratio}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
       if (this->m_plotAnnotations.ntags == 2) {
         latex.DrawLatexNDC(
             .41, .91, ("#splitline{#font[12]{" + tagname1 + "}}{ / #font[12]{" + tagname2 + "}}").c_str());
@@ -1319,7 +1294,7 @@ namespace gainCalibHelper {
       latex2.DrawLatexNDC(
           .41,
           .94,
-          fmt::sprintf("#scale[1.2]{SiPixel %s Gain Calibration Diff}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
+          fmt::sprintf("#scale[1.2]{SiPixelGainCalibration%s Diff}", (isForHLT_ ? "ForHLT" : "Offline")).c_str());
       if (this->m_plotAnnotations.ntags == 2) {
         latex2.DrawLatexNDC(
             .41, .91, ("#splitline{#font[12]{" + tagname1 + "}}{ - #font[12]{" + tagname2 + "}}").c_str());
@@ -1327,13 +1302,13 @@ namespace gainCalibHelper {
         latex2.DrawLatexNDC(.41, .91, (firstIOVsince + " - " + lastIOVsince).c_str());
       }
 
-      TPaveStats* st1 = (TPaveStats*)hratio->FindObject("stats");
+      TPaveStats* st1 = (TPaveStats*)array[0]->FindObject("stats");
       st1->SetTextSize(0.027);
       st1->SetLineColor(kRed);
       st1->SetTextColor(kRed);
       SiPixelPI::adjustStats(st1, 0.13, 0.84, 0.40, 0.94);
 
-      TPaveStats* st2 = (TPaveStats*)hdiff->FindObject("stats");
+      TPaveStats* st2 = (TPaveStats*)array[1]->FindObject("stats");
       st2->SetTextSize(0.027);
       st2->SetLineColor(kBlue);
       st2->SetTextColor(kBlue);
@@ -1345,18 +1320,16 @@ namespace gainCalibHelper {
       ltx.SetTextSize(0.040);
       ltx.SetTextAlign(11);
       canvas.cd(1);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-                       1 - gPad->GetTopMargin() + 0.01,
-                       ("SiPixel Gain Calib. Ratio IOV " + std::to_string(std::get<0>(firstiov)) + " / IOV " +
-                        std::to_string(std::get<0>(lastiov)))
-                           .c_str());
+      ltx.DrawLatexNDC(
+          gPad->GetLeftMargin(),
+          1 - gPad->GetTopMargin() + 0.01,
+          fmt::sprintf("SiPixel %s Ratio, IOV %s / %s", TypeName[myType], firstIOVsince, lastIOVsince).c_str());
 
       canvas.cd(2);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-                       1 - gPad->GetTopMargin() + 0.01,
-                       ("SiPixel Gain Calib. Diff IOV " + std::to_string(std::get<0>(firstiov)) + " - IOV " +
-                        std::to_string(std::get<0>(lastiov)))
-                           .c_str());
+      ltx.DrawLatexNDC(
+          gPad->GetLeftMargin(),
+          1 - gPad->GetTopMargin() + 0.01,
+          fmt::sprintf("SiPixel %s Diff, IOV %s - %s", TypeName[myType], firstIOVsince, lastIOVsince).c_str());
 
       std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -111,26 +111,26 @@ namespace {
       SiPixelGainCalibrationFPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationForHLT,
-                                                                    cond::payloadInspector::MULTI_IOV,
-                                                                    1>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_gain,
+                                                   SiPixelGainCalibrationForHLT,
+                                                   cond::payloadInspector::MULTI_IOV,
+                                                   1>;
   using SiPixelGainCalibForHLTPedestalByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationForHLT,
-                                                                    cond::payloadInspector::MULTI_IOV,
-                                                                    1>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_pedestal,
+                                                   SiPixelGainCalibrationForHLT,
+                                                   cond::payloadInspector::MULTI_IOV,
+                                                   1>;
 
   using SiPixelGainCalibForHLTGainByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationForHLT,
-                                                                    cond::payloadInspector::SINGLE_IOV,
-                                                                    2>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_gain,
+                                                   SiPixelGainCalibrationForHLT,
+                                                   cond::payloadInspector::SINGLE_IOV,
+                                                   2>;
   using SiPixelGainCalibForHLTPedestalByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationForHLT,
-                                                                    cond::payloadInspector::SINGLE_IOV,
-                                                                    2>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_pedestal,
+                                                   SiPixelGainCalibrationForHLT,
+                                                   cond::payloadInspector::SINGLE_IOV,
+                                                   2>;
 
   using SiPixelGainCalibForHLTGainDiffRatioTwoTags =
       SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_gain,

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -10,117 +10,105 @@
 
 namespace {
 
-  using SiPixelGainCalibrationForHLTGainsValues =
-      gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
-  using SiPixelGainCalibrationForHLTPedestalsValues =
-      gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                    SiPixelGainCalibrationForHLT>;
+  using namespace gainCalibHelper;
 
-  using SiPixelGainCalibrationForHLTGainsValuesBarrel = gainCalibHelper::
-      SiPixelGainCalibrationValuesPerRegion<true, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
-  using SiPixelGainCalibrationForHLTGainsValuesEndcap = gainCalibHelper::
-      SiPixelGainCalibrationValuesPerRegion<false, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTGainsValues =
+      SiPixelGainCalibrationValues<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTPedestalsValues =
+      SiPixelGainCalibrationValues<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
+
+  using SiPixelGainCalibrationForHLTGainsValuesBarrel =
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTGainsValuesEndcap =
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibrationForHLTPedestalsValuesBarrel =
-      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<true,
-                                                             gainCalibHelper::gainCalibPI::t_pedestal,
-                                                             SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibrationForHLTPedestalsValuesEndcap =
-      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<false,
-                                                             gainCalibHelper::gainCalibPI::t_pedestal,
-                                                             SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
-  using SiPixelGainCalibrationForHLTCorrelations =
-      gainCalibHelper::SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibrationForHLTCorrelations = SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibrationForHLTGainsByPart =
-      gainCalibHelper::SiPixelGainCalibrationValuesByPart<gainCalibHelper::gainCalibPI::t_gain,
-                                                          SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesByPart<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibrationForHLTPedestalsByPart =
-      gainCalibHelper::SiPixelGainCalibrationValuesByPart<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                          SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesByPart<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonSingleTag<gainCalibHelper::gainCalibPI::t_gain,
-                                                                      SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValueComparisonSingleTag<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibForHLTPedestalComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonSingleTag<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                      SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValueComparisonSingleTag<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValueComparisonTwoTags<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibForHLTPedestalComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValueComparisonTwoTags<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonBarrelSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonBarrelTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonBarrelTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainComparisonEndcapTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTPedestalComparisonEndcapTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainsBPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationBPIXMap<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibForHLTPedestalsBPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                     SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationBPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainsFPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationFPIXMap<gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationFPIXMap<gainCalibPI::t_gain, SiPixelGainCalibrationForHLT>;
   using SiPixelGainCalibForHLTPedestalsFPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationFPIXMap<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                     SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibrationFPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationForHLT>;
 
   using SiPixelGainCalibForHLTGainByRegionComparisonSingleTag =
       gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
@@ -145,11 +133,16 @@ namespace {
                                                                     2>;
 
   using SiPixelGainCalibForHLTGainDiffRatioTwoTags =
-      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                           SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_gain,
+                                       cond::payloadInspector::SINGLE_IOV,
+                                       2,
+                                       SiPixelGainCalibrationForHLT>;
+
   using SiPixelGainCalibForHLTPedestalDiffRatioTwoTags =
-      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                           SiPixelGainCalibrationForHLT>;
+      SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_pedestal,
+                                       cond::payloadInspector::SINGLE_IOV,
+                                       2,
+                                       SiPixelGainCalibrationForHLT>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationForHLT_PayloadInspector.cc
@@ -144,6 +144,13 @@ namespace {
                                                                     cond::payloadInspector::SINGLE_IOV,
                                                                     2>;
 
+  using SiPixelGainCalibForHLTGainDiffRatioTwoTags =
+      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_gain,
+                                                           SiPixelGainCalibrationForHLT>;
+  using SiPixelGainCalibForHLTPedestalDiffRatioTwoTags =
+      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                           SiPixelGainCalibrationForHLT>;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationForHLT) {
@@ -176,4 +183,6 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationForHLT) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalByRegionComparisonSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainByRegionComparisonTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalByRegionComparisonTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTGainDiffRatioTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibForHLTPedestalDiffRatioTwoTags);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -145,6 +145,14 @@ namespace {
                                                                     SiPixelGainCalibrationOffline,
                                                                     cond::payloadInspector::SINGLE_IOV,
                                                                     2>;
+
+  using SiPixelGainCalibOfflineGainDiffRatioTwoTags =
+      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_gain,
+                                                           SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibOfflinePedestalDiffRatioTwoTags =
+      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
+                                                           SiPixelGainCalibrationOffline>;
+
 }  // namespace
 
 PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {
@@ -177,4 +185,6 @@ PAYLOAD_INSPECTOR_MODULE(SiPixelGainCalibrationOffline) {
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalByRegionComparisonSingleTag);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainByRegionComparisonTwoTags);
   PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalByRegionComparisonTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflineGainDiffRatioTwoTags);
+  PAYLOAD_INSPECTOR_CLASS(SiPixelGainCalibOfflinePedestalDiffRatioTwoTags);
 }

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -113,26 +113,26 @@ namespace {
       SiPixelGainCalibrationFPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationOffline,
-                                                                    cond::payloadInspector::MULTI_IOV,
-                                                                    1>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_gain,
+                                                   SiPixelGainCalibrationOffline,
+                                                   cond::payloadInspector::MULTI_IOV,
+                                                   1>;
   using SiPixelGainCalibOfflinePedestalByRegionComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationOffline,
-                                                                    cond::payloadInspector::MULTI_IOV,
-                                                                    1>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_pedestal,
+                                                   SiPixelGainCalibrationOffline,
+                                                   cond::payloadInspector::MULTI_IOV,
+                                                   1>;
 
   using SiPixelGainCalibOfflineGainByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationOffline,
-                                                                    cond::payloadInspector::SINGLE_IOV,
-                                                                    2>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_gain,
+                                                   SiPixelGainCalibrationOffline,
+                                                   cond::payloadInspector::SINGLE_IOV,
+                                                   2>;
   using SiPixelGainCalibOfflinePedestalByRegionComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationOffline,
-                                                                    cond::payloadInspector::SINGLE_IOV,
-                                                                    2>;
+      SiPixelGainCalibrationByRegionComparisonBase<gainCalibPI::t_pedestal,
+                                                   SiPixelGainCalibrationOffline,
+                                                   cond::payloadInspector::SINGLE_IOV,
+                                                   2>;
 
   using SiPixelGainCalibOfflineGainDiffRatioTwoTags =
       SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_gain,

--- a/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
+++ b/CondCore/SiPixelPlugins/plugins/SiPixelGainCalibrationOffline_PayloadInspector.cc
@@ -10,119 +10,107 @@
 
 namespace {
 
-  using SiPixelGainCalibrationOfflineGainsValues =
-      gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
-  using SiPixelGainCalibrationOfflinePedestalsValues =
-      gainCalibHelper::SiPixelGainCalibrationValues<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                    SiPixelGainCalibrationOffline>;
+  using namespace gainCalibHelper;
 
-  using SiPixelGainCalibrationOfflineGainsValuesBarrel = gainCalibHelper::
-      SiPixelGainCalibrationValuesPerRegion<true, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
-  using SiPixelGainCalibrationOfflineGainsValuesEndcap = gainCalibHelper::
-      SiPixelGainCalibrationValuesPerRegion<false, gainCalibHelper::gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflineGainsValues =
+      SiPixelGainCalibrationValues<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflinePedestalsValues =
+      SiPixelGainCalibrationValues<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
+
+  using SiPixelGainCalibrationOfflineGainsValuesBarrel =
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflineGainsValuesEndcap =
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibrationOfflinePedestalsValuesBarrel =
-      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<true,
-                                                             gainCalibHelper::gainCalibPI::t_pedestal,
-                                                             SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesPerRegion<true, gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
   using SiPixelGainCalibrationOfflinePedestalsValuesEndcap =
-      gainCalibHelper::SiPixelGainCalibrationValuesPerRegion<false,
-                                                             gainCalibHelper::gainCalibPI::t_pedestal,
-                                                             SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesPerRegion<false, gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
-  using SiPixelGainCalibrationOfflineCorrelations =
-      gainCalibHelper::SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationOffline>;
+  using SiPixelGainCalibrationOfflineCorrelations = SiPixelGainCalibrationCorrelations<SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibrationOfflineGainsByPart =
-      gainCalibHelper::SiPixelGainCalibrationValuesByPart<gainCalibHelper::gainCalibPI::t_gain,
-                                                          SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesByPart<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
   using SiPixelGainCalibrationOfflinePedestalsByPart =
-      gainCalibHelper::SiPixelGainCalibrationValuesByPart<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                          SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesByPart<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonSingleTag<gainCalibHelper::gainCalibPI::t_gain,
-                                                                      SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValueComparisonSingleTag<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
   using SiPixelGainCalibOfflinePedestalComparisonSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonSingleTag<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                      SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValueComparisonSingleTag<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                                    SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValueComparisonTwoTags<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
   using SiPixelGainCalibOfflinePedestalComparisonTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValueComparisonTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                    SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValueComparisonTwoTags<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonBarrelSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonBarrelTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonBarrelTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<true,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<true,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapSingleTag =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::MULTI_IOV,
-                                                                       1,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::MULTI_IOV,
+                                                      1,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainComparisonEndcapTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_gain,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_gain,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflinePedestalComparisonEndcapTwoTags =
-      gainCalibHelper::SiPixelGainCalibrationValuesComparisonPerRegion<false,
-                                                                       gainCalibHelper::gainCalibPI::t_pedestal,
-                                                                       cond::payloadInspector::SINGLE_IOV,
-                                                                       2,
-                                                                       SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationValuesComparisonPerRegion<false,
+                                                      gainCalibPI::t_pedestal,
+                                                      cond::payloadInspector::SINGLE_IOV,
+                                                      2,
+                                                      SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainsBPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_gain,
-                                                     SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationBPIXMap<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+
   using SiPixelGainCalibOfflinePedestalsBPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationBPIXMap<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                     SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationBPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainsFPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationFPIXMap<gainCalibHelper::gainCalibPI::t_gain,
-                                                     SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationFPIXMap<gainCalibPI::t_gain, SiPixelGainCalibrationOffline>;
+
   using SiPixelGainCalibOfflinePedestalsFPIXMap =
-      gainCalibHelper::SiPixelGainCalibrationFPIXMap<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                     SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibrationFPIXMap<gainCalibPI::t_pedestal, SiPixelGainCalibrationOffline>;
 
   using SiPixelGainCalibOfflineGainByRegionComparisonSingleTag =
       gainCalibHelper::SiPixelGainCalibrationByRegionComparisonBase<gainCalibHelper::gainCalibPI::t_gain,
@@ -147,11 +135,16 @@ namespace {
                                                                     2>;
 
   using SiPixelGainCalibOfflineGainDiffRatioTwoTags =
-      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_gain,
-                                                           SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_gain,
+                                       cond::payloadInspector::SINGLE_IOV,
+                                       2,
+                                       SiPixelGainCalibrationOffline>;
+
   using SiPixelGainCalibOfflinePedestalDiffRatioTwoTags =
-      gainCalibHelper::SiPixelGainCalibDiffAndRatioTwoTags<gainCalibHelper::gainCalibPI::t_pedestal,
-                                                           SiPixelGainCalibrationOffline>;
+      SiPixelGainCalibDiffAndRatioBase<gainCalibPI::t_pedestal,
+                                       cond::payloadInspector::SINGLE_IOV,
+                                       2,
+                                       SiPixelGainCalibrationOffline>;
 
 }  // namespace
 

--- a/CondCore/SiPixelPlugins/test/SiPixelGainCalibrationComparator_DB.sh
+++ b/CondCore/SiPixelPlugins/test/SiPixelGainCalibrationComparator_DB.sh
@@ -1,0 +1,83 @@
+#!/bin/bash                                                                                                                                                                                                 
+# Save current working dir so img can be outputted there later                                                                                                                                              
+W_DIR=$(pwd);
+# Set SCRAM architecture var                                                                                                                                                                                
+SCRAM_ARCH=slc6_amd64_gcc630;
+export SCRAM_ARCH;
+source /afs/cern.ch/cms/cmsset_default.sh;
+eval `scram run -sh`;
+# Go back to original working directory                                                                                                                                                                     
+cd $W_DIR;
+# Run get payload data script                                                                                                                                                                               
+
+rm *.png
+mkdir $W_DIR/results_HLT
+mkdir $W_DIR/results_Offline
+                                                                              
+declare -a arr=("2" "112110" "112245" "117680" "129282" "188059" "189210" "199755" "205566" "233749" "237545" "256491" "268129" "278869" "290543" "294582" "295077" "298756" "303659" "312203" "313800" "320377" "322634" "323893" "326851")
+
+for i in "${arr[@]}"
+do
+    echo -e "\n dealing with IOV: "$i"\n"
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+	--plot plot_SiPixelGainCalibForHLTGainDiffRatioTwoTags \
+	--tag SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_HLT/GainsDiffRatio_${i}.png
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+	--plot plot_SiPixelGainCalibForHLTPedestalDiffRatioTwoTags \
+	--tag SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_HLT/PedestalsDiffRatio_${i}.png
+
+done
+
+declare -a arr2=("1" "112110" "112245" "117680" "129282" "188059" "189210" "199755" "205566" "233749" "237545" "256491" "268129" "278869" "290550" "294582" "295077" "298647" "303659" "312203" "313800" "320377" "322634" "323893" "326851")
+
+for i in "${arr2[@]}"
+do
+    echo -e "\n dealing with IOV: "$i"\n"
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
+	--plot plot_SiPixelGainCalibOfflineGainDiffRatioTwoTags \
+	--tag SiPixelGainCalibration_2009runs_hlt  \
+	--tagtwo SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_Offline/GainsDiffRatio_${i}.png
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
+	--plot plot_SiPixelGainCalibOfflinePedestalDiffRatioTwoTags \
+	--tag SiPixelGainCalibration_2009runs_hlt \
+	--tagtwo SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_Offline/PedestalsDiffRatio_${i}.png
+
+done

--- a/CondCore/SiPixelPlugins/test/SiPixelGainCalibrationComparator_DB.sh
+++ b/CondCore/SiPixelPlugins/test/SiPixelGainCalibrationComparator_DB.sh
@@ -9,22 +9,32 @@ eval `scram run -sh`;
 # Go back to original working directory                                                                                                                                                                     
 cd $W_DIR;
 # Run get payload data script                                                                                                                                                                               
+if [ -f *.png ]; then
+    rm *.png
+fi
 
-rm *.png
+if [ -d $W_DIR/results_HLT ]; then
+    rm -fr $W_DIR/results_HLT
+fi
 mkdir $W_DIR/results_HLT
+
+if [ -d $W_DIR/results_Offline ]; then
+    rm -fr $W_DIR/results_Offline
+fi
+
 mkdir $W_DIR/results_Offline
                                                                               
-declare -a arr=("2" "112110" "112245" "117680" "129282" "188059" "189210" "199755" "205566" "233749" "237545" "256491" "268129" "278869" "290543" "294582" "295077" "298756" "303659" "312203" "313800" "320377" "322634" "323893" "326851")
+declare -a arr=("1" "112110" "112245" "117680" "129282" "188059" "189210" "199755" "205566" "233749" "237545" "256491" "268129" "278869" "290543" "294582" "295077" "298756" "303659" "312203" "313800" "320377" "322634" "323893" "326851")
 
 for i in "${arr[@]}"
 do
-    echo -e "\n dealing with IOV: "$i"\n"
+    echo -e "\n\n dealing with IOV: "$i"\n"
 
     getPayloadData.py \
 	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
 	--plot plot_SiPixelGainCalibForHLTGainDiffRatioTwoTags \
-	--tag SiPixelGainCalibrationHLT_2009runs_hlt \
-	--tagtwo SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tag SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
 	--time_type Run \
 	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
 	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
@@ -36,8 +46,8 @@ do
     getPayloadData.py \
 	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
 	--plot plot_SiPixelGainCalibForHLTPedestalDiffRatioTwoTags \
-	--tag SiPixelGainCalibrationHLT_2009runs_hlt \
-	--tagtwo SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tag SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
 	--time_type Run \
 	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
 	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
@@ -46,19 +56,45 @@ do
     
     mv *.png  $W_DIR/results_HLT/PedestalsDiffRatio_${i}.png
 
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+	--plot plot_SiPixelGainCalibForHLTGainComparisonTwoTags \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tag SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_HLT/GainsComparison_${i}.png
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+	--plot plot_SiPixelGainCalibForHLTPedestalComparisonTwoTags \
+	--tagtwo SiPixelGainCalibrationHLT_2009runs_hlt \
+	--tag SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_HLT/PedestalsComparison_${i}.png
+
 done
 
 declare -a arr2=("1" "112110" "112245" "117680" "129282" "188059" "189210" "199755" "205566" "233749" "237545" "256491" "268129" "278869" "290550" "294582" "295077" "298647" "303659" "312203" "313800" "320377" "322634" "323893" "326851")
 
 for i in "${arr2[@]}"
 do
-    echo -e "\n dealing with IOV: "$i"\n"
+    echo -e "\n\n dealing with IOV: "$i"\n"
 
     getPayloadData.py \
 	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
 	--plot plot_SiPixelGainCalibOfflineGainDiffRatioTwoTags \
-	--tag SiPixelGainCalibration_2009runs_hlt  \
-	--tagtwo SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--tagtwo SiPixelGainCalibration_2009runs_hlt  \
+	--tag SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
 	--time_type Run \
 	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
 	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
@@ -70,8 +106,8 @@ do
     getPayloadData.py \
 	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
 	--plot plot_SiPixelGainCalibOfflinePedestalDiffRatioTwoTags \
-	--tag SiPixelGainCalibration_2009runs_hlt \
-	--tagtwo SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--tagtwo SiPixelGainCalibration_2009runs_hlt \
+	--tag SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
 	--time_type Run \
 	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
 	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
@@ -79,5 +115,32 @@ do
 	--test;
     
     mv *.png  $W_DIR/results_Offline/PedestalsDiffRatio_${i}.png
+
+    
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
+	--plot plot_SiPixelGainCalibOfflineGainComparisonTwoTags \
+	--tagtwo SiPixelGainCalibration_2009runs_hlt  \
+	--tag SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_Offline/GainsComparison_${i}.png
+
+    getPayloadData.py \
+	--plugin pluginSiPixelGainCalibrationOffline_PayloadInspector \
+	--plot plot_SiPixelGainCalibOfflinePedestalComparisonTwoTags \
+	--tagtwo SiPixelGainCalibration_2009runs_hlt \
+	--tag SiPixelGainCalibration_2009runs_ScaledForVCal_hlt \
+	--time_type Run \
+	--iovs '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--iovstwo '{"start_iov": "'$i'", "end_iov": "'$i'"}' \
+	--db Prod \
+	--test;
+    
+    mv *.png  $W_DIR/results_Offline/PedestalsComparison_${i}.png
 
 done

--- a/CondCore/SiPixelPlugins/test/testSiPixelGainCalibrationForHLT.sh
+++ b/CondCore/SiPixelPlugins/test/testSiPixelGainCalibrationForHLT.sh
@@ -225,3 +225,32 @@ getPayloadData.py \
     --test ;
 
 mv *.png  $W_DIR/plots_GainCalibForHLT/SingleTagGainsPedestalsCorrelations.png
+
+## diff and ratio
+
+getPayloadData.py \
+    --plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+    --plot plot_SiPixelGainCalibForHLTGainDiffRatioTwoTags \
+    --tagtwo SiPixelGainCalibrationHLT_2009runs_hlt \
+    --tag SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "310000", "end_iov": "310000"}' \
+    --iovstwo '{"start_iov": "310000", "end_iov": "310000"}'  \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_GainCalibForHLT/DiffAndRatio.png
+
+## diff and ratio reverse
+getPayloadData.py \
+    --plugin pluginSiPixelGainCalibrationForHLT_PayloadInspector \
+    --plot plot_SiPixelGainCalibForHLTGainDiffRatioTwoTags \
+    --tagtwo SiPixelGainCalibrationHLT_2009runs_ScaledForVCal_hlt \
+    --tag SiPixelGainCalibrationHLT_2009runs_hlt \
+    --time_type Run \
+    --iovs '{"start_iov": "310000", "end_iov": "310000"}' \
+    --iovstwo '{"start_iov": "310000", "end_iov": "310000"}' \
+    --db Prod \
+    --test ;
+
+mv *.png  $W_DIR/plots_GainCalibForHLT/DiffAndRatio_reverse.png


### PR DESCRIPTION
#### PR description:

This PR adds the support for plotting Pixel Gains Ratio and Differences between payloads.
This is useful to cross-check the output conditions for the workflow designed in https://github.com/cms-sw/cmssw/pull/30880.
Some clean-up of namespaces is also implemented here.

#### PR validation:

Relies on existing unit tests. 
An example of plot that can be produced with these changes is here:

![image](https://user-images.githubusercontent.com/5082376/92100077-9fa17200-eddb-11ea-94eb-3160583139d6.png)


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.
