### PR TITLE
Clean BuildFiles in JetMETCorrections

### DIFF
--- a/JetMETCorrections/Algorithms/BuildFile.xml
+++ b/JetMETCorrections/Algorithms/BuildFile.xml
@@ -1,9 +1,6 @@
 <use name="CondFormats/JetMETObjects"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/EgammaCandidates"/>
 <use name="DataFormats/JetReco"/>
-<use name="DataFormats/Math"/>
-<use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/JetMETCorrections/FFTJetModules/plugins/BuildFile.xml
+++ b/JetMETCorrections/FFTJetModules/plugins/BuildFile.xml
@@ -2,9 +2,7 @@
   <use name="CondCore/ESSources"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondCore/DBOutputService"/>
-  <use name="DataFormats/JetReco"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="JetMETCorrections/FFTJetObjects"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/JetMETCorrections/FFTJetObjects/BuildFile.xml
+++ b/JetMETCorrections/FFTJetObjects/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/Common"/>
 <use name="DataFormats/JetReco"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/JetMETObjects"/>

--- a/JetMETCorrections/IsolatedParticles/test/BuildFile.xml
+++ b/JetMETCorrections/IsolatedParticles/test/BuildFile.xml
@@ -4,16 +4,12 @@
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/CommonDetUnit"/>
-<use name="Geometry/TrackerGeometryBuilder"/>
 <use name="Geometry/Records"/>
-<use name="DataFormats/DetId"/>
 <use name="SimDataFormats/Vertex"/>
-<use name="TrackingTools/GeomPropagators"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
 <use name="TrackPropagation/SteppingHelixPropagator"/>

--- a/JetMETCorrections/JetCorrector/BuildFile.xml
+++ b/JetMETCorrections/JetCorrector/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="FWCore/MessageLogger"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/JetReco"/>
 <export>

--- a/JetMETCorrections/JetParton/BuildFile.xml
+++ b/JetMETCorrections/JetParton/BuildFile.xml
@@ -2,10 +2,7 @@
 <use name="DataFormats/Common"/>
 <use name="JetMETCorrections/Objects"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/JetReco"/>
-<use name="DataFormats/RecoCandidate"/>
 <export>
   <lib name="1"/>
 </export>

--- a/JetMETCorrections/JetVertexAssociation/test/BuildFile.xml
+++ b/JetMETCorrections/JetVertexAssociation/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/JetReco"/>
 <use name="clhep"/>

--- a/JetMETCorrections/MCJet/BuildFile.xml
+++ b/JetMETCorrections/MCJet/BuildFile.xml
@@ -1,7 +1,0 @@
-<use name="root"/>
-<use name="clhep"/>
-<use name="Geometry/Records"/>
-<use name="DataFormats/JetReco"/>
-<use name="DataFormats/Common"/>
-<export>
-</export>

--- a/JetMETCorrections/Modules/BuildFile.xml
+++ b/JetMETCorrections/Modules/BuildFile.xml
@@ -1,15 +1,10 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/JetMETObjects"/>
-<use name="CondCore/DBOutputService"/>
 <use name="CommonTools/Utils"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/JetReco"/>
-<use name="DataFormats/METReco"/>
-<use name="DataFormats/BTauReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="JetMETCorrections/Objects"/>
-<use name="JetMETCorrections/Algorithms"/>
 <use name="JetMETCorrections/JetCorrector"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>

--- a/JetMETCorrections/Modules/plugins/BuildFile.xml
+++ b/JetMETCorrections/Modules/plugins/BuildFile.xml
@@ -1,9 +1,9 @@
 <library file="*.cc" name="JetMETCorrectionsModulesPlugins">
+  <use name="CommonTools/UtilAlgos"/>
   <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/JetMETObjects"/>
   <use name="CondCore/DBOutputService"/>
   <use name="DataFormats/JetReco"/>
-  <use name="DataFormats/METReco"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>
@@ -11,6 +11,5 @@
   <use name="JetMETCorrections/Algorithms"/>
   <use name="JetMETCorrections/Objects"/>
   <use name="JetMETCorrections/Modules"/>
-  <use name="PhysicsTools/UtilAlgos"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/JetMETCorrections/Objects/BuildFile.xml
+++ b/JetMETCorrections/Objects/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/JetReco"/>
 <export>

--- a/JetMETCorrections/TauJet/BuildFile.xml
+++ b/JetMETCorrections/TauJet/BuildFile.xml
@@ -1,16 +1,8 @@
 <use name="clhep"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
-<use name="DataFormats/JetReco"/>
-<use name="DataFormats/TauReco"/>
 <use name="JetMETCorrections/Objects"/>
-<use name="TrackingTools/TransientTrack"/>
-<use name="Geometry/CaloGeometry"/>
-<use name="DataFormats/BTauReco"/>
-<use name="TrackingTools/TrackAssociator"/>
-<use name="RecoTauTag/RecoTau"/>
 <export>
   <lib name="1"/>
 </export>

--- a/JetMETCorrections/TauJet/plugins/BuildFile.xml
+++ b/JetMETCorrections/TauJet/plugins/BuildFile.xml
@@ -1,12 +1,9 @@
 <use name="clhep"/>
 <use name="DataFormats/Common"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/JetReco"/>
-<use name="JetMETCorrections/Objects"/>
 <use name="JetMETCorrections/JetCorrector"/>
-<use name="RecoTauTag/RecoTau"/>
 <library file="TauJetCorrectorExample.cc" name="TauJetCorrectorExample">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/JetMETCorrections/Type1MET/BuildFile.xml
+++ b/JetMETCorrections/Type1MET/BuildFile.xml
@@ -2,17 +2,11 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="CondFormats/EgammaObjects"/>
-<use name="CondFormats/JetMETObjects"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
-<use name="DataFormats/Math"/>
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/MuonReco"/>
-<use name="DataFormats/TauReco"/>
-<use name="DataFormats/VertexReco"/>
-<use name="JetMETCorrections/Objects"/>
 <use name="root"/>
 <export>
   <lib name="1"/>

--- a/JetMETCorrections/Type1MET/plugins/BuildFile.xml
+++ b/JetMETCorrections/Type1MET/plugins/BuildFile.xml
@@ -2,19 +2,17 @@
 </export>
 <library name="JetMETCorrectionsType1MET_plugins" file="*.cc">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
   <use name="CommonTools/Utils"/>
+  <use name="CondFormats/JetMETObjects"/>
   <use name="DataFormats/Candidate"/>
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/METReco"/>
   <use name="DataFormats/MuonReco"/>
   <use name="DataFormats/ParticleFlowCandidate"/>
   <use name="DataFormats/PatCandidates"/>
-  <use name="DataFormats/TauReco"/>
   <use name="DataFormats/VertexReco"/>
   <use name="JetMETCorrections/Objects"/>
   <use name="JetMETCorrections/Type1MET"/>
-  <use name="JetMETCorrections/JetCorrector"/>
 </library>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31368).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.