### PR TITLE
HCAL MAHI code update to take only pedestal noise terms for correlation terms of a noise covariance matrix

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -36,6 +36,8 @@ struct MahiNnlsWorkspace {
   //holds flat pedestal uncertainty
   float pedVal;
 
+  float noisecorr;
+
   //holds full covariance matrix for a pulse shape
   //varied in time
   std::array<SampleMatrix, MaxPVSize> pulseCovArray;
@@ -116,7 +118,7 @@ public:
 
   void phase1Debug(const HBHEChannelInfo& channelData, MahiDebugInfo& mdi) const;
 
-  void doFit(std::array<float, 3>& correctedOutput, const int nbx, const double noisecorr) const;
+  void doFit(std::array<float, 3>& correctedOutput, const int nbx) const;
 
   void setPulseShapeTemplate(int pulseShapeId,
                              const HcalPulseShapes& ps,
@@ -130,7 +132,7 @@ public:
 private:
   typedef std::pair<int, std::shared_ptr<FitterFuncs::PulseShapeFunctor> > ShapeWithId;
 
-  const float minimize(const double noisecorr) const;
+  const float minimize() const;
   void onePulseMinimize() const;
   void updateCov(const SampleMatrix& invCovMat) const;
   void resetPulseShapeTemplate(int pulseShapeId, const HcalPulseShapes& ps, unsigned int nSamples);
@@ -139,7 +141,7 @@ private:
                         FullSampleVector& pulseDeriv,
                         FullSampleMatrix& pulseCov) const;
 
-  float calculateArrivalTime(unsigned int iBX) const;
+  float calculateArrivalTime(const unsigned int iBX) const;
   float calculateChiSq() const;
   void nnls() const;
   void resetWorkspace() const;

--- a/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/MahiFit.h
@@ -33,6 +33,9 @@ struct MahiNnlsWorkspace {
   //holds diagonal noise terms
   SampleVector noiseTerms;
 
+  //holds diagonal pedestal noise terms
+  SampleVector pedVals;
+
   //holds flat pedestal uncertainty
   float pedVal;
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -69,16 +69,15 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
     auto const pedWidth = channelData.tsPedestalWidth(iTS);
 
     //Photostatistics
-    auto const noisePhoto = (amplitude > pedWidth) ? std::sqrt(amplitude * channelData.fcByPE()) : 0.f;
+    auto const noisePhotoSq = (amplitude > pedWidth) ? (amplitude * channelData.fcByPE()) : 0.f;
 
     //Total uncertainty from all sources
-    nnlsWork_.noiseTerms.coeffRef(iTS) = noiseADC * noiseADC + noisePhoto * noisePhoto + pedWidth * pedWidth;
+    nnlsWork_.noiseTerms.coeffRef(iTS) = noiseADC * noiseADC + noisePhotoSq + pedWidth * pedWidth;
 
     tsTOT += amplitude;
     if (iTS == nnlsWork_.tsOffset)
       tstrig += amplitude;
   }
-  const double noisecorr = channelData.noisecorr();
   tsTOT *= channelData.tsGain(0);
   tstrig *= channelData.tsGain(0);
 
@@ -90,15 +89,17 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
                                 channelData.tsPedestalWidth(2) * channelData.tsPedestalWidth(2) +
                                 channelData.tsPedestalWidth(3) * channelData.tsPedestalWidth(3));
 
+    nnlsWork_.noisecorr = channelData.noisecorr();
+
     // only do pre-fit with 1 pulse if chiSq threshold is positive
     if (chiSqSwitch_ > 0) {
-      doFit(reconstructedVals, 1, noisecorr);
+      doFit(reconstructedVals, 1);
       if (reconstructedVals[2] > chiSqSwitch_) {
-        doFit(reconstructedVals, 0, noisecorr);  //nbx=0 means use configured BXs
+        doFit(reconstructedVals, 0);  //nbx=0 means use configured BXs
         useTriple = true;
       }
     } else {
-      doFit(reconstructedVals, 0, noisecorr);
+      doFit(reconstructedVals, 0);
       useTriple = true;
     }
   } else {
@@ -112,7 +113,7 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
   chi2 = reconstructedVals[2];
 }
 
-void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx, const double noisecorr) const {
+void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx) const {
   unsigned int bxSize = 1;
 
   if (nbx == 1) {
@@ -175,7 +176,7 @@ void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx, const double
     }
   }
 
-  const float chiSq = minimize(noisecorr);
+  const float chiSq = minimize();
 
   bool foundintime = false;
   unsigned int ipulseintime = 0;
@@ -203,7 +204,7 @@ void MahiFit::doFit(std::array<float, 3>& correctedOutput, int nbx, const double
   }
 }
 
-const float MahiFit::minimize(const double noisecorr) const {
+const float MahiFit::minimize() const {
   nnlsWork_.invcovp.setZero(nnlsWork_.tsSize, nnlsWork_.nPulseTot);
   nnlsWork_.ampVec.setZero(nnlsWork_.nPulseTot);
 
@@ -212,9 +213,9 @@ const float MahiFit::minimize(const double noisecorr) const {
   invCovMat += nnlsWork_.noiseTerms.asDiagonal();
 
   //Add off-Diagonal components up to first order
-  if (noisecorr != 0) {
+  if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
-      auto const noiseCorrTerm = noisecorr * sqrt(nnlsWork_.noiseTerms.coeff(i - 1) * nnlsWork_.noiseTerms.coeff(i));
+      auto const noiseCorrTerm = nnlsWork_.noisecorr * sqrt(nnlsWork_.noiseTerms.coeff(i - 1) * nnlsWork_.noiseTerms.coeff(i));
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }
@@ -317,15 +318,14 @@ void MahiFit::updateCov(const SampleMatrix& samplecov) const {
     if (offset == pedestalBX_)
       continue;
     else {
-      auto const ampsq = amp * amp;
-      invCovMat += ampsq * nnlsWork_.pulseCovArray[offset + nnlsWork_.bxOffset];
+      invCovMat.noalias() += amp * amp * nnlsWork_.pulseCovArray[offset + nnlsWork_.bxOffset];
     }
   }
 
   nnlsWork_.covDecomp.compute(invCovMat);
 }
 
-float MahiFit::calculateArrivalTime(unsigned int itIndex) const {
+float MahiFit::calculateArrivalTime(const unsigned int itIndex) const {
   if (nnlsWork_.nPulseTot > 1) {
     SamplePulseMatrix pulseDerivMatTMP = nnlsWork_.pulseDerivMat;
     for (unsigned int iBX = 0; iBX < nnlsWork_.nPulseTot; ++iBX) {
@@ -350,10 +350,11 @@ void MahiFit::nnls() const {
   const unsigned int nsamples = nnlsWork_.tsSize;
 
   PulseVector updateWork;
+  PulseVector ampvecpermtest;
 
   nnlsWork_.invcovp = nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.pulseMat);
-  nnlsWork_.aTaMat = nnlsWork_.invcovp.transpose() * nnlsWork_.invcovp;
-  nnlsWork_.aTbVec = nnlsWork_.invcovp.transpose() * (nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
+  nnlsWork_.aTaMat.noalias() = nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.invcovp);
+  nnlsWork_.aTbVec.noalias() = nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
 
   int iter = 0;
   Index idxwmax = 0;
@@ -370,7 +371,7 @@ void MahiFit::nnls() const {
       if (nActive == 0)
         break;
 
-      updateWork = nnlsWork_.aTbVec - nnlsWork_.aTaMat * nnlsWork_.ampVec;
+      updateWork.noalias() = nnlsWork_.aTbVec - nnlsWork_.aTaMat.lazyProduct(nnlsWork_.ampVec);
 
       Index idxwmaxprev = idxwmax;
       float wmaxprev = wmax;
@@ -393,7 +394,7 @@ void MahiFit::nnls() const {
       if (nnlsWork_.nP == 0)
         break;
 
-      PulseVector ampvecpermtest = nnlsWork_.ampVec.head(nnlsWork_.nP);
+      ampvecpermtest.noalias() = nnlsWork_.ampVec.head(nnlsWork_.nP);
 
       solveSubmatrix(nnlsWork_.aTaMat, nnlsWork_.aTbVec, ampvecpermtest, nnlsWork_.nP);
 

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -217,8 +217,7 @@ const float MahiFit::minimize() const {
   //Add off-Diagonal components up to first order
   if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
-      auto const noiseCorrTerm =
-          nnlsWork_.noisecorr * nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i);
+      auto const noiseCorrTerm = nnlsWork_.noisecorr * nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i);
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -218,7 +218,7 @@ const float MahiFit::minimize() const {
   if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
       auto const noiseCorrTerm =
-        nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
+          nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }
@@ -358,7 +358,7 @@ void MahiFit::nnls() const {
   nnlsWork_.invcovp = nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.pulseMat);
   nnlsWork_.aTaMat.noalias() = nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.invcovp);
   nnlsWork_.aTbVec.noalias() =
-    nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
+      nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
 
   int iter = 0;
   Index idxwmax = 0;

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -218,7 +218,7 @@ const float MahiFit::minimize() const {
   if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
       auto const noiseCorrTerm =
-          nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
+          nnlsWork_.noisecorr * nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i);
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -217,7 +217,8 @@ const float MahiFit::minimize() const {
   //Add off-Diagonal components up to first order
   if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
-      auto const noiseCorrTerm = nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
+      auto const noiseCorrTerm =
+        nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }
@@ -356,7 +357,8 @@ void MahiFit::nnls() const {
 
   nnlsWork_.invcovp = nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.pulseMat);
   nnlsWork_.aTaMat.noalias() = nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.invcovp);
-  nnlsWork_.aTbVec.noalias() = nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
+  nnlsWork_.aTbVec.noalias() =
+    nnlsWork_.invcovp.transpose().lazyProduct(nnlsWork_.covDecomp.matrixL().solve(nnlsWork_.amplitudes));
 
   int iter = 0;
   Index idxwmax = 0;
@@ -656,5 +658,4 @@ void MahiFit::resetWorkspace() const {
   nnlsWork_.amplitudes.setZero();
   nnlsWork_.noiseTerms.setZero();
   nnlsWork_.pedVals.setZero();
-
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -74,7 +74,7 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
     //Total uncertainty from all sources
     nnlsWork_.noiseTerms.coeffRef(iTS) = noiseADC * noiseADC + noisePhotoSq + pedWidth * pedWidth;
 
-    nnlsWork_.pedVals.coeffRef(iTS) = pedWidth * pedWidth;
+    nnlsWork_.pedVals.coeffRef(iTS) = pedWidth;
 
     tsTOT += amplitude;
     if (iTS == nnlsWork_.tsOffset)

--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -74,6 +74,8 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
     //Total uncertainty from all sources
     nnlsWork_.noiseTerms.coeffRef(iTS) = noiseADC * noiseADC + noisePhotoSq + pedWidth * pedWidth;
 
+    nnlsWork_.pedVals.coeffRef(iTS) = pedWidth * pedWidth;
+
     tsTOT += amplitude;
     if (iTS == nnlsWork_.tsOffset)
       tstrig += amplitude;
@@ -215,7 +217,7 @@ const float MahiFit::minimize() const {
   //Add off-Diagonal components up to first order
   if (nnlsWork_.noisecorr != 0) {
     for (unsigned int i = 1; i < nnlsWork_.tsSize; ++i) {
-      auto const noiseCorrTerm = nnlsWork_.noisecorr * sqrt(nnlsWork_.noiseTerms.coeff(i - 1) * nnlsWork_.noiseTerms.coeff(i));
+      auto const noiseCorrTerm = nnlsWork_.noisecorr * sqrt(nnlsWork_.pedVals.coeff(i - 1) * nnlsWork_.pedVals.coeff(i));
       invCovMat(i - 1, i) += noiseCorrTerm;
       invCovMat(i, i - 1) += noiseCorrTerm;
     }
@@ -475,6 +477,7 @@ void MahiFit::setPulseShapeTemplate(const int pulseShapeId,
     nnlsWork_.tsSize = nSamples;
     nnlsWork_.amplitudes.resize(nSamples);
     nnlsWork_.noiseTerms.resize(nSamples);
+    nnlsWork_.pedVals.resize(nSamples);
   }
 }
 
@@ -652,4 +655,6 @@ void MahiFit::resetWorkspace() const {
   // NOT SURE THIS IS NEEDED
   nnlsWork_.amplitudes.setZero();
   nnlsWork_.noiseTerms.setZero();
+  nnlsWork_.pedVals.setZero();
+
 }


### PR DESCRIPTION
#### PR description:

This PR is a follow-up of the previous [PR #310614](https://github.com/cms-sw/cmssw/pull/31064). The previous updates, adding a noise correlation factor between adjacent time slices for MAHI was not fully self-consistent by [the previous study](https://indico.cern.ch/event/936151/contributions/3933432/attachments/2070567/3476700/pedestal.pdf) because the algorithm takes overall noise terms (pedestal + ADC + photostatistics) to calculate noise correlation while noise correlation factors between adjacent noise terms are obtained from minimum Bias which is not related to photostatistics term. So, in this PR, codes are updated to obtain noise correlation using only pedestal noise terms for self-consistency. The effect of this change is shown in [this presentation by Taeun Kwon](https://indico.cern.ch/event/954817/contributions/4012017/attachments/2101359/3532785/pedestal.pdf). Also, minor changes in MAHI are introduced in this PR for the speed-up of the algorithm. 

igprof reports for DIGI and RECO before and after this PR are given below for the measurment of CPU costs.
The sample used here : TTbar RelVal
CMSSW_release : CMSSW_11_2_0_pre6
Global tags : phase1_2024_realistic
PU input : /RelValMinBias_14TeV/CMSSW_10_6_1-106X_mcRun3_2021_realistic_v1_rsb-v1/GEN-SIM 

igprof report for DIGI before the change:
41.96 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_woPU_step2](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_woPU_step2)

igprof report for DIGI after the change:
39.04 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_woPU_step2](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_woPU_step2)

igprof report for RECO before the change w/o PU:
43.37 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_woPU_step3](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_woPU_step3)

igprof report for RECO after the change w/o PU:
39.95 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_woPU_step3](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_woPU_step3)

igprof report for RECO before the change w/ PU:
49.19 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_wPU_step3](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_before_wPU_step3)

igprof report for RECO after the change w/ PU:
47.69 sec / 1000 evts taken for mahiFit:minimization module.
[https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_wPU_step3](https://ktaeun.web.cern.ch/ktaeun/cgi-bin/igprof-navigator/igreport_perf_after_wPU_step3)

This PR is expected to decrease the timing cost by 5~10% of time spent on mahiFit:minimization module.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

A basic technical test was performed: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and shouldn't be backported.

<!-- Please replace this text with any link to  -->
