### PR TITLE
Update Run 3 data GTs to those used in 2020 MWGR3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -45,9 +45,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '111X_dataRun3_Express_v1',
+    'run3_data_express'        :   '111X_dataRun3_Express_v2',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v1',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '111X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR updates the Run 3 data GTs to those used in 2020 MWGR3. As there was only a single updated tag, which affects only a small range of IOVs near MWGR1, no changes are expected in any workflow. These changes are being made as a matter of principle, to keep `autoCond` up to date.

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Express_v1/111X_dataRun3_Express_v2

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v1/111X_dataRun3_Prompt_v2

#### PR validation:

`runTheMatrix.py -l 138.1,138.2 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 11_1_X.
