### PR TITLE
Fixed typo with recHit collection. Backport for 106X.

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/EGMSeedGainProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/EGMSeedGainProducer.cc
@@ -80,7 +80,7 @@ EGMSeedGainProducer<T>::produce(edm::StreamID streamID, edm::Event& iEvent, cons
   edm::Handle<EcalRecHitCollection> recHitsEB;
   iEvent.getByToken(recHitsEB_, recHitsEB);
   edm::Handle<EcalRecHitCollection> recHitsEE;
-  iEvent.getByToken(recHitsEB_, recHitsEE);
+  iEvent.getByToken(recHitsEE_, recHitsEE);
 
   unsigned nSrc = src->size();
   std::vector<int> gainSeed(nSrc,12);


### PR DESCRIPTION
#### PR description:

Providing a fix for a gainSeed issue with the EGM producer in nanoAOD.
A typo was causing the issue. The correction was to change recHitsEB_ ---> recHitsEE_.
This is a backport for 106X corresponding to #31293 

