### PR TITLE
protect gcc syntax from clang

### DIFF
--- a/CondFormats/Serialization/interface/Test.h
+++ b/CondFormats/Serialization/interface/Test.h
@@ -12,7 +12,7 @@
 // The compiler knows our default-constructed objects' members
 // may not be initialized when we serialize them.
 
-#if !defined( __clang__ )
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 

--- a/CondFormats/Serialization/interface/Test.h
+++ b/CondFormats/Serialization/interface/Test.h
@@ -11,7 +11,10 @@
 
 // The compiler knows our default-constructed objects' members
 // may not be initialized when we serialize them.
+
+#if !defined( __clang__ )
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 
 // The main test: constructs an object using the default constructor,
 // serializes it, deserializes it and finally checks whether they are equal.


### PR DESCRIPTION
solves a warning in modules build (the last one we currently have....)