### PR TITLE
Migrate dqmEnvSiPixelQuality from DQMEventInfo to DQMHarvestingMetadata

### DIFF
--- a/CalibTracker/SiPixelQuality/python/DQMEventInfoSiPixelQuality_cff.py
+++ b/CalibTracker/SiPixelQuality/python/DQMEventInfoSiPixelQuality_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from DQMServices.Core.DQMEDAnalyzer import DQMEDAnalyzer
-dqmEnvSiPixelQuality = DQMEDAnalyzer('DQMEventInfo',
-                                     subSystemFolder = cms.untracked.string('PixelPhase1')
-                                    )
+from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+dqmEnvSiPixelQuality = DQMEDHarvester('DQMHarvestingMetadata',
+                                      subSystemFolder = cms.untracked.string('PixelPhase1')
+                                      )
                             


### PR DESCRIPTION
#### PR description:

Allows to display on GUI metadata information for the SiPixel Bad Components PCL workflow.
This piece was leftover from the migration at https://github.com/cms-sw/cmssw/pull/28821.

#### PR validation:

Produced a test file using wf 1040.0 and injected to private local GUI:

without this PR:

![image](https://user-images.githubusercontent.com/5082376/94532042-a508a580-023d-11eb-9730-972a15c8e840.png)

with this PR:

![image](https://user-images.githubusercontent.com/5082376/94532114-bd78c000-023d-11eb-8277-f4ffa80131c4.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.