### PR TITLE
Replace string with InputTag in IntTestAnalyzer

### DIFF
--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -46,26 +46,26 @@ namespace edmtest {
 
   //--------------------------------------------------------------------
   //
-  class IntTestAnalyzer : public edm::EDAnalyzer {
+  class IntTestAnalyzer : public edm::global::EDAnalyzer<> {
   public:
     IntTestAnalyzer(edm::ParameterSet const& iPSet)
         : value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
-          moduleLabel_(iPSet.getUntrackedParameter<std::string>("moduleLabel"), "") {
-      consumes<IntProduct>(moduleLabel_);
-    }
+          token_(consumes(iPSet.getUntrackedParameter<edm::InputTag>("moduleLabel"))) {}
 
-    void analyze(edm::Event const& iEvent, edm::EventSetup const&) {
-      edm::Handle<IntProduct> handle;
-      iEvent.getByLabel(moduleLabel_, handle);
-      if (handle->value != value_) {
-        throw cms::Exception("ValueMissMatch") << "The value for \"" << moduleLabel_ << "\" is " << handle->value
-                                               << " but it was supposed to be " << value_;
+    void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
+      auto const& prod = iEvent.get(token_);
+      if (prod.value != value_) {
+        edm::ProductLabels labels;
+        labelsForToken(token_, labels);
+        throw cms::Exception("ValueMissMatch")
+            << "The value for \"" << labels.module << ":" << labels.productInstance << ":" << labels.process << "\" is "
+            << prod.value << " but it was supposed to be " << value_;
       }
     }
 
   private:
-    int value_;
-    edm::InputTag moduleLabel_;
+    int const value_;
+    edm::EDGetTokenT<IntProduct> const token_;
   };
 
   //--------------------------------------------------------------------

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -52,6 +52,13 @@ namespace edmtest {
         : value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
           token_(consumes(iPSet.getUntrackedParameter<edm::InputTag>("moduleLabel"))) {}
 
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<int>("valueMustMatch");
+      desc.addUntracked<edm::InputTag>("moduleLabel");
+      descriptions.addDefault(desc);
+    }
+
     void analyze(edm::StreamID, edm::Event const& iEvent, edm::EventSetup const&) const {
       auto const& prod = iEvent.get(token_);
       if (prod.value != value_) {

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -64,7 +64,7 @@ namespace edmtest {
       if (prod.value != value_) {
         edm::ProductLabels labels;
         labelsForToken(token_, labels);
-        throw cms::Exception("ValueMissMatch")
+        throw cms::Exception("ValueMismatch")
             << "The value for \"" << labels.module << ":" << labels.productInstance << ":" << labels.process << "\" is "
             << prod.value << " but it was supposed to be " << value_;
       }

--- a/FWCore/Framework/test/test_InputTag_cache_failure_cfg.py
+++ b/FWCore/Framework/test/test_InputTag_cache_failure_cfg.py
@@ -28,7 +28,7 @@ process.zInt = cms.EDProducer("IntProducer", ivalue=cms.int32(26))
 
 process.getOne = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(1),
-    moduleLabel = cms.untracked.string('one')
+    moduleLabel = cms.untracked.InputTag('one')
 )
 
 process.p = cms.Path(process.double+process.doubleTwo+process.zInt+process.getOne)

--- a/FWCore/Framework/test/test_deepCall_unscheduled_cfg.py
+++ b/FWCore/Framework/test/test_deepCall_unscheduled_cfg.py
@@ -59,7 +59,7 @@ process.result4 = cms.EDProducer("AddIntsProducer",
 
 process.get = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(4),
-    moduleLabel = cms.untracked.string('result4')
+    moduleLabel = cms.untracked.InputTag('result4')
 )
 
 process.t = cms.Task(process.one, process.result1, process.result2, process.result4)

--- a/FWCore/Framework/test/test_deepCall_unscheduled_fail_cfg.py
+++ b/FWCore/Framework/test/test_deepCall_unscheduled_fail_cfg.py
@@ -33,7 +33,7 @@ process.result4 = cms.EDProducer("AddIntsProducer",
 
 process.get = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(4),
-    moduleLabel = cms.untracked.string('result4')
+    moduleLabel = cms.untracked.InputTag('result4')
 )
 
 process.t = cms.Task(process.result1, process.result2, process.result4)

--- a/FWCore/Framework/test/test_offPath_unscheduled_cfg.py
+++ b/FWCore/Framework/test/test_offPath_unscheduled_cfg.py
@@ -28,12 +28,12 @@ process.two = cms.EDProducer("IntProducer",
 
 process.getOne = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(1),
-    moduleLabel = cms.untracked.string('one')
+    moduleLabel = cms.untracked.InputTag('one')
 )
 
 process.getTwo = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(2),
-    moduleLabel = cms.untracked.string('two')
+    moduleLabel = cms.untracked.InputTag('two')
 )
 
 process.t = cms.Task(process.one, process.two)

--- a/FWCore/Framework/test/test_onPath_unscheduled_cfg.py
+++ b/FWCore/Framework/test/test_onPath_unscheduled_cfg.py
@@ -47,12 +47,12 @@ process.two = cms.EDProducer("IntProducer",
 
 process.getOne = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(1),
-    moduleLabel = cms.untracked.string('one')
+    moduleLabel = cms.untracked.InputTag('one')
 )
 
 process.getTwo = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(2),
-    moduleLabel = cms.untracked.string('two')
+    moduleLabel = cms.untracked.InputTag('two')
 )
 
 process.p = cms.Path(process.one*process.getOne+process.two*process.getTwo)

--- a/FWCore/Framework/test/test_onPath_wrongOrder_unscheduled_fail_cfg.py
+++ b/FWCore/Framework/test/test_onPath_wrongOrder_unscheduled_fail_cfg.py
@@ -27,12 +27,12 @@ process.two = cms.EDProducer("IntProducer",
 
 process.getOne = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(1),
-    moduleLabel = cms.untracked.string('one')
+    moduleLabel = cms.untracked.InputTag('one')
 )
 
 process.getTwo = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(2),
-    moduleLabel = cms.untracked.string('two')
+    moduleLabel = cms.untracked.InputTag('two')
 )
 
 process.p = cms.Path(process.two*process.getOne+process.one*process.getTwo)

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -76,8 +76,6 @@ ModuleCallingContext state = Running
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'get' id = 3
-++++++ finished: global begin run for module: label = 'get' id = 3
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'one' id = 4
@@ -108,8 +106,6 @@ ModuleCallingContext state = Running
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'get' id = 3
-++++++ finished: global begin lumi for module: label = 'get' id = 3
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 4
@@ -512,8 +508,6 @@ ModuleCallingContext state = Running
 
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'get' id = 3
-++++++ finished: global end lumi for module: label = 'get' id = 3
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
@@ -544,8 +538,6 @@ ModuleCallingContext state = Running
 
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'get' id = 3
-++++++ finished: global end run for module: label = 'get' id = 3
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: global write run 1 : time = 1000030
 ++++ finished: global write run 1 : time = 1000030

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -44,10 +44,6 @@
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'getOne' id = 4
-++++++ finished: global begin run for module: label = 'getOne' id = 4
-++++++ starting: global begin run for module: label = 'getTwo' id = 6
-++++++ finished: global begin run for module: label = 'getTwo' id = 6
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
 ++++++ starting: begin run for module: stream = 0 label = 'two' id = 5
@@ -58,10 +54,6 @@
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'getOne' id = 4
-++++++ finished: global begin lumi for module: label = 'getOne' id = 4
-++++++ starting: global begin lumi for module: label = 'getTwo' id = 6
-++++++ finished: global begin lumi for module: label = 'getTwo' id = 6
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++++ starting: begin lumi for module: stream = 0 label = 'two' id = 5
@@ -160,10 +152,6 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'getOne' id = 4
-++++++ finished: global end lumi for module: label = 'getOne' id = 4
-++++++ starting: global end lumi for module: label = 'getTwo' id = 6
-++++++ finished: global end lumi for module: label = 'getTwo' id = 6
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: global write lumi: run = 1 lumi = 1 time = 1000000
 ++++ finished: global write lumi: run = 1 lumi = 1 time = 1000000
@@ -174,10 +162,6 @@
 ++++++ finished: end run for module: stream = 0 label = 'one' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'getOne' id = 4
-++++++ finished: global end run for module: label = 'getOne' id = 4
-++++++ starting: global end run for module: label = 'getTwo' id = 6
-++++++ finished: global end run for module: label = 'getTwo' id = 6
 ++++ finished: global end run 1 : time = 1000030
 ++++ starting: global write run 1 : time = 1000030
 ++++ finished: global write run 1 : time = 1000030

--- a/FWCore/Integration/test/acquireTest_cfg.py
+++ b/FWCore/Integration/test/acquireTest_cfg.py
@@ -42,19 +42,19 @@ process.busy2 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(2), iter
 process.busy3 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(2), iterations = cms.uint32(10*1000*1000))
 
 process.tester = cms.EDAnalyzer("IntTestAnalyzer",
-                                moduleLabel = cms.untracked.string("waiter"),
+                                moduleLabel = cms.untracked.InputTag("waiter"),
                                 valueMustMatch = cms.untracked.int32(5))
 
 process.filtertester = cms.EDAnalyzer("IntTestAnalyzer",
-                                      moduleLabel = cms.untracked.string("filterwaiter"),
+                                      moduleLabel = cms.untracked.InputTag("filterwaiter"),
                                       valueMustMatch = cms.untracked.int32(5))
 
 process.streamtester = cms.EDAnalyzer("IntTestAnalyzer",
-                                      moduleLabel = cms.untracked.string("streamwaiter"),
+                                      moduleLabel = cms.untracked.InputTag("streamwaiter"),
                                       valueMustMatch = cms.untracked.int32(5))
 
 process.streamfiltertester = cms.EDAnalyzer("IntTestAnalyzer",
-                                            moduleLabel = cms.untracked.string("streamfilterwaiter"),
+                                            moduleLabel = cms.untracked.InputTag("streamfilterwaiter"),
                                             valueMustMatch = cms.untracked.int32(5))
 
 process.task = cms.Task(process.busy1, process.busy2, process.busy3,

--- a/FWCore/Integration/test/testEDAliasAnalyze_cfg.py
+++ b/FWCore/Integration/test/testEDAliasAnalyze_cfg.py
@@ -8,7 +8,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.analyzer = cms.EDAnalyzer("IntTestAnalyzer",
-    moduleLabel = cms.untracked.string("intProducer"),
+    moduleLabel = cms.untracked.InputTag("intProducer"),
     valueMustMatch = cms.untracked.int32(1)
 )
 

--- a/FWCore/Integration/test/waiting_thread_cfg.py
+++ b/FWCore/Integration/test/waiting_thread_cfg.py
@@ -21,7 +21,7 @@ process.busy1 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(1), iter
 process.busy2 = cms.EDProducer("BusyWaitIntProducer",ivalue = cms.int32(2), iterations = cms.uint32(10*1000*1000))
 
 process.tester = cms.EDAnalyzer("IntTestAnalyzer",
-                                moduleLabel = cms.untracked.string("waiter"),
+                                moduleLabel = cms.untracked.InputTag("waiter"),
                                 valueMustMatch = cms.untracked.int32(5))
 
 process.task = cms.Task(process.busy1, process.busy2, process.waiter)

--- a/FWCore/MessageService/test/bug75836b_cfg.py
+++ b/FWCore/MessageService/test/bug75836b_cfg.py
@@ -5,7 +5,7 @@ process.source = cms.Source("EmptySource")
 
 process.doit = cms.EDAnalyzer ("IntTestAnalyzer",
 		valueMustMatch = cms.untracked.int32(90),
-		moduleLabel = cms.untracked.string("missing"))
+		moduleLabel = cms.untracked.InputTag("missing"))
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(3))
 

--- a/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
@@ -73,29 +73,29 @@ process.task = cms.Task(
 
 process.testerSync = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(-1),
-    moduleLabel = cms.untracked.string("dummySync"),
+    moduleLabel = cms.untracked.InputTag("dummySync"),
 )
 
 process.testerPseudoAsync = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(4),
-    moduleLabel = cms.untracked.string("dummyPseudoAsync"),
+    moduleLabel = cms.untracked.InputTag("dummyPseudoAsync"),
 )
 
 process.testerAsync = cms.EDAnalyzer("IntTestAnalyzer",
     valueMustMatch = cms.untracked.int32(15),
-    moduleLabel = cms.untracked.string("dummyAsync"),
+    moduleLabel = cms.untracked.InputTag("dummyAsync"),
 )
 
 process.testerSyncRetry = process.testerSync.clone(
-    moduleLabel = cms.untracked.string("dummySyncRetry")
+    moduleLabel = "dummySyncRetry"
 )
 
 process.testerPseudoAsyncRetry = process.testerPseudoAsync.clone(
-    moduleLabel = cms.untracked.string("dummyPseudoAsyncRetry")
+    moduleLabel = "dummyPseudoAsyncRetry"
 )
 
 process.testerAsyncRetry = process.testerAsync.clone(
-    moduleLabel = cms.untracked.string("dummyAsyncRetry")
+    moduleLabel = "dummyAsyncRetry"
 )
 
 process.p1 = cms.Path(process.testerSync, process.task)


### PR DESCRIPTION
#### PR description:

Also make the module `edm::global`. The change is motivated by me wanting to use product instance names for input products.

#### PR validation:

Framework and `HeterogeneousCore/SonicCore` unit tests pass.