### PR TITLE
Removed include of CommandLineParser.h from HcalLutAnalyzer

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/HcalLutAnalyzer.cc
@@ -32,7 +32,6 @@
 
 #include "CalibCalorimetry/HcalTPGAlgos/interface/XMLProcessor.h"
 #include "CalibCalorimetry/HcalTPGAlgos/interface/LutXml.h"
-#include "PhysicsTools/FWLite/interface/CommandLineParser.h"
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"


### PR DESCRIPTION
#### PR description:

The class was not being used. Removing it avoids a dependency on PhysicsTools/FWLite.

#### PR validation:

The code compiles.