### PR TITLE
clean magField->nominalValue()

### DIFF
--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -131,7 +131,7 @@ bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* the
 
   ndof -= 5.f;
   if
-    UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue()) < DBL_MIN)++ ndof;  // same as -4
+    UNLIKELY(theTSOS.magneticField()->nominalValue() == 0)++ ndof;  // same as -4
 
 #if defined(VI_DEBUG) || defined(EDM_ML_DEBUG)
   int chit[7] = {};
@@ -316,7 +316,7 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
 
   ndof = ndof - 5;
   if
-    UNLIKELY(std::abs(theTSOS.magneticField()->nominalValue()) < DBL_MIN)++ ndof;  // same as -4
+    UNLIKELY(theTSOS.magneticField()->nominalValue() == 0)++ ndof;  // same as -4
 
   //if geometricInnerState_ is false the state for projection to beam line is the state attached to the first hit: to be used for loopers
   //if geometricInnerState_ is true the state for projection to beam line is the one from the (geometrically) closest measurement to the beam line: to be sued for non-collision tracks

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -103,11 +103,10 @@ bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* the
   //perform the fit: the result's size is 1 if it succeded, 0 if fails
   Trajectory&& trajTmp =
       theFitter->fitOne(seed, hits, theTSOS, (nLoops > 0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
-  if
-    UNLIKELY(!trajTmp.isValid()) {
-      DPRINT("TrackFitters") << "fit failed " << algo_ << ": " << hits.size() << '|' << int(nLoops) << ' ' << std::endl;
-      return false;
-    }
+  if UNLIKELY (!trajTmp.isValid()) {
+    DPRINT("TrackFitters") << "fit failed " << algo_ << ": " << hits.size() << '|' << int(nLoops) << ' ' << std::endl;
+    return false;
+  }
 
   auto theTraj = new Trajectory(std::move(trajTmp));
   theTraj->setSeedRef(seedRef);
@@ -130,8 +129,8 @@ bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* the
   }
 
   ndof -= 5.f;
-  if
-    UNLIKELY(theTSOS.magneticField()->nominalValue() == 0)++ ndof;  // same as -4
+  if UNLIKELY (theTSOS.magneticField()->nominalValue() == 0)
+    ++ndof;  // same as -4
 
 #if defined(VI_DEBUG) || defined(EDM_ML_DEBUG)
   int chit[7] = {};
@@ -189,12 +188,11 @@ bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* the
     }
   }
 
-  if
-    UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()) {
-      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
-      delete theTraj;
-      return false;
-    }
+  if UNLIKELY (!stateForProjectionToBeamLineOnSurface.isValid()) {
+    edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
+    delete theTraj;
+    return false;
+  }
   const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
 
   LogDebug("TrackProducer") << "stateForProjectionToBeamLine=" << stateForProjectionToBeamLine;
@@ -212,11 +210,10 @@ bool TrackProducerAlgorithm<reco::Track>::buildTrack(const TrajectoryFitter* the
     tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
   }
 
-  if
-    UNLIKELY(!tscbl.isValid()) {
-      delete theTraj;
-      return false;
-    }
+  if UNLIKELY (!tscbl.isValid()) {
+    delete theTraj;
+    return false;
+  }
 
   GlobalPoint v = tscbl.trackStateAtPCA().position();
   math::XYZPoint pos(v.x(), v.y(), v.z());
@@ -269,8 +266,8 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
 
   Trajectory&& trajTmp =
       theFitter->fitOne(seed, hits, theTSOS, (nLoops > 0) ? TrajectoryFitter::looper : TrajectoryFitter::standard);
-  if
-    UNLIKELY(!trajTmp.isValid()) return false;
+  if UNLIKELY (!trajTmp.isValid())
+    return false;
 
   auto theTraj = new Trajectory(std::move(trajTmp));
   theTraj->setSeedRef(seedRef);
@@ -315,8 +312,8 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
   }
 
   ndof = ndof - 5;
-  if
-    UNLIKELY(theTSOS.magneticField()->nominalValue() == 0)++ ndof;  // same as -4
+  if UNLIKELY (theTSOS.magneticField()->nominalValue() == 0)
+    ++ndof;  // same as -4
 
   //if geometricInnerState_ is false the state for projection to beam line is the state attached to the first hit: to be used for loopers
   //if geometricInnerState_ is true the state for projection to beam line is the one from the (geometrically) closest measurement to the beam line: to be sued for non-collision tracks
@@ -333,12 +330,11 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
     }
   }
 
-  if
-    UNLIKELY(!stateForProjectionToBeamLineOnSurface.isValid()) {
-      edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
-      delete theTraj;
-      return false;
-    }
+  if UNLIKELY (!stateForProjectionToBeamLineOnSurface.isValid()) {
+    edm::LogError("CannotPropagateToBeamLine") << "the state on the closest measurement isnot valid. skipping track.";
+    delete theTraj;
+    return false;
+  }
 
   const FreeTrajectoryState& stateForProjectionToBeamLine = *stateForProjectionToBeamLineOnSurface.freeState();
 
@@ -356,11 +352,10 @@ bool TrackProducerAlgorithm<reco::GsfTrack>::buildTrack(const TrajectoryFitter* 
     tscbl = tscblBuilder(stateForProjectionToBeamLine, bs);
   }
 
-  if
-    UNLIKELY(tscbl.isValid() == false) {
-      delete theTraj;
-      return false;
-    }
+  if UNLIKELY (tscbl.isValid() == false) {
+    delete theTraj;
+    return false;
+  }
 
   GlobalPoint v = tscbl.trackStateAtPCA().position();
   math::XYZPoint pos(v.x(), v.y(), v.z());


### PR DESCRIPTION
#### PR description:
thanks to @VinInn I realized that in the `RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc` there is a fossil related to the usage of the nominal value of the magnetic field and the handling of it if off.
This update is following the usage in other places (like in [https://cmssdt.cern.ch/dxr/CMSSW/source/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc#72](https://cmssdt.cern.ch/dxr/CMSSW/source/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc#72))
in particular, the nominalValue() [1] returns an `int` which is never negative
and therefore the check has been updated

[1]
[https://cmssdt.cern.ch/lxr/source/MagneticField/Engine/interface/MagneticField.h](https://cmssdt.cern.ch/lxr/source/MagneticField/Engine/interface/MagneticField.h)