### PR TITLE
[DD4hep] Use dd4hep::Solid Directly

### DIFF
--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -300,7 +300,7 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
           rin = 0.5 * HGCalParameters::k_ScaleFromDD4Hep * (pars[5] + pars[8]);
           rout = 0.5 * HGCalParameters::k_ScaleFromDD4Hep * (pars[6] + pars[9]);
         } else if (dd4hep::isA<dd4hep::Tube>(fv.solid())) {
-	  dd4hep::Tube tubeSeg(fv.solid());
+          dd4hep::Tube tubeSeg(fv.solid());
           rin = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rMin();
           rout = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rMax();
         }

--- a/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomParameters.cc
@@ -11,7 +11,6 @@
 #include "DetectorDescription/Core/interface/DDSolid.h"
 #include "DetectorDescription/Core/interface/DDValue.h"
 #include "DetectorDescription/Core/interface/DDutils.h"
-#include "DetectorDescription/DDCMS/interface/DDShapes.h"
 #include "DetectorDescription/RegressionTest/interface/DDErrorDetection.h"
 #include "Geometry/HGCalCommonData/interface/HGCalTypes.h"
 #include "Geometry/HGCalCommonData/interface/HGCalWaferIndex.h"
@@ -297,13 +296,13 @@ void HGCalGeomParameters::loadGeometryHexagon(const cms::DDCompactView* cpv,
       double zz = HGCalParameters::k_ScaleFromDD4Hep * fv.translation().Z();
       if (itr == layers.end()) {
         double rin(0), rout(0);
-        if (fv.isA<dd4hep::Polyhedra>()) {
+        if (dd4hep::isA<dd4hep::Polyhedra>(fv.solid())) {
           rin = 0.5 * HGCalParameters::k_ScaleFromDD4Hep * (pars[5] + pars[8]);
           rout = 0.5 * HGCalParameters::k_ScaleFromDD4Hep * (pars[6] + pars[9]);
-        } else if (fv.isATubeSeg()) {
-          cms::dd::DDTubs tubeSeg(fv);
-          rin = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rIn();
-          rout = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rOut();
+        } else if (dd4hep::isA<dd4hep::Tube>(fv.solid())) {
+	  dd4hep::Tube tubeSeg(fv.solid());
+          rin = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rMin();
+          rout = HGCalParameters::k_ScaleFromDD4Hep * tubeSeg.rMax();
         }
         HGCalGeomParameters::layerParameters laypar(rin, rout, zz);
         layers[lay] = laypar;


### PR DESCRIPTION
Use DD4hep API to allow phasing out of the DDShape classes.

@bsunanda - please, check. Thanks.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->


#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
