### PR TITLE
PixelCPEClusterRepair Local Errors Bugfix

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -251,6 +251,17 @@ protected:
   bool DoLorentz_;
   bool LoadTemplatesFromDB_;
 
+  //errors for template reco for edge hits, based on observed residuals from
+  //studies likely done in 2011...
+  static constexpr float xEdgeXError_ = 23.0f;
+  static constexpr float xEdgeYError_ = 39.0f;
+
+  static constexpr float yEdgeXError_ = 24.0f;
+  static constexpr float yEdgeYError_ = 96.0f;
+
+  static constexpr float bothEdgeXError_ = 31.0f;
+  static constexpr float bothEdgeYError_ = 90.0f;
+
   //---------------------------------------------------------------------------
   //  Geometrical services to subclasses.
   //---------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -262,6 +262,8 @@ protected:
   static constexpr float bothEdgeXError_ = 31.0f;
   static constexpr float bothEdgeYError_ = 90.0f;
 
+  static constexpr float clusterSplitMaxError_ = 7777.7f;
+
   //---------------------------------------------------------------------------
   //  Geometrical services to subclasses.
   //---------------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -629,9 +629,9 @@ LocalError PixelCPEClusterRepair::localError(DetParam const& theDetParam, Cluste
 
   // Check if the errors were already set at the clusters splitting level
   if (theClusterParam.theCluster->getSplitClusterErrorX() > 0.0f &&
-      theClusterParam.theCluster->getSplitClusterErrorX() < 7777.7f &&
+      theClusterParam.theCluster->getSplitClusterErrorX() < clusterSplitMaxError_ &&
       theClusterParam.theCluster->getSplitClusterErrorY() > 0.0f &&
-      theClusterParam.theCluster->getSplitClusterErrorY() < 7777.7f) {
+      theClusterParam.theCluster->getSplitClusterErrorY() < clusterSplitMaxError_) {
     xerr = theClusterParam.theCluster->getSplitClusterErrorX() * micronsToCm;
     yerr = theClusterParam.theCluster->getSplitClusterErrorY() * micronsToCm;
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -658,19 +658,19 @@ LocalError PixelCPEClusterRepair::localError(DetParam const& theDetParam, Cluste
         yerr = 39.0f * micronsToCm;
       }
     }
-    // Use special edge hit errors for edge hits that we did not run the 2D reco on
+    // Use special edge hit errors (derived from observed RMS's) for edge hits that we did not run the 2D reco on
     //
     else if (!theClusterParamBase.filled_from_2d && (theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_)) {
       // for edge pixels assign errors according to observed residual RMS
       if (theClusterParam.edgeTypeX_ && !theClusterParam.edgeTypeY_) {
-        xerr = 23.0f * micronsToCm;
-        yerr = 39.0f * micronsToCm;
+        xerr = xEdgeXError_ * micronsToCm;
+        yerr = xEdgeYError_ * micronsToCm;
       } else if (!theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_) {
-        xerr = 24.0f * micronsToCm;
-        yerr = 96.0f * micronsToCm;
+        xerr = yEdgeXError_ * micronsToCm;
+        yerr = yEdgeYError_ * micronsToCm;
       } else if (theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_) {
-        xerr = 31.0f * micronsToCm;
-        yerr = 90.0f * micronsToCm;
+        xerr = bothEdgeXError_ * micronsToCm;
+        yerr = bothEdgeYError_ * micronsToCm;
       }
     } else {
       xerr = theClusterParam.templSigmaX_ * micronsToCm;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -362,40 +362,38 @@ void PixelCPEClusterRepair::callTempReco1D(DetParam const& theDetParam,
   // ******************************************************************
 
   //--- Check exit status
-  if
-    UNLIKELY(theClusterParam.ierr != 0) {
-      LogDebug("PixelCPEClusterRepair::localPosition")
-          << "reconstruction failed with error " << theClusterParam.ierr << "\n";
+  if UNLIKELY (theClusterParam.ierr != 0) {
+    LogDebug("PixelCPEClusterRepair::localPosition")
+        << "reconstruction failed with error " << theClusterParam.ierr << "\n";
 
-      theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
-      theClusterParam.qBin_ = 0;
+    theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
+    theClusterParam.qBin_ = 0;
 
-      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-      // In the x case, apply a rough Lorentz drift average correction
-      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-      float lorentz_drift = -999.9;
-      if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
-        lorentz_drift = 60.0f;  // in microns
-      else
-        lorentz_drift = 10.0f;  // in microns
-      // GG: trk angles needed to correct for bows/kinks
-      if (theClusterParam.with_track_angle) {
-        theClusterParam.templXrec_ =
-            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-            lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ =
-            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
-      } else {
-        edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
-                                               << "Should never be here. PixelCPEClusterRepair should always be called "
-                                                  "with track angles. This is a bad error !!! ";
+    // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
+    // In the x case, apply a rough Lorentz drift average correction
+    // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
+    float lorentz_drift = -999.9;
+    if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
+      lorentz_drift = 60.0f;  // in microns
+    else
+      lorentz_drift = 10.0f;  // in microns
+    // GG: trk angles needed to correct for bows/kinks
+    if (theClusterParam.with_track_angle) {
+      theClusterParam.templXrec_ =
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
+          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ =
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+    } else {
+      edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
+                                             << "Should never be here. PixelCPEClusterRepair should always be called "
+                                                "with track angles. This is a bad error !!! ";
 
-        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                     lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
-      }
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
+                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
     }
-  else {
+  } else {
     //--- Template Reco succeeded.  The probabilities are filled.
     theClusterParam.hasFilledProb_ = true;
 
@@ -483,38 +481,36 @@ void PixelCPEClusterRepair::callTempReco2D(DetParam const& theDetParam,
   // ******************************************************************
 
   //--- Check exit status
-  if
-    UNLIKELY(theClusterParam.ierr2 != 0) {
-      LogDebug("PixelCPEClusterRepair::localPosition")
-          << "2D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
+  if UNLIKELY (theClusterParam.ierr2 != 0) {
+    LogDebug("PixelCPEClusterRepair::localPosition")
+        << "2D reconstruction failed with error " << theClusterParam.ierr2 << "\n";
 
-      theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
-      theClusterParam.qBin_ = 0;
-      // GG: what do we do in this case?  For now, just return the cluster center of gravity in microns
-      // In the x case, apply a rough Lorentz drift average correction
-      float lorentz_drift = -999.9;
-      if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
-        lorentz_drift = 60.0f;  // in microns  // &&& replace with a constant (globally)
-      else
-        lorentz_drift = 10.0f;  // in microns
-      // GG: trk angles needed to correct for bows/kinks
-      if (theClusterParam.with_track_angle) {
-        theClusterParam.templXrec_ =
-            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-            lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ =
-            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
-      } else {
-        edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
-                                               << "Should never be here. PixelCPEClusterRepair should always be called "
-                                                  "with track angles. This is a bad error !!! ";
+    theClusterParam.probabilityX_ = theClusterParam.probabilityY_ = theClusterParam.probabilityQ_ = 0.f;
+    theClusterParam.qBin_ = 0;
+    // GG: what do we do in this case?  For now, just return the cluster center of gravity in microns
+    // In the x case, apply a rough Lorentz drift average correction
+    float lorentz_drift = -999.9;
+    if (!GeomDetEnumerators::isEndcap(theDetParam.thePart))
+      lorentz_drift = 60.0f;  // in microns  // &&& replace with a constant (globally)
+    else
+      lorentz_drift = 10.0f;  // in microns
+    // GG: trk angles needed to correct for bows/kinks
+    if (theClusterParam.with_track_angle) {
+      theClusterParam.templXrec_ =
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
+          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ =
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+    } else {
+      edm::LogError("PixelCPEClusterRepair") << "@SUB = PixelCPEClusterRepair::localPosition"
+                                             << "Should never be here. PixelCPEClusterRepair should always be called "
+                                                "with track angles. This is a bad error !!! ";
 
-        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                     lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
-      }
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
+                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
     }
-  else {
+  } else {
     //--- Template Reco succeeded.
     theClusterParam.hasFilledProb_ = true;
 
@@ -631,15 +627,27 @@ LocalError PixelCPEClusterRepair::localError(DetParam const& theDetParam, Cluste
   //--- (never used, in fact: let comment it out, shut up the complains of the static analyzer, and save a few CPU cycles)
   float xerr = 0.0f, yerr = 0.0f;
 
-  //--- Check status of both template calls.
-  if
-    UNLIKELY((theClusterParam.ierr != 0) || (theClusterParam.ierr2 != 0)) {
+  // Check if the errors were already set at the clusters splitting level
+  if (theClusterParam.theCluster->getSplitClusterErrorX() > 0.0f &&
+      theClusterParam.theCluster->getSplitClusterErrorX() < 7777.7f &&
+      theClusterParam.theCluster->getSplitClusterErrorY() > 0.0f &&
+      theClusterParam.theCluster->getSplitClusterErrorY() < 7777.7f) {
+    xerr = theClusterParam.theCluster->getSplitClusterErrorX() * micronsToCm;
+    yerr = theClusterParam.theCluster->getSplitClusterErrorY() * micronsToCm;
+
+    //cout << "Errors set at cluster splitting level : " << endl;
+    //cout << "xerr = " << xerr << endl;
+    //cout << "yerr = " << yerr << endl;
+  } else {
+    // If errors are not split at the cluster splitting level, set the errors here
+
+    //--- Check status of both template calls.
+    if UNLIKELY ((theClusterParam.ierr != 0) || (theClusterParam.ierr2 != 0)) {
       // If reconstruction fails the hit position is calculated from cluster center of gravity
       // corrected in x by average Lorentz drift. Assign huge errors.
       //
-      if
-        UNLIKELY(!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
-      throw cms::Exception("PixelCPEClusterRepair::localPosition :") << "A non-pixel detector type in here?";
+      if UNLIKELY (!GeomDetEnumerators::isTrackerPixel(theDetParam.thePart))
+        throw cms::Exception("PixelCPEClusterRepair::localPosition :") << "A non-pixel detector type in here?";
 
       // Assign better errors based on the residuals for failed template cases
       if (GeomDetEnumerators::isBarrel(theDetParam.thePart)) {
@@ -650,29 +658,26 @@ LocalError PixelCPEClusterRepair::localError(DetParam const& theDetParam, Cluste
         yerr = 39.0f * micronsToCm;
       }
     }
-  // Leave commented for now, until we study the interplay of failure modes
-  // of 1D template reco and edges.  For edge hits we run 2D reco by default!
-  //
-  // else if ( theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_ )  {
-  //   // for edge pixels assign errors according to observed residual RMS
-  //   if      ( theClusterParam.edgeTypeX_ && !theClusterParam.edgeTypeY_ ) {
-  //     xerr = 23.0f * micronsToCm;
-  //     yerr = 39.0f * micronsToCm;
-  //   }
-  //   else if ( !theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_ ) {
-  //     xerr = 24.0f * micronsToCm;
-  //     yerr = 96.0f * micronsToCm;
-  //   }
-  //   else if ( theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_ ) {
-  //     xerr = 31.0f * micronsToCm;
-  //     yerr = 90.0f * micronsToCm;
-  //   }
-  // }
-  else {
-    xerr = theClusterParam.templSigmaX_ * micronsToCm;
-    yerr = theClusterParam.templSigmaY_ * micronsToCm;
-    // &&& should also check ierr (saved as class variable) and return
-    // &&& nonsense (another class static) if the template fit failed.
+    // Use special edge hit errors for edge hits that we did not run the 2D reco on
+    //
+    else if (!theClusterParamBase.filled_from_2d && (theClusterParam.edgeTypeX_ || theClusterParam.edgeTypeY_)) {
+      // for edge pixels assign errors according to observed residual RMS
+      if (theClusterParam.edgeTypeX_ && !theClusterParam.edgeTypeY_) {
+        xerr = 23.0f * micronsToCm;
+        yerr = 39.0f * micronsToCm;
+      } else if (!theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_) {
+        xerr = 24.0f * micronsToCm;
+        yerr = 96.0f * micronsToCm;
+      } else if (theClusterParam.edgeTypeX_ && theClusterParam.edgeTypeY_) {
+        xerr = 31.0f * micronsToCm;
+        yerr = 90.0f * micronsToCm;
+      }
+    } else {
+      xerr = theClusterParam.templSigmaX_ * micronsToCm;
+      yerr = theClusterParam.templSigmaY_ * micronsToCm;
+      // &&& should also check ierr (saved as class variable) and return
+      // &&& nonsense (another class static) if the template fit failed.
+    }
   }
 
   if (theVerboseLevel > 9) {

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -254,56 +254,53 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
   // ******************************************************************
 
   // Check exit status
-  if
-    UNLIKELY(theClusterParam.ierr != 0) {
-      LogDebug("PixelCPETemplateReco::localPosition")
-          << "reconstruction failed with error " << theClusterParam.ierr << "\n";
+  if UNLIKELY (theClusterParam.ierr != 0) {
+    LogDebug("PixelCPETemplateReco::localPosition")
+        << "reconstruction failed with error " << theClusterParam.ierr << "\n";
 
-      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-      // In the x case, apply a rough Lorentz drift average correction
-      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-      float lorentz_drift = -999.9;
-      if (!fpix)
-        lorentz_drift = 60.0f;  // in microns
-      else
-        lorentz_drift = 10.0f;  // in microns
-      // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
-      if (theClusterParam.with_track_angle) {
-        theClusterParam.templXrec_ =
-            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-            lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ =
-            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
-      } else {
-        edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
-                                              << "Should never be here. PixelCPETemplateReco should always be called "
-                                                 "with track angles. This is a bad error !!! ";
+    // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
+    // In the x case, apply a rough Lorentz drift average correction
+    // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
+    float lorentz_drift = -999.9;
+    if (!fpix)
+      lorentz_drift = 60.0f;  // in microns
+    else
+      lorentz_drift = 10.0f;  // in microns
+    // ggiurgiu@jhu.edu, 21/09/2010 : trk angles needed to correct for bows/kinks
+    if (theClusterParam.with_track_angle) {
+      theClusterParam.templXrec_ =
+          theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
+          lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ =
+          theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
+    } else {
+      edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
+                                            << "Should never be here. PixelCPETemplateReco should always be called "
+                                               "with track angles. This is a bad error !!! ";
 
-        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                     lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
-      }
+      theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
+                                   lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+      theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
     }
-  else if
-    UNLIKELY(UseClusterSplitter_ && theClusterParam.templQbin_ == 0) {
-      cout << " PixelCPETemplateReco : We should never be here !!!!!!!!!!!!!!!!!!!!!!" << endl;
-      cout << "                 (int)UseClusterSplitter_ = " << (int)UseClusterSplitter_ << endl;
+  } else if UNLIKELY (UseClusterSplitter_ && theClusterParam.templQbin_ == 0) {
+    cout << " PixelCPETemplateReco : We should never be here !!!!!!!!!!!!!!!!!!!!!!" << endl;
+    cout << "                 (int)UseClusterSplitter_ = " << (int)UseClusterSplitter_ << endl;
 
-      //ierr =
-      //PixelTempSplit( ID, fpix, cotalpha_, cotbeta_,
-      //		clust_array_2d, ydouble, xdouble,
-      //		templ,
-      //		templYrec1_, templYrec2_, templSigmaY_, templProbY_,
-      //		templXrec1_, templXrec2_, templSigmaX_, templProbX_,
-      //		templQbin_ );
+    //ierr =
+    //PixelTempSplit( ID, fpix, cotalpha_, cotbeta_,
+    //		clust_array_2d, ydouble, xdouble,
+    //		templ,
+    //		templYrec1_, templYrec2_, templSigmaY_, templProbY_,
+    //		templXrec1_, templXrec2_, templSigmaX_, templProbX_,
+    //		templQbin_ );
 
-      // Commented for now (3/10/17) until we figure out how to resuscitate 2D template splitter
-      ///      std::vector< SiPixelTemplateStore2D > thePixelTemp2D_;
-      ///SiPixelTemplate2D::pushfile(ID, thePixelTemp2D_);
-      ///SiPixelTemplate2D templ2D_(thePixelTemp2D_);
+    // Commented for now (3/10/17) until we figure out how to resuscitate 2D template splitter
+    ///      std::vector< SiPixelTemplateStore2D > thePixelTemp2D_;
+    ///SiPixelTemplate2D::pushfile(ID, thePixelTemp2D_);
+    ///SiPixelTemplate2D templ2D_(thePixelTemp2D_);
 
-      theClusterParam.ierr = -123;
-      /*
+    theClusterParam.ierr = -123;
+    /*
        float dchisq;
        float templProbQ_;
        SiPixelTemplateSplit::PixelTempSplit( ID, theClusterParam.cotalpha, theClusterParam.cotbeta,
@@ -319,57 +316,57 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
        templ2D_ );
        
        */
-      if (theClusterParam.ierr != 0) {
-        LogDebug("PixelCPETemplateReco::localPosition")
-            << "reconstruction failed with error " << theClusterParam.ierr << "\n";
+    if (theClusterParam.ierr != 0) {
+      LogDebug("PixelCPETemplateReco::localPosition")
+          << "reconstruction failed with error " << theClusterParam.ierr << "\n";
 
-        // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
-        // In the x case, apply a rough Lorentz drift average correction
-        // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
-        float lorentz_drift = -999.9f;
-        if (!fpix)
-          lorentz_drift = 60.0f;  // in microns
-        else
-          lorentz_drift = 10.0f;  // in microns
+      // Gavril: what do we do in this case ? For now, just return the cluster center of gravity in microns
+      // In the x case, apply a rough Lorentz drift average correction
+      // To do: call PixelCPEGeneric whenever PixelTempReco1D fails
+      float lorentz_drift = -999.9f;
+      if (!fpix)
+        lorentz_drift = 60.0f;  // in microns
+      else
+        lorentz_drift = 10.0f;  // in microns
 
-        // ggiurgiu@jhu.edu, 12/09/2010 : trk angles needed to correct for bows/kinks
-        if (theClusterParam.with_track_angle) {
-          theClusterParam.templXrec_ =
-              theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
-              lorentz_drift * micronsToCm;  // rough Lorentz drift correction
-          theClusterParam.templYrec_ =
-              theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
-        } else {
-          edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
-                                                << "Should never be here. PixelCPETemplateReco should always be called "
-                                                   "with track angles. This is a bad error !!! ";
-
-          theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
-                                       lorentz_drift * micronsToCm;  // very rough Lorentz drift correction
-          theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
-        }
+      // ggiurgiu@jhu.edu, 12/09/2010 : trk angles needed to correct for bows/kinks
+      if (theClusterParam.with_track_angle) {
+        theClusterParam.templXrec_ =
+            theDetParam.theTopol->localX(theClusterParam.theCluster->x(), theClusterParam.loc_trk_pred) -
+            lorentz_drift * micronsToCm;  // rough Lorentz drift correction
+        theClusterParam.templYrec_ =
+            theDetParam.theTopol->localY(theClusterParam.theCluster->y(), theClusterParam.loc_trk_pred);
       } else {
-        // go from micrometer to centimeter
-        templXrec1_ *= micronsToCm;
-        templYrec1_ *= micronsToCm;
-        templXrec2_ *= micronsToCm;
-        templYrec2_ *= micronsToCm;
+        edm::LogError("PixelCPETemplateReco") << "@SUB = PixelCPETemplateReco::localPosition"
+                                              << "Should never be here. PixelCPETemplateReco should always be called "
+                                                 "with track angles. This is a bad error !!! ";
 
-        // go back to the module coordinate system
-        templXrec1_ += lp.x();
-        templYrec1_ += lp.y();
-        templXrec2_ += lp.x();
-        templYrec2_ += lp.y();
-
-        // calculate distance from each hit to the track and choose the hit closest to the track
-        float distX1 = std::abs(templXrec1_ - theClusterParam.trk_lp_x);
-        float distX2 = std::abs(templXrec2_ - theClusterParam.trk_lp_x);
-        float distY1 = std::abs(templYrec1_ - theClusterParam.trk_lp_y);
-        float distY2 = std::abs(templYrec2_ - theClusterParam.trk_lp_y);
-        theClusterParam.templXrec_ = (distX1 < distX2 ? templXrec1_ : templXrec2_);
-        theClusterParam.templYrec_ = (distY1 < distY2 ? templYrec1_ : templYrec2_);
+        theClusterParam.templXrec_ = theDetParam.theTopol->localX(theClusterParam.theCluster->x()) -
+                                     lorentz_drift * micronsToCm;  // very rough Lorentz drift correction
+        theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
       }
-    }  // else if ( UseClusterSplitter_ && templQbin_ == 0 )
+    } else {
+      // go from micrometer to centimeter
+      templXrec1_ *= micronsToCm;
+      templYrec1_ *= micronsToCm;
+      templXrec2_ *= micronsToCm;
+      templYrec2_ *= micronsToCm;
+
+      // go back to the module coordinate system
+      templXrec1_ += lp.x();
+      templYrec1_ += lp.y();
+      templXrec2_ += lp.x();
+      templYrec2_ += lp.y();
+
+      // calculate distance from each hit to the track and choose the hit closest to the track
+      float distX1 = std::abs(templXrec1_ - theClusterParam.trk_lp_x);
+      float distX2 = std::abs(templXrec2_ - theClusterParam.trk_lp_x);
+      float distY1 = std::abs(templYrec1_ - theClusterParam.trk_lp_y);
+      float distY2 = std::abs(templYrec2_ - theClusterParam.trk_lp_y);
+      theClusterParam.templXrec_ = (distX1 < distX2 ? templXrec1_ : templXrec2_);
+      theClusterParam.templYrec_ = (distY1 < distY2 ? templYrec1_ : templYrec2_);
+    }
+  }  // else if ( UseClusterSplitter_ && templQbin_ == 0 )
 
   else  // apparenly this is the good one!
   {
@@ -491,14 +488,14 @@ LocalError PixelCPETemplateReco::localError(DetParam const& theDetParam, Cluster
     } else if (edgex || edgey) {
       // for edge pixels assign errors according to observed residual RMS
       if (edgex && !edgey) {
-        xerr = 23.0f * micronsToCm;
-        yerr = 39.0f * micronsToCm;
+        xerr = xEdgeXError_ * micronsToCm;
+        yerr = xEdgeYError_ * micronsToCm;
       } else if (!edgex && edgey) {
-        xerr = 24.0f * micronsToCm;
-        yerr = 96.0f * micronsToCm;
+        xerr = yEdgeXError_ * micronsToCm;
+        yerr = yEdgeYError_ * micronsToCm;
       } else if (edgex && edgey) {
-        xerr = 31.0f * micronsToCm;
-        yerr = 90.0f * micronsToCm;
+        xerr = bothEdgeXError_ * micronsToCm;
+        yerr = bothEdgeYError_ * micronsToCm;
       } else {
         throw cms::Exception(" PixelCPETemplateReco::localError: Something wrong with pixel edge flag !!!");
       }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -283,8 +283,9 @@ LocalPoint PixelCPETemplateReco::localPosition(DetParam const& theDetParam, Clus
       theClusterParam.templYrec_ = theDetParam.theTopol->localY(theClusterParam.theCluster->y());
     }
   } else if UNLIKELY (UseClusterSplitter_ && theClusterParam.templQbin_ == 0) {
-    cout << " PixelCPETemplateReco : We should never be here !!!!!!!!!!!!!!!!!!!!!!" << endl;
-    cout << "                 (int)UseClusterSplitter_ = " << (int)UseClusterSplitter_ << endl;
+    edm::LogError("PixelCPETemplateReco") << " PixelCPETemplateReco: Qbin = 0 but using cluster splitter, we should "
+                                             "never be here !!!!!!!!!!!!!!!!!!!!!! \n"
+                                          << "(int)UseClusterSplitter_ = " << (int)UseClusterSplitter_ << endl;
 
     //ierr =
     //PixelTempSplit( ID, fpix, cotalpha_, cotbeta_,
@@ -438,9 +439,9 @@ LocalError PixelCPETemplateReco::localError(DetParam const& theDetParam, Cluster
 
   // Check if the errors were already set at the clusters splitting level
   if (theClusterParam.theCluster->getSplitClusterErrorX() > 0.0f &&
-      theClusterParam.theCluster->getSplitClusterErrorX() < 7777.7f &&
+      theClusterParam.theCluster->getSplitClusterErrorX() < clusterSplitMaxError_ &&
       theClusterParam.theCluster->getSplitClusterErrorY() > 0.0f &&
-      theClusterParam.theCluster->getSplitClusterErrorY() < 7777.7f) {
+      theClusterParam.theCluster->getSplitClusterErrorY() < clusterSplitMaxError_) {
     xerr = theClusterParam.theCluster->getSplitClusterErrorX() * micronsToCm;
     yerr = theClusterParam.theCluster->getSplitClusterErrorY() * micronsToCm;
 


### PR DESCRIPTION
This PR introduces a bug fix to the Cluster Repair CPE to solves the degradation in high pT trackng performance seen recently. The issue was traced back to ClusterRepair not implementing the functionality present in the PixelCPETemplateReco for the errors of the cluster splitting used in the Jet Core cluster splitting. 
This PR also includes a fix for a case in which the ClusterRepair CPE was discrepant with respect to the Template CPE: the errors of edge hits which the 2D reco was not run on which were not being set to the special values used in the template CPE. This fix also defines these errors as constants in the base class rather than having them as two sets of 'magic numbers' in the code. 

The PR is an immediate fix for the high pT tracking issue and the plan is that there will be a longer term restructuring of the Template and ClusterRepair CPE's so as to avoid duplicated code. 

@vberta Has done testing to show that this PR does recover the performance loss in high pT tracking, with slides shown [here](https://indico.cern.ch/event/934809/contributions/4015468/attachments/2101571/3533198/presentation_CRissue_OzFixTest4PR.pdf).

There was also a quick test done on the edge hit errors to ensure that the new PR does indeed match the output of the 1D template reco for edge hits where the 2D reco is not run. Results are [here](https://cernbox.cern.ch/index.php/s/vxbIHE0zUeXBtUz)

@mmusich @tsusa @VinInn @tvami @pmaksim1 @cmantill @mtosi