### PR TITLE
Use TransitionInfo in more interfaces (more)

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -17,7 +17,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -59,14 +58,9 @@ namespace edm {
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
 
   private:
-    bool doEvent(EventPrincipal const& ep,
-                 EventSetupImpl const& c,
-                 ActivityRegistry* act,
-                 ModuleCallingContext const* mcc);
+    bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by Worker but not something supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                      ModuleCallingContext const& iModuleCallingContext,
-                                      Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
@@ -74,14 +68,10 @@ namespace edm {
     void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-    bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const* mcc);
-    bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                              EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc);
+    bool doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    bool doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    bool doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+    bool doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -32,7 +32,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -66,14 +65,9 @@ namespace edm {
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
 
   private:
-    bool doEvent(EventPrincipal const& ep,
-                 EventSetupImpl const& c,
-                 ActivityRegistry* act,
-                 ModuleCallingContext const* mcc);
+    bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                      ModuleCallingContext const& iModuleCallingContext,
-                                      Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
@@ -81,14 +75,10 @@ namespace edm {
     void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                              EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc);
+    void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+    void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -24,7 +24,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -62,14 +61,9 @@ namespace edm {
     SerialTaskQueue* globalLuminosityBlocksQueue() { return &luminosityBlockQueue_; }
 
   private:
-    bool doEvent(EventPrincipal const& ep,
-                 EventSetupImpl const& c,
-                 ActivityRegistry* act,
-                 ModuleCallingContext const* mcc);
+    bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                      ModuleCallingContext const& iModuleCallingContext,
-                                      Principal const& iPrincipal) const {}
+    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();
@@ -77,14 +71,10 @@ namespace edm {
     void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
     void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-    void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
-    void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const* mcc);
-    void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                              EventSetupImpl const& c,
-                              ModuleCallingContext const* mcc);
+    void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+    void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+    void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -72,7 +72,8 @@ namespace edm {
 
   class Event : public EventBase {
   public:
-    Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const*);
+    Event(EventTransitionInfo const&, ModuleDescription const&, ModuleCallingContext const*);
+    Event(EventPrincipal const&, ModuleDescription const&, ModuleCallingContext const*);
     ~Event() override;
 
     //Used in conjunction with EDGetToken
@@ -492,8 +493,9 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if
-      UNLIKELY(result.failedToGet()) { return false; }
+    if UNLIKELY (result.failedToGet()) {
+      return false;
+    }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
@@ -504,8 +506,9 @@ namespace edm {
     BasicHandle bh = provRecorder_.getByLabel_(
         TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if
-      UNLIKELY(result.failedToGet()) { return false; }
+    if UNLIKELY (result.failedToGet()) {
+      return false;
+    }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
@@ -529,8 +532,9 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));  // throws on conversion error
-    if
-      UNLIKELY(result.failedToGet()) { return false; }
+    if UNLIKELY (result.failedToGet()) {
+      return false;
+    }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
@@ -540,8 +544,9 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     result = convert_handle<PROD>(std::move(bh));
-    if
-      UNLIKELY(result.failedToGet()) { return false; }
+    if UNLIKELY (result.failedToGet()) {
+      return false;
+    }
     addToGotBranchIDs(*result.provenance());
     return true;
   }
@@ -550,8 +555,9 @@ namespace edm {
   Handle<PROD> Event::getHandle(EDGetTokenT<PROD> token) const {
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     auto result = convert_handle<PROD>(std::move(bh));
-    if
-      LIKELY(not result.failedToGet()) { addToGotBranchIDs(*result.provenance()); }
+    if LIKELY (not result.failedToGet()) {
+      addToGotBranchIDs(*result.provenance());
+    }
     return result;
   }
 
@@ -559,8 +565,9 @@ namespace edm {
   PROD const& Event::get(EDGetTokenT<PROD> token) const noexcept(false) {
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     auto result = convert_handle<PROD>(std::move(bh));
-    if
-      LIKELY(not result.failedToGet()) { addToGotBranchIDs(*result.provenance()); }
+    if LIKELY (not result.failedToGet()) {
+      addToGotBranchIDs(*result.provenance());
+    }
     return *result;
   }
 
@@ -568,12 +575,11 @@ namespace edm {
   bool Event::getByLabel(InputTag const& tag, Handle<View<ELEMENT>>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), tag, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) {
-        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
-        h.swap(result);
-        return false;
-      }
+    if UNLIKELY (bh.failedToGet()) {
+      Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+      h.swap(result);
+      return false;
+    }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
@@ -585,12 +591,11 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(
         TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) {
-        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
-        h.swap(result);
-        return false;
-      }
+    if UNLIKELY (bh.failedToGet()) {
+      Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+      h.swap(result);
+      return false;
+    }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
@@ -604,12 +609,11 @@ namespace edm {
   bool Event::getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) {
-        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
-        h.swap(result);
-        return false;
-      }
+    if UNLIKELY (bh.failedToGet()) {
+      Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+      h.swap(result);
+      return false;
+    }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
@@ -618,12 +622,11 @@ namespace edm {
   bool Event::getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) {
-        Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
-        h.swap(result);
-        return false;
-      }
+    if UNLIKELY (bh.failedToGet()) {
+      Handle<View<ELEMENT>> h(std::move(bh.whyFailedFactory()));
+      h.swap(result);
+      return false;
+    }
     result = fillView_<ELEMENT>(bh);
     return true;
   }
@@ -631,19 +634,18 @@ namespace edm {
   template <typename ELEMENT>
   Handle<View<ELEMENT>> Event::getHandle(EDGetTokenT<View<ELEMENT>> token) const {
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) {
-        return Handle<View<ELEMENT>>(std::move(bh.whyFailedFactory()));
-        ;
-      }
+    if UNLIKELY (bh.failedToGet()) {
+      return Handle<View<ELEMENT>>(std::move(bh.whyFailedFactory()));
+    }
     return fillView_<ELEMENT>(bh);
   }
 
   template <typename ELEMENT>
   View<ELEMENT> const& Event::get(EDGetTokenT<View<ELEMENT>> token) const noexcept(false) {
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)), ELEMENT_TYPE, token, moduleCallingContext_);
-    if
-      UNLIKELY(bh.failedToGet()) { bh.whyFailedFactory()->make()->raise(); }
+    if UNLIKELY (bh.failedToGet()) {
+      bh.whyFailedFactory()->make()->raise();
+    }
     return *fillView_<ELEMENT>(bh);
   }
 

--- a/FWCore/Framework/interface/EventForOutput.h
+++ b/FWCore/Framework/interface/EventForOutput.h
@@ -6,7 +6,7 @@
 // Package:     Framework
 // Class  :     EventForOutput
 //
-/**\class EventForOutput EventForOutputForOutput.h FWCore/Framework/interface/EventForOutputForOutput.h
+/**\class edm::EventForOutput
 
 */
 /*----------------------------------------------------------------------
@@ -49,7 +49,8 @@ namespace edm {
 
   class EventForOutput : public OccurrenceForOutput {
   public:
-    EventForOutput(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const*);
+    EventForOutput(EventTransitionInfo const&, ModuleDescription const&, ModuleCallingContext const*);
+    EventForOutput(EventPrincipal const&, ModuleDescription const&, ModuleCallingContext const*);
     ~EventForOutput() override;
 
     EventAuxiliary const& eventAuxiliary() const { return aux_; }

--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -59,6 +59,13 @@ namespace edm {
     friend class edm::PileUp;
 
   public:
+    template <typename T>
+    explicit EventSetup(T const& info,
+                        unsigned int iTransitionID,
+                        ESProxyIndex const* iGetTokenIndices,
+                        bool iRequireToken)
+        : EventSetup(info.eventSetupImpl(), iTransitionID, iGetTokenIndices, iRequireToken) {}
+
     explicit EventSetup(EventSetupImpl const& iSetup,
                         unsigned int iTransitionID,
                         ESProxyIndex const* iGetTokenIndices,

--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -23,12 +23,14 @@ namespace edm {
   class EventPrincipal;
   class EventSetup;
   class EventSetupImpl;
+  class EventTransitionInfo;
   class FileBlock;
   class InputSource;
   struct InputSourceDescription;
   class LuminosityBlock;
   class LuminosityBlockForOutput;
   class LuminosityBlockPrincipal;
+  class LumiTransitionInfo;
   class OutputModule;
   struct OutputModuleDescription;
   class ParameterSet;
@@ -37,11 +39,13 @@ namespace edm {
   class PrincipalGetAdapter;
   class ProcessBlock;
   class ProcessBlockPrincipal;
+  class ProcessBlockTransitionInfo;
   class ProcessNameSelector;
   class ProductRegistryHelper;
   class Run;
   class RunForOutput;
   class RunPrincipal;
+  class RunTransitionInfo;
   class Schedule;
   class StreamID;
   class TypeID;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -49,8 +49,9 @@ namespace edm {
 
   class LuminosityBlock : public LuminosityBlockBase {
   public:
-    LuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                    ModuleDescription const& md,
+    LuminosityBlock(LumiTransitionInfo const&, ModuleDescription const&, ModuleCallingContext const*, bool isAtEnd);
+    LuminosityBlock(LuminosityBlockPrincipal const&,
+                    ModuleDescription const&,
                     ModuleCallingContext const*,
                     bool isAtEnd);
     ~LuminosityBlock() override;
@@ -344,20 +345,18 @@ namespace edm {
 
   template <typename PROD>
   Handle<PROD> LuminosityBlock::getHandle(EDGetTokenT<PROD> token) const {
-    if
-      UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
-        principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
-      }
+    if UNLIKELY (!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+    }
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return convert_handle<PROD>(std::move(bh));
   }
 
   template <typename PROD>
   PROD const& LuminosityBlock::get(EDGetTokenT<PROD> token) const noexcept(false) {
-    if
-      UNLIKELY(!provRecorder_.checkIfComplete<PROD>()) {
-        principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
-      }
+    if UNLIKELY (!provRecorder_.checkIfComplete<PROD>()) {
+      principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
+    }
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)), PRODUCT_TYPE, token, moduleCallingContext_);
     return *convert_handle<PROD>(std::move(bh));
   }

--- a/FWCore/Framework/interface/LuminosityBlockForOutput.h
+++ b/FWCore/Framework/interface/LuminosityBlockForOutput.h
@@ -39,8 +39,12 @@ namespace edm {
 
   class LuminosityBlockForOutput : public OccurrenceForOutput {
   public:
-    LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp,
-                             ModuleDescription const& md,
+    LuminosityBlockForOutput(LumiTransitionInfo const&,
+                             ModuleDescription const&,
+                             ModuleCallingContext const*,
+                             bool isAtEnd);
+    LuminosityBlockForOutput(LuminosityBlockPrincipal const&,
+                             ModuleDescription const&,
                              ModuleCallingContext const*,
                              bool isAtEnd);
     ~LuminosityBlockForOutput() override;

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -44,7 +44,8 @@ namespace edm {
 
   class Run : public RunBase {
   public:
-    Run(RunPrincipal const& rp, ModuleDescription const& md, ModuleCallingContext const*, bool isAtEnd);
+    Run(RunTransitionInfo const&, ModuleDescription const&, ModuleCallingContext const*, bool isAtEnd);
+    Run(RunPrincipal const&, ModuleDescription const&, ModuleCallingContext const*, bool isAtEnd);
     ~Run() override;
 
     //Used in conjunction with EDGetToken

--- a/FWCore/Framework/interface/RunForOutput.h
+++ b/FWCore/Framework/interface/RunForOutput.h
@@ -38,8 +38,13 @@ namespace edm {
 
   class RunForOutput : public OccurrenceForOutput {
   public:
-    RunForOutput(RunPrincipal const& rp,
-                 ModuleDescription const& md,
+    RunForOutput(RunTransitionInfo const&,
+                 ModuleDescription const&,
+                 ModuleCallingContext const*,
+                 bool isAtEnd,
+                 MergeableRunProductMetadata const* = nullptr);
+    RunForOutput(RunPrincipal const&,
+                 ModuleDescription const&,
                  ModuleCallingContext const*,
                  bool isAtEnd,
                  MergeableRunProductMetadata const* = nullptr);

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -33,7 +33,6 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -74,11 +73,10 @@ namespace edm {
       }
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
@@ -86,28 +84,18 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -35,7 +35,6 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
   class WaitingTaskWithArenaHolder;
@@ -73,9 +72,8 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 
     private:
-      bool doEvent(EventPrincipal const&, EventSetupImpl const&, ActivityRegistry*, ModuleCallingContext const*);
-      void doAcquire(EventPrincipal const&,
-                     EventSetupImpl const&,
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doAcquire(EventTransitionInfo const&,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
@@ -90,28 +88,18 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -36,7 +36,6 @@ namespace edm {
   class StreamID;
   class GlobalSchedule;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
   class WaitingTaskWithArenaHolder;
@@ -76,9 +75,8 @@ namespace edm {
       virtual bool wantsStreamLuminosityBlocks() const = 0;
 
     private:
-      bool doEvent(EventPrincipal const&, EventSetupImpl const&, ActivityRegistry*, ModuleCallingContext const*);
-      void doAcquire(EventPrincipal const&,
-                     EventSetupImpl const&,
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
+      void doAcquire(EventTransitionInfo const&,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
@@ -86,30 +84,20 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
 
-      void doBeginStream(StreamID id);
-      void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doBeginStream(StreamID);
+      void doEndStream(StreamID);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -126,10 +126,6 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
 
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -48,7 +48,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -127,18 +126,12 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
 
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
@@ -147,14 +140,10 @@ namespace edm {
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      bool doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void setEventSelectionInfo(
           std::map<std::string, std::vector<std::pair<std::string, int>>> const& outputModulePathPositions,

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -34,7 +34,6 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -79,7 +78,7 @@ namespace edm {
       LimitedTaskQueue& queue() { return queue_; }
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
       /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
@@ -91,28 +90,18 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -36,7 +36,6 @@ namespace edm {
   class PreallocationConfiguration;
   class StreamID;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -77,11 +76,10 @@ namespace edm {
       LimitedTaskQueue& queue() { return queue_; }
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
@@ -89,28 +87,18 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -37,7 +37,6 @@ namespace edm {
   class StreamID;
   class GlobalSchedule;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -80,35 +79,25 @@ namespace edm {
       LimitedTaskQueue& queue() { return queue_; }
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();
       void doEndJob();
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -49,7 +49,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -131,34 +130,23 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID id, RunPrincipal& ep, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
 
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      bool doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void setEventSelectionInfo(
           std::map<std::string, std::vector<std::pair<std::string, int>>> const& outputModulePathPositions,

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -130,10 +130,6 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
-      void doStreamEndRun(StreamID, RunTransitionInfo&, ModuleCallingContext const*);
-      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
-      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo&, ModuleCallingContext const*);
 
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -33,7 +33,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -75,11 +74,10 @@ namespace edm {
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);
@@ -89,16 +87,12 @@ namespace edm {
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
-      //For now, the following are just dummy implemenations with no ability for users to override
+      //For now, the following are just dummy implementations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
       void doRegisterThinnedAssociations(ProductRegistry const&, ThinnedAssociationsHelper&) {}

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -34,7 +34,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -74,11 +73,10 @@ namespace edm {
       virtual SerialTaskQueue* globalLuminosityBlocksQueue();
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);
@@ -88,14 +86,10 @@ namespace edm {
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -34,7 +34,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -74,11 +73,10 @@ namespace edm {
       virtual SerialTaskQueue* globalLuminosityBlocksQueue();
 
     private:
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);
@@ -88,14 +86,10 @@ namespace edm {
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*);
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -50,7 +50,6 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class SubProcessParentageHelper;
   class WaitingTask;
@@ -135,18 +134,14 @@ namespace edm {
 
       void doBeginJob();
       void doEndJob();
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
-      bool doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*);
-      bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& c,
-                                  ModuleCallingContext const*);
-      bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& c,
-                                ModuleCallingContext const*);
+      bool doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndRun(RunTransitionInfo const&, ModuleCallingContext const*);
+      bool doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
+      bool doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*);
 
       void setEventSelectionInfo(
           std::map<std::string, std::vector<std::pair<std::string, int>>> const& outputModulePathPositions,

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -32,6 +32,7 @@
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
 #include "FWCore/Framework/src/MakeModuleHelper.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 // forward declarations
 
@@ -141,13 +142,14 @@ namespace edm {
         }
       }
 
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
+      void doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
+          RunPrincipal const& rp = info.principal();
           Run r(rp, moduleDescription(), mcc, false);
           r.setConsumer(consumer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginRun),
                              this->consumer()->esGetTokenIndices(Transition::BeginRun),
                              false};
@@ -156,14 +158,15 @@ namespace edm {
           MyGlobalRunSummary::beginRun(cnstR, c, &rc, m_runSummaries[ri]);
         }
       }
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
+      void doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache) {
+          RunPrincipal const& rp = info.principal();
           Run r(rp, moduleDescription(), mcc, true);
           r.setConsumer(consumer());
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndRun),
                              this->consumer()->esGetTokenIndices(Transition::EndRun),
                              false};
@@ -172,17 +175,16 @@ namespace edm {
         }
       }
 
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& ci,
-                                  ModuleCallingContext const* mcc) final {
+      void doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
           LuminosityBlock lb(lbp, moduleDescription(), mcc, false);
           lb.setConsumer(consumer());
           LuminosityBlock const& cnstLb = lb;
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
                              false};
@@ -191,17 +193,16 @@ namespace edm {
           MyGlobalLuminosityBlockSummary::beginLuminosityBlock(cnstLb, c, &lc, m_lumiSummaries[li]);
         }
       }
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& ci,
-                                ModuleCallingContext const* mcc) final {
+      void doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
           LuminosityBlock lb(lbp, moduleDescription(), mcc, true);
           lb.setConsumer(consumer());
 
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
                              false};

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -45,7 +45,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ProductResolverIndexAndSkipBit;
   class ActivityRegistry;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTask;
 
@@ -124,14 +123,13 @@ namespace edm {
 
       const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&) = delete;  // stop default
 
-      bool doEvent(EventPrincipal const& ep, EventSetupImpl const& c, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int) {}
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
 
       virtual void setupStreamModules() = 0;
       virtual void doBeginJob() = 0;
@@ -139,20 +137,14 @@ namespace edm {
 
       void doBeginStream(StreamID id);
       void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
       virtual void setupRun(EDAnalyzerBase*, RunIndex) = 0;
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
       virtual void streamEndRunSummary(EDAnalyzerBase*, edm::Run const&, edm::EventSetup const&) = 0;
 
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
       virtual void setupLuminosityBlock(EDAnalyzerBase*, LuminosityBlockIndex) = 0;
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(EDAnalyzerBase*,
                                                    edm::LuminosityBlock const&,
                                                    edm::EventSetup const&) = 0;
@@ -160,14 +152,10 @@ namespace edm {
       virtual void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
-      virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
-      virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
-      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetupImpl const& c,
-                                          ModuleCallingContext const*) = 0;
-      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*) = 0;
+      virtual void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -70,18 +70,16 @@ namespace edm {
 
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) = delete;  // stop default
 
-      bool doEvent(EventPrincipal const&, EventSetupImpl const&, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
 
-      void doAcquire(EventPrincipal const&,
-                     EventSetupImpl const&,
+      void doAcquire(EventTransitionInfo const&,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
     };
   }  // namespace stream
 }  // namespace edm

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -70,18 +70,16 @@ namespace edm {
 
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) = delete;  // stop default
 
-      bool doEvent(EventPrincipal const&, EventSetupImpl const&, ActivityRegistry*, ModuleCallingContext const*);
+      bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
 
-      void doAcquire(EventPrincipal const&,
-                     EventSetupImpl const&,
+      void doAcquire(EventTransitionInfo const&,
                      ActivityRegistry*,
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
-                                                    ModuleCallingContext const& iModuleCallingContext,
-                                                    Principal const& iPrincipal) const {}
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
+      }
     };
   }  // namespace stream
 }  // namespace edm

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -30,6 +30,7 @@
 #include "FWCore/Framework/interface/stream/callAbilities.h"
 #include "FWCore/Framework/interface/stream/dummy_helpers.h"
 #include "FWCore/Framework/interface/stream/makeGlobal.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 // forward declarations
 
 namespace edm {
@@ -155,14 +156,15 @@ namespace edm {
         }
       }
 
-      void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
+      void doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
+          RunPrincipal const& rp = info.principal();
           Run r(rp, this->moduleDescription(), mcc, false);
           r.setConsumer(this->consumer());
           r.setProducer(this->producer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginRun),
                              this->consumer()->esGetTokenIndices(Transition::BeginRun),
                              false};
@@ -176,15 +178,16 @@ namespace edm {
         }
       }
 
-      void doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) final {
+      void doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kEndRunProducer) {
+          RunPrincipal const& rp = info.principal();
           Run r(rp, this->moduleDescription(), mcc, true);
           r.setConsumer(this->consumer());
           r.setProducer(this->producer());
 
           RunIndex ri = rp.index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndRun),
                              this->consumer()->esGetTokenIndices(Transition::EndRun),
                              false};
@@ -197,11 +200,10 @@ namespace edm {
         }
       }
 
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                  EventSetupImpl const& ci,
-                                  ModuleCallingContext const* mcc) final {
+      void doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or
                       T::HasAbility::kBeginLuminosityBlockProducer) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
           LuminosityBlock lb(lbp, this->moduleDescription(), mcc, false);
           lb.setConsumer(this->consumer());
           lb.setProducer(this->producer());
@@ -209,7 +211,7 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::RunContext rc(m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::BeginLuminosityBlock),
                              false};
@@ -223,11 +225,10 @@ namespace edm {
           }
         }
       }
-      void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                EventSetupImpl const& ci,
-                                ModuleCallingContext const* mcc) final {
+      void doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) final {
         if constexpr (T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or
                       T::HasAbility::kEndLuminosityBlockProducer) {
+          LuminosityBlockPrincipal const& lbp = info.principal();
           LuminosityBlock lb(lbp, this->moduleDescription(), mcc, true);
           lb.setConsumer(this->consumer());
           lb.setProducer(this->producer());
@@ -235,7 +236,7 @@ namespace edm {
           LuminosityBlockIndex li = lbp.index();
           RunIndex ri = lbp.runPrincipal().index();
           typename T::LuminosityBlockContext lc(m_lumis[li].get(), m_runs[ri].get(), m_global.get());
-          const EventSetup c{ci,
+          const EventSetup c{info,
                              static_cast<unsigned int>(Transition::EndLuminosityBlock),
                              this->consumer()->esGetTokenIndices(Transition::EndLuminosityBlock),
                              false};

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -49,7 +49,6 @@ namespace edm {
   class EDConsumerBase;
   class PreallocationConfiguration;
   class ProductResolverIndexAndSkipBit;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
 
   namespace maker {
@@ -153,35 +152,25 @@ namespace edm {
       virtual void doBeginJob() = 0;
       virtual void doEndJob() = 0;
 
-      void doBeginStream(StreamID id);
-      void doEndStream(StreamID id);
-      void doStreamBeginRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
+      void doBeginStream(StreamID);
+      void doEndStream(StreamID);
+      void doStreamBeginRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
       virtual void setupRun(T*, RunIndex) = 0;
-      void doStreamEndRun(StreamID id, RunPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const*);
+      void doStreamEndRun(StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
       virtual void streamEndRunSummary(T*, edm::Run const&, edm::EventSetup const&) = 0;
 
-      void doStreamBeginLuminosityBlock(StreamID id,
-                                        LuminosityBlockPrincipal const& ep,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*);
+      void doStreamBeginLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
       virtual void setupLuminosityBlock(T*, LuminosityBlockIndex) = 0;
-      void doStreamEndLuminosityBlock(StreamID id,
-                                      LuminosityBlockPrincipal const& ep,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const*);
+      void doStreamEndLuminosityBlock(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(T*, edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
 
       virtual void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void doEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
-      virtual void doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
-      virtual void doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const*) = 0;
-      virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetupImpl const& c,
-                                          ModuleCallingContext const*) = 0;
-      virtual void doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const*) = 0;
+      virtual void doBeginRun(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doEndRun(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doBeginLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
+      virtual void doEndLuminosityBlock(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
 
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "SharedResourcesRegistry.h"
 
@@ -27,15 +28,12 @@ namespace edm {
     SharedResourcesRegistry::instance()->registerSharedResource(SharedResourcesRegistry::kLegacyModuleResourceName);
   }
 
-  bool EDAnalyzer::doEvent(EventPrincipal const& ep,
-                           EventSetupImpl const& ci,
-                           ActivityRegistry* act,
-                           ModuleCallingContext const* mcc) {
-    Event e(ep, moduleDescription_, mcc);
+  bool EDAnalyzer::doEvent(EventTransitionInfo const& info, ActivityRegistry* act, ModuleCallingContext const* mcc) {
+    Event e(info, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
     this->analyze(e, c);
     return true;
   }
@@ -49,29 +47,28 @@ namespace edm {
 
   void EDAnalyzer::doEndJob() { this->endJob(); }
 
-  bool EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, false);
+  bool EDAnalyzer::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     const EventSetup c{
-        ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
     this->beginRun(r, c);
     return true;
   }
 
-  bool EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, true);
+  bool EDAnalyzer::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
     this->endRun(r, c);
     return true;
   }
 
-  bool EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetupImpl const& ci,
-                                          ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+  bool EDAnalyzer::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
-    const EventSetup c{ci,
+    const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
                        false};
@@ -79,12 +76,10 @@ namespace edm {
     return true;
   }
 
-  bool EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+  bool EDAnalyzer::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
-    const EventSetup c{ci,
+    const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
                        false};

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "SharedResourcesRegistry.h"
 
@@ -24,18 +25,15 @@ namespace edm {
 
   EDFilter::~EDFilter() {}
 
-  bool EDFilter::doEvent(EventPrincipal const& ep,
-                         EventSetupImpl const& c,
-                         ActivityRegistry* act,
-                         ModuleCallingContext const* mcc) {
+  bool EDFilter::doEvent(EventTransitionInfo const& info, ActivityRegistry* act, ModuleCallingContext const* mcc) {
     bool rc = false;
-    Event e(ep, moduleDescription_, mcc);
+    Event e(info, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
     rc = this->filter(
-        e, EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
+        e, EventSetup{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
     commit_(e, &previousParentageId_);
     return rc;
   }
@@ -49,50 +47,47 @@ namespace edm {
 
   void EDFilter::doEndJob() { this->endJob(); }
 
-  void EDFilter::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, false);
+  void EDFilter::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
     this->beginRun(
         cnstR,
-        EventSetup{c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
+        EventSetup{
+            info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
     commit_(r);
     return;
   }
 
-  void EDFilter::doEndRun(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, true);
+  void EDFilter::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
     this->endRun(
         cnstR,
-        EventSetup{c, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false});
+        EventSetup{info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false});
     commit_(r);
     return;
   }
 
-  void EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetupImpl const& c,
-                                        ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+  void EDFilter::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->beginLuminosityBlock(cnstLb,
-                               EventSetup{c,
+                               EventSetup{info,
                                           static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                                           esGetTokenIndices(Transition::BeginLuminosityBlock),
                                           false});
     commit_(lb);
   }
 
-  void EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                      EventSetupImpl const& c,
-                                      ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+  void EDFilter::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb,
-                             EventSetup{c,
+                             EventSetup{info,
                                         static_cast<unsigned int>(Transition::EndLuminosityBlock),
                                         esGetTokenIndices(Transition::EndLuminosityBlock),
                                         false});

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -10,7 +10,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
-
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -23,16 +23,13 @@ namespace edm {
 
   EDProducer::~EDProducer() {}
 
-  bool EDProducer::doEvent(EventPrincipal const& ep,
-                           EventSetupImpl const& ci,
-                           ActivityRegistry* act,
-                           ModuleCallingContext const* mcc) {
-    Event e(ep, moduleDescription_, mcc);
+  bool EDProducer::doEvent(EventTransitionInfo const& info, ActivityRegistry* act, ModuleCallingContext const* mcc) {
+    Event e(info, moduleDescription_, mcc);
     e.setConsumer(this);
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
@@ -46,32 +43,31 @@ namespace edm {
 
   void EDProducer::doEndJob() { this->endJob(); }
 
-  void EDProducer::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, false);
+  void EDProducer::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
     const EventSetup c{
-        ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
     this->beginRun(cnstR, c);
     commit_(r);
   }
 
-  void EDProducer::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-    Run r(rp, moduleDescription_, mcc, true);
+  void EDProducer::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
     Run const& cnstR = r;
-    const EventSetup c{ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
     this->endRun(cnstR, c);
     commit_(r);
   }
 
-  void EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetupImpl const& ci,
-                                          ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+  void EDProducer::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, false);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
-    const EventSetup c{ci,
+    const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
                        false};
@@ -79,12 +75,10 @@ namespace edm {
     commit_(lb);
   }
 
-  void EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-    LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+  void EDProducer::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+    LuminosityBlock lb(info, moduleDescription_, mcc, true);
     lb.setConsumer(this);
-    const EventSetup c{ci,
+    const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
                        false};

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -7,6 +7,7 @@
 #include "FWCore/Common/interface/TriggerResultsByName.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -17,6 +18,9 @@ namespace {
 namespace edm {
 
   std::string const Event::emptyString_;
+
+  Event::Event(EventTransitionInfo const& info, ModuleDescription const& md, ModuleCallingContext const* mcc)
+      : Event(info.principal(), md, mcc) {}
 
   Event::Event(EventPrincipal const& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext)
       : provRecorder_(ep, md, true /*always at end*/),

--- a/FWCore/Framework/src/EventForOutput.cc
+++ b/FWCore/Framework/src/EventForOutput.cc
@@ -4,11 +4,17 @@
 #include "FWCore/Common/interface/TriggerResultsByName.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
+
+  EventForOutput::EventForOutput(EventTransitionInfo const& info,
+                                 ModuleDescription const& md,
+                                 ModuleCallingContext const* mcc)
+      : EventForOutput(info.principal(), md, mcc) {}
 
   EventForOutput::EventForOutput(EventPrincipal const& ep,
                                  ModuleDescription const& md,

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -2,12 +2,19 @@
 
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
 
   std::string const LuminosityBlock::emptyString_;
+
+  LuminosityBlock::LuminosityBlock(LumiTransitionInfo const& info,
+                                   ModuleDescription const& md,
+                                   ModuleCallingContext const* mcc,
+                                   bool isAtEnd)
+      : LuminosityBlock(info.principal(), md, mcc, isAtEnd) {}
 
   LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal const& lbp,
                                    ModuleDescription const& md,

--- a/FWCore/Framework/src/LuminosityBlockForOutput.cc
+++ b/FWCore/Framework/src/LuminosityBlockForOutput.cc
@@ -2,10 +2,17 @@
 
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunForOutput.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
+
+  LuminosityBlockForOutput::LuminosityBlockForOutput(LumiTransitionInfo const& info,
+                                                     ModuleDescription const& md,
+                                                     ModuleCallingContext const* mcc,
+                                                     bool isAtEnd)
+      : LuminosityBlockForOutput(info.principal(), md, mcc, isAtEnd) {}
 
   LuminosityBlockForOutput::LuminosityBlockForOutput(LuminosityBlockPrincipal const& lbp,
                                                      ModuleDescription const& md,

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -1,12 +1,16 @@
 #include "FWCore/Framework/interface/Run.h"
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
 
   std::string const Run::emptyString_;
+
+  Run::Run(RunTransitionInfo const& info, ModuleDescription const& md, ModuleCallingContext const* mcc, bool isAtEnd)
+      : Run(info.principal(), md, mcc, isAtEnd) {}
 
   Run::Run(RunPrincipal const& rp,
            ModuleDescription const& md,

--- a/FWCore/Framework/src/RunForOutput.cc
+++ b/FWCore/Framework/src/RunForOutput.cc
@@ -1,10 +1,18 @@
 #include "FWCore/Framework/interface/RunForOutput.h"
 
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
 
 namespace edm {
+
+  RunForOutput::RunForOutput(RunTransitionInfo const& info,
+                             ModuleDescription const& md,
+                             ModuleCallingContext const* mcc,
+                             bool isAtEnd,
+                             MergeableRunProductMetadata const* mrpm)
+      : RunForOutput(info.principal(), md, mcc, isAtEnd, mrpm) {}
 
   RunForOutput::RunForOutput(RunPrincipal const& rp,
                              ModuleDescription const& md,

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -453,8 +453,7 @@ namespace edm {
                           WaitingTaskWithArenaHolder& holder) {
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     try {
-      convertException::wrap(
-          [&]() { this->implDoAcquire(info.principal(), info.eventSetupImpl(), &moduleCallingContext_, holder); });
+      convertException::wrap([&]() { this->implDoAcquire(info, &moduleCallingContext_, holder); });
     } catch (cms::Exception& ex) {
       exceptionContext(ex, &moduleCallingContext_);
       if (shouldRethrowException(std::current_exception(), parentContext, true)) {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -237,44 +237,27 @@ namespace edm {
     template <typename O>
     friend class workerhelper::CallImpl;
     virtual std::string workerType() const = 0;
-    virtual bool implDo(EventPrincipal const&, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
+    virtual bool implDo(EventTransitionInfo const&, ModuleCallingContext const*) = 0;
 
     virtual void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const = 0;
     virtual bool implNeedToRunSelection() const = 0;
 
-    virtual void implDoAcquire(EventPrincipal const&,
-                               EventSetupImpl const& c,
-                               ModuleCallingContext const* mcc,
-                               WaitingTaskWithArenaHolder& holder) = 0;
+    virtual void implDoAcquire(EventTransitionInfo const&,
+                               ModuleCallingContext const*,
+                               WaitingTaskWithArenaHolder&) = 0;
 
-    virtual bool implDoPrePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id,
-                                   RunPrincipal const& rp,
-                                   EventSetupImpl const& c,
-                                   ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id,
-                                 RunPrincipal const& rp,
-                                 EventSetupImpl const& c,
-                                 ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoBegin(LuminosityBlockPrincipal const& lbp,
-                             EventSetupImpl const& c,
-                             ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamBegin(StreamID id,
-                                   LuminosityBlockPrincipal const& lbp,
-                                   EventSetupImpl const& c,
-                                   ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoStreamEnd(StreamID id,
-                                 LuminosityBlockPrincipal const& lbp,
-                                 EventSetupImpl const& c,
-                                 ModuleCallingContext const* mcc) = 0;
-    virtual bool implDoEnd(LuminosityBlockPrincipal const& lbp,
-                           EventSetupImpl const& c,
-                           ModuleCallingContext const* mcc) = 0;
+    virtual bool implDoPrePrefetchSelection(StreamID, EventPrincipal const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoBegin(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoStreamBegin(StreamID, RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoStreamEnd(StreamID, RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoEnd(RunTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoBegin(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoStreamBegin(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoStreamEnd(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
+    virtual bool implDoEnd(LumiTransitionInfo const&, ModuleCallingContext const*) = 0;
     virtual void implBeginJob() = 0;
     virtual void implEndJob() = 0;
     virtual void implBeginStream(StreamID) = 0;
@@ -623,7 +606,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* /* context*/) {
         //Signal sentry is handled by the module
-        return iWorker->implDo(info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDo(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -650,7 +633,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoBegin(info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoBegin(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -675,7 +658,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamBegin(id, info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoStreamBegin(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -700,7 +683,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoEnd(info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoEnd(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -725,7 +708,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamEnd(id, info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoStreamEnd(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -751,7 +734,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoBegin(info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoBegin(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -776,7 +759,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamBegin(id, info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoStreamBegin(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -802,7 +785,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoEnd(info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoEnd(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,
@@ -827,7 +810,7 @@ namespace edm {
                        ModuleCallingContext const* mcc,
                        Arg::Context const* context) {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
-        return iWorker->implDoStreamEnd(id, info.principal(), info.eventSetupImpl(), mcc);
+        return iWorker->implDoStreamEnd(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
                                   WaitingTask* waitingTask,

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -8,6 +8,7 @@ WorkerT: Code common to all workers.
 ----------------------------------------------------------------------*/
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
@@ -21,9 +22,7 @@ WorkerT: Code common to all workers.
 namespace edm {
 
   class ModuleCallingContext;
-  class ModuleDescription;
   class ProductResolverIndexAndSkipBit;
-  class ProductRegistry;
   class ThinnedAssociationsHelper;
   class WaitingTaskWithArenaHolder;
 
@@ -65,61 +64,38 @@ namespace edm {
     template <typename D>
     void callWorkerEndStream(D, StreamID);
     template <typename D>
-    void callWorkerStreamBegin(
-        D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void callWorkerStreamBegin(D, StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
     template <typename D>
-    void callWorkerStreamEnd(
-        D, StreamID id, RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void callWorkerStreamEnd(D, StreamID, RunTransitionInfo const&, ModuleCallingContext const*);
     template <typename D>
-    void callWorkerStreamBegin(
-        D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void callWorkerStreamBegin(D, StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
     template <typename D>
-    void callWorkerStreamEnd(
-        D, StreamID id, LuminosityBlockPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc);
+    void callWorkerStreamEnd(D, StreamID, LumiTransitionInfo const&, ModuleCallingContext const*);
 
   protected:
     T& module() { return *module_; }
     T const& module() const { return *module_; }
 
   private:
-    bool implDo(EventPrincipal const& ep, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
+    bool implDo(EventTransitionInfo const&, ModuleCallingContext const*) override;
 
     void itemsToGetForSelection(std::vector<ProductResolverIndexAndSkipBit>&) const final;
     bool implNeedToRunSelection() const final;
 
-    void implDoAcquire(EventPrincipal const& ep,
-                       EventSetupImpl const& c,
-                       ModuleCallingContext const* mcc,
-                       WaitingTaskWithArenaHolder& holder) final;
+    void implDoAcquire(EventTransitionInfo const&, ModuleCallingContext const*, WaitingTaskWithArenaHolder&) final;
 
-    bool implDoPrePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) override;
+    bool implDoPrePrefetchSelection(StreamID, EventPrincipal const&, ModuleCallingContext const*) override;
     bool implDoBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
     bool implDoAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
     bool implDoEndProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) override;
-    bool implDoBegin(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id,
-                           RunPrincipal const& rp,
-                           EventSetupImpl const& c,
-                           ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id,
-                         RunPrincipal const& rp,
-                         EventSetupImpl const& c,
-                         ModuleCallingContext const* mcc) override;
-    bool implDoEnd(RunPrincipal const& rp, EventSetupImpl const& c, ModuleCallingContext const* mcc) override;
-    bool implDoBegin(LuminosityBlockPrincipal const& lbp,
-                     EventSetupImpl const& c,
-                     ModuleCallingContext const* mcc) override;
-    bool implDoStreamBegin(StreamID id,
-                           LuminosityBlockPrincipal const& lbp,
-                           EventSetupImpl const& c,
-                           ModuleCallingContext const* mcc) override;
-    bool implDoStreamEnd(StreamID id,
-                         LuminosityBlockPrincipal const& lbp,
-                         EventSetupImpl const& c,
-                         ModuleCallingContext const* mcc) override;
-    bool implDoEnd(LuminosityBlockPrincipal const& lbp,
-                   EventSetupImpl const& c,
-                   ModuleCallingContext const* mcc) override;
+    bool implDoBegin(RunTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoStreamBegin(StreamID, RunTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoStreamEnd(StreamID, RunTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoEnd(RunTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoBegin(LumiTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoStreamBegin(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoStreamEnd(StreamID, LumiTransitionInfo const&, ModuleCallingContext const*) override;
+    bool implDoEnd(LumiTransitionInfo const&, ModuleCallingContext const*) override;
     void implBeginJob() override;
     void implEndJob() override;
     void implBeginStream(StreamID) override;

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -47,14 +48,14 @@ namespace edm {
 
     EDAnalyzerBase::~EDAnalyzerBase() {}
 
-    bool EDAnalyzerBase::doEvent(EventPrincipal const& ep,
-                                 EventSetupImpl const& ci,
+    bool EDAnalyzerBase::doEvent(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -91,33 +92,31 @@ namespace edm {
       this->doEndProcessBlock_(constProcessBlock);
     }
 
-    void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const& ci,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -125,13 +124,11 @@ namespace edm {
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
 
-    void EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};
@@ -141,34 +138,27 @@ namespace edm {
 
     void EDAnalyzerBase::doBeginStream(StreamID id) { doBeginStream_(id); }
     void EDAnalyzerBase::doEndStream(StreamID id) { doEndStream_(id); }
-    void EDAnalyzerBase::doStreamBeginRun(StreamID id,
-                                          RunPrincipal const& rp,
-                                          EventSetupImpl const& ci,
-                                          ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
-    void EDAnalyzerBase::doStreamEndRun(StreamID id,
-                                        RunPrincipal const& rp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                      LuminosityBlockPrincipal const& lbp,
-                                                      EventSetupImpl const& ci,
+                                                      LumiTransitionInfo const& info,
                                                       ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -176,12 +166,11 @@ namespace edm {
     }
 
     void EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
-                                                    LuminosityBlockPrincipal const& lbp,
-                                                    EventSetupImpl const& ci,
+                                                    LumiTransitionInfo const& info,
                                                     ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -49,33 +50,33 @@ namespace edm {
 
     EDFilterBase::~EDFilterBase() {}
 
-    bool EDFilterBase::doEvent(EventPrincipal const& ep,
-                               EventSetupImpl const& ci,
+    bool EDFilterBase::doEvent(EventTransitionInfo const& info,
                                ActivityRegistry* act,
                                ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducer(
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
     }
 
-    void EDFilterBase::doAcquire(EventPrincipal const& ep,
-                                 EventSetupImpl const& ci,
+    void EDFilterBase::doAcquire(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc,
                                  WaitingTaskWithArenaHolder& holder) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -123,12 +124,12 @@ namespace edm {
       commit_(processBlock);
     }
 
-    void EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDFilterBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -136,26 +137,24 @@ namespace edm {
       commit_(r);
     }
 
-    void EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDFilterBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
     }
 
-    void EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDFilterBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -166,14 +165,12 @@ namespace edm {
       commit_(lb);
     }
 
-    void EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                            EventSetupImpl const& ci,
-                                            ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDFilterBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};
@@ -185,34 +182,27 @@ namespace edm {
 
     void EDFilterBase::doBeginStream(StreamID id) { doBeginStream_(id); }
     void EDFilterBase::doEndStream(StreamID id) { doEndStream_(id); }
-    void EDFilterBase::doStreamBeginRun(StreamID id,
-                                        RunPrincipal const& rp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDFilterBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
-    void EDFilterBase::doStreamEndRun(StreamID id,
-                                      RunPrincipal const& rp,
-                                      EventSetupImpl const& ci,
-                                      ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDFilterBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                    LuminosityBlockPrincipal const& lbp,
-                                                    EventSetupImpl const& ci,
+                                                    LumiTransitionInfo const& info,
                                                     ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -220,12 +210,11 @@ namespace edm {
     }
 
     void EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
-                                                  LuminosityBlockPrincipal const& lbp,
-                                                  EventSetupImpl const& ci,
+                                                  LumiTransitionInfo const& info,
                                                   ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -53,11 +54,10 @@ namespace edm {
 
     EDProducerBase::~EDProducerBase() {}
 
-    bool EDProducerBase::doEvent(EventPrincipal const& ep,
-                                 EventSetupImpl const& c,
+    bool EDProducerBase::doEvent(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducer(
@@ -66,22 +66,22 @@ namespace edm {
       this->produce(
           e.streamID(),
           e,
-          EventSetup{c, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
+          EventSetup{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false});
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
     }
 
-    void EDProducerBase::doAcquire(EventPrincipal const& ep,
-                                   EventSetupImpl const& ci,
+    void EDProducerBase::doAcquire(EventTransitionInfo const& info,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc,
                                    WaitingTaskWithArenaHolder& holder) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       const auto streamIndex = e.streamID().value();
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -129,12 +129,12 @@ namespace edm {
       commit_(processBlock);
     }
 
-    void EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDProducerBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -142,26 +142,24 @@ namespace edm {
       commit_(r);
     }
 
-    void EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDProducerBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
     }
 
-    void EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const& ci,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDProducerBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -172,14 +170,12 @@ namespace edm {
       commit_(lb);
     }
 
-    void EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDProducerBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};
@@ -191,50 +187,42 @@ namespace edm {
 
     void EDProducerBase::doBeginStream(StreamID id) { doBeginStream_(id); }
     void EDProducerBase::doEndStream(StreamID id) { doEndStream_(id); }
-    void EDProducerBase::doStreamBeginRun(StreamID id,
-                                          RunPrincipal const& rp,
-                                          EventSetupImpl const& c,
-                                          ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDProducerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       this->doStreamBeginRun_(
           id,
           r,
           EventSetup{
-              c, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
+              info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
     }
-    void EDProducerBase::doStreamEndRun(StreamID id,
-                                        RunPrincipal const& rp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDProducerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                      LuminosityBlockPrincipal const& lbp,
-                                                      EventSetupImpl const& c,
+                                                      LumiTransitionInfo const& info,
                                                       ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id,
                                           lb,
-                                          EventSetup{c,
+                                          EventSetup{info,
                                                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                                                      esGetTokenIndices(Transition::BeginLuminosityBlock),
                                                      false});
     }
 
     void EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
-                                                    LuminosityBlockPrincipal const& lbp,
-                                                    EventSetupImpl const& ci,
+                                                    LumiTransitionInfo const& info,
                                                     ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/global/OutputModuleBase.cc
+++ b/FWCore/Framework/src/global/OutputModuleBase.cc
@@ -247,12 +247,11 @@ namespace edm {
       return s.wantEvent(e);
     }
 
-    bool OutputModuleBase::doEvent(EventPrincipal const& ep,
-                                   EventSetupImpl const&,
+    bool OutputModuleBase::doEvent(EventTransitionInfo const& info,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       {
-        EventForOutput e(ep, moduleDescription_, mcc);
+        EventForOutput e(info, moduleDescription_, mcc);
         e.setConsumer(this);
         EventSignalsSentry sentry(act, mcc);
         write(e);
@@ -272,15 +271,15 @@ namespace edm {
       return true;
     }
 
-    bool OutputModuleBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       doBeginRun_(r);
       return true;
     }
 
-    bool OutputModuleBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       doEndRun_(r);
       return true;
@@ -294,19 +293,15 @@ namespace edm {
       writeRun(r);
     }
 
-    bool OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                  EventSetupImpl const&,
-                                                  ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       doBeginLuminosityBlock_(lb);
       return true;
     }
 
-    bool OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const&,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       doEndLuminosityBlock_(lb);
       return true;

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -48,14 +49,14 @@ namespace edm {
 
     EDAnalyzerBase::~EDAnalyzerBase() {}
 
-    bool EDAnalyzerBase::doEvent(EventPrincipal const& ep,
-                                 EventSetupImpl const& ci,
+    bool EDAnalyzerBase::doEvent(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -92,33 +93,31 @@ namespace edm {
       this->doEndProcessBlock_(constProcessBlock);
     }
 
-    void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const& ci,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -126,13 +125,11 @@ namespace edm {
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
 
-    void EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};
@@ -142,34 +139,27 @@ namespace edm {
 
     void EDAnalyzerBase::doBeginStream(StreamID id) { doBeginStream_(id); }
     void EDAnalyzerBase::doEndStream(StreamID id) { doEndStream_(id); }
-    void EDAnalyzerBase::doStreamBeginRun(StreamID id,
-                                          RunPrincipal const& rp,
-                                          EventSetupImpl const& ci,
-                                          ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doStreamBeginRun_(id, r, c);
     }
-    void EDAnalyzerBase::doStreamEndRun(StreamID id,
-                                        RunPrincipal const& rp,
-                                        EventSetupImpl const& ci,
-                                        ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
     void EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                      LuminosityBlockPrincipal const& lbp,
-                                                      EventSetupImpl const& ci,
+                                                      LumiTransitionInfo const& info,
                                                       ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -177,12 +167,11 @@ namespace edm {
     }
 
     void EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
-                                                    LuminosityBlockPrincipal const& lbp,
-                                                    EventSetupImpl const& ci,
+                                                    LumiTransitionInfo const& info,
                                                     ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/limited/OutputModuleBase.cc
+++ b/FWCore/Framework/src/limited/OutputModuleBase.cc
@@ -248,12 +248,11 @@ namespace edm {
       return s.wantEvent(e);
     }
 
-    bool OutputModuleBase::doEvent(EventPrincipal const& ep,
-                                   EventSetupImpl const&,
+    bool OutputModuleBase::doEvent(EventTransitionInfo const& info,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       {
-        EventForOutput e(ep, moduleDescription_, mcc);
+        EventForOutput e(info, moduleDescription_, mcc);
         e.setConsumer(this);
         EventSignalsSentry sentry(act, mcc);
         write(e);
@@ -273,15 +272,15 @@ namespace edm {
       return true;
     }
 
-    bool OutputModuleBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       doBeginRun_(r);
       return true;
     }
 
-    bool OutputModuleBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       doEndRun_(r);
       return true;
@@ -295,19 +294,15 @@ namespace edm {
       writeRun(r);
     }
 
-    bool OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                  EventSetupImpl const&,
-                                                  ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       doBeginLuminosityBlock_(lb);
       return true;
     }
 
-    bool OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const&,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       doEndLuminosityBlock_(lb);
       return true;

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -49,15 +50,15 @@ namespace edm {
       callWhenNewProductsRegistered_ = func;
     }
 
-    bool EDAnalyzerBase::doEvent(EventPrincipal const& ep,
-                                 EventSetupImpl const& ci,
+    bool EDAnalyzerBase::doEvent(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->analyze(e, c);
       return true;
     }
@@ -104,44 +105,40 @@ namespace edm {
       this->doEndProcessBlock_(constProcessBlock);
     }
 
-    void EDAnalyzerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRun_(cnstR, c);
     }
 
-    void EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const& ci,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDAnalyzerBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
       this->doBeginLuminosityBlock_(cnstLb, c);
     }
 
-    void EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDAnalyzerBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -44,17 +45,17 @@ namespace edm {
 
     EDFilterBase::~EDFilterBase() {}
 
-    bool EDFilterBase::doEvent(EventPrincipal const& ep,
-                               EventSetupImpl const& ci,
+    bool EDFilterBase::doEvent(EventTransitionInfo const& info,
                                ActivityRegistry* act,
                                ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       e.setProducer(this, &previousParentage_);
       bool returnValue = true;
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       returnValue = this->filter(e, c);
       commit_(e, &previousParentageId_);
       return returnValue;
@@ -110,37 +111,35 @@ namespace edm {
       commit_(processBlock);
     }
 
-    void EDFilterBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDFilterBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
       commit_(r);
     }
 
-    void EDFilterBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDFilterBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRun_(cnstR, c);
       r.setProducer(this);
       this->doEndRunProduce_(r, c);
       commit_(r);
     }
 
-    void EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDFilterBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -150,13 +149,11 @@ namespace edm {
       commit_(lb);
     }
 
-    void EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                            EventSetupImpl const& ci,
-                                            ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDFilterBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -22,6 +22,7 @@
 #include "FWCore/Framework/src/edmodule_mightGet_config.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -44,16 +45,16 @@ namespace edm {
 
     EDProducerBase::~EDProducerBase() {}
 
-    bool EDProducerBase::doEvent(EventPrincipal const& ep,
-                                 EventSetupImpl const& ci,
+    bool EDProducerBase::doEvent(EventTransitionInfo const& info,
                                  ActivityRegistry* act,
                                  ModuleCallingContext const* mcc) {
-      Event e(ep, moduleDescription_, mcc);
+      Event e(info, moduleDescription_, mcc);
       e.setConsumer(this);
       e.setProducer(this, &previousParentage_);
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{ci, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
       this->produce(e, c);
       commit_(e, &previousParentageId_);
       return true;
@@ -110,37 +111,35 @@ namespace edm {
       commit_(processBlock);
     }
 
-    void EDProducerBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, false);
+    void EDProducerBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
       commit_(r);
     }
 
-    void EDProducerBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const& ci, ModuleCallingContext const* mcc) {
-      Run r(rp, moduleDescription_, mcc, true);
+    void EDProducerBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       Run const& cnstR = r;
       r.setProducer(this);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
     }
 
-    void EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const& ci,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
+    void EDProducerBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -150,13 +149,11 @@ namespace edm {
       commit_(lb);
     }
 
-    void EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                              EventSetupImpl const& ci,
-                                              ModuleCallingContext const* mcc) {
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+    void EDProducerBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       lb.setProducer(this);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -240,12 +240,11 @@ namespace edm {
       return s.wantEvent(e);
     }
 
-    bool OutputModuleBase::doEvent(EventPrincipal const& ep,
-                                   EventSetupImpl const&,
+    bool OutputModuleBase::doEvent(EventTransitionInfo const& info,
                                    ActivityRegistry* act,
                                    ModuleCallingContext const* mcc) {
       {
-        EventForOutput e(ep, moduleDescription_, mcc);
+        EventForOutput e(info, moduleDescription_, mcc);
         e.setConsumer(this);
         EventSignalsSentry sentry(act, mcc);
         write(e);
@@ -256,15 +255,15 @@ namespace edm {
       return true;
     }
 
-    bool OutputModuleBase::doBeginRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       doBeginRun_(r);
       return true;
     }
 
-    bool OutputModuleBase::doEndRun(RunPrincipal const& rp, EventSetupImpl const&, ModuleCallingContext const* mcc) {
-      RunForOutput r(rp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      RunForOutput r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       doEndRun_(r);
       return true;
@@ -278,19 +277,15 @@ namespace edm {
       writeRun(r);
     }
 
-    bool OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                  EventSetupImpl const&,
-                                                  ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, false);
+    bool OutputModuleBase::doBeginLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, false);
       lb.setConsumer(this);
       doBeginLuminosityBlock_(lb);
       return true;
     }
 
-    bool OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                                EventSetupImpl const&,
-                                                ModuleCallingContext const* mcc) {
-      LuminosityBlockForOutput lb(lbp, moduleDescription_, mcc, true);
+    bool OutputModuleBase::doEndLuminosityBlock(LumiTransitionInfo const& info, ModuleCallingContext const* mcc) {
+      LuminosityBlockForOutput lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(this);
       doEndLuminosityBlock_(lb);
 

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -26,6 +26,7 @@
 
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 using namespace edm::stream;
 //
@@ -140,16 +141,16 @@ std::vector<edm::ConsumesInfo> EDAnalyzerAdaptorBase::consumesInfo() const {
   return m_streamModules[0]->consumesInfo();
 }
 
-bool EDAnalyzerAdaptorBase::doEvent(EventPrincipal const& ep,
-                                    EventSetupImpl const& ci,
+bool EDAnalyzerAdaptorBase::doEvent(EventTransitionInfo const& info,
                                     ActivityRegistry* act,
                                     ModuleCallingContext const* mcc) {
+  EventPrincipal const& ep = info.principal();
   assert(ep.streamID() < m_streamModules.size());
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
   const EventSetup c{
-      ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
   EventSignalsSentry sentry(act, mcc);
   mod->analyze(e, c);
   return true;
@@ -159,55 +160,53 @@ void EDAnalyzerAdaptorBase::doBeginStream(StreamID id) { m_streamModules[id]->be
 void EDAnalyzerAdaptorBase::doEndStream(StreamID id) { m_streamModules[id]->endStream(); }
 
 void EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
-                                             RunPrincipal const& rp,
-                                             EventSetupImpl const& ci,
+                                             RunTransitionInfo const& info,
                                              ModuleCallingContext const* mcc) {
+  RunPrincipal const& rp = info.principal();
   auto mod = m_streamModules[id];
   setupRun(mod, rp.index());
 
   Run r(rp, moduleDescription_, mcc, false);
   const EventSetup c{
-      ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+      info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
   r.setConsumer(mod);
   mod->beginRun(r, c);
 }
 
 void EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
-                                           RunPrincipal const& rp,
-                                           EventSetupImpl const& ci,
+                                           RunTransitionInfo const& info,
                                            ModuleCallingContext const* mcc) {
   auto mod = m_streamModules[id];
-  Run r(rp, moduleDescription_, mcc, true);
+  Run r(info, moduleDescription_, mcc, true);
   r.setConsumer(mod);
   const EventSetup c{
-      ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+      info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
   mod->endRun(r, c);
   streamEndRunSummary(mod, r, c);
 }
 
 void EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
-                                                         LuminosityBlockPrincipal const& lbp,
-                                                         EventSetupImpl const& ci,
+                                                         LumiTransitionInfo const& info,
                                                          ModuleCallingContext const* mcc) {
+  LuminosityBlockPrincipal const& lbp = info.principal();
   auto mod = m_streamModules[id];
   setupLuminosityBlock(mod, lbp.index());
 
   LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
   lb.setConsumer(mod);
-  const EventSetup c{ci,
+  const EventSetup c{info,
                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                      mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
                      false};
   mod->beginLuminosityBlock(lb, c);
 }
 void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
-                                                       LuminosityBlockPrincipal const& lbp,
-                                                       EventSetupImpl const& ci,
+                                                       LumiTransitionInfo const& info,
                                                        ModuleCallingContext const* mcc) {
   auto mod = m_streamModules[id];
-  LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+  LuminosityBlock lb(info, moduleDescription_, mcc, true);
   lb.setConsumer(mod);
-  const EventSetup c{ci,
+  const EventSetup c{info,
                      static_cast<unsigned int>(Transition::EndLuminosityBlock),
                      mod->esGetTokenIndices(Transition::EndLuminosityBlock),
                      false};

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 using namespace edm::stream;
 namespace edm {
@@ -43,10 +44,10 @@ namespace edm {
     //
     EDFilterAdaptorBase::EDFilterAdaptorBase() {}
 
-    bool EDFilterAdaptorBase::doEvent(EventPrincipal const& ep,
-                                      EventSetupImpl const& ci,
+    bool EDFilterAdaptorBase::doEvent(EventTransitionInfo const& info,
                                       ActivityRegistry* act,
                                       ModuleCallingContext const* mcc) {
+      EventPrincipal const& ep = info.principal();
       assert(ep.streamID() < m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
@@ -54,17 +55,17 @@ namespace edm {
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
     }
 
-    void EDFilterAdaptorBase::doAcquire(EventPrincipal const& ep,
-                                        EventSetupImpl const& ci,
+    void EDFilterAdaptorBase::doAcquire(EventTransitionInfo const& info,
                                         ActivityRegistry* act,
                                         ModuleCallingContext const* mcc,
                                         WaitingTaskWithArenaHolder& holder) {
+      EventPrincipal const& ep = info.principal();
       assert(ep.streamID() < m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
@@ -72,7 +73,7 @@ namespace edm {
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/EventAcquireSignalsSentry.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
 #include "FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 using namespace edm::stream;
 namespace edm {
@@ -43,10 +44,10 @@ namespace edm {
     //
     EDProducerAdaptorBase::EDProducerAdaptorBase() {}
 
-    bool EDProducerAdaptorBase::doEvent(EventPrincipal const& ep,
-                                        EventSetupImpl const& ci,
+    bool EDProducerAdaptorBase::doEvent(EventTransitionInfo const& info,
                                         ActivityRegistry* act,
                                         ModuleCallingContext const* mcc) {
+      EventPrincipal const& ep = info.principal();
       assert(ep.streamID() < m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
@@ -54,17 +55,17 @@ namespace edm {
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
     }
 
-    void EDProducerAdaptorBase::doAcquire(EventPrincipal const& ep,
-                                          EventSetupImpl const& ci,
+    void EDProducerAdaptorBase::doAcquire(EventTransitionInfo const& info,
                                           ActivityRegistry* act,
                                           ModuleCallingContext const* mcc,
                                           WaitingTaskWithArenaHolder& holder) {
+      EventPrincipal const& ep = info.principal();
       assert(ep.streamID() < m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       Event e(ep, moduleDescription(), mcc);
@@ -72,7 +73,7 @@ namespace edm {
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -21,6 +21,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/TransitionInfoTypes.h"
 
 //
 // constants, enums and typedefs
@@ -72,7 +73,7 @@ namespace edm {
         //Since only the first module will actually do the registration
         // we will change its callback to call all the callbacks
         firstMod->callWhenNewProductsRegistered([callbacks](BranchDescription const& iBD) {
-          for (auto c : callbacks) {
+          for (const auto& c : callbacks) {
             c(iBD);
           }
         });
@@ -179,43 +180,43 @@ namespace edm {
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamBeginRun(StreamID id,
-                                                         RunPrincipal const& rp,
-                                                         EventSetupImpl const& ci,
+                                                         RunTransitionInfo const& info,
                                                          ModuleCallingContext const* mcc) {
+      RunPrincipal const& rp = info.principal();
       auto mod = m_streamModules[id];
       setupRun(mod, rp.index());
 
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(mod);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+          info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
       mod->beginRun(r, c);
     }
+
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamEndRun(StreamID id,
-                                                       RunPrincipal const& rp,
-                                                       EventSetupImpl const& ci,
+                                                       RunTransitionInfo const& info,
                                                        ModuleCallingContext const* mcc) {
       auto mod = m_streamModules[id];
-      Run r(rp, moduleDescription_, mcc, true);
+      Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(mod);
       const EventSetup c{
-          ci, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
       mod->endRun(r, c);
       streamEndRunSummary(mod, r, c);
     }
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamBeginLuminosityBlock(StreamID id,
-                                                                     LuminosityBlockPrincipal const& lbp,
-                                                                     EventSetupImpl const& ci,
+                                                                     LumiTransitionInfo const& info,
                                                                      ModuleCallingContext const* mcc) {
+      LuminosityBlockPrincipal const& lbp = info.principal();
       auto mod = m_streamModules[id];
       setupLuminosityBlock(mod, lbp.index());
 
       LuminosityBlock lb(lbp, moduleDescription_, mcc, false);
       lb.setConsumer(mod);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
                          false};
@@ -224,13 +225,12 @@ namespace edm {
 
     template <typename T>
     void ProducingModuleAdaptorBase<T>::doStreamEndLuminosityBlock(StreamID id,
-                                                                   LuminosityBlockPrincipal const& lbp,
-                                                                   EventSetupImpl const& ci,
+                                                                   LumiTransitionInfo const& info,
                                                                    ModuleCallingContext const* mcc) {
       auto mod = m_streamModules[id];
-      LuminosityBlock lb(lbp, moduleDescription_, mcc, true);
+      LuminosityBlock lb(info, moduleDescription_, mcc, true);
       lb.setConsumer(mod);
-      const EventSetup c{ci,
+      const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          mod->esGetTokenIndices(Transition::EndLuminosityBlock),
                          false};


### PR DESCRIPTION
#### PR description:

Use the TransitionInfo classes in more interfaces in the Framework. This is the last in a series of pull requests simplifying some interfaces internal to the Framework with the TransitionInfo class. The main goal is to make the code more readable and understandable. It shouldn't affect output or performance. This one is focused on the interfaces from the Worker down into the module base classes.

I am not aware of anything controversial in the one.

#### PR validation:

There should be no change in behavior or output. This relies on existing tests.
