### PR TITLE
TrackBase: Reduce number of operations such as divisions, sqrts and multiplications

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -220,8 +220,14 @@ namespace reco {
     /// dz parameter (= dsz/cos(lambda)). This is the track z0 w.r.t (0,0,0) only if the refPoint is close to (0,0,0). See also function dz(myBeamSpot)
     double dz() const;
 
+    /// momentum vector magnitude square
+    double p2() const;
+
     /// momentum vector magnitude
     double p() const;
+
+    /// track transverse momentum square
+    double pt2() const;
 
     /// track transverse momentum
     double pt() const;
@@ -602,16 +608,29 @@ namespace reco {
   inline double TrackBase::d0() const { return -dxy(); }
 
   // dsz parameter (THIS IS NOT the SZ impact parameter to (0,0,0) if refPoint is far from (0,0,0): see parametrization definition above for details)
-  inline double TrackBase::dsz() const { return vz() * pt() / p() - (vx() * px() + vy() * py()) / pt() * pz() / p(); }
+  inline double TrackBase::dsz() const {
+    const auto thepinv = 1/p();
+    const auto theptoverp = pt() * thepinv;
+    return vz() * theptoverp - (vx() * px() + vy() * py()) / pt() * pz() * thepinv;
+  }
 
   // dz parameter (= dsz/cos(lambda)). This is the track z0 w.r.t (0,0,0) only if the refPoint is close to (0,0,0). See also function dz(myBeamSpot) below.
-  inline double TrackBase::dz() const { return vz() - (vx() * px() + vy() * py()) / pt() * (pz() / pt()); }
+  inline double TrackBase::dz() const {
+    const auto thept2inv = 1  / pt2();
+    return vz() - (vx() * px() + vy() * py()) * pz() * thept2inv;
+  }
+
+  // momentum vector magnitude square
+  inline double TrackBase::p2() const { return momentum_.Mag2(); }
 
   // momentum vector magnitude
-  inline double TrackBase::p() const { return momentum_.R(); }
+  inline double TrackBase::p() const { return sqrt(p2()); }
+
+  // track transverse momentum square
+  inline double TrackBase::pt2() const { return momentum_.Perp2(); }
 
   // track transverse momentum
-  inline double TrackBase::pt() const { return sqrt(momentum_.Perp2()); }
+  inline double TrackBase::pt() const { return sqrt(pt2()); }
 
   // x coordinate of momentum vector
   inline double TrackBase::px() const { return momentum_.x(); }
@@ -668,16 +687,19 @@ namespace reco {
   // (WARNING: this quantity can only be interpreted as the distance in the S-Z plane to the beamSpot, if the beam spot is reasonably close to the refPoint, since linear approximations are involved).
   // This is a good approximation for Tracker tracks.
   inline double TrackBase::dsz(const Point &myBeamSpot) const {
-    return (vz() - myBeamSpot.z()) * pt() / p() -
-           ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) / pt() * pz() / p();
+    const auto theptoverp = sqrt ( pt2() / p2() );
+    const auto thepinv = 1/p();
+    return (vz() - myBeamSpot.z()) * theptoverp -
+           ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) / pt() * pz() * thepinv;
   }
 
   // dz parameter with respect to a user-given beamSpot
   // (WARNING: this quantity can only be interpreted as the track z0, if the beamSpot is reasonably close to the refPoint, since linear approximations are involved).
   // This is a good approximation for Tracker tracks.
   inline double TrackBase::dz(const Point &myBeamSpot) const {
+    const auto theptinv2 = 1/pt2();
     return (vz() - myBeamSpot.z()) -
-           ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) / pt() * pz() / pt();
+           ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) * pz() * theptinv2;
   }
 
   // Track parameters with one-to-one correspondence to the covariance matrix
@@ -706,10 +728,23 @@ namespace reco {
 
   // error on Pt (set to 1000 TeV if charge==0 for safety)
   inline double TrackBase::ptError() const {
-    return (charge() != 0) ? sqrt(pt() * pt() * p() * p() / charge() / charge() * covariance(i_qoverp, i_qoverp) +
-                                  2 * pt() * p() / charge() * pz() * covariance(i_qoverp, i_lambda) +
-                                  pz() * pz() * covariance(i_lambda, i_lambda))
-                           : 1.e6;
+    const auto thecharge = charge();
+
+    if (thecharge != 0) {
+
+      const auto thept2 = pt2();
+      const auto thep2 = p2();
+      const auto thepz = pz();
+      const auto ptimespt = sqrt( thep2 * thept2 );
+      const auto oneovercharge = 1/thecharge;
+
+      return sqrt(thept2 * thep2 * oneovercharge * oneovercharge * covariance(i_qoverp, i_qoverp) +
+                  2 * ptimespt * oneovercharge * thepz * covariance(i_qoverp, i_lambda) +
+                  thepz * thepz * covariance(i_lambda, i_lambda));
+    }
+
+    return 1.e6;
+
   }
 
   // error on theta
@@ -719,7 +754,7 @@ namespace reco {
   inline double TrackBase::lambdaError() const { return error(i_lambda); }
 
   // error on eta
-  inline double TrackBase::etaError() const { return error(i_lambda) * p() / pt(); }
+  inline double TrackBase::etaError() const { return error(i_lambda) * sqrt( p2() / pt2() ); }
 
   // error on phi
   inline double TrackBase::phiError() const { return error(i_phi); }
@@ -734,7 +769,7 @@ namespace reco {
   inline double TrackBase::dszError() const { return error(i_dsz); }
 
   // error on dz
-  inline double TrackBase::dzError() const { return error(i_dsz) * p() / pt(); }
+  inline double TrackBase::dzError() const { return error(i_dsz) * sqrt( p2() / pt2() ); }
 
   // covariance of t0
   inline double TrackBase::covt0t0() const { return covt0t0_; }
@@ -778,11 +813,13 @@ namespace reco {
     int lostIn = hitPattern_.numberOfLostTrackerHits(HitPattern::MISSING_INNER_HITS);
     int lostOut = hitPattern_.numberOfLostTrackerHits(HitPattern::MISSING_OUTER_HITS);
 
-    if ((valid + lost + lostIn + lostOut) == 0) {
+    const auto tot = valid + lost + lostIn + lostOut;
+
+    if ( tot  == 0) {
       return -1;
     }
 
-    return valid / (double)(valid + lost + lostIn + lostOut);
+    return valid / (double)(tot);
   }
 
   //Track algorithm

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -609,14 +609,14 @@ namespace reco {
 
   // dsz parameter (THIS IS NOT the SZ impact parameter to (0,0,0) if refPoint is far from (0,0,0): see parametrization definition above for details)
   inline double TrackBase::dsz() const {
-    const auto thepinv = 1/p();
+    const auto thepinv = 1 / p();
     const auto theptoverp = pt() * thepinv;
     return vz() * theptoverp - (vx() * px() + vy() * py()) / pt() * pz() * thepinv;
   }
 
   // dz parameter (= dsz/cos(lambda)). This is the track z0 w.r.t (0,0,0) only if the refPoint is close to (0,0,0). See also function dz(myBeamSpot) below.
   inline double TrackBase::dz() const {
-    const auto thept2inv = 1  / pt2();
+    const auto thept2inv = 1 / pt2();
     return vz() - (vx() * px() + vy() * py()) * pz() * thept2inv;
   }
 
@@ -687,8 +687,8 @@ namespace reco {
   // (WARNING: this quantity can only be interpreted as the distance in the S-Z plane to the beamSpot, if the beam spot is reasonably close to the refPoint, since linear approximations are involved).
   // This is a good approximation for Tracker tracks.
   inline double TrackBase::dsz(const Point &myBeamSpot) const {
-    const auto theptoverp = sqrt ( pt2() / p2() );
-    const auto thepinv = 1/p();
+    const auto theptoverp = sqrt(pt2() / p2());
+    const auto thepinv = 1 / p();
     return (vz() - myBeamSpot.z()) * theptoverp -
            ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) / pt() * pz() * thepinv;
   }
@@ -697,7 +697,7 @@ namespace reco {
   // (WARNING: this quantity can only be interpreted as the track z0, if the beamSpot is reasonably close to the refPoint, since linear approximations are involved).
   // This is a good approximation for Tracker tracks.
   inline double TrackBase::dz(const Point &myBeamSpot) const {
-    const auto theptinv2 = 1/pt2();
+    const auto theptinv2 = 1 / pt2();
     return (vz() - myBeamSpot.z()) -
            ((vx() - myBeamSpot.x()) * px() + (vy() - myBeamSpot.y()) * py()) * pz() * theptinv2;
   }
@@ -731,12 +731,11 @@ namespace reco {
     const auto thecharge = charge();
 
     if (thecharge != 0) {
-
       const auto thept2 = pt2();
       const auto thep2 = p2();
       const auto thepz = pz();
-      const auto ptimespt = sqrt( thep2 * thept2 );
-      const auto oneovercharge = 1/thecharge;
+      const auto ptimespt = sqrt(thep2 * thept2);
+      const auto oneovercharge = 1 / thecharge;
 
       return sqrt(thept2 * thep2 * oneovercharge * oneovercharge * covariance(i_qoverp, i_qoverp) +
                   2 * ptimespt * oneovercharge * thepz * covariance(i_qoverp, i_lambda) +
@@ -744,7 +743,6 @@ namespace reco {
     }
 
     return 1.e6;
-
   }
 
   // error on theta
@@ -754,7 +752,7 @@ namespace reco {
   inline double TrackBase::lambdaError() const { return error(i_lambda); }
 
   // error on eta
-  inline double TrackBase::etaError() const { return error(i_lambda) * sqrt( p2() / pt2() ); }
+  inline double TrackBase::etaError() const { return error(i_lambda) * sqrt(p2() / pt2()); }
 
   // error on phi
   inline double TrackBase::phiError() const { return error(i_phi); }
@@ -769,7 +767,7 @@ namespace reco {
   inline double TrackBase::dszError() const { return error(i_dsz); }
 
   // error on dz
-  inline double TrackBase::dzError() const { return error(i_dsz) * sqrt( p2() / pt2() ); }
+  inline double TrackBase::dzError() const { return error(i_dsz) * sqrt(p2() / pt2()); }
 
   // covariance of t0
   inline double TrackBase::covt0t0() const { return covt0t0_; }
@@ -815,7 +813,7 @@ namespace reco {
 
     const auto tot = valid + lost + lostIn + lostOut;
 
-    if ( tot  == 0) {
+    if (tot == 0) {
       return -1;
     }
 


### PR DESCRIPTION
Performance optimisation: reduce number of operations such as divisions, sqrts and multiplications

#### PR description:
No change in the output, no dependency on other PRs.

This is a proposal to contribute to the discussion of this issue https://github.com/cms-sw/cmssw/issues/31326 .

The speedup in the event loop for CMSSW_11_2_0_pre5 is of about ~2%. However this performance improvement is not enough alone. More work would be needed to remove all the places in the code where things like `myTrack->ptError()/mytrack->pt()` are used (e.g. in pf muon reco) by implementing a method such as `ptErrorOverPt()` to avoid more divisions and sqrts.
