### PR TITLE
Cleanup BuildFile: remove duplicate GeneratorInterface/Pythia8Interface dep

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="GeneratorInterface/Pythia8Interface"/>
 <library file="Pythia8Hadronizer.cc,Py8toJetInput.cc,*Hook*.cc,LHA*.cc" name="GeneratorInterfacePythia8Filters">
   <use name="GeneratorInterface/PartonShowerVeto"/>
   <use name="GeneratorInterface/ExternalDecays"/>
@@ -16,6 +15,7 @@
 </library>
 
 <library file="Py*Gun.cc" name="GeneratorInterfacePythia8Guns">
+  <use name="GeneratorInterface/Pythia8Interface"/>
   <use name="GeneratorInterface/ExternalDecays"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
SCRAM complains about this
```
***WARNING: Multiple usage of "GeneratorInterface/Pythia8Interface". Please cleanup "use" in "non-export" section of "src/GeneratorInterface/Pythia8Interface/plugins/BuildFile".
```
