### PR TITLE
[HGCAL] Material budget code not working after CMSSW_11_2_0_pre2

### DIFF
--- a/Validation/Geometry/test/runP_HGCal_cfg.py
+++ b/Validation/Geometry/test/runP_HGCal_cfg.py
@@ -7,6 +7,8 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 import sys, re
 
+from FWCore.PythonFramework.CmsRun import CmsRun
+
 process = cms.Process("PROD")
 
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
@@ -78,7 +80,17 @@ process.source = cms.Source("PoolSource",
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
+'''
+process.Timing = cms.Service("Timing")
 
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck",
+  ignoreTotal          = cms.untracked.int32(1),
+  oncePerEventMode     = cms.untracked.bool(True),
+  moduleMemorySummary  = cms.untracked.bool(True),
+  showMallocInfo       = cms.untracked.bool(True),
+  monitorPssAndPrivate = cms.untracked.bool(True),
+)
+'''
 process.p1 = cms.Path(process.g4SimHits)
 process.g4SimHits.StackingAction.TrackNeutrino = cms.bool(True)
 process.g4SimHits.UseMagneticField = False
@@ -121,3 +133,9 @@ process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
 
      )
 ))
+
+
+cmsRun = CmsRun(process)
+cmsRun.run()
+
+


### PR DESCRIPTION
#### PR description:

After CMSSW_11_2_0_pre2 the usual workflow for the HGCAL material budget analysis stopped working with error [1]. The solution seems to be related with PR #28619 , which did the job for the Tracker and now also corrects error [1]. 

#### PR validation:

We tested the whole workflow locally in multiple ibs and prereleases. Details on the workflow can be found in [2]. We will soon correct the recipe to use python and not cmsRun executable in the 
relevant runP_HGCal_cfg.py line, among other updates to webpage [2].

#### This is not a backport. 

[1] 

An exception of category 'FileOpenError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing input source of type PoolSource
   [2] Calling RootInputFileSequence::initTheFile()
   Additional Info:
      [a] Input file file:single_neutrino_random.root could not be opened.
      [b] Fatal Root Error: @SUB=TClass::LoadClassInfo
no interpreter information for class TFile is available even though it has a TClass initialization routine.

[2] http://hgcal.web.cern.ch/hgcal/MaterialBudget/MaterialBudget/

@rovere @felicepantaleo @vargasa @ebrondol  

