### PR TITLE
Use std::string_view for MessageLogger category

### DIFF
--- a/FWCore/MessageLogger/interface/ErrorObj.h
+++ b/FWCore/MessageLogger/interface/ErrorObj.h
@@ -45,7 +45,7 @@ namespace edm {
   public:
     // --- birth/death:
     //
-    ErrorObj(const ELseverityLevel& sev, const ELstring& id, bool verbatim = false);
+    ErrorObj(const ELseverityLevel& sev, std::string_view id, bool verbatim = false);
     ErrorObj(const ErrorObj& orig);  // Same serial number and everything!
     virtual ~ErrorObj();
 
@@ -66,7 +66,7 @@ namespace edm {
     // mutators:
     //
     virtual void setSeverity(const ELseverityLevel& sev);
-    virtual void setID(const ELstring& ID);
+    virtual void setID(std::string_view ID);
     virtual void setModule(const ELstring& module);
     virtual void setSubroutine(const ELstring& subroutine);
     virtual void setContext(const std::string_view& context);
@@ -85,7 +85,7 @@ namespace edm {
 
     // ---  mutators for use by ELadministrator and ELtsErrorLog
     //
-    virtual void set(const ELseverityLevel& sev, const ELstring& id);
+    virtual void set(const ELseverityLevel& sev, std::string_view id);
     virtual void clear();
     virtual void setReactedTo(bool r);
 

--- a/FWCore/MessageLogger/interface/MessageLogger.h
+++ b/FWCore/MessageLogger/interface/MessageLogger.h
@@ -140,7 +140,7 @@ namespace edm {
 
   class LogWarning {
   public:
-    explicit LogWarning(std::string const& id)
+    explicit LogWarning(std::string_view id)
         : ap(ELwarning,
              id,
              false,
@@ -189,7 +189,7 @@ namespace edm {
 
   class LogError {
   public:
-    explicit LogError(std::string const& id)
+    explicit LogError(std::string_view id)
         : ap(ELerror, id, false, !MessageDrop::instance()->errorEnabled)  // Change log 24
     {}
     ~LogError();  // Change log 13
@@ -235,7 +235,7 @@ namespace edm {
 
   class LogSystem {
   public:
-    explicit LogSystem(std::string const& id) : ap(ELsevere, id) {}
+    explicit LogSystem(std::string_view id) : ap(ELsevere, id) {}
     ~LogSystem();  // Change log 13
 
     template <class T>
@@ -274,7 +274,7 @@ namespace edm {
 
   class LogInfo {
   public:
-    explicit LogInfo(std::string const& id)
+    explicit LogInfo(std::string_view id)
         : ap(ELinfo,
              id,
              false,
@@ -325,7 +325,7 @@ namespace edm {
   class LogVerbatim  // change log 2
   {
   public:
-    explicit LogVerbatim(std::string const& id)
+    explicit LogVerbatim(std::string_view id)
         : ap(ELinfo,
              id,
              true,
@@ -377,7 +377,7 @@ namespace edm {
   class LogPrint  // change log 3
   {
   public:
-    explicit LogPrint(std::string const& id)
+    explicit LogPrint(std::string_view id)
         : ap(ELwarning,
              id,
              true,
@@ -429,7 +429,7 @@ namespace edm {
   class LogProblem  // change log 4
   {
   public:
-    explicit LogProblem(std::string const& id)
+    explicit LogProblem(std::string_view id)
         : ap(ELerror, id, true, !MessageDrop::instance()->errorEnabled)  // Change log 24
     {}
     ~LogProblem();  // Change log 13
@@ -477,7 +477,7 @@ namespace edm {
   class LogImportant  // change log 11
   {
   public:
-    explicit LogImportant(std::string const& id)
+    explicit LogImportant(std::string_view id)
         : ap(ELerror, id, true, !MessageDrop::instance()->errorEnabled)  // Change log 24
     {}
     ~LogImportant();  // Change log 13
@@ -525,7 +525,7 @@ namespace edm {
   class LogAbsolute  // change log 4
   {
   public:
-    explicit LogAbsolute(std::string const& id)
+    explicit LogAbsolute(std::string_view id)
         : ap(ELsevere, id, true)  // true for verbatim
     {}
     ~LogAbsolute();  // Change log 13
@@ -564,8 +564,6 @@ namespace edm {
 
   };  // LogAbsolute
 
-  std::string stripLeadingDirectoryTree(const std::string& file);
-
   // change log 10:  removed onlyLowestDirectory()
 
   void LogStatistics();
@@ -573,7 +571,7 @@ namespace edm {
   class LogDebug_ {
   public:
     LogDebug_() : ap() {}
-    explicit LogDebug_(std::string const& id, std::string const& file, int line);  // Change log 17
+    explicit LogDebug_(std::string_view id, std::string_view file, int line);  // Change log 17
     ~LogDebug_();
 
     template <class T>
@@ -611,14 +609,14 @@ namespace edm {
 
   private:
     MessageSender ap;
-    std::string stripLeadingDirectoryTree(const std::string& file) const;
+    std::string_view stripLeadingDirectoryTree(std::string_view file) const;
     // change log 10
   };  // LogDebug_
 
   class LogTrace_ {
   public:
     LogTrace_() : ap() {}
-    explicit LogTrace_(std::string const& id);  // Change log 13
+    explicit LogTrace_(std::string_view id);  // Change log 13
     ~LogTrace_();
 
     template <class T>
@@ -663,7 +661,7 @@ namespace edm {
   namespace edmmltest {
     class LogWarningThatSuppressesLikeLogInfo {
     public:
-      explicit LogWarningThatSuppressesLikeLogInfo(std::string const& id)
+      explicit LogWarningThatSuppressesLikeLogInfo(std::string_view id)
           : ap(ELwarning,
                id,
                false,
@@ -739,7 +737,7 @@ namespace edm {
   void HaltMessageLogging();
   void FlushMessageLog();
   void clearMessageLog();
-  void GroupLogStatistics(std::string const& category);
+  void GroupLogStatistics(std::string_view category);
   bool isMessageProcessingSetUp();
 
   // Change Log 15

--- a/FWCore/MessageLogger/interface/MessageSender.h
+++ b/FWCore/MessageLogger/interface/MessageSender.h
@@ -31,7 +31,7 @@ namespace edm {
   public:
     // ---  birth/death:
     MessageSender() : errorobj_p() {}
-    MessageSender(ELseverityLevel const& sev, ELstring const& id, bool verbatim = false, bool suppressed = false);
+    MessageSender(ELseverityLevel const& sev, std::string_view id, bool verbatim = false, bool suppressed = false);
     ~MessageSender();
 
     // ---  stream out the next part of a message:

--- a/FWCore/MessageLogger/src/ErrorObj.cc
+++ b/FWCore/MessageLogger/src/ErrorObj.cc
@@ -71,7 +71,7 @@ namespace edm {
   // Birth/death:
   // ----------------------------------------------------------------------
 
-  ErrorObj::ErrorObj(const ELseverityLevel& sev, const ELstring& id, bool verbat) : verbatim(verbat) {
+  ErrorObj::ErrorObj(const ELseverityLevel& sev, std::string_view id, bool verbat) : verbatim(verbat) {
 #ifdef ErrorObjCONSTRUCTOR_TRACE
     std::cerr << "Constructor for ErrorObj\n";
 #endif
@@ -156,7 +156,7 @@ namespace edm {
                                              : (sev >= ELhighestSeverity) ? (ELseverityLevel)ELsevere : sev;
   }
 
-  void ErrorObj::setID(const ELstring& id) {
+  void ErrorObj::setID(std::string_view id) {
     myXid.id = ELstring(id, 0, maxIDlength);
     if (id.length() > maxIDlength)
       myIdOverflow = ELstring(id, maxIDlength, id.length() - maxIDlength);
@@ -204,7 +204,7 @@ namespace edm {
 
   }  // emitToken()
 
-  void ErrorObj::set(const ELseverityLevel& sev, const ELstring& id) {
+  void ErrorObj::set(const ELseverityLevel& sev, std::string_view id) {
     clear();
 
     myTimestamp = time(nullptr);

--- a/FWCore/MessageLogger/src/MessageLogger.cc
+++ b/FWCore/MessageLogger/src/MessageLogger.cc
@@ -108,26 +108,26 @@ namespace edm {
     return (MessageDrop::instance()->messageLoggerScribeIsRunning == MLSCRIBE_RUNNING_INDICATOR);
   }
 
-  void GroupLogStatistics(std::string const& category) {
+  void GroupLogStatistics(std::string_view category) {
     std::string* cat_p = new std::string(category);
     edm::MessageLoggerQ::MLqGRP(cat_p);  // Indicate a group summary category
     // Note that the scribe will be responsible for deleting cat_p
   }
 
-  edm::LogDebug_::LogDebug_(std::string const& id, std::string const& file, int line) : ap(ELdebug, id) {
+  edm::LogDebug_::LogDebug_(std::string_view id, std::string_view file, int line) : ap(ELdebug, id) {
     *this << " " << stripLeadingDirectoryTree(file) << ":" << line << "\n";
   }
 
-  std::string edm::LogDebug_::stripLeadingDirectoryTree(const std::string& file) const {
-    std::string::size_type lastSlash = file.find_last_of('/');
-    if (lastSlash == std::string::npos)
+  std::string_view edm::LogDebug_::stripLeadingDirectoryTree(const std::string_view file) const {
+    std::string_view::size_type lastSlash = file.find_last_of('/');
+    if (lastSlash == std::string_view::npos)
       return file;
     if (lastSlash == file.size() - 1)
       return file;
     return file.substr(lastSlash + 1, file.size() - lastSlash - 1);
   }
 
-  edm::LogTrace_::LogTrace_(std::string const& id) : ap(ELdebug, id, true) {}
+  edm::LogTrace_::LogTrace_(std::string_view id) : ap(ELdebug, id, true) {}
 
   void setStandAloneMessageThreshold(edm::ELseverityLevel const& severity) {
     edm::MessageLoggerQ::standAloneThreshold(severity);

--- a/FWCore/MessageLogger/src/MessageSender.cc
+++ b/FWCore/MessageLogger/src/MessageSender.cc
@@ -82,7 +82,7 @@ CMS_THREAD_SAFE static std::vector<
     tbb::concurrent_unordered_map<ErrorSummaryMapKey, AtomicUnsignedInt, ErrorSummaryMapKey::key_hash>>
     errorSummaryMaps;
 
-MessageSender::MessageSender(ELseverityLevel const& sev, ELstring const& id, bool verbatim, bool suppressed)
+MessageSender::MessageSender(ELseverityLevel const& sev, std::string_view id, bool verbatim, bool suppressed)
     : errorobj_p(suppressed ? nullptr : new ErrorObj(sev, id, verbatim), ErrorObjDeleter()) {
   //std::cout << "MessageSender ctor; new ErrorObj at: " << errorobj_p << '\n';
 }


### PR DESCRIPTION
#### PR description:

Resolves https://github.com/cms-sw/cmssw/issues/31475. Should avoid one `std::string` construction when the category is passed in as `char const*`.

#### PR validation:

Framework unit tests pass.