### PR TITLE
HCalTopology revision of HE-HF and HB-HE boundaries for |ieta|=16 and 29

### DIFF
--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -753,9 +753,9 @@ int HcalTopology::incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
   else if (aieta == firstHEQuadPhiRing() - 1 && ((id.iphi() + 1) % 4) != 0)
     neighbors[0] =
         HcalDetId(id.subdet(), (aieta + 1) * id.zside(), ((id.iphi() == 1) ? (71) : (id.iphi() - 2)), id.depth());
-  else if (aieta == lastHBRing() && id.subdet()==HcalBarrel)
+  else if (aieta == lastHBRing() && id.subdet() == HcalBarrel)
     neighbors[0] = HcalDetId(HcalEndcap, (aieta + 1) * id.zside(), id.iphi(), 1);
-  else if (aieta == lastHERing() && id.subdet()==HcalEndcap)
+  else if (aieta == lastHERing() && id.subdet() == HcalEndcap)
     neighbors[0] = HcalDetId(HcalForward, etaHE2HF_ * id.zside(), id.iphi(), 1);
   else
     neighbors[0] = HcalDetId(id.subdet(), (aieta + 1) * id.zside(), id.iphi(), id.depth());
@@ -790,9 +790,9 @@ int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
       neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi() + 2, id.depth());
   } else if (aieta == 1) {
     neighbors[0] = HcalDetId(id.subdet(), -aieta * id.zside(), id.iphi(), id.depth());
-  } else if (aieta == firstHERing() && id.subdet()==HcalEndcap) {
+  } else if (aieta == firstHERing() && id.subdet() == HcalEndcap) {
     neighbors[0] = HcalDetId(HcalBarrel, (aieta - 1) * id.zside(), id.iphi(), 1);
-  } else if (aieta == firstHFRing() && id.subdet()==HcalForward) {
+  } else if (aieta == firstHFRing() && id.subdet() == HcalForward) {
     neighbors[0] = HcalDetId(HcalEndcap, etaHF2HE_ * id.zside(), id.iphi(), 1);
   } else
     neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -753,7 +753,7 @@ int HcalTopology::incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
   else if (aieta == firstHEQuadPhiRing() - 1 && ((id.iphi() + 1) % 4) != 0)
     neighbors[0] =
         HcalDetId(id.subdet(), (aieta + 1) * id.zside(), ((id.iphi() == 1) ? (71) : (id.iphi() - 2)), id.depth());
-  else if (aieta == lastHBRing())
+  else if (aieta == lastHBRing() && id.subdet()==HcalBarrel)
     neighbors[0] = HcalDetId(HcalEndcap, (aieta + 1) * id.zside(), id.iphi(), 1);
   else if (aieta == lastHERing() && id.subdet()==HcalEndcap)
     neighbors[0] = HcalDetId(HcalForward, etaHE2HF_ * id.zside(), id.iphi(), 1);
@@ -765,7 +765,7 @@ int HcalTopology::incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
   return n;
 }
 
-/** Decreasing in |ieta|, there are be two neighbors of 40 and 21*/
+/** Decreasing in |ieta|, there are two neighbors of 40 and 21*/
 int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
   int n = 1;
   int aieta = id.ietaAbs();
@@ -790,7 +790,7 @@ int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
       neighbors[1] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi() + 2, id.depth());
   } else if (aieta == 1) {
     neighbors[0] = HcalDetId(id.subdet(), -aieta * id.zside(), id.iphi(), id.depth());
-  } else if (aieta == firstHERing()) {
+  } else if (aieta == firstHERing() && id.subdet()==HcalEndcap) {
     neighbors[0] = HcalDetId(HcalBarrel, (aieta - 1) * id.zside(), id.iphi(), 1);
   } else if (aieta == firstHFRing() && id.subdet()==HcalForward) {
     neighbors[0] = HcalDetId(HcalEndcap, etaHF2HE_ * id.zside(), id.iphi(), 1);

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -755,7 +755,7 @@ int HcalTopology::incAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
         HcalDetId(id.subdet(), (aieta + 1) * id.zside(), ((id.iphi() == 1) ? (71) : (id.iphi() - 2)), id.depth());
   else if (aieta == lastHBRing())
     neighbors[0] = HcalDetId(HcalEndcap, (aieta + 1) * id.zside(), id.iphi(), 1);
-  else if (aieta == lastHERing())
+  else if (aieta == lastHERing() && id.subdet()==HcalEndcap)
     neighbors[0] = HcalDetId(HcalForward, etaHE2HF_ * id.zside(), id.iphi(), 1);
   else
     neighbors[0] = HcalDetId(id.subdet(), (aieta + 1) * id.zside(), id.iphi(), id.depth());
@@ -792,7 +792,7 @@ int HcalTopology::decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const {
     neighbors[0] = HcalDetId(id.subdet(), -aieta * id.zside(), id.iphi(), id.depth());
   } else if (aieta == firstHERing()) {
     neighbors[0] = HcalDetId(HcalBarrel, (aieta - 1) * id.zside(), id.iphi(), 1);
-  } else if (aieta == firstHFRing()) {
+  } else if (aieta == firstHFRing() && id.subdet()==HcalForward) {
     neighbors[0] = HcalDetId(HcalEndcap, etaHF2HE_ * id.zside(), id.iphi(), 1);
   } else
     neighbors[0] = HcalDetId(id.subdet(), (aieta - 1) * id.zside(), id.iphi(), id.depth());


### PR DESCRIPTION
#### PR description:

Update HcalTopology for the ieta neighbor search of |ieta|=16 and 29, i.e. HB-HE boundary and HE-HF boundaries. These two |ieta| values correspind to both HB&HE towers and HE&HF towers. With this update, we specify different behaviors depending on if the tower belongs to HB or HE or to HE or HF [1].

The update will have implications on CaloTopoogy used in PF's navigator for HCAL.
https://cmssdt.cern.ch/lxr/source/RecoParticleFlow/PFClusterProducer/interface/PFHCALDenseIdNavigator.h
Before this update, some 2D layer-wise clusters consisted of rechits of different depths [2]. This will no longer happen with this update [3].

This unexpected behavior was attributed to the HcalTopology behavior as discussed above. In case one is interested in further details: for example, when we are looking for a lower ieta tower of HE ieta=29, we will want to simply decrease ieta by 1 while keeping depth. But, currently, regardless of HF or HE, ieta=29 invokes the special neighbor search which sets the neighbors’s depth to 1. Similarly, for example, when we are looking for the higher ieta for HF ieta=29, we will want to simply increase ieta by 1 while keeping depth. However, currently, regardless of HE or HF, ieta=29 invokes the special neighbor search which sets the neighbor’s depth to 1. These resulted in 2D layer-wise clusters with mixed depth before this PR.

We consulted with @bsunanda (primary author of HcalTopolgy) before this PR was made.

[1] for example, https://cms-docdb.cern.ch/cgi-bin/DocDB/RetrieveFile?docid=12962&filename=HCAL-Depth-Segmentation-Phase1-HE-HBOption1.pdf&version=6
[2] https://indico.cern.ch/event/949951/#12-studies-on-pf-clusters-in-h page-4, 18, 19
[3] https://indico.cern.ch/event/949951/contributions/3991032/attachments/2092837/3527202/plot_PFclusterSize_HFHAD.pdf

@bendavid @bsunanda @abdoulline @garvitaa @iashvili @jsalfeld

#### PR validation:

The validation is already discussed above. Also checked this update with matrix: 12634.99_TTbar_14TeV (2023PU) and 23434.99_TTbar (2026D49PU) to make sure it runs fine.

This PR creates widespread small changes related to the HE-HF and HB-HE boundaries to many reconstructed quantities.

The PF validation results can be found at:
http://hep.baylor.edu/hatake/PFval/HcalTopologyIeta16And29/
[Highlights]
http://hep.baylor.edu/hatake/PFval/HcalTopologyIeta16And29/OffsetStacks/stack_NuGun_test_vs_NuGun_ref.pdf
show changes consistent with the jenkin's test. Neutral hadrons have largest differences at |eta|=2.7-3.0, and it looks like they are a little more pulled toward loer |eta|. I think this is expected given no (unintended) energy sharing between depths at the 2D clustering stage, which is addressed in this PR.
http://hep.baylor.edu/hatake/PFval/HcalTopologyIeta16And29/FlatQCD_PU_2021_ParticleFlow/JetResponse/slimmedJetsPuppi/noJEC/reso_pt_rms.pdf
Jet energy resolution is either not negatively impacted or slightly improved at the high |eta| endcap.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not backport.
