### PR TITLE
L1T Phase2 NN Tau (11_1_X)

### DIFF
--- a/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
+++ b/L1Trigger/Configuration/python/L1Trigger_EventContent_cff.py
@@ -196,6 +196,8 @@ def _appendPhase2Digis(obj):
         'keep *_l1PFMetCalo_*_*',
         'keep *_l1PFMetPF_*_*',
         'keep *_l1PFMetPuppi_*_*',
+        'keep *_l1NNTauProducer_*_*',
+        'keep *_l1NNTauProducerPuppi_*_*',
         'keep *_TTStubsFromPhase2TrackerDigis_*_*',
         'keep *_TTClustersFromPhase2TrackerDigis_*_*',
         'keep *_TTTracksFromExtendedTrackletEmulation_*_*',

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -141,8 +141,8 @@ l1NNTauProducer = L1NNTauProducer.clone(
 l1NNTauProducerPuppi = L1NNTauProducerPuppi.clone(
   L1PFObjects = cms.InputTag("l1pfCandidates","Puppi")
 )
-_phase2_siml1emulator.add(l1NNTauProducer)
-_phase2_siml1emulator.add(l1NNTauProducerPuppi)
+#_phase2_siml1emulator.add(l1NNTauProducer)
+#_phase2_siml1emulator.add(l1NNTauProducerPuppi)
 
 # --> add modules
 #%% # Barrel EGamma

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -132,6 +132,18 @@ _phase2_siml1emulator.add(l1PFJetsTask)
 l1PFMetsTask = cms.Task(l1PFMetCalo , l1PFMetPF , l1PFMetPuppi)
 _phase2_siml1emulator.add(l1PFMetsTask)
 
+# NNTaus
+# ########################################################################
+from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cff import *
+l1NNTauProducer = L1NNTauProducer.clone(
+  L1PFObjects = cms.InputTag("l1pfCandidates","PF")
+)
+l1NNTauProducerPuppi = L1NNTauProducerPuppi.clone(
+  L1PFObjects = cms.InputTag("l1pfCandidates","Puppi")
+)
+_phase2_siml1emulator_ttrack.add(l1NNTauProducer)
+_phase2_siml1emulator_ttrack.add(l1NNTauProducerPuppi)
+
 # --> add modules
 #%% # Barrel EGamma
 #%% # ########################################################################

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -141,8 +141,8 @@ l1NNTauProducer = L1NNTauProducer.clone(
 l1NNTauProducerPuppi = L1NNTauProducerPuppi.clone(
   L1PFObjects = cms.InputTag("l1pfCandidates","Puppi")
 )
-_phase2_siml1emulator_ttrack.add(l1NNTauProducer)
-_phase2_siml1emulator_ttrack.add(l1NNTauProducerPuppi)
+_phase2_siml1emulator.add(l1NNTauProducer)
+_phase2_siml1emulator.add(l1NNTauProducerPuppi)
 
 # --> add modules
 #%% # Barrel EGamma

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -141,8 +141,8 @@ l1NNTauProducer = L1NNTauProducer.clone(
 l1NNTauProducerPuppi = L1NNTauProducerPuppi.clone(
   L1PFObjects = cms.InputTag("l1pfCandidates","Puppi")
 )
-#_phase2_siml1emulator.add(l1NNTauProducer)
-#_phase2_siml1emulator.add(l1NNTauProducerPuppi)
+_phase2_siml1emulator.add(l1NNTauProducer)
+_phase2_siml1emulator.add(l1NNTauProducerPuppi)
 
 # --> add modules
 #%% # Barrel EGamma

--- a/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
+++ b/L1Trigger/Phase2L1ParticleFlow/BuildFile.xml
@@ -9,6 +9,8 @@
 <use   name="L1Trigger/L1THGCal"/>
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/MVAUtils"/>
+<use   name="PhysicsTools/TensorFlow"/>
+<use   name="tensorflow"/>
 <use   name="roottmva"/>
 <use   name="hls"/>
 <export>

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
@@ -22,10 +22,10 @@ public:
 
 private:
   std::unique_ptr<TauNNId> fTauNNId_;
-  void addTau(l1t::PFCandidate &iCand,
+  void addTau(const l1t::PFCandidate &iCand,
               const l1t::PFCandidateCollection &iParts,
               std::unique_ptr<PFTauCollection> &outputTaus);
-  float deltaR(l1t::PFCandidate &iPart1, l1t::PFCandidate &iPart2);
+  float deltaR(const l1t::PFCandidate &iPart1, const l1t::PFCandidate &iPart2);
   void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
   double fSeedPt_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
@@ -27,7 +27,7 @@ private:
   void addTau(l1t::PFCandidate &iCand,
               const l1t::PFCandidateCollection &iParts,
               std::unique_ptr<PFTauCollection> &outputTaus);
-  float deltaR(auto iPart1, auto iPart2);
+  float deltaR(l1t::PFCandidate &iPart1, l1t::PFCandidate &iPart2);
   virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
   double fSeedPt_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
@@ -21,7 +21,7 @@ public:
   ~L1NNTauProducer() override;
 
 private:
-  TauNNId *fTauNNId;
+  std::unique_ptr<TauNNId> fTauNNId_;
   void addTau(l1t::PFCandidate &iCand,
               const l1t::PFCandidateCollection &iParts,
               std::unique_ptr<PFTauCollection> &outputTaus);

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
@@ -1,0 +1,41 @@
+#ifndef L1TRIGGER_PHASE2L1PARTICLEFLOW_L1NNTAU_H
+#define L1TRIGGER_PHASE2L1PARTICLEFLOW_L1NNTAU_H
+
+#include <iostream>
+#include <vector>
+#include <TLorentzVector.h>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h"
+
+using namespace l1t;
+
+class L1NNTauProducer : public edm::stream::EDProducer<> {
+public:
+  explicit L1NNTauProducer(const edm::ParameterSet &);
+  ~L1NNTauProducer();
+
+private:
+  TauNNId *fTauNNId;
+  void addTau(l1t::PFCandidate &iCand,
+              const l1t::PFCandidateCollection &iParts,
+              std::unique_ptr<PFTauCollection> &outputTaus);
+  float deltaR(auto iPart1, auto iPart2);
+  virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+
+  double fSeedPt_;
+  double fConeSize_;
+  double fTauSize_;
+  int fMaxTaus_;
+  int fNParticles_;
+  edm::EDGetTokenT<vector<l1t::PFCandidate> > fL1PFToken_;
+};
+
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh
@@ -1,9 +1,7 @@
 #ifndef L1TRIGGER_PHASE2L1PARTICLEFLOW_L1NNTAU_H
 #define L1TRIGGER_PHASE2L1PARTICLEFLOW_L1NNTAU_H
 
-#include <iostream>
 #include <vector>
-#include <TLorentzVector.h>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -20,7 +18,7 @@ using namespace l1t;
 class L1NNTauProducer : public edm::stream::EDProducer<> {
 public:
   explicit L1NNTauProducer(const edm::ParameterSet &);
-  ~L1NNTauProducer();
+  ~L1NNTauProducer() override;
 
 private:
   TauNNId *fTauNNId;
@@ -28,7 +26,7 @@ private:
               const l1t::PFCandidateCollection &iParts,
               std::unique_ptr<PFTauCollection> &outputTaus);
   float deltaR(l1t::PFCandidate &iPart1, l1t::PFCandidate &iPart2);
-  virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
+  void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;
 
   double fSeedPt_;
   double fConeSize_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -13,7 +13,7 @@ public:
   void initialize(const std::string &iName, const std::string &iWeightFile, int iNParticles);
   void SetNNVectorVar();
   float EvaluateNN();
-  float compute(l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts);
+  float compute(const l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts);
 
   std::string fInput_;
   int fNParticles_;

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -1,5 +1,5 @@
 #ifndef L1TRIGGER_PHASE2L1PARTICLEFLOWS_TAUNNID_H
-#define L1TRIGGER_PHASE2L1PARTICLEFLOWS_TAuNNID_H
+#define L1TRIGGER_PHASE2L1PARTICLEFLOWS_TAUNNID_H
 
 #include <string>
 #include "PhysicsTools/TensorFlow/interface/TensorFlow.h"

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -1,0 +1,30 @@
+#ifndef L1TRIGGER_PHASE2L1PARTICLEFLOWS_TAUNNID_H
+#define L1TRIGGER_PHASE2L1PARTICLEFLOWS_TAuNNID_H
+
+#include <string>
+#include "PhysicsTools/TensorFlow/interface/TensorFlow.h"
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+
+class TauNNId {
+public:
+  TauNNId();
+  ~TauNNId();
+
+  void initialize(const std::string &iName, const std::string &iWeightFile, int iNParticles);
+  void SetNNVectorVar();
+  float EvaluateNN();
+  float compute(l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts);
+
+  std::string fInput_;
+  int fNParticles_;
+  unique_ptr<float> fPt_;
+  unique_ptr<float> fEta_;
+  unique_ptr<float> fPhi_;
+  unique_ptr<float> fId_;
+
+private:
+  tensorflow::Session *session_;
+  tensorflow::GraphDef *graphDef_;
+  std::vector<float> NNvectorVar_;
+};
+#endif

--- a/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h
@@ -17,10 +17,10 @@ public:
 
   std::string fInput_;
   int fNParticles_;
-  unique_ptr<float> fPt_;
-  unique_ptr<float> fEta_;
-  unique_ptr<float> fPhi_;
-  unique_ptr<float> fId_;
+  unique_ptr<float[]> fPt_;
+  unique_ptr<float[]> fEta_;
+  unique_ptr<float[]> fPhi_;
+  unique_ptr<float[]> fId_;
 
 private:
   tensorflow::Session *session_;

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -66,7 +66,7 @@ void L1NNTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 }
 
 // create taus based on grid structure
-void L1NNTauProducer::addTau(l1t::PFCandidate& iCand,
+void L1NNTauProducer::addTau(const l1t::PFCandidate& iCand,
                              const l1t::PFCandidateCollection& iParts,
                              std::unique_ptr<l1t::PFTauCollection>& outputTaus) {
   l1t::PFCandidateCollection pfTauCands;
@@ -98,7 +98,7 @@ void L1NNTauProducer::addTau(l1t::PFCandidate& iCand,
   l1t::PFTau l1PFTau(tempP4, NN, 0, lId);
   outputTaus->push_back(l1PFTau);
 }
-float L1NNTauProducer::deltaR(l1t::PFCandidate& iPart1, l1t::PFCandidate& iPart2) {
+float L1NNTauProducer::deltaR(const l1t::PFCandidate& iPart1, const l1t::PFCandidate& iPart2) {
   float delta_r = 20;
   float pDPhi = fabs(iPart1.phi() - iPart2.phi());
   if (pDPhi > 2. * M_PI - pDPhi)

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -96,7 +96,7 @@ void L1NNTauProducer::addTau(l1t::PFCandidate& iCand,
   l1t::PFTau l1PFTau(tempP4, NN, 0, lId);
   outputTaus->push_back(l1PFTau);
 }
-float L1NNTauProducer::deltaR(auto iPart1, auto iPart2) {
+float L1NNTauProducer::deltaR(l1t::PFCandidate& iPart1, l1t::PFCandidate& iPart2) {
   float delta_r = 20;
   float pDPhi = fabs(iPart1.phi() - iPart2.phi());
   if (pDPhi > 2. * TMath::Pi() - pDPhi)

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -10,11 +10,11 @@ L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg)
       fNParticles_(cfg.getParameter<int>("nparticles")),
       fL1PFToken_(consumes<vector<l1t::PFCandidate> >(cfg.getParameter<edm::InputTag>("L1PFObjects"))) {
   std::string lNNFile = cfg.getParameter<std::string>("NNFileName");  //,"L1Trigger/Phase2L1Taus/data/tau_3layer.pb");
-  fTauNNId = new TauNNId();
+  fTauNNId_ = std::make_unique<TauNNId>();
   if (lNNFile.find("v0") == std::string::npos)
-    fTauNNId->initialize("input_1:0", lNNFile, fNParticles_);
+    fTauNNId_->initialize("input_1:0", lNNFile, fNParticles_);
   else if (lNNFile.find("v0") != std::string::npos)
-    fTauNNId->initialize("dense_1_input:0", lNNFile, fNParticles_);
+    fTauNNId_->initialize("dense_1_input:0", lNNFile, fNParticles_);
   produces<l1t::PFTauCollection>("L1PFTausNN");
 }
 
@@ -93,7 +93,7 @@ void L1NNTauProducer::addTau(l1t::PFCandidate& iCand,
     return;
   std::sort(
       pfTauCands.begin(), pfTauCands.end(), [](l1t::PFCandidate i, l1t::PFCandidate j) { return (i.pt() > j.pt()); });
-  float NN = fTauNNId->compute(iCand, pfTauCands);
+  float NN = fTauNNId_->compute(iCand, pfTauCands);
   math::PtEtaPhiMLorentzVector tempP4(lCand.Pt(), lCand.Eta(), lCand.Phi(), lCand.M());
   l1t::PFTau l1PFTau(tempP4, NN, 0, lId);
   outputTaus->push_back(l1PFTau);

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -1,0 +1,110 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/L1NNTauProducer.hh"
+
+L1NNTauProducer::L1NNTauProducer(const edm::ParameterSet& cfg)
+    : fSeedPt_(cfg.getParameter<double>("seedpt")),
+      fConeSize_(cfg.getParameter<double>("conesize")),
+      fTauSize_(cfg.getParameter<double>("tausize")),
+      fMaxTaus_(cfg.getParameter<int>("maxtaus")),
+      fNParticles_(cfg.getParameter<int>("nparticles")),
+      fL1PFToken_(consumes<vector<l1t::PFCandidate> >(cfg.getParameter<edm::InputTag>("L1PFObjects"))) {
+  std::string lNNFile = cfg.getParameter<std::string>("NNFileName");  //,"L1Trigger/Phase2L1Taus/data/tau_3layer.pb");
+  fTauNNId = new TauNNId();
+  if (lNNFile.find("v0") == std::string::npos)
+    fTauNNId->initialize("input_1:0", lNNFile, fNParticles_);
+  if (lNNFile.find("v0") != std::string::npos)
+    fTauNNId->initialize("dense_1_input:0", lNNFile, fNParticles_);
+  produces<l1t::PFTauCollection>("L1PFTausNN");
+}
+
+void L1NNTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<l1t::PFCandidateCollection> l1PFCandidates;
+  iEvent.getByToken(fL1PFToken_, l1PFCandidates);
+
+  l1t::PFCandidateCollection pfChargedHadrons;
+  l1t::PFCandidateCollection pfChargedHadrons_sort;
+  l1t::PFCandidateCollection pfChargedHadrons_seeds;
+  for (auto l1PFCand : *l1PFCandidates)
+    if ((l1PFCand.id() == l1t::PFCandidate::ChargedHadron || l1PFCand.id() == l1t::PFCandidate::Electron) &&
+        fabs(l1PFCand.eta()) < 2.5)
+      pfChargedHadrons_sort.push_back(l1PFCand);
+  std::sort(pfChargedHadrons_sort.begin(), pfChargedHadrons_sort.end(), [](l1t::PFCandidate i, l1t::PFCandidate j) {
+    return (i.pt() > j.pt());
+  });
+  auto lTaus = std::make_unique<l1t::PFTauCollection>();
+  if (pfChargedHadrons_sort.size() == 0) {
+    if (lTaus->size() == 0) {
+      PFTau dummy;
+      lTaus->push_back(dummy);
+    }
+    iEvent.put(std::move(lTaus), "L1PFTausNN");
+    return;
+  }
+  pfChargedHadrons_seeds.push_back(pfChargedHadrons_sort[0]);
+  for (unsigned int i0 = 1; i0 < pfChargedHadrons_sort.size(); i0++) {
+    bool pMatch = false;
+    for (unsigned int i1 = 0; i1 < pfChargedHadrons_seeds.size(); i1++) {
+      if (deltaR(pfChargedHadrons_seeds[i1], pfChargedHadrons_sort[i0]) < 0.4)
+        pMatch = true;
+    }
+    if (pMatch)
+      continue;
+    pfChargedHadrons_seeds.push_back(pfChargedHadrons_sort[i0]);
+    if (int(pfChargedHadrons_seeds.size()) > fMaxTaus_ - 1)
+      break;
+  }
+  for (unsigned int i0 = 0; i0 < pfChargedHadrons_seeds.size(); i0++) {
+    addTau(pfChargedHadrons_seeds[i0], (*l1PFCandidates), lTaus);
+  }
+  if (lTaus->size() == 0) {
+    PFTau dummy;
+    lTaus->push_back(dummy);
+  }
+  std::sort(lTaus->begin(), lTaus->end(), [](l1t::PFTau i, l1t::PFTau j) { return (i.pt() > j.pt()); });
+  iEvent.put(std::move(lTaus), "L1PFTausNN");
+}
+
+// create taus based on grid structure
+void L1NNTauProducer::addTau(l1t::PFCandidate& iCand,
+                             const l1t::PFCandidateCollection& iParts,
+                             std::unique_ptr<l1t::PFTauCollection>& outputTaus) {
+  l1t::PFCandidateCollection pfTauCands;
+  TLorentzVector lTot;
+  lTot.SetPtEtaPhiM(0, 0, 0, 0);
+  TLorentzVector lCand;
+  lCand.SetPtEtaPhiM(0, 0, 0, 0);
+  int lId = 0;
+  for (auto l1PFCand : iParts) {
+    if (deltaR(iCand, l1PFCand) > fConeSize_)
+      continue;
+    TLorentzVector pVec;
+    pVec.SetPtEtaPhiM(l1PFCand.pt(), l1PFCand.eta(), l1PFCand.phi(), 0);
+    lTot += pVec;
+    if (deltaR(iCand, l1PFCand) < fTauSize_ &&
+        (l1PFCand.id() == l1t::PFCandidate::Electron || l1PFCand.id() == l1t::PFCandidate::ChargedHadron ||
+         l1PFCand.id() == l1t::PFCandidate::Photon)) {
+      lId++;
+      lCand += pVec;
+    }
+    pfTauCands.push_back(l1PFCand);
+  }
+  if (lTot.Pt() < fSeedPt_)
+    return;
+  std::sort(
+      pfTauCands.begin(), pfTauCands.end(), [](l1t::PFCandidate i, l1t::PFCandidate j) { return (i.pt() > j.pt()); });
+  float NN = fTauNNId->compute(iCand, pfTauCands);
+  math::PtEtaPhiMLorentzVector tempP4(lCand.Pt(), lCand.Eta(), lCand.Phi(), lCand.M());
+  l1t::PFTau l1PFTau(tempP4, NN, 0, lId);
+  outputTaus->push_back(l1PFTau);
+}
+float L1NNTauProducer::deltaR(auto iPart1, auto iPart2) {
+  float delta_r = 20;
+  float pDPhi = fabs(iPart1.phi() - iPart2.phi());
+  if (pDPhi > 2. * TMath::Pi() - pDPhi)
+    pDPhi = 2. * TMath::Pi() - pDPhi;
+  delta_r = sqrt((iPart1.eta() - iPart2.eta()) * (iPart1.eta() - iPart2.eta()) + pDPhi * pDPhi);
+  return delta_r;
+}
+L1NNTauProducer::~L1NNTauProducer() {}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(L1NNTauProducer);

--- a/L1Trigger/Phase2L1ParticleFlow/python/L1NNTauProducer_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1NNTauProducer_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+L1NNTauProducer = cms.EDProducer("L1NNTauProducer",
+                                 seedpt          = cms.double(20),
+                                 conesize        = cms.double(0.4),
+                                 tausize         = cms.double(0.1),
+                                 maxtaus         = cms.int32(5),
+                                 nparticles      = cms.int32(10),
+                                 L1PFObjects     = cms.InputTag("L1PFProducer","l1pfCandidates"),
+                                 NNFileName      = cms.string("L1Trigger/Phase2L1ParticleFlow/data/tau_3layer.pb")
+                                 )
+
+
+L1NNTauProducerPuppi = cms.EDProducer("L1NNTauProducer",
+                                 seedpt          = cms.double(20),
+                                 conesize        = cms.double(0.4),
+                                 tausize         = cms.double(0.1),
+                                 maxtaus         = cms.int32(5),
+                                 nparticles      = cms.int32(10),
+                                 L1PFObjects     = cms.InputTag("L1PFProducer","l1pfCandidates"),
+                                 NNFileName      = cms.string("L1Trigger/Phase2L1ParticleFlow/data/tau_3layer_puppi.pb")
+                                 )

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -12,10 +12,11 @@ void TauNNId::initialize(const std::string &iInput, const std::string &iWeightFi
   graphDef_ = tensorflow::loadGraphDef(fp.fullPath());
   session_ = tensorflow::createSession(graphDef_);
   fNParticles_ = iNParticles;
-  fPt_ = std::make_unique<float>(fNParticles_);
-  fEta_ = std::make_unique<float>(fNParticles_);
-  fPhi_ = std::make_unique<float>(fNParticles_);
-  fId_ = std::make_unique<float>(fNParticles_);
+
+  fPt_ = std::make_unique<float[]>(fNParticles_);
+  fEta_ = std::make_unique<float[]>(fNParticles_);
+  fPhi_ = std::make_unique<float[]>(fNParticles_);
+  fId_ = std::make_unique<float[]>(fNParticles_);
   fInput_ = iInput;
 }
 void TauNNId::SetNNVectorVar() {

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -1,7 +1,5 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h"
-#include <iostream>
 #include <cmath>
-#include <TMath.h>
 
 TauNNId::TauNNId() { NNvectorVar_.clear(); }
 TauNNId::~TauNNId() {
@@ -10,14 +8,14 @@ TauNNId::~TauNNId() {
 }
 void TauNNId::initialize(const std::string &iInput, const std::string &iWeightFile, int iNParticles) {
   std::string cmssw_base_src = getenv("CMSSW_BASE");
-  graphDef_ = tensorflow::loadGraphDef((cmssw_base_src + "/src/" + iWeightFile).c_str());
+  graphDef_ = tensorflow::loadGraphDef(cmssw_base_src + "/src/" + iWeightFile);
   session_ = tensorflow::createSession(graphDef_);
   fNParticles_ = iNParticles;
   fPt_ = std::make_unique<float>(fNParticles_);
   fEta_ = std::make_unique<float>(fNParticles_);
   fPhi_ = std::make_unique<float>(fNParticles_);
   fId_ = std::make_unique<float>(fNParticles_);
-  fInput_ = iInput;  //tensorflow::run(session_, { { "input_1:0",input } }, { "dense_4/Sigmoid:0" }, &outputs);
+  fInput_ = iInput;
 }
 void TauNNId::SetNNVectorVar() {
   NNvectorVar_.clear();
@@ -30,13 +28,11 @@ void TauNNId::SetNNVectorVar() {
         NNvectorVar_.push_back(0);
       continue;
     }
-    fId_.get()[i0] == l1t::PFCandidate::Photon ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);    //Photon
-    fId_.get()[i0] == l1t::PFCandidate::Electron ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);  //Electron
-    fId_.get()[i0] == l1t::PFCandidate::Muon ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);      //Muon
-    fId_.get()[i0] == l1t::PFCandidate::NeutralHadron ? NNvectorVar_.push_back(1)
-                                                      : NNvectorVar_.push_back(0);  //Neutral Had
-    fId_.get()[i0] == l1t::PFCandidate::ChargedHadron ? NNvectorVar_.push_back(1)
-                                                      : NNvectorVar_.push_back(0);  //Charged Had
+    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Photon);         // Photon
+    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Electron);       // Electron
+    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::Muon);           // Muon
+    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::NeutralHadron);  // Neutral Had
+    NNvectorVar_.push_back(fId_.get()[i0] == l1t::PFCandidate::ChargedHadron);  // Charged Had
   }
 }
 float TauNNId::EvaluateNN() {
@@ -65,10 +61,10 @@ float TauNNId::compute(l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iPar
     fPt_.get()[i0] = iParts[i0].pt();
     fEta_.get()[i0] = iSeed.eta() - iParts[i0].eta();
     float lDPhi = iSeed.phi() - iParts[i0].phi();
-    if (lDPhi > TMath::Pi())
-      lDPhi -= TMath::Pi();
-    if (lDPhi < -TMath::Pi())
-      lDPhi += TMath::Pi();
+    if (lDPhi > M_PI)
+      lDPhi -= M_PI;
+    if (lDPhi < -M_PI)
+      lDPhi += M_PI;
     fPhi_.get()[i0] = lDPhi;
     fId_.get()[i0] = iParts[i0].id();
   }

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 #include <cmath>
 
 TauNNId::TauNNId() { NNvectorVar_.clear(); }
@@ -7,8 +8,8 @@ TauNNId::~TauNNId() {
   delete graphDef_;
 }
 void TauNNId::initialize(const std::string &iInput, const std::string &iWeightFile, int iNParticles) {
-  std::string cmssw_base_src = getenv("CMSSW_BASE");
-  graphDef_ = tensorflow::loadGraphDef(cmssw_base_src + "/src/" + iWeightFile);
+  edm::FileInPath fp(iWeightFile);
+  graphDef_ = tensorflow::loadGraphDef(fp.fullPath());
   session_ = tensorflow::createSession(graphDef_);
   fNParticles_ = iNParticles;
   fPt_ = std::make_unique<float>(fNParticles_);
@@ -47,7 +48,7 @@ float TauNNId::EvaluateNN() {
   return disc;
 }  //end EvaluateNN
 
-float TauNNId::compute(l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts) {
+float TauNNId::compute(const l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts) {
   for (int i0 = 0; i0 < fNParticles_; i0++) {
     fPt_.get()[i0] = 0;
     fEta_.get()[i0] = 0;

--- a/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/TauNNId.cc
@@ -1,0 +1,77 @@
+#include "L1Trigger/Phase2L1ParticleFlow/interface/TauNNId.h"
+#include <iostream>
+#include <cmath>
+#include <TMath.h>
+
+TauNNId::TauNNId() { NNvectorVar_.clear(); }
+TauNNId::~TauNNId() {
+  tensorflow::closeSession(session_);
+  delete graphDef_;
+}
+void TauNNId::initialize(const std::string &iInput, const std::string &iWeightFile, int iNParticles) {
+  std::string cmssw_base_src = getenv("CMSSW_BASE");
+  graphDef_ = tensorflow::loadGraphDef((cmssw_base_src + "/src/" + iWeightFile).c_str());
+  session_ = tensorflow::createSession(graphDef_);
+  fNParticles_ = iNParticles;
+  fPt_ = std::make_unique<float>(fNParticles_);
+  fEta_ = std::make_unique<float>(fNParticles_);
+  fPhi_ = std::make_unique<float>(fNParticles_);
+  fId_ = std::make_unique<float>(fNParticles_);
+  fInput_ = iInput;  //tensorflow::run(session_, { { "input_1:0",input } }, { "dense_4/Sigmoid:0" }, &outputs);
+}
+void TauNNId::SetNNVectorVar() {
+  NNvectorVar_.clear();
+  for (int i0 = 0; i0 < fNParticles_; i0++) {
+    NNvectorVar_.push_back(fPt_.get()[i0]);   //pT
+    NNvectorVar_.push_back(fEta_.get()[i0]);  //dEta from jet axis
+    NNvectorVar_.push_back(fPhi_.get()[i0]);  //dPhi from jet axis
+    if (fPt_.get()[i0] == 0) {
+      for (int i1 = 0; i1 < 5; i1++)
+        NNvectorVar_.push_back(0);
+      continue;
+    }
+    fId_.get()[i0] == l1t::PFCandidate::Photon ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);    //Photon
+    fId_.get()[i0] == l1t::PFCandidate::Electron ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);  //Electron
+    fId_.get()[i0] == l1t::PFCandidate::Muon ? NNvectorVar_.push_back(1) : NNvectorVar_.push_back(0);      //Muon
+    fId_.get()[i0] == l1t::PFCandidate::NeutralHadron ? NNvectorVar_.push_back(1)
+                                                      : NNvectorVar_.push_back(0);  //Neutral Had
+    fId_.get()[i0] == l1t::PFCandidate::ChargedHadron ? NNvectorVar_.push_back(1)
+                                                      : NNvectorVar_.push_back(0);  //Charged Had
+  }
+}
+float TauNNId::EvaluateNN() {
+  tensorflow::Tensor input(tensorflow::DT_FLOAT,
+                           {1, (unsigned int)NNvectorVar_.size()});  //was {1,35} but get size mismatch, CHECK
+  for (unsigned int i = 0; i < NNvectorVar_.size(); i++) {
+    input.matrix<float>()(0, i) = float(NNvectorVar_[i]);
+  }
+  std::vector<tensorflow::Tensor> outputs;
+  tensorflow::run(session_, {{fInput_, input}}, {"dense_4/Sigmoid:0"}, &outputs);
+  float disc = outputs[0].matrix<float>()(0, 0);
+  return disc;
+}  //end EvaluateNN
+
+float TauNNId::compute(l1t::PFCandidate &iSeed, l1t::PFCandidateCollection &iParts) {
+  for (int i0 = 0; i0 < fNParticles_; i0++) {
+    fPt_.get()[i0] = 0;
+    fEta_.get()[i0] = 0;
+    fPhi_.get()[i0] = 0;
+    fId_.get()[i0] = 0;
+  }
+  std::sort(iParts.begin(), iParts.end(), [](l1t::PFCandidate i, l1t::PFCandidate j) { return (i.pt() > j.pt()); });
+  for (unsigned int i0 = 0; i0 < iParts.size(); i0++) {
+    if (i0 > 10)
+      break;
+    fPt_.get()[i0] = iParts[i0].pt();
+    fEta_.get()[i0] = iSeed.eta() - iParts[i0].eta();
+    float lDPhi = iSeed.phi() - iParts[i0].phi();
+    if (lDPhi > TMath::Pi())
+      lDPhi -= TMath::Pi();
+    if (lDPhi < -TMath::Pi())
+      lDPhi += TMath::Pi();
+    fPhi_.get()[i0] = lDPhi;
+    fId_.get()[i0] = iParts[i0].id();
+  }
+  SetNNVectorVar();
+  return EvaluateNN();
+}


### PR DESCRIPTION
#### PR description:
11_1_X:  L1T Phase2 NNTau reconstruction based on PF and Puppi
 - producers (PF and Puppi) and configurations
 - included in L1T Phase2 sequence
 - included in FEVTDEBUG Phase2 EventContent

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
