### PR TITLE
Update Run 3 geometry DB payloads

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -69,17 +69,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v8', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v7',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v8',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v7', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v8', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v8', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '112X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:

This PR updates the geometry DB payloads in the Run 3 MC global tags. The changes and their validation are described in the [21 Sep 2020 AlCaDB presentation](https://indico.cern.ch/event/953248/#33-run-3-geometry-for-11_2) by @cvuosalo.

The Run 3 data GTs will be updated once release validation of the payloads has been completed.

The global tag diffs are the same for all six scenarios:

Attn: @cvuosalo @ianna 

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v7/112X_mcRun3_2021_design_v8

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v7/112X_mcRun3_2021_realistic_v8

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v7/112X_mcRun3_2021cosmics_realistic_deco_v8

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v8/112X_mcRun3_2021_realistic_HI_v9

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v7/112X_mcRun3_2023_realistic_v8

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v7/112X_mcRun3_2024_realistic_v8

#### PR validation:

Please see the [21 Sep 2020 AlCaDB presentation](https://indico.cern.ch/event/953248/#33-run-3-geometry-for-11_2) by @cvuosalo for details.

In addition, a technical test was performed: `runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0,7.24 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.