### PR TITLE
Conditions Updater for HLT: Added OMS service as source of Run and Lumi info

### DIFF
--- a/CondCore/DBOutputService/interface/OnlineDBOutputService.h
+++ b/CondCore/DBOutputService/interface/OnlineDBOutputService.h
@@ -21,18 +21,16 @@
 
 namespace cond {
 
-  cond::Time_t getLatestLumiFromFile(const std::string& fileName) {
-    cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
-    std::ifstream lastLumiFile(fileName);
-    if (lastLumiFile) {
-      lastLumiFile >> lastLumiProcessed;
-    }
-    return lastLumiProcessed;
-  }
+  cond::Time_t getLatestLumiFromFile(const std::string& fileName);
+
+  cond::Time_t getLastLumiFromOMS(const std::string& omsServiceUrl);
 
   namespace service {
 
     class OnlineDBOutputService : public PoolDBOutputService {
+    public:
+      static constexpr const char* const MSGSOURCE = "OnlineDBOuputService";
+
     public:
       OnlineDBOutputService(const edm::ParameterSet& iConfig, edm::ActivityRegistry& iAR);
 
@@ -84,12 +82,11 @@ namespace cond {
       cond::persistency::Session getReadOnlyCache(cond::Time_t targetTime);
 
     private:
-      static constexpr const char* const MSGSOURCE = "OnlineDBOuputService";
       cond::Time_t m_runNumber;
       size_t m_latencyInLumisections;
+      std::string m_omsServiceUrl;
       std::string m_lastLumiUrl;
       std::string m_lastLumiFile;
-      //std::chrono::time_point<std::chrono::steady_clock> m_startRunTime;
       std::string m_preLoadConnectionString;
       bool m_debug;
 

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -75,6 +75,7 @@ namespace cond {
                                       << ", because is less or equal to last available since = " << lastSince;
               if (m_autoCommit)
                 doCommitTransaction();
+              scope.close();
               return thePayloadHash;
             }
           }

--- a/CondCore/DBOutputService/src/OnlineDBOutputService.cc
+++ b/CondCore/DBOutputService/src/OnlineDBOutputService.cc
@@ -3,34 +3,13 @@
 #include <curl/curl.h>
 //
 
-cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::ParameterSet& iConfig,
-                                                            edm::ActivityRegistry& iAR)
-    : PoolDBOutputService(iConfig, iAR),
-      m_runNumber(iConfig.getUntrackedParameter<unsigned long long>("runNumber", 0)),
-      m_latencyInLumisections(iConfig.getUntrackedParameter<unsigned int>("latency", 1)),
-      m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
-      m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
-      m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
-  if (!m_lastLumiUrl.empty()) {
-    startTransaction();
-    auto lastRun = PoolDBOutputService::session().getLastRun();
-    if (lastRun.isOnGoing()) {
-      m_runNumber = lastRun.run;
-    }
-  } else {
-    m_lastLumiFile = iConfig.getUntrackedParameter<std::string>("lastLumiFile", "");
-  }
-}
-
-cond::service::OnlineDBOutputService::~OnlineDBOutputService() {}
-
 static size_t getHtmlCallback(void* contents, size_t size, size_t nmemb, void* ptr) {
   // Cast ptr to std::string pointer and append contents to that string
   ((std::string*)ptr)->append((char*)contents, size * nmemb);
   return size * nmemb;
 }
 
-bool getLatestLumiFromDAQ(const std::string& urlString, std::string& info) {
+bool getInfoFromDAQ(const std::string& urlString, std::string& info) {
   CURL* curl;
   CURLcode res;
   std::string htmlBuffer;
@@ -63,30 +42,90 @@ bool getLatestLumiFromDAQ(const std::string& urlString, std::string& info) {
   return ret;
 }
 
+namespace cond {
+
+  cond::Time_t getLatestLumiFromFile(const std::string& fileName) {
+    cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
+    std::ifstream lastLumiFile(fileName);
+    if (lastLumiFile) {
+      lastLumiFile >> lastLumiProcessed;
+    }
+    return lastLumiProcessed;
+  }
+
+  cond::Time_t getLastLumiFromOMS(const std::string& omsServiceUrl) {
+    cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
+    unsigned int lastL = 0;
+    std::string info("");
+    if (!getInfoFromDAQ(omsServiceUrl, info))
+      throw Exception("Can't get data from OMS Service.");
+    std::istringstream sinfo(info);
+    std::string srun;
+    if (!std::getline(sinfo, srun, ',')) {
+      throw Exception("Can't get run runmber info from OMS Service.");
+    }
+    std::string slumi;
+    if (!std::getline(sinfo, slumi, ',')) {
+      throw Exception("Can't get lumi id from OMS Service.");
+    }
+    unsigned int run = boost::lexical_cast<unsigned int>(srun);
+    unsigned int lumi = boost::lexical_cast<unsigned int>(slumi);
+    lastLumiProcessed = cond::time::lumiTime(run, lumi);
+    edm::LogInfo(service::OnlineDBOutputService::MSGSOURCE)
+        << "Last lumi: " << lastLumiProcessed << " Current run: " << run << " lumi id:" << lumi;
+    return lastLumiProcessed;
+  }
+
+}  // namespace cond
+
+cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::ParameterSet& iConfig,
+                                                            edm::ActivityRegistry& iAR)
+    : PoolDBOutputService(iConfig, iAR),
+      m_runNumber(iConfig.getUntrackedParameter<unsigned long long>("runNumber", 0)),
+      m_latencyInLumisections(iConfig.getUntrackedParameter<unsigned int>("latency", 1)),
+      m_omsServiceUrl(iConfig.getUntrackedParameter<std::string>("omsServiceUrl", "")),
+      m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
+      m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
+      m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
+  if (m_omsServiceUrl.empty()) {
+    if (!m_lastLumiUrl.empty()) {
+      startTransaction();
+      auto lastRun = PoolDBOutputService::session().getLastRun();
+      if (lastRun.isOnGoing()) {
+        m_runNumber = lastRun.run;
+      }
+    } else {
+      m_lastLumiFile = iConfig.getUntrackedParameter<std::string>("lastLumiFile", "");
+    }
+  }
+}
+
+cond::service::OnlineDBOutputService::~OnlineDBOutputService() {}
+
 cond::Time_t cond::service::OnlineDBOutputService::getLastLumiProcessed() {
   cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
   unsigned int lastL = 0;
-  if (!m_lastLumiUrl.empty()) {
-    std::string info("");
-    if (!getLatestLumiFromDAQ(m_lastLumiUrl, info))
-      throw Exception("Can't get last Lumisection from DAQ.");
-    lastL = boost::lexical_cast<unsigned int>(info);
-    lastLumiProcessed = cond::time::lumiTime(m_runNumber, lastL);
-    edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
-                            << " lumi id:" << lastL;
+  std::string info("");
+  if (!m_omsServiceUrl.empty()) {
+    lastLumiProcessed = cond::getLastLumiFromOMS(m_omsServiceUrl);
   } else {
-    if (m_lastLumiFile.empty()) {
-      //auto t1 = std::chrono::steady_clock::now();
-      //auto deltat = std::chrono::duration_cast<std::chrono::seconds>( t1 - m_startRunTime ).count();
-      //lastL = (unsigned int)(deltat/23);
-      //lastLumiProcessed = cond::time::lumiTime( m_runNumber, lastL );
-      //edm::LogInfo( MSGSOURCE ) << "Last lumi: "<<lastLumiProcessed<<" Current run: "<<m_runNumber<<" lumi id:"<<lastL;
-      throw Exception("File name for last lumi has not been provided.");
+    if (!m_lastLumiUrl.empty()) {
+      std::string info("");
+      if (!getInfoFromDAQ(m_lastLumiUrl, info))
+        throw Exception("Can't get last Lumisection from DAQ.");
+      lastL = boost::lexical_cast<unsigned int>(info);
+      lastLumiProcessed = cond::time::lumiTime(m_runNumber, lastL);
+      edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
+                              << " lumi id:" << lastL;
     } else {
-      lastLumiProcessed = cond::getLatestLumiFromFile(m_lastLumiFile);
-      auto upkTime = cond::time::unpack(lastLumiProcessed);
-      edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << upkTime.first
-                              << " lumi id:" << upkTime.second;
+      if (m_lastLumiFile.empty()) {
+        throw Exception("File name for last lumi has not been provided.");
+      } else {
+        lastLumiProcessed = cond::getLatestLumiFromFile(m_lastLumiFile);
+        auto upkTime = cond::time::unpack(lastLumiProcessed);
+        edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << upkTime.first
+                                << " lumi id:" << upkTime.second;
+      }
     }
   }
   return lastLumiProcessed;

--- a/CondCore/DBOutputService/src/OnlineDBOutputService.cc
+++ b/CondCore/DBOutputService/src/OnlineDBOutputService.cc
@@ -55,7 +55,6 @@ namespace cond {
 
   cond::Time_t getLastLumiFromOMS(const std::string& omsServiceUrl) {
     cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
-    unsigned int lastL = 0;
     std::string info("");
     if (!getInfoFromDAQ(omsServiceUrl, info))
       throw Exception("Can't get data from OMS Service.");
@@ -104,7 +103,6 @@ cond::service::OnlineDBOutputService::~OnlineDBOutputService() {}
 
 cond::Time_t cond::service::OnlineDBOutputService::getLastLumiProcessed() {
   cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
-  unsigned int lastL = 0;
   std::string info("");
   if (!m_omsServiceUrl.empty()) {
     lastLumiProcessed = cond::getLastLumiFromOMS(m_omsServiceUrl);
@@ -113,7 +111,7 @@ cond::Time_t cond::service::OnlineDBOutputService::getLastLumiProcessed() {
       std::string info("");
       if (!getInfoFromDAQ(m_lastLumiUrl, info))
         throw Exception("Can't get last Lumisection from DAQ.");
-      lastL = boost::lexical_cast<unsigned int>(info);
+      unsigned int lastL = boost::lexical_cast<unsigned int>(info);
       lastLumiProcessed = cond::time::lumiTime(m_runNumber, lastL);
       edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
                               << " lumi id:" << lastL;

--- a/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
+++ b/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_COND_WEB'
+process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 #process.CondDB.DBParameters.messageLevel = cms.untracked.int32(3)
 

--- a/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_cfg.py
+++ b/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_cfg.py
@@ -8,15 +8,21 @@ process.source = cms.Source("EmptyIOVSource",
     interval = cms.uint64(11)
 )
 
+process.MessageLogger = cms.Service("MessageLogger",
+                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
+                                    destinations = cms.untracked.vstring('cout')
+                                    )
+
 process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('.')
     ),
     #timetype = cms.untracked.string('runnumber'),
+    autoCommit = cms.untracked.bool(True),
     connect = cms.string('sqlite_file:test_lumi.db'),
     preLoadConnectionString = cms.untracked.string('sqlite_file:test_lumi.db'),
-    runNumber = cms.untracked.uint64(120000),
+    omsServiceUrl = cms.untracked.string('http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('PedestalsRcd'),
         tag = cms.string('mytest'),
@@ -26,7 +32,8 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
 )
 
 process.mytest = cms.EDAnalyzer("LumiBasedUpdateAnalyzer",
-    record = cms.string('PedestalsRcd')
+    record = cms.string('PedestalsRcd'),
+    omsServiceUrl = cms.untracked.string('http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection')
 )
 
 process.p = cms.Path(process.mytest)

--- a/CondCore/DBOutputService/test/python/writeInt_cfg.py
+++ b/CondCore/DBOutputService/test/python/writeInt_cfg.py
@@ -24,7 +24,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           )
 
 process.mytest = cms.EDAnalyzer("writeInt",
-                                Number=cms.int32(_CurrentRun_)
+                                Number=cms.int32(100000)
                                 )
 
 process.p = cms.Path(process.mytest)

--- a/CondCore/DBOutputService/test/python/writeMultipleRecords_oracle_cfg.py
+++ b/CondCore/DBOutputService/test/python/writeMultipleRecords_oracle_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = cms.string('oracle://cms_orcoff_prep/CMS_COND_WEB')
-process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/test'
+process.CondDB.connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS')
+process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.source = cms.Source("EmptyIOVSource",
     lastValue = cms.uint64(1),

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
@@ -25,6 +25,7 @@ private:
   std::string m_lastLumiFile;
   cond::Time_t m_prevLumi;
   std::chrono::time_point<std::chrono::steady_clock> m_prevLumiTime;
+  std::string m_omsServiceUrl;
   // ----------member data ---------------------------
 };
 #endif


### PR DESCRIPTION
#### PR description:

The OMS online service has been recently developed to provided the info about on-going Run and Lumisection ID. This PR integrates the access to this service to obtain the two parameters in the context of condition updates for the HLT workflow

#### PR validation:

Since the OMS service is available only at the P5 network, a specific test has been executed in a dedicated online deployment.  
The existing unit and integration tests have been executed in the normal offline CMSSW environment, to validate the offline use cases.

