### PR TITLE
PPS: code to copy-without-children moved from copy constructor to a named method

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -53,14 +53,16 @@ public:
   using RotationMatrix = ROOT::Math::Rotation3D;
   using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 
+  DetGeomDesc() = default;
+
   // Constructor from old DD DDFilteredView
   DetGeomDesc(const DDFilteredView& fv);
   // Constructor from DD4Hep DDFilteredView
   DetGeomDesc(const cms::DDFilteredView& fv);
 
-  DetGeomDesc(const DetGeomDesc&);
-  DetGeomDesc& operator=(const DetGeomDesc&);
   virtual ~DetGeomDesc();
+
+  DetGeomDesc* makeCopyWithoutChildren() const;
 
   // general info
   const std::string& name() const { return m_name; }

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -53,8 +53,6 @@ public:
   using RotationMatrix = ROOT::Math::Rotation3D;
   using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 
-  DetGeomDesc() = default;
-
   // Constructor from old DD DDFilteredView
   DetGeomDesc(const DDFilteredView& fv);
   // Constructor from DD4Hep DDFilteredView
@@ -62,7 +60,8 @@ public:
 
   virtual ~DetGeomDesc();
 
-  DetGeomDesc* makeCopyWithoutChildren() const;
+  enum CopyMode { cmWithChildren, cmWithoutChildren };
+  DetGeomDesc(const DetGeomDesc& ref, CopyMode cm = cmWithChildren);
 
   // general info
   const std::string& name() const { return m_name; }

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -128,7 +128,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::applyAlignments(const DetGeo
   bufferIdealGeo.emplace_back(&idealDetRoot);
 
   std::deque<DetGeomDesc*> bufferAlignedGeo;
-  DetGeomDesc* alignedDetRoot = idealDetRoot.makeCopyWithoutChildren();
+  DetGeomDesc* alignedDetRoot = new DetGeomDesc(idealDetRoot, DetGeomDesc::cmWithoutChildren);
   bufferAlignedGeo.emplace_back(alignedDetRoot);
 
   while (!bufferIdealGeo.empty()) {
@@ -169,7 +169,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::applyAlignments(const DetGeo
       bufferIdealGeo.emplace_back(idealDetChild);
 
       // create new node with the same information as in idealDetChild and add it as a child of alignedDet
-      DetGeomDesc* alignedDetChild = idealDetChild->makeCopyWithoutChildren();
+      DetGeomDesc* alignedDetChild = new DetGeomDesc(*idealDetChild, DetGeomDesc::cmWithoutChildren);
       alignedDet->addComponent(alignedDetChild);
 
       bufferAlignedGeo.emplace_back(alignedDetChild);

--- a/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
+++ b/Geometry/VeryForwardGeometryBuilder/plugins/CTPPSGeometryESModule.cc
@@ -128,7 +128,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::applyAlignments(const DetGeo
   bufferIdealGeo.emplace_back(&idealDetRoot);
 
   std::deque<DetGeomDesc*> bufferAlignedGeo;
-  DetGeomDesc* alignedDetRoot = new DetGeomDesc(idealDetRoot);
+  DetGeomDesc* alignedDetRoot = idealDetRoot.makeCopyWithoutChildren();
   bufferAlignedGeo.emplace_back(alignedDetRoot);
 
   while (!bufferIdealGeo.empty()) {
@@ -169,7 +169,7 @@ std::unique_ptr<DetGeomDesc> CTPPSGeometryESModule::applyAlignments(const DetGeo
       bufferIdealGeo.emplace_back(idealDetChild);
 
       // create new node with the same information as in idealDetChild and add it as a child of alignedDet
-      DetGeomDesc* alignedDetChild = new DetGeomDesc(*idealDetChild);
+      DetGeomDesc* alignedDetChild = idealDetChild->makeCopyWithoutChildren();
       alignedDet->addComponent(alignedDetChild);
 
       bufferAlignedGeo.emplace_back(alignedDetChild);

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -58,21 +58,24 @@ DetGeomDesc::DetGeomDesc(const cms::DDFilteredView& fv)
       m_z(geant_units::operators::convertCmToMm(fv.translation().z()))  // converted from cm (DD4hep) to mm
 {}
 
-DetGeomDesc::DetGeomDesc(const DetGeomDesc& ref) { (*this) = ref; }
+DetGeomDesc* DetGeomDesc::makeCopyWithoutChildren() const {
+  DetGeomDesc* output = new DetGeomDesc;
 
-DetGeomDesc& DetGeomDesc::operator=(const DetGeomDesc& ref) {
-  m_name = ref.m_name;
-  m_copy = ref.m_copy;
-  m_isDD4hep = ref.m_isDD4hep;
-  m_trans = ref.m_trans;
-  m_rot = ref.m_rot;
-  m_params = ref.m_params;
-  m_isABox = ref.m_isABox;
-  m_diamondBoxParams = ref.m_diamondBoxParams;
-  m_sensorType = ref.m_sensorType;
-  m_geographicalID = ref.m_geographicalID;
-  m_z = ref.m_z;
-  return (*this);
+  // copy all data members except children (m_container)
+  output->m_name = m_name;
+  output->m_copy = m_copy;
+  output->m_isDD4hep = m_isDD4hep;
+  output->m_trans = m_trans;
+  output->m_rot = m_rot;
+  output->m_params = m_params;
+  output->m_isABox = m_isABox;
+  output->m_diamondBoxParams = m_diamondBoxParams;
+  output->m_sensorType = m_sensorType;
+  output->m_geographicalID = m_geographicalID;
+
+  output->m_z = m_z;
+
+  return output;
 }
 
 DetGeomDesc::~DetGeomDesc() { deepDeleteComponents(); }
@@ -116,8 +119,7 @@ void DetGeomDesc::deleteComponents() { m_container.erase(m_container.begin(), m_
 
 void DetGeomDesc::deepDeleteComponents() {
   for (auto& it : m_container) {
-    it->deepDeleteComponents();
-    delete it;
+    delete it;  // the destructor calls deepDeleteComponents
   }
   clearComponents();
 }

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -58,24 +58,22 @@ DetGeomDesc::DetGeomDesc(const cms::DDFilteredView& fv)
       m_z(geant_units::operators::convertCmToMm(fv.translation().z()))  // converted from cm (DD4hep) to mm
 {}
 
-DetGeomDesc* DetGeomDesc::makeCopyWithoutChildren() const {
-  DetGeomDesc* output = new DetGeomDesc;
+DetGeomDesc::DetGeomDesc(const DetGeomDesc& ref, CopyMode cm) {
+  m_name = ref.m_name;
+  m_copy = ref.m_copy;
+  m_isDD4hep = ref.m_isDD4hep;
+  m_trans = ref.m_trans;
+  m_rot = ref.m_rot;
+  m_params = ref.m_params;
+  m_isABox = ref.m_isABox;
+  m_diamondBoxParams = ref.m_diamondBoxParams;
+  m_sensorType = ref.m_sensorType;
+  m_geographicalID = ref.m_geographicalID;
 
-  // copy all data members except children (m_container)
-  output->m_name = m_name;
-  output->m_copy = m_copy;
-  output->m_isDD4hep = m_isDD4hep;
-  output->m_trans = m_trans;
-  output->m_rot = m_rot;
-  output->m_params = m_params;
-  output->m_isABox = m_isABox;
-  output->m_diamondBoxParams = m_diamondBoxParams;
-  output->m_sensorType = m_sensorType;
-  output->m_geographicalID = m_geographicalID;
+  if (cm == cmWithChildren)
+    m_container = ref.m_container;
 
-  output->m_z = m_z;
-
-  return output;
+  m_z = ref.m_z;
 }
 
 DetGeomDesc::~DetGeomDesc() { deepDeleteComponents(); }


### PR DESCRIPTION
#### PR description:

This is a technical PR to address issue https://github.com/cms-sw/cmssw/issues/25434. The code to perform a shall copy (without children) is moved from copy constructor to a named method to avoid misunderstandings.

No change in results is expected due to this PR.

#### PR validation:

The two plots below (top for "direct" simu, bottom for reco) document that there is indeed no change due to this PR.

![dirsim_cmp](https://user-images.githubusercontent.com/17830858/93457698-9cc87600-f8df-11ea-9843-cd56eacff643.png)
![reco_cmp](https://user-images.githubusercontent.com/17830858/93457701-9df9a300-f8df-11ea-9663-00e660e91771.png)
