### PR TITLE
Cleanup BuildFile: Remove duplicates

### DIFF
--- a/TrackingTools/PatternTools/BuildFile.xml
+++ b/TrackingTools/PatternTools/BuildFile.xml
@@ -16,7 +16,6 @@
 <use name="DataFormats/TrajectorySeed"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/CLHEP"/>
-<use name="DataFormats/TrackCandidate"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="TrackingTools/TransientTrackingRecHit"/>
 <use name="FWCore/Framework"/>


### PR DESCRIPTION
SCRAM complains
```
***WARNING: Multiple usage of "DataFormats/TrackCandidate". Please cleanup "use" in "non-export" section of "src/TrackingTools/PatternTools/BuildFile".
```