### PR TITLE
Improve DumpFEDRawDataProduct

### DIFF
--- a/DataFormats/FEDRawData/test/DumpFEDRawDataProduct.cc
+++ b/DataFormats/FEDRawData/test/DumpFEDRawDataProduct.cc
@@ -5,71 +5,92 @@
  *
 */
 
-#include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h>
-#include <DataFormats/FEDRawData/interface/FEDHeader.h>
-#include <DataFormats/FEDRawData/interface/FEDTrailer.h>
-#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
-
 #include <iostream>
 #include <iomanip>
 
+#include "DataFormats/FEDRawData/interface/FEDHeader.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDTrailer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 using namespace edm;
-using namespace std;
+
+namespace {
+  template <typename T>
+  std::set<T> make_set(std::vector<T> const& v) {
+    std::set<T> s;
+    for (auto const& e : v)
+      s.insert(e);
+    return s;
+  }
+
+  template <typename T>
+  std::set<T> make_set(std::vector<T>&& v) {
+    std::set<T> s;
+    for (auto& e : v)
+      s.insert(std::move(e));
+    return s;
+  }
+}  // anonymous namespace
 
 namespace test {
 
-  class DumpFEDRawDataProduct : public EDAnalyzer {
+  class DumpFEDRawDataProduct : public edm::global::EDAnalyzer<> {
   private:
-    std::set<int> FEDids_;
-    std::string label_;
-    bool dumpPayload_;
+    const std::set<int> feds_;
+    const edm::EDGetTokenT<FEDRawDataCollection> token_;
+    const bool dumpPayload_;
 
   public:
-    DumpFEDRawDataProduct(const ParameterSet& pset) {
-      std::vector<int> ids;
-      label_ = pset.getUntrackedParameter<std::string>("label", "source");
-      consumes<FEDRawDataCollection>(label_);
-      ids = pset.getUntrackedParameter<std::vector<int> >("feds", std::vector<int>());
-      dumpPayload_ = pset.getUntrackedParameter<bool>("dumpPayload", false);
-      for (std::vector<int>::iterator i = ids.begin(); i != ids.end(); i++)
-        FEDids_.insert(*i);
-    }
+    DumpFEDRawDataProduct(const ParameterSet& pset)
+        : feds_(make_set(pset.getUntrackedParameter<std::vector<int>>("feds"))),
+          token_(consumes<FEDRawDataCollection>(pset.getUntrackedParameter<edm::InputTag>("label"))),
+          dumpPayload_(pset.getUntrackedParameter<bool>("dumpPayload")) {}
 
-    void analyze(const Event& e, const EventSetup& c) {
-      cout << "--- Run: " << e.id().run() << " Event: " << e.id().event() << endl;
+    void analyze(edm::StreamID sid, const Event& e, const EventSetup& c) const override {
+      edm::LogSystem out("DumpFEDRawDataProduct");
       Handle<FEDRawDataCollection> rawdata;
-      e.getByLabel(label_, rawdata);
+      e.getByToken(token_, rawdata);
       for (int i = 0; i <= FEDNumbering::lastFEDId(); i++) {
         const FEDRawData& data = rawdata->FEDData(i);
         size_t size = data.size();
 
-        if (size > 0 && (FEDids_.empty() || FEDids_.find(i) != FEDids_.end())) {
-          cout << "FED# " << setw(4) << i << " " << setw(8) << size << " bytes ";
+        if (size > 0 && (feds_.empty() || feds_.find(i) != feds_.end())) {
+          out << "FED# " << std::setw(4) << i << " " << std::setw(8) << size << " bytes ";
 
           FEDHeader header(data.data());
-          FEDTrailer trailer(data.data() + size - 8);
+          FEDTrailer trailer(data.data() + size - FEDTrailer::length);
 
-          cout << " L1Id: " << setw(8) << header.lvl1ID();
-          cout << " BXId: " << setw(4) << header.bxID();
-          cout << endl;
+          out << " L1Id: " << std::setw(8) << header.lvl1ID();
+          out << " BXId: " << std::setw(4) << header.bxID();
+          out << '\n';
 
           if (dumpPayload_) {
             const uint64_t* payload = (uint64_t*)(data.data());
-            cout << hex << setfill('0');
+            out << std::hex << std::setfill('0');
             for (unsigned int i = 0; i < data.size() / sizeof(uint64_t); i++) {
-              cout << setw(4) << i << "  " << setw(16) << payload[i] << endl;
+              out << std::setw(4) << i << "  " << std::setw(16) << payload[i] << '\n';
             }
-            cout << dec << setfill(' ');
+            out << std::dec << std::setfill(' ');
           }
 
-          // 	  CPPUNIT_ASSERT(trailer.check()==true);
-          // 	  CPPUNIT_ASSERT(trailer.lenght()==(int)data.size()/8);
+          if (not trailer.check()) {
+            out << "    FED trailer check failed\n";
+          }
+          if (trailer.fragmentLength() * 8 != data.size()) {
+            out << "    FED fragment size mismatch: " << trailer.fragmentLength() << " (fragment length) vs "
+                << (float)data.size() / 8 << " (data size) words\n";
+          }
+        } else if (size == 0 && feds_.find(i) != feds_.end()) {
+          out << "FED# " << std::setw(4) << i << " " << std::setw(8) << size << " bytes\n";
         }
       }
     }
   };
+
   DEFINE_FWK_MODULE(DumpFEDRawDataProduct);
 }  // namespace test


### PR DESCRIPTION
#### PR description:

Re-implement the checks on the trailer validity and fragment size.

General changes:
  - migrate to thread-safe global module
  - migrate from string to InputTag
  - migrate from getByLabel to getByToken
  - migrate from iostream to MessageLogger

#### PR validation:

Tested on MC samples from CMSSW 10.6.0 and 11.2.0-pre3.
