### PR TITLE
Protect against ill-defined track momenta and reffited tau vertices for tauReco@mini (10_6_X)

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -65,6 +65,8 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(const si
 
   //Find candidates/tracks associated to thePV
   for(const auto& cand: cands){
+    //MB: Skip candidates with ill-defined momentum as they return ill-defined tracks (why it happens?)
+    if (!std::isfinite(cand.pt())) continue;  //MB: it is enough to check just pt (?)
     if(cand.vertexRef().isNull()) continue;
     int quality = cand.pvAssociationQuality();
     if(cand.vertexRef().key()!=thePVkey ||
@@ -72,8 +74,6 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(const si
 	quality!=pat::PackedCandidate::UsedInFitLoose)) continue;
     const reco::Track *track = cand.bestTrack();
     if(track == nullptr) continue;
-    //MB: Skip tracks with ill-defined momentum (why it happens?)
-    if(!std::isfinite(track->pt()) || !std::isfinite(track->eta()) || !std::isfinite(track->phi())) continue;
     //Remove signal (tau) tracks
     //MB: Only deltaR deltaPt overlap removal possible (?)
     //MB: It should be fine as pat objects stores same track info with same presision 

--- a/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFTauMiniAODPrimaryVertexProducer.cc
@@ -72,6 +72,8 @@ void PFTauMiniAODPrimaryVertexProducer::nonTauTracksInPVFromPackedCands(const si
 	quality!=pat::PackedCandidate::UsedInFitLoose)) continue;
     const reco::Track *track = cand.bestTrack();
     if(track == nullptr) continue;
+    //MB: Skip tracks with ill-defined momentum (why it happens?)
+    if(!std::isfinite(track->pt()) || !std::isfinite(track->eta()) || !std::isfinite(track->phi())) continue;
     //Remove signal (tau) tracks
     //MB: Only deltaR deltaPt overlap removal possible (?)
     //MB: It should be fine as pat objects stores same track info with same presision 

--- a/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
@@ -183,6 +183,14 @@ void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent,const edm::Event
 	  } else {
 	    transVtx = avf.vertex(transTracks, *beamSpot);
 	  }
+	  if (!transVtx.isValid()) {
+	    fitOK = false;
+	  } else {
+	    //MB: protect against rare cases when transVtx is valid but its position is ill-defined
+	    reco::Vertex::Point pvPos(transVtx.position());
+	    if (!std::isfinite(pvPos.z())) //MB: it is enough to check one coordinate (?)
+	      fitOK = false;
+	  }
 	} else fitOK = false;
 	if ( fitOK ) thePV = transVtx;
       }

--- a/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
+++ b/RecoTauTag/RecoTau/src/PFTauPrimaryVertexProducerBase.cc
@@ -187,8 +187,7 @@ void PFTauPrimaryVertexProducerBase::produce(edm::Event& iEvent,const edm::Event
 	    fitOK = false;
 	  } else {
 	    //MB: protect against rare cases when transVtx is valid but its position is ill-defined
-	    reco::Vertex::Point pvPos(transVtx.position());
-	    if (!std::isfinite(pvPos.z())) //MB: it is enough to check one coordinate (?)
+	    if (!std::isfinite(transVtx.position().z())) //MB: it is enough to check one coordinate (?)
 	      fitOK = false;
 	  }
 	} else fitOK = false;


### PR DESCRIPTION
#### PR description:

As title says; in miniAOD samples (recent 94X/102X productions) there are rare tracks within pat:PackedCandidates (mainly lostTracks collection) with ill-defined momenta, i.e. pt being inf and/or eta nan. Those tracks used to (re)fit tau vertex result with a vertex with an undefined position (reco::Vertex::Point(nan,nan,nan)), but claiming to be a valid transient vertex. This PR protects against such issues - ill-defined tracks are not used for the fit and vertices with invalid position are not used for further processing.

This PR has not impact on official workflows, while it fixes issue causing failures in the tauReco@mini (unoffical) workflow.


#### PR validation:

* Validated with tauReco@mini (unofficial) workflow that failures observed with original code are fixed.
* Matrix tests (`runTheMatrix.py -l limited -i all --ibeos`) successful (with master).


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #31582 to 10_6_X for processing existing and UL (re)MiniAOD samples.