### PR TITLE
Fix L1T EG Phase2 Track match

### DIFF
--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -13,10 +13,16 @@ namespace L1TkElectronTrackMatchAlgo {
                double& dph,
                double& dr,
                double& deta);
+  void doMatchClusterET(BXVector<l1t::EGamma>::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta);
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta);
 
   double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
   double deltaPhi(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
+  double deltaPhiClusterET(BXVector<l1t::EGamma>::const_iterator egIter, const edm::Ptr<L1TTTrackType>& pTrk);
   double deltaEta(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);
   GlobalPoint calorimeterPosition(double phi, double eta, double e);
 

--- a/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
+++ b/L1Trigger/L1TTrackMatch/interface/L1TkElectronTrackMatchAlgo.h
@@ -14,10 +14,10 @@ namespace L1TkElectronTrackMatchAlgo {
                double& dr,
                double& deta);
   void doMatchClusterET(BXVector<l1t::EGamma>::const_iterator egIter,
-               const edm::Ptr<L1TTTrackType>& pTrk,
-               double& dph,
-               double& dr,
-               double& deta);
+                        const edm::Ptr<L1TTTrackType>& pTrk,
+                        double& dph,
+                        double& dr,
+                        double& deta);
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta);
 
   double deltaR(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -89,7 +89,7 @@ private:
 
   float trkQualityChi2_;
   bool useTwoStubsPT_;
-  bool useClusterET_;  // use cluster et to extrapolate tracks  
+  bool useClusterET_;  // use cluster et to extrapolate tracks
   float trkQualityPtMin_;
   std::vector<double> dPhiCutoff_;
   std::vector<double> dRCutoff_;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkElectronTrackProducer.cc
@@ -89,6 +89,7 @@ private:
 
   float trkQualityChi2_;
   bool useTwoStubsPT_;
+  bool useClusterET_;  // use cluster et to extrapolate tracks  
   float trkQualityPtMin_;
   std::vector<double> dPhiCutoff_;
   std::vector<double> dRCutoff_;
@@ -130,6 +131,7 @@ L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iC
   trkQualityChi2_ = (float)iConfig.getParameter<double>("TrackChi2");
   trkQualityPtMin_ = (float)iConfig.getParameter<double>("TrackMinPt");
   useTwoStubsPT_ = iConfig.getParameter<bool>("useTwoStubsPT");
+  useClusterET_ = iConfig.getParameter<bool>("useClusterET");
   dPhiCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaPhi");
   dRCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaR");
   dEtaCutoff_ = iConfig.getParameter<std::vector<double> >("TrackEGammaDeltaEta");
@@ -202,7 +204,10 @@ void L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetu
         double dPhi = 99.;
         double dR = 99.;
         double dEta = 99.;
-        L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta);
+        if (useClusterET_)
+          L1TkElectronTrackMatchAlgo::doMatchClusterET(egIter, L1TrackPtr, dPhi, dR, dEta);
+        else
+          L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta);
         if (dR < drmin && selectMatchedTrack(dR, dPhi, dEta, trkPt, eta_ele)) {
           drmin = dR;
           itrack = itr;

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -11,14 +11,14 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     # Quality cuts on Track and Track L1EG matching criteria
     TrackChi2           = cms.double(1e10), # minimum Chi2 to select tracks
     TrackMinPt          = cms.double(10.0), # minimum Pt to select tracks
-	useTwoStubsPT       = cms.bool( False ),
+    useTwoStubsPT       = cms.bool( False ),
+    useClusterET       = cms.bool( False ),
     TrackEGammaMatchType = cms.string("PtDependentCut"),
     TrackEGammaDeltaPhi = cms.vdouble(0.07, 0.0, 0.0), # functional Delta Phi cut parameters to match Track with L1EG objects
     TrackEGammaDeltaR   = cms.vdouble(0.08, 0.0, 0.0), # functional Delta R cut parameters to match Track with L1EG objects
-    # Delta Eta cutoff to match Track with L1EG objects
-    # are considered. (unused in default configuration)
-    TrackEGammaDeltaEta = cms.vdouble(1e10, 0.0, 0.0), 
-	  RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
+    TrackEGammaDeltaEta = cms.vdouble(1e10, 0.0, 0.0), # Delta Eta cutoff to match Track with L1EG objects
+                                                       # are considered. (unused in default configuration)
+    RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
 						# else absolute.
     # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
     # the isolation is below RelIsoCut are written into
@@ -79,10 +79,10 @@ L1TkElectronsHGC=L1TkElectrons.clone(
 
 
 L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
-#     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
-    TrackEGammaMatchType = cms.string("EllipticalCut"),
-    TrackEGammaDeltaEta = cms.vdouble(0.0075, 0.0075,1e10),
-    maxChi2IsoTracks = cms.double(100),
+    # L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
+    TrackEGammaMatchType = cms.string("EllipticalCut")
+    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10)
+    maxChi2IsoTracks = cms.double(100)
     minNStubsIsoTracks = cms.int32(4)
 )
 

--- a/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkElectronTrackProducer_cfi.py
@@ -6,7 +6,7 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     L1EGammaInputTag = cms.InputTag("simCaloStage2Digis",""),
     # Only the L1EG objects that have ET > ETmin in GeV
     # are considered. ETmin < 0 means that no cut is applied.
-    ETmin = cms.double( -1.0 ),             
+    ETmin = cms.double( -1.0 ),
     L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"),
     # Quality cuts on Track and Track L1EG matching criteria
     TrackChi2           = cms.double(1e10), # minimum Chi2 to select tracks
@@ -25,7 +25,7 @@ L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
     # the output collection. When RelIsoCut < 0, no cut is applied.
 		# When RelativeIsolation = False, IsoCut is in GeV.
     # Determination of the isolation w.r.t. L1Tracks :
-    IsoCut = cms.double( -0.10 ), 		
+    IsoCut = cms.double( -0.10 ),
     PTMINTRA = cms.double( 2. ),	# in GeV
 	  DRmin = cms.double( 0.03),
 	  DRmax = cms.double( 0.2 ),
@@ -80,10 +80,10 @@ L1TkElectronsHGC=L1TkElectrons.clone(
 
 L1TkElectronsEllipticMatchHGC = L1TkElectronsHGC.clone(
     # L1TrackInputTag = cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks")
-    TrackEGammaMatchType = cms.string("EllipticalCut")
-    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10)
-    maxChi2IsoTracks = cms.double(100)
-    minNStubsIsoTracks = cms.int32(4)
+    TrackEGammaMatchType = cms.string("EllipticalCut"),
+    TrackEGammaDeltaEta = cms.vdouble(0.01, 0.01,1e10),
+    maxChi2IsoTracks = cms.double(100),
+    minNStubsIsoTracks = cms.int32(4),
 )
 
 

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -33,10 +33,10 @@ namespace L1TkElectronTrackMatchAlgo {
   }
   // ------------ match EGamma and Track
   void doMatchClusterET(l1t::EGammaBxCollection::const_iterator egIter,
-               const edm::Ptr<L1TTTrackType>& pTrk,
-               double& dph,
-               double& dr,
-               double& deta) {
+                        const edm::Ptr<L1TTTrackType>& pTrk,
+                        double& dph,
+                        double& dr,
+                        double& deta) {
     GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
     dph = L1TkElectronTrackMatchAlgo::deltaPhiClusterET(egIter, pTrk);
     dr = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
@@ -66,10 +66,10 @@ namespace L1TkElectronTrackMatchAlgo {
     double et = egIter->et();
     double pt = pTrk->momentum().perp();
     double curv = pTrk->rInv();
-        
+
     double dphi_curv = (asin(er * curv * pt / (2.0 * et)));
     double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
-        
+
     double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
     return dphi;
   }

--- a/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
+++ b/L1Trigger/L1TTrackMatch/src/L1TkElectronTrackMatchAlgo.cc
@@ -32,6 +32,17 @@ namespace L1TkElectronTrackMatchAlgo {
     deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
   }
   // ------------ match EGamma and Track
+  void doMatchClusterET(l1t::EGammaBxCollection::const_iterator egIter,
+               const edm::Ptr<L1TTTrackType>& pTrk,
+               double& dph,
+               double& dr,
+               double& deta) {
+    GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    dph = L1TkElectronTrackMatchAlgo::deltaPhiClusterET(egIter, pTrk);
+    dr = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
+  }
+  // ------------ match EGamma and Track
   void doMatch(const GlobalPoint& epos, const edm::Ptr<L1TTTrackType>& pTrk, double& dph, double& dr, double& deta) {
     dph = L1TkElectronTrackMatchAlgo::deltaPhi(epos, pTrk);
     dr = L1TkElectronTrackMatchAlgo::deltaR(epos, pTrk);
@@ -45,6 +56,20 @@ namespace L1TkElectronTrackMatchAlgo {
     double dphi_curv = (asin(er * curv / (2.0)));
     double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
 
+    double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
+    return dphi;
+  }
+  // --------------- use cluster et to extrapolate tracks
+  double deltaPhiClusterET(l1t::EGammaBxCollection::const_iterator egIter, const edm::Ptr<L1TTTrackType>& pTrk) {
+    GlobalPoint epos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    double er = epos.perp();
+    double et = egIter->et();
+    double pt = pTrk->momentum().perp();
+    double curv = pTrk->rInv();
+        
+    double dphi_curv = (asin(er * curv * pt / (2.0 * et)));
+    double trk_phi_ecal = reco::deltaPhi(pTrk->momentum().phi(), dphi_curv);
+        
     double dphi = reco::deltaPhi(trk_phi_ecal, epos.phi());
     return dphi;
   }
@@ -62,7 +87,7 @@ namespace L1TkElectronTrackMatchAlgo {
     double ez = epos.z();
     double z0 = pTrk->POCA().z();
     double theta = 0.0;
-    if (ez >= 0)
+    if (ez - z0 >= 0)
       theta = atan(er / fabs(ez - z0));
     else
       theta = M_PI - atan(er / fabs(ez - z0));


### PR DESCRIPTION
#### PR description:

The PR addresses a minor problem in the matching of L1 tracks & EG standalone objects (see [Jack Li talk @ EG L1 P2 meeting ](https://indico.cern.ch/event/933640/contributions/3923081/attachments/2066176/3467521/EgammaMeeting_30Jun.pdf) for details).

This is a "minimalistic" backport of https://github.com/cms-sw/cmssw/pull/31235 (stripping down EG validation code).

#### PR validation:

See the original PR for validation plots.

