### PR TITLE
Migrate ESProducers in L1Trigger from setConsumes() to type-deducing consumes()

### DIFF
--- a/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
+++ b/L1Trigger/L1THGCal/plugins/HGCalTriggerGeometryESProducer.cc
@@ -35,12 +35,12 @@ HGCalTriggerGeometryESProducer::HGCalTriggerGeometryESProducer(const edm::Parame
       isV9Geometry_(iConfig.getParameter<bool>("isV9Geometry")) {
   auto cc = setWhatProduced(this);
   if (isV9Geometry_) {
-    cc.setConsumes(ee_geometry_token_, edm::ESInputTag{"", "HGCalEESensitive"})
-        .setConsumes(hsi_geometry_token_, edm::ESInputTag{"", "HGCalHESiliconSensitive"})
-        .setConsumes(hsc_geometry_token_, edm::ESInputTag{"", "HGCalHEScintillatorSensitive"})
-        .setConsumes(nose_geometry_token_, edm::ESInputTag{"", "HGCalHFNoseSensitive"});
+    ee_geometry_token_ = cc.consumes(edm::ESInputTag{"", "HGCalEESensitive"});
+    hsi_geometry_token_ = cc.consumes(edm::ESInputTag{"", "HGCalHESiliconSensitive"});
+    hsc_geometry_token_ = cc.consumes(edm::ESInputTag{"", "HGCalHEScintillatorSensitive"});
+    nose_geometry_token_ = cc.consumes(edm::ESInputTag{"", "HGCalHFNoseSensitive"});
   } else {
-    cc.setConsumes(calo_geometry_token_);
+    calo_geometry_token_ = cc.consumes();
   }
 }
 

--- a/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
+++ b/L1Trigger/RPCTrigger/plugins/RPCConeBuilder.cc
@@ -64,7 +64,9 @@ private:
 
 RPCConeBuilder::RPCConeBuilder(const edm::ParameterSet& iConfig)
     : m_towerBeg(iConfig.getParameter<int>("towerBeg")), m_towerEnd(iConfig.getParameter<int>("towerEnd")) {
-  setWhatProduced(this).setConsumes(m_rpcGeometryToken).setConsumes(m_l1RPCConeDefinitionToken);
+  auto cc = setWhatProduced(this);
+  m_rpcGeometryToken = cc.consumes();
+  m_l1RPCConeDefinitionToken = cc.consumes();
 }
 
 // ------------ method called to produce the data  ------------

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_cbc3.h
@@ -92,7 +92,9 @@ public:
   /// Constructor
   ES_TTStubAlgorithm_cbc3(const edm::ParameterSet &p) {
     mPerformZMatching2S = p.getParameter<bool>("zMatching2S");
-    setWhatProduced(this).setConsumes(mGeomToken).setConsumes(mTopoToken);
+    auto cc = setWhatProduced(this);
+    mGeomToken = cc.consumes();
+    mTopoToken = cc.consumes();
   }
 
   /// Destructor

--- a/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
+++ b/L1Trigger/TrackTrigger/interface/TTStubAlgorithm_official.h
@@ -145,7 +145,9 @@ public:
       setTiltedCut.push_back(iPSet->getParameter<std::vector<double>>("TiltedCut"));
     }
 
-    setWhatProduced(this).setConsumes(mGeomToken).setConsumes(mTopoToken);
+    auto cc = setWhatProduced(this);
+    mGeomToken = cc.consumes();
+    mTopoToken = cc.consumes();
   }
 
   /// Destructor

--- a/L1Trigger/TrackerDTC/plugins/ProducerES.cc
+++ b/L1Trigger/TrackerDTC/plugins/ProducerES.cc
@@ -35,13 +35,13 @@ namespace trackerDTC {
   };
 
   ProducerES::ProducerES(const ParameterSet& iConfig) : iConfig_(iConfig) {
-    setWhatProduced(this)
-        .setConsumes(getTokenTTStubAlgorithm_)
-        .setConsumes(getTokenMagneticField_)
-        .setConsumes(getTokenTrackerGeometry_)
-        .setConsumes(getTokenTrackerTopology_)
-        .setConsumes(getTokenCablingMap_)
-        .setConsumes(getTokenGeometryConfiguration_);
+    auto cc = setWhatProduced(this);
+    getTokenTTStubAlgorithm_ = cc.consumes();
+    getTokenMagneticField_ = cc.consumes();
+    getTokenTrackerGeometry_ = cc.consumes();
+    getTokenTrackerTopology_ = cc.consumes();
+    getTokenCablingMap_ = cc.consumes();
+    getTokenGeometryConfiguration_ = cc.consumes();
   }
 
   unique_ptr<Setup> ProducerES::produce(const SetupRcd& setupRcd) {

--- a/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
+++ b/L1TriggerConfig/DTTPGConfigProducers/src/DTConfigDBProducer.cc
@@ -143,9 +143,11 @@ DTConfigDBProducer::DTConfigDBProducer(const edm::ParameterSet &p) {
   m_UseT0 = p.getParameter<bool>("UseT0");  // CB check for a better way to do it
 
   if (not cfgConfig) {
-    cc.setConsumes(m_dttpgParamsToken).setConsumes(m_ccb_confToken).setConsumes(m_keyListToken);
+    m_dttpgParamsToken = cc.consumes();
+    m_ccb_confToken = cc.consumes();
+    m_keyListToken = cc.consumes();
     if (m_UseT0) {
-      cc.setConsumes(m_t0iToken);
+      m_t0iToken = cc.consumes();
     }
   }
 }

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TCaloParamsOnlineProd.cc
@@ -19,9 +19,9 @@ using namespace XERCES_CPP_NAMESPACE;
 
 class L1TCaloParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams> {
 private:
-  unsigned int exclusiveLayer;  // 0 - process calol1 and calol2, 1 - only calol1, 2 - only calol2
-  bool transactionSafe;
-  edm::ESGetToken<l1t::CaloParams, L1TCaloParamsRcd> baseSettings_token;
+  const edm::ESGetToken<l1t::CaloParams, L1TCaloParamsRcd> baseSettings_token;
+  const unsigned int exclusiveLayer;  // 0 - process calol1 and calol2, 1 - only calol1, 2 - only calol2
+  const bool transactionSafe;
 
   bool readCaloLayer1OnlineSettings(l1t::CaloParamsHelperO2O& paramsHelper,
                                     std::map<std::string, l1t::Parameter>& conf,
@@ -210,11 +210,10 @@ bool L1TCaloParamsOnlineProd::readCaloLayer2OnlineSettings(l1t::CaloParamsHelper
 }
 
 L1TCaloParamsOnlineProd::L1TCaloParamsOnlineProd(const edm::ParameterSet& iConfig)
-    : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams>(iConfig) {
-  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
-  exclusiveLayer = iConfig.getParameter<uint32_t>("exclusiveLayer");
-  transactionSafe = iConfig.getParameter<bool>("transactionSafe");
-}
+    : L1ConfigOnlineProdBaseExt<L1TCaloParamsO2ORcd, l1t::CaloParams>(iConfig),
+      baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()),
+      exclusiveLayer(iConfig.getParameter<uint32_t>("exclusiveLayer")),
+      transactionSafe(iConfig.getParameter<bool>("transactionSafe")) {}
 
 std::unique_ptr<const l1t::CaloParams> L1TCaloParamsOnlineProd::newObject(const std::string& objectKey,
                                                                           const L1TCaloParamsO2ORcd& record) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonBarrelParamsOnlineProd.cc
@@ -15,8 +15,8 @@ using namespace XERCES_CPP_NAMESPACE;
 
 class L1TMuonBarrelParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams> {
 private:
-  bool transactionSafe;
-  edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> baseSettings_token;
+  const bool transactionSafe;
+  const edm::ESGetToken<L1TMuonBarrelParams, L1TMuonBarrelParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonBarrelParams> newObject(const std::string& objectKey,
@@ -27,10 +27,9 @@ public:
 };
 
 L1TMuonBarrelParamsOnlineProd::L1TMuonBarrelParamsOnlineProd(const edm::ParameterSet& iConfig)
-    : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams>(iConfig) {
-  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
-  transactionSafe = iConfig.getParameter<bool>("transactionSafe");
-}
+    : L1ConfigOnlineProdBaseExt<L1TMuonBarrelParamsO2ORcd, L1TMuonBarrelParams>(iConfig),
+      transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
+      baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
 
 std::unique_ptr<const L1TMuonBarrelParams> L1TMuonBarrelParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonBarrelParamsO2ORcd& record) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapForestOnlineProxy.cc
@@ -10,7 +10,7 @@
 
 class L1TMuonEndCapForestOnlineProxy : public edm::ESProducer {
 private:
-  edm::ESGetToken<L1TMuonEndCapForest, L1TMuonEndCapForestRcd> baseSettings_token;
+  const edm::ESGetToken<L1TMuonEndCapForest, L1TMuonEndCapForestRcd> baseSettings_token;
 
 public:
   std::unique_ptr<L1TMuonEndCapForest> produce(const L1TMuonEndCapForestO2ORcd& record);
@@ -19,9 +19,8 @@ public:
   ~L1TMuonEndCapForestOnlineProxy(void) override {}
 };
 
-L1TMuonEndCapForestOnlineProxy::L1TMuonEndCapForestOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this).setConsumes(baseSettings_token);
-}
+L1TMuonEndCapForestOnlineProxy::L1TMuonEndCapForestOnlineProxy(const edm::ParameterSet& iConfig)
+    : baseSettings_token(setWhatProduced(this).consumes()) {}
 
 std::unique_ptr<L1TMuonEndCapForest> L1TMuonEndCapForestOnlineProxy::produce(const L1TMuonEndCapForestO2ORcd& record) {
   const L1TMuonEndCapForestRcd& baseRcd = record.template getRecord<L1TMuonEndCapForestRcd>();

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonEndCapParamsOnlineProd.cc
@@ -14,8 +14,8 @@
 
 class L1TMuonEndCapParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams> {
 private:
-  bool transactionSafe;
-  edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> baseSettings_token;
+  const bool transactionSafe;
+  const edm::ESGetToken<L1TMuonEndCapParams, L1TMuonEndCapParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonEndCapParams> newObject(const std::string& objectKey,
@@ -26,10 +26,9 @@ public:
 };
 
 L1TMuonEndCapParamsOnlineProd::L1TMuonEndCapParamsOnlineProd(const edm::ParameterSet& iConfig)
-    : L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams>(iConfig) {
-  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
-  transactionSafe = iConfig.getParameter<bool>("transactionSafe");
-}
+    : L1ConfigOnlineProdBaseExt<L1TMuonEndCapParamsO2ORcd, L1TMuonEndCapParams>(iConfig),
+      transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
+      baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
 
 std::unique_ptr<const L1TMuonEndCapParams> L1TMuonEndCapParamsOnlineProd::newObject(
     const std::string& objectKey, const L1TMuonEndCapParamsO2ORcd& record) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonGlobalParamsOnlineProd.cc
@@ -14,8 +14,8 @@
 
 class L1TMuonGlobalParamsOnlineProd : public L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams> {
 private:
-  bool transactionSafe;
-  edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> baseSettings_token;
+  const bool transactionSafe;
+  const edm::ESGetToken<L1TMuonGlobalParams, L1TMuonGlobalParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<const L1TMuonGlobalParams> newObject(const std::string &objectKey,
@@ -26,10 +26,9 @@ public:
 };
 
 L1TMuonGlobalParamsOnlineProd::L1TMuonGlobalParamsOnlineProd(const edm::ParameterSet &iConfig)
-    : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig) {
-  wrappedSetWhatProduced(iConfig).setConsumes(baseSettings_token);
-  transactionSafe = iConfig.getParameter<bool>("transactionSafe");
-}
+    : L1ConfigOnlineProdBaseExt<L1TMuonGlobalParamsO2ORcd, L1TMuonGlobalParams>(iConfig),
+      transactionSafe(iConfig.getParameter<bool>("transactionSafe")),
+      baseSettings_token(wrappedSetWhatProduced(iConfig).consumes()) {}
 
 std::unique_ptr<const L1TMuonGlobalParams> L1TMuonGlobalParamsOnlineProd::newObject(
     const std::string &objectKey, const L1TMuonGlobalParamsO2ORcd &record) {

--- a/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
+++ b/L1TriggerConfig/L1TConfigProducers/src/L1TMuonOverlapParamsOnlineProxy.cc
@@ -10,7 +10,7 @@
 
 class L1TMuonOverlapParamsOnlineProxy : public edm::ESProducer {
 private:
-  edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> baseSettings_token;
+  const edm::ESGetToken<L1TMuonOverlapParams, L1TMuonOverlapParamsRcd> baseSettings_token;
 
 public:
   std::unique_ptr<L1TMuonOverlapParams> produce(const L1TMuonOverlapParamsO2ORcd& record);
@@ -19,9 +19,8 @@ public:
   ~L1TMuonOverlapParamsOnlineProxy(void) override {}
 };
 
-L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig) : edm::ESProducer() {
-  setWhatProduced(this).setConsumes(baseSettings_token);
-}
+L1TMuonOverlapParamsOnlineProxy::L1TMuonOverlapParamsOnlineProxy(const edm::ParameterSet& iConfig)
+    : baseSettings_token(setWhatProduced(this).consumes()) {}
 
 std::unique_ptr<L1TMuonOverlapParams> L1TMuonOverlapParamsOnlineProxy::produce(
     const L1TMuonOverlapParamsO2ORcd& record) {


### PR DESCRIPTION
#### PR description:

This PR migrates `setConsumes()` calls to the simpler consumes introduced in #31223.

#### PR validation:

Code compiles.