### PR TITLE
Run4-gem53 Correct a sub-scenario for muon version M8

### DIFF
--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -1034,7 +1034,7 @@ muonDict = {
             'Geometry/MuonCommonData/data/rpcf/2026/v3/rpcf.xml',
             'Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml',
             'Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml',
-            'Geometry/MuonCommonData/data/gem21/TDR_Dev/gem21.xml',
+            'Geometry/MuonCommonData/data/gem21/TDR_Eta16/gem21.xml',
             'Geometry/MuonCommonData/data/mfshield/2026/v4/mfshield.xml',
             'Geometry/MuonCommonData/data/me0/TDR_Dev/v3/me0.xml',
         ],


### PR DESCRIPTION
#### PR description:

The geometry xml for 16 strip GE21 is included which matches the strip specification in the PR

#### PR validation:

The setup with this is tested separately in GEM specific PR #31367

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special