### PR TITLE
add back incorrectly removed dependencies to DataFormats/ParticleFlowReco

### DIFF
--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -7,6 +7,14 @@
 <use name="DataFormats/Candidate"/>
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CaloGeometry"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/EgammaCandidates"/>
+<use name="DataFormats/EgammaReco"/>
+<use name="DataFormats/GeometryVector"/>
+<use name="DataFormats/GsfTrackReco"/>
+<use name="DataFormats/Math"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/MessageLogger"/>
 <use name="rootcore"/>
 <use name="rootmath"/>
 <use name="vdt_headers"/>


### PR DESCRIPTION
Correctly (imo) one issue with #31459 and also adding other missing entries to the buildfile.
