### PR TITLE
xrd commands are deprecated, use xrdfs instead

### DIFF
--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -12,15 +12,15 @@ import re
 
 defaultEOSRootPath = '/eos/cms/store/lhe'
 defaultEOSLoadPath = 'root://eoscms/'
-defaultEOSlistCommand = 'xrd eoscms dirlist '
-defaultEOSmkdirCommand = 'xrd eoscms mkdir '
-defaultEOSfeCommand = 'xrd eoscms existfile '
+defaultEOSlistCommand = 'xrdfs eoscms ls '
+defaultEOSmkdirCommand = 'xrdfs eoscms mkdir '
+defaultEOSfeCommand = 'xrdfs eoscms stat -q IsReadable '
 defaultEOScpCommand = 'xrdcp -np '
 
 def findXrdDir(theDirRecord):
 
     elements = theDirRecord.split(' ')
-    if len(elements) > 1:
+    if len(elements):
         return elements[-1].rstrip('\n').split('/')[-1]
     else:
         return None
@@ -65,7 +65,7 @@ def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt):
         theCommand = defaultEOSfeCommand+' '+newFileName
         exeFullList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE)
         result = exeFullList.stdout.readlines()
-        if result[0].rstrip('\n') == 'The file exists.':
+        if result[-1].rstrip('\n') == 'Query:  IsReadable':
             addFile = False
             print('File '+newFileName+' already exists: do you want to overwrite? [y/n]')
             reply = raw_input()

--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -12,9 +12,9 @@ import re
 
 defaultEOSRootPath = '/eos/cms/store/lhe'
 defaultEOSLoadPath = 'root://eoscms/'
-defaultEOSlistCommand = 'xrdfs eoscms ls '
-defaultEOSmkdirCommand = 'xrdfs eoscms mkdir '
-defaultEOSfeCommand = 'xrdfs eoscms stat -q IsReadable '
+defaultEOSlistCommand = 'xrdfs root://eoscms.cern.ch ls '
+defaultEOSmkdirCommand = 'xrdfs root://eoscms.cern.ch mkdir '
+defaultEOSfeCommand = 'xrdfs root://eoscms.cern.ch stat -q IsReadable '
 defaultEOScpCommand = 'xrdcp -np '
 
 def findXrdDir(theDirRecord):


### PR DESCRIPTION
`xrd` command is deprecated and it is suggested to use `xrdfs`. Few workflows[a] in 11.2 and 11.1 IBs are failing due to this. This PR suggests to use `xrdfs` command instead

[a] wf: 1370.* , 25125.*
LHE input from article  18334
Note: this tool is DEPRECATED, use xrdfs instead.
Issue to load LHE files, please check and try again.
