### PR TITLE
[DD4hep] Remove ".*:" aka "any" Namespace Definition from a Part Selector

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -947,6 +947,9 @@ void Converter<PartSelector>::operator()(xml_h element) const {
            "+++ PartSelector for %s path: %s",
            specParName.c_str(),
            path.c_str());
+  if (path.substr(0, 3) == std::string(".*:")) {
+    path = path.substr(3);
+  }
   registry.specpars[specParName].paths.emplace_back(path);
 }
 

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -617,8 +617,7 @@ const ExpandedNodes& DDFilteredView::history() {
   for (int nit = level; nit > 0; --nit) {
     for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
-        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()),
-                        *begin(split(j, "/"))) and
+        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), *begin(split(j, "/"))) and
                 (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset")));
       });
       if (k != end(i.second.paths)) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -478,7 +478,7 @@ std::string_view DDFilteredView::get<string_view>(const string& key) const {
   int level = it_.back().GetLevel();
   for_each(begin(refs), end(refs), [&](auto const& i) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
-      auto const& names = split(realTopName(j), "/");
+      auto const& names = split(j, "/");
       int count = names.size();
       bool flag = false;
       for (int nit = level; count > 0 and nit > 0; --nit) {
@@ -618,7 +618,7 @@ const ExpandedNodes& DDFilteredView::history() {
     for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
         return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()),
-                        *begin(split(realTopName(j), "/"))) and
+                        *begin(split(j, "/"))) and
                 (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset")));
       });
       if (k != end(i.second.paths)) {


### PR DESCRIPTION
#### PR description:

* This allows the #31573 integration without splitting 
`Geometry/TrackerCommonData/data/PhaseI/trackerStructureTopology.xml`

This is the only XML file where ` .*: ` namespace is used. The old DD required this definition to attach the `Part Selector` to multiple nodes in various namespaces. Since this removal is fully tested in #31573, it's safe to assume the "any" namespace is not needed for DD4hep processing.

@ghugo83 and @cvuosalo - FYI, this solution is more performant then keeping this namespace and performing a regular expression comparison.

* Piggyback on this PR to improve performance by dropping a check on a top name - `split` takes care of it now.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
