### PR TITLE
Migrate ESProducers in reconstruction from setConsumes() to type-deducing consumes()

### DIFF
--- a/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionESProducer.h
@@ -24,18 +24,16 @@ class JetCorrector;
 template <class Corrector>
 class JetCorrectionESProducer : public edm::ESProducer {
 private:
-  edm::ParameterSet mParameterSet;
-  std::string mLevel;
-  edm::ESGetToken<JetCorrectorParametersCollection, JetCorrectionsRecord> mToken;
+  const edm::ParameterSet mParameterSet;
+  const std::string mLevel;
+  const edm::ESGetToken<JetCorrectorParametersCollection, JetCorrectionsRecord> mToken;
 
 public:
-  JetCorrectionESProducer(edm::ParameterSet const& fConfig) : mParameterSet(fConfig) {
-    std::string label = fConfig.getParameter<std::string>("@module_label");
-    mLevel = fConfig.getParameter<std::string>("level");
-    auto algo = fConfig.getParameter<std::string>("algorithm");
-
-    setWhatProduced(this, label).setConsumes(mToken, edm::ESInputTag{"", algo});
-  }
+  JetCorrectionESProducer(edm::ParameterSet const& fConfig)
+      : mParameterSet(fConfig),
+        mLevel(fConfig.getParameter<std::string>("level")),
+        mToken(setWhatProduced(this, fConfig.getParameter<std::string>("@module_label"))
+                   .consumes(edm::ESInputTag{"", fConfig.getParameter<std::string>("algorithm")})) {}
 
   ~JetCorrectionESProducer() override {}
 

--- a/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
+++ b/JetMETCorrections/Modules/interface/JetResolutionESProducer.h
@@ -23,7 +23,7 @@ private:
 public:
   JetResolutionESProducer(edm::ParameterSet const& fConfig) {
     auto label = fConfig.getParameter<std::string>("label");
-    setWhatProduced(this, label).setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = setWhatProduced(this, label).consumes(edm::ESInputTag{"", label});
   }
 
   ~JetResolutionESProducer() override {}
@@ -40,7 +40,7 @@ private:
 public:
   JetResolutionScaleFactorESProducer(edm::ParameterSet const& fConfig) {
     auto label = fConfig.getParameter<std::string>("label");
-    setWhatProduced(this, label).setConsumes(token_, edm::ESInputTag{"", label});
+    token_ = setWhatProduced(this, label).consumes(edm::ESInputTag{"", label});
   }
 
   ~JetResolutionScaleFactorESProducer() override {}

--- a/JetMETCorrections/Modules/plugins/JetCorrectionESChain.cc
+++ b/JetMETCorrections/Modules/plugins/JetCorrectionESChain.cc
@@ -38,7 +38,7 @@ JetCorrectionESChain::JetCorrectionESChain(edm::ParameterSet const& fParameters)
   auto cc = setWhatProduced(this, label);
   tokens_.resize(correctors.size());
   for (size_t i = 0; i < correctors.size(); ++i) {
-    cc.setConsumes(tokens_[i], edm::ESInputTag{"", correctors[i]});
+    tokens_[i] = cc.consumes(edm::ESInputTag{"", correctors[i]});
   }
 }
 

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodESProducer.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodESProducer.cc
@@ -31,16 +31,12 @@ public:
   std::shared_ptr<const QGLikelihoodObject> produce(const QGLikelihoodRcd&);
 
 private:
-  edm::ESGetToken<QGLikelihoodObject, QGLikelihoodRcd> token_;
+  const edm::ESGetToken<QGLikelihoodObject, QGLikelihoodRcd> token_;
 };
 
-QGLikelihoodESProducer::QGLikelihoodESProducer(const edm::ParameterSet& iConfig) {
-  //the following line is needed to tell the framework what
-  // data is being produced
-  std::string label = iConfig.getParameter<std::string>("@module_label");
-  auto algo = iConfig.getParameter<std::string>("algo");
-  setWhatProduced(this, label).setConsumes(token_, edm::ESInputTag{"", algo});
-}
+QGLikelihoodESProducer::QGLikelihoodESProducer(const edm::ParameterSet& iConfig)
+    : token_(setWhatProduced(this, iConfig.getParameter<std::string>("@module_label"))
+                 .consumes(edm::ESInputTag{"", iConfig.getParameter<std::string>("algo")})) {}
 
 // Produce the data
 std::shared_ptr<const QGLikelihoodObject> QGLikelihoodESProducer::produce(const QGLikelihoodRcd& iRecord) {

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsESProducer.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodSystematicsESProducer.cc
@@ -30,16 +30,12 @@ public:
   std::shared_ptr<const QGLikelihoodSystematicsObject> produce(const QGLikelihoodSystematicsRcd&);
 
 private:
-  edm::ESGetToken<QGLikelihoodSystematicsObject, QGLikelihoodSystematicsRcd> token_;
+  const edm::ESGetToken<QGLikelihoodSystematicsObject, QGLikelihoodSystematicsRcd> token_;
 };
 
-QGLikelihoodSystematicsESProducer::QGLikelihoodSystematicsESProducer(const edm::ParameterSet& iConfig) {
-  //the following line is needed to tell the framework what
-  // data is being produced
-  std::string label(iConfig.getParameter<std::string>("@module_label"));
-  auto algo = iConfig.getParameter<std::string>("algo");
-  setWhatProduced(this, label).setConsumes(token_, edm::ESInputTag{"", algo});
-}
+QGLikelihoodSystematicsESProducer::QGLikelihoodSystematicsESProducer(const edm::ParameterSet& iConfig)
+    : token_(setWhatProduced(this, iConfig.getParameter<std::string>("@module_label"))
+                 .consumes(edm::ESInputTag{"", iConfig.getParameter<std::string>("algo")})) {}
 
 // Produce the data
 std::shared_ptr<const QGLikelihoodSystematicsObject> QGLikelihoodSystematicsESProducer::produce(

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducer.cc
@@ -52,9 +52,9 @@ VolumeBasedMagneticFieldESProducer::VolumeBasedMagneticFieldESProducer(const edm
       conf_{iConfig, debug_},
       version_{iConfig.getParameter<std::string>("version")} {
   auto cc = setWhatProduced(this, iConfig.getUntrackedParameter<std::string>("label", ""));
-  cc.setConsumes(cpvToken_, edm::ESInputTag{"", "magfield"});
+  cpvToken_ = cc.consumes(edm::ESInputTag{"", "magfield"});
   if (useParametrizedTrackerField_) {
-    cc.setConsumes(paramFieldToken_, edm::ESInputTag{"", iConfig.getParameter<string>("paramLabel")});
+    paramFieldToken_ = cc.consumes(edm::ESInputTag{"", iConfig.getParameter<string>("paramLabel")});
   }
 }
 

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -101,26 +101,26 @@ VolumeBasedMagneticFieldESProducerFromDB::VolumeBasedMagneticFieldESProducerFrom
     auto const label = closerNominalLabel(current);
     edm::LogInfo("MagneticField") << "Current :" << current
                                   << " (from valueOverride card); using map configuration with label: " << label;
-    setWhatProduced(
-        this, &VolumeBasedMagneticFieldESProducerFromDB::chooseConfigViaParameter, edm::es::Label(myConfigLabel))
-        .setConsumes(knownFromParamConfigToken_, edm::ESInputTag(""s, std::string(label)));
+    auto cc = setWhatProduced(
+        this, &VolumeBasedMagneticFieldESProducerFromDB::chooseConfigViaParameter, edm::es::Label(myConfigLabel));
+    knownFromParamConfigToken_ = cc.consumes(edm::ESInputTag(""s, std::string(label)));
   }
 
   auto const label = iConfig.getUntrackedParameter<std::string>("label");
   auto const myConfigTag = edm::ESInputTag(iConfig.getParameter<std::string>("@module_label"), myConfigLabel);
 
   //We use the MagFieldConfig created above to decide which FileBlob to use
-  setWhatProduced(this, label)
-      .setMayConsume(
-          mayConsumeBlobToken_,
-          [](auto const& iGet, edm::ESTransientHandle<MagFieldConfig> iConfig) {
-            if (iConfig->version == "parametrizedMagneticField") {
-              return iGet.nothing();
-            }
-            return iGet("", std::to_string(iConfig->geometryVersion));
-          },
-          edm::ESProductTag<MagFieldConfig, IdealMagneticFieldRecord>(myConfigTag))
-      .setConsumes(chosenConfigToken_, myConfigTag);  //Use same tag as the choice
+  auto cc = setWhatProduced(this, label);
+  cc.setMayConsume(
+      mayConsumeBlobToken_,
+      [](auto const& iGet, edm::ESTransientHandle<MagFieldConfig> iConfig) {
+        if (iConfig->version == "parametrizedMagneticField") {
+          return iGet.nothing();
+        }
+        return iGet("", std::to_string(iConfig->geometryVersion));
+      },
+      edm::ESProductTag<MagFieldConfig, IdealMagneticFieldRecord>(myConfigTag));
+  chosenConfigToken_ = cc.consumes(myConfigTag);  //Use same tag as the choice
 }
 
 std::shared_ptr<MagFieldConfig const> VolumeBasedMagneticFieldESProducerFromDB::chooseConfigAtRuntime(

--- a/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducer.cc
+++ b/MagneticField/GeomBuilder/plugins/dd4hep/DD4hep_VolumeBasedMagneticFieldESProducer.cc
@@ -58,9 +58,9 @@ DD4hep_VolumeBasedMagneticFieldESProducer::DD4hep_VolumeBasedMagneticFieldESProd
   LogTrace("MagGeoBuilder") << "info:Constructing a DD4hep_VolumeBasedMagneticFieldESProducer";
 
   auto cc = setWhatProduced(this, iConfig.getUntrackedParameter<std::string>("label", ""));
-  cc.setConsumes(cpvToken_, edm::ESInputTag{"", "magfield"});
+  cpvToken_ = cc.consumes(edm::ESInputTag{"", "magfield"});
   if (useParametrizedTrackerField_) {
-    cc.setConsumes(paramFieldToken_, edm::ESInputTag{"", iConfig.getParameter<std::string>("paramLabel")});
+    paramFieldToken_ = cc.consumes(edm::ESInputTag{"", iConfig.getParameter<std::string>("paramLabel")});
   }
 }
 

--- a/MagneticField/ParametrizedEngine/plugins/AutoParametrizedMagneticFieldProducer.cc
+++ b/MagneticField/ParametrizedEngine/plugins/AutoParametrizedMagneticFieldProducer.cc
@@ -47,7 +47,7 @@ AutoParametrizedMagneticFieldProducer::AutoParametrizedMagneticFieldProducer(con
 {
   auto cc = setWhatProduced(this, iConfig.getUntrackedParameter<std::string>("label", ""));
   if (currentOverride_ < 0) {
-    cc.setConsumes(runInfoToken_);
+    runInfoToken_ = cc.consumes();
   }
 }
 

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -14,11 +14,10 @@
 
 CharmTagger::Tokens::Tokens(const edm::ParameterSet &configuration, edm::ESConsumesCollector &&cc) {
   if (configuration.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(gbrForest_,
-                   edm::ESInputTag{"",
-                                   configuration.existsAs<std::string>("gbrForestLabel")
-                                       ? configuration.getParameter<std::string>("gbrForestLabel")
-                                       : ""});
+    gbrForest_ = cc.consumes(edm::ESInputTag{"",
+                                             configuration.existsAs<std::string>("gbrForestLabel")
+                                                 ? configuration.getParameter<std::string>("gbrForestLabel")
+                                                 : ""});
   }
 }
 

--- a/RecoBTag/Combined/src/CandidateChargeBTagComputer.cc
+++ b/RecoBTag/Combined/src/CandidateChargeBTagComputer.cc
@@ -4,7 +4,7 @@
 
 CandidateChargeBTagComputer::Tokens::Tokens(const edm::ParameterSet& parameters, edm::ESConsumesCollector&& cc) {
   if (parameters.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(gbrForest_, edm::ESInputTag{"", parameters.getParameter<std::string>("gbrForestLabel")});
+    gbrForest_ = cc.consumes(edm::ESInputTag{"", parameters.getParameter<std::string>("gbrForestLabel")});
   }
 }
 

--- a/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
+++ b/RecoBTag/Combined/src/CombinedMVAV2JetTagComputer.cc
@@ -17,16 +17,13 @@ using namespace reco;
 
 CombinedMVAV2JetTagComputer::Tokens::Tokens(const edm::ParameterSet &params, edm::ESConsumesCollector &&cc) {
   if (params.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(
-        gbrForest_,
-        edm::ESInputTag{
-            "",
-            params.existsAs<std::string>("gbrForestLabel") ? params.getParameter<std::string>("gbrForestLabel") : ""});
+    gbrForest_ = cc.consumes(edm::ESInputTag{
+        "", params.existsAs<std::string>("gbrForestLabel") ? params.getParameter<std::string>("gbrForestLabel") : ""});
   }
   const auto &inputComputerNames = params.getParameter<std::vector<std::string> >("jetTagComputers");
   computers_.resize(inputComputerNames.size());
   for (size_t i = 0; i < inputComputerNames.size(); ++i) {
-    cc.setConsumes(computers_[i], edm::ESInputTag{"", inputComputerNames[i]});
+    computers_[i] = cc.consumes(edm::ESInputTag{"", inputComputerNames[i]});
   }
 }
 

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -11,11 +11,10 @@
 CandidateBoostedDoubleSecondaryVertexComputer::Tokens::Tokens(const edm::ParameterSet& parameters,
                                                               edm::ESConsumesCollector&& cc) {
   if (parameters.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(gbrForest_,
-                   edm::ESInputTag{"",
-                                   parameters.existsAs<std::string>("gbrForestLabel")
-                                       ? parameters.getParameter<std::string>("gbrForestLabel")
-                                       : ""});
+    gbrForest_ = cc.consumes(edm::ESInputTag{"",
+                                             parameters.existsAs<std::string>("gbrForestLabel")
+                                                 ? parameters.getParameter<std::string>("gbrForestLabel")
+                                                 : ""});
   }
 }
 

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -14,10 +14,8 @@
 
 ElectronTagger::Tokens::Tokens(const edm::ParameterSet& cfg, edm::ESConsumesCollector&& cc) {
   if (cfg.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(
-        gbrForest_,
-        edm::ESInputTag{
-            "", cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""});
+    gbrForest_ = cc.consumes(edm::ESInputTag{
+        "", cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""});
   }
 }
 

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -15,10 +15,8 @@
 
 MuonTagger::Tokens::Tokens(const edm::ParameterSet& cfg, edm::ESConsumesCollector&& cc) {
   if (cfg.getParameter<bool>("useCondDB")) {
-    cc.setConsumes(
-        gbrForest_,
-        edm::ESInputTag{
-            "", cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""});
+    gbrForest_ = cc.consumes(edm::ESInputTag{
+        "", cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""});
   }
 }
 

--- a/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
+++ b/RecoBTau/JetTagComputer/src/GenericMVAJetTagComputer.cc
@@ -31,9 +31,8 @@ static std::vector<std::string> getCalibrationLabels(const edm::ParameterSet &pa
   }
 }
 
-GenericMVAJetTagComputer::Tokens::Tokens(const edm::ParameterSet &params, edm::ESConsumesCollector &&cc) {
-  cc.setConsumes(calib_, edm::ESInputTag{"", params.getParameter<std::string>("recordLabel")});
-}
+GenericMVAJetTagComputer::Tokens::Tokens(const edm::ParameterSet &params, edm::ESConsumesCollector &&cc)
+    : calib_(cc.consumes(edm::ESInputTag{"", params.getParameter<std::string>("recordLabel")})) {}
 
 GenericMVAJetTagComputer::GenericMVAJetTagComputer(const edm::ParameterSet &params, Tokens tokens)
     : computerCache_(getCalibrationLabels(params, categorySelector_)), tokens_{tokens} {}

--- a/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
+++ b/RecoLocalCalo/HcalRecAlgos/plugins/HcalChannelPropertiesEP.cc
@@ -29,12 +29,16 @@ public:
 
   inline HcalChannelPropertiesEP(const edm::ParameterSet&) {
     auto cc1 = setWhatProduced(this, &HcalChannelPropertiesEP::produce1);
-    cc1.setConsumes(topoToken_).setConsumes(paramsToken_);
+    topoToken_ = cc1.consumes();
+    paramsToken_ = cc1.consumes();
 
     auto cc2 = setWhatProduced(this, &HcalChannelPropertiesEP::produce2);
     edm::ESInputTag qTag("", "withTopo");
-    cc2.setConsumes(condToken_).setConsumes(myParamsToken_);
-    cc2.setConsumes(sevToken_).setConsumes(qualToken_, qTag).setConsumes(geomToken_);
+    condToken_ = cc2.consumes();
+    myParamsToken_ = cc2.consumes();
+    sevToken_ = cc2.consumes();
+    qualToken_ = cc2.consumes(qTag);
+    geomToken_ = cc2.consumes();
   }
 
   inline ~HcalChannelPropertiesEP() override {}

--- a/RecoLocalFastTime/FTLClusterizer/plugins/MTDCPEESProducer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/plugins/MTDCPEESProducer.cc
@@ -25,14 +25,12 @@ public:
   std::unique_ptr<MTDClusterParameterEstimator> produce(const MTDCPERecord&);
 
 private:
-  edm::ParameterSet pset_;
-  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> ddToken_;
+  const edm::ParameterSet pset_;
+  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> ddToken_;
 };
 
-MTDCPEESProducer::MTDCPEESProducer(const edm::ParameterSet& p) {
-  pset_ = p;
-  setWhatProduced(this, "MTDCPEBase").setConsumes(ddToken_);
-}
+MTDCPEESProducer::MTDCPEESProducer(const edm::ParameterSet& p)
+    : pset_(p), ddToken_(setWhatProduced(this, "MTDCPEBase").consumes()) {}
 
 // Configuration descriptions
 void MTDCPEESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
+++ b/RecoLocalFastTime/FTLRecProducers/plugins/MTDTimeCalibESProducer.cc
@@ -36,7 +36,9 @@ private:
 
 MTDTimeCalibESProducer::MTDTimeCalibESProducer(const edm::ParameterSet& p) {
   pset_ = p;
-  setWhatProduced(this, "MTDTimeCalib").setConsumes(ddToken_).setConsumes(topoToken_);
+  auto cc = setWhatProduced(this, "MTDTimeCalib");
+  ddToken_ = cc.consumes();
+  topoToken_ = cc.consumes();
 }
 
 // Configuration descriptions

--- a/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
+++ b/RecoLocalTracker/Phase2TrackerRecHits/plugins/Phase2StripCPEESProducer.cc
@@ -47,9 +47,9 @@ Phase2StripCPEESProducer::Phase2StripCPEESProducer(const edm::ParameterSet& p) {
   pset_ = p.getParameter<edm::ParameterSet>("parameters");
   auto c = setWhatProduced(this, name);
   if (cpeNum_ != GEOMETRIC) {
-    c.setConsumes(magfieldToken_);
-    c.setConsumes(pDDToken_);
-    c.setConsumes(lorentzAngleToken_);
+    magfieldToken_ = c.consumes();
+    pDDToken_ = c.consumes();
+    lorentzAngleToken_ = c.consumes();
   }
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEClusterRepairESProducer.cc
@@ -47,13 +47,13 @@ PixelCPEClusterRepairESProducer::PixelCPEClusterRepairESProducer(const edm::Para
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_)
-      .setConsumes(pDDToken_)
-      .setConsumes(hTTToken_)
-      .setConsumes(templateDBobjectToken_)
-      .setConsumes(templateDBobject2DToken_);
+  magfieldToken_ = c.consumes();
+  pDDToken_ = c.consumes();
+  hTTToken_ = c.consumes();
+  templateDBobjectToken_ = c.consumes();
+  templateDBobject2DToken_ = c.consumes();
   if (DoLorentz_) {
-    c.setConsumes(lorentzAngleToken_, edm::ESInputTag("", "fromAlignment"));
+    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
   }
 
   //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -56,15 +56,15 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet& p)
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_, magname)
-      .setConsumes(pDDToken_)
-      .setConsumes(hTTToken_)
-      .setConsumes(lorentzAngleToken_, edm::ESInputTag("", laLabel));
+  magfieldToken_ = c.consumes(magname);
+  pDDToken_ = c.consumes();
+  hTTToken_ = c.consumes();
+  lorentzAngleToken_ = c.consumes(edm::ESInputTag("", laLabel));
   if (useLAWidthFromDB_) {
-    c.setConsumes(lorentzAngleWidthToken_, edm::ESInputTag("", "forWidth"));
+    lorentzAngleWidthToken_ = c.consumes(edm::ESInputTag("", "forWidth"));
   }
   if (UseErrorsFromTemplates_) {
-    c.setConsumes(genErrorDBObjectToken_);
+    genErrorDBObjectToken_ = c.consumes();
   }
 
   //std::cout<<" ESProducer "<<myname<<" "<<useLAWidthFromDB_<<" "<<useLAAlignmentOffsets_<<" "

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPETemplateRecoESProducer.cc
@@ -43,9 +43,12 @@ PixelCPETemplateRecoESProducer::PixelCPETemplateRecoESProducer(const edm::Parame
 
   pset_ = p;
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magfieldToken_).setConsumes(pDDToken_).setConsumes(hTTToken_).setConsumes(templateDBobjectToken_);
+  magfieldToken_ = c.consumes();
+  pDDToken_ = c.consumes();
+  hTTToken_ = c.consumes();
+  templateDBobjectToken_ = c.consumes();
   if (DoLorentz_) {
-    c.setConsumes(lorentzAngleToken_, edm::ESInputTag("", "fromAlignment"));
+    lorentzAngleToken_ = c.consumes(edm::ESInputTag("", "fromAlignment"));
   }
   //std::cout<<" from ES Producer Templates "<<myname<<" "<<DoLorentz_<<std::endl;  //dk
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/plugins/StripCPEESProducer.cc
@@ -55,13 +55,13 @@ StripCPEESProducer::StripCPEESProducer(const edm::ParameterSet& p) {
 
   cpeNum = enumMap[type];
   parametersPSet = (p.exists("parameters") ? p.getParameter<edm::ParameterSet>("parameters") : p);
-  setWhatProduced(this, name)
-      .setConsumes(pDDToken_)
-      .setConsumes(magfieldToken_)
-      .setConsumes(lorentzAngleToken_)
-      .setConsumes(backPlaneCorrectionToken_)
-      .setConsumes(confObjToken_)
-      .setConsumes(latencyToken_);
+  auto cc = setWhatProduced(this, name);
+  pDDToken_ = cc.consumes();
+  magfieldToken_ = cc.consumes();
+  lorentzAngleToken_ = cc.consumes();
+  backPlaneCorrectionToken_ = cc.consumes();
+  confObjToken_ = cc.consumes();
+  latencyToken_ = cc.consumes();
 }
 
 std::unique_ptr<StripClusterParameterEstimator> StripCPEESProducer::produce(const TkStripCPERecord& iRecord) {

--- a/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
+++ b/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
@@ -36,14 +36,13 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
 };
 
 using namespace edm;
 
-MTDDetLayerGeometryESProducer::MTDDetLayerGeometryESProducer(const edm::ParameterSet& p) {
-  setWhatProduced(this).setConsumes(geomToken_);
-}
+MTDDetLayerGeometryESProducer::MTDDetLayerGeometryESProducer(const edm::ParameterSet& p)
+    : geomToken_(setWhatProduced(this).consumes()) {}
 
 std::unique_ptr<MTDDetLayerGeometry> MTDDetLayerGeometryESProducer::produce(const MTDRecoGeometryRecord& record) {
   auto mtdDetLayerGeometry = std::make_unique<MTDDetLayerGeometry>();

--- a/RecoMTD/TransientTrackingRecHit/plugins/MTDTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoMTD/TransientTrackingRecHit/plugins/MTDTransientTrackingRecHitBuilderESProducer.cc
@@ -31,16 +31,15 @@ public:
   std::unique_ptr<TransientTrackingRecHitBuilder> produce(const TransientRecHitRecord&);
 
 private:
-  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geomToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geomToken_;
 };
 
 using namespace edm;
 using namespace std;
 
 MTDTransientTrackingRecHitBuilderESProducer::MTDTransientTrackingRecHitBuilderESProducer(
-    const ParameterSet& parameterSet) {
-  setWhatProduced(this, parameterSet.getParameter<string>("ComponentName")).setConsumes(geomToken_);
-}
+    const ParameterSet& parameterSet)
+    : geomToken_(setWhatProduced(this, parameterSet.getParameter<string>("ComponentName")).consumes()) {}
 
 std::unique_ptr<TransientTrackingRecHitBuilder> MTDTransientTrackingRecHitBuilderESProducer::produce(
     const TransientRecHitRecord& iRecord) {

--- a/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
+++ b/RecoMuon/DetLayers/plugins/MuonDetLayerGeometryESProducer.cc
@@ -54,12 +54,12 @@ private:
 using namespace edm;
 
 MuonDetLayerGeometryESProducer::MuonDetLayerGeometryESProducer(const edm::ParameterSet& p) {
-  setWhatProduced(this)
-      .setConsumes(dtToken_)
-      .setConsumes(cscToken_)
-      .setConsumes(gemToken_)
-      .setConsumes(me0Token_)
-      .setConsumes(rpcToken_);
+  auto cc = setWhatProduced(this);
+  dtToken_ = cc.consumes();
+  cscToken_ = cc.consumes();
+  gemToken_ = cc.consumes();
+  me0Token_ = cc.consumes();
+  rpcToken_ = cc.consumes();
 }
 
 std::unique_ptr<MuonDetLayerGeometry> MuonDetLayerGeometryESProducer::produce(const MuonRecoGeometryRecord& record) {

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/ClusterShapeHitFilterESProducer.cc
@@ -58,12 +58,12 @@ ClusterShapeHitFilterESProducer::ClusterShapeHitFilterESProducer(const edm::Para
 
   edm::LogInfo("ClusterShapeHitFilterESProducer") << " with name: " << componentName;
 
-  setWhatProduced(this, componentName)
-      .setConsumes(fieldToken_)
-      .setConsumes(geoToken_)
-      .setConsumes(topolToken_)
-      .setConsumes(pixelToken_)
-      .setConsumes(stripToken_);
+  auto cc = setWhatProduced(this, componentName);
+  fieldToken_ = cc.consumes();
+  geoToken_ = cc.consumes();
+  topolToken_ = cc.consumes();
+  pixelToken_ = cc.consumes();
+  stripToken_ = cc.consumes();
 }
 
 /*****************************************************************************/

--- a/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
+++ b/RecoTracker/GeometryESProducer/plugins/TrackerRecoGeometryESProducer.cc
@@ -41,8 +41,8 @@ TrackerRecoGeometryESProducer::TrackerRecoGeometryESProducer(const edm::Paramete
   // aligned and a misaligned geometry in the same job.
   // The default parameter ("") makes this change transparent to the user
   // See FastSimulation/Configuration/data/ for examples of cfi's.
-  c.setConsumes(geomToken_, edm::ESInputTag("", p.getUntrackedParameter<std::string>("trackerGeometryLabel")));
-  c.setConsumes(tTopToken_);
+  tTopToken_ = c.consumes();
+  geomToken_ = c.consumes(edm::ESInputTag("", p.getUntrackedParameter<std::string>("trackerGeometryLabel")));
 }
 
 std::unique_ptr<GeometricSearchTracker> TrackerRecoGeometryESProducer::produce(

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -125,13 +125,13 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
 
   std::tie(pixelQualityFlags_, pixelQualityDebugFlags_) = pixelFlags(p);
   if (pixelQualityFlags_ != 0) {
-    c.setConsumes(pixelQualityToken_);
-    c.setConsumes(pixelCablingToken_);
+    pixelQualityToken_ = c.consumes();
+    pixelCablingToken_ = c.consumes();
   }
 
   std::tie(stripQualityFlags_, stripQualityDebugFlags_) = stripFlags(p);
   if (stripQualityFlags_ != 0) {
-    c.setConsumes(stripQualityToken_, edm::ESInputTag("", p.getParameter<std::string>("SiStripQualityLabel")));
+    stripQualityToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("SiStripQualityLabel")));
     if (stripQualityFlags_ & MeasurementTrackerImpl::BadStrips) {
       auto makeBadStripCuts = [](edm::ParameterSet const &pset) {
         return StMeasurementConditionSet::BadStripCuts(pset.getParameter<uint32_t>("maxBad"),
@@ -146,18 +146,18 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
     }
   }
 
-  c.setConsumes(pixelCPEToken_, edm::ESInputTag("", p.getParameter<std::string>("PixelCPE")));
-  c.setConsumes(stripCPEToken_, edm::ESInputTag("", p.getParameter<std::string>("StripCPE")));
-  c.setConsumes(hitMatcherToken_, edm::ESInputTag("", p.getParameter<std::string>("HitMatcher")));
-  c.setConsumes(trackerTopologyToken_);
-  c.setConsumes(trackerGeomToken_);
-  c.setConsumes(geometricSearchTrackerToken_);
+  pixelCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("PixelCPE")));
+  stripCPEToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("StripCPE")));
+  hitMatcherToken_ = c.consumes(edm::ESInputTag("", p.getParameter<std::string>("HitMatcher")));
+  trackerTopologyToken_ = c.consumes();
+  trackerGeomToken_ = c.consumes();
+  geometricSearchTrackerToken_ = c.consumes();
 
   //FIXME:: just temporary solution for phase2!
   auto phase2 = p.getParameter<std::string>("Phase2StripCPE");
   if (not phase2.empty()) {
     usePhase2_ = true;
-    c.setConsumes(phase2TrackerCPEToken_, edm::ESInputTag("", phase2));
+    phase2TrackerCPEToken_ = c.consumes(edm::ESInputTag("", phase2));
   }
 }
 

--- a/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/CosmicNavigationSchool.cc
@@ -344,9 +344,9 @@ public:
   SkippingLayerCosmicNavigationSchoolESProducer(const edm::ParameterSet& iConfig) : config_(iConfig) {
     //the following line is needed to tell the framework what
     // data is being produced
-    setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"))
-        .setConsumes(magFieldToken_)
-        .setConsumes(geometricSearchTrackerToken_);
+    auto cc = setWhatProduced(this, iConfig.getParameter<std::string>("ComponentName"));
+    magFieldToken_ = cc.consumes();
+    geometricSearchTrackerToken_ = cc.consumes();
   }
 
   using ReturnType = std::unique_ptr<NavigationSchool>;

--- a/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
+++ b/RecoTracker/TkNavigation/plugins/NavigationSchoolESProducer.cc
@@ -42,9 +42,9 @@ NavigationSchoolESProducer::NavigationSchoolESProducer(const edm::ParameterSet& 
   //the following line is needed to tell the framework what
   // data is being produced
 
-  setWhatProduced(this, navigationSchoolName_)
-      .setConsumes(magFieldToken_, edm::ESInputTag("", iConfig.getParameter<std::string>("SimpleMagneticField")))
-      .setConsumes(geometricSearchTrackerToken_);
+  auto cc = setWhatProduced(this, navigationSchoolName_);
+  magFieldToken_ = cc.consumes(edm::ESInputTag("", iConfig.getParameter<std::string>("SimpleMagneticField")));
+  geometricSearchTrackerToken_ = cc.consumes();
 
   //now do what ever other initialization is needed
 }

--- a/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
+++ b/RecoTracker/TkNavigation/plugins/TkMSParameterizationBuilder.cc
@@ -66,9 +66,9 @@ private:
 };
 
 TkMSParameterizationBuilder::TkMSParameterizationBuilder(edm::ParameterSet const& pset) {
-  setWhatProduced(this, "")
-      .setConsumes(theNavSchoolToken_, edm::ESInputTag("", pset.getParameter<std::string>("navigationSchool")))
-      .setConsumes(thePropagatorToken_, edm::ESInputTag("", "PropagatorWithMaterial"));
+  auto cc = setWhatProduced(this, "");
+  theNavSchoolToken_ = cc.consumes(edm::ESInputTag("", pset.getParameter<std::string>("navigationSchool")));
+  thePropagatorToken_ = cc.consumes(edm::ESInputTag("", "PropagatorWithMaterial"));
 }
 
 TkMSParameterizationBuilder::ReturnType TkMSParameterizationBuilder::produce(TkMSParameterizationRecord const& iRecord) {

--- a/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
+++ b/RecoTracker/TransientTrackingRecHit/plugins/TkTransientTrackingRecHitBuilderESProducer.cc
@@ -44,41 +44,32 @@ private:
   bool const computeCoarseLocalPositionFromDisk_;
 };
 
-namespace {
-  template <typename T, typename R>
-  void setConsumes(edm::ESConsumesCollector& iCollector,
-                   std::optional<edm::ESGetToken<T, R>>& iToken,
-                   std::string const& iLabel) {
-    iToken = iCollector.consumesFrom<T, R>(edm::ESInputTag("", iLabel));
-  }
-}  // namespace
-
 using namespace edm;
 
 TkTransientTrackingRecHitBuilderESProducer::TkTransientTrackingRecHitBuilderESProducer(const edm::ParameterSet& p)
     : computeCoarseLocalPositionFromDisk_(p.getParameter<bool>("ComputeCoarseLocalPositionFromDisk")) {
   std::string const myname = p.getParameter<std::string>("ComponentName");
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(geomToken_);
+  geomToken_ = c.consumes();
 
   std::string const sname = p.getParameter<std::string>("StripCPE");
   if (sname != "Fake") {
-    setConsumes(c, spToken_, sname);
+    spToken_ = c.consumes(edm::ESInputTag("", sname));
   }
 
   std::string const pname = p.getParameter<std::string>("PixelCPE");
   if (pname != "Fake") {
-    setConsumes(c, ppToken_, pname);
+    ppToken_ = c.consumes(edm::ESInputTag("", pname));
   }
 
   auto const mname = p.getParameter<std::string>("Matcher");
   if (mname != "Fake") {
-    setConsumes(c, mpToken_, mname);
+    mpToken_ = c.consumes(edm::ESInputTag("", mname));
   }
 
   auto const P2otname = p.getParameter<std::string>("Phase2StripCPE");
   if (!P2otname.empty()) {
-    setConsumes(c, p2OTToken_, P2otname);
+    p2OTToken_ = c.consumes(edm::ESInputTag("", P2otname));
   }
 }
 

--- a/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
+++ b/TrackPropagation/SteppingHelixPropagator/plugins/SteppingHelixPropagatorESProducer.cc
@@ -35,9 +35,9 @@ SteppingHelixPropagatorESProducer::SteppingHelixPropagatorESProducer(const edm::
     : pset_{p}, setVBFPointer_{pset_.getParameter<bool>("SetVBFPointer")} {
   std::string myname = p.getParameter<std::string>("ComponentName");
   auto c = setWhatProduced(this, myname);
-  c.setConsumes(magToken_);
+  magToken_ = c.consumes();
   if (setVBFPointer_) {
-    c.setConsumes(vbMagToken_, edm::ESInputTag("", pset_.getParameter<std::string>("VBFName")));
+    vbMagToken_ = c.consumes(edm::ESInputTag("", pset_.getParameter<std::string>("VBFName")));
   }
 }
 

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.h
@@ -22,7 +22,7 @@ public:
 
 private:
   const int maxComp_;
-  edm::ESGetToken<DistanceBetweenComponents<N>, TrackingComponentsRecord> distToken_;
+  const edm::ESGetToken<DistanceBetweenComponents<N>, TrackingComponentsRecord> distToken_;
 };
 
 #include "TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc"

--- a/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
+++ b/TrackingTools/GsfTools/plugins/CloseComponentsMergerESProducer.icc
@@ -17,10 +17,9 @@
 
 template <unsigned int N>
 CloseComponentsMergerESProducer<N>::CloseComponentsMergerESProducer(const edm::ParameterSet& p)
-    : maxComp_(p.getParameter<int>("MaxComponents")) {
-  setWhatProduced(this, p.getParameter<std::string>("ComponentName"))
-      .setConsumes(distToken_, edm::ESInputTag("", p.getParameter<std::string>("DistanceMeasure")));
-}
+    : maxComp_(p.getParameter<int>("MaxComponents")),
+      distToken_(setWhatProduced(this, p.getParameter<std::string>("ComponentName"))
+                     .consumes(edm::ESInputTag("", p.getParameter<std::string>("DistanceMeasure")))) {}
 
 template <unsigned int N>
 CloseComponentsMergerESProducer<N>::~CloseComponentsMergerESProducer() {

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectoryFitterESProducer.cc
@@ -43,11 +43,11 @@ private:
 
 GsfTrajectoryFitterESProducer::GsfTrajectoryFitterESProducer(const edm::ParameterSet& p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
-  setWhatProduced(this, myname)
-      .setConsumes(matUpdatorToken_, edm::ESInputTag("", p.getParameter<std::string>("MaterialEffectsUpdator")))
-      .setConsumes(propagatorToken_, edm::ESInputTag("", p.getParameter<std::string>("GeometricalPropagator")))
-      .setConsumes(mergerToken_, edm::ESInputTag("", p.getParameter<std::string>("Merger")))
-      .setConsumes(geoToken_, edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
+  auto cc = setWhatProduced(this, myname);
+  matUpdatorToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("MaterialEffectsUpdator")));
+  propagatorToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("GeometricalPropagator")));
+  mergerToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Merger")));
+  geoToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
 }
 
 GsfTrajectoryFitterESProducer::~GsfTrajectoryFitterESProducer() {}

--- a/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
+++ b/TrackingTools/GsfTracking/plugins/GsfTrajectorySmootherESProducer.cc
@@ -42,11 +42,11 @@ private:
 GsfTrajectorySmootherESProducer::GsfTrajectorySmootherESProducer(const edm::ParameterSet& p)
     : scale_(p.getParameter<double>("ErrorRescaling")) {
   std::string myname = p.getParameter<std::string>("ComponentName");
-  setWhatProduced(this, myname)
-      .setConsumes(matToken_, edm::ESInputTag("", p.getParameter<std::string>("MaterialEffectsUpdator")))
-      .setConsumes(propagatorToken_, edm::ESInputTag("", p.getParameter<std::string>("GeometricalPropagator")))
-      .setConsumes(mergerToken_, edm::ESInputTag("", p.getParameter<std::string>("Merger")))
-      .setConsumes(geoToken_, edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
+  auto cc = setWhatProduced(this, myname);
+  matToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("MaterialEffectsUpdator")));
+  propagatorToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("GeometricalPropagator")));
+  mergerToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Merger")));
+  geoToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
 }
 
 std::unique_ptr<TrajectorySmoother> GsfTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord& iRecord) {

--- a/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/BeamHaloPropagatorESProducer.cc
@@ -67,10 +67,10 @@ BeamHaloPropagatorESProducer::BeamHaloPropagatorESProducer(const ParameterSet& p
   theEndCapTrackerPropagatorName = parameterSet.getParameter<string>("EndCapTrackerPropagator");
   theCrossingTrackerPropagatorName = parameterSet.getParameter<string>("CrossingTrackerPropagator");
 
-  setWhatProduced(this, myname)
-      .setConsumes(magToken_)
-      .setConsumes(endcapToken_, edm::ESInputTag(""s, theEndCapTrackerPropagatorName))
-      .setConsumes(crossToken_, edm::ESInputTag(""s, theCrossingTrackerPropagatorName));
+  auto cc = setWhatProduced(this, myname);
+  magToken_ = cc.consumes();
+  endcapToken_ = cc.consumes(edm::ESInputTag(""s, theEndCapTrackerPropagatorName));
+  crossToken_ = cc.consumes(edm::ESInputTag(""s, theCrossingTrackerPropagatorName));
 }
 
 BeamHaloPropagatorESProducer::~BeamHaloPropagatorESProducer() {}

--- a/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
+++ b/TrackingTools/Producers/src/SmartPropagatorESProducer.cc
@@ -61,10 +61,10 @@ SmartPropagatorESProducer::SmartPropagatorESProducer(const ParameterSet& paramet
 
   theEpsilon = parameterSet.getParameter<double>("Epsilon");
 
-  setWhatProduced(this, myname)
-      .setConsumes(magToken_)
-      .setConsumes(trackerToken_, edm::ESInputTag("", parameterSet.getParameter<string>("TrackerPropagator")))
-      .setConsumes(muonToken_, edm::ESInputTag("", parameterSet.getParameter<string>("MuonPropagator")));
+  auto cc = setWhatProduced(this, myname);
+  magToken_ = cc.consumes();
+  trackerToken_ = cc.consumes(edm::ESInputTag("", parameterSet.getParameter<string>("TrackerPropagator")));
+  muonToken_ = cc.consumes(edm::ESInputTag("", parameterSet.getParameter<string>("MuonPropagator")));
 }
 
 SmartPropagatorESProducer::~SmartPropagatorESProducer() {}

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
@@ -12,7 +12,10 @@ using namespace edm;
 
 GlobalDetLayerGeometryESProducer::GlobalDetLayerGeometryESProducer(const edm::ParameterSet& p) {
   std::string myName = p.getParameter<std::string>("ComponentName");
-  setWhatProduced(this, myName).setConsumes(trackerToken_).setConsumes(muonToken_).setConsumes(mtdToken_);
+  auto cc = setWhatProduced(this, myName);
+  trackerToken_ = cc.consumes();
+  muonToken_ = cc.consumes();
+  mtdToken_ = cc.consumes();
 }
 
 GlobalDetLayerGeometryESProducer::~GlobalDetLayerGeometryESProducer() {}

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
@@ -39,7 +39,8 @@ MuonDetIdAssociatorMaker::MuonDetIdAssociatorMaker(edm::ParameterSet const& pSet
       includeBadChambers_{pSet.getParameter<bool>("includeBadChambers")},
       includeGEM_{pSet.getParameter<bool>("includeGEM")},
       includeME0_{pSet.getParameter<bool>("includeME0")} {
-  iCollector.setConsumes(geomToken_).setConsumes(badChambersToken_);
+  geomToken_ = iCollector.consumes();
+  badChambersToken_ = iCollector.consumes();
 }
 
 std::unique_ptr<DetIdAssociator> MuonDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {

--- a/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/FlexibleKFFittingSmootherESProducer.cc
@@ -59,9 +59,9 @@ namespace {
   class FlexibleKFFittingSmootherESProducer : public edm::ESProducer {
   public:
     FlexibleKFFittingSmootherESProducer(const edm::ParameterSet& p) {
-      setWhatProduced(this, p.getParameter<std::string>("ComponentName"))
-          .setConsumes(standardToken_, edm::ESInputTag("", p.getParameter<std::string>("standardFitter")))
-          .setConsumes(looperToken_, edm::ESInputTag("", p.getParameter<std::string>("looperFitter")));
+      auto cc = setWhatProduced(this, p.getParameter<std::string>("ComponentName"));
+      standardToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("standardFitter")));
+      looperToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("looperFitter")));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFFittingSmootherESProducer.cc
@@ -14,9 +14,9 @@ namespace {
   public:
     KFFittingSmootherESProducer(const edm::ParameterSet& p) : pset_{p} {
       std::string myname = p.getParameter<std::string>("ComponentName");
-      setWhatProduced(this, myname)
-          .setConsumes(fitToken_, edm::ESInputTag("", pset_.getParameter<std::string>("Fitter")))
-          .setConsumes(smoothToken_, edm::ESInputTag("", pset_.getParameter<std::string>("Smoother")));
+      auto cc = setWhatProduced(this, myname);
+      fitToken_ = cc.consumes(edm::ESInputTag("", pset_.getParameter<std::string>("Fitter")));
+      smoothToken_ = cc.consumes(edm::ESInputTag("", pset_.getParameter<std::string>("Smoother")));
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectoryFitterESProducer.cc
@@ -46,11 +46,11 @@ namespace {
   KFTrajectoryFitterESProducer::KFTrajectoryFitterESProducer(const edm::ParameterSet& p)
       : minHits_{p.getParameter<int>("minHits")} {
     std::string myname = p.getParameter<std::string>("ComponentName");
-    setWhatProduced(this, myname)
-        .setConsumes(propToken_, edm::ESInputTag("", p.getParameter<std::string>("Propagator")))
-        .setConsumes(updToken_, edm::ESInputTag("", p.getParameter<std::string>("Updator")))
-        .setConsumes(estToken_, edm::ESInputTag("", p.getParameter<std::string>("Estimator")))
-        .setConsumes(geoToken_, edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
+    auto cc = setWhatProduced(this, myname);
+    propToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Propagator")));
+    updToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Updator")));
+    estToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Estimator")));
+    geoToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
   }
 
   std::unique_ptr<TrajectoryFitter> KFTrajectoryFitterESProducer::produce(const TrajectoryFitterRecord& iRecord) {

--- a/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
+++ b/TrackingTools/TrackFitters/plugins/KFTrajectorySmootherESProducer.cc
@@ -47,11 +47,11 @@ namespace {
   KFTrajectorySmootherESProducer::KFTrajectorySmootherESProducer(const edm::ParameterSet& p)
       : rescaleFactor_{p.getParameter<double>("errorRescaling")}, minHits_{p.getParameter<int>("minHits")} {
     std::string myname = p.getParameter<std::string>("ComponentName");
-    setWhatProduced(this, myname)
-        .setConsumes(propToken_, edm::ESInputTag("", p.getParameter<std::string>("Propagator")))
-        .setConsumes(updToken_, edm::ESInputTag("", p.getParameter<std::string>("Updator")))
-        .setConsumes(estToken_, edm::ESInputTag("", p.getParameter<std::string>("Estimator")))
-        .setConsumes(geoToken_, edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
+    auto cc = setWhatProduced(this, myname);
+    propToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Propagator")));
+    updToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Updator")));
+    estToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("Estimator")));
+    geoToken_ = cc.consumes(edm::ESInputTag("", p.getParameter<std::string>("RecoGeometry")));
   }
 
   std::unique_ptr<TrajectorySmoother> KFTrajectorySmootherESProducer::produce(const TrajectoryFitterRecord& iRecord) {

--- a/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
+++ b/TrackingTools/TransientTrack/plugins/TransientTrackBuilderESProducer.cc
@@ -11,7 +11,9 @@
 using namespace edm;
 
 TransientTrackBuilderESProducer::TransientTrackBuilderESProducer(const edm::ParameterSet& p) {
-  setWhatProduced(this, p.getParameter<std::string>("ComponentName")).setConsumes(magToken_).setConsumes(geomToken_);
+  auto cc = setWhatProduced(this, p.getParameter<std::string>("ComponentName"));
+  magToken_ = cc.consumes();
+  geomToken_ = cc.consumes();
 }
 
 std::unique_ptr<TransientTrackBuilder> TransientTrackBuilderESProducer::produce(const TransientTrackRecord& iRecord) {


### PR DESCRIPTION
#### PR description:

This PR migrates `setConsumes()` calls to the simpler consumes introduced in #31223.

#### PR validation:

Code compiles.