### PR TITLE
Fix compilation in Geometry/MTDCommonData for gcc10 and 9

### DIFF
--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -82,7 +82,6 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   }
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
-      (!preTDR &&
       (!preTDR && (1 > modCopy ||
                    static_cast<unsigned>(std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule)) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -83,7 +83,7 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
       (!preTDR &&
-       (1 > modCopy || (unsigned)std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule) < modCopy))) {
+       (1 > modCopy || static_cast<unsigned>(std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule)) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "
                                << "****************** Bad module copy = " << modCopy
                                << ", Volume Number = " << baseNumber.getCopyNumber(4);

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -82,7 +82,8 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
   }
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
-      (!preTDR && (1 > modCopy || std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule) < modCopy))) {
+      (!preTDR &&
+       (1 > modCopy || (unsigned)std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "
                                << "****************** Bad module copy = " << modCopy
                                << ", Volume Number = " << baseNumber.getCopyNumber(4);

--- a/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
+++ b/Geometry/MTDCommonData/src/ETLNumberingScheme.cc
@@ -83,7 +83,8 @@ uint32_t ETLNumberingScheme::getUnitID(const MTDBaseNumber& baseNumber) const {
 
   if ((preTDR && (1 > modCopy || ETLDetId::kETLv1maxModule < modCopy)) ||
       (!preTDR &&
-       (1 > modCopy || static_cast<unsigned>(std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule)) < modCopy))) {
+      (!preTDR && (1 > modCopy ||
+                   static_cast<unsigned>(std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule)) < modCopy))) {
     edm::LogWarning("MTDGeom") << "ETLNumberingScheme::getUnitID(): "
                                << "****************** Bad module copy = " << modCopy
                                << ", Volume Number = " << baseNumber.getCopyNumber(4);


### PR DESCRIPTION
#### PR description:

Geometry/MTDCommonData fails to compile in gcc10 and gcc9 
because of 
```
  /data/cmsbld/jenkins/workspace/build-any-ib/w/tmp/BUILDROOT/915ba8a2f00f0d1d62c35486d637e2be/opt/cmssw/slc7_amd64_gcc10/cms/cmssw/CMSSW_11_2_X_2020-09-24-2300/src/Geometry/MTDCommonData/src/ETLNumberingScheme.cc:85:98: error: comparison of integer expressions of different signedness: 'const int' and 'const uint32_t' {aka 'const unsigned int'} [-Werror=sign-compare]
    85 |       (!preTDR && (1 > modCopy || std::max(ETLDetId::kETLv4maxModule, ETLDetId::kETLv5maxModule) < modCopy))) {
```
see 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc10/CMSSW_11_2_X_2020-09-24-2300/Geometry/MTDCommonData
std::max returns int and modCopy is uint_32. 
It looks like this PR did it
https://github.com/cms-sw/cmssw/pull/31511

#### PR validation:

builds with gcc10 IB

