### PR TITLE
HF shower shape fix for custom JME NanoAOD workflow

### DIFF
--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -9,7 +9,7 @@ from RecoJets.JetProducers.PileupJetID_cfi import pileupJetIdCalculator, pileupJ
 from RecoJets.JetProducers.PileupJetID_cfi import _chsalgos_81x, _chsalgos_94x, _chsalgos_102x
 
 from PhysicsTools.NanoAOD.common_cff import Var, P4Vars
-from PhysicsTools.NanoAOD.jets_cff   import jetTable, jetCorrFactorsNano, updatedJets, finalJets, qgtagger
+from PhysicsTools.NanoAOD.jets_cff   import jetTable, jetCorrFactorsNano, updatedJets, finalJets, qgtagger, hfJetShowerShapeforNanoAOD
 from PhysicsTools.NanoAOD.jets_cff   import genJetTable, genJetFlavourAssociation, genJetFlavourTable
 
 from PhysicsTools.PatAlgos.tools.jetCollectionTools import GenJetAdder, RecoJetAdder
@@ -644,6 +644,20 @@ def ReclusterAK4CHSJets(proc, recoJA, runOnMC):
   #
   proc.jetTable.variables.btagDeepFlavG   = DEEPJETVARS.btagDeepFlavG  
   proc.jetTable.variables.btagDeepFlavUDS = DEEPJETVARS.btagDeepFlavUDS
+
+  #Adding hf shower shape producer to the jet sequence. By default this producer is not automatically rerun at the NANOAOD step
+  #The following lines make sure it is.
+  hfJetShowerShapeforCustomNanoAOD = "hfJetShowerShapeforCustomNanoAOD"
+  setattr(proc, hfJetShowerShapeforCustomNanoAOD, hfJetShowerShapeforNanoAOD.clone(jets="updatedJets",vertices="offlineSlimmedPrimaryVertices") )
+  proc.jetSequence.insert(proc.jetSequence.index(proc.updatedJetsWithUserData), getattr(proc, hfJetShowerShapeforCustomNanoAOD))
+  proc.updatedJetsWithUserData.userFloats.hfsigmaEtaEta = cms.InputTag('hfJetShowerShapeforCustomNanoAOD:sigmaEtaEta')
+  proc.updatedJetsWithUserData.userFloats.hfsigmaPhiPhi = cms.InputTag('hfJetShowerShapeforCustomNanoAOD:sigmaPhiPhi')
+  proc.updatedJetsWithUserData.userInts.hfcentralEtaStripSize = cms.InputTag('hfJetShowerShapeforCustomNanoAOD:centralEtaStripSize')
+  proc.updatedJetsWithUserData.userInts.hfadjacentEtaStripsSize = cms.InputTag('hfJetShowerShapeforCustomNanoAOD:adjacentEtaStripsSize')
+  proc.jetTable.variables.hfsigmaEtaEta = Var("userFloat('hfsigmaEtaEta')",float,doc="sigmaEtaEta for HF jets (noise discriminating variable)",precision=10)
+  proc.jetTable.variables.hfsigmaPhiPhi = Var("userFloat('hfsigmaPhiPhi')",float,doc="sigmaPhiPhi for HF jets (noise discriminating variable)",precision=10)
+  proc.jetTable.variables.hfcentralEtaStripSize = Var("userInt('hfcentralEtaStripSize')", int, doc="eta size of the central tower strip in HF (noise discriminating variable) ")
+  proc.jetTable.variables.hfadjacentEtaStripsSize = Var("userInt('hfadjacentEtaStripsSize')", int, doc="eta size of the strips next to the central tower strip in HF (noise discriminating variable) ")
 
   return proc
 


### PR DESCRIPTION
#### PR description:

This is a fix of https://github.com/cms-sw/cmssw/pull/31271 that resulted in failure due to the HF shower shape producer not being run for the custom JME NANOAOD (the producer is hidden behind era modifiers). 
The proposed fix doesn't rely on any specific modifier. 

A maybe more elegant way would be to check whether hfJetShowerShapeforNanoAOD is already present in jetSequence and add it if not. Suggestions to achieve this is welcome.  

#### PR validation:

runTheMatrix.py -l 1325.7,10042.0,10024.0,10224.0,10824.0,10224.15,11024.15,25202.15  -i all --ibeos
gave no error (those are workflows where the NANOAOD step is run, the last three with custom JME configuration). 
