### PR TITLE
Clean BuildFiles in IO subsystems

### DIFF
--- a/IOMC/EventVertexGenerators/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/BuildFile.xml
@@ -12,4 +12,3 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/PPSObjects"/>
 <use name="CondCore/DBOutputService"/>
-<use name="DataFormats/Candidate"/>

--- a/IOMC/EventVertexGenerators/test/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use name="FWCore/PluginManager"/>
   <use name="DataFormats/Common"/>
   <use name="FWCore/Framework"/>
   <use name="boost"/>

--- a/IOMC/Input/BuildFile.xml
+++ b/IOMC/Input/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Sources"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="FWCore/PluginManager"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="hepmc"/>
 <use name="clhep"/>

--- a/IOMC/Input/plugins/BuildFile.xml
+++ b/IOMC/Input/plugins/BuildFile.xml
@@ -1,12 +1,10 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="boost"/>
 <use name="hepmc"/>
 <library name="GeneratorInterfaceHepMCWriter" file="HepMCEventWriter.cc">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/Sources"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/IOMC/RandomEngine/test/BuildFile.xml
+++ b/IOMC/RandomEngine/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Provenance"/>
 <use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="IOMC/RandomEngine"/>

--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -8,8 +8,6 @@
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Services"/>
   <use name="FWCore/Utilities"/>
-  <use name="DataFormats/StdDictionaries"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
 </bin>
 
 <bin name="edmFileUtil" file="EdmFileUtil.cpp,CollUtil.cc">

--- a/IOPool/Input/test/BuildFile.xml
+++ b/IOPool/Input/test/BuildFile.xml
@@ -7,7 +7,6 @@
   <library file="IOExerciser.cc" name="IOExerciser">
     <flags EDM_PLUGIN="1"/>
     <use name="FWCore/Framework"/>
-    <use name="FWCore/PluginManager"/>
     <use name="FWCore/ParameterSet"/>
   </library>
 

--- a/IOPool/Streamer/BuildFile.xml
+++ b/IOPool/Streamer/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="FWCore/Catalog"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Sources"/>
 <use name="FWCore/Utilities"/>

--- a/IOPool/Streamer/plugins/BuildFile.xml
+++ b/IOPool/Streamer/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/ServiceRegistry"/>
 <use name="IOPool/Streamer"/>
 <library file="*.cc" name="IOPoolStreamerPlugins">
   <flags EDM_PLUGIN="1"/>

--- a/IOPool/Streamer/test/BuildFile.xml
+++ b/IOPool/Streamer/test/BuildFile.xml
@@ -10,7 +10,6 @@
     <use name="FWCore/PluginManager"/>
     <use name="FWCore/ServiceRegistry"/>
     <use name="FWCore/Services"/>
-    <use name="FWCore/ParameterSetReader"/>
     <flags TEST_RUNNER_ARGS="all"/>
     <flags PRE_TEST="WriteStreamerFile"/>
   </bin>

--- a/IOPool/TFileAdaptor/test/BuildFile.xml
+++ b/IOPool/TFileAdaptor/test/BuildFile.xml
@@ -1,6 +1,4 @@
 <use name="FWCore/PluginManager"/>
-<use name="IOPool/TFileAdaptor"/>
-<use name="Utilities/StorageFactory"/>
 <use name="rootcore"/>
 <bin name="test_TFileAdaptor_TFile" file="tfileTest.cpp">
 </bin>

--- a/IORawData/CaloPatterns/BuildFile.xml
+++ b/IORawData/CaloPatterns/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="xerces-c"/>
+<use name="CalibFormats/HcalObjects"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/HcalDetId"/>
@@ -7,5 +8,4 @@
 <use name="CondFormats/HcalObjects"/>
 <use name="root"/>
 <use name="stdcxx-fs"/>
-<use name="CalibCalorimetry/HcalAlgos"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31515).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
