### PR TITLE
Clean BuildFiles in Fireworks

### DIFF
--- a/Fireworks/Calo/BuildFile.xml
+++ b/Fireworks/Calo/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DataFormats/CaloTowers"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/EcalDetId"/>
-<use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/FWLite"/>

--- a/Fireworks/Calo/plugins/BuildFile.xml
+++ b/Fireworks/Calo/plugins/BuildFile.xml
@@ -8,12 +8,10 @@
   <use name="DataFormats/L1Trigger"/>
   <use name="DataFormats/L1THGCal"/>
   <use name="DataFormats/METReco"/>
-  <use name="DataFormats/PatCandidates"/>
   <use name="DataFormats/TauReco"/>
   <use name="DataFormats/TrackReco"/>
   <use name="Fireworks/Calo"/>
   <use name="Fireworks/Core"/>
-  <use name="Fireworks/Tracks"/>
   <use name="rootinteractive"/>
   <use name="rooteve"/>
   <use name="rootrgl"/>

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -2,13 +2,10 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/DetId"/>
-<use name="DataFormats/EcalDetId"/>
-<use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/FWLite"/>
 <use name="DataFormats/L1GlobalTrigger"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/Scalers"/>
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Common"/>

--- a/Fireworks/Electrons/plugins/BuildFile.xml
+++ b/Fireworks/Electrons/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <library name="FireworksElectronsPlugins" file="*.cc">
-  <use name="DataFormats/EcalDetId"/>
   <use name="DataFormats/EgammaCandidates"/>
   <use name="DataFormats/EgammaReco"/>
   <use name="DataFormats/GsfTrackReco"/>

--- a/Fireworks/Eve/BuildFile.xml
+++ b/Fireworks/Eve/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Framework"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>

--- a/Fireworks/FWInterface/BuildFile.xml
+++ b/Fireworks/FWInterface/BuildFile.xml
@@ -1,9 +1,5 @@
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Framework"/>
 <use name="DataFormats/Provenance"/>
-<use name="DataFormats/TrackReco"/>
-<use name="TrackingTools/TrajectoryState"/>
-<use name="TrackingTools/PatternTools"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
 <use name="Fireworks/Core"/>

--- a/Fireworks/FWInterface/plugins/BuildFile.xml
+++ b/Fireworks/FWInterface/plugins/BuildFile.xml
@@ -1,14 +1,10 @@
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Framework"/>
 <use name="Fireworks/FWInterface"/>
-<use name="CondFormats/DataRecord"/>
-<use name="CondFormats/RunInfo"/>
 <use name="SimDataFormats/Track"/>
 <use name="SimDataFormats/TrackingHit"/>
-<use name="SimDataFormats/CaloHit"/>
-<use name="SimDataFormats/Vertex"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <use name="SimGeneral/TrackingAnalysis"/>
+<use name="TrackingTools/PatternTools"/>
 <use name="rootcore"/>
 <use name="rootgeom"/>
 <use name="rooteve"/>

--- a/Fireworks/Geometry/BuildFile.xml
+++ b/Fireworks/Geometry/BuildFile.xml
@@ -1,10 +1,6 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/MessageLogger"/>
 <use name="Geometry/CommonDetUnit"/>
-<use name="Geometry/MuonNumbering"/>
-<use name="Geometry/EcalCommonData"/>
-<use name="Geometry/CSCGeometryBuilder"/>
 <use name="DetectorDescription/Core"/>
 <use name="Geometry/CaloGeometry"/>
 <use name="Geometry/HGCalGeometry"/>
@@ -16,8 +12,6 @@
 <use name="Geometry/Records"/>
 <use name="DataFormats/GeometrySurface"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/SiStripDetId"/>
-<use name="DataFormats/SiPixelDetId"/>
 <use name="Fireworks/Core"/>
 <use name="rootcore"/>
 <use name="rootgeom"/>

--- a/Fireworks/Geometry/plugins/BuildFile.xml
+++ b/Fireworks/Geometry/plugins/BuildFile.xml
@@ -23,7 +23,6 @@
 <library file="DumpSimGeometry.cc" name="FireworksGeometryDumpSimGeometryPlugin">
   <use name="Fireworks/Geometry"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>
@@ -31,7 +30,6 @@
 
 <library file="MFProducer.cc" name="FireworksGeometryMFProducerPlugin">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="clhep"/>
   <use name="MagneticField/Engine"/>
@@ -46,7 +44,6 @@
   <use name="rootgeom"/>
   <use name="rootcore"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/DTGeometry"/>
@@ -63,7 +60,6 @@
   <use name="rootgeom"/>
   <use name="rootcore"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="Geometry/CaloGeometry"/>
   <use name="Geometry/DTGeometry"/>

--- a/Fireworks/ParticleFlow/BuildFile.xml
+++ b/Fireworks/ParticleFlow/BuildFile.xml
@@ -1,8 +1,6 @@
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="Fireworks/Core"/>
-<use name="Fireworks/Candidates"/>
 <use name="Fireworks/Tracks"/>
-<use name="Fireworks/Calo"/>
 <use name="rooteve"/>
 <export>
   <lib name="1"/>

--- a/Fireworks/ParticleFlow/plugins/BuildFile.xml
+++ b/Fireworks/ParticleFlow/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
   <use name="DataFormats/ParticleFlowReco"/>
   <use name="DataFormats/PatCandidates"/>
   <use name="DataFormats/TrackReco"/>
+  <use name="Fireworks/Candidates"/>
   <use name="Fireworks/ParticleFlow"/>
   <use name="rooteve"/>
   <use name="rootrgl"/>

--- a/Fireworks/Tracks/BuildFile.xml
+++ b/Fireworks/Tracks/BuildFile.xml
@@ -5,7 +5,6 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/SiPixelCluster"/>
 <use name="DataFormats/SiPixelDetId"/>
-<use name="DataFormats/SiStripCluster"/>
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrackerRecHit2D"/>

--- a/Fireworks/Tracks/plugins/BuildFile.xml
+++ b/Fireworks/Tracks/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
   <use name="DataFormats/SiStripDigi"/>
   <use name="DataFormats/TrackReco"/>
   <use name="DataFormats/TrackingRecHit"/>
-  <use name="DataFormats/GeometrySurface"/>
   <use name="Fireworks/Core"/>
   <use name="Fireworks/Tracks"/>
   <use name="Fireworks/Calo"/>

--- a/Fireworks/Vertices/BuildFile.xml
+++ b/Fireworks/Vertices/BuildFile.xml
@@ -1,5 +1,3 @@
-<use name="DataFormats/VertexReco"/>
-<use name="Fireworks/Core"/>
 <use name="rootcore"/>
 <use name="opengl"/>
 <use name="rooteve"/>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31445).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.