### PR TITLE
Clean BuildFiles in FWCore

### DIFF
--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -184,7 +184,6 @@
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
   <use name="DataFormats/TestObjects"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
@@ -205,7 +204,6 @@
 <bin name="TestFWCoreFrameworkeventprocessor" file="testRunner.cpp,eventprocessor2_t.cppunit.cc,eventprocessor_t.cppunit.cc">
   <lib name="FWCoreFrameworkTest"/>
   <use name="DataFormats/Provenance"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
@@ -228,7 +226,6 @@
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
   <use name="DataFormats/TestObjects"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/Utilities"/>
@@ -258,13 +255,11 @@
 
 <bin name="TestFWCoreFrameworkGlobalStreamOne" file="TestDriver.cpp">
   <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_global_stream_one.sh"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
   <use name="FWCore/Utilities"/>
 </bin>
 
 <bin name="TestFWCoreFrameworkMayConsumesDeadlock" file="TestDriver.cpp">
   <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_deadlock_test.sh"/>
-  <use name="DataFormats/WrappedStdDictionaries"/>
   <use name="FWCore/Utilities"/>
 </bin>
 

--- a/FWCore/Integration/bin/BuildFile.xml
+++ b/FWCore/Integration/bin/BuildFile.xml
@@ -11,5 +11,4 @@
   <use name="FWCore/TestProcessor"/>
   <use name="FWCore/SharedMemory"/>
   <use name="FWCore/Services"/>
-  <use name="FWCore/Utilities"/>
 </bin>

--- a/FWCore/MessageService/test/BuildFile.xml
+++ b/FWCore/MessageService/test/BuildFile.xml
@@ -259,8 +259,6 @@
   <use name="boost_program_options"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/PluginManager"/>
-  <use name="FWCore/ServiceRegistry"/>
 </bin>
 
 <bin file="fmt_test.cppunit.cpp">

--- a/FWCore/Services/bin/BuildFile.xml
+++ b/FWCore/Services/bin/BuildFile.xml
@@ -2,7 +2,6 @@
   <use name="FWCore/Utilities"/>
   <use name="FWCore/Catalog"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Services"/>
 </bin>

--- a/FWCore/Services/test/BuildFile.xml
+++ b/FWCore/Services/test/BuildFile.xml
@@ -1,13 +1,11 @@
 <library file="StuckAnalyzer.cc" name="StuckAnalyzer">
   <flags EDM_PLUGIN="1"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/Framework"/>
 </library>
 
 <library file="SiteLocalConfigServiceTester.cc" name="SiteLocalConfigUnitTestClient">
   <flags EDM_PLUGIN="1"/>
   <use name="FWCore/Services"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/Framework"/>
 </library>
 

--- a/FWCore/TFWLiteSelector/test/BuildFile.xml
+++ b/FWCore/TFWLiteSelector/test/BuildFile.xml
@@ -1,6 +1,5 @@
 <bin file="TestRunnerFWCoreTFWLiteSelector.cpp">
   <flags TEST_RUNNER_ARGS=" /bin/bash FWCore/TFWLiteSelector/test run_all_t.sh"/>
   <use name="FWCore/Utilities"/>
-  <use name="FWCore/TFWLiteSelectorTest"/>
   <use name="FWCore/FWLite"/>
 </bin>

--- a/FWCore/TestProcessor/test/BuildFile.xml
+++ b/FWCore/TestProcessor/test/BuildFile.xml
@@ -2,7 +2,6 @@
   <use name="boost"/>
   <use name="cppunit"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/Utilities"/>
   <use name="FWCore/TestProcessor"/>
   <use name="FWCore/Integration"/>
 </bin>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31533).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.