### PR TITLE
Fix to issue 31502: problem with FakeHLT in PU 2017-2018 relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -925,12 +925,9 @@ upgradeProperties[2017] = {
 # standard PU sequences
 for key in list(upgradeProperties[2017].keys()):
     upgradeProperties[2017][key+'PU'] = deepcopy(upgradeProperties[2017][key])
-    upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU','RecoFakeHLTPU','HARVESTFakeHLTPU'] + \
+    upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU'] + \
+                                                     (['RecoPU','HARVESTPU'] if '202' in key else ['RecoFakeHLTPU','HARVESTFakeHLTPU']) + \ #2021, 2023 and 2023 still run not FakeHLT Menus
                                                      (['Nano'] if 'Design' not in key else [])
-    if '202' in key:   #2021, 2023 and 2023 still run not FakeHLT Menus
-               upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU','RecoPU','HARVESTPU'] + \
-                                                     (['Nano'] if 'Design' not in key else [])
-
 
 upgradeProperties[2026] = {
     '2026D49' : {
@@ -1179,4 +1176,3 @@ upgradeFragments = OrderedDict([
     ('TenTau_E_15_500_Eta3p1_pythia8_cfi', UpgradeFragment(Kby(9,100),'TenTau_15_500_Eta3p1')),
     ('QCD_Pt_1800_2400_14TeV_TuneCP5_cfi', UpgradeFragment(Kby(9,50), 'QCD_Pt_1800_2400_14')),
 ])
-

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -927,6 +927,10 @@ for key in list(upgradeProperties[2017].keys()):
     upgradeProperties[2017][key+'PU'] = deepcopy(upgradeProperties[2017][key])
     upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU','RecoFakeHLTPU','HARVESTFakeHLTPU'] + \
                                                      (['Nano'] if 'Design' not in key else [])
+    if '202' in key:   #2021, 2023 and 2023 still run not FakeHLT Menus
+               upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU','RecoPU','HARVESTPU'] + \
+                                                     (['Nano'] if 'Design' not in key else [])
+
 
 upgradeProperties[2026] = {
     '2026D49' : {

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -926,7 +926,7 @@ upgradeProperties[2017] = {
 for key in list(upgradeProperties[2017].keys()):
     upgradeProperties[2017][key+'PU'] = deepcopy(upgradeProperties[2017][key])
     upgradeProperties[2017][key+'PU']['ScenToRun'] = ['GenSim','DigiPU'] + \
-                                                     (['RecoPU','HARVESTPU'] if '202' in key else ['RecoFakeHLTPU','HARVESTFakeHLTPU']) + \ #2021, 2023 and 2023 still run not FakeHLT Menus
+                                                     (['RecoPU','HARVESTPU'] if '202' in key else ['RecoFakeHLTPU','HARVESTFakeHLTPU']) + \
                                                      (['Nano'] if 'Design' not in key else [])
 
 upgradeProperties[2026] = {


### PR DESCRIPTION
#### PR description:

Upon creation of PR https://github.com/cms-sw/cmssw/pull/31472 202X upgrade samples were wrongly assigned FakeHLT Menu configurations for DQM/Validation steps.

This step fixes the issue as reported on https://github.com/cms-sw/cmssw/issues/31502

#### PR validation:

Validated with 
runTheMatrix.py --list=11834.99,12634.99,13034.99


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No