### PR TITLE
Allow setting connect string from SiteLocalConfig

### DIFF
--- a/CondCore/ESSources/plugins/BuildFile.xml
+++ b/CondCore/ESSources/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="FWCore/Catalog"/>
 <use name="FWCore/Framework"/>
 <use name="CondCore/ESSources"/>
 <library file="*.cc" name="CondCoreESSourcesPlugins">

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -22,8 +22,10 @@
 #include "CondCore/ESSources/interface/DataProxy.h"
 
 #include "CondCore/CondDB/interface/PayloadProxy.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include <exception>
 
 #include <iomanip>
@@ -123,6 +125,17 @@ CondDBESSource::CondDBESSource(const edm::ParameterSet& iConfig)
     globaltag = iConfig.getParameter<std::string>("globaltag");
     // the global tag _requires_ a connection string
     m_connectionString = iConfig.getParameter<std::string>("connect");
+
+    if (!globaltag.empty()) {
+      edm::Service<edm::SiteLocalConfig> siteLocalConfig;
+      if (siteLocalConfig.isAvailable()) {
+        if (siteLocalConfig->useLocalConnectString()) {
+          std::string const& localConnectPrefix = siteLocalConfig->localConnectPrefix();
+          std::string const& localConnectSuffix = siteLocalConfig->localConnectSuffix();
+          m_connectionString = localConnectPrefix + globaltag + localConnectSuffix;
+        }
+      }
+    }
   } else if (iConfig.exists("connect"))  // default connection string
     m_connectionString = iConfig.getParameter<std::string>("connect");
 

--- a/FWCore/Catalog/interface/SiteLocalConfig.h
+++ b/FWCore/Catalog/interface/SiteLocalConfig.h
@@ -47,6 +47,9 @@ namespace edm {
     virtual struct addrinfo const* statisticsDestination() const = 0;
     virtual std::set<std::string> const* statisticsInfo() const = 0;
     virtual std::string const& siteName(void) const = 0;
+    virtual bool useLocalConnectString() const = 0;
+    virtual std::string const& localConnectPrefix() const = 0;
+    virtual std::string const& localConnectSuffix() const = 0;
 
     // implicit copy constructor
     // implicit assignment operator

--- a/FWCore/Catalog/test/FileLocator_t.cpp
+++ b/FWCore/Catalog/test/FileLocator_t.cpp
@@ -4,6 +4,8 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include <boost/filesystem.hpp>
 
+#include <string>
+
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
 
@@ -29,13 +31,14 @@ namespace {
       return nullptr;
     }
     std::set<std::string> const* statisticsInfo() const final { return nullptr; }
-    std::string const& siteName(void) const final {
-      static const std::string s_value = "TEST";
-      return s_value;
-    }
+    std::string const& siteName(void) const final { return m_emptyString; }
+    bool useLocalConnectString() const final { return false; }
+    std::string const& localConnectPrefix() const final { return m_emptyString; }
+    std::string const& localConnectSuffix() const final { return m_emptyString; }
 
   private:
     std::vector<std::string> m_catalogs;
+    std::string m_emptyString;
   };
 }  // namespace
 

--- a/FWCore/Services/bin/cmsGetFnConnect.cc
+++ b/FWCore/Services/bin/cmsGetFnConnect.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include <iostream>
 #include <cstring>
+#include <memory>
 
 int main(int argc, char* argv[]) {
   if ((argc != 2) || (strncmp(argv[1], "frontier://", 11) != 0)) {

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -47,6 +47,9 @@ namespace edm {
       struct addrinfo const* statisticsDestination() const override;
       std::set<std::string> const* statisticsInfo() const override;
       std::string const& siteName() const override;
+      bool useLocalConnectString() const override;
+      std::string const& localConnectPrefix() const override;
+      std::string const& localConnectSuffix() const override;
 
       // implicit copy constructor
       // implicit assignment operator
@@ -88,6 +91,9 @@ namespace edm {
       std::set<std::string> m_statisticsInfo;
       bool m_statisticsInfoAvail;
       std::string m_siteName;
+      bool m_useLocalConnectString = false;
+      std::string m_localConnectPrefix;
+      std::string m_localConnectSuffix;
     };
 
     inline bool isProcessWideService(SiteLocalConfigService const*) { return true; }

--- a/FWCore/Services/test/full-site-local-config.testfile
+++ b/FWCore/Services/test/full-site-local-config.testfile
@@ -9,10 +9,9 @@
     <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=srm"/>
   </local-stage-out>
   <calib-data>
-    <frontier-connect>
-      <proxy url="http://cmsfrontier.dummy.foo:3128"/>
-      <proxy url="http://cmsfrontier.dummy.foo:3128"/>
-    </frontier-connect>
+    <local-connect>
+      <connectString prefix="Test:Prefix" suffix="Test.Suffix"/>
+    </local-connect>
   </calib-data>
   <source-config>
     <cache-temp-dir name="/a/b/c"/>

--- a/FWCore/Services/test/source-site-local-config.testfile
+++ b/FWCore/Services/test/source-site-local-config.testfile
@@ -9,10 +9,9 @@
     <catalog url="trivialcatalog_file:/dummy/storage.xml?protocol=srm"/>
   </local-stage-out>
   <calib-data>
-    <frontier-connect>
-      <proxy url="http://cmsfrontier.dummy.foo:3128"/>
-      <proxy url="http://cmsfrontier.dummy.foo:3128"/>
-    </frontier-connect>
+    <local-connect>
+      <connectString prefix="Test:Prefix" suffix="Test.Suffix"/>
+    </local-connect>
   </calib-data>
   <source-config>
     <cache-temp-dir name="/a/b/c"/>

--- a/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
+++ b/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Services/src/SiteLocalConfigService.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
@@ -99,5 +100,13 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
     REQUIRE(slc.useLocalConnectString() == false);
     REQUIRE(slc.localConnectPrefix() == "OverridePrefix");
     REQUIRE(slc.localConnectSuffix() == "OverrideSuffix");
+  }
+
+  SECTION("throwtest-site-local-config.testfile") {
+    edm::ParameterSet pset;
+    pset.addUntrackedParameter<std::string>("siteLocalConfigFileUrl",
+                                            dirString + "/throwtest-site-local-config.testfile");
+
+    REQUIRE_THROWS_AS(edm::service::SiteLocalConfigService(pset), cms::Exception);
   }
 }

--- a/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
+++ b/FWCore/Services/test/test_catch2_SiteLocalConfigService.cc
@@ -46,6 +46,9 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
     CHECK(slc.statisticsInfo()->size() == 1);
     CHECK(slc.statisticsInfo()->find("dn") != slc.statisticsInfo()->end());
     CHECK(slc.siteName() == "DUMMY");
+    REQUIRE(slc.useLocalConnectString() == true);
+    REQUIRE(slc.localConnectPrefix() == "Test:Prefix");
+    REQUIRE(slc.localConnectSuffix() == "Test.Suffix");
   }
 
   SECTION("overrides") {
@@ -63,6 +66,9 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
     pset.addUntrackedParameter<bool>("overridePrefetching", false);
     pset.addUntrackedParameter<std::string>("overrideStatisticsDestination", "");
     pset.addUntrackedParameter<std::vector<std::string> >("overrideStatisticsInfo", {{"nodn"}});
+    pset.addUntrackedParameter<bool>("overrideUseLocalConnectString", false);
+    pset.addUntrackedParameter<std::string>("overrideLocalConnectPrefix", "OverridePrefix");
+    pset.addUntrackedParameter<std::string>("overrideLocalConnectSuffix", "OverrideSuffix");
 
     edm::service::SiteLocalConfigService slc(pset);
 
@@ -90,5 +96,8 @@ TEST_CASE("Test SiteLocalConfigService", "[sitelocalconfig]") {
     CHECK(slc.statisticsInfo()->size() == 1);
     CHECK(slc.statisticsInfo()->find("nodn") != slc.statisticsInfo()->end());
     CHECK(slc.siteName() == "DUMMY");
+    REQUIRE(slc.useLocalConnectString() == false);
+    REQUIRE(slc.localConnectPrefix() == "OverridePrefix");
+    REQUIRE(slc.localConnectSuffix() == "OverrideSuffix");
   }
 }

--- a/FWCore/Services/test/test_sitelocalconfig_no_source_cfg.py
+++ b/FWCore/Services/test/test_sitelocalconfig_no_source_cfg.py
@@ -10,7 +10,10 @@ process.tester = cms.EDAnalyzer("SiteLocalConfigServiceTester",
                             sourceReadHint=cms.untracked.string(""),
                             sourceTTreeCacheSize=cms.untracked.uint32(0),
                             sourceNativeProtocols=cms.untracked.vstring(),
-                            sourceValuesSet=cms.untracked.bool(False)
+                            sourceValuesSet=cms.untracked.bool(False),
+                            expectedUseLocalConnectString = cms.untracked.bool(False),
+                            expectedLocalConnectPrefix = cms.untracked.string(""),
+                            expectedLocalConnectSuffix = cms.untracked.string("")
 )
 
 process.o = cms.EndPath(process.tester)

--- a/FWCore/Services/test/test_sitelocalconfig_override_cfg.py
+++ b/FWCore/Services/test/test_sitelocalconfig_override_cfg.py
@@ -10,7 +10,11 @@ process.tester = cms.EDAnalyzer("SiteLocalConfigServiceTester",
                             sourceReadHint=cms.untracked.string("direct-unbuffered"),
                             sourceTTreeCacheSize=cms.untracked.uint32(0),
                             sourceNativeProtocols=cms.untracked.vstring("rfio"),
-                            sourceValuesSet=cms.untracked.bool(True)
+                            sourceValuesSet=cms.untracked.bool(True),
+                            expectedUseLocalConnectString = cms.untracked.bool(True),
+                            expectedLocalConnectPrefix = cms.untracked.string("TestOverride:Prefix"),
+                            expectedLocalConnectSuffix = cms.untracked.string("TestOverride.Suffix")
+
 )
 
 process.o = cms.EndPath(process.tester)
@@ -20,4 +24,8 @@ process.add_(cms.Service("SiteLocalConfigService",
                          overrideSourceCacheHintDir=cms.untracked.string("storage-only"),
                          overrideSourceReadHint=cms.untracked.string("direct-unbuffered"),
                          overrideSourceNativeProtocols=cms.untracked.vstring("rfio"),
-                         overrideSourceTTreeCacheSize=cms.untracked.uint32(0)))
+                         overrideSourceTTreeCacheSize=cms.untracked.uint32(0),
+                         overrideUseLocalConnectString = cms.untracked.bool(True),
+                         overrideLocalConnectPrefix = cms.untracked.string("TestOverride:Prefix"),
+                         overrideLocalConnectSuffix = cms.untracked.string("TestOverride.Suffix")
+))

--- a/FWCore/Services/test/test_sitelocalconfig_source_cfg.py
+++ b/FWCore/Services/test/test_sitelocalconfig_source_cfg.py
@@ -10,7 +10,10 @@ process.tester = cms.EDAnalyzer("SiteLocalConfigServiceTester",
                             sourceReadHint=cms.untracked.string("read-ahead-buffered"),
                             sourceTTreeCacheSize=cms.untracked.uint32(10000),
                             sourceNativeProtocols=cms.untracked.vstring("dcache","file"),
-                            sourceValuesSet=cms.untracked.bool(True)
+                            sourceValuesSet=cms.untracked.bool(True),
+                            expectedUseLocalConnectString = cms.untracked.bool(True),
+                            expectedLocalConnectPrefix = cms.untracked.string("Test:Prefix"),
+                            expectedLocalConnectSuffix = cms.untracked.string("Test.Suffix")
 )
 
 process.o = cms.EndPath(process.tester)

--- a/FWCore/Services/test/throwtest-site-local-config.testfile
+++ b/FWCore/Services/test/throwtest-site-local-config.testfile
@@ -1,0 +1,12 @@
+<site-local-config>
+<site name="DUMMY">
+  <calib-data>
+    <frontier-connect>
+      <proxy url="http://cmsfrontier.dummy.foo:3128"/>
+    </frontier-connect>
+    <local-connect>
+      <connectString prefix="Test:Prefix" suffix="Test.Suffix"/>
+    </local-connect>
+  </calib-data>
+</site>
+</site-local-config>


### PR DESCRIPTION
#### PR description:

Add support for setting the connection string in PoolDBESSource based on the site local config XML file and the global tag. Here is an example of of how to modify the XML file:  

```
<site-local-config>
<site name="DUMMY">
   ...
   <calib-data>
      ...
      <local-connect>
         <connectString prefix="anything1" suffix="anything2"/>
      </local-connect>
...
```

If a non-empty globaltag is in the PoolDBESSource configuration and ```<local-connect>``` is in the XML file as shown above, then the connection string will be overwritten by the result of concatenating the prefix plus the globaltag plus the suffix. The prefix and suffix are from the XML file and can be set to anything or nothing. 

An exception will be thrown if ```<local-connect>``` and ```<frontier-connect>``` are both set in the same XML file.

It is also possible to override the prefix and suffix from the configuration of the SiteLocalConfigService. It is also possible to force overwriting of the connection string in the same way.

This is primarily intended for use at sites where the worker nodes do not have network connectivity and the data normally retrieved from a database must be put into a local file.

#### PR validation:

Extended SiteLocalConfig unit tests to cover these new variables.

This should not change any behavior or results until a site local config XML file modified or the override configuration parameters are used. Existing tests of PoolDBESSource verify that. 

We have not yet tested this on remote worker nodes that do not have network connectivity. The intent is to do that testing after the PR is merged and if necessary make further changes.
