### PR TITLE
Ensure HGCAL RecHit map is filled also without RECO

### DIFF
--- a/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
+++ b/Fireworks/Calo/interface/FWHeatmapProxyBuilderTemplate.h
@@ -44,7 +44,7 @@ public:
   // ---------- member functions ---------------------------
 
 protected:
-  const std::unordered_map<DetId, const HGCRecHit*>* hitmap;
+  std::unordered_map<DetId, const HGCRecHit*>* hitmap = new std::unordered_map<DetId, const HGCRecHit*>;
 
   static constexpr uint8_t gradient_steps = 9;
   static constexpr uint8_t gradient[3][gradient_steps] = {{static_cast<uint8_t>(0.2082 * 255),
@@ -93,11 +93,41 @@ protected:
 
   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc) override {
     if (item()->getConfig()->template value<bool>("Heatmap")) {
+      hitmap->clear();
+
+      edm::Handle<HGCRecHitCollection> recHitHandleEE;
+      edm::Handle<HGCRecHitCollection> recHitHandleFH;
+      edm::Handle<HGCRecHitCollection> recHitHandleBH;
+
       const edm::EventBase* event = iItem->getEvent();
 
-      edm::Handle<std::unordered_map<DetId, const HGCRecHit*>> hitMapHandle;
-      event->getByLabel(edm::InputTag("hgcalRecHitMapProducer"), hitMapHandle);
-      hitmap = &*hitMapHandle;
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCEERecHits"), recHitHandleEE);
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCHEFRecHits"), recHitHandleFH);
+      event->getByLabel(edm::InputTag("HGCalRecHit", "HGCHEBRecHits"), recHitHandleBH);
+
+      if (recHitHandleEE.isValid()) {
+        const auto& rechitsEE = *recHitHandleEE;
+
+        for (unsigned int i = 0; i < rechitsEE.size(); ++i) {
+          (*hitmap)[rechitsEE[i].detid().rawId()] = &rechitsEE[i];
+        }
+      }
+
+      if (recHitHandleFH.isValid()) {
+        const auto& rechitsFH = *recHitHandleFH;
+
+        for (unsigned int i = 0; i < rechitsFH.size(); ++i) {
+          (*hitmap)[rechitsFH[i].detid().rawId()] = &rechitsFH[i];
+        }
+      }
+
+      if (recHitHandleBH.isValid()) {
+        const auto& rechitsBH = *recHitHandleBH;
+
+        for (unsigned int i = 0; i < rechitsBH.size(); ++i) {
+          (*hitmap)[rechitsBH[i].detid().rawId()] = &rechitsBH[i];
+        }
+      }
     }
 
     FWSimpleProxyBuilder::build(iItem, product, vc);


### PR DESCRIPTION
#### PR description:

This PR ensures the HGCAL RecHit map is available in Fireworks, since the Producer introduced by [#30061](https://github.com/cms-sw/cmssw/pull/30061) may not be run (e.g. without RECO). No changes are expected in the output, it restores the correct cmsShow functionality for the 3D RecHit view.

#### PR validation:

The following Exception thrown by cmsShow is fixed:
`The data is registered in the file but is not available for this event`
.