### PR TITLE
[DD4hep] MTD Shapes Use Cleanup - Use dd4hep::Solid Directly

### DIFF
--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -18,6 +18,7 @@
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
 
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
 

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -18,8 +18,6 @@
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
 
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
-#include "DetectorDescription/DDCMS/interface/DDShapes.h"
-#include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
 
@@ -254,14 +252,14 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
           return ss.str();
         };
 
-        if (!fv.isABox()) {
+        if (!dd4hep::isA<dd4hep::Box>(fv.solid())) {
           throw cms::Exception("TestMTDIdealGeometry") << "MTD sensitive element not a DDBox";
           break;
         }
-        dd::DDBox mySens(fv);
-        spos << "Solid shape name: " << DDSolidShapesName::name(fv.legacyShape(dd::getCurrentShape(fv))) << "\n";
-        spos << "Box dimensions: " << fround(convertCmToMm(mySens.halfX())) << " "
-             << fround(convertCmToMm(mySens.halfY())) << " " << fround(convertCmToMm(mySens.halfZ())) << "\n";
+        dd4hep::Box mySens(fv.solid());
+        spos << "Solid shape name: " << DDSolidShapesName::name(fv.legacyShape(fv.shape())) << "\n";
+        spos << "Box dimensions: " << fround(convertCmToMm(mySens.x())) << " " << fround(convertCmToMm(mySens.y()))
+             << " " << fround(convertCmToMm(mySens.z())) << "\n";
 
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
@@ -273,7 +271,7 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
              << fround(z.Y()) << " " << fround(z.Z()) << "\n";
 
         DD3Vector zeroLocal(0., 0., 0.);
-        DD3Vector cn1Local(mySens.halfX(), mySens.halfY(), mySens.halfZ());
+        DD3Vector cn1Local(mySens.x(), mySens.y(), mySens.z());
         double distLocal = cn1Local.R();
         DD3Vector zeroGlobal = (fv.rotation())(zeroLocal) + fv.translation();
         DD3Vector cn1Global = (fv.rotation())(cn1Local) + fv.translation();


### PR DESCRIPTION
#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->
@fabiocos - FYI

* Use cleaner API: a `FilteredView` itself is not a `Box`, but rather a `FilteredView::shape` is a `Box`
* Use dd4hep Shape type comparison and Shape accessors

This is done in preparation of removing extra classes that duplicate the DD4hep ones:
https://cmssdt.cern.ch/lxr/source/DetectorDescription/DDCMS/interface/DDShapes.h

The functionality is unchanged and the comparison tests pass.

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
