### PR TITLE
to make static analyzer happy in RunningAverage

### DIFF
--- a/FWCore/Utilities/interface/RunningAverage.h
+++ b/FWCore/Utilities/interface/RunningAverage.h
@@ -29,7 +29,8 @@ namespace edm {
 
     int upper() const {
       auto lm = mean();
-      return lm += (std::abs(m_buffer[0] - lm) + std::abs(m_buffer[N / 2] - lm));
+      lm += (std::abs(m_buffer[0] - lm) + std::abs(m_buffer[N / 2] - lm));
+      return lm;
     }  // about 2 sigma
 
     void update(unsigned int q) {

--- a/FWCore/Utilities/interface/RunningAverage.h
+++ b/FWCore/Utilities/interface/RunningAverage.h
@@ -29,8 +29,7 @@ namespace edm {
 
     int upper() const {
       auto lm = mean();
-      lm += (std::abs(m_buffer[0] - lm) + std::abs(m_buffer[N / 2] - lm));
-      return lm;
+      return lm + (std::abs(m_buffer[0] - lm) + std::abs(m_buffer[N / 2] - lm));
     }  // about 2 sigma
 
     void update(unsigned int q) {


### PR DESCRIPTION
SA reported a dead assignment
<img width="653" alt="Screen Shot 2020-09-03 at 8 02 20 AM" src="https://user-images.githubusercontent.com/4676718/92132316-d798bd00-edbb-11ea-980e-dad4679cbee2.png">

this seems more like a false positive.
I think that this update should remove the issue at no cost in performance
