### PR TITLE
Conclude removal of type specification from RecoBTag

### DIFF
--- a/RecoBTag/Combined/python/pfDeepCSVJetTags_cfi.py
+++ b/RecoBTag/Combined/python/pfDeepCSVJetTags_cfi.py
@@ -1,19 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-pfDeepCSVJetTags = cms.EDProducer(
-	'DeepFlavourJetTagsProducer',
-	src = cms.InputTag('pfDeepCSVTagInfos'),
-  checkSVForDefaults = cms.bool(False),
-  meanPadding = cms.bool(False),
-	NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourNoSL.json'),
-  toAdd = cms.PSet(
-      probcc = cms.string('probc')
-      ),
-	)
+pfDeepCSVJetTags = cms.EDProducer('DeepFlavourJetTagsProducer',
+    src = cms.InputTag('pfDeepCSVTagInfos'),
+    checkSVForDefaults = cms.bool(False),
+    meanPadding = cms.bool(False),
+    NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepFlavourNoSL.json'),
+    toAdd = cms.PSet(
+        probcc = cms.string('probc')
+    ),
+)
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
 phase1Pixel.toModify(pfDeepCSVJetTags, 
-                     NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseI.json'),
+                     NNConfig = 'RecoBTag/Combined/data/DeepCSV_PhaseI.json',
                      checkSVForDefaults = True,
                      meanPadding = True,
                      toAdd = cms.PSet()
@@ -21,7 +20,7 @@ phase1Pixel.toModify(pfDeepCSVJetTags,
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(pfDeepCSVJetTags, 
-                       NNConfig = cms.FileInPath('RecoBTag/Combined/data/DeepCSV_PhaseII.json'),
+                       NNConfig = 'RecoBTag/Combined/data/DeepCSV_PhaseII.json',
                        checkSVForDefaults = True,
                        meanPadding = True,
                        toAdd = cms.PSet()


### PR DESCRIPTION
#### PR description:

A couple of parameters were forgotten in #31538, when the type specification was removed from cloned/modified configs
This is completed here (together with some "innocent" realignment of the config parameters listed for `pfDeepCSVJetTags`)