### PR TITLE
drop type specs in RecoBTag

### DIFF
--- a/RecoBTag/CTagging/python/CombinedCharmTagJetTags_cff.py
+++ b/RecoBTag/CTagging/python/CombinedCharmTagJetTags_cff.py
@@ -4,11 +4,11 @@ from RecoBTag.CTagging.pfNegativeCombinedCvsLJetTags_cfi import *
 from RecoBTag.CTagging.pfPositiveCombinedCvsLJetTags_cfi import *
 
 pfNegativeCombinedCvsBJetTags = pfNegativeCombinedCvsLJetTags.clone(
-   jetTagComputer = cms.string('charmTagsNegativeComputerCvsB')
+   jetTagComputer = 'charmTagsNegativeComputerCvsB'
    )
 
 pfPositiveCombinedCvsBJetTags = pfPositiveCombinedCvsLJetTags.clone(
-   jetTagComputer = cms.string('charmTagsPositiveComputerCvsB')
+   jetTagComputer = 'charmTagsPositiveComputerCvsB'
    )
 
 CombinedCharmTagJetTagsTask = cms.Task(

--- a/RecoBTag/CTagging/python/charmTagJetTags_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagJetTags_cfi.py
@@ -12,5 +12,5 @@ pfCombinedCvsLJetTags  = cms.EDProducer(
 )
 
 pfCombinedCvsBJetTags = pfCombinedCvsLJetTags.clone(
-   jetTagComputer = cms.string('charmTagsComputerCvsB')
+   jetTagComputer = 'charmTagsComputerCvsB'
    )

--- a/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
+++ b/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
@@ -14,38 +14,37 @@ phase1Pixel.toModify(charmTagsComputerCvsB, weightFile = cms.FileInPath('RecoBTa
 # Negative tagger
 #
 
-charmTagsNegativeComputerCvsL = charmTagsComputerCvsL.clone()
-
-charmTagsNegativeComputerCvsL.slComputerCfg.vertexFlip = cms.bool(True)
-charmTagsNegativeComputerCvsL.slComputerCfg.trackFlip = cms.bool(True)
-charmTagsNegativeComputerCvsL.slComputerCfg.SoftLeptonFlip = cms.bool(True)
-charmTagsNegativeComputerCvsL.slComputerCfg.trackSelection.sip3dSigMax = 0
-charmTagsNegativeComputerCvsL.slComputerCfg.trackPseudoSelection.sip3dSigMax = 0
-charmTagsNegativeComputerCvsL.slComputerCfg.trackPseudoSelection.sip2dSigMin = -99999.9
-charmTagsNegativeComputerCvsL.slComputerCfg.trackPseudoSelection.sip2dSigMax = -2.0
-
-charmTagsNegativeComputerCvsB = charmTagsComputerCvsB.clone()
-
-charmTagsNegativeComputerCvsB.slComputerCfg.vertexFlip = cms.bool(True)
-charmTagsNegativeComputerCvsB.slComputerCfg.trackFlip = cms.bool(True)
-charmTagsNegativeComputerCvsB.slComputerCfg.SoftLeptonFlip = cms.bool(True)
-charmTagsNegativeComputerCvsB.slComputerCfg.trackSelection.sip3dSigMax = 0
-charmTagsNegativeComputerCvsB.slComputerCfg.trackPseudoSelection.sip3dSigMax = 0
-charmTagsNegativeComputerCvsB.slComputerCfg.trackPseudoSelection.sip2dSigMin = -99999.9
-charmTagsNegativeComputerCvsB.slComputerCfg.trackPseudoSelection.sip2dSigMax = -2.0
-
+charmTagsNegativeComputerCvsL = charmTagsComputerCvsL.clone(
+    slComputerCfg = dict(vertexFlip     = True,
+		 	 trackFlip      = True,
+		 	 SoftLeptonFlip = True,
+		 	 trackSelection = dict(sip3dSigMax = 0),
+		 	 trackPseudoSelection = dict(
+				sip3dSigMax = 0,
+				sip2dSigMin = -99999.9,
+				sip2dSigMax = -2.0   )
+    )
+)
+charmTagsNegativeComputerCvsB = charmTagsComputerCvsB.clone(
+    slComputerCfg = dict(vertexFlip     = True,
+		 	 trackFlip      = True,
+		 	 SoftLeptonFlip = True,
+		 	 trackSelection = dict(sip3dSigMax = 0),
+		 	 trackPseudoSelection = dict(
+				sip3dSigMax = 0,
+				sip2dSigMin = -99999.9,
+				sip2dSigMax = -2.0   )
+    )
+)
 #
 # Positive tagger
 #
 
 charmTagsPositiveComputerCvsL = charmTagsComputerCvsL.clone(
+    slComputerCfg = dict(trackSelection = dict(sip3dSigMin = 0),
+                         trackPseudoSelection = dict(sip3dSigMin = 0))
 )
-
-charmTagsPositiveComputerCvsL.slComputerCfg.trackSelection.sip3dSigMin = 0
-charmTagsPositiveComputerCvsL.slComputerCfg.trackPseudoSelection.sip3dSigMin = 0
-
 charmTagsPositiveComputerCvsB = charmTagsComputerCvsB.clone(
+    slComputerCfg = dict(trackSelection = dict(sip3dSigMin = 0),
+                         trackPseudoSelection = dict(sip3dSigMin = 0))
 )
-
-charmTagsPositiveComputerCvsB.slComputerCfg.trackSelection.sip3dSigMin = 0
-charmTagsPositiveComputerCvsB.slComputerCfg.trackPseudoSelection.sip3dSigMin = 0

--- a/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
+++ b/RecoBTag/CTagging/python/charmTaggerProducer_cff.py
@@ -3,12 +3,12 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.CTagging.charmTagsComputerCvsL_cfi import *
 
 charmTagsComputerCvsB = charmTagsComputerCvsL.clone(
-   weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_sklearn.weight.xml'),   
+   weightFile = 'RecoBTag/CTagging/data/c_vs_b_sklearn.weight.xml',   
    variables = c_vs_b_vars_vpset
    )
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(charmTagsComputerCvsB, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_b_PhaseI.xml'))
+phase1Pixel.toModify(charmTagsComputerCvsB, weightFile = 'RecoBTag/CTagging/data/c_vs_b_PhaseI.xml')
 
 #
 # Negative tagger

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -35,7 +35,7 @@ charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(charmTagsComputerCvsL, 
-                     weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'),
+                     weightFile = 'RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml',
                      slComputerCfg = dict(correctVertexMass = True),
                      defaultValueNoTracks = True
 )

--- a/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
+++ b/RecoBTag/CTagging/python/charmTagsComputerCvsL_cfi.py
@@ -34,6 +34,8 @@ charmTagsComputerCvsL = cms.ESProducer(
 charmTagsComputerCvsL.slComputerCfg.correctVertexMass = False
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(charmTagsComputerCvsL, weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'))
-phase1Pixel.toModify(charmTagsComputerCvsL, slComputerCfg = dict(correctVertexMass = True))
-phase1Pixel.toModify(charmTagsComputerCvsL, defaultValueNoTracks = cms.bool(True))
+phase1Pixel.toModify(charmTagsComputerCvsL, 
+                     weightFile = cms.FileInPath('RecoBTag/CTagging/data/c_vs_udsg_PhaseI.xml'),
+                     slComputerCfg = dict(correctVertexMass = True),
+                     defaultValueNoTracks = True
+)

--- a/RecoBTag/CTagging/python/pfInclusiveSecondaryVertexFinderCvsLTagInfos_cfi.py
+++ b/RecoBTag/CTagging/python/pfInclusiveSecondaryVertexFinderCvsLTagInfos_cfi.py
@@ -4,11 +4,10 @@ from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
 
 # use external SV collection made from IVF
 pfInclusiveSecondaryVertexFinderCvsLTagInfos = pfSecondaryVertexTagInfos.clone(
-   extSVCollection  = cms.InputTag('inclusiveCandidateSecondaryVerticesCvsL'),
-   extSVDeltaRToJet = cms.double(0.3),
-   useExternalSV    = cms.bool(True)
+    extSVCollection  = 'inclusiveCandidateSecondaryVerticesCvsL',
+    extSVDeltaRToJet = 0.3,
+    useExternalSV    = True,
+    vertexCuts = dict(fracPV = 0.79, ## 4 out of 5 is discarded
+    		      distSig2dMin = 1.5 # relaxed w.r.t taginfos used in btagger
+		     )
 )
-pfInclusiveSecondaryVertexFinderCvsLTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
-pfInclusiveSecondaryVertexFinderCvsLTagInfos.vertexCuts.distSig2dMin = 1.5 # relaxed w.r.t taginfos used in btagger
-
-

--- a/RecoBTag/CTagging/python/pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos_cfi.py
+++ b/RecoBTag/CTagging/python/pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.CTagging.pfInclusiveSecondaryVertexFinderCvsLTagInfos_cfi import *
 
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos = pfInclusiveSecondaryVertexFinderCvsLTagInfos.clone()
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.extSVDeltaRToJet = cms.double(-0.3)
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.vertexCuts.distVal2dMin = -2.5
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.vertexCuts.distVal2dMax = -0.01
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.vertexCuts.distSig2dMin = -99999.9
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.vertexCuts.distSig2dMax = -1.5
-pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos.vertexCuts.maxDeltaRToJetAxis = -0.5
+pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos = pfInclusiveSecondaryVertexFinderCvsLTagInfos.clone(
+    extSVDeltaRToJet = -0.3,
+    vertexCuts = dict(distVal2dMin = -2.5,
+		      distVal2dMax = -0.01,
+		      distSig2dMin = -99999.9,
+		      distSig2dMax = -1.5,
+		      maxDeltaRToJetAxis = -0.5)
+)

--- a/RecoBTag/Combined/python/caloDeepCSVJetTags_cfi.py
+++ b/RecoBTag/Combined/python/caloDeepCSVJetTags_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
 
-caloDeepCSVJetTags = pfDeepCSVJetTags.clone(src = cms.InputTag('caloDeepCSVTagInfos'))
+caloDeepCSVJetTags = pfDeepCSVJetTags.clone(src = 'caloDeepCSVTagInfos')

--- a/RecoBTag/Combined/python/deepFlavour_cff.py
+++ b/RecoBTag/Combined/python/deepFlavour_cff.py
@@ -11,7 +11,7 @@ from RecoBTag.Combined.pfDeepCMVADiscriminatorsJetTags_cfi import pfDeepCMVADisc
 ##
 
 pfDeepCSVNegativeTagInfos = pfDeepCSVTagInfos.clone(
-    svTagInfos=cms.InputTag('pfInclusiveSecondaryVertexFinderNegativeTagInfos'),
+    svTagInfos='pfInclusiveSecondaryVertexFinderNegativeTagInfos',
     computer = dict(
         vertexFlip = True,
         trackFlip = True,
@@ -27,7 +27,7 @@ pfDeepCSVNegativeTagInfos = pfDeepCSVTagInfos.clone(
     )
 
 pfNegativeDeepCSVJetTags = pfDeepCSVJetTags.clone(
-	src=cms.InputTag('pfDeepCSVNegativeTagInfos')
+	src='pfDeepCSVNegativeTagInfos'
 	)
 
 pfDeepCSVPositiveTagInfos = pfDeepCSVTagInfos.clone(
@@ -43,23 +43,23 @@ pfDeepCSVPositiveTagInfos = pfDeepCSVTagInfos.clone(
     )
 
 pfPositiveDeepCSVJetTags = pfDeepCSVJetTags.clone(
-	src=cms.InputTag('pfDeepCSVPositiveTagInfos')
+	src='pfDeepCSVPositiveTagInfos'
 	)
 
 # Deep CMVA
 pfDeepCMVANegativeTagInfos = pfDeepCMVATagInfos.clone(
-	deepNNTagInfos = cms.InputTag('pfDeepCSVNegativeTagInfos')
+	deepNNTagInfos = 'pfDeepCSVNegativeTagInfos'
 	)
 	
 pfNegativeDeepCMVAJetTags = pfDeepCMVAJetTags.clone(
-	src=cms.InputTag('pfDeepCMVANegativeTagInfos')
+	src='pfDeepCMVANegativeTagInfos'
 	)
 
 pfDeepCMVAPositiveTagInfos = pfDeepCMVATagInfos.clone(
-	deepNNTagInfos = cms.InputTag('pfDeepCSVPositiveTagInfos')
+	deepNNTagInfos = 'pfDeepCSVPositiveTagInfos'
 	)
 pfPositiveDeepCMVAJetTags = pfDeepCMVAJetTags.clone(
-	src=cms.InputTag('pfDeepCMVAPositiveTagInfos')
+	src='pfDeepCMVAPositiveTagInfos'
 	)
 
 

--- a/RecoBTag/Combined/python/pfDeepCSVJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfDeepCSVJetTags_cfi.py
@@ -12,13 +12,17 @@ pfDeepCSVJetTags = cms.EDProducer(
 	)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(pfDeepCSVJetTags, NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseI.json'))
-phase1Pixel.toModify(pfDeepCSVJetTags, checkSVForDefaults = cms.bool(True))
-phase1Pixel.toModify(pfDeepCSVJetTags, meanPadding = cms.bool(True))
-phase1Pixel.toModify(pfDeepCSVJetTags, toAdd = cms.PSet())
+phase1Pixel.toModify(pfDeepCSVJetTags, 
+                     NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseI.json'),
+                     checkSVForDefaults = True,
+                     meanPadding = True,
+                     toAdd = cms.PSet()
+)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-phase2_common.toModify(pfDeepCSVJetTags, NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseII.json'))
-phase2_common.toModify(pfDeepCSVJetTags, checkSVForDefaults = cms.bool(True))
-phase2_common.toModify(pfDeepCSVJetTags, meanPadding = cms.bool(True))
-phase2_common.toModify(pfDeepCSVJetTags, toAdd = cms.PSet())
+phase2_common.toModify(pfDeepCSVJetTags, 
+                       NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseII.json'),
+                       checkSVForDefaults = True,
+                       meanPadding = True,
+                       toAdd = cms.PSet()
+)

--- a/RecoBTag/ImpactParameter/python/candidateNegativeOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidateNegativeOnlyJetBProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.candidateJetBProbabilityComputer_cfi import *
 
 # negativeOnlyJetBProbability btag computer
 candidateNegativeOnlyJetBProbabilityComputer = candidateJetBProbabilityComputer.clone(
-    trackIpSign = cms.int32(-1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = -1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/candidateNegativeOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidateNegativeOnlyJetProbabilityComputer_cfi.py
@@ -4,7 +4,7 @@ from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import *
 
 # negativeOnlyJetProbability btag computer
 candidateNegativeOnlyJetProbabilityComputer = candidateJetProbabilityComputer.clone(
-    trackIpSign = cms.int32(-1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = -1 ## 0 = use both, 1 = positive only, -1 = negative only
 )
 
 

--- a/RecoBTag/ImpactParameter/python/candidateNegativeTrackCounting3D3rdComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidateNegativeTrackCounting3D3rdComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.candidateNegativeTrackCounting3D2ndComputer_cfi im
 
 # negativeTrackCounting3D3rd btag computer
 candidateNegativeTrackCounting3D3rdComputer = candidateNegativeTrackCounting3D2ndComputer.clone(
-    nthTrack = cms.int32(3)
+    nthTrack = 3
 )

--- a/RecoBTag/ImpactParameter/python/candidatePositiveOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidatePositiveOnlyJetBProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.candidateJetBProbabilityComputer_cfi import *
 
 # positiveOnlyJetBProbability btag computer
 candidatePositiveOnlyJetBProbabilityComputer = candidateJetBProbabilityComputer.clone(
-    trackIpSign = cms.int32(1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = 1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/candidatePositiveOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidatePositiveOnlyJetProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import *
 
 # positiveOnlyJetProbability btag computer
 candidatePositiveOnlyJetProbabilityComputer = candidateJetProbabilityComputer.clone(
-    trackIpSign = cms.int32(1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = 1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/candidateTrackCounting3D3rdComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/candidateTrackCounting3D3rdComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.candidateTrackCounting3D2ndComputer_cfi import *
 
 # trackCounting3D3rd btag computer
 candidateTrackCounting3D3rdComputer = candidateTrackCounting3D2ndComputer.clone(
-    nthTrack = cms.int32(3)
+    nthTrack = 3
 )

--- a/RecoBTag/ImpactParameter/python/negativeOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeOnlyJetBProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.jetBProbabilityComputer_cfi import *
 
 # negativeOnlyJetBProbability btag computer
 negativeOnlyJetBProbabilityComputer = jetBProbabilityComputer.clone(
-    trackIpSign = cms.int32(-1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = -1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/negativeOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeOnlyJetProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.jetProbabilityComputer_cfi import *
 
 # negativeOnlyJetProbability btag computer
 negativeOnlyJetProbabilityComputer = jetProbabilityComputer.clone(
-    trackIpSign = cms.int32(-1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = -1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/negativeTrackCounting3D3rdComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeTrackCounting3D3rdComputer_cfi.py
@@ -4,7 +4,7 @@ from RecoBTag.ImpactParameter.negativeTrackCounting3D2ndComputer_cfi import *
 
 # negativeTrackCounting3D3rd btag computer
 negativeTrackCounting3D3rdComputer = negativeTrackCounting3D2ndComputer.clone(
-    nthTrack = cms.int32(3)
+    nthTrack = 3
 )
 
 

--- a/RecoBTag/ImpactParameter/python/pfImpactParameterAK8TagInfos_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameterAK8TagInfos_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import *
 
 pfImpactParameterAK8TagInfos = pfImpactParameterTagInfos.clone(
-    computeProbabilities = cms.bool(False),
-    computeGhostTrack = cms.bool(False),
-    jets = cms.InputTag("ak8PFJetsPuppi"),
-    maxDeltaR = cms.double(0.8)
+    computeProbabilities = False,
+    computeGhostTrack    = False,
+    jets                 = "ak8PFJetsPuppi",
+    maxDeltaR            = 0.8
 )

--- a/RecoBTag/ImpactParameter/python/pfImpactParameterCA15TagInfos_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameterCA15TagInfos_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import *
 
 pfImpactParameterCA15TagInfos = pfImpactParameterTagInfos.clone(
-    computeProbabilities = cms.bool(False),
-    computeGhostTrack = cms.bool(False),
-    jets = cms.InputTag("ca15PFJetsCHS"),
-    maxDeltaR = cms.double(1.5)
+    computeProbabilities = False,
+    computeGhostTrack    = False,
+    jets                 = "ca15PFJetsCHS",
+    maxDeltaR            = 1.5
 )

--- a/RecoBTag/ImpactParameter/python/positiveOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/positiveOnlyJetBProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.jetBProbabilityComputer_cfi import *
 
 # positiveOnlyJetBProbability btag computer
 positiveOnlyJetBProbabilityComputer = jetBProbabilityComputer.clone(
-    trackIpSign = cms.int32(1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = 1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/positiveOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/positiveOnlyJetProbabilityComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.jetProbabilityComputer_cfi import *
 
 # positiveOnlyJetProbability btag computer
 positiveOnlyJetProbabilityComputer = jetProbabilityComputer.clone(
-    trackIpSign = cms.int32(1) ## 0 = use both, 1 = positive only, -1 = negative only
+    trackIpSign = 1 ## 0 = use both, 1 = positive only, -1 = negative only
 )

--- a/RecoBTag/ImpactParameter/python/trackCounting3D1stComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/trackCounting3D1stComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.trackCounting3D2ndComputer_cfi import *
 
 # trackCounting3D1st btag computer
 trackCounting3D1stComputer = trackCounting3D2ndComputer.clone(
-    nthTrack = cms.int32(1)
+    nthTrack = 1
 )

--- a/RecoBTag/ImpactParameter/python/trackCounting3D3rdComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/trackCounting3D3rdComputer_cfi.py
@@ -4,5 +4,5 @@ from RecoBTag.ImpactParameter.trackCounting3D2ndComputer_cfi import *
 
 # trackCounting3D3rd btag computer
 trackCounting3D3rdComputer = trackCounting3D2ndComputer.clone(
-    nthTrack = cms.int32(3)
+    nthTrack = 3
 )

--- a/RecoBTag/ONNXRuntime/python/pfNegativeDeepFlavourJetTags_cfi.py
+++ b/RecoBTag/ONNXRuntime/python/pfNegativeDeepFlavourJetTags_cfi.py
@@ -3,5 +3,5 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.ONNXRuntime.pfDeepFlavourJetTags_cfi import pfDeepFlavourJetTags
 
 pfNegativeDeepFlavourJetTags = pfDeepFlavourJetTags.clone(
-        src = cms.InputTag('pfNegativeDeepFlavourTagInfos')
+        src = 'pfNegativeDeepFlavourTagInfos'
         )

--- a/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateBoostedDoubleSecondaryVertexAK8Computer_cfi.py
@@ -10,4 +10,4 @@ candidateBoostedDoubleSecondaryVertexAK8Computer = cms.ESProducer("CandidateBoos
 )
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(candidateBoostedDoubleSecondaryVertexAK8Computer, weightFile = cms.FileInPath('RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_PhaseI_v1.weights.xml.gz'))
+phase1Pixel.toModify(candidateBoostedDoubleSecondaryVertexAK8Computer, weightFile = 'RecoBTag/SecondaryVertex/data/BoostedDoubleSV_AK8_BDT_PhaseI_v1.weights.xml.gz')

--- a/RecoBTag/SecondaryVertex/python/candidateNegativeCombinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidateNegativeCombinedSecondaryVertexV2Computer_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexV2Computer_cfi import *
 
-candidateNegativeCombinedSecondaryVertexV2Computer = candidateCombinedSecondaryVertexV2Computer.clone()
-candidateNegativeCombinedSecondaryVertexV2Computer.vertexFlip = True
-candidateNegativeCombinedSecondaryVertexV2Computer.trackFlip = True
-candidateNegativeCombinedSecondaryVertexV2Computer.trackSelection.sip3dSigMax = 0
-candidateNegativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip3dSigMax = 0
-candidateNegativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip2dSigMin = -99999.9
-candidateNegativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip2dSigMax = -2.0
+candidateNegativeCombinedSecondaryVertexV2Computer = candidateCombinedSecondaryVertexV2Computer.clone(
+    vertexFlip = True,
+    trackFlip  = True,
+    trackSelection = dict(sip3dSigMax = 0),
+    trackPseudoSelection = dict(sip3dSigMax = 0,
+                                sip2dSigMin = -99999.9,
+                                sip2dSigMax = -2.0)
+)

--- a/RecoBTag/SecondaryVertex/python/candidatePositiveCombinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/candidatePositiveCombinedSecondaryVertexV2Computer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.candidateCombinedSecondaryVertexV2Computer_cfi import *
 
-candidatePositiveCombinedSecondaryVertexV2Computer = candidateCombinedSecondaryVertexV2Computer.clone()
-candidatePositiveCombinedSecondaryVertexV2Computer.trackSelection.sip3dSigMin = 0
-candidatePositiveCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip3dSigMin = 0
+candidatePositiveCombinedSecondaryVertexV2Computer = candidateCombinedSecondaryVertexV2Computer.clone(
+    trackSelection = dict(sip3dSigMin = 0),
+    trackPseudoSelection = dict(sip3dSigMin = 0)
+)

--- a/RecoBTag/SecondaryVertex/python/ghostTrackVertexTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/ghostTrackVertexTagInfos_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackVertexReco_cff import *
 
-ghostTrackVertexTagInfos = secondaryVertexTagInfos.clone()
-ghostTrackVertexTagInfos.vertexReco = ghostTrackVertexRecoBlock.vertexReco
-ghostTrackVertexTagInfos.vertexCuts.multiplicityMin = 1
+ghostTrackVertexTagInfos = secondaryVertexTagInfos.clone(
+    vertexReco = ghostTrackVertexRecoBlock.vertexReco,
+    vertexCuts = dict(multiplicityMin = 1)
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderFilteredNegativeTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderFilteredNegativeTagInfos_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderFilteredTagInfos_cfi import *
 
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos = inclusiveSecondaryVertexFinderFilteredTagInfos.clone()
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.extSVDeltaRToJet = cms.double(-0.4)
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.vertexCuts.distVal2dMin = -2.5
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.vertexCuts.distVal2dMax = -0.01
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.vertexCuts.distSig2dMin = -99999.9
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.vertexCuts.distSig2dMax = -2.0
-inclusiveSecondaryVertexFinderFilteredNegativeTagInfos.vertexCuts.maxDeltaRToJetAxis = -0.5
+inclusiveSecondaryVertexFinderFilteredNegativeTagInfos = inclusiveSecondaryVertexFinderFilteredTagInfos.clone(
+    extSVDeltaRToJet = -0.4,
+    vertexCuts = dict(distVal2dMin = -2.5,
+                      distVal2dMax = -0.01,
+                      distSig2dMin = -99999.9,
+                      distSig2dMax = -2.0,
+                      maxDeltaRToJetAxis = -0.5)
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderFilteredTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderFilteredTagInfos_cfi.py
@@ -2,12 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 
-inclusiveSecondaryVertexFinderFilteredTagInfos = secondaryVertexTagInfos.clone()
-
+inclusiveSecondaryVertexFinderFilteredTagInfos = secondaryVertexTagInfos.clone(
 # filtered IVF as used in some analyses
-inclusiveSecondaryVertexFinderFilteredTagInfos.extSVCollection     = cms.InputTag('bToCharmDecayVertexMerged')
-inclusiveSecondaryVertexFinderFilteredTagInfos.extSVDeltaRToJet    = cms.double(0.4)
-inclusiveSecondaryVertexFinderFilteredTagInfos.useExternalSV = cms.bool(True)
-inclusiveSecondaryVertexFinderFilteredTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
-inclusiveSecondaryVertexFinderFilteredTagInfos.vertexCuts.distSig2dMin = 2.0
-
+    extSVCollection  = 'bToCharmDecayVertexMerged',
+    extSVDeltaRToJet = 0.4,
+    useExternalSV    = True,
+    vertexCuts = dict(fracPV = 0.79, ## 4 out of 5 is discarded
+                      distSig2dMin = 2.0)
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderNegativeTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderNegativeTagInfos_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderTagInfos_cfi import *
 
-inclusiveSecondaryVertexFinderNegativeTagInfos = inclusiveSecondaryVertexFinderTagInfos.clone()
-inclusiveSecondaryVertexFinderNegativeTagInfos.extSVDeltaRToJet = cms.double(-0.3)
-inclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distVal2dMin = -2.5
-inclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distVal2dMax = -0.01
-inclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distSig2dMin = -99999.9
-inclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.distSig2dMax = -2.0
-inclusiveSecondaryVertexFinderNegativeTagInfos.vertexCuts.maxDeltaRToJetAxis = -0.5
+inclusiveSecondaryVertexFinderNegativeTagInfos = inclusiveSecondaryVertexFinderTagInfos.clone(
+    extSVDeltaRToJet = -0.3,
+    vertexCuts = dict(distVal2dMin = -2.5,
+                      distVal2dMax = -0.01,
+                      distSig2dMin = -99999.9,
+                      distSig2dMax = -2.0,
+                      maxDeltaRToJetAxis = -0.5)
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
@@ -2,11 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 
-inclusiveSecondaryVertexFinderTagInfos = secondaryVertexTagInfos.clone()
-
+inclusiveSecondaryVertexFinderTagInfos = secondaryVertexTagInfos.clone(
 # use external SV collection made from IVF
-inclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveSecondaryVertices')
-inclusiveSecondaryVertexFinderTagInfos.extSVDeltaRToJet    = cms.double(0.3)
-inclusiveSecondaryVertexFinderTagInfos.useExternalSV = cms.bool(True)
-inclusiveSecondaryVertexFinderTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
-inclusiveSecondaryVertexFinderTagInfos.vertexCuts.distSig2dMin = 2.0
+    extSVCollection  = 'inclusiveSecondaryVertices',
+    extSVDeltaRToJet = 0.3,
+    useExternalSV    = True,
+    vertexCuts       = dict(fracPV = 0.79, ## 4 out of 5 is discarded
+                            distSig2dMin = 2.0)
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVerticesFiltered_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVerticesFiltered_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
 
-inclusiveSecondaryVerticesFiltered = bVertexFilter.clone()
-inclusiveSecondaryVerticesFiltered.vertexFilter.multiplicityMin = 2
-inclusiveSecondaryVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveSecondaryVertices")
+inclusiveSecondaryVerticesFiltered = bVertexFilter.clone(
+    vertexFilter = dict(multiplicityMin = 2),
+    secondaryVertices = "inclusiveSecondaryVertices"
+)

--- a/RecoBTag/SecondaryVertex/python/negativeCombinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/negativeCombinedSecondaryVertexV2Computer_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexV2Computer_cfi import *
 
-negativeCombinedSecondaryVertexV2Computer = combinedSecondaryVertexV2Computer.clone()
-negativeCombinedSecondaryVertexV2Computer.vertexFlip = True
-negativeCombinedSecondaryVertexV2Computer.trackFlip = True
-negativeCombinedSecondaryVertexV2Computer.trackSelection.sip3dSigMax = 0
-negativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip3dSigMax = 0
-negativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip2dSigMin = -99999.9
-negativeCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip2dSigMax = -2.0
+negativeCombinedSecondaryVertexV2Computer = combinedSecondaryVertexV2Computer.clone(
+    vertexFlip = True,
+    trackFlip  = True,
+    trackSelection = dict(sip3dSigMax = 0),
+    trackPseudoSelection = dict(sip3dSigMax = 0,
+                                sip2dSigMin = -99999.9,
+                                sip2dSigMax = -2.0)
+)

--- a/RecoBTag/SecondaryVertex/python/pfGhostTrackVertexTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfGhostTrackVertexTagInfos_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackVertexReco_cff import *
 
-pfGhostTrackVertexTagInfos = pfSecondaryVertexTagInfos.clone()
-pfGhostTrackVertexTagInfos.vertexReco = ghostTrackVertexRecoBlock.vertexReco
-pfGhostTrackVertexTagInfos.vertexCuts.multiplicityMin = 1
+pfGhostTrackVertexTagInfos = pfSecondaryVertexTagInfos.clone(
+    vertexReco = ghostTrackVertexRecoBlock.vertexReco,
+    vertexCuts = dict(multiplicityMin = 1)
+)

--- a/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderAK8TagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderAK8TagInfos_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import *
 
 pfInclusiveSecondaryVertexFinderAK8TagInfos = pfInclusiveSecondaryVertexFinderTagInfos.clone(
-    trackIPTagInfos  = cms.InputTag("pfImpactParameterAK8TagInfos"),
-    extSVDeltaRToJet = cms.double(0.8)
+    trackIPTagInfos  = "pfImpactParameterAK8TagInfos",
+    extSVDeltaRToJet = 0.8,
+    trackSelection = dict(jetDeltaRMax = 0.8), # plays no role since using IVF vertices
+    vertexCuts = dict(maxDeltaRToJetAxis = 0.8)
 )
-pfInclusiveSecondaryVertexFinderAK8TagInfos.trackSelection.jetDeltaRMax = cms.double(0.8) # plays no role since using IVF vertices
-pfInclusiveSecondaryVertexFinderAK8TagInfos.vertexCuts.maxDeltaRToJetAxis = cms.double(0.8)

--- a/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderCA15TagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderCA15TagInfos_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import *
 
 pfInclusiveSecondaryVertexFinderCA15TagInfos = pfInclusiveSecondaryVertexFinderTagInfos.clone(
-    trackIPTagInfos  = cms.InputTag("pfImpactParameterCA15TagInfos"),
-    extSVDeltaRToJet = cms.double(1.5)
+    trackIPTagInfos  = "pfImpactParameterCA15TagInfos",
+    extSVDeltaRToJet = 1.5,
+    trackSelection = dict(jetDeltaRMax = 1.5), # plays no role since using IVF vertices
+    vertexCuts = dict(maxDeltaRToJetAxis = 1.5)
 )
-pfInclusiveSecondaryVertexFinderCA15TagInfos.trackSelection.jetDeltaRMax = cms.double(1.5) # plays no role since using IVF vertices
-pfInclusiveSecondaryVertexFinderCA15TagInfos.vertexCuts.maxDeltaRToJetAxis = cms.double(1.5)

--- a/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfInclusiveSecondaryVertexFinderTagInfos_cfi.py
@@ -2,13 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
 
-pfInclusiveSecondaryVertexFinderTagInfos = pfSecondaryVertexTagInfos.clone()
-
+pfInclusiveSecondaryVertexFinderTagInfos = pfSecondaryVertexTagInfos.clone(
 # use external SV collection made from IVF
-pfInclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveCandidateSecondaryVertices')
-pfInclusiveSecondaryVertexFinderTagInfos.extSVDeltaRToJet    = cms.double(0.3)
-pfInclusiveSecondaryVertexFinderTagInfos.useExternalSV = cms.bool(True)
-pfInclusiveSecondaryVertexFinderTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
-pfInclusiveSecondaryVertexFinderTagInfos.vertexCuts.distSig2dMin = 2.0
-
-
+    extSVCollection  = 'inclusiveCandidateSecondaryVertices',
+    extSVDeltaRToJet = 0.3,
+    useExternalSV    = True,
+    vertexCuts = dict(fracPV = 0.79, ## 4 out of 5 is discarded
+                      distSig2dMin = 2.0)
+)

--- a/RecoBTag/SecondaryVertex/python/pfSecondaryVertexNegativeTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/pfSecondaryVertexNegativeTagInfos_cfi.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import *
 
-pfSecondaryVertexNegativeTagInfos = pfSecondaryVertexTagInfos.clone()
-pfSecondaryVertexNegativeTagInfos.vertexCuts.distVal2dMin = -2.5
-pfSecondaryVertexNegativeTagInfos.vertexCuts.distVal2dMax = -0.01
-pfSecondaryVertexNegativeTagInfos.vertexCuts.distSig2dMin = -99999.9
-pfSecondaryVertexNegativeTagInfos.vertexCuts.distSig2dMax = -3.0
-pfSecondaryVertexNegativeTagInfos.vertexCuts.maxDeltaRToJetAxis = -0.5
+pfSecondaryVertexNegativeTagInfos = pfSecondaryVertexTagInfos.clone(
+    vertexCuts = dict(distVal2dMin = -2.5,
+                      distVal2dMax = -0.01,
+                      distSig2dMin = -99999.9,
+                      distSig2dMax = -3.0,
+                      maxDeltaRToJetAxis = -0.5)
+)

--- a/RecoBTag/SecondaryVertex/python/positiveCombinedSecondaryVertexV2Computer_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/positiveCombinedSecondaryVertexV2Computer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexV2Computer_cfi import *
 
-positiveCombinedSecondaryVertexV2Computer = combinedSecondaryVertexV2Computer.clone()
-positiveCombinedSecondaryVertexV2Computer.trackSelection.sip3dSigMin = 0
-positiveCombinedSecondaryVertexV2Computer.trackPseudoSelection.sip3dSigMin = 0
+positiveCombinedSecondaryVertexV2Computer = combinedSecondaryVertexV2Computer.clone(
+    trackSelection = dict(sip3dSigMin = 0),
+    trackPseudoSelection = dict(sip3dSigMin = 0)
+)

--- a/RecoBTag/SecondaryVertex/python/secondaryVertexNegativeTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertexNegativeTagInfos_cfi.py
@@ -2,9 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 
-secondaryVertexNegativeTagInfos = secondaryVertexTagInfos.clone()
-secondaryVertexNegativeTagInfos.vertexCuts.distVal2dMin = -2.5
-secondaryVertexNegativeTagInfos.vertexCuts.distVal2dMax = -0.01
-secondaryVertexNegativeTagInfos.vertexCuts.distSig2dMin = -99999.9
-secondaryVertexNegativeTagInfos.vertexCuts.distSig2dMax = -3.0
-secondaryVertexNegativeTagInfos.vertexCuts.maxDeltaRToJetAxis = -0.5
+secondaryVertexNegativeTagInfos = secondaryVertexTagInfos.clone(
+    vertexCuts = dict(distVal2dMin = -2.5,
+                      distVal2dMax = -0.01,
+                      distSig2dMin = -99999.9,
+                      distSig2dMax = -3.0,
+                      maxDeltaRToJetAxis = -0.5)
+)


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389), [PR#31523](https://github.com/cms-sw/cmssw/pull/31523))

In this PR, total 41 files changed. 
- RecoBTag/CTagging  : 6 files 
- RecoBTag/Combined : 3 files
- RecoBTag/ImpactParameter :  15 files 
- RecoBTag/ONNXRuntime : 1 file
- RecoBTag/SecondaryVertex : 16 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).