### PR TITLE
PPS: fixes related to ForwardProton::LHCSector

### DIFF
--- a/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -389,7 +389,8 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
   // save reco candidate
   const double sign_z = (armId == 0) ? +1. : -1.;  // CMS convention
   const FP::Point vertex(0., vtx_y, 0.);
-  const double cos_th = sqrt(1. - th_x * th_x - th_y * th_y);
+  const double cos_th_sq = sqrt(1. - th_x * th_x - th_y * th_y);
+  const double cos_th = (cos_th_sq > 0.) ? sqrt(cos_th_sq) : 1.;
   const double p = lhcInfo.energy() * (1. - xi);
   const FP::Vector momentum(-p * th_x,  // the signs reflect change LHC --> CMS convention
                             +p * th_y,
@@ -437,7 +438,8 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const
   // save proton candidate
   const double sign_z = (CTPPSDetId(track->rpId()).arm() == 0) ? +1. : -1.;  // CMS convention
   const FP::Point vertex(0., 0., 0.);
-  const double cos_th = sqrt(1. - th_y * th_y);
+  const double cos_th_sq = 1. - th_y * th_y;
+  const double cos_th = (cos_th_sq > 0.) ? sqrt(cos_th_sq) : 1.;
   const double p = lhcInfo.energy() * (1. - xi);
   const FP::Vector momentum(0., p * th_y, sign_z * p * cos_th);
 

--- a/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -389,7 +389,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromMultiRP(const 
   // save reco candidate
   const double sign_z = (armId == 0) ? +1. : -1.;  // CMS convention
   const FP::Point vertex(0., vtx_y, 0.);
-  const double cos_th_sq = sqrt(1. - th_x * th_x - th_y * th_y);
+  const double cos_th_sq = 1. - th_x * th_x - th_y * th_y;
   const double cos_th = (cos_th_sq > 0.) ? sqrt(cos_th_sq) : 1.;
   const double p = lhcInfo.energy() * (1. - xi);
   const FP::Vector momentum(-p * th_x,  // the signs reflect change LHC --> CMS convention

--- a/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -428,10 +428,11 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const
 
   const double ep_xi = 1E-4;
   const double dL_y_dxi = (oit->second.s_L_y_vs_xi->Eval(xi + ep_xi) - L_y) / ep_xi;
-  const double th_y_unc_sq = th_y*th_y * (pow(track->yUnc() / track->y(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
+  const double th_y_unc_sq = th_y * th_y * (pow(track->yUnc() / track->y(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
 
   if (verbosity_)
-    os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << sqrt(th_y_unc_sq) << "." << std::endl;
+    os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << sqrt(th_y_unc_sq) << "."
+       << std::endl;
 
   using FP = reco::ForwardProton;
 

--- a/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
+++ b/RecoPPS/ProtonReconstruction/src/ProtonReconstructionAlgorithm.cc
@@ -428,10 +428,10 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const
 
   const double ep_xi = 1E-4;
   const double dL_y_dxi = (oit->second.s_L_y_vs_xi->Eval(xi + ep_xi) - L_y) / ep_xi;
-  const double th_y_unc = th_y * sqrt(pow(track->yUnc() / track->y(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
+  const double th_y_unc_sq = th_y*th_y * (pow(track->yUnc() / track->y(), 2.) + pow(dL_y_dxi * xi_unc / L_y, 2.));
 
   if (verbosity_)
-    os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << th_y_unc << "." << std::endl;
+    os << "    xi = " << xi << " +- " << xi_unc << ", th_y = " << th_y << " +- " << sqrt(th_y_unc_sq) << "." << std::endl;
 
   using FP = reco::ForwardProton;
 
@@ -445,7 +445,7 @@ reco::ForwardProton ProtonReconstructionAlgorithm::reconstructFromSingleRP(const
 
   FP::CovarianceMatrix cm;
   cm((int)FP::Index::xi, (int)FP::Index::xi) = xi_unc * xi_unc;
-  cm((int)FP::Index::th_y, (int)FP::Index::th_y) = th_y_unc * th_y_unc;
+  cm((int)FP::Index::th_y, (int)FP::Index::th_y) = th_y_unc_sq;
 
   CTPPSLocalTrackLiteRefVector trk;
   trk.push_back(track);

--- a/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
+++ b/Validation/CTPPS/plugins/CTPPSProtonReconstructionSimulationValidator.cc
@@ -286,7 +286,7 @@ void CTPPSProtonReconstructionSimulationValidator::analyze(const edm::Event &iEv
       if (!rec_pr.validFit())
         continue;
 
-      unsigned int idx;
+      unsigned int idx = 12345;
 
       bool mom_set = false;
       FourVector mom;
@@ -295,7 +295,8 @@ void CTPPSProtonReconstructionSimulationValidator::analyze(const edm::Event &iEv
         idx = 0;
         mom_set = proton_45_set;
         mom = mom_45;
-      } else {
+      }
+      if (rec_pr.lhcSector() == reco::ForwardProton::LHCSector::sector56) {
         idx = 1;
         mom_set = proton_56_set;
         mom = mom_56;
@@ -334,7 +335,8 @@ void CTPPSProtonReconstructionSimulationValidator::analyze(const edm::Event &iEv
     if (rec_pr.lhcSector() == reco::ForwardProton::LHCSector::sector45) {
       time_set_45 = true;
       time_45 = rec_pr.time();
-    } else {
+    }
+    if (rec_pr.lhcSector() == reco::ForwardProton::LHCSector::sector56) {
       time_set_56 = true;
       time_56 = rec_pr.time();
     }


### PR DESCRIPTION
#### PR description:

This PR contains fixes to two rare problems related to ``ForwardProton::LHCSector``.

1) In ProtonReconstructionAlgorithm.cc: rarely, it may happen that the scattering angles (th_x or th_y) are reconstructed large (mis-reconstruction). In this case, an argument to sqrt becomes negative and consequently proton's momentum z component is assigned NAN. The (undefined) sign of p.z is used in the method ``ForwardProton::lhcSector()`` which in turn returns an invalid value. This PR fixes this problem by checking the sqrt argument and if negative using a realistic value for p.z, yielding correct LHC sector identification.

2) In CTPPSProtonReconstructionSimulationValidator.cc: explicitly check whether proton was reconstructed in LHC sector 56 - protons with invalid sector do no longer pass to the "sector 56" category.

The above problems were spotted in the "direct" simulation with an occurrence O(1 in million events). Therefore the impact of these fixes is expected negligible.

#### PR validation:

The following plots compare results before this PR (blue) and after the PR (red dashed). The top one is for "direct" simulation, the bottom is for Run2 data reconstruction. No differences are observed - compatible with the rare nature of the problems being fixed.

For the few failing events isolated in the "direct" simulation, it has been checked that the proposed PR fixes the problem.

![dirsim_cmp](https://user-images.githubusercontent.com/17830858/94370126-58628480-00ee-11eb-80ac-93f4660aae2a.png)
![reco_cmp](https://user-images.githubusercontent.com/17830858/94370127-58fb1b00-00ee-11eb-8ab6-05f57ada6af5.png)


