### PR TITLE
update IT CPE conditions, post dual slope ToT activation (also for other T* geometries)

### DIFF
--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -66,17 +66,17 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T17' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T20' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_T15_v5_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T17' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T20' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T17' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T20' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_T15_v5_mc',SiPixelTemplatesRecord,connectionString, "", "2020-05-02 23:00:00.000"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T17' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T20' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
     'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }


### PR DESCRIPTION
#### PR description:

Title says it all, now that https://github.com/cms-sw/cmssw/pull/31253 is merged, we should update the Templates / GenErrors also for the all the other active geometries to keep into account the activation of the dual slope ToT in the phase-2 digitizer and clusterizer. This is especially true for D49 (i.e. T15) which is the one we keep validating, as the change in the clusterizer / digitizer affects everything.
**caveat**: T17 and T20 are eligible for clean-up and soon to be removed.

#### PR validation:

None so far, draft PR pending validation.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
cc @emiglior @OzAmram @tvami @skinnari
