### PR TITLE
Migrate ESProducers in Fireworks from setConsumes() to type-deducing consumes()

### DIFF
--- a/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
+++ b/Fireworks/Geometry/plugins/TGeoMgrFromDdd.cc
@@ -84,17 +84,14 @@ private:
   std::map<std::string, TGeoMaterial*> nameToMaterial_;
   std::map<std::string, TGeoMedium*> nameToMedium_;
 
-  edm::ESGetToken<DDCompactView, IdealGeometryRecord> viewToken_;
+  const edm::ESGetToken<DDCompactView, IdealGeometryRecord> viewToken_;
 };
 
 TGeoMgrFromDdd::TGeoMgrFromDdd(const edm::ParameterSet& pset)
     : m_level(pset.getUntrackedParameter<int>("level")),
       m_verbose(pset.getUntrackedParameter<bool>("verbose")),
-      m_fullname(pset.getUntrackedParameter<bool>("fullName")) {
-  // The following line is needed to tell the framework what data is
-  // being produced.
-  setWhatProduced(this).setConsumes(viewToken_);
-}
+      m_fullname(pset.getUntrackedParameter<bool>("fullName")),
+      viewToken_(setWhatProduced(this).consumes()) {}
 
 void TGeoMgrFromDdd::fillDescriptions(edm::ConfigurationDescriptions& conf) {
   edm::ParameterSetDescription desc;

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -103,14 +103,14 @@ FWRecoGeometryESProducer::FWRecoGeometryESProducer(const edm::ParameterSet& pset
   m_timing = pset.getUntrackedParameter<bool>("Timing", false);
   auto cc = setWhatProduced(this);
   if (m_tracker or m_muon) {
-    cc.setConsumes(m_trackingGeomToken);
+    m_trackingGeomToken = cc.consumes();
   }
   if (m_timing) {
-    cc.setConsumes(m_ftlBarrelGeomToken, edm::ESInputTag{"", "FastTimeBarrel"})
-        .setConsumes(m_ftlEndcapGeomToken, edm::ESInputTag{"", "SFBX"});
+    m_ftlBarrelGeomToken = cc.consumes(edm::ESInputTag{"", "FastTimeBarrel"});
+    m_ftlEndcapGeomToken = cc.consumes(edm::ESInputTag{"", "SFBX"});
   }
   if (m_calo) {
-    cc.setConsumes(m_caloGeomToken);
+    m_caloGeomToken = cc.consumes();
   }
 }
 

--- a/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWTGeoRecoGeometryESProducer.cc
@@ -67,13 +67,13 @@ FWTGeoRecoGeometryESProducer::FWTGeoRecoGeometryESProducer(const edm::ParameterS
 
   auto cc = setWhatProduced(this);
   if (m_tracker || m_muon) {
-    cc.setConsumes(m_trackingGeomToken);
+    m_trackingGeomToken = cc.consumes();
   }
   if (m_tracker) {
-    cc.setConsumes(m_trackerTopologyToken);
+    m_trackerTopologyToken = cc.consumes();
   }
   if (m_calo) {
-    cc.setConsumes(m_caloGeomToken);
+    m_caloGeomToken = cc.consumes();
   }
 }
 


### PR DESCRIPTION
#### PR description:

This PR migrates `setConsumes()` calls to the simpler consumes introduced in #31223.

#### PR validation:

Code compiles.