### PR TITLE
ASAN: protection against accessing invalid memory when ieta==0

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
@@ -126,8 +126,9 @@ void ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 int ParticleTowerProducer::eta2ieta(double eta) const {
   // binary search in the array of towers eta edges
 
-  int ieta = 0;
-  while (fabs(eta) > hi::etaedge[ieta] && ieta < ietaMax - 1) {
+  int ieta = 1;
+  double xeta = fabs(eta);
+  while (xeta > hi::etaedge[ieta] && ieta < ietaMax - 1) {
     ++ieta;
   }
 


### PR DESCRIPTION
Workflow 301.0 step3 fails in  ASAN IBs [a]. This could happen if `ieta==0` (https://github.com/cms-sw/cmssw/blob/master/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc#L181). This PR proposes a protected against `ieta==0` and also call `fabs` once


[a]
https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_2_ASAN_X_2020-09-25-2300/pyRelValMatrixLogs/run/301.0_Pyquen_DiJet_pt80to120_2760GeV+Pyquen_DiJet_pt80to120_2760GeV+DIGIHIMIX+RECOHIMIX+HARVESTHI2018PPRECO/step3_Pyquen_DiJet_pt80to120_2760GeV+Pyquen_DiJet_pt80to120_2760GeV+DIGIHIMIX+RECOHIMIX+HARVESTHI2018PPRECO.log#/
```
0x2afcfb1f93d8 is located 8 bytes to the left of global variable 'etaedge' defined in 'RecoHI/HiJetAlgos/plugins/HITowerHelper.h:5:36'
```