### PR TITLE
drop type specs in RecoParticleFlow

### DIFF
--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_cff.py
@@ -22,7 +22,7 @@ from RecoEgamma.EgammaIsolationAlgos.particleBasedIsoProducer_cff import *
 from RecoParticleFlow.PFProducer.chargedHadronPFTrackIsolation_cfi import *
 
 from RecoJets.JetProducers.fixedGridRhoProducerFastjet_cfi import *
-fixedGridRhoFastjetAllTmp = fixedGridRhoFastjetAll.clone(pfCandidatesTag = cms.InputTag("particleFlowTmp"))
+fixedGridRhoFastjetAllTmp = fixedGridRhoFastjetAll.clone(pfCandidatesTag = "particleFlowTmp")
 
 particleFlowTmpTask = cms.Task(particleFlowTmp)
 particleFlowTmpSeq = cms.Sequence(particleFlowTmpTask)

--- a/RecoParticleFlow/Configuration/python/RecoParticleFlow_refit_cff.py
+++ b/RecoParticleFlow/Configuration/python/RecoParticleFlow_refit_cff.py
@@ -9,8 +9,9 @@ from RecoTracker.Configuration.RecoTracker_cff import *
 
 import Geometry.CaloEventSetup.caloTowerConstituents_cfi
 
-CaloTowerConstituentsMapBuilder = Geometry.CaloEventSetup.caloTowerConstituents_cfi.caloTowerConstituents.clone()
-CaloTowerConstituentsMapBuilder.MapFile = "Geometry/CaloTopology/data/CaloTowerEEGeometric.map.gz"
+CaloTowerConstituentsMapBuilder = Geometry.CaloEventSetup.caloTowerConstituents_cfi.caloTowerConstituents.clone(
+    MapFile = "Geometry/CaloTopology/data/CaloTowerEEGeometric.map.gz"
+)
 
 particleFlowRecoTask = cms.Task(
     ckftracksTask,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECALUncorrected_cfi.py
@@ -91,7 +91,7 @@ _positionCalcECAL_all_nodepth = cms.PSet(
     timeResolutionCalcEndcap = _timeResolutionECALEndcap,
 )
 _positionCalcECAL_3x3_nodepth = _positionCalcECAL_all_nodepth.clone(
-    posCalcNCrystals = cms.int32(9)
+    posCalcNCrystals = 9
 )
 _positionCalcECAL_all_withdepth = cms.PSet(
     algoName = cms.string("ECAL2DPositionCalcWithDepthCorr"),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHE_cfi.py
@@ -144,5 +144,5 @@ run3_HB.toModify(particleFlowClusterHBHE,
 
 # HCALonly WF
 particleFlowClusterHBHEOnly = particleFlowClusterHBHE.clone(
-    recHitsSource = cms.InputTag("particleFlowRecHitHBHEOnly")
+    recHitsSource = "particleFlowRecHitHBHEOnly"
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -53,5 +53,5 @@ run3_HB.toModify(particleFlowClusterHCAL,
 
 # HCALonly WF
 particleFlowClusterHCALOnly = particleFlowClusterHCAL.clone(
-    clustersSource = cms.InputTag("particleFlowClusterHBHEOnly")
+    clustersSource = "particleFlowClusterHBHEOnly"
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHF_cfi.py
@@ -76,7 +76,7 @@ _positionCalcHF_cross_nodepth = cms.PSet(
 )
 
 _positionCalcHF_all_nodepth = _positionCalcHF_cross_nodepth.clone(
-    posCalcNCrystals = cms.int32(-1)
+    posCalcNCrystals = -1
     )
 
 #pf clusters

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
@@ -49,7 +49,7 @@ _positionCalcHO_cross_nodepth = cms.PSet(
 )
 
 _positionCalcHO_all_nodepth = _positionCalcHO_cross_nodepth.clone(
-    posCalcNCrystals = cms.int32(-1)
+    posCalcNCrystals = -1
 )
 
 #pf clusters

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECALUncorrected_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECALUncorrected_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterECALUncorrected_cfi import *
 
-particleFlowClusterOOTECALUncorrected = particleFlowClusterECALUncorrected.clone()
-particleFlowClusterOOTECALUncorrected.recHitsSource = cms.InputTag("particleFlowRecHitOOTECAL")
+particleFlowClusterOOTECALUncorrected = particleFlowClusterECALUncorrected.clone(
+    recHitsSource = "particleFlowRecHitOOTECAL"
+)

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterOOTECAL_cff.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cff import *
 
-particleFlowClusterOOTECAL = particleFlowClusterECAL.clone()
-particleFlowClusterOOTECAL.inputECAL = cms.InputTag("particleFlowClusterOOTECALUncorrected")
+particleFlowClusterOOTECAL = particleFlowClusterECAL.clone(
+    inputECAL = "particleFlowClusterOOTECALUncorrected"
+)
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(particleFlowClusterOOTECAL,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterTimeAssigner_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterTimeAssigner_cfi.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterTimeAssignerDefault_cfi import *
 
-particleFlowTimeAssignerECAL = particleFlowClusterTimeAssignerDefault.clone()
-particleFlowTimeAssignerECAL.timeSrc = cms.InputTag('ecalBarrelClusterFastTimer:PerfectResolutionModel')
-particleFlowTimeAssignerECAL.timeResoSrc = cms.InputTag('ecalBarrelClusterFastTimer:PerfectResolutionModelResolution')
-
+particleFlowTimeAssignerECAL = particleFlowClusterTimeAssignerDefault.clone(
+    timeSrc     = 'ecalBarrelClusterFastTimer:PerfectResolutionModel',
+    timeResoSrc = 'ecalBarrelClusterFastTimer:PerfectResolutionModelResolution'
+)
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -56,5 +56,5 @@ run3_HB.toModify(particleFlowRecHitHBHE,
 
 # HCALonly WF
 particleFlowRecHitHBHEOnly = particleFlowRecHitHBHE.clone(
-    producers = { 0: dict(src = cms.InputTag("hbheprereco","")) }
+    producers = { 0: dict(src = "hbheprereco:") }
 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitOOTECAL_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitOOTECAL_cff.py
@@ -1,10 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitECAL_cfi import *
 
-particleFlowRecHitOOTECAL = particleFlowRecHitECAL.clone()
-particleFlowRecHitOOTECAL.producers[0].qualityTests[1].timingCleaning = False
-particleFlowRecHitOOTECAL.producers[1].qualityTests[1].timingCleaning = False
-
+particleFlowRecHitOOTECAL = particleFlowRecHitECAL.clone( 
+    producers = {0 : dict(qualityTests = {1 : dict(timingCleaning = False) } ), 
+		 1 : dict(qualityTests = {1 : dict(timingCleaning = False) } )}
+)
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 
 ## EB

--- a/RecoParticleFlow/PFProducer/python/electronPFIsolationValues_cff.py
+++ b/RecoParticleFlow/PFProducer/python/electronPFIsolationValues_cff.py
@@ -74,22 +74,15 @@ elPFIsoValuePU03PFId = cms.EDProducer("PFCandIsolatorFromDeposits",
 
 
 
-elPFIsoValueCharged04PFId = elPFIsoValueCharged03PFId.clone()
-elPFIsoValueCharged04PFId.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueCharged04PFId = elPFIsoValueCharged03PFId.clone(deposits = {0: dict(deltaR = 0.4)})
 
+elPFIsoValueChargedAll04PFId = elPFIsoValueChargedAll03PFId.clone(deposits = {0: dict(deltaR = 0.4)})
 
-elPFIsoValueChargedAll04PFId = elPFIsoValueChargedAll03PFId.clone()
-elPFIsoValueChargedAll04PFId.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueGamma04PFId = elPFIsoValueGamma03PFId.clone(deposits = {0: dict(deltaR = 0.4)})
 
-elPFIsoValueGamma04PFId = elPFIsoValueGamma03PFId.clone()
-elPFIsoValueGamma04PFId.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValueNeutral04PFId = elPFIsoValueNeutral03PFId.clone(deposits = {0: dict(deltaR = 0.4)})
 
-
-elPFIsoValueNeutral04PFId = elPFIsoValueNeutral03PFId.clone()
-elPFIsoValueNeutral04PFId.deposits[0].deltaR = cms.double(0.4)
-
-elPFIsoValuePU04PFId = elPFIsoValuePU03PFId.clone()
-elPFIsoValuePU04PFId.deposits[0].deltaR = cms.double(0.4)
+elPFIsoValuePU04PFId = elPFIsoValuePU03PFId.clone(deposits = {0: dict(deltaR = 0.4)})
 
 ##########Now the PFNoId
 elPFIsoValueCharged03NoPFId     =  elPFIsoValueCharged03PFId.clone()           

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -30,7 +30,7 @@ particleBasedIsolationTmp = _particleBasedIsolation.clone(
 #change particleBasedIsolation object to tmp
 IsoConeDefinitionsPhotonsTmp = copy.deepcopy(IsoConeDefinitions)
 for iPSet in IsoConeDefinitionsPhotonsTmp:
-  iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp")
+  iPSet.particleBasedIsolation = "particleBasedIsolationTmp:gedPhotonsTmp"
 
 #photon isolation sums
 egmPhotonIsolationCITK = _egmPhotonIsolationAOD.clone(
@@ -46,7 +46,7 @@ egmElectronIsolationCITK = _egmElectronIsolationCITK.clone(
 )
 
 for iPSet in egmElectronIsolationCITK.isolationConeDefinitions:
-  iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedGsfElectronsTmp")
+  iPSet.particleBasedIsolation = "particleBasedIsolationTmp:gedGsfElectronsTmp"
 
 #electrons pileup isolation sum
 egmElectronIsolationPileUpCITK = _egmElectronIsolationCITKPileUp.clone(
@@ -55,7 +55,7 @@ egmElectronIsolationPileUpCITK = _egmElectronIsolationCITKPileUp.clone(
 )
 
 for iPSet in egmElectronIsolationPileUpCITK.isolationConeDefinitions:
-  iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedGsfElectronsTmp")
+  iPSet.particleBasedIsolation = "particleBasedIsolationTmp:gedGsfElectronsTmp"
 
 photonIDValueMaps = cms.EDProducer(
   "PhotonIDValueMapProducer",

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cff.py
@@ -20,38 +20,42 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfSortByType_cff import pfPileUp
 from RecoEgamma.EgammaIsolationAlgos.egmIsolationDefinitions_cff import pfNoPileUpCandidates
 from RecoEgamma.EgammaIsolationAlgos.egmIsoConeDefinitions_cfi import IsoConeDefinitions
 
-particleBasedIsolationTmp = _particleBasedIsolation.clone()
-particleBasedIsolationTmp.photonProducer =  cms.InputTag("gedPhotonsTmp")
-particleBasedIsolationTmp.electronProducer = cms.InputTag("gedGsfElectronsTmp")
-particleBasedIsolationTmp.pfCandidates = cms.InputTag("particleFlowTmp")
-particleBasedIsolationTmp.valueMapPhoPFblockIso = cms.string("gedPhotonsTmp")
-particleBasedIsolationTmp.valueMapElePFblockIso = cms.string("gedGsfElectronsTmp")
-
-egmPhotonIsolationCITK = _egmPhotonIsolationAOD.clone()
-egmElectronIsolationCITK = _egmElectronIsolationCITK.clone()
-egmElectronIsolationPileUpCITK = _egmElectronIsolationCITKPileUp.clone()
-
+particleBasedIsolationTmp = _particleBasedIsolation.clone(
+    photonProducer        = "gedPhotonsTmp",
+    electronProducer      = "gedGsfElectronsTmp",
+    pfCandidates          = "particleFlowTmp",
+    valueMapPhoPFblockIso = "gedPhotonsTmp",
+    valueMapElePFblockIso = "gedGsfElectronsTmp"
+)
 #change particleBasedIsolation object to tmp
 IsoConeDefinitionsPhotonsTmp = copy.deepcopy(IsoConeDefinitions)
 for iPSet in IsoConeDefinitionsPhotonsTmp:
   iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedPhotonsTmp")
 
+#photon isolation sums
+egmPhotonIsolationCITK = _egmPhotonIsolationAOD.clone(
+    srcToIsolate        = "gedPhotonsTmp",
+    srcForIsolationCone = "pfNoPileUpCandidates",
+    isolationConeDefinitions = IsoConeDefinitionsPhotonsTmp
+)
+
+#electrons isolation sums
+egmElectronIsolationCITK = _egmElectronIsolationCITK.clone(
+    srcToIsolate        = "gedGsfElectronsTmp",
+    srcForIsolationCone = "pfNoPileUpCandidates"
+)
+
 for iPSet in egmElectronIsolationCITK.isolationConeDefinitions:
   iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedGsfElectronsTmp")
 
+#electrons pileup isolation sum
+egmElectronIsolationPileUpCITK = _egmElectronIsolationCITKPileUp.clone(
+    srcToIsolate        = "gedGsfElectronsTmp",
+    srcForIsolationCone = "pfPileUpAllChargedParticles"
+)
+
 for iPSet in egmElectronIsolationPileUpCITK.isolationConeDefinitions:
   iPSet.particleBasedIsolation = cms.InputTag("particleBasedIsolationTmp", "gedGsfElectronsTmp")
-
-#photon isolation sums
-egmPhotonIsolationCITK.srcToIsolate = cms.InputTag("gedPhotonsTmp")
-egmPhotonIsolationCITK.srcForIsolationCone = cms.InputTag("pfNoPileUpCandidates")
-egmPhotonIsolationCITK.isolationConeDefinitions = IsoConeDefinitionsPhotonsTmp
-#electrons isolation sums
-egmElectronIsolationCITK.srcToIsolate = cms.InputTag("gedGsfElectronsTmp")
-egmElectronIsolationCITK.srcForIsolationCone = cms.InputTag("pfNoPileUpCandidates")
-#electrons pileup isolation sum
-egmElectronIsolationPileUpCITK.srcToIsolate = cms.InputTag("gedGsfElectronsTmp")
-egmElectronIsolationPileUpCITK.srcForIsolationCone = cms.InputTag("pfPileUpAllChargedParticles")
 
 photonIDValueMaps = cms.EDProducer(
   "PhotonIDValueMapProducer",

--- a/RecoParticleFlow/PFProducer/python/pfElectronInterestingDetIds_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/pfElectronInterestingDetIds_cfi.py
@@ -3,10 +3,10 @@ import FWCore.ParameterSet.Config as cms
 import RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi
 
 pfElectronInterestingEcalDetIdEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("pfElectronTranslator","pf"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "pfElectronTranslator:pf",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 pfElectronInterestingEcalDetIdEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("pfElectronTranslator","pf"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "pfElectronTranslator:pf",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )

--- a/RecoParticleFlow/PFProducer/python/pfLinker_cff.py
+++ b/RecoParticleFlow/PFProducer/python/pfLinker_cff.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 import RecoParticleFlow.PFProducer.pfLinker_cfi
 import RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi
-particleFlow = RecoParticleFlow.PFProducer.pfLinker_cfi.pfLinker.clone()
-particleFlow.PFCandidate = [cms.InputTag("particleFlowTmp")]
-particleFlowPtrs = RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi.particleFlowTmpPtrs.clone()
-particleFlowPtrs.src = "particleFlow"
-
+particleFlow = RecoParticleFlow.PFProducer.pfLinker_cfi.pfLinker.clone(
+    PFCandidate = ["particleFlowTmp"]
+)
+particleFlowPtrs = RecoParticleFlow.PFProducer.particleFlowTmpPtrs_cfi.particleFlowTmpPtrs.clone(
+    src = "particleFlow"
+)
 from Configuration.Eras.Modifier_phase2_hgcal_cff import phase2_hgcal
 phase2_hgcal.toModify(particleFlow, forceElectronsInHGCAL = True)

--- a/RecoParticleFlow/PFProducer/python/pfPhotonInterestingDetIds_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/pfPhotonInterestingDetIds_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 import RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi
 pfPhotonInterestingEcalDetIdEB = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("pfPhotonTranslator","pfphot"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB")
+    basicClustersLabel = "pfPhotonTranslator:pfphot",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEB"
     )
 
 pfPhotonInterestingEcalDetIdEE = RecoEcal.EgammaClusterProducers.interestingDetIdCollectionProducer_cfi.interestingDetIdCollectionProducer.clone(
-    basicClustersLabel = cms.InputTag("pfPhotonTranslator","pfphot"),
-    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE")
+    basicClustersLabel = "pfPhotonTranslator:pfphot",
+    recHitsLabel       = "ecalRecHit:EcalRecHitsEE"
     )

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cff.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cff.py
@@ -1,5 +1,9 @@
 import TrackingTools.GsfTracking.GsfElectronMaterialEffects_cfi
-ElectronMaterialEffects_forPreId = TrackingTools.GsfTracking.GsfElectronMaterialEffects_cfi.ElectronMaterialEffects.clone()
+
+ElectronMaterialEffects_forPreId = TrackingTools.GsfTracking.GsfElectronMaterialEffects_cfi.ElectronMaterialEffects.clone(
+    ComponentName = 'ElectronMaterialEffects_forPreId',
+    BetheHeitlerParametrization = 'BetheHeitler_cdfmom_nC3_O5.par'
+)
 from RecoParticleFlow.PFTracking.trackerDrivenElectronSeeds_cfi import *
 CloseComponentsMerger_forPreId = cms.ESProducer("CloseComponentsMergerESProducer5D",
     ComponentName = cms.string('CloseComponentsMerger_forPreId'),
@@ -24,5 +28,3 @@ GsfTrajectorySmoother_forPreId = cms.ESProducer("GsfTrajectorySmootherESProducer
     RecoGeometry = cms.string('GlobalDetLayerGeometry')
 )
 
-ElectronMaterialEffects_forPreId.ComponentName = 'ElectronMaterialEffects_forPreId'
-ElectronMaterialEffects_forPreId.BetheHeitlerParametrization = 'BetheHeitler_cdfmom_nC3_O5.par'

--- a/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/trackerDrivenElectronSeeds_cfi.py
@@ -59,11 +59,11 @@ for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
 # Therefore we let the seeds depend on the 'before mixing' generalTracks collection
 # TODO: investigate whether the dependence on trajectories can be avoided
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
-trackerDrivenElectronSeedsTmp = trackerDrivenElectronSeeds.clone(TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing")))
+trackerDrivenElectronSeedsTmp = trackerDrivenElectronSeeds.clone(TkColList = ["generalTracksBeforeMixing"])
 import FastSimulation.Tracking.ElectronSeedTrackRefFix_cfi
 _fastSim_trackerDrivenElectronSeeds = FastSimulation.Tracking.ElectronSeedTrackRefFix_cfi.fixedTrackerDrivenElectronSeeds.clone()
-_fastSim_trackerDrivenElectronSeeds.seedCollection.setModuleLabel("trackerDrivenElectronSeedsTmp"),
-_fastSim_trackerDrivenElectronSeeds.idCollection = cms.VInputTag("trackerDrivenElectronSeedsTmp:preid",)
+_fastSim_trackerDrivenElectronSeeds.seedCollection.setModuleLabel("trackerDrivenElectronSeedsTmp")
+_fastSim_trackerDrivenElectronSeeds.idCollection = ["trackerDrivenElectronSeedsTmp:preid",]
 fastSim.toReplaceWith(trackerDrivenElectronSeeds,_fastSim_trackerDrivenElectronSeeds)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The references were [PR#30700](https://github.com/cms-sw/cmssw/pull/30700), [PR#30827](https://github.com/cms-sw/cmssw/pull/30827), [PR#30947](https://github.com/cms-sw/cmssw/pull/30947),[PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332))

In this PR, total 19 files updated. 
- RecoParticleFlow/{Configuration} 2 files 
- RecoParticleFlow/{PFClusterProducer} 10 files 
- RecoParticleFlow/{PFProducer} 5 files 
- RecoParticleFlow/{PFTracking} 2 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).