### PR TITLE
Migrate ESProducers in DetectorDescription from setConsumes() to type-deducing consumes()

### DIFF
--- a/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDDetectorESProducer.cc
@@ -73,14 +73,14 @@ DDDetectorESProducer::DDDetectorESProducer(const ParameterSet& iConfig)
                              &DDDetectorESProducer::produceMagField,
                              edm::es::Label(iConfig.getParameter<std::string>("@module_label")));
     if (fromDB_) {
-      c.setConsumes(mfToken_, edm::ESInputTag("", label_));
+      mfToken_ = c.consumes(edm::ESInputTag("", label_));
     }
     findingRecord<IdealMagneticFieldRecord>();
   } else {
     auto c = setWhatProduced(
         this, &DDDetectorESProducer::produceGeom, edm::es::Label(iConfig.getParameter<std::string>("@module_label")));
     if (fromDB_) {
-      c.setConsumes(geomToken_, edm::ESInputTag("", label_));
+      geomToken_ = c.consumes(edm::ESInputTag("", label_));
     }
     findingRecord<IdealGeometryRecord>();
   }

--- a/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDSpecParRegistryESProducer.cc
@@ -45,12 +45,12 @@ public:
   ReturnType produce(const DDSpecParRegistryRcd&);
 
 private:
-  edm::ESGetToken<DDDetector, IdealGeometryRecord> m_token;
+  const edm::ESGetToken<DDDetector, IdealGeometryRecord> m_token;
 };
 
-DDSpecParRegistryESProducer::DDSpecParRegistryESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(m_token,
-                                    edm::ESInputTag("", iConfig.getParameter<std::string>("appendToDataLabel")));
+DDSpecParRegistryESProducer::DDSpecParRegistryESProducer(const edm::ParameterSet& iConfig)
+    : m_token(
+          setWhatProduced(this).consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("appendToDataLabel")))) {
 }
 
 DDSpecParRegistryESProducer::~DDSpecParRegistryESProducer() {}

--- a/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
@@ -47,12 +47,11 @@ public:
   ReturnType produce(const DDVectorRegistryRcd&);
 
 private:
-  edm::ESGetToken<DDDetector, IdealGeometryRecord> m_token;
+  const edm::ESGetToken<DDDetector, IdealGeometryRecord> m_token;
 };
 
-DDVectorRegistryESProducer::DDVectorRegistryESProducer(const edm::ParameterSet& iConfig) {
-  setWhatProduced(this).setConsumes(m_token, edm::ESInputTag("", iConfig.getParameter<string>("appendToDataLabel")));
-}
+DDVectorRegistryESProducer::DDVectorRegistryESProducer(const edm::ParameterSet& iConfig)
+    : m_token(setWhatProduced(this).consumes(edm::ESInputTag("", iConfig.getParameter<string>("appendToDataLabel")))) {}
 
 DDVectorRegistryESProducer::~DDVectorRegistryESProducer() {}
 


### PR DESCRIPTION
#### PR description:

This PR migrates `setConsumes()` calls to the simpler consumes introduced in #31223.



#### PR validation:

Code compiles.