### PR TITLE
Improve SwitchProducer error message for inconsistent output products

### DIFF
--- a/FWCore/Integration/test/SwitchProducer_t.cpp
+++ b/FWCore/Integration/test/SwitchProducer_t.cpp
@@ -234,11 +234,16 @@ TEST_CASE("Configuration with different branches", s_tag) {
     edm::test::TestProcessor::Config config1{baseConfig1};
     REQUIRE_THROWS_WITH(
         edm::test::TestProcessor(config1),
-        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case"));
+        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case") &&
+            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
+            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
 
     edm::test::TestProcessor::Config config2{baseConfig2};
-    REQUIRE_THROWS(edm::test::TestProcessor(config1),
-                   Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case"));
+    REQUIRE_THROWS_WITH(
+        edm::test::TestProcessor(config2),
+        Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case") &&
+            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
+            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
   }
 }
 
@@ -260,11 +265,16 @@ TEST_CASE("Configuration with different branches with EDAlias", s_tag) {
     edm::test::TestProcessor::Config config1{baseConfig1};
     REQUIRE_THROWS_WITH(
         edm::test::TestProcessor(config1),
-        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case"));
+        Catch::Contains("that does not produce a product") && Catch::Contains("that is produced by the chosen case") &&
+            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
+            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
 
     edm::test::TestProcessor::Config config2{baseConfig2};
-    REQUIRE_THROWS(edm::test::TestProcessor(config1),
-                   Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case"));
+    REQUIRE_THROWS_WITH(
+        edm::test::TestProcessor(config2),
+        Catch::Contains("with a product") && Catch::Contains("that is not produced by the chosen case") &&
+            Catch::Contains("Products for case s@test1") && Catch::Contains("Products for case s@test2") &&
+            Catch::Contains("edmtestIntProduct \n") && Catch::Contains("edmtestIntProduct foo"));
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR resolves (partially) #31230. The exception message includes now a suggestion to use EDAlias, and lists the products (friendly class name and product instance name) for all cases, along
```
  SwitchProducer s has a case s@test1 that does not produce a product BranchKey
  (edmtestIntProduct, s, foo, TEST) that is produced by the chosen case
  s@test2. If the intention is to produce only a subset of the products listed
  below, each case with more products needs to be replacated with an EDAlias to
  only the necessary products, and the EDProducer itself needs to be moved to a
  Task.
  
  Products for case s@test1 (friendly class name, product instance name):
   edmtestIntProduct 
  Products for case s@test2 (friendly class name, product instance name):
   edmtestIntProduct 
   edmtestIntProduct foo
```

#### PR validation:

Framework unit tests succeed