### PR TITLE
Remove setConsumes() from ESConsumesCollector

### DIFF
--- a/FWCore/Framework/interface/ESConsumesCollector.h
+++ b/FWCore/Framework/interface/ESConsumesCollector.h
@@ -91,18 +91,6 @@ namespace edm {
       return ESGetToken<Product, Record>{m_transitionID, index, m_consumer->back().productKey_.name().value()};
     }
 
-    template <typename Product, typename Record>
-    ESConsumesCollector& setConsumes(ESGetToken<Product, Record>& token, ESInputTag const& tag) {
-      token = consumesFrom<Product, Record>(tag);
-      return *this;
-    }
-
-    template <typename Product, typename Record>
-    ESConsumesCollector& setConsumes(ESGetToken<Product, Record>& token) {
-      token = consumesFrom<Product, Record>();
-      return *this;
-    }
-
     ESConsumesCollectorAdaptor consumes();
     ESConsumesCollectorWithTagAdaptor consumes(ESInputTag tag);
 
@@ -114,7 +102,7 @@ namespace edm {
     auto registerMayConsume(std::unique_ptr<Collector> iCollector, PTag const& productTag) {
       //NOTE: for now, just treat like standard consumes request for the product needed to
       // do the decision
-      setConsumes(iCollector->token(), productTag.inputTag());
+      iCollector->token() = consumes(productTag.inputTag());
 
       using namespace edm::eventsetup;
       ESTokenIndex index{static_cast<ESTokenIndex::Value_t>(m_consumer->size())};

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -654,18 +654,6 @@ private:
   edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
 };
 
-class SetConsumesProducer : public ESProducer {
-public:
-  SetConsumesProducer() { setWhatProduced(this, "setConsumes").setConsumes(token_); }
-  std::unique_ptr<edm::eventsetup::test::DummyData> produce(const DummyRecord& iRecord) {
-    auto const& data = iRecord.get(token_);
-    return std::make_unique<edm::eventsetup::test::DummyData>(data);
-  }
-
-private:
-  edm::ESGetToken<edm::eventsetup::test::DummyData, DummyRecord> token_;
-};
-
 //This is used only to test compilation
 class [[maybe_unused]] ESConsumesCollectorProducer : public ESProducer {
 public:
@@ -788,17 +776,6 @@ void testEventsetup::getDataWithESGetTokenTest() {
       provider.add(dummyProv);
     }
     {
-      edm::eventsetup::ComponentDescription description("SetConsumesProducer", "setConsumes", false);
-      edm::ParameterSet ps;
-      ps.addParameter<std::string>("name", "setConsumes");
-      ps.registerIt();
-      description.pid_ = ps.id();
-      auto dummyProv = std::make_shared<SetConsumesProducer>();
-      dummyProv->setDescription(description);
-      dummyProv->setAppendToDataLabel(ps);
-      provider.add(dummyProv);
-    }
-    {
       edm::eventsetup::ComponentDescription description("SetMayConsumeProducer", "setMayConsumeSuceed", false);
       edm::ParameterSet ps;
       ps.addParameter<std::string>("name", "setMayConsumeSuceed");
@@ -890,17 +867,6 @@ void testEventsetup::getDataWithESGetTokenTest() {
     }
     {
       DummyDataConsumer consumer{edm::ESInputTag("", "consumesFrom")};
-      consumer.updateLookup(provider.recordsToProxyIndices());
-      consumer.prefetch(provider.eventSetupImpl());
-      EventSetup eventSetup{provider.eventSetupImpl(),
-                            static_cast<unsigned int>(edm::Transition::Event),
-                            consumer.esGetTokenIndices(edm::Transition::Event),
-                            true};
-      const DummyData& data = eventSetup.getData(consumer.m_token);
-      CPPUNIT_ASSERT(kBad.value_ == data.value_);
-    }
-    {
-      DummyDataConsumer consumer{edm::ESInputTag("", "setConsumes")};
       consumer.updateLookup(provider.recordsToProxyIndices());
       consumer.prefetch(provider.eventSetupImpl());
       EventSetup eventSetup{provider.eventSetupImpl(),


### PR DESCRIPTION
#### PR description:

The functionality was replaced with the type-deducing `consumes()` in  #31223. All ESProducer code that used `setConsumes()` should have been already migrated to the type-deducing `consumes()`.

#### PR validation:

Framework unit tests pass.