### PR TITLE
Protect against ill-defined track momenta and reffited tau vertices for tauReco@mini

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -63,6 +63,9 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(
     std::vector<const reco::Track *> &nonTauTracks) {
   //Find candidates/tracks associated to thePV
   for (const auto &cand : cands) {
+    //MB: Skip candidates with ill-defined momentum as they return ill-defined tracks (why it happens?)
+    if (!std::isfinite(cand.pt()))  //MB: it is enough to check just pt (?)
+      continue;
     if (cand.vertexRef().isNull())
       continue;
     int quality = cand.pvAssociationQuality();
@@ -71,9 +74,6 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(
       continue;
     const reco::Track *track = cand.bestTrack();
     if (track == nullptr)
-      continue;
-    //MB: Skip tracks with ill-defined momentum (why it happens?)
-    if (!std::isfinite(track->pt()) || !std::isfinite(track->eta()) || !std::isfinite(track->phi()))
       continue;
     //Remove signal (tau) tracks
     //MB: Only deltaR deltaPt overlap removal possible (?)

--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -72,6 +72,9 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(
     const reco::Track *track = cand.bestTrack();
     if (track == nullptr)
       continue;
+    //MB: Skip tracks with ill-defined momentum (why it happens?)
+    if (!std::isfinite(track->pt()) || !std::isfinite(track->eta()) || !std::isfinite(track->phi()))
+      continue;
     //Remove signal (tau) tracks
     //MB: Only deltaR deltaPt overlap removal possible (?)
     //MB: It should be fine as pat objects stores same track info with same presision

--- a/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
@@ -204,6 +204,14 @@ void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent, const edm::Even
           } else {
             transVtx = avf.vertex(transTracks, *beamSpot);
           }
+          if (!transVtx.isValid()) {
+            fitOK = false;
+          } else {
+            //MB: protect against rare cases when transVtx is valid but its position is ill-defined
+            reco::Vertex::Point pvPos(transVtx.position());
+            if (!std::isfinite(pvPos.z()))  //MB: it is enough to check one coordinate (?)
+              fitOK = false;
+          }
         } else
           fitOK = false;
         if (fitOK)

--- a/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
@@ -208,8 +208,7 @@ void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent, const edm::Even
             fitOK = false;
           } else {
             //MB: protect against rare cases when transVtx is valid but its position is ill-defined
-            reco::Vertex::Point pvPos(transVtx.position());
-            if (!std::isfinite(pvPos.z()))  //MB: it is enough to check one coordinate (?)
+            if (!std::isfinite(transVtx.position().z()))  //MB: it is enough to check one coordinate (?)
               fitOK = false;
           }
         } else


### PR DESCRIPTION

#### PR description:

As title says; in miniAOD samples (recent 94X/102X productions) there are rare tracks within pat:PackedCandidates (mainly lostTracks collection) with ill-defined momenta, i.e. pt being inf and/or eta nan. Those tracks used to (re)fit tau vertex result with a vertex with an undefined position (reco::Vertex::Point(nan,nan,nan)), but claiming to be a valid transient vertex. This PR protects against such issues - ill-defined tracks are not used for the fit and vertices with invalid position are not used for further processing.

This PR has not impact on official workflows, while it fixes issue causing failures in the tauReco@mini (unoffical) workflow.

We foresee a backport to 10_6_X release series.

It was not checked if the ill-defined momenta are feature introduced in creation of pat::PackedCandidates (it can be caused either by compression or forcing a given mass of a candidate) or already original reco::Tracks are affected => probably should be followed up by XPOG. An example of problematic pat::PackedCandidate can be found in /store/mc/RunIIAutumn18MiniAOD/TauGun_Pt-15to3000_13TeV_pythia8/MINIAODSIM/102X_upgrade2018_realistic_v15-v1/120000/1C5E6BED-FAFA-BC49-AC3C-DDBCC35CBE24.root, Run 1, Event 1556024, LumiSection 1557.


#### PR validation:

* Validated with tauReco@mini (unofficial) workflow that failures observed with original code are fixed.
* Matrix tests (`runTheMatrix.py -l limited -i all --ibeos`) successful.

