### PR TITLE
MTD: update ETLDetId to accomodate larger module numbers

### DIFF
--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -14,10 +14,10 @@
 
 class ETLDetId : public MTDDetId {
 public:
-  static const uint32_t kETLmoduleOffset = 7;
-  static const uint32_t kETLmoduleMask = 0x1FF;
-  static const uint32_t kETLmodTypeOffset = 5;
-  static const uint32_t kETLmodTypeMask = 0x3;
+  static const uint32_t kETLmoduleOffset = 5;    //7
+  static const uint32_t kETLmoduleMask = 0x7FF;  //0x1FF
+  static const uint32_t kETLmodTypeOffset = 3;   //5
+  static const uint32_t kETLmodTypeMask = 0x3;   //0x3
 
   static constexpr int kETLv1maxRing = 11;
   static constexpr int kETLv1maxModule = 176;
@@ -31,8 +31,14 @@ public:
   static const uint32_t kETLsectorMask = 0x3;
 
   static constexpr int kETLv4maxRing = 16;
-  static constexpr int kETLv4maxModule = 248;
+  static constexpr int kETLv4maxSector = 4;
+  static constexpr int kETLv4maxModule = 517;  //248
   static constexpr int kETLv4nDisc = 2;
+
+  static constexpr int kETLv5maxRing = 14;
+  static constexpr int kETLv5maxSector = 2;
+  static constexpr int kETLv5maxModule = 517;
+  static constexpr int kETLv5nDisc = kETLv4nDisc;
 
   static constexpr uint32_t kSoff = 4;
 
@@ -95,6 +101,8 @@ public:
   inline int nDisc() const {
     return (((((id_ >> kRodRingOffset) & kRodRingMask) - 1) >> kETLnDiscOffset) & kETLnDiscMask) + 1;
   }
+
+  uint32_t newForm(const uint32_t& rawid);
 };
 
 std::ostream& operator<<(std::ostream&, const ETLDetId&);

--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -32,7 +32,7 @@ public:
 
   static constexpr int kETLv4maxRing = 16;
   static constexpr int kETLv4maxSector = 4;
-  static constexpr int kETLv4maxModule = 517;  //248
+  static constexpr int kETLv4maxModule = 248;
   static constexpr int kETLv4nDisc = 2;
 
   static constexpr int kETLv5maxRing = 14;

--- a/DataFormats/ForwardDetId/interface/ETLDetId.h
+++ b/DataFormats/ForwardDetId/interface/ETLDetId.h
@@ -60,9 +60,7 @@ public:
   ETLDetId(const uint32_t& raw_id) {
     uint32_t tmpId = raw_id;
     if ((tmpId & kETLformatV2) == 0) {
-      uint32_t fixedP = tmpId & (0xFFFFFFFF - kETLoldFieldMask);          // unchanged part of id
-      uint32_t shiftP = (tmpId & kETLoldFieldMask) >> kETLoldToNewShift;  // shifted part
-      tmpId = (fixedP | shiftP) + kETLformatV2;
+      tmpId = newForm(tmpId);
     }
     id_ = MTDDetId(tmpId).rawId();
   }
@@ -71,9 +69,7 @@ public:
   ETLDetId(const DetId& det_id) {
     uint32_t tmpId = det_id.rawId();
     if ((tmpId & kETLformatV2) == 0) {
-      uint32_t fixedP = tmpId & (0xFFFFFFFF - kETLoldFieldMask);          // unchanged part of id
-      uint32_t shiftP = (tmpId & kETLoldFieldMask) >> kETLoldToNewShift;  // shifted part
-      tmpId = (fixedP | shiftP) + kETLformatV2;
+      tmpId = newForm(tmpId);
     }
     id_ = MTDDetId(tmpId).rawId();
   }
@@ -130,7 +126,7 @@ public:
   uint32_t newForm(const uint32_t& rawid) {
     uint32_t fixedP = rawid & (0xFFFFFFFF - kETLoldFieldMask);          // unchanged part of id
     uint32_t shiftP = (rawid & kETLoldFieldMask) >> kETLoldToNewShift;  // shifted part
-    return (fixedP | shiftP);
+    return ((fixedP | shiftP) | kETLformatV2);
   }
 };
 

--- a/DataFormats/ForwardDetId/src/ETLDetId.cc
+++ b/DataFormats/ForwardDetId/src/ETLDetId.cc
@@ -11,3 +11,13 @@ std::ostream& operator<<(std::ostream& os, const ETLDetId& id) {
      << " Module type : " << id.modType() << std::endl;
   return os;
 }
+
+uint32_t ETLDetId::newForm(const uint32_t& rawid) {
+  uint32_t rawid_new = 0;
+  rawid_new |= (MTDType::ETL & ETLDetId::kMTDsubdMask) << ETLDetId::kMTDsubdOffset |
+               (mtdSide() & ETLDetId::kZsideMask) << ETLDetId::kZsideOffset |
+               (mtdRR() & ETLDetId::kRodRingMask) << ETLDetId::kRodRingOffset |
+               (module() & ETLDetId::kETLmoduleMask) << (ETLDetId::kETLmoduleOffset - 2) |
+               (modType() & ETLDetId::kETLmodTypeMask) << (kETLmodTypeOffset - 2);
+  return rawid_new;
+}

--- a/DataFormats/ForwardDetId/src/ETLDetId.cc
+++ b/DataFormats/ForwardDetId/src/ETLDetId.cc
@@ -11,13 +11,3 @@ std::ostream& operator<<(std::ostream& os, const ETLDetId& id) {
      << " Module type : " << id.modType() << std::endl;
   return os;
 }
-
-uint32_t ETLDetId::newForm(const uint32_t& rawid) {
-  uint32_t rawid_new = 0;
-  rawid_new |= (MTDType::ETL & ETLDetId::kMTDsubdMask) << ETLDetId::kMTDsubdOffset |
-               (mtdSide() & ETLDetId::kZsideMask) << ETLDetId::kZsideOffset |
-               (mtdRR() & ETLDetId::kRodRingMask) << ETLDetId::kRodRingOffset |
-               (module() & ETLDetId::kETLmoduleMask) << (ETLDetId::kETLmoduleOffset - 2) |
-               (modType() & ETLDetId::kETLmodTypeMask) << (kETLmodTypeOffset - 2);
-  return rawid_new;
-}

--- a/DataFormats/ForwardDetId/src/classes_def.xml
+++ b/DataFormats/ForwardDetId/src/classes_def.xml
@@ -30,8 +30,15 @@
   <class name="BTLDetId" ClassVersion="3">
    <version ClassVersion="3" checksum="1515591716"/>
   </class>
-  <class name="ETLDetId" ClassVersion="3">
+  <class name="ETLDetId" ClassVersion="4">
+   <version ClassVersion="4" checksum="1644731879"/>
    <version ClassVersion="3" checksum="1644731879"/>
+   <ioread sourceClass = "ETLDetId" version="[-3]" targetClass="ETLDetId" source="" target="">
+    <![CDATA[
+       ETLDetId tmp(newObj->newForm(newObj->rawId()));
+        *newObj=tmp;
+    ]]>
+   </ioread>
   </class>
   <class name="HFNoseDetId" ClassVersion="0">
    <version ClassVersion="0" checksum="1469396081"/>

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -82,7 +82,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   }
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
-      (!preTDR && (1 > modCopy || std::max(ETLDetId::kETLv4maxModule,ETLDetId::kETLv5maxModule) < modCopy))) {
+      (!preTDR && (1 > modCopy || std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "
                                << "****************** Bad module copy = " << modCopy
                                << ", Volume Number = " << baseNumber.getCopyNumber(4);

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -82,7 +82,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   }
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
-      (!preTDR && (1 > modCopy || ETLDetId::kETLv4maxModule < modCopy))) {
+      (!preTDR && (1 > modCopy || std::max(ETLDetId::kETLv4maxModule,ETLDetId::kETLv5maxModule) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "
                                << "****************** Bad module copy = " << modCopy
                                << ", Volume Number = " << baseNumber.getCopyNumber(4);


### PR DESCRIPTION
#### PR description:

This PR is an update of #30557 . 

The future ETL v5 (to be implemented in a following PR) introduces D-shaped sectors, instead of the quarters used in ETL v4. The new, D-shaped sectors comprise more than 512 modules, which is the maximum number of modules that can be accommodated using the bits presently allocated in ETLDetId. ETLDetId.h has been modified to fix this issue, by adding 2 bits. The new ETLDetId is backward compatible with the older versions, thanks to a dedicated compatibility code implemented, and active in all relevant constructors.

#### PR validation:

The dedicated geometry tests provide the desired ETL det id, test wf 23234.0 and 23434.999 complete successfully. See discussion in #30557 for earlier checks.