### PR TITLE
Initialize vars to nullptr in HTXSRivetProducer, fix #31474

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -37,7 +37,8 @@ public:
     usesResource("Rivet");
     _prodMode = cfg.getParameter<string>("ProductionMode");
     m_HiggsProdMode = HTXS::UNKNOWN;
-
+    _HTXS = nullptr;
+    _analysisHandler = nullptr;
     produces<HTXS::HiggsClassification>("HiggsClassification").setBranchAlias("HiggsClassification");
   }
 


### PR DESCRIPTION
Resolves: #31474

#### PR description:

Fixes relvals failure (hopefully) in ASAN, see #31474 

#### PR validation:

relvals running withot sigsegv
