### PR TITLE
add missing dependency to GeneratorInterface/GenFilters

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/BuildFile.xml
+++ b/GeneratorInterface/GenFilters/plugins/BuildFile.xml
@@ -22,6 +22,7 @@
   <use name="DataFormats/JetReco"/>
   <use name="DataFormats/EgammaReco"/>
   <use name="DataFormats/Math"/>
+  <use name="SimDataFormats/HTXS"/>
   <use name="fastjet"/>
   <use name="boost"/>
   <use name="heppdt"/>


### PR DESCRIPTION
HTXSFilter.cc requires SimDataFormats/HTXS which was not in the BuildFile.