### PR TITLE
Remove unused MVA parameters from GsfElectronProducer

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -137,10 +137,6 @@ public:
     bool isEndcaps;
     bool isFiducial;
 
-    // BDT output (if available)
-    double minMVA;
-    double minMvaByPassForIsolated;
-
     // transverse impact parameter wrt beam spot
     double maxTIP;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -205,8 +205,6 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
     psd0.add<bool>("isFiducial", false);
     psd0.add<bool>("seedFromTEC", true);
     psd0.add<double>("maxTIP", 999999999.0);
-    psd0.add<double>("minMVA", -0.4);
-    psd0.add<double>("minMvaByPassForIsolated", -0.4);
     // preselection parameters
     desc.add<edm::ParameterSetDescription>("preselection", psd0);
   }
@@ -271,8 +269,6 @@ namespace {
         .isBarrel = pset.getParameter<bool>("isBarrel"),
         .isEndcaps = pset.getParameter<bool>("isEndcaps"),
         .isFiducial = pset.getParameter<bool>("isFiducial"),
-        .minMVA = pset.getParameter<double>("minMVA"),
-        .minMvaByPassForIsolated = pset.getParameter<double>("minMvaByPassForIsolated"),
         .maxTIP = pset.getParameter<double>("maxTIP"),
         .seedFromTEC = pset.getParameter<bool>("seedFromTEC"),
     };


### PR DESCRIPTION
#### PR description:

Title says it all. These configuration parameters have just confused us in EGM when comparing working points, so it's better to remove them.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
