### PR TITLE
move Egamma related dictionaries to package where class is defined

### DIFF
--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -27,4 +27,8 @@
   <class name="edm::ValueMap<reco::CaloCluster>" />
   <class name="edm::Wrapper<edm::ValueMap<reco::CaloCluster> >" />
 
+  <class name="edm::ValueMap<reco::CaloClusterPtr>" />
+  <class name="edm::ValueMap<reco::CaloClusterPtrVector>" />
+  <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtr> >" />
+  <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtrVector> >" />
 </lcgdict>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -156,5 +156,8 @@
   <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::CaloCluster>,reco::CaloCluster,edm::refhelper::FindUsingAdvance<vector<reco::CaloCluster>,reco::CaloCluster> >,edm::Ref<vector<reco::ClusterShape>,reco::ClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::ClusterShape>,reco::ClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::CaloCluster>,vector<reco::ClusterShape>,unsigned int> >::Find> >" />
   <class name="edm::Wrapper<edm::RefVector<edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >,edm::helpers::KeyVal<edm::Ref<vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<vector<reco::SuperCluster>,reco::SuperCluster> >,edm::Ref<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape,edm::refhelper::FindUsingAdvance<vector<reco::HFEMClusterShape>,reco::HFEMClusterShape> > >,edm::AssociationMap<edm::OneToOne<vector<reco::SuperCluster>,vector<reco::HFEMClusterShape>,unsigned int> >::Find> >" />
 
+   <class name="std::vector<reco::SuperClusterRef>" />
+   <class name="edm::ValueMap<reco::SuperClusterRef>" />
+   <class name="edm::Wrapper<edm::ValueMap<reco::SuperClusterRef> >" />
 </lcgdict>
 

--- a/DataFormats/EgammaTrackReco/src/classes_def.xml
+++ b/DataFormats/EgammaTrackReco/src/classes_def.xml
@@ -1,12 +1,4 @@
 <lcgdict>
-
-   <class name="std::vector<reco::SuperClusterRef>" />
-   <class name="edm::ValueMap<reco::SuperClusterRef>" />
-   <class name="edm::Wrapper<edm::ValueMap<reco::SuperClusterRef> >" />
-   <class name="edm::ValueMap<reco::CaloClusterPtr>" />
-   <class name="edm::ValueMap<reco::CaloClusterPtrVector>" />
-   <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtr> >" />
-   <class name="edm::Wrapper<edm::ValueMap<reco::CaloClusterPtrVector> >" />
    <class name="reco::ConversionTrack" ClassVersion="11">
     <version ClassVersion="11" checksum="1446912891"/>
     <version ClassVersion="10" checksum="2951396223"/>


### PR DESCRIPTION
DataFormats/EgammaTrackReco has a number of dictionaries corresponding to classes defined elsewhere. This PR moves them to their appropriate home.