### PR TITLE
10_6_X backport of  "HCAL: slimmed collections... for miniAOD" (PR #31375)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -37,6 +37,7 @@ MicroEventContent = cms.PSet(
         'keep EcalRecHitsSorted_reducedEgamma_*_*',
         'keep recoGsfTracks_reducedEgamma_*_*',
         'keep HBHERecHitsSorted_reducedEgamma_*_*',
+        'keep *_slimmedHcalRecHits_*_*',
         'drop *_*_caloTowers_*',
         'drop *_*_pfCandidates_*',
         'drop *_*_genJets_*',

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -28,6 +28,7 @@ from PhysicsTools.PatAlgos.slimming.MicroEventContent_cff import *
 from RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi  import *
 from RecoLuminosity.LumiProducer.bunchSpacingProducer_cfi import bunchSpacingProducer
 from HeavyFlavorAnalysis.Onia2MuMu.OniaPhotonConversionProducer_cfi import PhotonCandidates as oniaPhotonCandidates
+from RecoLocalCalo.HcalRecProducers.HcalHitSelection_cfi import *
 
 slimmingTask = cms.Task(
     packedPFCandidatesTask,
@@ -57,6 +58,7 @@ slimmingTask = cms.Task(
     slimmedMETs,
     metFilterPathsTask,
     reducedEgamma,
+    slimmedHcalRecHits,
     bunchSpacingProducer,
     oniaPhotonCandidates
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -11,5 +11,12 @@ reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                          )
                                     )
 
+slimmedHcalRecHits = reducedHcalRecHits.clone(
+          hbheTag = "reducedHcalRecHits:hbhereco",
+          hfTag   = "reducedHcalRecHits:hfreco",
+          hoTag   = "reducedHcalRecHits:horeco",
+          interestingDetIds = ()
+       )
+
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toModify(reducedHcalRecHits.interestingDetIds, func = lambda list: list.remove(cms.InputTag("interestingOotEgammaIsoHCALDetId")) )

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitSelection_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi import *
 reducedHcalRecHits = cms.EDProducer("HcalHitSelection",
                                     hbheTag = cms.InputTag('hbhereco'),
                                     hfTag = cms.InputTag('hfreco'),


### PR DESCRIPTION
#### PR description:

Two tiny-size "simmedHcalRecHits" collections
(HBHERecHitsSorted_slimmedHcalRecHits and HFRecHitsSorted_slimmedHcalRecHits) added to minAOD.

They contain solely RecHits with non-0 (noise) flags set. This is "slimmed" version (without HcalRecHits "interesting" for Egamma) of "reducedHcalRecHits" collections included in AOD.

#### PR validation:

runTheMatrix.py -l 136.88811   OK

#### if this PR is a backport please specify the original PR:

Yes,  backport of  https://github.com/cms-sw/cmssw/pull/31375
