### PR TITLE
Fix EDConsumerBase to look up consumed module label from EDAlias with product type and instance name as well

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -12,6 +12,7 @@
 #include "DataFormats/Provenance/interface/BranchKey.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
+#include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
@@ -122,7 +123,8 @@ namespace edm {
     bool anyProductProduced() const { return transient_.anyProductProduced_; }
 
     // Looks if a (type, moduleLabel, productInstanceName) is an alias to some other branch
-    std::optional<std::string> aliasToModule(TypeID const& type,
+    std::optional<std::string> aliasToModule(KindOfType kindOfType,
+                                             TypeID const& type,
                                              std::string_view moduleLabel,
                                              std::string_view productInstanceName) const;
 
@@ -147,8 +149,8 @@ namespace edm {
 
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 
-      enum { kType, kModuleLabel, kProductInstanceName, kAliasForModuleLabel };
-      std::vector<std::tuple<TypeID, std::string, std::string, std::string>> aliasToOriginal_;
+      enum { kKind, kType, kModuleLabel, kProductInstanceName, kAliasForModuleLabel };
+      std::vector<std::tuple<KindOfType, TypeID, std::string, std::string, std::string>> aliasToOriginal_;
     };
 
   private:

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -170,6 +170,9 @@ namespace edm {
     void initializeLookupTables(std::set<TypeID> const* productTypesConsumed,
                                 std::set<TypeID> const* elementTypesConsumed,
                                 std::string const* processName);
+    void addElementTypesForAliases(std::set<TypeID> const* elementTypesConsumed,
+                                   std::map<TypeID, TypeID> const& containedTypeMap,
+                                   std::map<TypeID, std::vector<TypeWithDict>> const& containedTypeToBaseTypesMap);
 
     void checkDictionariesOfConsumedTypes(std::set<TypeID> const* productTypesConsumed,
                                           std::set<TypeID> const* elementTypesConsumed,

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -155,7 +155,8 @@ namespace edm {
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 
       enum { kKind, kType, kModuleLabel, kProductInstanceName, kAliasForModuleLabel };
-      std::vector<std::tuple<KindOfType, TypeID, std::string, std::string, std::string>> aliasToOriginal_;
+      using AliasToOriginalVector = std::vector<std::tuple<KindOfType, TypeID, std::string, std::string, std::string>>;
+      AliasToOriginalVector aliasToOriginal_;
     };
 
   private:

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -21,7 +21,6 @@
 
 #include <iosfwd>
 #include <map>
-#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -123,10 +122,16 @@ namespace edm {
     bool anyProductProduced() const { return transient_.anyProductProduced_; }
 
     // Looks if a (type, moduleLabel, productInstanceName) is an alias to some other branch
-    std::optional<std::string> aliasToModule(KindOfType kindOfType,
-                                             TypeID const& type,
-                                             std::string_view moduleLabel,
-                                             std::string_view productInstanceName) const;
+    //
+    // Can return multiple modules if kindOfType is ELEMENT_TYPE (i.e.
+    // the product is consumed via edm::View) and there is ambiguity
+    // (in which case actual Event::get() would eventually lead to an
+    // exception). In that case all possible modules whose product
+    // could be consumed are returned.
+    std::vector<std::string> aliasToModules(KindOfType kindOfType,
+                                            TypeID const& type,
+                                            std::string_view moduleLabel,
+                                            std::string_view productInstanceName) const;
 
     ProductResolverIndex const& getNextIndexValue(BranchType branchType) const;
 

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -20,8 +20,11 @@
 
 #include <iosfwd>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
+#include <string_view>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -118,9 +121,10 @@ namespace edm {
     bool productProduced(BranchType branchType) const { return transient_.productProduced_[branchType]; }
     bool anyProductProduced() const { return transient_.anyProductProduced_; }
 
-    std::vector<std::pair<std::string, std::string>> const& aliasToOriginal() const {
-      return transient_.aliasToOriginal_;
-    }
+    // Looks if a (type, moduleLabel, productInstanceName) is an alias to some other branch
+    std::optional<std::string> aliasToModule(TypeID const& type,
+                                             std::string_view moduleLabel,
+                                             std::string_view productInstanceName) const;
 
     ProductResolverIndex const& getNextIndexValue(BranchType branchType) const;
 
@@ -143,7 +147,8 @@ namespace edm {
 
       std::map<BranchID, ProductResolverIndex> branchIDToIndex_;
 
-      std::vector<std::pair<std::string, std::string>> aliasToOriginal_;
+      enum { kType, kModuleLabel, kProductInstanceName, kAliasForModuleLabel };
+      std::vector<std::tuple<TypeID, std::string, std::string, std::string>> aliasToOriginal_;
     };
 
   private:

--- a/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductResolverIndexHelper.h
@@ -134,6 +134,7 @@ namespace edm {
       unsigned int numberOfMatches() const { return numberOfMatches_; }
       bool isFullyResolved(unsigned int i) const;
       char const* moduleLabel(unsigned int i) const;
+      char const* productInstanceName(unsigned int i) const;
       char const* processName(unsigned int i) const;
 
     private:

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -296,7 +296,7 @@ namespace edm {
                                                std::set<TypeID> const* elementTypesConsumed,
                                                std::string const* processName) {
     std::map<TypeID, TypeID> containedTypeMap;
-    std::map<TypeID, std::vector<TypeWithDict> > containedTypeToBaseTypesMap;
+    std::map<TypeID, std::vector<TypeWithDict>> containedTypeToBaseTypesMap;
 
     std::vector<std::string> missingDictionaries;
     std::vector<std::string> branchNamesForMissing;
@@ -459,7 +459,13 @@ namespace edm {
     checkDictionariesOfConsumedTypes(
         productTypesConsumed, elementTypesConsumed, containedTypeMap, containedTypeToBaseTypesMap);
 
-    // Add contained types for all EDAliases
+    addElementTypesForAliases(elementTypesConsumed, containedTypeMap, containedTypeToBaseTypesMap);
+  }
+
+  void ProductRegistry::addElementTypesForAliases(
+      std::set<TypeID> const* elementTypesConsumed,
+      std::map<TypeID, TypeID> const& containedTypeMap,
+      std::map<TypeID, std::vector<TypeWithDict>> const& containedTypeToBaseTypesMap) {
     Transients::AliasToOriginalVector elementAliases;
     for (auto& item : transient_.aliasToOriginal_) {
       auto iterContainedType = containedTypeMap.find(std::get<Transients::kType>(item));
@@ -509,7 +515,7 @@ namespace edm {
       std::set<TypeID> const* productTypesConsumed,
       std::set<TypeID> const* elementTypesConsumed,
       std::map<TypeID, TypeID> const& containedTypeMap,
-      std::map<TypeID, std::vector<TypeWithDict> >& containedTypeToBaseTypesMap) {
+      std::map<TypeID, std::vector<TypeWithDict>>& containedTypeToBaseTypesMap) {
     std::vector<std::string> missingDictionaries;
     std::set<std::string> consumedTypesWithMissingDictionaries;
 

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -604,10 +604,10 @@ namespace edm {
     return itFind->second;
   }
 
-  std::optional<std::string> ProductRegistry::aliasToModule(KindOfType kindOfType,
-                                                            TypeID const& type,
-                                                            std::string_view moduleLabel,
-                                                            std::string_view productInstanceName) const {
+  std::vector<std::string> ProductRegistry::aliasToModules(KindOfType kindOfType,
+                                                           TypeID const& type,
+                                                           std::string_view moduleLabel,
+                                                           std::string_view productInstanceName) const {
     auto aliasFields = [](auto const& item) {
       return std::tie(std::get<Transients::kKind>(item),
                       std::get<Transients::kType>(item),
@@ -620,10 +620,11 @@ namespace edm {
                          transient_.aliasToOriginal_.end(),
                          target,
                          [aliasFields](auto const& item, auto const& target) { return aliasFields(item) < target; });
-    if (found == transient_.aliasToOriginal_.end() or aliasFields(*found) != target) {
-      return std::nullopt;
+    std::vector<std::string> ret;
+    for (; found != transient_.aliasToOriginal_.end() and aliasFields(*found) == target; ++found) {
+      ret.emplace_back(std::get<Transients::kAliasForModuleLabel>(*found));
     }
-    return std::get<Transients::kAliasForModuleLabel>(*found);
+    return ret;
   }
 
   void ProductRegistry::print(std::ostream& os) const {

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -460,7 +460,7 @@ namespace edm {
         productTypesConsumed, elementTypesConsumed, containedTypeMap, containedTypeToBaseTypesMap);
 
     // Add contained types for all EDAliases
-    std::vector<decltype(transient_.aliasToOriginal_)::value_type> elementAliases;
+    Transients::AliasToOriginalVector elementAliases;
     for (auto& item : transient_.aliasToOriginal_) {
       auto iterContainedType = containedTypeMap.find(std::get<Transients::kType>(item));
       if (iterContainedType == containedTypeMap.end()) {

--- a/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductResolverIndexHelper.cc
@@ -129,6 +129,17 @@ namespace edm {
     return &productResolverIndexHelper_->processNames_[startInProcessNames];
   }
 
+  char const* ProductResolverIndexHelper::Matches::productInstanceName(unsigned int i) const {
+    if (i >= numberOfMatches_) {
+      throw Exception(errors::LogicError)
+          << "ProductResolverIndexHelper::Matches::productInstanceName - Argument is out of range.\n";
+    }
+    unsigned int start =
+        productResolverIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].startInBigNamesContainer();
+    auto moduleLabelSize = strlen(&productResolverIndexHelper_->bigNamesContainer_[start]);
+    return &productResolverIndexHelper_->bigNamesContainer_[start + moduleLabelSize + 1];
+  }
+
   char const* ProductResolverIndexHelper::Matches::moduleLabel(unsigned int i) const {
     if (i >= numberOfMatches_) {
       throw Exception(errors::LogicError)

--- a/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productResolverIndexHelper_t.cppunit.cc
@@ -232,6 +232,7 @@ void TestProductResolverIndexHelper::testManyEntries() {
   CPPUNIT_ASSERT(indexB3 == 17);
 
   CPPUNIT_ASSERT(std::string(matches.moduleLabel(4)) == "labelB");
+  CPPUNIT_ASSERT(std::string(matches.productInstanceName(4)) == "instanceB");
   CPPUNIT_ASSERT(std::string(matches.processName(4)) == "processB3");
   CPPUNIT_ASSERT(std::string(matches.processName(0)) == "");
 

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -455,10 +455,11 @@ namespace {
     // Ignore the source products, we are only interested in module products.
     // As far as I know, it should never be anything else so throw if something
     // unknown gets passed in.
-    if (std::string(consumedModuleLabel) != "source") {
+    if (std::string_view(consumedModuleLabel) != "source") {
       throw cms::Exception("EDConsumerBase", "insertFoundModuleLabel")
-          << "Couldn't find ModuleDescription for the consumed module label: " << std::string(consumedModuleLabel)
-          << "\n";
+          << "Couldn't find ModuleDescription for the consumed product type: '" << consumedType.className()
+          << "' module label: '" << consumedModuleLabel << "' product instance name: '" << consumedProductInstance
+          << "'";
     }
   }
 }  // namespace

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -428,7 +428,8 @@ namespace {
 }  // namespace
 
 namespace {
-  void insertFoundModuleLabel(edm::TypeID consumedType,
+  void insertFoundModuleLabel(edm::KindOfType consumedTypeKind,
+                              edm::TypeID consumedType,
                               const char* consumedModuleLabel,
                               const char* consumedProductInstance,
                               std::vector<ModuleDescription const*>& modules,
@@ -444,7 +445,8 @@ namespace {
       return;
     }
     // Deal with EDAlias's by converting to the original module label first
-    if (auto aliasToModuleLabel = preg.aliasToModule(consumedType, consumedModuleLabel, consumedProductInstance)) {
+    if (auto aliasToModuleLabel =
+            preg.aliasToModule(consumedTypeKind, consumedType, consumedModuleLabel, consumedProductInstance)) {
       if (auto it = labelsToDesc.find(*aliasToModuleLabel); it != labelsToDesc.end()) {
         if (alreadyFound.insert(consumedModuleLabel).second) {
           modules.push_back(it->second);
@@ -488,14 +490,21 @@ void EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescripti
               iHelper.index(
                   *itKind, itInfo->m_type, consumedModuleLabel, consumedProductInstance, consumedProcessName) !=
                   ProductResolverIndexInvalid) {
-            insertFoundModuleLabel(
-                itInfo->m_type, consumedModuleLabel, consumedProductInstance, modules, alreadyFound, labelsToDesc, preg);
+            insertFoundModuleLabel(*itKind,
+                                   itInfo->m_type,
+                                   consumedModuleLabel,
+                                   consumedProductInstance,
+                                   modules,
+                                   alreadyFound,
+                                   labelsToDesc,
+                                   preg);
           }
         } else {  // process name was empty
           auto matches = iHelper.relatedIndexes(*itKind, itInfo->m_type, consumedModuleLabel, consumedProductInstance);
           for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
             if (processName == matches.processName(j)) {
-              insertFoundModuleLabel(itInfo->m_type,
+              insertFoundModuleLabel(*itKind,
+                                     itInfo->m_type,
                                      consumedModuleLabel,
                                      consumedProductInstance,
                                      modules,
@@ -510,7 +519,8 @@ void EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescripti
         auto matches = iHelper.relatedIndexes(*itKind, itInfo->m_type);
         for (unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
           if (processName == matches.processName(j)) {
-            insertFoundModuleLabel(itInfo->m_type,
+            insertFoundModuleLabel(*itKind,
+                                   itInfo->m_type,
                                    matches.moduleLabel(j),
                                    matches.productInstanceName(j),
                                    modules,

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -445,12 +445,19 @@ namespace {
       return;
     }
     // Deal with EDAlias's by converting to the original module label first
-    if (auto aliasToModuleLabel =
-            preg.aliasToModule(consumedTypeKind, consumedType, consumedModuleLabel, consumedProductInstance)) {
-      if (auto it = labelsToDesc.find(*aliasToModuleLabel); it != labelsToDesc.end()) {
-        if (alreadyFound.insert(consumedModuleLabel).second) {
-          modules.push_back(it->second);
+    if (auto aliasToModuleLabels =
+            preg.aliasToModules(consumedTypeKind, consumedType, consumedModuleLabel, consumedProductInstance);
+        not aliasToModuleLabels.empty()) {
+      bool foundInLabelsToDesc = false;
+      for (auto const& label : aliasToModuleLabels) {
+        if (auto it = labelsToDesc.find(label); it != labelsToDesc.end()) {
+          if (alreadyFound.insert(label).second) {
+            modules.push_back(it->second);
+          }
+          foundInLabelsToDesc = true;
         }
+      }
+      if (foundInLabelsToDesc) {
         return;
       }
     }

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1493,7 +1493,13 @@ namespace edm {
     i = 0;
     for (auto const& worker : allWorkers()) {
       std::vector<ModuleDescription const*>& modules = modulesWhoseProductsAreConsumedBy.at(i);
-      worker->modulesWhoseProductsAreConsumed(modules, preg, labelToDesc);
+      try {
+        worker->modulesWhoseProductsAreConsumed(modules, preg, labelToDesc);
+      } catch (cms::Exception& ex) {
+        ex.addContext("Calling Worker::modulesWhoseProductsAreConsumed() for module " +
+                      worker->description().moduleLabel());
+        throw;
+      }
       ++i;
     }
   }

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -216,7 +216,18 @@ void testProductRegistry::testAddAlias() {
   reg.addLabelAlias(*floatBranch_, "aliasf", "instanceAlias");
 
   reg.setFrozen(false);
-  std::vector<std::pair<std::string, std::string> > const& v = reg.aliasToOriginal();
-  CPPUNIT_ASSERT(v.at(0).first == "aliasf" && v.at(0).second == "labelf" && v.at(1).first == "aliasi" &&
-                 v.at(1).second == "labeli");
+  {
+    auto notFound = reg.aliasToModule(intBranch_->unwrappedTypeID(), "alias", "instance");
+    CPPUNIT_ASSERT(notFound.has_value() == false);
+  }
+  {
+    auto found = reg.aliasToModule(intBranch_->unwrappedTypeID(), "aliasi", "instanceAlias");
+    CPPUNIT_ASSERT(found.has_value());
+    CPPUNIT_ASSERT(*found == "labeli");
+  }
+  {
+    auto found = reg.aliasToModule(floatBranch_->unwrappedTypeID(), "aliasf", "instanceAlias");
+    CPPUNIT_ASSERT(found.has_value());
+    CPPUNIT_ASSERT(*found == "labelf");
+  }
 }

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -236,7 +236,8 @@ namespace edmtest {
       if (checkSize_) {
         auto const& prod = e.get(token_);
         if (prod.size() != size_) {
-          throw cms::Exception("Assert") << "Product size " << prod.size() << " differs from expectation " << size_;
+          throw cms::Exception("SizeMismatch")
+              << "Product size " << prod.size() << " differs from expectation " << size_;
         }
       }
     }

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -215,6 +215,40 @@ namespace edmtest {
 
   //--------------------------------------------------------------------
   //
+  // Consumes View<Simple>
+  //
+  class SimpleViewAnalyzer : public edm::global::EDAnalyzer<> {
+  public:
+    explicit SimpleViewAnalyzer(edm::ParameterSet const& p)
+        : token_(consumes(p.getUntrackedParameter<edm::InputTag>("label"))),
+          size_(p.getUntrackedParameter<unsigned int>("sizeMustMatch")),
+          checkSize_(p.getUntrackedParameter<bool>("checkSize")) {}
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      desc.addUntracked<bool>("checkSize", true);
+      desc.addUntracked<unsigned int>("sizeMustMatch");
+      desc.addUntracked<edm::InputTag>("label");
+      descriptions.addDefault(desc);
+    }
+
+    void analyze(edm::StreamID, edm::Event const& e, edm::EventSetup const&) const {
+      if (checkSize_) {
+        auto const& prod = e.get(token_);
+        if (prod.size() != size_) {
+          throw cms::Exception("Assert") << "Product size " << prod.size() << " differs from expectation " << size_;
+        }
+      }
+    }
+
+  private:
+    edm::EDGetTokenT<edm::View<Simple>> const token_;
+    unsigned int const size_;
+    bool const checkSize_;
+  };
+
+  //--------------------------------------------------------------------
+  //
   class DSVAnalyzer : public edm::EDAnalyzer {
   public:
     DSVAnalyzer(edm::ParameterSet const&) {}
@@ -288,6 +322,7 @@ using edmtest::IntTestAnalyzer;
 using edmtest::MultipleIntsAnalyzer;
 using edmtest::NonAnalyzer;
 using edmtest::SCSimpleAnalyzer;
+using edmtest::SimpleViewAnalyzer;
 DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
 DEFINE_FWK_MODULE(MultipleIntsAnalyzer);
@@ -296,4 +331,5 @@ DEFINE_FWK_MODULE(edmtest::IntFromRunConsumingAnalyzer);
 DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);
 DEFINE_FWK_MODULE(ConsumingOneSharedResourceAnalyzer);
 DEFINE_FWK_MODULE(SCSimpleAnalyzer);
+DEFINE_FWK_MODULE(SimpleViewAnalyzer);
 DEFINE_FWK_MODULE(DSVAnalyzer);

--- a/FWCore/Integration/test/BuildFile.xml
+++ b/FWCore/Integration/test/BuildFile.xml
@@ -292,6 +292,13 @@
     <use name="FWCore/ServiceRegistry"/>
   </library>
 
+  <library file="PathsAndConsumesOfModulesTestService.cc" name="FWCoreIntegrationPathsAndConsumesOfModulesTestService">
+    <flags EDM_PLUGIN="1"/>
+    <use name="DataFormats/Provenance"/>
+    <use name="FWCore/ParameterSet"/>
+    <use name="FWCore/ServiceRegistry"/>
+  </library>
+
   <library file="OtherThingAnalyzer.cc,OtherThingRefComparer.cc" name="TestOtherThingAnalyzer">
     <flags EDM_PLUGIN="1"/>
     <use name="DataFormats/Common"/>

--- a/FWCore/Integration/test/PathsAndConsumesOfModulesTestService.cc
+++ b/FWCore/Integration/test/PathsAndConsumesOfModulesTestService.cc
@@ -1,0 +1,84 @@
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace edmtest {
+  class PathsAndConsumesOfModulesTestService {
+  public:
+    PathsAndConsumesOfModulesTestService(edm::ParameterSet const& pset, edm::ActivityRegistry& iRegistry)
+        : modulesConsumes_(pset.getParameter<decltype(modulesConsumes_)>("modulesAndConsumes")) {
+      iRegistry.watchPreBeginJob(this, &PathsAndConsumesOfModulesTestService::preBeginJob);
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+
+      edm::ParameterSetDescription validator;
+      validator.add<std::string>("key");
+      validator.add<std::vector<std::string>>("value");
+      desc.addVPSet("modulesAndConsumes", validator, std::vector<edm::ParameterSet>());
+
+      descriptions.addWithDefaultLabel(desc);
+      descriptions.setComment("This service is intended to be used in framework tests.");
+    }
+
+    void preBeginJob(edm::PathsAndConsumesOfModulesBase const& pathsAndConsumes, edm::ProcessContext const&) const {
+      auto const& allModules = pathsAndConsumes.allModules();
+      for (auto const& moduleToCheck : modulesConsumes_) {
+        auto found =
+            std::find_if(allModules.begin(), allModules.end(), [&moduleToCheck](edm::ModuleDescription const* desc) {
+              return desc->moduleLabel() == moduleToCheck.first;
+            });
+        if (found == allModules.end()) {
+          cms::Exception ex("Assert");
+          ex << "Module " << moduleToCheck.first
+             << " not found in PathsAndConsumesOfModulesBase, that has the following modules:\n";
+          for (edm::ModuleDescription const* desc : allModules) {
+            if (desc) {
+              ex << " " << desc->moduleLabel() << "\n";
+            } else {
+              ex << " nullptr\n";
+            }
+          }
+          throw ex;
+        }
+
+        std::set<std::string> tocheck(moduleToCheck.second.begin(), moduleToCheck.second.end());
+        for (edm::ModuleDescription const* desc : pathsAndConsumes.modulesWhoseProductsAreConsumedBy((*found)->id())) {
+          auto found = tocheck.find(desc->moduleLabel());
+          if (found == tocheck.end()) {
+            cms::Exception ex("Assert");
+            ex << "Module " << moduleToCheck.first << " consumes " << desc->moduleLabel()
+               << " that was not one of the expected modules:\n";
+            for (auto const& m : moduleToCheck.second) {
+              ex << " " << m << "\n";
+            }
+            throw ex;
+          }
+          tocheck.erase(found);
+        }
+        if (not tocheck.empty()) {
+          cms::Exception ex("Assert");
+          ex << "Module " << moduleToCheck.first << " was expected to consume the following modules, but it did not\n";
+          for (auto const& m : tocheck) {
+            ex << " " << m << "\n";
+          }
+          throw ex;
+        }
+      }
+    }
+
+  private:
+    std::vector<std::pair<std::string, std::vector<std::string>>> modulesConsumes_;
+  };
+}  // namespace edmtest
+
+using edmtest::PathsAndConsumesOfModulesTestService;
+DEFINE_FWK_SERVICE(PathsAndConsumesOfModulesTestService);

--- a/FWCore/Integration/test/PathsAndConsumesOfModulesTestService.cc
+++ b/FWCore/Integration/test/PathsAndConsumesOfModulesTestService.cc
@@ -37,7 +37,7 @@ namespace edmtest {
               return desc->moduleLabel() == moduleToCheck.first;
             });
         if (found == allModules.end()) {
-          cms::Exception ex("Assert");
+          cms::Exception ex("TestFailure");
           ex << "Module " << moduleToCheck.first
              << " not found in PathsAndConsumesOfModulesBase, that has the following modules:\n";
           for (edm::ModuleDescription const* desc : allModules) {
@@ -54,7 +54,7 @@ namespace edmtest {
         for (edm::ModuleDescription const* desc : pathsAndConsumes.modulesWhoseProductsAreConsumedBy((*found)->id())) {
           auto found = tocheck.find(desc->moduleLabel());
           if (found == tocheck.end()) {
-            cms::Exception ex("Assert");
+            cms::Exception ex("TestFailure");
             ex << "Module " << moduleToCheck.first << " consumes " << desc->moduleLabel()
                << " that was not one of the expected modules:\n";
             for (auto const& m : moduleToCheck.second) {
@@ -65,7 +65,7 @@ namespace edmtest {
           tocheck.erase(found);
         }
         if (not tocheck.empty()) {
-          cms::Exception ex("Assert");
+          cms::Exception ex("TestFailure");
           ex << "Module " << moduleToCheck.first << " was expected to consume the following modules, but it did not\n";
           for (auto const& m : tocheck) {
             ex << " " << m << "\n";

--- a/FWCore/Integration/test/run_TestEDAlias.sh
+++ b/FWCore/Integration/test/run_TestEDAlias.sh
@@ -22,6 +22,10 @@ pushd ${LOCAL_TMP_DIR}
   echo "Test output"
   cmsRun ${LOCAL_TEST_DIR}/${test}Analyze_cfg.py testEDAliasTask.root || die "cmsRun ${test}Analyze_cfg.py testEDAliasPath.root" $?
 
+  echo "*************************************************"
+  echo "Test EDAlias aliasing for many modules"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModules_cfg.py || die "cmsRun ${test}ManyModules_cfg.py 1" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/run_TestEDAlias.sh
+++ b/FWCore/Integration/test/run_TestEDAlias.sh
@@ -26,6 +26,14 @@ pushd ${LOCAL_TMP_DIR}
   echo "Test EDAlias aliasing for many modules"
   cmsRun ${LOCAL_TEST_DIR}/${test}ManyModules_cfg.py || die "cmsRun ${test}ManyModules_cfg.py 1" $?
 
+  echo "*************************************************"
+  echo "Test EDAlias aliasing for many modules with possibly ambiguous get via edm::View"
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModulesAmbiguous_cfg.py && die "cmsRun ${test}ManyModulesAmbiguous_cfg.py 1" $?
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModulesAmbiguous_cfg.py includeAliasToFoo=0 || die "cmsRun ${test}ManyModulesAmbiguous_cfg.py includeAliasToFoo=0" $?
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModulesAmbiguous_cfg.py includeAliasToBar=0 || die "cmsRun ${test}ManyModulesAmbiguous_cfg.py includeAliasToBar=0" $?
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModulesAmbiguous_cfg.py consumerGets=0 || die "cmsRun ${test}ManyModulesAmbiguous_cfg.py consumerGets=0" $?
+  cmsRun ${LOCAL_TEST_DIR}/${test}ManyModulesAmbiguous_cfg.py explicitProcessName=1 & die "cmsRun ${test}ManyModulesAmbiguous_cfg.py explicitProcessName=1" $?
+
 popd
 
 exit 0

--- a/FWCore/Integration/test/testEDAliasManyModulesAmbiguous_cfg.py
+++ b/FWCore/Integration/test/testEDAliasManyModulesAmbiguous_cfg.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing()
+options.register("includeAliasToFoo", 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Include case Foo in EDAlias")
+options.register("includeAliasToBar", 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Include case Bar in EDAlias")
+options.register("consumerGets", 1,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Consumer gets event product")
+options.register("explicitProcessName", 0,
+                 VarParsing.multiplicity.singleton,
+                 VarParsing.varType.int,
+                 "Use explicit process name in consumer InputTag")
+options.parseArguments()
+
+process.maxEvents.input = 1
+process.source = cms.Source("EmptySource")
+
+
+process.simpleProducerFoo = cms.EDProducer("OVSimpleProducer", size = cms.int32(10))
+process.simpleProducerBar = cms.EDProducer("OVSimpleProducer", size = cms.int32(5))
+
+process.simpleProducer = cms.EDAlias()
+if options.includeAliasToFoo != 0:
+    process.simpleProducer.simpleProducerFoo = cms.VPSet(
+        cms.PSet(
+            type = cms.string("edmtestSimplesOwned")
+        )
+    )
+if options.includeAliasToBar != 0:
+    process.simpleProducer.simpleProducerBar = cms.VPSet(
+        cms.PSet(
+            type = cms.string("edmtestSimpleDerivedsOwned"),
+            fromProductInstance = cms.string("derived"),
+            toProductInstance = cms.string("")
+        )
+    )
+
+process.simpleViewConsumer = cms.EDAnalyzer("SimpleViewAnalyzer",
+    label = cms.untracked.InputTag("simpleProducer"),
+    sizeMustMatch = cms.untracked.uint32(10),
+    checkSize = cms.untracked.bool(options.consumerGets != 0)
+)
+if options.includeAliasToFoo == 0:
+    process.simpleViewConsumer.sizeMustMatch = 5
+if options.explicitProcessName != 0:
+    process.simpleViewConsumer.label.setProcessName("TEST")
+
+dependsOn = []
+if options.includeAliasToFoo != 0:
+    dependsOn.append("simpleProducerFoo")
+if options.includeAliasToBar != 0:
+    dependsOn.append("simpleProducerBar")
+process.PathsAndConsumesOfModulesTestService = cms.Service("PathsAndConsumesOfModulesTestService",
+    modulesAndConsumes = cms.VPSet(
+        cms.PSet(
+            key = cms.string("simpleViewConsumer"),
+            value = cms.vstring(dependsOn)
+        ),
+    )
+)
+
+process.t = cms.Task(
+    process.simpleProducerFoo,
+    process.simpleProducerBar
+)
+
+process.p = cms.Path(
+    process.simpleViewConsumer,
+    process.t
+)

--- a/FWCore/Integration/test/testEDAliasManyModules_cfg.py
+++ b/FWCore/Integration/test/testEDAliasManyModules_cfg.py
@@ -1,0 +1,55 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.maxEvents.input = 1
+process.source = cms.Source("EmptySource")
+
+process.intProducerFoo = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+process.intProducerBar = cms.EDProducer("IntProducer", ivalue = cms.int32(2))
+process.intConsumer = cms.EDAnalyzer("IntTestAnalyzer",
+    moduleLabel = cms.untracked.InputTag("intProducer"),
+    valueMustMatch = cms.untracked.int32(1)
+)
+process.intConsumer2 = process.intConsumer.clone(
+    moduleLabel = ("intProducer", "test"),
+    valueMustMatch = 2
+)
+
+process.intProducer = cms.EDAlias(
+    intProducerFoo = cms.VPSet(
+        cms.PSet(
+            type = cms.string("edmtestIntProduct"),
+        )
+    ),
+    intProducerBar = cms.VPSet(
+        cms.PSet(
+            type = cms.string("edmtestIntProduct"),
+            fromProductInstance = cms.string(""),
+            toProductInstance = cms.string("test"),
+        )
+    )
+)
+
+process.PathsAndConsumesOfModulesTestService = cms.Service("PathsAndConsumesOfModulesTestService",
+    modulesAndConsumes = cms.VPSet(
+        cms.PSet(
+            key = cms.string("intConsumer"),
+            value = cms.vstring("intProducerFoo")
+        ),
+        cms.PSet(
+            key = cms.string("intConsumer2"),
+            value = cms.vstring("intProducerBar")
+        )
+    )
+)
+
+process.t = cms.Task(
+    process.intProducerFoo,
+    process.intProducerBar
+)
+process.p = cms.Path(
+    process.intConsumer +
+    process.intConsumer2,
+    process.t
+)

--- a/FWCore/Integration/test/testEDAliasManyModules_cfg.py
+++ b/FWCore/Integration/test/testEDAliasManyModules_cfg.py
@@ -5,6 +5,7 @@ process = cms.Process("TEST")
 process.maxEvents.input = 1
 process.source = cms.Source("EmptySource")
 
+###########
 process.intProducerFoo = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
 process.intProducerBar = cms.EDProducer("IntProducer", ivalue = cms.int32(2))
 process.intConsumer = cms.EDAnalyzer("IntTestAnalyzer",
@@ -31,6 +32,36 @@ process.intProducer = cms.EDAlias(
     )
 )
 
+###########
+process.intVecProducerFoo = cms.EDProducer("IntVectorProducer",
+    count = cms.int32(10),
+    ivalue = cms.int32(0),
+    delta = cms.int32(1)
+)
+process.intVecProducerBar = process.intVecProducerFoo.clone(ivalue = 100)
+process.intViewConsumer = cms.EDProducer("IntVecPtrVectorProducer",
+    target = cms.InputTag('intVecProducer')
+)
+process.intViewConsumer2 = cms.EDProducer("IntVecPtrVectorProducer",
+    target = cms.InputTag("intVecProducer", "test")
+)
+
+process.intVecProducer = cms.EDAlias(
+    intVecProducerFoo = cms.VPSet(
+        cms.PSet(
+            type = cms.string("ints")
+        )
+    ),
+    intVecProducerBar = cms.VPSet(
+        cms.PSet(
+            type = cms.string("ints"),
+            fromProductInstance = cms.string(""),
+            toProductInstance = cms.string("test"),
+        )
+    )
+)
+
+###########
 process.PathsAndConsumesOfModulesTestService = cms.Service("PathsAndConsumesOfModulesTestService",
     modulesAndConsumes = cms.VPSet(
         cms.PSet(
@@ -40,16 +71,28 @@ process.PathsAndConsumesOfModulesTestService = cms.Service("PathsAndConsumesOfMo
         cms.PSet(
             key = cms.string("intConsumer2"),
             value = cms.vstring("intProducerBar")
-        )
+        ),
+        cms.PSet(
+            key = cms.string("intViewConsumer"),
+            value = cms.vstring("intVecProducerFoo")
+        ),
+        cms.PSet(
+            key = cms.string("intViewConsumer2"),
+            value = cms.vstring("intVecProducerBar")
+        ),
     )
 )
 
 process.t = cms.Task(
     process.intProducerFoo,
-    process.intProducerBar
+    process.intProducerBar,
+    process.intVecProducerFoo,
+    process.intVecProducerBar,
 )
 process.p = cms.Path(
     process.intConsumer +
-    process.intConsumer2,
+    process.intConsumer2 +
+    process.intViewConsumer +
+    process.intViewConsumer2,
     process.t
 )

--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -328,6 +328,18 @@ namespace edm {
       return a;
     }
   };
+  // read an std::vector<std::pair<std::string, T>> from std::vector<PSet>
+  template <typename T>
+  struct ParameterTypeTraits<std::vector<std::pair<std::string, T>>> {
+    using GetType = std::vector<edm::ParameterSet>;
+    static auto convert(std::vector<edm::ParameterSet> vpset, std::string const& iName) {
+      std::vector<std::pair<std::string, T>> ret(vpset.size());
+      std::transform(vpset.begin(), vpset.end(), ret.begin(), [](edm::ParameterSet const& pset) {
+        return std::pair(pset.getParameter<std::string>("key"), pset.getParameter<T>("value"));
+      });
+      return ret;
+    }
+  };
   // ----------------------------------------------------------------------
 
   template <>


### PR DESCRIPTION
#### PR description:

This PR resolves https://github.com/cms-sw/cmssw/issues/30937 by making `EDConsumerBase` and `ProductRegistry` to use product type and instance name in addition to the module label when resolving alias-for module label for an EDAlias branch. 

#### PR validation:

Framework unit tests run.