### PR TITLE
HCAL: slimmed collections with non-0 noise flags RecHits for miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -32,6 +32,7 @@ MicroEventContent = cms.PSet(
         'keep EcalRecHitsSorted_reducedEgamma_*_*',
         'keep recoGsfTracks_reducedEgamma_*_*',
         'keep HBHERecHitsSorted_reducedEgamma_*_*',
+        'keep *_slimmedHcalRecHits_*_*',
         'drop *_*_caloTowers_*',
         'drop *_*_pfCandidates_*',
         'drop *_*_genJets_*',

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -27,6 +27,7 @@ from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer
 from HeavyFlavorAnalysis.Onia2MuMu.OniaPhotonConversionProducer_cfi import PhotonCandidates as oniaPhotonCandidates
+from RecoLocalCalo.HcalRecProducers.HcalHitSelection_cfi import *
 
 slimmingTask = cms.Task(
     packedPFCandidatesTask,
@@ -55,6 +56,7 @@ slimmingTask = cms.Task(
     slimmedMETs,
     metFilterPathsTask,
     reducedEgamma,
+    slimmedHcalRecHits,
     bunchSpacingProducer,
     oniaPhotonCandidates
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -11,5 +11,12 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                          )
                                     )
 
+slimmedHcalRecHits = reducedHcalRecHits.clone(
+          hbheTag = cms.InputTag("reducedHcalRecHits","hbhereco"),
+          hfTag   = cms.InputTag("reducedHcalRecHits","hfreco"),
+          hoTag   = cms.InputTag(""),
+          interestingDetIds = cms.VInputTag()
+       )
+
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(reducedHcalRecHits.interestingDetIds, func = lambda list: list.remove(cms.InputTag("interestingOotEgammaIsoHCALDetId")) )

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
 reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                     hbheTag = cms.InputTag('hbhereco'),
                                     hfTag = cms.InputTag('hfreco'),

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -15,7 +15,7 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
 slimmedHcalRecHits = reducedHcalRecHits.clone(
           hbheTag = "reducedHcalRecHits:hbhereco",
           hfTag   = "reducedHcalRecHits:hfreco",
-          hoTag   = "",
+          hoTag   = "reducedHcalRecHits:horeco",
           interestingDetIds = ()
        )
 

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -13,10 +13,10 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                     )
 
 slimmedHcalRecHits = reducedHcalRecHits.clone(
-          hbheTag = cms.InputTag("reducedHcalRecHits","hbhereco"),
-          hfTag   = cms.InputTag("reducedHcalRecHits","hfreco"),
-          hoTag   = cms.InputTag(""),
-          interestingDetIds = cms.VInputTag()
+          hbheTag = "reducedHcalRecHits:hbhereco",
+          hfTag   = "reducedHcalRecHits:hfreco",
+          hoTag   = "",
+          interestingDetIds = ()
        )
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -192,7 +192,6 @@ void HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   if (!iEvent.getByToken(tok_ho_, ho))
     return;
-  iEvent.getByToken(tok_ho_, ho);
   auto ho_out = std::make_unique<HORecHitCollection>();
   skim(ho, *ho_out, hoSeverityLevel);
   iEvent.put(std::move(ho_out), hoTag.label());

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -169,7 +169,6 @@ void HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   iEvent.getByToken(tok_hbhe_, hbhe);
   iEvent.getByToken(tok_hf_, hf);
-  iEvent.getByToken(tok_ho_, ho);
 
   toBeKept.clear();
   edm::Handle<DetIdCollection> detId;
@@ -191,6 +190,9 @@ void HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   skim(hf, *hf_out);
   iEvent.put(std::move(hf_out), hfTag.label());
 
+  if (!iEvent.getByToken(tok_ho_, ho))
+    return;
+  iEvent.getByToken(tok_ho_, ho);
   auto ho_out = std::make_unique<HORecHitCollection>();
   skim(ho, *ho_out, hoSeverityLevel);
   iEvent.put(std::move(ho_out), hoTag.label());

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -169,6 +169,7 @@ void HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   iEvent.getByToken(tok_hbhe_, hbhe);
   iEvent.getByToken(tok_hf_, hf);
+  iEvent.getByToken(tok_ho_, ho);
 
   toBeKept.clear();
   edm::Handle<DetIdCollection> detId;
@@ -190,8 +191,6 @@ void HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   skim(hf, *hf_out);
   iEvent.put(std::move(hf_out), hfTag.label());
 
-  if (!iEvent.getByToken(tok_ho_, ho))
-    return;
   auto ho_out = std::make_unique<HORecHitCollection>();
   skim(ho, *ho_out, hoSeverityLevel);
   iEvent.put(std::move(ho_out), hoTag.label());


### PR DESCRIPTION
#### PR description:

Two tiny-size "simmedHcalRecHits" collections
(HBHERecHitsSorted_slimmedHcalRecHits and  HFRecHitsSorted_slimmedHcalRecHits) added to minAOD.

They contain solely RecHits with non-0 (noise) flags set.  This is "slimmed" version (without HcalRecHits "interesting" for Egamma) of "reducedHcalRecHits" collections included in AOD.  
Having them in minAOD would help to better asses the effect of HCAL noise in physics analyses.

Comes out from a discussion between HCAL DPG and JetMET.

#### PR validation:

(1)
For 136.88811_RunJetHT2018D...  (100 ev)  - 
reminiAOD   (step2) :  the size of files:  new  10121622,  std/reference  10116469   ->  factor  1.0005   
New collections contain (per 100 ev):  2 HBHERecHits and 13 HF RecHits respectively  

(2)
Estimates on bigger statistics 
2018D JetHT RelVal with ~3.37*10^5 ev

https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/1100pre6_110X_dataRun2_PromptLike_v3_RelVal_2018D-v1_vs_1100pre5_110X_dataRun2_PromptLike_Candidate_2019_08_02_16_53_14_RelVal_2018D-v1_RelVal/JetHT/RecHits/index.html

 HBRecHits  with non-0 flags   ~4x10^-2 / ev
 HERecHits  with non-0 flags   ~6x10^-3 / ev
 HFRecHits  with non-0 flags   ~0.15 / ev

So,  1 RecHit per ~6 JetHT 2018 events.

(3)
runTheMatrix.py -l limited      is OK   

#### if this PR is a backport 

No