### PR TITLE
Adding check to ensure L1Menu consistency in the HLT  : 112X

### DIFF
--- a/CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h
+++ b/CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h
@@ -102,6 +102,12 @@ public:
      */
   const std::string& getFirmwareUuid() const { return uuid_firmware_; };
 
+  /** gets the hash of the L1 firmware 
+     *
+     * @return the hash identifying the L1 firmware 
+     */
+  const unsigned long getFirmwareUuidHashed() const;
+
   /** get scale set name
      *
      * @return scale set name
@@ -155,6 +161,12 @@ public:
      * @param x [in] number of uGT boards
      */
   void setNmodules(const unsigned int x) { n_modules_ = x; };
+
+  /** hash computation function
+     *
+     * @return computed hash
+     */
+  static unsigned long murmurHashNeutral2(const void* key, int len, unsigned int seed);
 
 protected:
   std::map<std::string, L1TUtmAlgorithm> algorithm_map_; /**< map of algorithm <algorithm name, L1TUtmAlgorithm> */

--- a/CondFormats/L1TObjects/src/L1TUtmTriggerMenu.cc
+++ b/CondFormats/L1TObjects/src/L1TUtmTriggerMenu.cc
@@ -1,2 +1,67 @@
 // auto-generated file by import_utm.pl
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
+
+//copied from tmUtil
+const unsigned long L1TUtmTriggerMenu::getFirmwareUuidHashed() const {
+  const void* key = getFirmwareUuid().c_str();
+  int len = getFirmwareUuid().size();
+  unsigned int seed = 3735927486;
+  return murmurHashNeutral2(key, len, seed);
+}
+
+//copied from tmUtil
+unsigned long L1TUtmTriggerMenu::murmurHashNeutral2(const void* key, int len, unsigned int seed) {
+  // 'm' and 'r' are mixing constants generated offline.
+  // They're not really 'magic', they just happen to work well.
+
+  const unsigned int m = 0x5bd1e995;
+  const int r = 24;
+
+  // Initialize the hash to a 'random' value
+
+  unsigned int h = seed ^ len;
+
+  // Mix 4 bytes at a time into the hash
+
+  const unsigned char* data = (const unsigned char*)key;
+
+  while (len >= 4) {
+    unsigned int k;
+
+    k = data[0];
+    k |= data[1] << 8;
+    k |= data[2] << 16;
+    k |= data[3] << 24;
+
+    k *= m;
+    k ^= k >> r;
+    k *= m;
+
+    h *= m;
+    h ^= k;
+
+    data += 4;
+    len -= 4;
+  }
+
+  // Handle the last few bytes of the input array
+
+  switch (len) {
+    case 3:
+      h ^= data[2] << 16;
+    case 2:
+      h ^= data[1] << 8;
+    case 1:
+      h ^= data[0];
+      h *= m;
+  };
+
+  // Do a few final mixes of the hash to ensure the last few
+  // bytes are well-incorporated.
+
+  h ^= h >> 13;
+  h *= m;
+  h ^= h >> 15;
+
+  return h;
+}

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -178,6 +178,7 @@ private:
   bool m_isDebugEnabled;
 
   bool m_getPrescaleColumnFromData;
+  bool m_requireMenuToMatchAlgoBlkInput;
   edm::InputTag m_algoblkInputTag;
   edm::EDGetToken m_algoblkInputToken;
 

--- a/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
+++ b/L1Trigger/L1TGlobal/python/simGtStage2Digis_cfi.py
@@ -17,6 +17,7 @@ simGtStage2Digis = cms.EDProducer("L1TGlobalProducer",
     AlgorithmTriggersUnmasked = cms.bool(True),    
     AlgorithmTriggersUnprescaled = cms.bool(True),
     GetPrescaleColumnFromData = cms.bool(False),
+    RequireMenuToMatchAlgoBlkInput = cms.bool(False),
     AlgoBlkInputTag = cms.InputTag("gtStage2Digis")
     # deprecated in Mike's version of producer:                              
     #ProduceL1GtDaqRecord = cms.bool(True),


### PR DESCRIPTION

#### PR description:

The L1 result is packed into the RAW data as 512 bits which each bit corresponding to a given L1 seed.  Which seed corresponds to a given bit is determined by the L1 menu which is sent as conditions data. It is possible for the wrong L1 menu to be read if the corresponding entry in the global tag is incorrect. In this case the bits will not correspond to the L1 seeds the HLT thinks they do and thus when it thinks its requiring EG40 to pass, its really requiring Mu16 (as a hypothetical example). 

This PR adds the function which can convert the the firmware uuid to the hash of the firmware uuid send in the RAW data along with the L1 results. This can be then checked by the L1 GT emulator (L1TGlobalProducer) to ensure that the correct menu is being re-emulated and throw an exception if not. 

Note L1TGlobalProducer has two distinct use cases
1) to emulate the L1 Global trigger when emulating the L1 in the MC or emulating a different L1 menu on the data
2) to create the map of L1 objects to seeds which is needed for the HLT to properly use the seeds in its filters

It is use case 2) where we need to check that the menu we are emulating to create the l1 object map is the same as the menu used to create the L1 result in the RAW data. This is why this is an optional check (which will always be enabled in the HLT) as it doesnt make sense for use case 1)

Zero physics changes are expected. 

#### PR validation:

runTheMatrix tests succeeded.

testing with the incorrect menu resulted in the exception being thrown
