### PR TITLE
Migrate ESProducers in Calib* and Cond* from setConsumes() to type-deducing consumes()

### DIFF
--- a/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
+++ b/CalibCalorimetry/CaloTPG/plugins/CaloTPGTranscoderULUTs.cc
@@ -106,7 +106,10 @@ CaloTPGTranscoderULUTs::CaloTPGTranscoderULUTs(const edm::ParameterSet& iConfig)
       lsbQIE11(iConfig.getParameter<edm::ParameterSet>("tpScales")
                    .getParameter<edm::ParameterSet>("HBHE")
                    .getParameter<double>("LSBQIE11")) {
-  setWhatProduced(this).setConsumes(lutMetadataToken).setConsumes(theTrigTowerGeometryToken).setConsumes(topoToken);
+  auto cc = setWhatProduced(this);
+  lutMetadataToken = cc.consumes();
+  theTrigTowerGeometryToken = cc.consumes();
+  topoToken = cc.consumes();
 }
 
 CaloTPGTranscoderULUTs::~CaloTPGTranscoderULUTs() {

--- a/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
+++ b/CalibCalorimetry/CastorCalib/plugins/CastorDbProducer.cc
@@ -79,14 +79,14 @@ CastorDbProducer::CastorDbProducer(const edm::ParameterSet& fConfig)
     : ESProducer(), mDumpRequest(), mDumpStream(nullptr) {
   //the following line is needed to tell the framework what
   // data is being produced
-  setWhatProduced(this)
-      .setConsumes(pedestalsToken_)
-      .setConsumes(pedestalWidthsToken_)
-      .setConsumes(gainsToken_)
-      .setConsumes(gainWidthsToken_)
-      .setConsumes(qieDataToken_)
-      .setConsumes(channelQualityToken_)
-      .setConsumes(electronicsMapToken_);
+  auto cc = setWhatProduced(this);
+  pedestalsToken_ = cc.consumes();
+  pedestalWidthsToken_ = cc.consumes();
+  gainsToken_ = cc.consumes();
+  gainWidthsToken_ = cc.consumes();
+  qieDataToken_ = cc.consumes();
+  channelQualityToken_ = cc.consumes();
+  electronicsMapToken_ = cc.consumes();
 
   //now do what ever other initialization is needed
 

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionService.cc
@@ -60,11 +60,11 @@ EcalLaserCorrectionService::EcalLaserCorrectionService(const edm::ParameterSet& 
   // data is being produced
   //  setWhatProduced (this, (dependsOn (&EcalLaserCorrectionService::apdpnCallback)));
 
-  setWhatProduced(this)
-      .setConsumes(alphaToken_)
-      .setConsumes(apdpnRefToken_)
-      .setConsumes(apdpnToken_)
-      .setConsumes(linearToken_);
+  auto cc = setWhatProduced(this);
+  alphaToken_ = cc.consumes();
+  apdpnRefToken_ = cc.consumes();
+  apdpnToken_ = cc.consumes();
+  linearToken_ = cc.consumes();
 
   maxExtrapolationTimeInSec_ = fConfig.getParameter<unsigned int>("maxExtrapolationTimeInSec");
 

--- a/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
+++ b/CalibCalorimetry/EcalLaserCorrection/plugins/EcalLaserCorrectionServiceMC.cc
@@ -50,11 +50,11 @@ EcalLaserCorrectionServiceMC::EcalLaserCorrectionServiceMC(const edm::ParameterS
   // data is being produced
   // setWhatProduced (this, (dependsOn (&EcalLaserCorrectionServiceMC::apdpnCallback)));
 
-  setWhatProduced(this)
-      .setConsumes(alphaToken_)
-      .setConsumes(apdpnRefToken_)
-      .setConsumes(apdpnToken_)
-      .setConsumes(linearToken_);
+  auto cc = setWhatProduced(this);
+  alphaToken_ = cc.consumes();
+  apdpnRefToken_ = cc.consumes();
+  apdpnToken_ = cc.consumes();
+  linearToken_ = cc.consumes();
 
   //now do what ever other initialization is needed
 }

--- a/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalDbProducer.cc
@@ -87,7 +87,7 @@ private:
         dumpName_ = "Effective" + dumpName_;
       }
     }
-    void setConsumes(edm::ESConsumesCollector& cc) { cc.setConsumes(token_, edm::ESInputTag{"", LABEL}); }
+    void setConsumes(edm::ESConsumesCollector& cc) { token_ = cc.consumes(edm::ESInputTag{"", LABEL}); }
     void setupHcalDbService(HostType& host,
                             const RecordType& record,
                             const std::vector<std::string>& dumpRequest,
@@ -148,7 +148,8 @@ private:
     TokenAndTopologyHolder() = default;
 
     void setConsumes(edm::ESConsumesCollector&& cc, const edm::ESInputTag& tag) {
-      cc.setConsumes(token_, tag).setConsumes(topoToken_);
+      token_ = cc.consumes(tag);
+      topoToken_ = cc.consumes();
     }
 
     const auto& token() const { return token_; }

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -196,86 +196,88 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations(const edm::ParameterSet& iCon
     std::cout << "Load parameters for " << objectName << std::endl;
 #endif
     if ((objectName == "Pedestals") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::producePedestals).setConsumes(topoTokens_[kPedestals]);
+      topoTokens_[kPedestals] = setWhatProduced(this, &HcalHardcodeCalibrations::producePedestals).consumes();
       findingRecord<HcalPedestalsRcd>();
     }
     if ((objectName == "PedestalWidths") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::producePedestalWidths).setConsumes(topoTokens_[kPedestalWidths]);
+      topoTokens_[kPedestalWidths] = setWhatProduced(this, &HcalHardcodeCalibrations::producePedestalWidths).consumes();
       findingRecord<HcalPedestalWidthsRcd>();
     }
     if ((objectName == "EffectivePedestals") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceEffectivePedestals, edm::es::Label("effective"))
-          .setConsumes(topoTokens_[kEffectivePedestals]);
+      topoTokens_[kEffectivePedestals] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceEffectivePedestals, edm::es::Label("effective"))
+              .consumes();
       findingRecord<HcalPedestalsRcd>();
     }
     if ((objectName == "EffectivePedestalWidths") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"))
-          .setConsumes(topoTokens_[kEffectivePedestalWidths]);
+      topoTokens_[kEffectivePedestalWidths] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"))
+              .consumes();
       findingRecord<HcalPedestalWidthsRcd>();
     }
     if ((objectName == "Gains") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceGains).setConsumes(topoTokens_[kGains]);
+      topoTokens_[kGains] = setWhatProduced(this, &HcalHardcodeCalibrations::produceGains).consumes();
       findingRecord<HcalGainsRcd>();
     }
     if ((objectName == "GainWidths") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceGainWidths).setConsumes(topoTokens_[kGainWidths]);
+      topoTokens_[kGainWidths] = setWhatProduced(this, &HcalHardcodeCalibrations::produceGainWidths).consumes();
       findingRecord<HcalGainWidthsRcd>();
     }
     if ((objectName == "QIEData") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceQIEData).setConsumes(topoTokens_[kQIEData]);
+      topoTokens_[kQIEData] = setWhatProduced(this, &HcalHardcodeCalibrations::produceQIEData).consumes();
       findingRecord<HcalQIEDataRcd>();
     }
     if ((objectName == "QIETypes") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceQIETypes).setConsumes(topoTokens_[kQIETypes]);
+      topoTokens_[kQIETypes] = setWhatProduced(this, &HcalHardcodeCalibrations::produceQIETypes).consumes();
       findingRecord<HcalQIETypesRcd>();
     }
     if ((objectName == "ChannelQuality") || (objectName == "channelQuality") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceChannelQuality).setConsumes(topoTokens_[kChannelQuality]);
+      topoTokens_[kChannelQuality] = setWhatProduced(this, &HcalHardcodeCalibrations::produceChannelQuality).consumes();
       findingRecord<HcalChannelQualityRcd>();
     }
     if ((objectName == "ElectronicsMap") || (objectName == "electronicsMap") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceElectronicsMap).setConsumes(topoTokens_[kElectronicsMap]);
+      topoTokens_[kElectronicsMap] = setWhatProduced(this, &HcalHardcodeCalibrations::produceElectronicsMap).consumes();
       findingRecord<HcalElectronicsMapRcd>();
     }
     if ((objectName == "ZSThresholds") || (objectName == "zsThresholds") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceZSThresholds).setConsumes(topoTokens_[kZSThresholds]);
+      topoTokens_[kZSThresholds] = setWhatProduced(this, &HcalHardcodeCalibrations::produceZSThresholds).consumes();
       findingRecord<HcalZSThresholdsRcd>();
     }
     if ((objectName == "RespCorrs") || (objectName == "ResponseCorrection") || all) {
       auto c = setWhatProduced(this, &HcalHardcodeCalibrations::produceRespCorrs);
-      c.setConsumes(topoTokens_[kRespCorrs]);
+      topoTokens_[kRespCorrs] = c.consumes();
       if (he_recalibration) {
-        c.setConsumes(heDarkeningToken_, edm::ESInputTag("", "HE"));
+        heDarkeningToken_ = c.consumes(edm::ESInputTag("", "HE"));
       }
       if (hb_recalibration) {
-        c.setConsumes(hbDarkeningToken_, edm::ESInputTag("", "HB"));
+        hbDarkeningToken_ = c.consumes(edm::ESInputTag("", "HB"));
       }
       findingRecord<HcalRespCorrsRcd>();
     }
     if ((objectName == "LUTCorrs") || (objectName == "LUTCorrection") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceLUTCorrs).setConsumes(topoTokens_[kLUTCorrs]);
+      topoTokens_[kLUTCorrs] = setWhatProduced(this, &HcalHardcodeCalibrations::produceLUTCorrs).consumes();
       findingRecord<HcalLUTCorrsRcd>();
     }
     if ((objectName == "PFCorrs") || (objectName == "PFCorrection") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::producePFCorrs).setConsumes(topoTokens_[kPFCorrs]);
+      topoTokens_[kPFCorrs] = setWhatProduced(this, &HcalHardcodeCalibrations::producePFCorrs).consumes();
       findingRecord<HcalPFCorrsRcd>();
     }
     if ((objectName == "TimeCorrs") || (objectName == "TimeCorrection") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceTimeCorrs).setConsumes(topoTokens_[kTimeCorrs]);
+      topoTokens_[kTimeCorrs] = setWhatProduced(this, &HcalHardcodeCalibrations::produceTimeCorrs).consumes();
       findingRecord<HcalTimeCorrsRcd>();
     }
     if ((objectName == "L1TriggerObjects") || (objectName == "L1Trigger") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceL1TriggerObjects)
-          .setConsumes(topoTokens_[kL1TriggerObjects]);
+      topoTokens_[kL1TriggerObjects] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceL1TriggerObjects).consumes();
       findingRecord<HcalL1TriggerObjectsRcd>();
     }
     if ((objectName == "ValidationCorrs") || (objectName == "ValidationCorrection") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceValidationCorrs)
-          .setConsumes(topoTokens_[kValidationCorrs]);
+      topoTokens_[kValidationCorrs] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceValidationCorrs).consumes();
       findingRecord<HcalValidationCorrsRcd>();
     }
     if ((objectName == "LutMetadata") || (objectName == "lutMetadata") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceLutMetadata).setConsumes(topoTokens_[kLutMetadata]);
+      topoTokens_[kLutMetadata] = setWhatProduced(this, &HcalHardcodeCalibrations::produceLutMetadata).consumes();
       findingRecord<HcalLutMetadataRcd>();
     }
     if ((objectName == "DcsValues") || all) {
@@ -287,33 +289,33 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations(const edm::ParameterSet& iCon
       findingRecord<HcalDcsMapRcd>();
     }
     if ((objectName == "RecoParams") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceRecoParams).setConsumes(topoTokens_[kRecoParams]);
+      topoTokens_[kRecoParams] = setWhatProduced(this, &HcalHardcodeCalibrations::produceRecoParams).consumes();
       findingRecord<HcalRecoParamsRcd>();
     }
     if ((objectName == "LongRecoParams") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceLongRecoParams).setConsumes(topoTokens_[kLongRecoParams]);
+      topoTokens_[kLongRecoParams] = setWhatProduced(this, &HcalHardcodeCalibrations::produceLongRecoParams).consumes();
       findingRecord<HcalLongRecoParamsRcd>();
     }
     if ((objectName == "ZDCLowGainFractions") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceZDCLowGainFractions)
-          .setConsumes(topoTokens_[kZDCLowGainFractions]);
+      topoTokens_[kZDCLowGainFractions] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceZDCLowGainFractions).consumes();
       findingRecord<HcalZDCLowGainFractionsRcd>();
     }
     if ((objectName == "MCParams") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceMCParams).setConsumes(topoTokens_[kMCParams]);
+      topoTokens_[kMCParams] = setWhatProduced(this, &HcalHardcodeCalibrations::produceMCParams).consumes();
       findingRecord<HcalMCParamsRcd>();
     }
     if ((objectName == "FlagHFDigiTimeParams") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceFlagHFDigiTimeParams)
-          .setConsumes(topoTokens_[kFlagHFDigiTimeParams]);
+      topoTokens_[kFlagHFDigiTimeParams] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceFlagHFDigiTimeParams).consumes();
       findingRecord<HcalFlagHFDigiTimeParamsRcd>();
     }
     if ((objectName == "FrontEndMap") || (objectName == "frontEndMap") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceFrontEndMap).setConsumes(topoTokens_[kFrontEndMap]);
+      topoTokens_[kFrontEndMap] = setWhatProduced(this, &HcalHardcodeCalibrations::produceFrontEndMap).consumes();
       findingRecord<HcalFrontEndMapRcd>();
     }
     if ((objectName == "SiPMParameters") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceSiPMParameters).setConsumes(topoTokens_[kSiPMParameters]);
+      topoTokens_[kSiPMParameters] = setWhatProduced(this, &HcalHardcodeCalibrations::produceSiPMParameters).consumes();
       findingRecord<HcalSiPMParametersRcd>();
     }
     if ((objectName == "SiPMCharacteristics") || all) {
@@ -321,8 +323,8 @@ HcalHardcodeCalibrations::HcalHardcodeCalibrations(const edm::ParameterSet& iCon
       findingRecord<HcalSiPMCharacteristicsRcd>();
     }
     if ((objectName == "TPChannelParameters") || all) {
-      setWhatProduced(this, &HcalHardcodeCalibrations::produceTPChannelParameters)
-          .setConsumes(topoTokens_[kTPChannelParameters]);
+      topoTokens_[kTPChannelParameters] =
+          setWhatProduced(this, &HcalHardcodeCalibrations::produceTPChannelParameters).consumes();
       findingRecord<HcalTPChannelParametersRcd>();
     }
     if ((objectName == "TPParameters") || all) {

--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -36,52 +36,54 @@ HcalTextCalibrations::HcalTextCalibrations(const edm::ParameterSet& iConfig)
     mInputs[objectName] = fp.fullPath();
     //   std::cout << objectName << " with file " << fp.fullPath() << std::endl;
     if (objectName == "Pedestals") {
-      setWhatProduced(this, &HcalTextCalibrations::producePedestals).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::producePedestals).consumes();
       findingRecord<HcalPedestalsRcd>();
     } else if (objectName == "PedestalWidths") {
-      setWhatProduced(this, &HcalTextCalibrations::producePedestalWidths).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::producePedestalWidths).consumes();
       findingRecord<HcalPedestalWidthsRcd>();
     } else if (objectName == "EffectivePedestals") {
-      setWhatProduced(this, &HcalTextCalibrations::produceEffectivePedestals, edm::es::Label("effective"))
-          .setConsumes(mTokens[objectName]);
+      mTokens[objectName] =
+          setWhatProduced(this, &HcalTextCalibrations::produceEffectivePedestals, edm::es::Label("effective"))
+              .consumes();
       findingRecord<HcalPedestalsRcd>();
     } else if (objectName == "EffectivePedestalWidths") {
-      setWhatProduced(this, &HcalTextCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"))
-          .setConsumes(mTokens[objectName]);
+      mTokens[objectName] =
+          setWhatProduced(this, &HcalTextCalibrations::produceEffectivePedestalWidths, edm::es::Label("effective"))
+              .consumes();
       findingRecord<HcalPedestalWidthsRcd>();
     } else if (objectName == "Gains") {
-      setWhatProduced(this, &HcalTextCalibrations::produceGains).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceGains).consumes();
       findingRecord<HcalGainsRcd>();
     } else if (objectName == "GainWidths") {
-      setWhatProduced(this, &HcalTextCalibrations::produceGainWidths).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceGainWidths).consumes();
       findingRecord<HcalGainWidthsRcd>();
     } else if (objectName == "QIEData") {
-      setWhatProduced(this, &HcalTextCalibrations::produceQIEData).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceQIEData).consumes();
       findingRecord<HcalQIEDataRcd>();
     } else if (objectName == "QIETypes") {
-      setWhatProduced(this, &HcalTextCalibrations::produceQIETypes).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceQIETypes).consumes();
       findingRecord<HcalQIETypesRcd>();
     } else if (objectName == "ChannelQuality") {
-      setWhatProduced(this, &HcalTextCalibrations::produceChannelQuality, edm::es::Label("withTopo"))
-          .setConsumes(mTokens[objectName]);
+      mTokens[objectName] =
+          setWhatProduced(this, &HcalTextCalibrations::produceChannelQuality, edm::es::Label("withTopo")).consumes();
       findingRecord<HcalChannelQualityRcd>();
     } else if (objectName == "ZSThresholds") {
-      setWhatProduced(this, &HcalTextCalibrations::produceZSThresholds).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceZSThresholds).consumes();
       findingRecord<HcalZSThresholdsRcd>();
     } else if (objectName == "RespCorrs") {
-      setWhatProduced(this, &HcalTextCalibrations::produceRespCorrs).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceRespCorrs).consumes();
       findingRecord<HcalRespCorrsRcd>();
     } else if (objectName == "LUTCorrs") {
-      setWhatProduced(this, &HcalTextCalibrations::produceLUTCorrs).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceLUTCorrs).consumes();
       findingRecord<HcalLUTCorrsRcd>();
     } else if (objectName == "PFCorrs") {
-      setWhatProduced(this, &HcalTextCalibrations::producePFCorrs).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::producePFCorrs).consumes();
       findingRecord<HcalPFCorrsRcd>();
     } else if (objectName == "TimeCorrs") {
-      setWhatProduced(this, &HcalTextCalibrations::produceTimeCorrs).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceTimeCorrs).consumes();
       findingRecord<HcalTimeCorrsRcd>();
     } else if (objectName == "L1TriggerObjects") {
-      setWhatProduced(this, &HcalTextCalibrations::produceL1TriggerObjects).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceL1TriggerObjects).consumes();
       findingRecord<HcalL1TriggerObjectsRcd>();
     } else if (objectName == "ElectronicsMap") {
       setWhatProduced(this, &HcalTextCalibrations::produceElectronicsMap);
@@ -90,10 +92,10 @@ HcalTextCalibrations::HcalTextCalibrations(const edm::ParameterSet& iConfig)
       setWhatProduced(this, &HcalTextCalibrations::produceFrontEndMap);
       findingRecord<HcalFrontEndMapRcd>();
     } else if (objectName == "ValidationCorrs") {
-      setWhatProduced(this, &HcalTextCalibrations::produceValidationCorrs).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceValidationCorrs).consumes();
       findingRecord<HcalValidationCorrsRcd>();
     } else if (objectName == "LutMetadata") {
-      setWhatProduced(this, &HcalTextCalibrations::produceLutMetadata).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceLutMetadata).consumes();
       findingRecord<HcalLutMetadataRcd>();
     } else if (objectName == "DcsValues") {
       setWhatProduced(this, &HcalTextCalibrations::produceDcsValues);
@@ -102,31 +104,31 @@ HcalTextCalibrations::HcalTextCalibrations(const edm::ParameterSet& iConfig)
       setWhatProduced(this, &HcalTextCalibrations::produceDcsMap);
       findingRecord<HcalDcsMapRcd>();
     } else if (objectName == "RecoParams") {
-      setWhatProduced(this, &HcalTextCalibrations::produceRecoParams).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceRecoParams).consumes();
       findingRecord<HcalRecoParamsRcd>();
     } else if (objectName == "TimingParams") {
-      setWhatProduced(this, &HcalTextCalibrations::produceTimingParams).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceTimingParams).consumes();
       findingRecord<HcalTimingParamsRcd>();
     } else if (objectName == "LongRecoParams") {
-      setWhatProduced(this, &HcalTextCalibrations::produceLongRecoParams).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceLongRecoParams).consumes();
       findingRecord<HcalLongRecoParamsRcd>();
     } else if (objectName == "ZDCLowGainFractions") {
-      setWhatProduced(this, &HcalTextCalibrations::produceZDCLowGainFractions).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceZDCLowGainFractions).consumes();
       findingRecord<HcalZDCLowGainFractionsRcd>();
     } else if (objectName == "MCParams") {
-      setWhatProduced(this, &HcalTextCalibrations::produceMCParams).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceMCParams).consumes();
       findingRecord<HcalMCParamsRcd>();
     } else if (objectName == "FlagHFDigiTimeParams") {
-      setWhatProduced(this, &HcalTextCalibrations::produceFlagHFDigiTimeParams).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceFlagHFDigiTimeParams).consumes();
       findingRecord<HcalFlagHFDigiTimeParamsRcd>();
     } else if (objectName == "SiPMParameters") {
-      setWhatProduced(this, &HcalTextCalibrations::produceSiPMParameters).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceSiPMParameters).consumes();
       findingRecord<HcalSiPMParametersRcd>();
     } else if (objectName == "SiPMCharacteristics") {
       setWhatProduced(this, &HcalTextCalibrations::produceSiPMCharacteristics);
       findingRecord<HcalSiPMCharacteristicsRcd>();
     } else if (objectName == "TPChannelParameters") {
-      setWhatProduced(this, &HcalTextCalibrations::produceTPChannelParameters).setConsumes(mTokens[objectName]);
+      mTokens[objectName] = setWhatProduced(this, &HcalTextCalibrations::produceTPChannelParameters).consumes();
       findingRecord<HcalTPChannelParametersRcd>();
     } else if (objectName == "TPParameters") {
       setWhatProduced(this, &HcalTextCalibrations::produceTPParameters);

--- a/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
+++ b/CalibCalorimetry/HcalTPGEventSetup/src/HcalTPGCoderULUT.cc
@@ -84,7 +84,8 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
   //the following line is needed to tell the framework what
   // data is being produced
   auto cc = setWhatProduced(this);
-  cc.setConsumes(topoToken_).setConsumes(delayToken_, edm::ESInputTag{"", "HBHE"});
+  topoToken_ = cc.consumes();
+  delayToken_ = cc.consumes(edm::ESInputTag{"", "HBHE"});
 
   if (!(read_Ascii_ || read_XML_)) {
     LUTGenerationMode_ = iConfig.getParameter<bool>("LUTGenerationMode");
@@ -95,7 +96,7 @@ HcalTPGCoderULUT::HcalTPGCoderULUT(const edm::ParameterSet& iConfig) {
     linearLSB_QIE11Overlap_ = scales.getParameter<double>("LSBQIE11Overlap");
     maskBit_ = iConfig.getParameter<int>("MaskBit");
     FG_HF_thresholds_ = iConfig.getParameter<std::vector<uint32_t> >("FG_HF_thresholds");
-    cc.setConsumes(serviceToken_);
+    serviceToken_ = cc.consumes();
   } else {
     ifilename_ = iConfig.getParameter<edm::FileInPath>("inputLUTs");
   }

--- a/CalibPPS/ESProducers/plugins/CTPPSBeamParametersFromLHCInfoESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSBeamParametersFromLHCInfoESSource.cc
@@ -31,14 +31,16 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
+  const edm::ESGetToken<LHCInfo, LHCInfoRcd> lhcInfoToken_;
 
   CTPPSBeamParameters defaultParameters_;
 };
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSBeamParametersFromLHCInfoESSource::CTPPSBeamParametersFromLHCInfoESSource(const edm::ParameterSet& iConfig) {
+CTPPSBeamParametersFromLHCInfoESSource::CTPPSBeamParametersFromLHCInfoESSource(const edm::ParameterSet& iConfig)
+    : lhcInfoToken_(
+          setWhatProduced(this).consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")))) {
   defaultParameters_.setBeamDivergenceX45(iConfig.getParameter<double>("beamDivX45"));
   defaultParameters_.setBeamDivergenceY45(iConfig.getParameter<double>("beamDivX56"));
   defaultParameters_.setBeamDivergenceX56(iConfig.getParameter<double>("beamDivY45"));
@@ -54,9 +56,6 @@ CTPPSBeamParametersFromLHCInfoESSource::CTPPSBeamParametersFromLHCInfoESSource(c
   defaultParameters_.setVtxStddevX(iConfig.getParameter<double>("vtxStddevX"));
   defaultParameters_.setVtxStddevY(iConfig.getParameter<double>("vtxStddevY"));
   defaultParameters_.setVtxStddevZ(iConfig.getParameter<double>("vtxStddevZ"));
-
-  setWhatProduced(this).setConsumes(lhcInfoToken_,
-                                    edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")));
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
+++ b/CalibPPS/ESProducers/plugins/CTPPSInterpolatedOpticalFunctionsESSource.cc
@@ -38,9 +38,9 @@ private:
 
 CTPPSInterpolatedOpticalFunctionsESSource::CTPPSInterpolatedOpticalFunctionsESSource(const edm::ParameterSet &iConfig)
     : currentCrossingAngle_(-1.), currentDataValid_(false) {
-  setWhatProduced(this, iConfig.getParameter<std::string>("opticsLabel"))
-      .setConsumes(opticsToken_, edm::ESInputTag("", iConfig.getParameter<std::string>("opticsLabel")))
-      .setConsumes(lhcInfoToken_, edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")));
+  auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("opticsLabel"));
+  opticsToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("opticsLabel")));
+  lhcInfoToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("lhcInfoLabel")));
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
+++ b/CalibTracker/SiPhase2TrackerESProducers/plugins/SiPhase2OuterTrackerFakeLorentzAngleESSource.cc
@@ -30,14 +30,14 @@ SiPhase2OuterTrackerFakeLorentzAngleESSource::SiPhase2OuterTrackerFakeLorentzAng
   // the following line is needed to tell the framework what
   // data is being produced
   if (recordName_ == "LorentzAngle") {
-    setWhatProduced(this, &SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTLA)
-        .setConsumes(m_tTopoToken)
-        .setConsumes(m_geomDetToken);
+    auto cc = setWhatProduced(this, &SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTLA);
+    m_tTopoToken = cc.consumes();
+    m_geomDetToken = cc.consumes();
     findingRecord<SiPhase2OuterTrackerLorentzAngleRcd>();
   } else if (recordName_ == "SimLorentzAngle") {
-    setWhatProduced(this, &SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTSimLA)
-        .setConsumes(m_tTopoToken)
-        .setConsumes(m_geomDetToken);
+    auto cc = setWhatProduced(this, &SiPhase2OuterTrackerFakeLorentzAngleESSource::produceOTSimLA);
+    m_tTopoToken = cc.consumes();
+    m_geomDetToken = cc.consumes();
     findingRecord<SiPhase2OuterTrackerLorentzAngleSimRcd>();
   }
 }

--- a/CalibTracker/SiPixelESProducers/plugins/PixelFEDChannelCollectionProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/PixelFEDChannelCollectionProducer.cc
@@ -47,16 +47,11 @@ public:
 
 private:
   // ----------member data ---------------------------
-  edm::ESGetToken<SiPixelFEDChannelContainer, SiPixelStatusScenariosRcd> qualityToken_;
+  const edm::ESGetToken<SiPixelFEDChannelContainer, SiPixelStatusScenariosRcd> qualityToken_;
 };
 
-PixelFEDChannelCollectionProducer::PixelFEDChannelCollectionProducer(const edm::ParameterSet& iConfig) {
-  //the following line is needed to tell the framework what
-  // data is being produced
-  setWhatProduced(this).setConsumes(qualityToken_);
-
-  //now do what ever other initialization is needed
-}
+PixelFEDChannelCollectionProducer::PixelFEDChannelCollectionProducer(const edm::ParameterSet& iConfig)
+    : qualityToken_(setWhatProduced(this).consumes()) {}
 
 PixelFEDChannelCollectionProducer::~PixelFEDChannelCollectionProducer() {
   // do anything here that needs to be done at destruction time

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -40,9 +40,9 @@ private:
 };
 
 SiPixel2DTemplateDBObjectESProducer::SiPixel2DTemplateDBObjectESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this)
-      .setConsumes(magfieldToken_)
-      .setConsumes(dbToken_, edm::ESInputTag{"", "numerator"});  // The correct default
+  auto cc = setWhatProduced(this);
+  magfieldToken_ = cc.consumes();
+  dbToken_ = cc.consumes(edm::ESInputTag{"", "numerator"});  // The correct default
 }
 
 SiPixel2DTemplateDBObjectESProducer::~SiPixel2DTemplateDBObjectESProducer() {}

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelGenErrorDBObjectESProducer.cc
@@ -40,32 +40,31 @@ private:
 };
 
 SiPixelGenErrorDBObjectESProducer::SiPixelGenErrorDBObjectESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this)
-      .setMayConsume(
-          genErrorToken_,
-          [](const auto& get, edm::ESTransientHandle<MagneticField> iMagfield) {
-            const GlobalPoint center(0.0, 0.0, 0.0);
-            const float theMagField = iMagfield->inTesla(center).mag();
-            if (theMagField >= -0.1 && theMagField < 1.0)
-              return get("", "0T");
-            else if (theMagField >= 1.0 && theMagField < 2.5)
-              return get("", "2T");
-            else if (theMagField >= 2.5 && theMagField < 3.25)
-              return get("", "3T");
-            else if (theMagField >= 3.25 && theMagField < 3.65)
-              return get("", "35T");
-            else if (theMagField >= 3.9 && theMagField < 4.1)
-              return get("", "4T");
-            else {
-              if (theMagField >= 4.1 || theMagField < -0.1)
-                edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixelGenError")
-                    << "Magnetic field is " << theMagField;
-              //return get("", "3.8T");
-              return get("", "");
-            }
-          },
-          edm::ESProductTag<MagneticField, IdealMagneticFieldRecord>("", ""))
-      .setConsumes(magfieldToken_);
+  auto cc = setWhatProduced(this);
+  cc.setMayConsume(
+      genErrorToken_,
+      [](const auto& get, edm::ESTransientHandle<MagneticField> iMagfield) {
+        const GlobalPoint center(0.0, 0.0, 0.0);
+        const float theMagField = iMagfield->inTesla(center).mag();
+        if (theMagField >= -0.1 && theMagField < 1.0)
+          return get("", "0T");
+        else if (theMagField >= 1.0 && theMagField < 2.5)
+          return get("", "2T");
+        else if (theMagField >= 2.5 && theMagField < 3.25)
+          return get("", "3T");
+        else if (theMagField >= 3.25 && theMagField < 3.65)
+          return get("", "35T");
+        else if (theMagField >= 3.9 && theMagField < 4.1)
+          return get("", "4T");
+        else {
+          if (theMagField >= 4.1 || theMagField < -0.1)
+            edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixelGenError") << "Magnetic field is " << theMagField;
+          //return get("", "3.8T");
+          return get("", "");
+        }
+      },
+      edm::ESProductTag<MagneticField, IdealMagneticFieldRecord>("", ""));
+  magfieldToken_ = cc.consumes();
 }
 
 std::shared_ptr<const SiPixelGenErrorDBObject> SiPixelGenErrorDBObjectESProducer::produce(

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelTemplateDBObjectESProducer.cc
@@ -41,32 +41,31 @@ private:
 };
 
 SiPixelTemplateDBObjectESProducer::SiPixelTemplateDBObjectESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this)
-      .setMayConsume(
-          templateToken_,
-          [](const auto& get, edm::ESTransientHandle<MagneticField> iMagfield) {
-            const GlobalPoint center(0.0, 0.0, 0.0);
-            const float theMagField = iMagfield->inTesla(center).mag();
-            if (theMagField >= -0.1 && theMagField < 1.0)
-              return get("", "0T");
-            else if (theMagField >= 1.0 && theMagField < 2.5)
-              return get("", "2T");
-            else if (theMagField >= 2.5 && theMagField < 3.25)
-              return get("", "3T");
-            else if (theMagField >= 3.25 && theMagField < 3.65)
-              return get("", "35T");
-            else if (theMagField >= 3.9 && theMagField < 4.1)
-              return get("", "4T");
-            else {
-              if (theMagField >= 4.1 || theMagField < -0.1)
-                edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixelTemplate")
-                    << "Magnetic field is " << theMagField;
-              //return get("", "3.8T");
-              return get("", "");
-            }
-          },
-          edm::ESProductTag<MagneticField, IdealMagneticFieldRecord>("", ""))
-      .setConsumes(magfieldToken_);
+  auto cc = setWhatProduced(this);
+  cc.setMayConsume(
+      templateToken_,
+      [](const auto& get, edm::ESTransientHandle<MagneticField> iMagfield) {
+        const GlobalPoint center(0.0, 0.0, 0.0);
+        const float theMagField = iMagfield->inTesla(center).mag();
+        if (theMagField >= -0.1 && theMagField < 1.0)
+          return get("", "0T");
+        else if (theMagField >= 1.0 && theMagField < 2.5)
+          return get("", "2T");
+        else if (theMagField >= 2.5 && theMagField < 3.25)
+          return get("", "3T");
+        else if (theMagField >= 3.25 && theMagField < 3.65)
+          return get("", "35T");
+        else if (theMagField >= 3.9 && theMagField < 4.1)
+          return get("", "4T");
+        else {
+          if (theMagField >= 4.1 || theMagField < -0.1)
+            edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixelTemplate") << "Magnetic field is " << theMagField;
+          //return get("", "3.8T");
+          return get("", "");
+        }
+      },
+      edm::ESProductTag<MagneticField, IdealMagneticFieldRecord>("", ""));
+  magfieldToken_ = cc.consumes();
 }
 
 std::shared_ptr<const SiPixelTemplateDBObject> SiPixelTemplateDBObjectESProducer::produce(

--- a/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/TkDetMapESProducer.cc
@@ -24,7 +24,9 @@ private:
 };
 
 TkDetMapESProducer::TkDetMapESProducer(const edm::ParameterSet&) {
-  setWhatProduced(this).setConsumes(tTopoToken_).setConsumes(geomDetToken_);
+  auto cc = setWhatProduced(this);
+  tTopoToken_ = cc.consumes();
+  geomDetToken_ = cc.consumes();
 }
 
 namespace {

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBackPlaneCorrectionFakeESSource.cc
@@ -45,7 +45,9 @@ private:
 };
 
 SiStripBackPlaneCorrectionFakeESSource::SiStripBackPlaneCorrectionFakeESSource(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(m_tTopoToken).setConsumes(m_geomDetToken);
+  auto cc = setWhatProduced(this);
+  m_tTopoToken = cc.consumes();
+  m_geomDetToken = cc.consumes();
   findingRecord<SiStripBackPlaneCorrectionRcd>();
 
   m_valuePerModuleGeometry = iConfig.getParameter<std::vector<double>>("BackPlaneCorrection_PerModuleGeometry");

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripBadModuleConfigurableFakeESSource.cc
@@ -45,7 +45,7 @@ private:
   bool m_printDebug;
   bool m_doByAPVs;
   SiStripDetInfoFileReader m_detInfoFileReader;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackTopoToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackTopoToken_;
 
   std::vector<uint32_t> selectDetectors(const TrackerTopology* tTopo, const std::vector<uint32_t>& detIds) const;
   std::vector<std::pair<uint32_t, std::vector<uint32_t>>> selectAPVs() const;
@@ -55,8 +55,8 @@ private:
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
 
-SiStripBadModuleConfigurableFakeESSource::SiStripBadModuleConfigurableFakeESSource(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(trackTopoToken_);
+SiStripBadModuleConfigurableFakeESSource::SiStripBadModuleConfigurableFakeESSource(const edm::ParameterSet& iConfig)
+    : trackTopoToken_(setWhatProduced(this).consumes()) {
   findingRecord<SiStripBadModuleRcd>();
 
   m_badComponentList = iConfig.getUntrackedParameter<Parameters>("BadComponentList");

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripHashedDetIdFakeESSource.cc
@@ -17,14 +17,13 @@ public:
   virtual std::unique_ptr<SiStripHashedDetId> produce(const SiStripHashedDetIdRcd&);
 
 private:
-  edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
 };
 
 using namespace sistrip;
 
-SiStripHashedDetIdFakeESSource::SiStripHashedDetIdFakeESSource(const edm::ParameterSet& pset) {
-  setWhatProduced(this).setConsumes(geomDetToken_);
-}
+SiStripHashedDetIdFakeESSource::SiStripHashedDetIdFakeESSource(const edm::ParameterSet& pset)
+    : geomDetToken_(setWhatProduced(this).consumes()) {}
 
 SiStripHashedDetIdFakeESSource::~SiStripHashedDetIdFakeESSource() {}
 

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripLorentzAngleFakeESSource.cc
@@ -113,7 +113,9 @@ namespace {  // helper methods
 }  // namespace
 
 SiStripLorentzAngleFakeESSource::SiStripLorentzAngleFakeESSource(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(m_tTopoToken).setConsumes(m_geomDetToken);
+  auto cc = setWhatProduced(this);
+  m_tTopoToken = cc.consumes();
+  m_geomDetToken = cc.consumes();
   findingRecord<SiStripLorentzAngleRcd>();
 
   m_TIB_EstimatedValuesMin = iConfig.getParameter<std::vector<double>>("TIB_EstimatedValuesMin");

--- a/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
+++ b/CalibTracker/SiStripESProducers/plugins/fake/SiStripNoisesFakeESSource.cc
@@ -41,7 +41,7 @@ public:
   ReturnType produce(const SiStripNoisesRcd&);
 
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_tTopoToken;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> m_tTopoToken;
   bool m_stripLengthMode;
   double m_noisePar0;
   SiStripFakeAPVParameters m_noisePar1;
@@ -61,8 +61,8 @@ namespace {  // helper methods
   }
 }  // namespace
 
-SiStripNoisesFakeESSource::SiStripNoisesFakeESSource(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(m_tTopoToken);
+SiStripNoisesFakeESSource::SiStripNoisesFakeESSource(const edm::ParameterSet& iConfig)
+    : m_tTopoToken(setWhatProduced(this).consumes()) {
   findingRecord<SiStripNoisesRcd>();
 
   m_stripLengthMode = iConfig.getParameter<bool>("StripLengthMode");

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripConnectivity.cc
@@ -18,13 +18,13 @@ public:
 
 private:
   struct FecTokens {
-    FecTokens(edm::ESConsumesCollector&& cc) { cc.setConsumes(fedCabling); }
-    edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCabling;
+    FecTokens(edm::ESConsumesCollector&& cc) : fedCabling(cc.consumes()) {}
+    const edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCabling;
   };
   struct DetTokens {
-    DetTokens(edm::ESConsumesCollector&& cc) { cc.setConsumes(fedCabling).setConsumes(tTopo); }
-    edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCabling;
-    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopo;
+    DetTokens(edm::ESConsumesCollector&& cc) : fedCabling(cc.consumes()), tTopo(cc.consumes()) {}
+    const edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCabling;
+    const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopo;
   };
   const FecTokens fecTokens_;
   const DetTokens detTokens_;

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripHashedDetIdESModule.cc
@@ -23,13 +23,13 @@ public:
   std::unique_ptr<SiStripHashedDetId> produce(const SiStripHashedDetIdRcd&);
 
 private:
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 
 // -----------------------------------------------------------------------------
 //
-SiStripHashedDetIdESModule::SiStripHashedDetIdESModule(const edm::ParameterSet& pset) {
-  setWhatProduced(this, &SiStripHashedDetIdESModule::produce).setConsumes(geomToken_);
+SiStripHashedDetIdESModule::SiStripHashedDetIdESModule(const edm::ParameterSet& pset)
+    : geomToken_(setWhatProduced(this, &SiStripHashedDetIdESModule::produce).consumes()) {
   edm::LogVerbatim("HashedDetId") << "[SiStripHashedDetIdESSourceFromGeom::" << __func__ << "]"
                                   << " Constructing object...";
 }

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
@@ -34,17 +34,15 @@ private:
 };
 
 SiStripRegionConnectivity::SiStripRegionConnectivity(const edm::ParameterSet& pset)
-    :
-
-      etadivisions_(pset.getUntrackedParameter<unsigned int>("EtaDivisions", 10)),
+    : etadivisions_(pset.getUntrackedParameter<unsigned int>("EtaDivisions", 10)),
       phidivisions_(pset.getUntrackedParameter<unsigned int>("PhiDivisions", 10)),
       etamax_(pset.getUntrackedParameter<double>("EtaMax", 2.4))
 
 {
-  setWhatProduced(this, &SiStripRegionConnectivity::produceRegionCabling)
-      .setConsumes(detcablingToken_)
-      .setConsumes(tkgeomToken_)
-      .setConsumes(tTopoToken_);
+  auto cc = setWhatProduced(this, &SiStripRegionConnectivity::produceRegionCabling);
+  detcablingToken_ = cc.consumes();
+  tkgeomToken_ = cc.consumes();
+  tTopoToken_ = cc.consumes();
 }
 
 SiStripRegionConnectivity::~SiStripRegionConnectivity() {}

--- a/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
+++ b/CalibTracker/SiStripESProducers/plugins/real/SiStripQualityESProducer.cc
@@ -123,7 +123,7 @@ SiStripQualityESProducer::SiStripQualityESProducer(const edm::ParameterSet& iCon
   }
 
   if (doRunInfo) {
-    cc.setConsumes(runInfoToken_, edm::ESInputTag{"", runInfoTagName});
+    runInfoToken_ = cc.consumes(edm::ESInputTag{"", runInfoTagName});
   }
 }
 

--- a/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
+++ b/CondTools/Hcal/interface/BufferedBoostIOESProducer.h
@@ -34,14 +34,14 @@ class BufferedBoostIOESProducer : public edm::ESProducer {
 public:
   typedef std::unique_ptr<DataType> ReturnType;
 
-  inline BufferedBoostIOESProducer(const edm::ParameterSet&) { setWhatProduced(this).setConsumes(token_); }
+  inline BufferedBoostIOESProducer(const edm::ParameterSet&) : token_(setWhatProduced(this).consumes()) {}
 
   inline ~BufferedBoostIOESProducer() override {}
 
   ReturnType produce(const MyRecord&);
 
 private:
-  edm::ESGetToken<OOTPileupCorrectionBuffer, MyRecord> token_;
+  const edm::ESGetToken<OOTPileupCorrectionBuffer, MyRecord> token_;
 };
 
 template <class DataType, class MyRecord>

--- a/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ConfigOnlineProdBaseExt.h
@@ -93,8 +93,8 @@ template <class TRcd, class TData>
 edm::ESConsumesCollectorT<TRcd> L1ConfigOnlineProdBaseExt<TRcd, TData>::wrappedSetWhatProduced(
     const edm::ParameterSet& iConfig) {
   auto collector = setWhatProduced(this);
-  collector.setConsumes(keyList_token);
-  collector.setConsumes(key_token);
+  keyList_token = collector.consumes();
+  key_token = collector.consumes();
   return collector;
 }
 

--- a/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
+++ b/CondTools/L1TriggerExt/interface/L1ObjectKeysOnlineProdBaseExt.h
@@ -29,7 +29,7 @@ public:
 
 private:
   // ----------member data ---------------------------
-  edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> L1TriggerKeyExt_token;
+  const edm::ESGetToken<L1TriggerKeyExt, L1TriggerKeyExtRcd> L1TriggerKeyExt_token;
 
 protected:
   l1t::OMDSReader m_omdsReader;

--- a/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
+++ b/CondTools/L1TriggerExt/plugins/L1TriggerKeyOnlineProdExt.cc
@@ -17,7 +17,7 @@ L1TriggerKeyOnlineProdExt::L1TriggerKeyOnlineProdExt(const edm::ParameterSet& iC
     //now do what ever other initialization is needed
   }
 
-  cc.setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"", "SubsystemKeysOnly"});
+  L1TriggerKeyExt_token = cc.consumes(edm::ESInputTag{"", "SubsystemKeysOnly"});
 }
 
 L1TriggerKeyOnlineProdExt::~L1TriggerKeyOnlineProdExt() {

--- a/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
+++ b/CondTools/L1TriggerExt/src/L1ObjectKeysOnlineProdBaseExt.cc
@@ -5,18 +5,12 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 L1ObjectKeysOnlineProdBaseExt::L1ObjectKeysOnlineProdBaseExt(const edm::ParameterSet& iConfig)
-    : m_omdsReader(iConfig.getParameter<std::string>("onlineDB"),
-                   iConfig.getParameter<std::string>("onlineAuthentication")) {
-  //the following line is needed to tell the framework what
-  // data is being produced
-
-  // The subsystemLabel is used by L1TriggerKeyOnlineProdExt to identify the
-  // L1TriggerKeysExt to concatenate.
-  setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"))
-      .setConsumes(L1TriggerKeyExt_token, edm::ESInputTag{"", "SubsystemKeysOnly"});
-
-  //now do what ever other initialization is needed
-}
+    // The subsystemLabel is used by L1TriggerKeyOnlineProdExt to identify the
+    // L1TriggerKeysExt to concatenate.
+    : L1TriggerKeyExt_token(setWhatProduced(this, iConfig.getParameter<std::string>("subsystemLabel"))
+                                .consumes(edm::ESInputTag{"", "SubsystemKeysOnly"})),
+      m_omdsReader(iConfig.getParameter<std::string>("onlineDB"),
+                   iConfig.getParameter<std::string>("onlineAuthentication")) {}
 
 L1ObjectKeysOnlineProdBaseExt::~L1ObjectKeysOnlineProdBaseExt() {
   // do anything here that needs to be done at desctruction time


### PR DESCRIPTION
#### PR description:

Migrating `setConsumes()` calls to the simpler consumes introduced in https://github.com/cms-sw/cmssw/pull/31223.

#### PR validation:

Code compiles