### PR TITLE
Clean BuildFiles in DataFormats

### DIFF
--- a/CommonTools/Utils/BuildFile.xml
+++ b/CommonTools/Utils/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="DataFormats/Math"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Reflection"/>
-<use name="FWCore/SOA"/>
+<use name="FWCore/SOA" source_only="1"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>
 <use name="boost"/>

--- a/DataFormats/CSCDigi/test/BuildFile.xml
+++ b/DataFormats/CSCDigi/test/BuildFile.xml
@@ -1,6 +1,4 @@
-<use name="FWCore/Framework"/>
 <use name="DataFormats/CSCDigi"/>
-<use name="DataFormats/DetId"/>
 <bin name="testCSCDigis" file="testCSCDigis.cpp">
   <use name="cppunit"/>
   <use name="DataFormats/FEDRawData"/>

--- a/DataFormats/CSCRecHit/BuildFile.xml
+++ b/DataFormats/CSCRecHit/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/TrackingRecHit"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/CSCRecHit/test/BuildFile.xml
+++ b/DataFormats/CSCRecHit/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/CSCRecHit"/>
@@ -8,7 +7,6 @@
 <use name="CommonTools/UtilAlgos"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="root"/>
-<use name="DataFormats/GeometryVector"/>
 <library file="CSCSharesInputTest.cc" name="CSCSharesInputTest">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DataFormats/CTPPSDigi/BuildFile.xml
+++ b/DataFormats/CTPPSDigi/BuildFile.xml
@@ -1,5 +1,4 @@
-<use name="FWCore/Framework"/>
-<use name="DataFormats/CTPPSDetId"/>
+<use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/CaloTowers/test/BuildFile.xml
+++ b/DataFormats/CaloTowers/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/CaloTowers"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
 <library file="CaloTowersDump.cc" name="CaloTowersDump">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/DataFormats/Common/BuildFile.xml
+++ b/DataFormats/Common/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="DataFormats/Provenance"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="boost"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -11,8 +11,6 @@
 </bin>
 
 <bin file="DictionaryTools_t.cpp">
-  <use name="DataFormats/StdDictionaries"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
 </bin>
 
 <bin file="Wrapper_t.cpp">

--- a/DataFormats/DTDigi/test/BuildFile.xml
+++ b/DataFormats/DTDigi/test/BuildFile.xml
@@ -1,7 +1,5 @@
 <use name="FWCore/Framework"/>
 <use name="DataFormats/DTDigi"/>
-<use name="DataFormats/DetId"/>
 <bin name="testDTDigis" file="testDTDigis.cpp">
   <use name="cppunit"/>
-  <use name="DataFormats/FEDRawData"/>
 </bin>

--- a/DataFormats/GEMRecHit/BuildFile.xml
+++ b/DataFormats/GEMRecHit/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
-<use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/CSCRecHit"/>
 <use name="rootrflx"/>
 <export>

--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/CLHEP"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/RecoCandidate"/>

--- a/DataFormats/HcalDigi/test/BuildFile.xml
+++ b/DataFormats/HcalDigi/test/BuildFile.xml
@@ -2,7 +2,6 @@
   <flags EDM_PLUGIN="1"/>
   <use name="DataFormats/HcalDigi"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/ParameterSet"/>
 </library>
 
 <iftool name="cuda-gcc-support">

--- a/DataFormats/HcalIsolatedTrack/BuildFile.xml
+++ b/DataFormats/HcalIsolatedTrack/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/L1Trigger"/>
-<use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HcalRecHit/test/BuildFile.xml
+++ b/DataFormats/HcalRecHit/test/BuildFile.xml
@@ -8,10 +8,7 @@
 <iftool name="cuda-gcc-support">
   <bin name="test_hcal_reco" file="test_hcal_reco.cu">
     <use name="cuda"/>
-    <use name="DataFormats/CaloRecHit"/>
     <use name="DataFormats/HcalRecHit"/>
-    <use name="DataFormats/HcalDetId"/>
-    <use name="DataFormats/HcalDigi"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>
   </bin>
 </iftool>

--- a/DataFormats/HeavyIonEvent/BuildFile.xml
+++ b/DataFormats/HeavyIonEvent/BuildFile.xml
@@ -1,8 +1,6 @@
 <use name="root"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Candidate"/>
-<use name="CondFormats/HIObjects"/>
-<use name="CondFormats/DataRecord"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HepMCCandidate/BuildFile.xml
+++ b/DataFormats/HepMCCandidate/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="root"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/METReco/BuildFile.xml
+++ b/DataFormats/METReco/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/HcalRecHit"/>
-<use name="FWCore/Utilities"/>
 <use name="root"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/MuonSeed/BuildFile.xml
+++ b/DataFormats/MuonSeed/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/TrackReco"/>
-<use name="DataFormats/TrackingRecHit"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/NanoAOD/BuildFile.xml
+++ b/DataFormats/NanoAOD/BuildFile.xml
@@ -1,7 +1,5 @@
 <use name="FWCore/Utilities"/>
-<use name="FWCore/Common"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="DataFormats/Math"/>
 <use name="boost"/>
 <export>

--- a/DataFormats/ParticleFlowCandidate/BuildFile.xml
+++ b/DataFormats/ParticleFlowCandidate/BuildFile.xml
@@ -5,8 +5,6 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/GsfTrackReco"/>
-<use name="DataFormats/DTRecHit"/>
-<use name="DataFormats/CSCRecHit"/>
 <use name="DataFormats/MuonReco"/>
 <use name="FWCore/Utilities"/>
 <use name="rootcore"/>

--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -1,7 +1,5 @@
 <use name="DataFormats/CaloRecHit"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/EgammaCandidates "/>
-<use name="DataFormats/EgammaReco "/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/TrajectorySeed"/>

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Utilities"/>
 <use name="FWCore/Common"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/MuonReco"/>
 <use name="DataFormats/TauReco"/>

--- a/DataFormats/ProtonReco/BuildFile.xml
+++ b/DataFormats/ProtonReco/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/TrackReco"/>
 <use name="DataFormats/CTPPSReco"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/RecoCandidate/BuildFile.xml
+++ b/DataFormats/RecoCandidate/BuildFile.xml
@@ -7,7 +7,6 @@
 <use name="DataFormats/GsfTrackReco"/>
 <use name="DataFormats/HcalRecHit"/>
 <use name="clhep"/>
-<use name="SimDataFormats/GeneratorProducts"/>
 <use name="SimDataFormats/TrackingAnalysis"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Scouting/BuildFile.xml
+++ b/DataFormats/Scouting/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="FWCore/Utilities"/>
 <use name="DataFormats/Common"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/Streamer/BuildFile.xml
+++ b/DataFormats/Streamer/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Provenance"/>
-<use name="DataFormats/StdDictionaries"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/TestObjects/test/BuildFile.xml
+++ b/DataFormats/TestObjects/test/BuildFile.xml
@@ -2,6 +2,4 @@
 <use name="DataFormats/TestObjects"/>
 <bin file="Enum_t.cpp">
   <use name="FWCore/Reflection"/>
-  <use name="DataFormats/StdDictionaries"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
 </bin>

--- a/DataFormats/TrajectorySeed/BuildFile.xml
+++ b/DataFormats/TrajectorySeed/BuildFile.xml
@@ -1,11 +1,8 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/CLHEP"/>
 <use name="DataFormats/TrajectoryState"/>
-<use name="DataFormats/SiStripDetId"/>
-<use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackingRecHit"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/CommonDetUnit"/>
 <use name="clhepheader"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/V0Candidate/BuildFile.xml
+++ b/DataFormats/V0Candidate/BuildFile.xml
@@ -1,9 +1,5 @@
-<use name="DataFormats/CaloRecHit"/>
-<use name="DataFormats/Common"/>
-<use name="DataFormats/Math"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/VertexReco"/>
-<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/VertexReco/BuildFile.xml
+++ b/DataFormats/VertexReco/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
-<use name="FWCore/Utilities"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoHI/HiEvtPlaneAlgos/BuildFile.xml
+++ b/RecoHI/HiEvtPlaneAlgos/BuildFile.xml
@@ -11,4 +11,5 @@
 <use name="DataFormats/CaloTowers"/>
 <use name="CondCore/DBOutputService"/>
 <use name="CondFormats/DataRecord"/>
+<use name="CondFormats/HIObjects"/>
 <flags EDM_PLUGIN="1"/>

--- a/RecoHI/HiJetAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="RecoHI/HiJetAlgos"/>
 <use name="DataFormats/JetReco"/>
 <use name="CondFormats/DataRecord"/>
+<use name="CondFormats/HIObjects"/>
 <use name="CondCore/DBOutputService"/>
 <flags EDM_PLUGIN="1"/>
 <library file="*.cc" name="HiJetAlgosPlugins">


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31445).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.