### PR TITLE
Fix sorting in TTUTrackingAlg (11_1_X)

### DIFF
--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
@@ -133,14 +133,6 @@ private:
     }
   };
 
-  struct SortBySector {
-    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_sectorId < (*b).m_sectorId); }
-  };
-
-  struct SortByLayer {
-    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_stationId < (*b).m_stationId); }
-  };
-
   inline void print(const std::vector<Seed*>& seeds) {
     std::vector<Seed*>::const_iterator itr;
     for (itr = seeds.begin(); itr != seeds.end(); ++itr)

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
@@ -125,14 +125,6 @@ private:
 
   std::vector<std::unique_ptr<Seed>> m_initialseeds;
 
-  struct CompareSeeds {
-    bool operator()(const Seed* a, const Seed* b) {
-      //std::cout << (*a).m_sectorId << " " << (*b).m_sectorId << " "
-      //<< (*a).m_stationId << " " << (*b).m_stationId << std::endl;
-      return ((*a).m_sectorId == (*b).m_sectorId) && ((*a).m_stationId == (*b).m_stationId);
-    }
-  };
-
   inline void print(const std::vector<Seed*>& seeds) {
     std::vector<Seed*>::const_iterator itr;
     for (itr = seeds.begin(); itr != seeds.end(); ++itr)

--- a/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
+++ b/L1Trigger/RPCTechnicalTrigger/interface/TTUTrackingAlg.h
@@ -134,11 +134,11 @@ private:
   };
 
   struct SortBySector {
-    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_sectorId <= (*b).m_sectorId); }
+    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_sectorId < (*b).m_sectorId); }
   };
 
   struct SortByLayer {
-    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_stationId <= (*b).m_stationId); }
+    bool operator()(const Seed* a, const Seed* b) { return ((*a).m_stationId < (*b).m_stationId); }
   };
 
   inline void print(const std::vector<Seed*>& seeds) {

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUTrackingAlg.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUTrackingAlg.cc
@@ -224,8 +224,12 @@ void TTUTrackingAlg::ghostBuster(Track* currentTrk) {
 
   std::vector<Seed*>::iterator seedItr;
 
-  std::sort(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), SortBySector());
-  std::sort(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), SortByLayer());
+  std::sort(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), [](const Seed* a, const Seed* b) {
+    if (a->m_sectorId == b->m_sectorId) {
+      return a->m_stationId < b->m_stationId;
+    }
+    return a->m_sectorId < b->m_sectorId;
+  });
 
   seedItr = std::unique(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), CompareSeeds());
 

--- a/L1Trigger/RPCTechnicalTrigger/src/TTUTrackingAlg.cc
+++ b/L1Trigger/RPCTechnicalTrigger/src/TTUTrackingAlg.cc
@@ -231,7 +231,9 @@ void TTUTrackingAlg::ghostBuster(Track* currentTrk) {
     return a->m_sectorId < b->m_sectorId;
   });
 
-  seedItr = std::unique(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), CompareSeeds());
+  seedItr = std::unique(currentTrk->m_seeds.begin(), currentTrk->m_seeds.end(), [](const Seed* a, const Seed* b) {
+    return a->m_sectorId == b->m_sectorId and a->m_stationId == b->m_stationId;
+  });
 
   currentTrk->m_seeds.resize(seedItr - currentTrk->m_seeds.begin());
 


### PR DESCRIPTION
#### PR description:

Backport of #31415 

> This PR fixes a bug in the sorting comparison functions in `TTUTrackingAlg` that cause crashes reported in https://github.com/cms-sw/cmssw/issues/31258 and https://github.com/cms-sw/cmssw/issues/31410. The `std::sort` requires the comparison functor to meet the requirements of [`Compare`](https://en.cppreference.com/w/cpp/named_req/Compare) (loosely needs "less than"), which the current "less or equal than" does not meet, leading to undefined behavior. This PR changes the functors to use "less than" comparison.
> 
> Furthermore, as pointed out in https://github.com/cms-sw/cmssw/issues/31258#issuecomment-683773504, this PR proposes to fix a logic bug in the code that assumes `std::sort()`  to be stable (it is not) by combining the two comparison operations into one, and replacing the function structs with lambdas.
> 
> For consistency this PR also changes the subsequent call to `std::unique()` to use a lambda instead of function object.
> 

#### PR validation:

The crash reported in #31410 disappears, limited matrix runs.
