### PR TITLE
Update dummy emap to include layers 3-6 of GE0

### DIFF
--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -81,13 +81,16 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
   for (int re = -1; re <= 1; re = re + 2) {
     for (int st = GEMDetId::minStationId0; st <= GEMDetId::maxStationId; ++st) {
       int maxVFat = maxVFatGE11_;
+      int maxLayerId = GEMDetId::maxLayerId;
       if (st == 2)
         maxVFat = maxVFatGE21_;
-      if (st == 0)
+      if (st == 0) {
         maxVFat = maxVFatGE0_;
+        maxLayerId = GEMDetId::maxLayerId0;
+      }
 
       for (int ch = 1; ch <= GEMDetId::maxChamberId; ++ch) {
-        for (int ly = 1; ly <= GEMDetId::maxLayerId; ++ly) {
+        for (int ly = 1; ly <= maxLayerId; ++ly) {
           GEMDetId gemId(re, 1, st, ly, ch, 0);
 
           GEMROMapping::chamEC ec;

--- a/CondFormats/GEMObjects/src/GEMeMap.cc
+++ b/CondFormats/GEMObjects/src/GEMeMap.cc
@@ -82,9 +82,9 @@ void GEMeMap::convertDummy(GEMROMapping& romap) {
     for (int st = GEMDetId::minStationId0; st <= GEMDetId::maxStationId; ++st) {
       int maxVFat = maxVFatGE11_;
       int maxLayerId = GEMDetId::maxLayerId;
-      if (st == 2)
+      if (GEMSubDetId::station(st) == GEMSubDetId::Station::GE21)
         maxVFat = maxVFatGE21_;
-      if (st == 0) {
+      if (GEMSubDetId::station(st) == GEMSubDetId::Station::GE0) {
         maxVFat = maxVFatGE0_;
         maxLayerId = GEMDetId::maxLayerId0;
       }

--- a/DataFormats/MuonDetId/interface/GEMSubDetId.h
+++ b/DataFormats/MuonDetId/interface/GEMSubDetId.h
@@ -9,7 +9,7 @@
 
 class GEMSubDetId {
 public:
-  enum class Station { ME0 = 0, GE11 = 1, GE21 = 2 };
+  enum class Station { GE0 = 0, ME0 = 0, GE11 = 1, GE21 = 2 };
   static Station station(uint16_t st) {
     Station returnValue = Station::GE11;
     if (st == 0) {


### PR DESCRIPTION
#### PR description:

GE0 will be incorporated into GEM and so will use the GEM emap. Currently the dummy emap only considers 2 layers per subsystem, but GE0 will have 6 layers. GE0 digis can be packed/unpacked with this update, but it breaks existing RAW where the dummy emap was used since the mapping are different. I believe that we can break this now and there shouldn't be any existing datasets that would be affected, as we discussed last week @jshlee.

@hyunyong 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
