### PR TITLE
fix squashed fastsim decays for backport to C94x #31575

### DIFF
--- a/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
+++ b/FastSimulation/SimplifiedGeometryPropagator/src/ParticleManager.cc
@@ -250,21 +250,13 @@ std::unique_ptr<fastsim::Particle> fastsim::ParticleManager::nextGenParticle()
         }
         // particles which do not descend from exotics must be produced within the beampipe
         int exoticRelativeId = 0;
-        if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_)  //
-        	{
-        		exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
-        		if (!isExotic(exoticRelativeId)) {
-        			continue;
-        		}
-        	}
-
-
-        // particle must be produced within the beampipe
-        if(productionVertex->position().perp2()*lengthUnitConversionFactor2_ > beamPipeRadius2_)
-        {
-            continue;
+        if (productionVertex->position().perp2() * lengthUnitConversionFactor2_ > beamPipeRadius2_) { //
+            exoticRelativesChecker(productionVertex, exoticRelativeId, 0);
+            if (!isExotic(exoticRelativeId)) {
+                continue;
+            }
         }
-        
+
         // particle must not decay before it reaches the beam pipe
         if(endVertex && endVertex->position().perp2()*lengthUnitConversionFactor2_ < beamPipeRadius2_)
         {


### PR DESCRIPTION
A few lines from the backport that went into 
https://github.com/cms-sw/cmssw/pull/31575 

were not placed between the HEAD<<<< and ===== deliminators. Deleting those lines here. 