### PR TITLE
Restore option to match GEM digis to simhits

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
+++ b/Validation/MuonCSCDigis/src/CSCStubMatcher.cc
@@ -22,7 +22,7 @@ CSCStubMatcher::CSCStubMatcher(const edm::ParameterSet& pSet, edm::ConsumesColle
   maxBXLCT_ = cscLCT.getParameter<int>("maxBX");
   verboseLCT_ = cscLCT.getParameter<int>("verbose");
   minNHitsChamberLCT_ = cscLCT.getParameter<int>("minNHitsChamber");
-  addGhostLCTs_ = cscLCT.getParameter<bool>("addGhostLCTs");
+  addGhostLCTs_ = cscLCT.getParameter<bool>("addGhosts");
 
   const auto& cscMPLCT = pSet.getParameter<edm::ParameterSet>("cscMPLCT");
   minBXMPLCT_ = cscMPLCT.getParameter<int>("minBX");

--- a/Validation/MuonGEMDigis/interface/GEMDigiMatcher.h
+++ b/Validation/MuonGEMDigis/interface/GEMDigiMatcher.h
@@ -154,6 +154,8 @@ private:
   bool verboseCluster_;
   bool verboseCoPad_;
 
+  bool matchToSimLink_;
+
   std::map<unsigned int, GEMDigiSimLinkContainer> detid_to_simLinks_;
 
   std::map<unsigned int, GEMDigiContainer> detid_to_digis_;

--- a/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
+++ b/Validation/MuonGEMDigis/python/muonGEMDigiPSet.py
@@ -13,6 +13,7 @@ muonGEMDigiPSet = cms.PSet(
         minBX = cms.int32(-1),
         maxBX = cms.int32(1),
         matchDeltaStrip = cms.int32(1),
+        matchToSimLink = cms.bool(True)
     ),
     gemUnpackedStripDigi = cms.PSet(
         verbose = cms.int32(0),

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -11,7 +11,9 @@ GEMDigiMatcher::GEMDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   const auto& gemDigi = pset.getParameterSet("gemStripDigi");
   minBXDigi_ = gemDigi.getParameter<int>("minBX");
   maxBXDigi_ = gemDigi.getParameter<int>("maxBX");
+  matchDeltaStrip_ = gemDigi.getParameter<int>("matchDeltaStrip");
   verboseDigi_ = gemDigi.getParameter<int>("verbose");
+  matchToSimLink_ = gemDigi.getParameter<int>("matchToSimLink");
 
   const auto& gemPad = pset.getParameterSet("gemPadDigi");
   minBXPad_ = gemPad.getParameter<int>("minBX");
@@ -131,10 +133,12 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
     edm::LogInfo("GEMDigiMatcher") << "Matching simtrack to GEM digis" << endl;
   for (auto id : muonSimHitMatcher_->detIds()) {
     GEMDetId p_id(id);
-
+    const auto& hit_strips = muonSimHitMatcher_->hitStripsInDetId(id, matchDeltaStrip_);
     const auto& digis_in_det = digis.get(p_id);
 
     for (auto d = digis_in_det.first; d != digis_in_det.second; ++d) {
+      bool isMatched = false;
+
       // check that the digi is within BX range
       if (d->bx() < minBXDigi_ || d->bx() > maxBXDigi_)
         continue;
@@ -142,21 +146,33 @@ void GEMDigiMatcher::matchDigisToSimTrack(const GEMDigiCollection& digis) {
       if (verboseDigi_)
         edm::LogInfo("GEMDigiMatcher") << "GEMDigi " << p_id << " " << *d << endl;
 
-      // check that the digi matches to at least one GEMDigiSimLink
-      for (const auto& sl : detid_to_simLinks_[p_id.rawId()]) {
-        if (sl.getStrip() == d->strip() and sl.getBx() == d->bx()) {
-          detid_to_digis_[p_id.rawId()].push_back(*d);
-          chamber_to_digis_[p_id.chamberId().rawId()].push_back(*d);
-          superchamber_to_digis_[p_id.superChamberId().rawId()].push_back(*d);
-          if (verboseDigi_)
-            edm::LogInfo("GEMDigiMatcher") << "...was matched!" << endl;
-          break;
+      // GEN-SIM-DIGI-RAW monte carlo
+      if (matchToSimLink_) {
+        // check that the digi matches to at least one GEMDigiSimLink
+        for (const auto& sl : detid_to_simLinks_[p_id.rawId()]) {
+          if (sl.getStrip() == d->strip() and sl.getBx() == d->bx()) {
+            isMatched = true;
+            break;
+          }
         }
+      }
+      // GEN-SIM-RAW monte carlo
+      else {
+        // check that it matches a strip that was hit by SimHits from our track
+        if (hit_strips.find(d->strip()) != hit_strips.end()) {
+          isMatched = true;
+        }
+      }
+      if (isMatched) {
+        detid_to_digis_[p_id.rawId()].push_back(*d);
+        chamber_to_digis_[p_id.chamberId().rawId()].push_back(*d);
+        superchamber_to_digis_[p_id.superChamberId().rawId()].push_back(*d);
+        if (verboseDigi_)
+          edm::LogInfo("GEMDigiMatcher") << "...was matched!" << endl;
       }
     }
   }
 }
-
 void GEMDigiMatcher::matchPadsToSimTrack(const GEMPadDigiCollection& pads) {
   const auto& det_ids = muonSimHitMatcher_->detIds();
   for (const auto& id : det_ids) {


### PR DESCRIPTION
#### PR description:

In #30608 I enabled the option to match GEM digis to GEM simlinks. That is fine for most GEN-SIM-DIGI-RAW samples for Run-3 or Phase-2. In some currently used Run-3 GEN-SIM-RAW samples the GEM simlinks are not available. So I need to restore the option to match GEM digis directly to GEM simhits for those GEN-SIM-RAW samples.

I also fixed a typo in the CSC stub matcher configuration.

#### PR validation:

Tested with WF 11650.0.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A