### PR TITLE
added --sites options for runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import os
 class Matrix(dict):
     def __setitem__(self,key,value):
         if key in self:
@@ -177,11 +178,17 @@ class InputInfo(object):
             #print the_queries
             return the_queries
 
+        site = " site=T2_CH_CERN"
+        if "CMSSW_DAS_QUERY_SITES" in os.environ:
+            if os.environ["CMSSW_DAS_QUERY_SITES"]:
+                site = " site=%s" % os.environ["CMSSW_DAS_QUERY_SITES"]
+            else:
+                site = ""
         if len(self.run) is not 0:
-            return ["file {0}={1} run={2} site=T2_CH_CERN".format(query_by, query_source, query_run) for query_run in self.run]
+            return ["file {0}={1} run={2}{3}".format(query_by, query_source, query_run, site) for query_run in self.run]
             #return ["file {0}={1} run={2} ".format(query_by, query_source, query_run) for query_run in self.run]
         else:
-            return ["file {0}={1} site=T2_CH_CERN".format(query_by, query_source)]
+            return ["file {0}={1}{2}".format(query_by, query_source, site)]
             #return ["file {0}={1} ".format(query_by, query_source)]
 
     def __str__(self):

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import sys
+import sys, os
 
 from Configuration.PyReleaseValidation.MatrixReader import MatrixReader
 from Configuration.PyReleaseValidation.MatrixRunner import MatrixRunner
@@ -281,9 +281,15 @@ if __name__ == '__main__':
                       default=False,
                       action='store_true')
 
+    parser.add_option('--sites',
+                      help='Run DAS query to get data from a specific site (default is T2_CH_CERN). Set it to empty string to search all sites.',
+                      dest='dasSites',
+                      default='T2_CH_CERN',
+                      action='store')
+
     opt,args = parser.parse_args()
+    os.environ["CMSSW_DAS_QUERY_SITES"]=opt.dasSites
     if opt.IBEos:
-      import os
       try:from commands import getstatusoutput as run_cmd
       except:from subprocess import getstatusoutput as run_cmd
 


### PR DESCRIPTION
As requested here #22278 , added `--sites <site>` option to `runTheMatrix.py` script to select a specific site for recycle data. Setting it to emptry string will allow to search all sites.

This resolves #22278