### PR TITLE
Fix pulls for gem/me0 in MuonSelectors (and simplify it a bit)

### DIFF
--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -7,7 +7,6 @@
 // Original Author:  Jake Ribnik, Dmytro Kovalskyi
 
 #include "DataFormats/MuonReco/interface/Muon.h"
-#include "TMath.h"
 #include <string>
 
 namespace reco {

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -243,12 +243,12 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
           }
         } else {  // We are in the CSCs
           const float pullTot2 =
-              std::pow(muon.pullX(i, 1, arbitrationType), 2.) + std::pow(muon.pullY(i, 1, arbitrationType), 2.);
+              std::pow(muon.pullX(i - 4, 2, arbitrationType), 2.) + std::pow(muon.pullY(i - 4, 2, arbitrationType), 2.);
           if (pullTot2 > 1.f) {
             // reduce weight
             if (use_match_dist_penalty) {
               const float dxy2 =
-                  std::pow(muon.dX(i, 1, arbitrationType), 2.) + std::pow(muon.dY(i, 1, arbitrationType), 2.);
+                  std::pow(muon.dX(i - 4, 2, arbitrationType), 2.) + std::pow(muon.dY(i - 4, 2, arbitrationType), 2.);
               // only use pull if 3 sigma is not smaller than 3 cm
               if (dxy2 < 9.f && pullTot2 > 9.f) {
                 if (dxy2 > 1.f)

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -192,7 +192,7 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
       }
 
       // if track has matching segment, but the matching is not high quality, penalize
-      if (station_has_segmentmatch[i - 1] > 0 && 42 == 42) {
+      if (station_has_segmentmatch[i - 1] > 0) {
         if (i <= 4) {  // we are in the DTs
           if (muon.dY(i, 1, arbitrationType) < 999999.f &&
               muon.dX(i, 1, arbitrationType) < 999999.f) {  // have both X and Y match
@@ -546,20 +546,15 @@ bool muon::isGoodMuon(const reco::Muon& muon,
       return true;
 
     int nMatch = 0;
-    for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = muon.matches().begin();
-         chamberMatch != muon.matches().end();
-         ++chamberMatch) {
-      if (chamberMatch->detector() != 3)
+    for (const auto& chamberMatch : muon.matches()) {
+      if (chamberMatch.detector() != MuonSubdetId::RPC)
         continue;
 
-      const float trkX = chamberMatch->x;
-      const float errX = chamberMatch->xErr;
+      const float trkX = chamberMatch.x;
+      const float errX = chamberMatch.xErr;
 
-      for (std::vector<reco::MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
-           rpcMatch != chamberMatch->rpcMatches.end();
-           ++rpcMatch) {
-        const float rpcX = rpcMatch->x;
-
+      for (const auto& rpcMatch : chamberMatch.rpcMatches) {
+        const float rpcX = rpcMatch.x;
         const float dX = std::abs(rpcX - trkX);
         if (dX < maxAbsDx or dX / errX < maxAbsPullX) {
           ++nMatch;
@@ -584,20 +579,20 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         continue;
 
       const float trkX = chamberMatch.x;
-      const float errX = chamberMatch.xErr;
+      const float errX2 = chamberMatch.xErr * chamberMatch.xErr;
       const float trkY = chamberMatch.y;
-      const float errY = chamberMatch.yErr;
+      const float errY2 = chamberMatch.yErr * chamberMatch.yErr;
 
       for (const auto& segment : chamberMatch.me0Matches) {
         const float me0X = segment.x;
-        const float me0ErrX = segment.xErr;
+        const float me0ErrX2 = segment.xErr * segment.xErr;
         const float me0Y = segment.y;
-        const float me0ErrY = segment.yErr;
+        const float me0ErrY2 = segment.yErr * segment.yErr;
 
         const float dX = std::abs(me0X - trkX);
         const float dY = std::abs(me0Y - trkY);
-        const float pullX = dX / std::sqrt(errX * errX + me0ErrX * me0ErrX);
-        const float pullY = dY / std::sqrt(errY * errY + me0ErrY * me0ErrY);
+        const float pullX = dX / std::sqrt(errX2 + me0ErrX2);
+        const float pullY = dY / std::sqrt(errY2 + me0ErrY2);
 
         if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;
@@ -619,20 +614,20 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         continue;
 
       const float trkX = chamberMatch.x;
-      const float errX = chamberMatch.xErr;
+      const float errX2 = chamberMatch.xErr * chamberMatch.xErr;
       const float trkY = chamberMatch.y;
-      const float errY = chamberMatch.yErr;
+      const float errY2 = chamberMatch.yErr * chamberMatch.yErr;
 
       for (const auto& segment : chamberMatch.gemMatches) {
         const float gemX = segment.x;
-        const float gemErrX = segment.xErr;
+        const float gemErrX2 = segment.xErr * segment.xErr;
         const float gemY = segment.y;
-        const float gemErrY = segment.yErr;
+        const float gemErrY2 = segment.yErr * segment.yErr;
 
         const float dX = std::abs(gemX - trkX);
         const float dY = std::abs(gemY - trkY);
-        const float pullX = dX / std::sqrt(errX * errX + gemErrX * gemErrX);
-        const float pullY = dY / std::sqrt(errY * errY + gemErrY * gemErrY);
+        const float pullX = dX / std::sqrt(errX2 + gemErrX2);
+        const float pullY = dY / std::sqrt(errY2 + gemErrY2);
 
         if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -220,9 +220,9 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (muon.dX(i, 1, arbitrationType) < 3.f && muon.pullX(i, 1, arbitrationType) > 3.f) {
                   if (muon.dX(i, 1, arbitrationType) > 1.f)
-                    station_weight[i - 1] *= 1.f / std::pow(muon.dX(i, 1, arbitrationType), .125);
+                    station_weight[i - 1] *= 1.f / std::pow(muon.dX(i, 1, arbitrationType), .25);
                 } else {
-                  station_weight[i - 1] *= 1.f / std::pow(muon.pullX(i, 1, arbitrationType), .125);
+                  station_weight[i - 1] *= 1.f / std::pow(muon.pullX(i, 1, arbitrationType), .25);
                 }
               }
             }
@@ -234,9 +234,9 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (muon.dY(i, 1, arbitrationType) < 3. && muon.pullY(i, 1, arbitrationType) > 3.) {
                   if (muon.dY(i, 1, arbitrationType) > 1.f)
-                    station_weight[i - 1] *= 1.f / std::pow(muon.dY(i, 1, arbitrationType), .125);
+                    station_weight[i - 1] *= 1.f / std::pow(muon.dY(i, 1, arbitrationType), .25);
                 } else {
-                  station_weight[i - 1] *= 1.f / std::pow(muon.pullY(i, 1, arbitrationType), .125);
+                  station_weight[i - 1] *= 1.f / std::pow(muon.pullY(i, 1, arbitrationType), .25);
                 }
               }
             }
@@ -250,7 +250,7 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               const float dxy2 =
                   std::pow(muon.dX(i, 1, arbitrationType), 2.) + std::pow(muon.dY(i, 1, arbitrationType), 2.);
               // only use pull if 3 sigma is not smaller than 3 cm
-              if (dxy2 < 9.f && pullTot2 < 9.f) {
+              if (dxy2 < 9.f && pullTot2 > 9.f) {
                 if (dxy2 > 1.f)
                   station_weight[i - 1] *= 1.f / std::pow(dxy2, .125);
               } else {

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -194,42 +194,33 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
       // if track has matching segment, but the matching is not high quality, penalize
       if (station_has_segmentmatch[i - 1] > 0 && 42 == 42) {
         if (i <= 4) {  // we are in the DTs
-          if (muon.dY(i, 1, arbitrationType) < 999999 &&
-              muon.dX(i, 1, arbitrationType) < 999999) {  // have both X and Y match
-            if (TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
-                            TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)) > 1.) {
+          if (muon.dY(i, 1, arbitrationType) < 999999.f &&
+              muon.dX(i, 1, arbitrationType) < 999999.f) {  // have both X and Y match
+            const float pullTot2 =
+                std::pow(muon.pullX(i, 1, arbitrationType), 2.) + std::pow(muon.pullY(i, 1, arbitrationType), 2.);
+            if (pullTot2 > 1.) {
+              const float dxy2 =
+                  std::pow(muon.dX(i, 1, arbitrationType), 2.) + std::pow(muon.dY(i, 1, arbitrationType), 2.);
               // reduce weight
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
-                if (TMath::Sqrt(TMath::Power(muon.dX(i, 1, arbitrationType), 2.) +
-                                TMath::Power(muon.dY(i, 1, arbitrationType), 2.)) < 3. &&
-                    TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
-                                TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)) > 3.) {
-                  station_weight[i - 1] *=
-                      1. /
-                      TMath::Power(TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i, 1, arbitrationType), 2.) +
-                                                                  TMath::Power(muon.dY(i, 1, arbitrationType), 2.)),
-                                              (double)1.),
-                                   .25);
+                if (dxy2 < 9. && pullTot2 > 9.f) {
+                  station_weight[i - 1] *= 1. / TMath::Power(std::max(std::sqrt(dxy2), 1.f), .25f);
                 } else {
-                  station_weight[i - 1] *=
-                      1. / TMath::Power(TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
-                                                    TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)),
-                                        .25);
+                  station_weight[i - 1] *= 1. / TMath::Power(std::sqrt(pullTot2), .25f);
                 }
               }
             }
-          } else if (muon.dY(i, 1, arbitrationType) >= 999999) {  // has no match in Y
+          } else if (muon.dY(i, 1, arbitrationType) >= 999999.f) {  // has no match in Y
             // has a match in X. Pull larger that 1 to avoid increasing the weight (just penalize, don't anti-penalize)
-            if (muon.pullX(i, 1, arbitrationType) > 1.) {
+            if (muon.pullX(i, 1, arbitrationType) > 1.f) {
               // reduce weight
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
-                if (muon.dX(i, 1, arbitrationType) < 3. && muon.pullX(i, 1, arbitrationType) > 3.) {
-                  station_weight[i - 1] *=
-                      1. / TMath::Power(TMath::Max((double)muon.dX(i, 1, arbitrationType), (double)1.), .25);
+                if (muon.dX(i, 1, arbitrationType) < 3.f && muon.pullX(i, 1, arbitrationType) > 3.f) {
+                  station_weight[i - 1] *= 1. / TMath::Power(TMath::Max(muon.dX(i, 1, arbitrationType), 1.f), .25f);
                 } else {
-                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullX(i, 1, arbitrationType), .25);
+                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullX(i, 1, arbitrationType), .25f);
                 }
               }
             }
@@ -240,35 +231,26 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (muon.dY(i, 1, arbitrationType) < 3. && muon.pullY(i, 1, arbitrationType) > 3.) {
-                  station_weight[i - 1] *=
-                      1. / TMath::Power(TMath::Max((double)muon.dY(i, 1, arbitrationType), (double)1.), .25);
+                  station_weight[i - 1] *= 1. / TMath::Power(TMath::Max(muon.dY(i, 1, arbitrationType), 1.f), .25f);
                 } else {
-                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullY(i, 1, arbitrationType), .25);
+                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullY(i, 1, arbitrationType), .25f);
                 }
               }
             }
           }
         } else {  // We are in the CSCs
-          if (TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
-                          TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)) > 1.) {
+          const float pullTot2 =
+              std::pow(muon.pullX(i, 1, arbitrationType), 2.) + std::pow(muon.pullY(i, 1, arbitrationType), 2.);
+          if (pullTot2 > 1.f) {
             // reduce weight
             if (use_match_dist_penalty) {
+              const float dxy2 =
+                  std::pow(muon.dX(i, 1, arbitrationType), 2.) + std::pow(muon.dY(i, 1, arbitrationType), 2.);
               // only use pull if 3 sigma is not smaller than 3 cm
-              if (TMath::Sqrt(TMath::Power(muon.dX(i - 4, 2, arbitrationType), 2.) +
-                              TMath::Power(muon.dY(i - 4, 2, arbitrationType), 2.)) < 3. &&
-                  TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
-                              TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)) > 3.) {
-                station_weight[i - 1] *=
-                    1. /
-                    TMath::Power(TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i - 4, 2, arbitrationType), 2.) +
-                                                                TMath::Power(muon.dY(i - 4, 2, arbitrationType), 2.)),
-                                            (double)1.),
-                                 .25);
+              if (dxy2 < 9.f && pullTot2 < 9.f) {
+                station_weight[i - 1] *= 1. / TMath::Power(std::max(std::sqrt(dxy2), 1.f), .25f);
               } else {
-                station_weight[i - 1] *=
-                    1. / TMath::Power(TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
-                                                  TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)),
-                                      .25);
+                station_weight[i - 1] *= 1. / TMath::Power(std::sqrt(pullTot2), .25f);
               }
             }
           }
@@ -566,15 +548,15 @@ bool muon::isGoodMuon(const reco::Muon& muon,
       if (chamberMatch->detector() != 3)
         continue;
 
-      const double trkX = chamberMatch->x;
-      const double errX = chamberMatch->xErr;
+      const float trkX = chamberMatch->x;
+      const float errX = chamberMatch->xErr;
 
       for (std::vector<reco::MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
            rpcMatch != chamberMatch->rpcMatches.end();
            ++rpcMatch) {
-        const double rpcX = rpcMatch->x;
+        const float rpcX = rpcMatch->x;
 
-        const double dX = fabs(rpcX - trkX);
+        const float dX = fabs(rpcX - trkX);
         if (dX < maxAbsDx or dX / errX < maxAbsPullX) {
           ++nMatch;
           break;
@@ -597,21 +579,21 @@ bool muon::isGoodMuon(const reco::Muon& muon,
       if (chamberMatch.detector() != MuonSubdetId::ME0)
         continue;
 
-      const double trkX = chamberMatch.x;
-      const double errX = chamberMatch.xErr;
-      const double trkY = chamberMatch.y;
-      const double errY = chamberMatch.yErr;
+      const float trkX = chamberMatch.x;
+      const float errX = chamberMatch.xErr;
+      const float trkY = chamberMatch.y;
+      const float errY = chamberMatch.yErr;
 
       for (const auto& segment : chamberMatch.me0Matches) {
-        const double me0X = segment.x;
-        const double me0ErrX = segment.xErr;
-        const double me0Y = segment.y;
-        const double me0ErrY = segment.yErr;
+        const float me0X = segment.x;
+        const float me0ErrX = segment.xErr;
+        const float me0Y = segment.y;
+        const float me0ErrY = segment.yErr;
 
-        const double dX = fabs(me0X - trkX);
-        const double dY = fabs(me0Y - trkY);
-        const double pullX = dX / std::sqrt(errX + me0ErrX);
-        const double pullY = dY / std::sqrt(errY + me0ErrY);
+        const float dX = fabs(me0X - trkX);
+        const float dY = fabs(me0Y - trkY);
+        const float pullX = dX / std::sqrt(errX * errX + me0ErrX * me0ErrX);
+        const float pullY = dY / std::sqrt(errY * errY + me0ErrY * me0ErrY);
 
         if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;
@@ -632,21 +614,21 @@ bool muon::isGoodMuon(const reco::Muon& muon,
       if (chamberMatch.detector() != MuonSubdetId::GEM)
         continue;
 
-      const double trkX = chamberMatch.x;
-      const double errX = chamberMatch.xErr;
-      const double trkY = chamberMatch.y;
-      const double errY = chamberMatch.yErr;
+      const float trkX = chamberMatch.x;
+      const float errX = chamberMatch.xErr;
+      const float trkY = chamberMatch.y;
+      const float errY = chamberMatch.yErr;
 
       for (const auto& segment : chamberMatch.gemMatches) {
-        const double gemX = segment.x;
-        const double gemErrX = segment.xErr;
-        const double gemY = segment.y;
-        const double gemErrY = segment.yErr;
+        const float gemX = segment.x;
+        const float gemErrX = segment.xErr;
+        const float gemY = segment.y;
+        const float gemErrY = segment.yErr;
 
-        const double dX = fabs(gemX - trkX);
-        const double dY = fabs(gemY - trkY);
-        const double pullX = dX / std::sqrt(errX + gemErrX);
-        const double pullY = dY / std::sqrt(errY + gemErrY);
+        const float dX = fabs(gemX - trkX);
+        const float dY = fabs(gemY - trkY);
+        const float pullX = dX / std::sqrt(errX * errX + gemErrX * gemErrX);
+        const float pullY = dY / std::sqrt(errY * errY + gemErrY * gemErrY);
 
         if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -180,7 +180,7 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
           // inside the chamber.
           // remark: the additional scale of 0.5 normalizes Err to run from 0 to 1 in y
           station_weight[i - 1] = station_weight[i - 1] * attenuate_weight_regain * 0.5f *
-	    (std::erf(stations_w_track_at_boundary[i - 1] / 6.f) + 1.f);
+                                  (std::erf(stations_w_track_at_boundary[i - 1] / 6.f) + 1.f);
         } else if (station_has_segmentmatch[i - 1] <= 0 &&
                    stations_w_track_at_boundary[i - 1] == 0.f) {  // no segment match and track well inside chamber
           // full penalization
@@ -205,8 +205,8 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (dxy2 < 9.f && pullTot2 > 9.f) {
-		  if (dxy2 > 1.f)
-		    station_weight[i - 1] *= 1.f / std::pow(dxy2, .125);
+                  if (dxy2 > 1.f)
+                    station_weight[i - 1] *= 1.f / std::pow(dxy2, .125);
                 } else {
                   station_weight[i - 1] *= 1.f / std::pow(pullTot2, .125);
                 }
@@ -219,8 +219,8 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (muon.dX(i, 1, arbitrationType) < 3.f && muon.pullX(i, 1, arbitrationType) > 3.f) {
-		  if (muon.dX(i, 1, arbitrationType) > 1.f)
-		    station_weight[i - 1] *= 1.f / std::pow(muon.dX(i, 1, arbitrationType), .125);
+                  if (muon.dX(i, 1, arbitrationType) > 1.f)
+                    station_weight[i - 1] *= 1.f / std::pow(muon.dX(i, 1, arbitrationType), .125);
                 } else {
                   station_weight[i - 1] *= 1.f / std::pow(muon.pullX(i, 1, arbitrationType), .125);
                 }
@@ -233,8 +233,8 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
               if (use_match_dist_penalty) {
                 // only use pull if 3 sigma is not smaller than 3 cm
                 if (muon.dY(i, 1, arbitrationType) < 3. && muon.pullY(i, 1, arbitrationType) > 3.) {
-		  if (muon.dY(i, 1, arbitrationType) > 1.f)
-		    station_weight[i - 1] *= 1.f / std::pow(muon.dY(i, 1, arbitrationType), .125);
+                  if (muon.dY(i, 1, arbitrationType) > 1.f)
+                    station_weight[i - 1] *= 1.f / std::pow(muon.dY(i, 1, arbitrationType), .125);
                 } else {
                   station_weight[i - 1] *= 1.f / std::pow(muon.pullY(i, 1, arbitrationType), .125);
                 }
@@ -251,10 +251,10 @@ float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::Arbitration
                   std::pow(muon.dX(i, 1, arbitrationType), 2.) + std::pow(muon.dY(i, 1, arbitrationType), 2.);
               // only use pull if 3 sigma is not smaller than 3 cm
               if (dxy2 < 9.f && pullTot2 < 9.f) {
-		if (dxy2 > 1.f)
-		  station_weight[i - 1] *= 1.f / std::pow(dxy2, .125);
-	      } else {
-		station_weight[i - 1] *= 1.f / std::pow(pullTot2, .125);
+                if (dxy2 > 1.f)
+                  station_weight[i - 1] *= 1.f / std::pow(dxy2, .125);
+              } else {
+                station_weight[i - 1] *= 1.f / std::pow(pullTot2, .125);
               }
             }
           }

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -353,7 +353,7 @@ bool muon::isGoodMuon(const reco::Muon& muon,
     // the number of required stations but still greater than zero
     if (syncMinNMatchesNRequiredStationsInBarrelOnly) {
       // Note that we only do this in the barrel region!
-      if (fabs(muon.eta()) < 1.2) {
+      if (std::abs(muon.eta()) < 1.2) {
         if (minNumberOfMatches > numRequiredStations)
           minNumberOfMatches = numRequiredStations;
         if (minNumberOfMatches < 1)  //SK: this only happens for negative values
@@ -403,11 +403,11 @@ bool muon::isGoodMuon(const reco::Muon& muon,
     detector = lastSegBit < 4 ? 1 : 2;
 
     // Check x information
-    if (fabs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
-        fabs(muon.dX(station, detector, arbitrationType)) > maxAbsDx)
+    if (std::abs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
+        std::abs(muon.dX(station, detector, arbitrationType)) > maxAbsDx)
       return false;
 
-    if (applyAlsoAngularCuts && fabs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX)
+    if (applyAlsoAngularCuts && std::abs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX)
       return false;
 
     // Is this a tight algorithm, i.e. do we bother to check y information?
@@ -415,11 +415,11 @@ bool muon::isGoodMuon(const reco::Muon& muon,
 
       // Check y information
       if (detector == 2) {  // CSC
-        if (fabs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
-            fabs(muon.dY(station, 2, arbitrationType)) > maxAbsDy)
+        if (std::abs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
+            std::abs(muon.dY(station, 2, arbitrationType)) > maxAbsDy)
           return false;
 
-        if (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY)
+        if (applyAlsoAngularCuts && std::abs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY)
           return false;
       } else {
         //
@@ -444,12 +444,12 @@ bool muon::isGoodMuon(const reco::Muon& muon,
           if (muon.dY(stationIdx, 1, arbitrationType) > 999998)  // no y-information
             continue;
 
-          if (fabs(muon.pullY(stationIdx, 1, arbitrationType, true)) > maxAbsPullY &&
-              fabs(muon.dY(stationIdx, 1, arbitrationType)) > maxAbsDy) {
+          if (std::abs(muon.pullY(stationIdx, 1, arbitrationType, true)) > maxAbsPullY &&
+              std::abs(muon.dY(stationIdx, 1, arbitrationType)) > maxAbsDy) {
             return false;
           }
 
-          if (applyAlsoAngularCuts && fabs(muon.pullDyDz(stationIdx, 1, arbitrationType, true)) > maxAbsPullY)
+          if (applyAlsoAngularCuts && std::abs(muon.pullDyDz(stationIdx, 1, arbitrationType, true)) > maxAbsPullY)
             return false;
 
           // If we get this far then great this is a good muon
@@ -493,9 +493,9 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         station = stationIdx < 4 ? stationIdx + 1 : stationIdx - 3;
         detector = stationIdx < 4 ? 1 : 2;
 
-        if ((fabs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
-             fabs(muon.dX(station, detector, arbitrationType)) > maxAbsDx) ||
-            (applyAlsoAngularCuts && fabs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX))
+        if ((std::abs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
+             std::abs(muon.dX(station, detector, arbitrationType)) > maxAbsDx) ||
+            (applyAlsoAngularCuts && std::abs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX))
           continue;
         else if (detector == 1)
           existsGoodDTSegX = true;
@@ -503,9 +503,9 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         // Is this a tight algorithm?  If yes, use y information
         if (maxAbsDy < 999999) {
           if (detector == 2) {  // CSC
-            if ((fabs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
-                 fabs(muon.dY(station, 2, arbitrationType)) > maxAbsDy) ||
-                (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY))
+            if ((std::abs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
+                 std::abs(muon.dY(station, 2, arbitrationType)) > maxAbsDy) ||
+                (applyAlsoAngularCuts && std::abs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY))
               continue;
           } else {
             if (muon.dY(station, 1, arbitrationType) > 999998)  // no y-information
@@ -513,9 +513,9 @@ bool muon::isGoodMuon(const reco::Muon& muon,
             else
               existsDTSegY = true;
 
-            if ((fabs(muon.pullY(station, 1, arbitrationType, true)) > maxAbsPullY &&
-                 fabs(muon.dY(station, 1, arbitrationType)) > maxAbsDy) ||
-                (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 1, arbitrationType, true)) > maxAbsPullY)) {
+            if ((std::abs(muon.pullY(station, 1, arbitrationType, true)) > maxAbsPullY &&
+                 std::abs(muon.dY(station, 1, arbitrationType)) > maxAbsDy) ||
+                (applyAlsoAngularCuts && std::abs(muon.pullDyDz(station, 1, arbitrationType, true)) > maxAbsPullY)) {
               continue;
             }
           }
@@ -560,7 +560,7 @@ bool muon::isGoodMuon(const reco::Muon& muon,
            ++rpcMatch) {
         const float rpcX = rpcMatch->x;
 
-        const float dX = fabs(rpcX - trkX);
+        const float dX = std::abs(rpcX - trkX);
         if (dX < maxAbsDx or dX / errX < maxAbsPullX) {
           ++nMatch;
           break;
@@ -594,8 +594,8 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         const float me0Y = segment.y;
         const float me0ErrY = segment.yErr;
 
-        const float dX = fabs(me0X - trkX);
-        const float dY = fabs(me0Y - trkY);
+        const float dX = std::abs(me0X - trkX);
+        const float dY = std::abs(me0Y - trkY);
         const float pullX = dX / std::sqrt(errX * errX + me0ErrX * me0ErrX);
         const float pullY = dY / std::sqrt(errY * errY + me0ErrY * me0ErrY);
 
@@ -629,8 +629,8 @@ bool muon::isGoodMuon(const reco::Muon& muon,
         const float gemY = segment.y;
         const float gemErrY = segment.yErr;
 
-        const float dX = fabs(gemX - trkX);
-        const float dY = fabs(gemY - trkY);
+        const float dX = std::abs(gemX - trkX);
+        const float dY = std::abs(gemY - trkY);
         const float pullX = dX / std::sqrt(errX * errX + gemErrX * gemErrX);
         const float pullY = dY / std::sqrt(errY * errY + gemErrY * gemErrY);
 
@@ -698,7 +698,7 @@ bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::Ar
              isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       break;
     case muon::TMLastStationOptimizedLowPtLoose:
-      if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
+      if (muon.pt() < 8. && std::abs(muon.eta()) < 1.2)
         return muon.isTrackerMuon() &&
                isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, false);
       else
@@ -706,7 +706,7 @@ bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::Ar
                isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, false, false);
       break;
     case muon::TMLastStationOptimizedLowPtTight:
-      if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
+      if (muon.pt() < 8. && std::abs(muon.eta()) < 1.2)
         return muon.isTrackerMuon() &&
                isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       else
@@ -723,11 +723,11 @@ bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::Ar
       break;
     case muon::GMTkChiCompatibility:
       return muon.isGlobalMuon() && muon.isQualityValid() &&
-             fabs(muon.combinedQuality().trkRelChi2 - muon.innerTrack()->normalizedChi2()) < 2.0;
+             std::abs(muon.combinedQuality().trkRelChi2 - muon.innerTrack()->normalizedChi2()) < 2.0;
       break;
     case muon::GMStaChiCompatibility:
       return muon.isGlobalMuon() && muon.isQualityValid() &&
-             fabs(muon.combinedQuality().staRelChi2 - muon.outerTrack()->normalizedChi2()) < 2.0;
+             std::abs(muon.combinedQuality().staRelChi2 - muon.outerTrack()->normalizedChi2()) < 2.0;
       break;
     case muon::GMTkKinkTight:
       return muon.isGlobalMuon() && muon.isQualityValid() && muon.combinedQuality().trkKink < 100.0;
@@ -749,7 +749,7 @@ bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::Ar
              isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, true);
       break;
     case muon::TMLastStationOptimizedBarrelLowPtLoose:
-      if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
+      if (muon.pt() < 8. && std::abs(muon.eta()) < 1.2)
         return muon.isTrackerMuon() &&
                isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, false);
       else
@@ -757,7 +757,7 @@ bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::Ar
                isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, true, false);
       break;
     case muon::TMLastStationOptimizedBarrelLowPtTight:
-      if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
+      if (muon.pt() < 8. && std::abs(muon.eta()) < 1.2)
         return muon.isTrackerMuon() &&
                isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       else
@@ -806,7 +806,7 @@ bool muon::overlap(
       // here we know how close they are
       if (chamber1->id == chamber2->id) {
         // found the same chamber
-        if (fabs(chamber1->x - chamber2->x) <
+        if (std::abs(chamber1->x - chamber2->x) <
             pullX * sqrt(chamber1->xErr * chamber1->xErr + chamber2->xErr * chamber2->xErr)) {
           if (betterMuon == 1)
             nMatches2--;
@@ -816,7 +816,7 @@ bool muon::overlap(
             return true;
           continue;
         }
-        if (fabs(chamber1->y - chamber2->y) <
+        if (std::abs(chamber1->y - chamber2->y) <
             pullY * sqrt(chamber1->yErr * chamber1->yErr + chamber2->yErr * chamber2->yErr)) {
           if (betterMuon == 1)
             nMatches2--;
@@ -847,9 +847,9 @@ bool muon::overlap(
 
         // Now we have to make sure that both tracks are close to an edge
         // FIXME: ignored Y coordinate for now
-        if (fabs(chamber1->edgeX) > chamber1->xErr * pullX)
+        if (std::abs(chamber1->edgeX) > chamber1->xErr * pullX)
           continue;
-        if (fabs(chamber2->edgeX) > chamber2->xErr * pullX)
+        if (std::abs(chamber2->edgeX) > chamber2->xErr * pullX)
           continue;
         if (chamber1->x * chamber2->x < 0) {  // check if the same edge
           if (betterMuon == 1)
@@ -887,8 +887,8 @@ bool muon::isTightMuon(const reco::Muon& muon, const reco::Vertex& vtx) {
   bool hits = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
               muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0;
 
-  bool ip =
-      fabs(muon.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.muonBestTrack()->dz(vtx.position())) < 0.5;
+  bool ip = std::abs(muon.muonBestTrack()->dxy(vtx.position())) < 0.2 &&
+            std::abs(muon.muonBestTrack()->dz(vtx.position())) < 0.5;
 
   return muID && hits && ip;
 }
@@ -925,7 +925,8 @@ bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx, bool run2
 
   bool ishighq = muon.innerTrack()->quality(reco::Track::highPurity);
 
-  bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(muon.innerTrack()->dz(vtx.position())) < 20.;
+  bool ip =
+      std::abs(muon.innerTrack()->dxy(vtx.position())) < 0.3 && std::abs(muon.innerTrack()->dz(vtx.position())) < 20.;
 
   return layers && ip && (ishighq | run2016_hip_mitigation);
 }
@@ -953,7 +954,8 @@ bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx) {
 
   bool momQuality = muon.tunePMuonBestTrack()->ptError() / muon.tunePMuonBestTrack()->pt() < 0.3;
 
-  bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.innerTrack()->dz(vtx.position())) < 0.5;
+  bool ip =
+      std::abs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && std::abs(muon.innerTrack()->dz(vtx.position())) < 0.5;
 
   return muID && hits && momQuality && ip;
 }
@@ -968,7 +970,8 @@ bool muon::isTrackerHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx) 
 
   bool momQuality = muon.tunePMuonBestTrack()->ptError() / muon.tunePMuonBestTrack()->pt() < 0.3;
 
-  bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.innerTrack()->dz(vtx.position())) < 0.5;
+  bool ip =
+      std::abs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && std::abs(muon.innerTrack()->dz(vtx.position())) < 0.5;
 
   return muID && hits && momQuality && ip;
 }
@@ -1016,10 +1019,10 @@ bool outOfTimeMuon(const reco::Muon& muon) {
   const auto& combinedTime = muon.time();
   const auto& rpcTime = muon.rpcTime();
   bool combinedTimeIsOk = (combinedTime.nDof > 7);
-  bool rpcTimeIsOk = (rpcTime.nDof > 1 && fabs(rpcTime.timeAtIpInOutErr) < 0.001);
+  bool rpcTimeIsOk = (rpcTime.nDof > 1 && std::abs(rpcTime.timeAtIpInOutErr) < 0.001);
   bool outOfTime = false;
   if (rpcTimeIsOk) {
-    if ((fabs(rpcTime.timeAtIpInOut) > 10) && !(combinedTimeIsOk && fabs(combinedTime.timeAtIpInOut) < 10))
+    if ((std::abs(rpcTime.timeAtIpInOut) > 10) && !(combinedTimeIsOk && std::abs(combinedTime.timeAtIpInOut) < 10))
       outOfTime = true;
   } else {
     if (combinedTimeIsOk && (combinedTime.timeAtIpInOut > 20 || combinedTime.timeAtIpInOut < -45))
@@ -1057,8 +1060,8 @@ reco::Muon::Selector muon::makeSelectorBitset(reco::Muon const& muon,
   }
   if (muon::isMediumMuon(muon, run2016_hip_mitigation)) {
     selectors |= reco::Muon::CutBasedIdMedium;
-    if (vertex and fabs(muon.muonBestTrack()->dz(vertex->position())) < 0.1 and
-        fabs(muon.muonBestTrack()->dxy(vertex->position())) < 0.02)
+    if (vertex and std::abs(muon.muonBestTrack()->dz(vertex->position())) < 0.1 and
+        std::abs(muon.muonBestTrack()->dxy(vertex->position())) < 0.02)
       selectors |= reco::Muon::CutBasedIdMediumPrompt;
   }
 

--- a/HeavyFlavorAnalysis/RecoDecay/test/stubs/TestBPHRecoDecay.cc
+++ b/HeavyFlavorAnalysis/RecoDecay/test/stubs/TestBPHRecoDecay.cc
@@ -21,6 +21,7 @@
 #include "RecoVertex/KinematicFit/interface/TwoTrackMassKinematicConstraint.h"
 #include <TH1.h>
 #include <TFile.h>
+#include <TMath.h>
 
 #include <set>
 #include <string>

--- a/PhysicsTools/PatAlgos/src/SoftMuonMvaEstimator.cc
+++ b/PhysicsTools/PatAlgos/src/SoftMuonMvaEstimator.cc
@@ -7,6 +7,8 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 
+#include "TMath.h"
+
 using namespace pat;
 
 SoftMuonMvaEstimator::SoftMuonMvaEstimator(const edm::FileInPath& weightsfile) {


### PR DESCRIPTION
#### PR description:

The relevant part of this PR is the following **fix** for the computation of the pulls in the chamber matching for both GEM and ME0 :
![Immagine](https://user-images.githubusercontent.com/4069749/92996154-a9c51e00-f509-11ea-9088-0928eb93a492.jpg)
(see lines 599-600 and lines 613-614 of DataFormats/MuonReco/src/MuonSelectors.cc )
The pulls were previously computed by normalizing on the square root of the sum of the errors, instead than on the quadratic sum of the same errors.

@ArnabPurohit @trocino could you please check and confirm that such a fix is actually needed? (The alternative is that some weird definition for those pulls was preferred on purpose instead...)

While applying that fix, I profited for integrating also some code simplification meant to improve the performance of the same MuonSelectors:
- Avoid unneeded, and sometimes repeated, computations
- Avoid converting `float` inputs into `double,` and then convert back again to `float` 
- Replace `TMath` functions with `std` ones
- Replace `fabs` with `std::abs`

Further optimizations are still possible:
- Move fully to `float`, also in the methods and their arguments
- Store squares of errors in the muon matches instead of the errors themselves, so that one can avoid repetedly computing square roots and squares when produced and accessed

Regressions are expected:
- whenever the pulls of the matches for GEM and ME0 are used
- probably some very minor additional ones due to possible different rounding approximations because of the other performance related updates



#### PR validation:

It builds, and a few matrix tests succeed.
I didn't try to validate the output by comparing with the baseline
I will try to evaluate possible changes (hopefully an improvement) in cpu performance, and I will update this description with it

