### PR TITLE
Clean BuildFiles in GeneratorInterface part 2

### DIFF
--- a/GeneratorInterface/AlpgenInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/AlpgenInterface/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <library name="GeneratorInterfaceAlpgenSource" file="AlpgenSource.cc">
-  <use name="DataFormats/Math"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>

--- a/GeneratorInterface/CascadeInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/CascadeInterface/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
   <use name="pydata"/>
 </architecture>
 <library file="Cascade2GeneratorFilter.cc,Cascade2Hadronizer.cc" name="GeneratorInterfaceCascadeInterfacePlugin">
-  <use name="GeneratorInterface/PartonShowerVeto"/>
   <use name="GeneratorInterface/ExternalDecays"/>
   <use name="GeneratorInterface/CascadeInterface"/>
   <use name="GeneratorInterface/Pythia6Interface"/>

--- a/GeneratorInterface/Core/bin/BuildFile.xml
+++ b/GeneratorInterface/Core/bin/BuildFile.xml
@@ -4,6 +4,5 @@
   <use name="FWCore/TestProcessor"/>
   <use name="FWCore/SharedMemory"/>
   <use name="FWCore/Services"/>
-  <use name="FWCore/Utilities"/>
   <use name="SimDataFormats/GeneratorProducts"/>
 </bin>

--- a/GeneratorInterface/EvtGenInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/EvtGenInterface/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
   <use name="GeneratorInterface/EvtGenInterface"/>
-  <use name="SimGeneral/HepPDTRecord"/>
   <use name="heppdt"/>
   <use name="clhep"/>
   <use name="hepmc"/>

--- a/GeneratorInterface/GenFilters/plugins/BuildFile.xml
+++ b/GeneratorInterface/GenFilters/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <library name="GeneratorInterfaceGenFiltersPlugins" file="*.cc">
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/Utilities"/>
@@ -16,11 +15,9 @@
   <use name="TrackingTools/Records"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="FWCore/ServiceRegistry"/>
-  <use name="CommonTools/BaseParticlePropagator"/>
   <use name="TrackingTools/GeomPropagators"/>
   <use name="DataFormats/HepMCCandidate"/>
   <use name="DataFormats/JetReco"/>
-  <use name="DataFormats/EgammaReco"/>
   <use name="DataFormats/Math"/>
   <use name="fastjet"/>
   <use name="boost"/>

--- a/GeneratorInterface/LHEInterface/test/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <library file="DummyLHEAnalyzer.cc">
-  <use name="PhysicsTools/HepMCCandAlgos"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="FWCore/Framework"/>
   <flags EDM_PLUGIN="1"/>

--- a/GeneratorInterface/PhotosInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/PhotosInterface/plugins/BuildFile.xml
@@ -1,7 +1,5 @@
 <library file="PhotosInterface.cc" name="PhotosInterfaceDefault">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
   <use name="GeneratorInterface/PhotosInterface"/>
   <use name="photos"/>
@@ -12,8 +10,6 @@
 
 <library file="PhotosppInterface.cc" name="PhotosppInterface">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
   <use name="GeneratorInterface/PhotosInterface"/>
   <use name="photospp"/>

--- a/GeneratorInterface/PomwigInterface/test/SDDijetsAnalyzer.cc
+++ b/GeneratorInterface/PomwigInterface/test/SDDijetsAnalyzer.cc
@@ -56,7 +56,6 @@ private:
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
-//#include "PhysicsTools/CandUtils/interface/Thrust.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <library file="Tauolapp/*.cc" name="TauolappInterface">
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
   <use name="FWCore/PluginManager"/>
   <use name="GeneratorInterface/TauolaInterface"/>
   <use name="SimGeneral/HepPDTRecord"/>
@@ -15,13 +14,9 @@
 </library>
 
 <library file="TauSpinner/*.cc" name="TauSpinnerInterface">
-  <use name="FWCore/Concurrency"/>
   <use name="FWCore/Framework"/>
-  <use name="FWCore/ParameterSet"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="SimDataFormats/GeneratorProducts"/>
-  <use name="DataFormats/Candidate"/>
-  <use name="DataFormats/HepMCCandidate"/>
   <use name="tauolapp"/>
   <use name="lhapdf"/>
   <use name="root"/>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/30866).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

This one is nice because it breaks the dependency of `GeneratorInterface` on the `PhysicsTools` subsystem.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
