### PR TITLE
Change Phase-2 geometry scenario from D41 to D49 in HBHE darkening analyzer

### DIFF
--- a/CalibCalorimetry/HcalPlugins/test/hbhedarkeninganalyzer_cfg.py
+++ b/CalibCalorimetry/HcalPlugins/test/hbhedarkeninganalyzer_cfg.py
@@ -7,7 +7,7 @@ process.source = cms.Source("EmptySource")
 
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("Configuration.Geometry.GeometryExtended2018Reco_cff")
-#process.load("Configuration.Geometry.GeometryExtended2026D41Reco_cff")
+#process.load("Configuration.Geometry.GeometryExtended2026D49Reco_cff")
 process.load("CalibCalorimetry.HcalPlugins.HBHEDarkening_cff")
 
 import CalibCalorimetry.HcalPlugins.Hcal_Conditions_forGlobalTag_cff


### PR DESCRIPTION
#### PR description:

This PR changes the phase 2 geometry from the deprecated `D41` scenario to the `D49` scenario in the python configuration for the HBHE darkening analyzer. Only a single commented line is affected. The commented line has not been removed because one might wish to run the darkening analyzer on Phase-2 MC.

This PR would resolve issue #31081 for AlCa.

#### PR validation:

Code compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.