### PR TITLE
Added configurable wait time for external process communication (10_6_X backport)

### DIFF
--- a/FWCore/Integration/test/TestInterProcessProd.cc
+++ b/FWCore/Integration/test/TestInterProcessProd.cc
@@ -20,7 +20,7 @@ namespace testinter {
   struct StreamCache {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
-          channel_("testProd", id_),
+          channel_("testProd", id_, 60),
           readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
           deserializer_{readBuffer_},
           br_deserializer_{readBuffer_},

--- a/FWCore/Integration/test/TestInterProcessRandomProd.cc
+++ b/FWCore/Integration/test/TestInterProcessRandomProd.cc
@@ -31,7 +31,7 @@ namespace testinter {
   struct StreamCache {
     StreamCache(const std::string& iConfig, int id)
         : id_{id},
-          channel_("testProd", id_),
+          channel_("testProd", id_, 60),
           readBuffer_{channel_.sharedMemoryName(), channel_.fromWorkerBufferInfo()},
           writeBuffer_{std::string("Rand") + channel_.sharedMemoryName(), channel_.toWorkerBufferInfo()},
           deserializer_{readBuffer_},

--- a/FWCore/SharedMemory/interface/ControllerChannel.h
+++ b/FWCore/SharedMemory/interface/ControllerChannel.h
@@ -39,7 +39,7 @@ namespace edm::shared_memory {
     /** iName is used as the base for the shared memory name. The full name uses iID as well as getpid() to create the value sharedMemoryName().
      iID allows multiple ControllChannels to use the same base name iName.
      */
-    ControllerChannel(std::string const& iName, int iID);
+    ControllerChannel(std::string const& iName, int iID, unsigned int iMaxWaitInSeconds);
     ~ControllerChannel();
     ControllerChannel(const ControllerChannel&) = delete;
     const ControllerChannel& operator=(const ControllerChannel&) = delete;
@@ -60,7 +60,7 @@ namespace edm::shared_memory {
       using namespace boost::posix_time;
       //std::cout << id_ << " waiting for external process" << std::endl;
 
-      if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+      if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(maxWaitInSeconds_))) {
         //std::cout << id_ << " FAILED waiting for external process" << std::endl;
         throw cms::Exception("ExternalFailed");
       } else {
@@ -115,6 +115,7 @@ namespace edm::shared_memory {
 
     // ---------- member data --------------------------------
     int id_;
+    unsigned int maxWaitInSeconds_;
     std::string smName_;
     boost::interprocess::managed_shared_memory managed_sm_;
     BufferInfo* toWorkerBufferInfo_;

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -90,7 +90,7 @@ bool ControllerChannel::wait(scoped_lock<named_mutex>& lock, edm::Transition iTr
 
   //std::cout << id_ << " waiting" << std::endl;
   using namespace boost::posix_time;
-  if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(60))) {
+  if (not cndToMain_.timed_wait(lock, microsec_clock::universal_time() + seconds(maxWaitInSeconds_))) {
     //std::cout << id_ << " waiting FAILED" << std::endl;
     return false;
   }

--- a/FWCore/SharedMemory/src/ControllerChannel.cc
+++ b/FWCore/SharedMemory/src/ControllerChannel.cc
@@ -31,8 +31,9 @@ using namespace boost::interprocess;
 // constructors and destructor
 //
 
-ControllerChannel::ControllerChannel(std::string const& iName, int id)
+ControllerChannel::ControllerChannel(std::string const& iName, int id, unsigned int iMaxWaitInSeconds)
     : id_{id},
+      maxWaitInSeconds_{iMaxWaitInSeconds},
       smName_{uniqueName(iName)},
       managed_sm_{open_or_create, smName_.c_str(), 1024},
       toWorkerBufferInfo_{bufferInfo(channel_names::kToWorkerBufferInfo, managed_sm_)},

--- a/FWCore/SharedMemory/test/test_channels.cc
+++ b/FWCore/SharedMemory/test/test_channels.cc
@@ -10,7 +10,7 @@ namespace {
   int controller(int argc, char** argv) {
     using namespace edm::shared_memory;
 
-    ControllerChannel channel("TestChannel", 0);
+    ControllerChannel channel("TestChannel", 0, 60);
 
     //Pipe has to close AFTER we tell the worker to stop
     auto closePipe = [](FILE* iFile) { pclose(iFile); };

--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -1,8 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 class ExternalGeneratorFilter(cms.EDFilter):
-    def __init__(self, prod, _external_process_verbose_ = cms.untracked.bool(False)):
+    def __init__(self, prod, _external_process_waitTime_ = cms.untracked.uint32(60), _external_process_verbose_ = cms.untracked.bool(False)):
         self.__dict__['_external_process_verbose_']=_external_process_verbose_
+        self.__dict__['_external_process_waitTime_']=_external_process_waitTime_
         self.__dict__['_prod'] = prod
         super(cms.EDFilter,self).__init__('ExternalGeneratorFilter')
     def __setattr__(self, name, value):
@@ -29,6 +30,7 @@ class ExternalGeneratorFilter(cms.EDFilter):
         newpset.addString(True, "@external_type", self._prod.type_())
         newpset.addString(False,"@python_config", self._prod.dumpPython())
         newpset.addBool(False,"_external_process_verbose_", self._external_process_verbose_.value())
+        newpset.addUInt32(False,"_external_process_waitTime_", self._external_process_waitTime_.value())
         self._prod.insertContentsInto(newpset)
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
     def dumpPython(self, options=cms.PrintOptions()):


### PR DESCRIPTION
#### PR description:

**This PR is a backport of #31441 and #31458**

The SharedMemory package now allows configurable timeouts for waiting on the external process. The ExternalGeneratorFilter module now has a parameter to control the value. The default is the original 60s.

#### PR validation:

Code compiles. All unit tests that make use of the SharedMemory package were run and succeeded.
It also solves issue #31426.