### PR TITLE
drop type specs in RecoMET

### DIFF
--- a/RecoMET/METPUSubtraction/python/mitigatedMETSequence_cff.py
+++ b/RecoMET/METPUSubtraction/python/mitigatedMETSequence_cff.py
@@ -11,7 +11,7 @@ from JetMETCorrections.Configuration.DefaultJEC_cff import *
 from RecoJets.JetProducers.PileupJetIDParams_cfi import JetIdParams
 
 from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
-kt6PFJets = kt4PFJets.clone(rParam = cms.double(0.6), doRhoFastjet = True )
+kt6PFJets = kt4PFJets.clone(rParam = 0.6, doRhoFastjet = True )
 
 calibratedAK4PFJetsForPFMVAMEt = cms.EDProducer('PFJetCorrectionProducer',
     src = cms.InputTag('ak4PFJets'),
@@ -100,25 +100,25 @@ puJetIdForPFNoPUMEt = pileupJetId.clone(
         PhilV1
         ),
 #    label = cms.string("fullId"), #MM does not work for weird reasons, cannot be cloned properly
-    produceJetIds = cms.bool(True),
-    runMvas = cms.bool(True),
-    jets = cms.InputTag("calibratedAK4PFJetsForPFNoPUMEt"),
-    applyJec = cms.bool(False),
-    inputIsCorrected = cms.bool(True),
+    produceJetIds    = True,
+    runMvas          = True,
+    jets             = "calibratedAK4PFJetsForPFNoPUMEt",
+    applyJec         = False,
+    inputIsCorrected = True,
     )
 pfNoPUMEtSequence += puJetIdForPFNoPUMEt
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
 pfNoPUMEtSequence += type0PFMEtCorrection
 pfCandidateToVertexAssociationForPFNoPUMEt = pfCandidateToVertexAssociation.clone(
-    MaxNumberOfAssociations = cms.int32(1),	
-    doReassociation = cms.bool(False),
-    FinalAssociation = cms.untracked.int32(1),			    
-    nTrackWeight = cms.double(0.)
+    MaxNumberOfAssociations = 1,	
+    doReassociation         = False,
+    FinalAssociation        = 1,			    
+    nTrackWeight            = 0.
 )
 pfNoPUMEtSequence += pfCandidateToVertexAssociationForPFNoPUMEt
 pfMETcorrType0ForPFNoPUMEt = pfMETcorrType0.clone(
-    srcPFCandidateToVertexAssociations = cms.InputTag('pfCandidateToVertexAssociationForPFNoPUMEt')
+    srcPFCandidateToVertexAssociations = 'pfCandidateToVertexAssociationForPFNoPUMEt'
 )
 pfNoPUMEtSequence += pfMETcorrType0ForPFNoPUMEt
 

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_cff.py
@@ -48,12 +48,12 @@ puJetIdForPFMVAMEt = _pileupJetIdEvaluator.clone(
         label = cms.string("full")
         )
         ),
-    produceJetIds = cms.bool(True),
-    runMvas = cms.bool(True),
-    jets = cms.InputTag("calibratedAK4PFJetsForPFMVAMEt"),#calibratedAK4PFJetsForPFMVAMEt
-    applyJec = cms.bool(True),
-    inputIsCorrected = cms.bool(True),
-    jec     = cms.string("AK4PF"),
+    produceJetIds    = True,
+    runMvas          = True,
+    jets             = "calibratedAK4PFJetsForPFMVAMEt",#calibratedAK4PFJetsForPFMVAMEt
+    applyJec         = True,
+    inputIsCorrected = True,
+    jec              = "AK4PF",
 )
 
 

--- a/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
+++ b/RecoMET/METPUSubtraction/python/mvaPFMET_leptons_cfi.py
@@ -51,7 +51,7 @@ kt6PFJetsForRhoComputationVoronoiMet = dummy.clone(
 
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator
 hpsPFTauDiscriminationByDecayModeFinding = hpsSelectionDiscriminator.clone(
-        PFTauProducer = cms.InputTag('hpsPFTauProducer')
+        PFTauProducer = 'hpsPFTauProducer'
             )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack

--- a/RecoMET/METPUSubtraction/python/pfNoPUMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/pfNoPUMET_cff.py
@@ -18,25 +18,25 @@ puJetIdForPFNoPUMEt = pileupJetId.clone(
         PhilV1
         ),
 #    label = cms.string("fullId"), #MM does not work for weird reasons, cannot be cloned properly
-    produceJetIds = cms.bool(True),
-    runMvas = cms.bool(True),
-    jets = cms.InputTag("calibratedAK4PFJetsForPFNoPUMEt"),
-    applyJec = cms.bool(False),
-    inputIsCorrected = cms.bool(True),
+    produceJetIds    = True,
+    runMvas          = True,
+    jets             = "calibratedAK4PFJetsForPFNoPUMEt",
+    applyJec         = False,
+    inputIsCorrected = True,
     )
 pfNoPUMEtSequence += puJetIdForPFNoPUMEt
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
 pfNoPUMEtSequence += type0PFMEtCorrection
 pfCandidateToVertexAssociationForPFNoPUMEt = pfCandidateToVertexAssociation.clone(
-    MaxNumberOfAssociations = cms.int32(1),	
-    doReassociation = cms.bool(False),
-    FinalAssociation = cms.untracked.int32(1),			    
-    nTrackWeight = cms.double(0.)
+    MaxNumberOfAssociations = 1,	
+    doReassociation         = False,
+    FinalAssociation        = 1,			    
+    nTrackWeight            = 0.
 )
 pfNoPUMEtSequence += pfCandidateToVertexAssociationForPFNoPUMEt
 pfMETcorrType0ForPFNoPUMEt = pfMETcorrType0.clone(
-    srcPFCandidateToVertexAssociations = cms.InputTag('pfCandidateToVertexAssociationForPFNoPUMEt')
+    srcPFCandidateToVertexAssociations = 'pfCandidateToVertexAssociationForPFNoPUMEt'
 )
 pfNoPUMEtSequence += pfMETcorrType0ForPFNoPUMEt
 

--- a/RecoMET/METPUSubtraction/python/pfNoPUchsMET_cff.py
+++ b/RecoMET/METPUSubtraction/python/pfNoPUchsMET_cff.py
@@ -19,22 +19,22 @@ puJetIdForPFNoPUchsMEt = pileupJetId.clone(
         full_53x_chs,
         cutbased
         ),
-    label = cms.string("fullId"),
-    produceJetIds = cms.bool(True),
-    runMvas = cms.bool(True),
-    jets = cms.InputTag("calibratedAK4PFchsJetsForPFNoPUchsMEt"),
-    applyJec = cms.bool(False),
-    inputIsCorrected = cms.bool(True),                                     
+    label            = "fullId",
+    produceJetIds    = True,
+    runMvas          = True,
+    jets             = "calibratedAK4PFchsJetsForPFNoPUchsMEt",
+    applyJec         = False,
+    inputIsCorrected = True,                                     
 )
 pfNoPUchsMEtSequence += puJetIdForPFNoPUchsMEt
 
 from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
 pfNoPUchsMEtSequence += type0PFMEtCorrection
 pfCandidateToVertexAssociationForPFNoPUchsMEt = pfCandidateToVertexAssociation.clone(
-    MaxNumberOfAssociations = cms.int32(1),	
-    doReassociation = cms.bool(False),
-    FinalAssociation = cms.untracked.int32(1),			    
-    nTrackWeight = cms.double(0.)
+    MaxNumberOfAssociations = 1,	
+    doReassociation         = False,
+    FinalAssociation        = 1,			    
+    nTrackWeight            = 0.
 )
 pfNoPUchsMEtSequence += pfCandidateToVertexAssociationForPFNoPUchsMEt
 pfMETcorrType0ForPFNoPUchsMEt = pfMETcorrType0.clone(

--- a/RecoMET/METProducers/python/CaloMET_cfi.py
+++ b/RecoMET/METProducers/python/CaloMET_cfi.py
@@ -11,10 +11,10 @@ caloMet = cms.EDProducer(
     )
 
 ##____________________________________________________________________________||
-caloMetBEFO = caloMet.clone()
-caloMetBEFO.src = "towerMakerWithHO"
-caloMetBEFO.alias = 'caloMetBEFO'
-
+caloMetBEFO = caloMet.clone(
+    src   = "towerMakerWithHO",
+    alias = 'caloMetBEFO'
+)
 ##____________________________________________________________________________||
 caloMetBE = cms.EDProducer(
     "CaloMETProducer",
@@ -26,8 +26,8 @@ caloMetBE = cms.EDProducer(
 )
 
 ##____________________________________________________________________________||
-caloMetBEO = caloMetBE.clone()
-caloMetBEO.src = "towerMakerWithHO"
-caloMetBEO.alias = 'caloMetBEO'
-
+caloMetBEO = caloMetBE.clone(
+    src   = "towerMakerWithHO",
+    alias = 'caloMetBEO'
+)
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/python/TCMET_cfi.py
+++ b/RecoMET/METProducers/python/TCMET_cfi.py
@@ -63,8 +63,8 @@ tcMet = cms.EDProducer(
     )
 
 ##____________________________________________________________________________||
-tcMetWithPFclusters = tcMet.clone()
-tcMetWithPFclusters.alias = cms.string('tcMetWithPFclusters')
-tcMetWithPFclusters.usePFClusters = cms.bool(True)
-
+tcMetWithPFclusters = tcMet.clone(
+    alias         = 'tcMetWithPFclusters',
+    usePFClusters = True
+)
 ##____________________________________________________________________________||


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389))

In this PR, total 7 files updated. 
- RecoMET/{METPUSubtraction} 5 files 
- RecoMET/{METProducers} 2 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).