### PR TITLE
Fix FKDTree unit test

### DIFF
--- a/CommonTools/RecoAlgos/test/FKDTree_t.cpp
+++ b/CommonTools/RecoAlgos/test/FKDTree_t.cpp
@@ -46,9 +46,11 @@ void TestFKDTree::test2D() {
     for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
       float y;
-      if (x <= maxX && x >= minX)
+      if (x <= maxX && x >= minX) {
         y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
-
+        if (y == maxY)
+          y = 1.f;  // avoid y = maxY
+      }
       points.emplace_back(x, y, id);
       id++;
     }
@@ -94,8 +96,11 @@ void TestFKDTree::test3D() {
     for (unsigned int i = 0; i < numberOfPointsOutsideTheBox; ++i) {
       float x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX));
       float y;
-      if (x <= maxX && x >= minX)
+      if (x <= maxX && x >= minX) {
         y = maxY + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(1.f - maxY));
+        if (y == maxY)
+          y = 1.f;  // avoid y = maxY
+      }
       float z = minZ + static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) / std::fabs(maxZ - minZ));
 
       points.emplace_back(x, y, z, id);


### PR DESCRIPTION
#### PR description:

Small fix in FKDTree unit test. After the fix, the points generated outside the box (numberOfPointsOutsideTheBox) cannot stay on the box faces anymore. 
Solve https://github.com/cms-sw/cmssw/issues/28841


#### PR validation:

Run 1000 times `../tmp/slc7_amd64_gcc820/src/CommonTools/RecoAlgos/test/FKDTree_t/FKDTree_t` with no error.
Previously, I got 2 errors in plain `CMSSW_11_2_X_2020-09-06-2300`.