### PR TITLE
Add more SONIC module types

### DIFF
--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -52,11 +52,11 @@ These parameters can be prepopulated and validated by the client using `fillDesc
 The `mode` and `allowedTries` parameters are always necessary (example values are shown here, but other values are also allowed).
 These parameters are described in the next section.
 
-An example producer can be found in the [test](./test) folder.
-
 In addition, there is a `SonicOneEDAnalyzer` class template for user analysis, e.g. to produce simple ROOT files.
 Only `Sync` mode is supported for clients used with One modules,
-but otherwise, the above template be followed (replace `void produce(edm::Event&` with `void analyze(edm::Event const&` above).
+but otherwise, the above template can be followed (replace `void produce(edm::Event&` with `void analyze(edm::Event const&` above).
+
+Examples of the producer, filter, and analyzer can be found in the [test](./test) folder.
 
 ## For developers
 

--- a/HeterogeneousCore/SonicCore/README.md
+++ b/HeterogeneousCore/SonicCore/README.md
@@ -5,6 +5,7 @@ SONIC: Services for Optimized Network Inference on Coprocessors
 ## For analyzers
 
 The `SonicEDProducer` class template extends the basic Stream producer module in CMSSW.
+Similarly, `SonicEDFilter` extends the basic Stream filter module (replace `void produce` with `bool filter` below).
 
 To implement a concrete derived producer class, the following skeleton can be used:
 ```cpp
@@ -52,6 +53,10 @@ The `mode` and `allowedTries` parameters are always necessary (example values ar
 These parameters are described in the next section.
 
 An example producer can be found in the [test](./test) folder.
+
+In addition, there is a `SonicOneEDAnalyzer` class template for user analysis, e.g. to produce simple ROOT files.
+Only `Sync` mode is supported for clients used with One modules,
+but otherwise, the above template be followed (replace `void produce(edm::Event&` with `void analyze(edm::Event const&` above).
 
 ## For developers
 

--- a/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
@@ -1,0 +1,36 @@
+#ifndef HeterogeneousCore_SonicCore_SonicAcquirer
+#define HeterogeneousCore_SonicCore_SonicAcquirer
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+
+template <typename Client, typename Module>
+class SonicAcquirer : public Module {
+public:
+  //typedef to simplify usage
+  typedef typename Client::Input Input;
+  //constructor
+  SonicAcquirer(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {}
+  //destructor
+  ~SonicAcquirer() override = default;
+
+  //derived classes use a dedicated acquire() interface that incorporates client_.input()
+  //(no need to interact with callback holder)
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, edm::WaitingTaskWithArenaHolder holder) final {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    acquire(iEvent, iSetup, client_.input());
+    sonic_utils::printDebugTime(client_.debugName(), "acquire() time: ", t0);
+    t_dispatch_ = std::chrono::high_resolution_clock::now();
+    client_.dispatch(holder);
+  }
+  virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
+
+protected:
+  //for debugging
+  void setDebugName(const std::string& debugName) { client_.setDebugName(debugName); }
+  //members
+  Client client_;
+  std::chrono::time_point<std::chrono::high_resolution_clock> t_dispatch_;
+};
+
+#endif

--- a/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicAcquirer.h
@@ -1,8 +1,13 @@
 #ifndef HeterogeneousCore_SonicCore_SonicAcquirer
 #define HeterogeneousCore_SonicCore_SonicAcquirer
 
+#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
+
+#include <chrono>
 
 template <typename Client, typename Module>
 class SonicAcquirer : public Module {

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -26,6 +26,7 @@ public:
   void setDebugName(const std::string& debugName);
   const std::string& debugName() const { return debugName_; }
   const std::string& clientName() const { return clientName_; }
+  SonicMode mode() const { return mode_; }
 
   //main operation
   virtual void dispatch(edm::WaitingTaskWithArenaHolder holder) { dispatcher_->dispatch(std::move(holder)); }

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -31,6 +31,9 @@ public:
   //main operation
   virtual void dispatch(edm::WaitingTaskWithArenaHolder holder) { dispatcher_->dispatch(std::move(holder)); }
 
+  //alternate operation when ExternalWork is not used
+  virtual void dispatch() { dispatcher_->dispatch(); }
+
   //helper: does nothing by default
   virtual void reset() {}
 
@@ -42,6 +45,8 @@ protected:
 
   void start(edm::WaitingTaskWithArenaHolder holder);
 
+  void start();
+
   void finish(bool success, std::exception_ptr eptr = std::exception_ptr{});
 
   //members
@@ -49,6 +54,7 @@ protected:
   std::unique_ptr<SonicDispatcher> dispatcher_;
   unsigned allowedTries_, tries_;
   edm::WaitingTaskWithArenaHolder holder_;
+  bool hasHolder_;
 
   //for logging/debugging
   std::string clientName_, debugName_, fullDebugName_;

--- a/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicClientBase.h
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <exception>
 #include <memory>
+#include <optional>
 
 enum class SonicMode { Sync = 1, Async = 2, PseudoAsync = 3 };
 
@@ -53,8 +54,7 @@ protected:
   SonicMode mode_;
   std::unique_ptr<SonicDispatcher> dispatcher_;
   unsigned allowedTries_, tries_;
-  edm::WaitingTaskWithArenaHolder holder_;
-  bool hasHolder_;
+  std::optional<edm::WaitingTaskWithArenaHolder> holder_;
 
   //for logging/debugging
   std::string clientName_, debugName_, fullDebugName_;

--- a/HeterogeneousCore/SonicCore/interface/SonicDispatcher.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicDispatcher.h
@@ -16,6 +16,9 @@ public:
   //main operation
   virtual void dispatch(edm::WaitingTaskWithArenaHolder holder);
 
+  //alternate operation when ExternalWork is not used
+  virtual void dispatch();
+
 protected:
   SonicClientBase* client_;
 };

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -1,8 +1,8 @@
-#ifndef HeterogeneousCore_SonicCore_SonicEDProducer
-#define HeterogeneousCore_SonicCore_SonicEDProducer
+#ifndef HeterogeneousCore_SonicCore_SonicEDFilter
+#define HeterogeneousCore_SonicCore_SonicEDFilter
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
@@ -12,18 +12,18 @@
 #include <string>
 #include <chrono>
 
-//this is a stream producer because client operations are not multithread-safe in general
+//this is a stream filter because client operations are not multithread-safe in general
 //it is designed such that the user never has to interact with the client or the acquire() callback directly
 template <typename Client, typename... Capabilities>
-class SonicEDProducer : public edm::stream::EDProducer<edm::ExternalWork, Capabilities...> {
+class SonicEDFilter : public edm::stream::EDFilter<edm::ExternalWork, Capabilities...> {
 public:
   //typedefs to simplify usage
   typedef typename Client::Input Input;
   typedef typename Client::Output Output;
   //constructor
-  SonicEDProducer(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {}
+  SonicEDFilter(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {}
   //destructor
-  ~SonicEDProducer() override = default;
+  ~SonicEDFilter() override = default;
 
   //derived classes use a dedicated acquire() interface that incorporates client_.input()
   //(no need to interact with callback holder)
@@ -36,18 +36,20 @@ public:
   }
   virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
   //derived classes use a dedicated produce() interface that incorporates client_.output()
-  void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) final {
+  bool filter(edm::Event& iEvent, edm::EventSetup const& iSetup) final {
     //measure time between acquire and produce
     sonic_utils::printDebugTime(client_.debugName(), "dispatch() time: ", t_dispatch_);
 
     auto t0 = std::chrono::high_resolution_clock::now();
-    produce(iEvent, iSetup, client_.output());
+    bool result = produce(iEvent, iSetup, client_.output());
     sonic_utils::printDebugTime(client_.debugName(), "produce() time: ", t0);
 
     //reset client data
     client_.reset();
+
+    return result;
   }
-  virtual void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) = 0;
+  virtual bool filter(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) = 0;
 
 protected:
   //for debugging

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -41,7 +41,7 @@ public:
     sonic_utils::printDebugTime(client_.debugName(), "dispatch() time: ", t_dispatch_);
 
     auto t0 = std::chrono::high_resolution_clock::now();
-    bool result = produce(iEvent, iSetup, client_.output());
+    bool result = filter(iEvent, iSetup, client_.output());
     sonic_utils::printDebugTime(client_.debugName(), "produce() time: ", t0);
 
     //reset client data

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -42,7 +42,7 @@ public:
 
     auto t0 = std::chrono::high_resolution_clock::now();
     bool result = filter(iEvent, iSetup, client_.output());
-    sonic_utils::printDebugTime(client_.debugName(), "produce() time: ", t0);
+    sonic_utils::printDebugTime(client_.debugName(), "filter() time: ", t0);
 
     //reset client data
     client_.reset();

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -16,12 +16,13 @@
 //this is a stream filter because client operations are not multithread-safe in general
 //it is designed such that the user never has to interact with the client or the acquire() callback directly
 template <typename Client, typename... Capabilities>
-class SonicEDFilter : public SonicAcquirer<Client,edm::stream::EDFilter<edm::ExternalWork, Capabilities...>> {
+class SonicEDFilter : public SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>> {
 public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDFilter(edm::ParameterSet const& cfg) : SonicAcquirer<Client,edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg) {}
+  SonicEDFilter(edm::ParameterSet const& cfg)
+      : SonicAcquirer<Client, edm::stream::EDFilter<edm::ExternalWork, Capabilities...>>(cfg) {}
   //destructor
   ~SonicEDFilter() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDFilter.h
@@ -1,12 +1,7 @@
 #ifndef HeterogeneousCore_SonicCore_SonicEDFilter
 #define HeterogeneousCore_SonicCore_SonicEDFilter
 
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
 #include "HeterogeneousCore/SonicCore/interface/SonicAcquirer.h"
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -8,6 +8,7 @@
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicAcquirer.h"
 
 #include <string>
 #include <chrono>
@@ -15,46 +16,28 @@
 //this is a stream producer because client operations are not multithread-safe in general
 //it is designed such that the user never has to interact with the client or the acquire() callback directly
 template <typename Client, typename... Capabilities>
-class SonicEDProducer : public edm::stream::EDProducer<edm::ExternalWork, Capabilities...> {
+class SonicEDProducer : public SonicAcquirer<Client,edm::stream::EDProducer<edm::ExternalWork, Capabilities...>> {
 public:
-  //typedefs to simplify usage
-  typedef typename Client::Input Input;
+  //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDProducer(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {}
+  SonicEDProducer(edm::ParameterSet const& cfg) : SonicAcquirer<Client,edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg) {}
   //destructor
   ~SonicEDProducer() override = default;
 
-  //derived classes use a dedicated acquire() interface that incorporates client_.input()
-  //(no need to interact with callback holder)
-  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, edm::WaitingTaskWithArenaHolder holder) final {
-    auto t0 = std::chrono::high_resolution_clock::now();
-    acquire(iEvent, iSetup, client_.input());
-    sonic_utils::printDebugTime(client_.debugName(), "acquire() time: ", t0);
-    t_dispatch_ = std::chrono::high_resolution_clock::now();
-    client_.dispatch(holder);
-  }
-  virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
   //derived classes use a dedicated produce() interface that incorporates client_.output()
   void produce(edm::Event& iEvent, edm::EventSetup const& iSetup) final {
     //measure time between acquire and produce
-    sonic_utils::printDebugTime(client_.debugName(), "dispatch() time: ", t_dispatch_);
+    sonic_utils::printDebugTime(this->client_.debugName(), "dispatch() time: ", this->t_dispatch_);
 
     auto t0 = std::chrono::high_resolution_clock::now();
-    produce(iEvent, iSetup, client_.output());
-    sonic_utils::printDebugTime(client_.debugName(), "produce() time: ", t0);
+    produce(iEvent, iSetup, this->client_.output());
+    sonic_utils::printDebugTime(this->client_.debugName(), "produce() time: ", t0);
 
     //reset client data
-    client_.reset();
+    this->client_.reset();
   }
   virtual void produce(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) = 0;
-
-protected:
-  //for debugging
-  void setDebugName(const std::string& debugName) { client_.setDebugName(debugName); }
-  //members
-  Client client_;
-  std::chrono::time_point<std::chrono::high_resolution_clock> t_dispatch_;
 };
 
 #endif

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -16,12 +16,13 @@
 //this is a stream producer because client operations are not multithread-safe in general
 //it is designed such that the user never has to interact with the client or the acquire() callback directly
 template <typename Client, typename... Capabilities>
-class SonicEDProducer : public SonicAcquirer<Client,edm::stream::EDProducer<edm::ExternalWork, Capabilities...>> {
+class SonicEDProducer : public SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>> {
 public:
   //typedef to simplify usage
   typedef typename Client::Output Output;
   //constructor
-  SonicEDProducer(edm::ParameterSet const& cfg) : SonicAcquirer<Client,edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg) {}
+  SonicEDProducer(edm::ParameterSet const& cfg)
+      : SonicAcquirer<Client, edm::stream::EDProducer<edm::ExternalWork, Capabilities...>>(cfg) {}
   //destructor
   ~SonicEDProducer() override = default;
 

--- a/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicEDProducer.h
@@ -1,12 +1,7 @@
 #ifndef HeterogeneousCore_SonicCore_SonicEDProducer
 #define HeterogeneousCore_SonicCore_SonicEDProducer
 
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
 #include "HeterogeneousCore/SonicCore/interface/SonicAcquirer.h"
 

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -30,8 +30,6 @@ public:
   ~SonicOneEDAnalyzer() override = default;
 
   //derived classes still use a dedicated acquire() interface that incorporates client_.input() for consistency
-  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, edm::WaitingTaskWithArenaHolder holder) final {
-  }
   virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
   //derived classes use a dedicated analyze() interface that incorporates client_.output()
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) final {

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -39,8 +39,7 @@ public:
 
     //pattern similar to ExternalWork, but blocking
     auto t1 = std::chrono::high_resolution_clock::now();
-    edm::WaitingTaskWithArenaHolder holder;
-    client_.dispatch(holder);
+    client_.dispatch();
 
     //measure time between acquire and produce
     sonic_utils::printDebugTime(client_.debugName(), "dispatch() time: ", t1);

--- a/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
+++ b/HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h
@@ -1,0 +1,66 @@
+#ifndef HeterogeneousCore_SonicCore_SonicOneEDAnalyzer
+#define HeterogeneousCore_SonicCore_SonicOneEDAnalyzer
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicClientBase.h"
+#include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
+
+#include <string>
+#include <chrono>
+
+//this is a one analyzer to enable writing trees/histograms for analysis users with results from inference as a service
+template <typename Client, typename... Capabilities>
+class SonicOneEDAnalyzer : public edm::one::EDAnalyzer<Capabilities...> {
+public:
+  //typedefs to simplify usage
+  typedef typename Client::Input Input;
+  typedef typename Client::Output Output;
+  //constructor
+  SonicOneEDAnalyzer(edm::ParameterSet const& cfg) : client_(cfg.getParameter<edm::ParameterSet>("Client")) {
+    //ExternalWork is not compatible with one modules, so Sync mode is enforced
+    if (client_.mode() != SonicMode::Sync)
+      throw cms::Exception("UnsupportedMode") << "SonicOneEDAnalyzer can only use Sync mode for clients";
+  }
+  //destructor
+  ~SonicOneEDAnalyzer() override = default;
+
+  //derived classes still use a dedicated acquire() interface that incorporates client_.input() for consistency
+  void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, edm::WaitingTaskWithArenaHolder holder) final {
+  }
+  virtual void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) = 0;
+  //derived classes use a dedicated analyze() interface that incorporates client_.output()
+  void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) final {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    acquire(iEvent, iSetup, client_.input());
+    sonic_utils::printDebugTime(client_.debugName(), "acquire() time: ", t0);
+
+    //pattern similar to ExternalWork, but blocking
+    auto t1 = std::chrono::high_resolution_clock::now();
+    edm::WaitingTaskWithArenaHolder holder;
+    client_.dispatch(holder);
+
+    //measure time between acquire and produce
+    sonic_utils::printDebugTime(client_.debugName(), "dispatch() time: ", t1);
+
+    auto t2 = std::chrono::high_resolution_clock::now();
+    analyze(iEvent, iSetup, client_.output());
+    sonic_utils::printDebugTime(client_.debugName(), "analyze() time: ", t2);
+
+    //reset client data
+    client_.reset();
+  }
+  virtual void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) = 0;
+
+protected:
+  //for debugging
+  void setDebugName(const std::string& debugName) { client_.setDebugName(debugName); }
+  //members
+  Client client_;
+};
+
+#endif

--- a/HeterogeneousCore/SonicCore/interface/sonic_utils.h
+++ b/HeterogeneousCore/SonicCore/interface/sonic_utils.h
@@ -1,0 +1,13 @@
+#ifndef HeterogeneousCore_SonicCore_sonic_utils
+#define HeterogeneousCore_SonicCore_sonic_utils
+
+#include <string_view>
+#include <chrono>
+
+namespace sonic_utils {
+	using TimePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
+
+	void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0);
+}
+
+#endif

--- a/HeterogeneousCore/SonicCore/interface/sonic_utils.h
+++ b/HeterogeneousCore/SonicCore/interface/sonic_utils.h
@@ -5,9 +5,9 @@
 #include <chrono>
 
 namespace sonic_utils {
-	using TimePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
+  using TimePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
-	void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0);
-}
+  void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0);
+}  // namespace sonic_utils
 
 #endif

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -34,7 +34,6 @@ void SonicClientBase::start(edm::WaitingTaskWithArenaHolder holder) {
 }
 
 void SonicClientBase::start() {
-  holder_.reset();
   tries_ = 0;
   if (!debugName_.empty())
     t0_ = std::chrono::high_resolution_clock::now();
@@ -62,9 +61,10 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
     edm::LogInfo(fullDebugName_) << "Client time: "
                                  << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0_).count();
   }
-  if (holder_)
+  if (holder_) {
     holder_->doneWaiting(eptr);
-  else if (eptr)
+    holder_.reset();
+  } else if (eptr)
     std::rethrow_exception(eptr);
 }
 

--- a/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicClientBase.cc
@@ -62,9 +62,9 @@ void SonicClientBase::finish(bool success, std::exception_ptr eptr) {
     edm::LogInfo(fullDebugName_) << "Client time: "
                                  << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0_).count();
   }
-  if(holder_)
+  if (holder_)
     holder_->doneWaiting(eptr);
-  else if(eptr)
+  else if (eptr)
     std::rethrow_exception(eptr);
 }
 

--- a/HeterogeneousCore/SonicCore/src/SonicDispatcher.cc
+++ b/HeterogeneousCore/SonicCore/src/SonicDispatcher.cc
@@ -5,3 +5,8 @@ void SonicDispatcher::dispatch(edm::WaitingTaskWithArenaHolder holder) {
   client_->start(std::move(holder));
   client_->evaluate();
 }
+
+void SonicDispatcher::dispatch() {
+  client_->start();
+  client_->evaluate();
+}

--- a/HeterogeneousCore/SonicCore/src/sonic_utils.cc
+++ b/HeterogeneousCore/SonicCore/src/sonic_utils.cc
@@ -1,0 +1,14 @@
+#include "HeterogeneousCore/SonicCore/interface/sonic_utils.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <string_view>
+#include <string>
+#include <chrono>
+
+namespace sonic_utils {
+	void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0){
+		auto t1 = std::chrono::high_resolution_clock::now();
+		if(debugName.empty()) return;
+		edm::LogInfo(std::string(debugName)) << msg << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+	}
+}

--- a/HeterogeneousCore/SonicCore/src/sonic_utils.cc
+++ b/HeterogeneousCore/SonicCore/src/sonic_utils.cc
@@ -5,9 +5,10 @@
 #include <chrono>
 
 namespace sonic_utils {
-	void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0){
-		auto t1 = std::chrono::high_resolution_clock::now();
-		if(debugName.empty()) return;
-		edm::LogInfo(debugName) << msg << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
-	}
-}
+  void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0) {
+    auto t1 = std::chrono::high_resolution_clock::now();
+    if (debugName.empty())
+      return;
+    edm::LogInfo(debugName) << msg << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+  }
+}  // namespace sonic_utils

--- a/HeterogeneousCore/SonicCore/src/sonic_utils.cc
+++ b/HeterogeneousCore/SonicCore/src/sonic_utils.cc
@@ -2,13 +2,12 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <string_view>
-#include <string>
 #include <chrono>
 
 namespace sonic_utils {
 	void printDebugTime(std::string_view debugName, std::string_view msg, const TimePoint& t0){
 		auto t1 = std::chrono::high_resolution_clock::now();
 		if(debugName.empty()) return;
-		edm::LogInfo(std::string(debugName)) << msg << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+		edm::LogInfo(debugName) << msg << std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
 	}
 }

--- a/HeterogeneousCore/SonicCore/test/BuildFile.xml
+++ b/HeterogeneousCore/SonicCore/test/BuildFile.xml
@@ -1,6 +1,8 @@
 <environment>
-  <test name="TestHeterogeneousCoreSonicCore" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py"/>
-  <library file="SonicDummyProducer.cc">
+  <test name="TestHeterogeneousCoreSonicCoreProducer" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py moduleType=Producer"/>
+  <test name="TestHeterogeneousCoreSonicCoreFilter" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py moduleType=Filter"/>
+  <test name="TestHeterogeneousCoreSonicCoreOneAnalyzer" command="cmsRun ${LOCALTOP}/src/HeterogeneousCore/SonicCore/test/sonicTestAna_cfg.py"/>
+  <library file="SonicDummyProducer.cc,SonicDummyFilter.cc,SonicDummyOneAnalyzer.cc" name="HeterogeneousCoreSonicCoreTest">
     <flags EDM_PLUGIN="1"/>
     <use name="HeterogeneousCore/SonicCore"/>
     <use name="DataFormats/TestObjects"/>

--- a/HeterogeneousCore/SonicCore/test/SonicDummyFilter.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyFilter.cc
@@ -1,0 +1,42 @@
+#include "DummyClient.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicEDFilter.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <memory>
+
+namespace sonictest {
+  class SonicDummyFilter : public SonicEDFilter<DummyClient> {
+  public:
+    explicit SonicDummyFilter(edm::ParameterSet const& cfg)
+        : SonicEDFilter<DummyClient>(cfg), input_(cfg.getParameter<int>("input")) {
+      //for debugging
+      setDebugName("SonicDummyFilter");
+      putToken_ = produces<edmtest::IntProduct>();
+    }
+
+    void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override { iInput = input_; }
+
+    bool filter(edm::Event& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+      iEvent.emplace(putToken_, iOutput);
+      return true;
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      DummyClient::fillPSetDescription(desc);
+      desc.add<int>("input");
+      //to ensure distinct cfi names
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    //members
+    int input_;
+    edm::EDPutTokenT<edmtest::IntProduct> putToken_;
+  };
+}  // namespace sonictest
+
+using sonictest::SonicDummyFilter;
+DEFINE_FWK_MODULE(SonicDummyFilter);

--- a/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
@@ -1,0 +1,43 @@
+#include "DummyClient.h"
+#include "HeterogeneousCore/SonicCore/interface/SonicOneEDAnalyzer.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <memory>
+
+namespace sonictest {
+  //designed similar to IntTestAnalyzer
+  class SonicDummyOneAnalyzer : public SonicOneEDAnalyzer<DummyClient> {
+  public:
+    explicit SonicDummyOneAnalyzer(edm::ParameterSet const& cfg)
+        : SonicOneEDAnalyzer<DummyClient>(cfg), input_(cfg.getParameter<int>("input")), expected_(cfg.getParameter<int>("expected")) {
+      //for debugging
+      setDebugName("SonicDummyOneAnalyzer");
+    }
+
+    void acquire(edm::Event const& iEvent, edm::EventSetup const& iSetup, Input& iInput) override { iInput = input_; }
+
+    void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
+      if (iOutput != expected_)
+        throw cms::Exception("ValueMismatch") << "The value is " << iOutput << " but it was supposed to be " << expected_;
+    }
+
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+      edm::ParameterSetDescription desc;
+      DummyClient::fillPSetDescription(desc);
+      desc.add<int>("input");
+      desc.add<int>("expected");
+      //to ensure distinct cfi names
+      descriptions.addWithDefaultLabel(desc);
+    }
+
+  private:
+    //members
+    int input_, expected_;
+  };
+}  // namespace sonictest
+
+using sonictest::SonicDummyOneAnalyzer;
+DEFINE_FWK_MODULE(SonicDummyOneAnalyzer);

--- a/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
+++ b/HeterogeneousCore/SonicCore/test/SonicDummyOneAnalyzer.cc
@@ -12,7 +12,9 @@ namespace sonictest {
   class SonicDummyOneAnalyzer : public SonicOneEDAnalyzer<DummyClient> {
   public:
     explicit SonicDummyOneAnalyzer(edm::ParameterSet const& cfg)
-        : SonicOneEDAnalyzer<DummyClient>(cfg), input_(cfg.getParameter<int>("input")), expected_(cfg.getParameter<int>("expected")) {
+        : SonicOneEDAnalyzer<DummyClient>(cfg),
+          input_(cfg.getParameter<int>("input")),
+          expected_(cfg.getParameter<int>("expected")) {
       //for debugging
       setDebugName("SonicDummyOneAnalyzer");
     }
@@ -21,7 +23,8 @@ namespace sonictest {
 
     void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup, Output const& iOutput) override {
       if (iOutput != expected_)
-        throw cms::Exception("ValueMismatch") << "The value is " << iOutput << " but it was supposed to be " << expected_;
+        throw cms::Exception("ValueMismatch")
+            << "The value is " << iOutput << " but it was supposed to be " << expected_;
     }
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/HeterogeneousCore/SonicCore/test/sonicTestAna_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTestAna_cfg.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.options.numberOfThreads = 2
+process.options.numberOfStreams = 0
+
+process.dummySyncAna = cms.EDAnalyzer("SonicDummyOneAnalyzer",
+    input = cms.int32(1),
+    expected = cms.int32(-1),
+    Client = cms.PSet(
+        mode = cms.string("Sync"),
+        factor = cms.int32(-1),
+        wait = cms.int32(10),
+        allowedTries = cms.untracked.uint32(0),
+        fails = cms.uint32(0),
+    ),
+)
+
+process.dummySyncAnaRetry = process.dummySyncAna.clone(
+    Client = dict(
+        wait = 2,
+        allowedTries = 2,
+        fails = 1,
+    )
+)
+
+process.p1 = cms.Path(process.dummySyncAna)
+process.p2 = cms.Path(process.dummySyncAnaRetry)

--- a/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
+++ b/HeterogeneousCore/SonicCore/test/sonicTest_cfg.py
@@ -1,4 +1,15 @@
 import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+options = VarParsing()
+options.register("moduleType","", VarParsing.multiplicity.singleton, VarParsing.varType.string)
+options.parseArguments()
+
+_allowedModuleTypes = ["Producer","Filter"]
+if options.moduleType not in ["Producer","Filter"]:
+    raise ValueError("Unknown module type: {} (allowed: {})".format(options.moduleType,_allowedModuleTypes))
+_moduleName = "SonicDummy"+options.moduleType
+_moduleClass = getattr(cms,"ED"+options.moduleType)
 
 process = cms.Process("Test")
 
@@ -9,7 +20,7 @@ process.maxEvents.input = 1
 process.options.numberOfThreads = 2
 process.options.numberOfStreams = 0
 
-process.dummySync = cms.EDProducer("SonicDummyProducer",
+process.dummySync = _moduleClass(_moduleName,
     input = cms.int32(1),
     Client = cms.PSet(
         mode = cms.string("Sync"),
@@ -20,7 +31,7 @@ process.dummySync = cms.EDProducer("SonicDummyProducer",
     ),
 )
 
-process.dummyPseudoAsync = cms.EDProducer("SonicDummyProducer",
+process.dummyPseudoAsync = _moduleClass(_moduleName,
     input = cms.int32(2),
     Client = cms.PSet(
         mode = cms.string("PseudoAsync"),
@@ -31,7 +42,7 @@ process.dummyPseudoAsync = cms.EDProducer("SonicDummyProducer",
     ),
 )
 
-process.dummyAsync = cms.EDProducer("SonicDummyProducer",
+process.dummyAsync = _moduleClass(_moduleName,
     input = cms.int32(3),
     Client = cms.PSet(
         mode = cms.string("Async"),


### PR DESCRIPTION
#### PR description:

* Add `SonicEDFilter` (also a `stream` module)
* Add `SonicOneEDAnalyzer` (a `one` module, synchronous calls required since ExternalWork is not compatible)

It turns out that ExternalWork is not available for `stream` or `global` EDAnalyzer modules. This could be added in the framework, but I haven't had time to do that so far. It will be considered for a later development item, if there are motivating use cases. (The `one` analyzer module is intended to facilitate rapid prototyping by end users who want ML inference results for their analysis. For more complicated cases, it's still probably best to use `SonicEDProducer` for inference and a separate `one` analyzer just to write the ROOT files.)

Some common operations are extracted into utility functions and a common base class for modules that use ExternalWork. (The common base class re-introduces some template dependent scope issues, but these are contained within SonicCore, and should not affect downstream implementation.) Documentation and tests are updated accordingly.

#### PR validation:

Unit tests pass.