### PR TITLE
DAQ: added 16bit event info (flags) to FRD format

### DIFF
--- a/EventFilter/Utilities/interface/AuxiliaryMakers.h
+++ b/EventFilter/Utilities/interface/AuxiliaryMakers.h
@@ -9,6 +9,7 @@ namespace evf {
     edm::EventAuxiliary makeEventAuxiliary(const tcds::Raw_v1*,
                                            unsigned int runNumber,
                                            unsigned int lumiSection,
+                                           bool isRealData,
                                            const edm::EventAuxiliary::ExperimentType&,
                                            const std::string& processGUID,
                                            bool verifyLumiSection);

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -132,7 +132,7 @@ private:
 
   typedef std::pair<InputFile*, InputChunk*> ReaderInfo;
 
-  uint16 detectedFRDversion_ = 0;
+  uint16_t detectedFRDversion_ = 0;
   std::unique_ptr<InputFile> currentFile_;
   bool chunkIsFree_ = false;
 

--- a/EventFilter/Utilities/interface/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/interface/FedRawDataInputSource.h
@@ -132,7 +132,7 @@ private:
 
   typedef std::pair<InputFile*, InputChunk*> ReaderInfo;
 
-  uint32 detectedFRDversion_ = 0;
+  uint16 detectedFRDversion_ = 0;
   std::unique_ptr<InputFile> currentFile_;
   bool chunkIsFree_ = false;
 

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -66,7 +66,6 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
   if (detectedFRDversion_ == 0) {
     fin_.read((char*)&detectedFRDversion_, sizeof(uint16_t));
     fin_.read((char*)&flags_, sizeof(uint16_t));
-    detectedFRDversion_ = detectedFRDversion_ & 0xffff;
     assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= 6);
     if (buffer_.size() < FRDHeaderVersionSize[detectedFRDversion_])
       buffer_.resize(FRDHeaderVersionSize[detectedFRDversion_]);

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -64,7 +64,8 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
   }
 
   if (detectedFRDversion_ == 0) {
-    fin_.read((char*)&detectedFRDversion_, sizeof(uint32_t));
+    fin_.read((char*)&detectedFRDversion_, sizeof(uint16_t));
+    fin_.read((char*)&flags_, sizeof(uint16_t));
     detectedFRDversion_ = detectedFRDversion_ & 0xffff;
     assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= 6);
     if (buffer_.size() < FRDHeaderVersionSize[detectedFRDversion_])

--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -65,7 +65,8 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
 
   if (detectedFRDversion_ == 0) {
     fin_.read((char*)&detectedFRDversion_, sizeof(uint32_t));
-    assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= 5);
+    detectedFRDversion_ = detectedFRDversion_ & 0xffff;
+    assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= 6);
     if (buffer_.size() < FRDHeaderVersionSize[detectedFRDversion_])
       buffer_.resize(FRDHeaderVersionSize[detectedFRDversion_]);
     *((uint32_t*)(&buffer_[0])) = detectedFRDversion_;

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -42,6 +42,7 @@ private:
   const bool verifyChecksum_;
   const bool useL1EventID_;
   uint16_t detectedFRDversion_ = 0;
+  uint16_t flags_ = 0;
 };
 
 #endif  // EventFilter_Utilities_FRDStreamSource_h

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -41,7 +41,7 @@ private:
   const bool verifyAdler32_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
-  unsigned int detectedFRDversion_ = 0;
+  uint16 detectedFRDversion_ = 0;
 };
 
 #endif  // EventFilter_Utilities_FRDStreamSource_h

--- a/EventFilter/Utilities/plugins/FRDStreamSource.h
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.h
@@ -41,7 +41,7 @@ private:
   const bool verifyAdler32_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
-  uint16 detectedFRDversion_ = 0;
+  uint16_t detectedFRDversion_ = 0;
 };
 
 #endif  // EventFilter_Utilities_FRDStreamSource_h

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -116,7 +116,7 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
     uint32 flags = 0;
     if (!e.eventAuxiliary().isRealData())
       flags |= FRDEVENT_MASK_ISGENDATA;
-    *bufPtr++ = (uint32) ((frdVersion_ & 0xffff) | flags  << 16);
+    *bufPtr++ = (uint32)((frdVersion_ & 0xffff) | flags << 16);
   }
   *bufPtr++ = (uint32)e.id().run();
   *bufPtr++ = (uint32)e.luminosityBlock();

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -51,7 +51,6 @@ private:
   edm::EDGetTokenT<FEDRawDataCollection> token_;
   unsigned int numEventsPerFile_;
   unsigned int frdVersion_;
-  bool fillFRDEventFlags_;
   unsigned long long totsize;
   unsigned long long writtensize;
   unsigned long long writtenSizeLast;
@@ -70,8 +69,7 @@ RawEventOutputModuleForBU<Consumer>::RawEventOutputModuleForBU(edm::ParameterSet
       instance_(ps.getUntrackedParameter<std::string>("ProductInstance", "")),
       token_(consumes<FEDRawDataCollection>(edm::InputTag(label_, instance_))),
       numEventsPerFile_(ps.getUntrackedParameter<unsigned int>("numEventsPerFile", 100)),
-      frdVersion_(ps.getUntrackedParameter<unsigned int>("frdVersion", 5)),
-      fillFRDEventFlags_(ps.getUntrackedParameter<bool>("fillFRDEventFlags", true)),
+      frdVersion_(ps.getUntrackedParameter<unsigned int>("frdVersion", 6)),
       totsize(0LL),
       writtensize(0LL),
       writtenSizeLast(0LL),
@@ -115,10 +113,9 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
   if (frdVersion_ <= 5) {
     *bufPtr++ = (uint32)frdVersion_;  // version number only
   } else {
-    uint32 flags = FRDEVENT_MASK_FROMOUTPUTMODULE;
-    if (e.eventAuxiliary().isRealData())
-      flags |= FRDEVENT_MASK_ISREALDATA;
-    if (!fillFRDEventFlags_) flags = 0;
+    uint32 flags = 0;
+    if (!e.eventAuxiliary().isRealData())
+      flags |= FRDEVENT_MASK_ISGENDATA;
     *bufPtr++ = (uint32) ((frdVersion_ & 0xffff) | flags  << 16);
   }
   *bufPtr++ = (uint32)e.id().run();

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -113,10 +113,12 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
   if (frdVersion_ <= 5) {
     *bufPtr++ = (uint32)frdVersion_;  // version number only
   } else {
-    uint32 flags = 0;
+    uint16 flags = 0;
     if (!e.eventAuxiliary().isRealData())
       flags |= FRDEVENT_MASK_ISGENDATA;
-    *bufPtr++ = (uint32)((frdVersion_ & 0xffff) | flags << 16);
+    *(uint16*)bufPtr = (uint16)(frdVersion_ & 0xffff);
+    *((uint16*)bufPtr + 1) = flags;
+    bufPtr++;
   }
   *bufPtr++ = (uint32)e.id().run();
   *bufPtr++ = (uint32)e.luminosityBlock();

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -9,6 +9,7 @@ namespace evf {
     edm::EventAuxiliary makeEventAuxiliary(const tcds::Raw_v1* tcds,
                                            unsigned int runNumber,
                                            unsigned int lumiSection,
+                                           bool isRealData,
                                            const edm::EventAuxiliary::ExperimentType& eventType,
                                            const std::string& processGUID,
                                            bool verifyLumiSection) {
@@ -38,7 +39,7 @@ namespace evf {
       return edm::EventAuxiliary(eventId,
                                  processGUID,
                                  edm::Timestamp(time),
-                                 true,
+                                 isRealData,
                                  eventType,
                                  (int)tcds->header.bxid,
                                  ((uint32_t)(tcds->bst.lhcFillHigh) << 16) | tcds->bst.lhcFillLow,

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -29,12 +29,15 @@ namespace evf {
       const uint64_t orbitnr = ((uint64_t)tcds->header.orbitHigh << 16) | tcds->header.orbitLow;
       const uint32_t recordLumiSection = tcds->header.lumiSection;
 
-      if (verifyLumiSection && recordLumiSection != lumiSection)
-        edm::LogWarning("AuxiliaryMakers")
-            << "Lumisection mismatch, external : " << lumiSection << ", record : " << recordLumiSection;
-      if ((orbitnr >> 18) + 1 != recordLumiSection)
-        edm::LogWarning("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection
-                                           << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;
+      if (isRealData) {
+        //warnings are disabled for generated data
+        if (verifyLumiSection && recordLumiSection != lumiSection)
+          edm::LogWarning("AuxiliaryMakers")
+              << "Lumisection mismatch, external : " << lumiSection << ", record : " << recordLumiSection;
+        if ((orbitnr >> 18) + 1 != recordLumiSection)
+          edm::LogWarning("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection
+                                             << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;
+      }
 
       return edm::EventAuxiliary(eventId,
                                  processGUID,

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -483,8 +483,8 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
       readNextChunkIntoBuffer(currentFile_.get());
 
       if (detectedFRDversion_ == 0) {
-        detectedFRDversion_ = *((uint32*)dataPosition);
-        if (detectedFRDversion_ > 5)
+        detectedFRDversion_ = *((uint16_t*)dataPosition);
+        if (detectedFRDversion_ > 6)
           throw cms::Exception("FedRawDataInputSource::getNextEvent")
               << "Unknown FRD version -: " << detectedFRDversion_;
         assert(detectedFRDversion_ >= 1);
@@ -622,7 +622,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
 
   if (useL1EventID_) {
     eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, L1EventID_);
-    edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true, edm::EventAuxiliary::PhysicsTrigger);
+    edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, event_->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
     aux.setProcessHistoryID(processHistoryID_);
     makeEvent(eventPrincipal, aux);
   } else if (tcds_pointer_ == nullptr) {
@@ -631,7 +631,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
           << "No TCDS or GTP FED in event with FEDHeader EID -: " << L1EventID_;
     }
     eventID_ = edm::EventID(eventRunNumber_, currentLumiSection_, GTPEventID_);
-    edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true, edm::EventAuxiliary::PhysicsTrigger);
+    edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, event_->isRealData(), edm::EventAuxiliary::PhysicsTrigger);
     aux.setProcessHistoryID(processHistoryID_);
     makeEvent(eventPrincipal, aux);
   } else {
@@ -641,6 +641,7 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) {
         evf::evtn::makeEventAuxiliary(tcds,
                                       eventRunNumber_,
                                       currentLumiSection_,
+                                      event_->isRealData(),
                                       static_cast<edm::EventAuxiliary::ExperimentType>(fedHeader.triggerType()),
                                       processGUID(),
                                       !fileListLoopMode_);
@@ -1338,9 +1339,9 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
 
     //detect FRD event version. Skip file Header if it exists
     if (detectedFRDversion_ == 0 && chunk->offset_ == 0) {
-      detectedFRDversion_ = *((uint32*)(chunk->buf_ + file->rawHeaderSize_));
+      detectedFRDversion_ = *((uint16_t*)(chunk->buf_ + file->rawHeaderSize_));
     }
-    assert(detectedFRDversion_ <= 5);
+    assert(detectedFRDversion_ <= 6);
     chunk->readComplete_ =
         true;  //this is atomic to secure the sequential buffer fill before becoming available for processing)
     file->chunks_[chunk->fileIndex_] = chunk;  //put the completed chunk in the file chunk vector at predetermined index

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -131,8 +131,7 @@ process.out = cms.OutputModule("RawStreamFileWriterForBU",
     ProductLabel = cms.untracked.string("s"),
     numEventsPerFile= cms.untracked.uint32(options.eventsPerFile),
     frdFileVersion=cms.untracked.uint32(options.frdFileVersion),
-    frdVersion=cms.untracked.uint32(5),
-    fillFRDEventFlags=cms.untracked.bool(False)
+    frdVersion=cms.untracked.uint32(6),
     )
 
 process.p = cms.Path(process.s+process.a)

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -131,7 +131,8 @@ process.out = cms.OutputModule("RawStreamFileWriterForBU",
     ProductLabel = cms.untracked.string("s"),
     numEventsPerFile= cms.untracked.uint32(options.eventsPerFile),
     frdFileVersion=cms.untracked.uint32(options.frdFileVersion),
-    frdVersion=cms.untracked.uint32(5)
+    frdVersion=cms.untracked.uint32(5),
+    fillFRDEventFlags=cms.untracked.bool(False)
     )
 
 process.p = cms.Path(process.s+process.a)

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -144,9 +144,7 @@ public:
   uint32 adler32() const { return adler32_; }
   uint32 crc32c() const { return crc32c_; }
 
-  bool isRealData() const {
-    return !(flags_ & FRDEVENT_MASK_ISGENDATA);
-  }
+  bool isRealData() const { return !(flags_ & FRDEVENT_MASK_ISGENDATA); }
 
 private:
   uint8* buf_;

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -15,6 +15,18 @@
  * 14-Nov-2013 - RKM  - Added event size, adler32 and padding size (version #3)
  * 15-Oct-2014 - WDD  - Event number from 32 bits to 64 bits (version #4)
  * 01-Apr-2015 - SM   - replaced adler32 with crc32c which is accelerated in SSE 4.2 (version #5)
+ * 22-Sep-2020 - SM   - reused high version 16-bits for event info via flags (version #6)
+ *
+ *
+ * Version 6 Format:
+ *   uint16 - format version number
+ *   uint16 - eventf flags
+ *   uint32 - run number
+ *   uint32 - lumi number
+ *   uint32 - event number
+ *   uint32 - event size
+ *   uint32 - crc32c checksum of FED data (excluding event header)
+ *   variable size - FED data
  *
  * Version 5 Format:
  *   uint32 - format version number
@@ -57,14 +69,22 @@
 
 #include "IOPool/Streamer/interface/MsgTools.h"
 
+struct FRDEventHeader_V6 {
+  uint16 version_;
+  uint16 flags_;
+  uint32 run_;
+  uint32 lumi_;
+  uint32 event_;
+  uint32 eventSize_;
+  uint32 crc32c_;
+};
+
 struct FRDEventHeader_V5 {
   uint32 version_;
   uint32 run_;
   uint32 lumi_;
-  uint32 eventLow_;
-  uint32 eventHigh_;
+  uint32 event_;
   uint32 eventSize_;
-  uint32 paddingSize_;
   uint32 crc32c_;
 };
 
@@ -101,6 +121,9 @@ struct FRDEventHeader_V1 {
   uint32 event_;
 };
 
+const uint16 FRDEVENT_MASK_FROMOUTPUTMODULE = 1;
+const uint16 FRDEVENT_MASK_ISREALDATA = 1 << 1;
+
 const uint32 FRDHeaderVersionSize[6] = {
     0, 2 * sizeof(uint32), (4 + 1024) * sizeof(uint32), 7 * sizeof(uint32), 8 * sizeof(uint32), 6 * sizeof(uint32)};
 
@@ -112,7 +135,8 @@ public:
   void* payload() const { return payload_; }
   uint32 size() const { return size_; }
 
-  uint32 version() const { return version_; }
+  uint16 version() const { return version_; }
+  uint16 flags() const { return flags_; }
   uint32 run() const { return run_; }
   uint32 lumi() const { return lumi_; }
   uint64 event() const { return event_; }
@@ -121,11 +145,17 @@ public:
   uint32 adler32() const { return adler32_; }
   uint32 crc32c() const { return crc32c_; }
 
+  //can only be MC with output module flag
+  bool isRealData() const {
+    return !(flags_ & FRDEVENT_MASK_FROMOUTPUTMODULE) || (flags_ & FRDEVENT_MASK_ISREALDATA);
+  }
+
 private:
   uint8* buf_;
   void* payload_;
   uint32 size_;
-  uint32 version_;
+  uint16 version_;
+  uint16 flags_;
   uint32 run_;
   uint32 lumi_;
   uint64 event_;

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -20,7 +20,7 @@
  *
  * Version 6 Format:
  *   uint16 - format version number
- *   uint16 - eventf flags
+ *   uint16 - event flags
  *   uint32 - run number
  *   uint32 - lumi number
  *   uint32 - event number

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -121,8 +121,7 @@ struct FRDEventHeader_V1 {
   uint32 event_;
 };
 
-const uint16 FRDEVENT_MASK_FROMOUTPUTMODULE = 1;
-const uint16 FRDEVENT_MASK_ISREALDATA = 1 << 1;
+const uint16 FRDEVENT_MASK_ISGENDATA = 1;
 
 const uint32 FRDHeaderVersionSize[6] = {
     0, 2 * sizeof(uint32), (4 + 1024) * sizeof(uint32), 7 * sizeof(uint32), 8 * sizeof(uint32), 6 * sizeof(uint32)};
@@ -145,9 +144,8 @@ public:
   uint32 adler32() const { return adler32_; }
   uint32 crc32c() const { return crc32c_; }
 
-  //can only be MC with output module flag
   bool isRealData() const {
-    return !(flags_ & FRDEVENT_MASK_FROMOUTPUTMODULE) || (flags_ & FRDEVENT_MASK_ISREALDATA);
+    return !(flags_ & FRDEVENT_MASK_ISGENDATA);
   }
 
 private:

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -10,6 +10,7 @@
  */
 
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 /**
  * Constructor for the FRD event message viewer.
@@ -19,6 +20,7 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
       payload_(nullptr),
       size_(0),
       version_(0),
+      flags_(0),
       run_(0),
       lumi_(0),
       event_(0),
@@ -27,21 +29,24 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
       adler32_(0),
       crc32c_(0) {
   uint32* bufPtr = static_cast<uint32*>(buf);
-  version_ = *bufPtr;
-  // if the version number is rather large, then we assume that the true
-  // version number is one.  (In version one of the format, there was
-  // no version number in the data, and the run number appeared first.)
-  if (version_ >= 32) {
-    version_ = 1;
+
+  // In version one of the format, there was no version number in the data,
+  // and the run number (32-bit) appeared first.
+  // This format is no longer supported
+  version_ = *bufPtr | 0xffff;
+
+  if (version_<2) {
+    throw cms::Exception("FRDEventMsgView") << "FRD version is " << version_ << " is no longer supported";
   }
 
-  size_ = 0;
-
-  // version number
-  if (version_ >= 2) {
-    size_ += sizeof(uint32);
-    ++bufPtr;
+  // Version 6 repurposes unused high 16-bits of 32-bit version
+  // assuming we no longer need version 1 detection
+  if (version_>=6) {
+    flags_ = *bufPtr >> 16;
   }
+
+  size_ = sizeof(uint32);
+  ++bufPtr;
 
   // run number
   run_ = *bufPtr;

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -35,13 +35,13 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
   // This format is no longer supported
   version_ = *bufPtr | 0xffff;
 
-  if (version_<2) {
+  if (version_ < 2) {
     throw cms::Exception("FRDEventMsgView") << "FRD version " << version_ << " is no longer supported";
   }
 
   // Version 6 repurposes unused high 16-bits of 32-bit version
   // assuming we no longer need version 1 detection
-  if (version_>=6) {
+  if (version_ >= 6) {
     flags_ = *bufPtr >> 16;
   }
 

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -33,16 +33,18 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
   // In version one of the format, there was no version number in the data,
   // and the run number (32-bit) appeared first.
   // This format is no longer supported
-  version_ = *bufPtr | 0xffff;
+  version_ = *(uint16*)bufPtr;
 
-  if (version_ < 2) {
-    throw cms::Exception("FRDEventMsgView") << "FRD version " << version_ << " is no longer supported";
+  if (version_ < 2 || version_> 6) {
+    throw cms::Exception("FRDEventMsgView") << "FRD version " << version_ << " is not supported";
   }
 
   // Version 6 repurposes unused high 16-bits of 32-bit version
-  // assuming we no longer need version 1 detection
-  if (version_ >= 6) {
-    flags_ = *bufPtr >> 16;
+  // assuming we no longer need version 1 support
+  flags_ = *((uint16*)bufPtr + 1);
+
+  if (version_ < 6 && flags_) {
+    throw cms::Exception("FRDEventMsgView") << "FRD flags can not be used in version " << version_;
   }
 
   size_ = sizeof(uint32);

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -36,7 +36,7 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
   version_ = *bufPtr | 0xffff;
 
   if (version_<2) {
-    throw cms::Exception("FRDEventMsgView") << "FRD version is " << version_ << " is no longer supported";
+    throw cms::Exception("FRDEventMsgView") << "FRD version " << version_ << " is no longer supported";
   }
 
   // Version 6 repurposes unused high 16-bits of 32-bit version

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -35,7 +35,7 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
   // This format is no longer supported
   version_ = *(uint16*)bufPtr;
 
-  if (version_ < 2 || version_> 6) {
+  if (version_ < 2 || version_ > 6) {
     throw cms::Exception("FRDEventMsgView") << "FRD version " << version_ << " is not supported";
   }
 


### PR DESCRIPTION
#### PR description:
Goal of these changes is to propagate data/MC flag to FedRawDataInputSource and EventAuxiliary for raw samples converted from offline datasets. Information is added to the Raw data (FRD format) header, where version is shrunk to use 16-bits and other 16 bits reused for flags (2 used initially).  Version is bumped to v6 of the format.

Raw Output Module, which is used for conversions of offline datasets to FRD, betect data/MC flag in the event stores it in raw output (FRD version needs to be set to 6 or higher in that case). Check for the ancient FRD v1 has also now been removed. Compatibility with current real FRD data (v5 generated by the DAQ) is fully preserved.

#### PR validation:

Tested write + read chain with the generated data (fake BU); with the patch it is possible to generate new format, but also old one. Both modes have been tested. With v6 being default generated format, functional check is now part of the "RunBUFU" unit test.