### PR TITLE
Update Run 3 data GTs to those used in 2020 MWGR3 [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -45,7 +45,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '110X_dataRun3_Prompt_v3',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '111X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR updates the Run 3 data GTs to those used in 2020 MWGR3. As there was only a single updated tag, which affects only a small range of IOVs near MWGR1, no changes are expected in any workflow. These changes are being made as a matter of principle, to keep `autoCond` up to date.

This PR is a backport of #31358. The GT used here is the same as that used in the PR to master. Relative to the PR to master, there is an additional update to PPS tags which had already been included in the version of `autoCond` in the master branch. These PPS updates should not affect any workflow.

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_dataRun3_Prompt_v3/111X_dataRun3_Prompt_v2

#### PR validation:

`runTheMatrix.py -l 138.1 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #31358. It is needed because we would like to exercise workflows for Run-3 data in the release series used in MWGRs.
