### PR TITLE
Fix unit test failure in DQM/Integration (issue 31592)

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/BuildFile.xml
@@ -8,6 +8,4 @@
 <use name="Utilities/Xerces"/>
 <use name="xerces-c"/>
 <use name="stdcxx-fs"/>
-<export>
-  <lib name="1"/>
-</export>
+<flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

An issue (https://github.com/cms-sw/cmssw/issues/31592) appeared after the most recent BuilFile cleaning PR (https://github.com/cms-sw/cmssw/pull/31548).

I guess the problem is that the BuildFile declares a normal library instead of an EDM plugin library, so that's what I suggest to change in this PR (inspired by [1]). Before my cleaning PR, this library was linked against by some other plugin, and that's how the plugin got registered in the past [2].

Now, the plugin can be found again with `edmPluginHelp -p L1GtTriggerMaskTechTrigTrivialProducer` and the previously-failing unit test succeeds.

[1] <https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/EgammaPhotonProducers/BuildFile.xml>
[2] <https://github.com/cms-sw/cmssw/pull/31548/files#diff-d35b5dbd3e30c40bee4cc0c5bd6ae022L13>

#### PR validation:

* the `L1GtTriggerMaskTechTrigTrivialProducer` can be found once again with `edmPluginHelp`
* unit test `./src/DQM/Integration/test/runtest.sh scal_dqm_sourceclient-live_cfg.py` passes again

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.
