### PR TITLE
Fix `scram b code-checks` warnings associated with FWCore

### DIFF
--- a/DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h
+++ b/DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h
@@ -23,7 +23,11 @@ namespace edm {
                              Timestamp const& theTime,
                              Timestamp const& theEndTime)
         : processHistoryID_(), id_(theRun, theLumi), beginTime_(theTime), endTime_(theEndTime) {}
+    LuminosityBlockAuxiliary(LuminosityBlockAuxiliary&&) = default;
+    LuminosityBlockAuxiliary(LuminosityBlockAuxiliary const&) = default;
     ~LuminosityBlockAuxiliary() {}
+    LuminosityBlockAuxiliary& operator=(LuminosityBlockAuxiliary&&) = default;
+    LuminosityBlockAuxiliary& operator=(LuminosityBlockAuxiliary const&) = default;
     void write(std::ostream& os) const;
     ProcessHistoryID const& processHistoryID() const { return processHistoryID_; }
     void setProcessHistoryID(ProcessHistoryID const& phid) { processHistoryID_ = phid; }

--- a/FWCore/Framework/interface/HistoryAppender.h
+++ b/FWCore/Framework/interface/HistoryAppender.h
@@ -13,6 +13,8 @@ namespace edm {
   class HistoryAppender {
   public:
     HistoryAppender();
+    HistoryAppender(HistoryAppender const&) = delete;
+    HistoryAppender& operator=(HistoryAppender const&) = delete;
 
     // Used to append the current process to the process history
     // when necessary. Optimized to cache the results so it
@@ -22,9 +24,6 @@ namespace edm {
                                                                  ProcessConfiguration const& pc);
 
   private:
-    HistoryAppender(HistoryAppender const&) = delete;
-    HistoryAppender& operator=(HistoryAppender const&) = delete;
-
     // Throws if the new process name is already in the process
     // process history
     void checkProcessHistory(ProcessHistory const& ph, ProcessConfiguration const& pc) const;

--- a/FWCore/Framework/interface/ProductRegistryHelper.h
+++ b/FWCore/Framework/interface/ProductRegistryHelper.h
@@ -49,7 +49,7 @@ namespace edm {
     };
 
     struct BranchAliasSetter {
-      BranchAliasSetter(TypeLabelItem& iItem, EDPutToken iToken) : value_(iItem), token_(std::move(iToken)) {}
+      BranchAliasSetter(TypeLabelItem& iItem, EDPutToken iToken) : value_(iItem), token_(iToken) {}
 
       BranchAliasSetter& setBranchAlias(std::string alias) {
         value_.branchAlias_ = std::move(alias);

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -38,6 +38,8 @@ namespace edm {
                        public virtual EDProducerBase {
     public:
       EDProducer() = default;
+      EDProducer(const EDProducer&) = delete;
+      EDProducer& operator=(const EDProducer&) = delete;
 
       // ---------- const member functions ---------------------
       bool wantsProcessBlocks() const final { return WantsProcessBlockTransitions<T...>::value; }
@@ -66,10 +68,6 @@ namespace edm {
       // ---------- member functions ---------------------------
 
     private:
-      EDProducer(const EDProducer&) = delete;
-
-      const EDProducer& operator=(const EDProducer&) = delete;
-
       // ---------- member data --------------------------------
     };
 

--- a/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
+++ b/FWCore/Framework/src/LuminosityBlockProcessingStatus.h
@@ -98,7 +98,7 @@ namespace edm {
     }
     edm::Timestamp const& lastTimestamp() const { return endTime_; }
 
-    void setNextSyncValue(IOVSyncValue iValue) { nextSyncValue_ = std::move(iValue); }
+    void setNextSyncValue(IOVSyncValue const& iValue) { nextSyncValue_ = iValue; }
 
     const IOVSyncValue nextSyncValue() const { return nextSyncValue_; }
 

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -39,6 +39,8 @@ namespace edm {
   class OutputModuleCommunicator {
   public:
     OutputModuleCommunicator() = default;
+    OutputModuleCommunicator(const OutputModuleCommunicator&) = delete;
+    OutputModuleCommunicator& operator=(const OutputModuleCommunicator&) = delete;
     virtual ~OutputModuleCommunicator();
 
     virtual void closeFile() = 0;
@@ -83,10 +85,6 @@ namespace edm {
     virtual ModuleDescription const& description() const = 0;
 
   private:
-    OutputModuleCommunicator(const OutputModuleCommunicator&) = delete;  // stop default
-
-    const OutputModuleCommunicator& operator=(const OutputModuleCommunicator&) = delete;  // stop default
-
     // ---------- member data --------------------------------
   };
 }  // namespace edm

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -61,6 +61,8 @@ namespace edm {
 
     Path(Path const&);
 
+    Path& operator=(Path const&) = delete;
+
     template <typename T>
     void runAllModulesAsync(WaitingTask*,
                             typename T::MyPrincipal const&,
@@ -99,10 +101,6 @@ namespace edm {
     void setPathStatusInserter(PathStatusInserter* pathStatusInserter, Worker* pathStatusInserterWorker);
 
   private:
-    // If you define this be careful about the pointer in the
-    // PlaceInPathContext object in the contained WorkerInPath objects.
-    Path const& operator=(Path const&) = delete;  // stop default
-
     int timesRun_;
     int timesPassed_;
     int timesFailed_;

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -50,6 +50,9 @@ namespace edm {
                      service::TriggerNamesService const& iNameService,
                      ProcessContext const* iProcessContext);
 
+    SystemTimeKeeper(const SystemTimeKeeper&) = delete;
+    SystemTimeKeeper& operator=(const SystemTimeKeeper&) = delete;
+
     // ---------- const member functions ---------------------
 
     // ---------- static member functions --------------------
@@ -86,10 +89,6 @@ namespace edm {
     void fillTriggerTimingReport(TriggerTimingReport& rep) const;
 
   private:
-    SystemTimeKeeper(const SystemTimeKeeper&) = delete;  // stop default
-
-    const SystemTimeKeeper& operator=(const SystemTimeKeeper&) = delete;  // stop default
-
     PathTiming& pathTiming(StreamContext const&, PathContext const&);
     bool checkBounds(unsigned int id) const;
 

--- a/FWCore/Utilities/interface/CPUTimer.h
+++ b/FWCore/Utilities/interface/CPUTimer.h
@@ -39,6 +39,8 @@ namespace edm {
     CPUTimer();
     ~CPUTimer();
     CPUTimer(CPUTimer&&) = default;
+    CPUTimer(const CPUTimer&) = delete;
+    CPUTimer& operator=(const CPUTimer&) = delete;
 
     struct Times {
       Times() : real_(0), cpu_(0) {}
@@ -60,10 +62,6 @@ namespace edm {
     void add(const Times& t);
 
   private:
-    CPUTimer(const CPUTimer&) = delete;  // stop default
-
-    const CPUTimer& operator=(const CPUTimer&) = delete;  // stop default
-
     Times calculateDeltaTime() const;
 
     // ---------- member data --------------------------------

--- a/FWCore/Utilities/interface/LuminosityBlockIndex.h
+++ b/FWCore/Utilities/interface/LuminosityBlockIndex.h
@@ -33,6 +33,7 @@ namespace edm {
   class LuminosityBlockIndex {
   public:
     LuminosityBlockIndex(const LuminosityBlockIndex&) = default;
+    LuminosityBlockIndex() = delete;
     LuminosityBlockIndex& operator=(const LuminosityBlockIndex&) = default;
     ~LuminosityBlockIndex() = default;
 
@@ -52,8 +53,6 @@ namespace edm {
     friend class LuminosityBlockPrincipal;
 
     explicit LuminosityBlockIndex(unsigned int iValue) : value_{iValue} {}
-
-    LuminosityBlockIndex() = delete;
 
     // ---------- member data --------------------------------
     unsigned int value_;

--- a/FWCore/Utilities/interface/RunIndex.h
+++ b/FWCore/Utilities/interface/RunIndex.h
@@ -32,6 +32,7 @@ namespace edm {
   class RunIndex {
   public:
     ~RunIndex() = default;
+    RunIndex() = delete;
     RunIndex(const RunIndex&) = default;
     RunIndex& operator=(const RunIndex&) = default;
 
@@ -49,8 +50,6 @@ namespace edm {
     ///Only the RunPrincipal is allowed to make one of these
     friend class RunPrincipal;
     explicit RunIndex(unsigned int iIndex) : value_(iIndex) {}
-
-    RunIndex() = delete;
 
     // ---------- member data --------------------------------
     unsigned int value_;

--- a/FWCore/Utilities/interface/Signal.h
+++ b/FWCore/Utilities/interface/Signal.h
@@ -40,6 +40,8 @@ namespace edm {
       Signal() = default;
       ~Signal() = default;
       Signal(Signal&&) = default;
+      Signal(const Signal&) = delete;
+      Signal& operator=(const Signal&) = delete;
 
       // ---------- const member functions ---------------------
       template <typename... Args>
@@ -69,10 +71,6 @@ namespace edm {
       }
 
     private:
-      Signal(const Signal&) = delete;  // stop default
-
-      const Signal& operator=(const Signal&) = delete;  // stop default
-
       // ---------- member data --------------------------------
       slot_list_type m_slots;
     };

--- a/FWCore/Utilities/interface/StreamID.h
+++ b/FWCore/Utilities/interface/StreamID.h
@@ -30,6 +30,7 @@ namespace edm {
   class StreamID {
   public:
     ~StreamID() = default;
+    StreamID() = delete;
     StreamID(const StreamID&) = default;
     StreamID& operator=(const StreamID&) = default;
 
@@ -48,8 +49,6 @@ namespace edm {
     friend class Schedule;
     friend class EventPrincipal;
     explicit StreamID(unsigned int iValue) : value_(iValue) {}
-
-    StreamID() = delete;
 
     // ---------- member data --------------------------------
     unsigned int value_;

--- a/FWCore/Utilities/interface/TypeToGet.h
+++ b/FWCore/Utilities/interface/TypeToGet.h
@@ -37,6 +37,7 @@ namespace edm {
      and iKind should be edm::ProductType **/
     TypeToGet(TypeID const& iID, KindOfType iKind) : m_type(iID), m_kind(iKind) {}
 
+    TypeToGet() = delete;
     // ---------- const member functions ---------------------
     TypeID const& type() const { return m_type; }
     KindOfType kind() const { return m_kind; }
@@ -67,8 +68,6 @@ namespace edm {
     static KindOfType kindOfTypeFor(edm::View<T>*) {
       return ELEMENT_TYPE;
     }
-
-    TypeToGet() = delete;
 
     // ---------- member data --------------------------------
     TypeID m_type;

--- a/FWCore/Utilities/interface/WallclockTimer.h
+++ b/FWCore/Utilities/interface/WallclockTimer.h
@@ -39,6 +39,8 @@ namespace edm {
     WallclockTimer();
     ~WallclockTimer();
     WallclockTimer(WallclockTimer&&) = default;
+    WallclockTimer(const WallclockTimer&) = delete;
+    WallclockTimer& operator=(const WallclockTimer&) = delete;
 
     // ---------- const member functions ---------------------
     double realTime() const;
@@ -53,10 +55,6 @@ namespace edm {
     void add(double t);
 
   private:
-    WallclockTimer(const WallclockTimer&) = delete;  // stop default
-
-    const WallclockTimer& operator=(const WallclockTimer&) = delete;  // stop default
-
     double calculateDeltaTime() const;
 
     // ---------- member data --------------------------------


### PR DESCRIPTION
#### PR description:

Mostly this was moving `=delete` methods to public section and removing unnecessary uses of `std::move`.

#### PR validation:

code compiles. Running `scram b code-checks` no longer gives any warning for FWCore/Framework or FWCore/Utilities.