### PR TITLE
ParticleNetAK4 jet tagger

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -49,6 +49,7 @@ supportedBtagInfos = [
   , 'pfParticleNetTagInfos'
     # ParticleNet (AK4) tag infos
   , 'pfParticleNetAK4TagInfos'
+  , 'pfNegativeParticleNetAK4TagInfos'
     # Pixel Cluster tag infos
   , 'pixelClusterTagInfos'
     # HiggsInteractionNet tag infos
@@ -267,6 +268,11 @@ for disc in _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs:
 # update supportedMetaDiscr
 for disc in _pfParticleNetAK4JetTagsMetaDiscrs:
     supportedMetaDiscr[disc] = _pfParticleNetAK4JetTagsProbs
+# -----------------------------------
+# setup Negative ParticleNet AK4
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfNegativeParticleNetAK4JetTagsProbs
+for disc in _pfNegativeParticleNetAK4JetTagsProbs:
+    supportedBtagDiscr[disc] = [["pfNegativeParticleNetAK4TagInfos"]]
 # -----------------------------------
 
 # -----------------------------------

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -45,8 +45,10 @@ supportedBtagInfos = [
   , 'pfDeepDoubleXTagInfos'
     # DeepBoostedJet tag infos
   , 'pfDeepBoostedJetTagInfos'
-    # ParticleNet tag infos
+    # ParticleNet (AK8) tag infos
   , 'pfParticleNetTagInfos'
+    # ParticleNet (AK4) tag infos
+  , 'pfParticleNetAK4TagInfos'
     # Pixel Cluster tag infos
   , 'pixelClusterTagInfos'
     # HiggsInteractionNet tag infos
@@ -243,7 +245,7 @@ for disc in _pfMassDecorrelatedDeepBoostedJetTagsMetaDiscrs:
 # -----------------------------------
 
 # -----------------------------------
-# setup ParticleNet
+# setup ParticleNet AK8
 from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs, _pfParticleNetJetTagsMetaDiscrs, \
     _pfMassDecorrelatedParticleNetJetTagsProbs, _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs
 # update supportedBtagDiscr
@@ -255,8 +257,22 @@ for disc in _pfParticleNetJetTagsMetaDiscrs:
 for disc in _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs:
     supportedMetaDiscr[disc] = _pfMassDecorrelatedParticleNetJetTagsProbs
 # -----------------------------------
+
+# -----------------------------------
+# setup ParticleNet AK4
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsProbs, _pfParticleNetAK4JetTagsMetaDiscrs
+# update supportedBtagDiscr
+for disc in _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs:
+    supportedBtagDiscr[disc] = [["pfParticleNetAK4TagInfos"]]
+# update supportedMetaDiscr
+for disc in _pfParticleNetAK4JetTagsMetaDiscrs:
+    supportedMetaDiscr[disc] = _pfParticleNetAK4JetTagsProbs
+# -----------------------------------
+
+# -----------------------------------
 # setup HiggsInteractionNet
 from RecoBTag.ONNXRuntime.pfHiggsInteractionNet_cff import _pfHiggsInteractionNetTagsProbs
 # update supportedBtagDiscr 
 for disc in _pfHiggsInteractionNetTagsProbs:
     supportedBtagDiscr[disc] = [["pfHiggsInteractionNetTagInfos"]]
+# -----------------------------------

--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -9,6 +9,7 @@ def applyDeepBtagging( process, postfix="" ) :
     from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
+    from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll as pfParticleNetAK4JetTagsAll
 
     # update slimmed jets to include DeepFlavour (keep same name)
     # make clone for DeepFlavour-less slimmed jets, so output name is preserved
@@ -31,7 +32,7 @@ def applyDeepBtagging( process, postfix="" ) :
           'pfDeepFlavourJetTags:probc',
           'pfDeepFlavourJetTags:probuds',
           'pfDeepFlavourJetTags:probg',
-       ],
+       ] + pfParticleNetAK4JetTagsAll,
        postfix = 'SlimmedDeepFlavour'+postfix,
        printWarning = False
     )

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -329,7 +329,11 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
     runNegativeVertexing = False
     runNegativeCvsLVertexing = False
     for btagInfo in requiredTagInfos:
-        if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeTagInfos' or btagInfo == 'pfNegativeDeepFlavourTagInfos':
+        if btagInfo in (
+            'pfInclusiveSecondaryVertexFinderNegativeTagInfos',
+            'pfNegativeDeepFlavourTagInfos',
+            'pfNegativeParticleNetAK4TagInfos',
+            ):
             runNegativeVertexing = True
         if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos':
             runNegativeCvsLVertexing = True
@@ -711,7 +715,15 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
 
             if 'ParticleNetAK4TagInfos' in btagInfo:
-                # TODO: add negative tag
+                if btagInfo == 'pfNegativeParticleNetAK4TagInfos':
+                    secondary_vertices = btagPrefix + \
+                        'inclusiveCandidateNegativeSecondaryVertices' + labelName + postfix
+                    flip_ip_sign = True
+                    sip3dSigMax = 10
+                else:
+                    secondary_vertices = svSource
+                    flip_ip_sign = False
+                    sip3dSigMax = -1
                 if pfCandidates.value() == 'packedPFCandidates':
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
                     puppi_value_map = ""
@@ -727,10 +739,12 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     btag.pfParticleNetAK4TagInfos.clone(
                                       jets = jetSource,
                                       vertices = pvSource,
-                                      secondary_vertices = svSource,
+                                      secondary_vertices = secondary_vertices,
                                       pf_candidates = pfCandidates,
                                       puppi_value_map = puppi_value_map,
                                       vertex_associator = vertex_associator,
+                                      flip_ip_sign = flip_ip_sign,
+                                      sip3dSigMax = sip3dSigMax,
                                       ),
                                     process, task)
 

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -710,6 +710,30 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                       ),
                                     process, task)
 
+            if 'ParticleNetAK4TagInfos' in btagInfo:
+                # TODO: add negative tag
+                if pfCandidates.value() == 'packedPFCandidates':
+                    # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
+                    puppi_value_map = ""
+                    vertex_associator = ""
+                elif pfCandidates.value() == 'particleFlow':
+                    raise ValueError("Running pfDeepBoostedJetTagInfos with reco::PFCandidates is currently not supported.")
+                    # case 2: running on new jet collection whose daughters are PFCandidates (e.g., cluster jets in RECO/AOD)
+                    puppi_value_map = "puppi"
+                    vertex_associator = "primaryVertexAssociation:original"
+                else:
+                    raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
+                addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
+                                    btag.pfParticleNetAK4TagInfos.clone(
+                                      jets = jetSource,
+                                      vertices = pvSource,
+                                      secondary_vertices = svSource,
+                                      pf_candidates = pfCandidates,
+                                      puppi_value_map = puppi_value_map,
+                                      vertex_associator = vertex_associator,
+                                      ),
+                                    process, task)
+
             acceptedTagInfos.append(btagInfo)
         elif hasattr(toptag, btagInfo) :
             acceptedTagInfos.append(btagInfo)

--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -12,6 +12,7 @@ from RecoBTag.ONNXRuntime.pfDeepDoubleX_cff import *
 from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import *
 from RecoBTag.ONNXRuntime.pfHiggsInteractionNet_cff import *
 from RecoBTag.ONNXRuntime.pfParticleNet_cff import *
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import *
 from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import *
 from RecoBTag.PixelCluster.pixelClusterTagInfos_cfi import *
 

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -53,6 +53,8 @@ private:
   const bool include_neutrals_;
   const bool sort_by_sip2dsig_;
   const double min_puppi_wgt_;
+  const bool flip_ip_sign_;
+  const double max_sip3dsig_;
 
   edm::EDGetTokenT<edm::View<reco::Jet>> jet_token_;
   edm::EDGetTokenT<VertexCollection> vtx_token_;
@@ -109,6 +111,8 @@ DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(const edm::Paramete
       include_neutrals_(iConfig.getParameter<bool>("include_neutrals")),
       sort_by_sip2dsig_(iConfig.getParameter<bool>("sort_by_sip2dsig")),
       min_puppi_wgt_(iConfig.getParameter<double>("min_puppi_wgt")),
+      flip_ip_sign_(iConfig.getParameter<bool>("flip_ip_sign")),
+      max_sip3dsig_(iConfig.getParameter<double>("sip3dSigMax")),
       jet_token_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))),
       vtx_token_(consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
       sv_token_(consumes<SVCollection>(iConfig.getParameter<edm::InputTag>("secondary_vertices"))),
@@ -146,6 +150,8 @@ void DeepBoostedJetTagInfoProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<bool>("include_neutrals", true);
   desc.add<bool>("sort_by_sip2dsig", false);
   desc.add<double>("min_puppi_wgt", 0.01);
+  desc.add<bool>("flip_ip_sign", false);
+  desc.add<double>("sip3dSigMax", -1);
   desc.add<edm::InputTag>("vertices", edm::InputTag("offlinePrimaryVertices"));
   desc.add<edm::InputTag>("secondary_vertices", edm::InputTag("inclusiveCandidateSecondaryVertices"));
   desc.add<edm::InputTag>("pf_candidates", edm::InputTag("particleFlow"));
@@ -259,15 +265,24 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
   };
 
   std::vector<reco::CandidatePtr> daughters;
-  for (const auto &cand : jet.daughterPtrVector()) {
+  for (const auto &dau : jet.daughterPtrVector()) {
     // remove particles w/ extremely low puppi weights
-    if ((puppiWgt(cand)) < min_puppi_wgt_)
+    // [Note] use jet daughters here to get the puppiWgt correctly
+    if ((puppiWgt(dau)) < min_puppi_wgt_)
       continue;
-    auto daugh = pfcands_->ptrAt(cand.key());
-    if (!include_neutrals_ && (daugh->charge() == 0 || daugh->pt() < min_pt_for_track_properties_))
+    // from here: get the original reco/packed candidate not scaled by the puppi weight
+    auto cand = pfcands_->ptrAt(dau.key());
+    // charged candidate selection (for Higgs Interaction Net)
+    if (!include_neutrals_ && (cand->charge() == 0 || cand->pt() < min_pt_for_track_properties_))
       continue;
-    // get the original reco/packed candidate not scaled by the puppi weight
-    daughters.push_back(daugh);
+    // only when computing the nagative tagger: remove charged candidates with high sip3d
+    if (flip_ip_sign_ && cand->charge()) {
+      TrackInfoBuilder trkinfo(track_builder_);
+      trkinfo.buildTrackInfo(&(*cand), jet_dir, jet_ref_track_dir, *pv_);
+      if (trkinfo.getTrackSip3dSig() > max_sip3dsig_)
+        continue;
+    }
+    daughters.push_back(cand);
   }
 
   std::vector<btagbtvdeep::SortingClass<reco::CandidatePtr>> c_sorted;
@@ -319,6 +334,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
         ((packed_cand && !packed_cand->hasTrackDetails()) || (reco_cand && !useTrackProperties(reco_cand))))
       continue;
 
+    const float ip_sign = flip_ip_sign_ ? -1 : 1;
+
     auto candP4 = use_puppiP4_ ? puppi_wgt_cache.at(cand.key()) * cand->p4() : cand->p4();
     if (packed_cand) {
       float hcal_fraction = 0.;
@@ -341,10 +358,10 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
       fts.fill("pfcand_isNeutralHad", std::abs(packed_cand->pdgId()) == 130);
 
       // impact parameters
-      fts.fill("pfcand_dz", packed_cand->dz());
-      fts.fill("pfcand_dxy", packed_cand->dxy());
-      fts.fill("pfcand_dzsig", packed_cand->bestTrack() ? packed_cand->dz() / packed_cand->dzError() : 0);
-      fts.fill("pfcand_dxysig", packed_cand->bestTrack() ? packed_cand->dxy() / packed_cand->dxyError() : 0);
+      fts.fill("pfcand_dz", ip_sign * packed_cand->dz());
+      fts.fill("pfcand_dxy", ip_sign * packed_cand->dxy());
+      fts.fill("pfcand_dzsig", packed_cand->bestTrack() ? ip_sign * packed_cand->dz() / packed_cand->dzError() : 0);
+      fts.fill("pfcand_dxysig", packed_cand->bestTrack() ? ip_sign * packed_cand->dxy() / packed_cand->dxyError() : 0);
 
     } else if (reco_cand) {
       // get vertex association quality
@@ -372,8 +389,8 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
 
       // impact parameters
       const auto *trk = reco_cand->bestTrack();
-      float dz = trk ? trk->dz(pv_->position()) : 0;
-      float dxy = trk ? trk->dxy(pv_->position()) : 0;
+      float dz = trk ? ip_sign * trk->dz(pv_->position()) : 0;
+      float dxy = trk ? ip_sign * trk->dxy(pv_->position()) : 0;
       fts.fill("pfcand_dz", dz);
       fts.fill("pfcand_dzsig", trk ? dz / trk->dzError() : 0);
       fts.fill("pfcand_dxy", dxy);
@@ -438,10 +455,10 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
       fts.fill("pfcand_btagEtaRel", trkinfo.getTrackEtaRel());
       fts.fill("pfcand_btagPtRatio", trkinfo.getTrackPtRatio());
       fts.fill("pfcand_btagPParRatio", trkinfo.getTrackPParRatio());
-      fts.fill("pfcand_btagSip2dVal", trkinfo.getTrackSip2dVal());
-      fts.fill("pfcand_btagSip2dSig", trkinfo.getTrackSip2dSig());
-      fts.fill("pfcand_btagSip3dVal", trkinfo.getTrackSip3dVal());
-      fts.fill("pfcand_btagSip3dSig", trkinfo.getTrackSip3dSig());
+      fts.fill("pfcand_btagSip2dVal", ip_sign * trkinfo.getTrackSip2dVal());
+      fts.fill("pfcand_btagSip2dSig", ip_sign * trkinfo.getTrackSip2dSig());
+      fts.fill("pfcand_btagSip3dVal", ip_sign * trkinfo.getTrackSip3dVal());
+      fts.fill("pfcand_btagSip3dSig", ip_sign * trkinfo.getTrackSip3dSig());
       fts.fill("pfcand_btagJetDistVal", trkinfo.getTrackJetDistVal());
     } else {
       fts.fill("pfcand_normchi2", 999);
@@ -516,7 +533,7 @@ void DeepBoostedJetTagInfoProducer::fillSVFeatures(DeepBoostedJetFeatures &fts, 
     fts.fill("sv_d3d", d3d.value());
     fts.fill("sv_d3dsig", d3d.significance());
 
-    fts.fill("sv_costhetasvpv", vertexDdotP(*sv, *pv_));
+    fts.fill("sv_costhetasvpv", (flip_ip_sign_ ? -1.f : 1.f) * vertexDdotP(*sv, *pv_));
   }
 }
 

--- a/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepBoostedJetTagInfoProducer.cc
@@ -47,6 +47,7 @@ private:
 
   const double jet_radius_;
   const double min_jet_pt_;
+  const double max_jet_eta_;
   const double min_pt_for_track_properties_;
   const bool use_puppiP4_;
   const bool include_neutrals_;
@@ -102,6 +103,7 @@ const std::vector<std::string> DeepBoostedJetTagInfoProducer::sv_features_{
 DeepBoostedJetTagInfoProducer::DeepBoostedJetTagInfoProducer(const edm::ParameterSet &iConfig)
     : jet_radius_(iConfig.getParameter<double>("jet_radius")),
       min_jet_pt_(iConfig.getParameter<double>("min_jet_pt")),
+      max_jet_eta_(iConfig.getParameter<double>("max_jet_eta")),
       min_pt_for_track_properties_(iConfig.getParameter<double>("min_pt_for_track_properties")),
       use_puppiP4_(iConfig.getParameter<bool>("use_puppiP4")),
       include_neutrals_(iConfig.getParameter<bool>("include_neutrals")),
@@ -138,6 +140,7 @@ void DeepBoostedJetTagInfoProducer::fillDescriptions(edm::ConfigurationDescripti
   edm::ParameterSetDescription desc;
   desc.add<double>("jet_radius", 0.8);
   desc.add<double>("min_jet_pt", 150);
+  desc.add<double>("max_jet_eta", 99);
   desc.add<double>("min_pt_for_track_properties", -1);
   desc.add<bool>("use_puppiP4", true);
   desc.add<bool>("include_neutrals", true);
@@ -198,7 +201,7 @@ void DeepBoostedJetTagInfoProducer::produce(edm::Event &iEvent, const edm::Event
     // fill values only if above pt threshold and has daughters, otherwise left
     // empty
     bool fill_vars = true;
-    if (jet.pt() < min_jet_pt_)
+    if (jet.pt() < min_jet_pt_ || std::abs(jet.eta()) > max_jet_eta_)
       fill_vars = false;
     if (jet.numberOfDaughters() == 0)
       fill_vars = false;
@@ -398,12 +401,17 @@ void DeepBoostedJetTagInfoProducer::fillParticleFeatures(DeepBoostedJetFeatures 
     fts.fill("pfcand_drminsv", drminpfcandsv);
 
     // subjets
-    auto subjets = patJet->subjets();
-    std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
-      return p1->pt() > p2->pt();
-    });  // sort by pt
-    fts.fill("pfcand_drsubjet1", !subjets.empty() ? reco::deltaR(*cand, *subjets.at(0)) : -1);
-    fts.fill("pfcand_drsubjet2", subjets.size() > 1 ? reco::deltaR(*cand, *subjets.at(1)) : -1);
+    if (patJet->nSubjetCollections() > 0) {
+      auto subjets = patJet->subjets();
+      std::sort(subjets.begin(), subjets.end(), [](const edm::Ptr<pat::Jet> &p1, const edm::Ptr<pat::Jet> &p2) {
+        return p1->pt() > p2->pt();
+      });  // sort by pt
+      fts.fill("pfcand_drsubjet1", !subjets.empty() ? reco::deltaR(*cand, *subjets.at(0)) : -1);
+      fts.fill("pfcand_drsubjet2", subjets.size() > 1 ? reco::deltaR(*cand, *subjets.at(1)) : -1);
+    } else {
+      fts.fill("pfcand_drsubjet1", -1);
+      fts.fill("pfcand_drsubjet2", -1);
+    }
 
     const reco::Track *trk = nullptr;
     if (packed_cand) {

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4DiscriminatorsJetTags_cfi.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4DiscriminatorsJetTags_cfi.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+pfParticleNetAK4DiscriminatorsJetTags = cms.EDProducer(
+   'BTagProbabilityToDiscriminator',
+   discriminators = cms.VPSet(
+      cms.PSet(
+         name = cms.string('BvsAll'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            ),
+         denominator=cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+         ),
+      ),
+      cms.PSet(
+         name = cms.string('CvsL'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('CvsB'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('QvsG'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+            ),
+         ),
+
+      )
+   )

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -34,3 +34,19 @@ _pfParticleNetAK4JetTagsMetaDiscrs = ['pfParticleNetAK4DiscriminatorsJetTags:' +
                                       for disc in pfParticleNetAK4DiscriminatorsJetTags.discriminators]
 
 _pfParticleNetAK4JetTagsAll = _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs
+
+
+# === Negative tags ===
+pfNegativeParticleNetAK4TagInfos = pfParticleNetAK4TagInfos.clone(
+    flip_ip_sign = True,
+    sip3dSigMax = 10,
+    secondary_vertices = 'inclusiveCandidateNegativeSecondaryVertices',
+)
+
+pfNegativeParticleNetAK4JetTags = pfParticleNetAK4JetTags.clone(
+    src = 'pfNegativeParticleNetAK4TagInfos',
+)
+
+# probs
+_pfNegativeParticleNetAK4JetTagsProbs = ['pfNegativeParticleNetAK4JetTags:' + flav_name 
+                                         for flav_name in pfNegativeParticleNetAK4JetTags.flav_names]

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
+from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from RecoBTag.ONNXRuntime.pfParticleNetAK4DiscriminatorsJetTags_cfi import pfParticleNetAK4DiscriminatorsJetTags
+
+pfParticleNetAK4TagInfos = pfDeepBoostedJetTagInfos.clone(
+    jet_radius = 0.4,
+    min_jet_pt = 15,
+    min_puppi_wgt = -1,
+    use_puppiP4 = False,
+)
+
+pfParticleNetAK4JetTags = boostedJetONNXJetTagsProducer.clone(
+    src = 'pfParticleNetAK4TagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess.json',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/particle-net.onnx',
+    flav_names = ["probb",  "probbb",  "probc",   "probcc",  "probuds", "probg", "probundef", "probpu"],
+)
+
+from CommonTools.PileupAlgos.Puppi_cff import puppi
+from PhysicsTools.PatAlgos.slimming.primaryVertexAssociation_cfi import primaryVertexAssociation
+
+# This task is not used, useful only if we run it from RECO jets (RECO/AOD)
+pfParticleNetAK4Task = cms.Task(puppi, primaryVertexAssociation, pfParticleNetAK4TagInfos,
+                                pfParticleNetAK4JetTags, pfParticleNetAK4DiscriminatorsJetTags)
+
+# declare all the discriminators
+# probs
+_pfParticleNetAK4JetTagsProbs = ['pfParticleNetAK4JetTags:' + flav_name
+                                 for flav_name in pfParticleNetAK4JetTags.flav_names]
+# meta-taggers
+_pfParticleNetAK4JetTagsMetaDiscrs = ['pfParticleNetAK4DiscriminatorsJetTags:' + disc.name.value()
+                                      for disc in pfParticleNetAK4DiscriminatorsJetTags.discriminators]
+
+_pfParticleNetAK4JetTagsAll = _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs

--- a/RecoBTag/ONNXRuntime/test/test_particle_net_ak4_cfg.py
+++ b/RecoBTag/ONNXRuntime/test/test_particle_net_ak4_cfg.py
@@ -1,0 +1,76 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing('analysis')
+options.inputFiles = '/store/mc/RunIISummer19UL17MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v4/30000/FFA0194D-1BBC-EF4F-9B8F-8FBED2C62FC8.root'
+options.maxEvents = 1000
+options.parseArguments()
+
+process = cms.Process("PATtest")
+
+## MessageLogger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+
+## Options and Output Report
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+## Source
+process.source = cms.Source("PoolSource",
+    fileNames=cms.untracked.vstring(options.inputFiles)
+)
+## Maximal Number of Events
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(options.maxEvents))
+
+## Geometry and Detector Conditions (needed for a few patTuple production steps)
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic')
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+## Output Module Configuration (expects a path 'p')
+from PhysicsTools.PatAlgos.patEventContent_cff import patEventContentNoCleaning
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName = cms.untracked.string('patTuple.root'),
+                               ## save only events passing the full path
+                               #SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
+                               ## save PAT output; you need a '*' to unpack the list of commands
+                               ## 'patEventContent'
+                               outputCommands = cms.untracked.vstring('drop *', *patEventContentNoCleaning )
+                               )
+
+patAlgosToolsTask = getPatAlgosToolsTask(process)
+process.outpath = cms.EndPath(process.out, patAlgosToolsTask)
+
+## and add them to the event content
+from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll as pfParticleNetAK4JetTagsAll
+
+updateJetCollection(
+   process,
+   jetSource = cms.InputTag('slimmedJets'),
+   pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+   svSource = cms.InputTag('slimmedSecondaryVertices'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+   btagDiscriminators = [
+          'pfDeepFlavourJetTags:probb',
+          'pfDeepFlavourJetTags:probbb',
+          'pfDeepFlavourJetTags:problepb',
+          'pfDeepFlavourJetTags:probc',
+          'pfDeepFlavourJetTags:probuds',
+          'pfDeepFlavourJetTags:probg',
+       ] + pfParticleNetAK4JetTagsAll
+   )
+
+from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
+process.out.outputCommands.append('keep *_slimmedJets*_*_*')
+process.out.outputCommands.append('keep *_offlineSlimmedPrimaryVertices*_*_*')
+process.out.outputCommands.append('keep *_slimmedSecondaryVertices*_*_*')
+process.out.outputCommands.append('keep *_selectedPatJets*_*_*')
+process.out.outputCommands.append('keep *_selectedUpdatedPatJets*_*_*')
+process.out.outputCommands.append('keep *_updatedPatJets*_*_*')
+
+process.out.fileName = 'test_particle_net_ak4_MINIAODSIM.root'


### PR DESCRIPTION
#### PR description:

This PR adds the ParticleNet tagger for AK4 jets. `ParticleNetAK4` is a multi-class tagger for 
 - jet flavour tagging (b, c vs light jets)
 - quark/gluon tagging 
 - pileup jet identification

The current version is trained on standard AK4 CHS jets using UL18 MC. The tagger is based on the [ParticleNet](https://arxiv.org/abs/1902.08570) graph neural network architecture, which is also used in CMSSW for boosted AK8 jet tagging. 

The new `ParticleNetAK4` tagger shows significant performance improvements:
 - large improvements in b-/c-tagging compared to DeepJet, particularly at high pT
 - large improvements in q/g-tagging compared to quark-gluon likelihood, similar/better than DeepJet q/g discriminant
 - similar/better performance in PU rejection than pileup jet ID

More details and comparisons can be found in the presentations in the BTV [[1](https://indico.cern.ch/event/916809/contributions/3995352/attachments/2095427/3521933/ParticleNet_AK4_BTVWG_20200902_H_Qu.pdf), [2](https://indico.cern.ch/event/953344/contributions/4013944/attachments/2106180/3542103/ParticleNet_AK4_BTV_20200921_H_Qu.pdf)] and the JME [[1](https://indico.cern.ch/event/942994/contributions/3964881/attachments/2084240/3501195/ParticleNet_AK4_JMAR_20200803_H_Qu.pdf), [2](https://indico.cern.ch/event/956305/contributions/4027291/attachments/2111830/3552486/ParticleNet_AK4_JMAR_20200929_H_Qu.pdf)) groups.

#### Requires:

https://github.com/cms-data/RecoBTag-Combined/pull/35

#### PR validation:

Implementation of this PR has been verified with the training framework and shows consistent results.

*[Timing]*
Evaluated by running 1k ttbar events using `RecoBTag/ONNXRuntime/test/test_particle_net_ak4_cfg.py`.
```
TimeReport   0.000065     0.000065     0.000065  pfParticleNetAK4DiscriminatorsJetTags
TimeReport   0.036854     0.036854     0.036854  pfParticleNetAK4JetTags
TimeReport   0.002803     0.002803     0.002803  pfParticleNetAK4TagInfos
```

For comparison, below is for DeepJet:
```
TimeReport   0.009825     0.009825     0.009825  pfDeepFlavourJetTags
TimeReport   0.000764     0.000764     0.000764  pfDeepFlavourTagInfos
```

*[Timing for 1325.518]*: https://github.com/cms-sw/cmssw/pull/31570#issuecomment-699823805
Timing for UL reMINIAOD workflow 1325.518 increases by ~6% (0.453879 s/ev -> 0.471795 s/ev).


*[Memory]*

Model init (1.8MB) + execution (3.5MB):
 - http://hqu.web.cern.ch/hqu/dev/cgi-bin/igprof-navigator/ParticleNetAK4-TTHad-CMSSW_11_2_0_pre6-PR31570-MEM_LIVE_99/796
 - http://hqu.web.cern.ch/hqu/dev/cgi-bin/igprof-navigator/ParticleNetAK4-TTHad-CMSSW_11_2_0_pre6-PR31570-MEM_LIVE_99/493



FYI @camclean @alefisico