### PR TITLE
[DD4hep] Allow Namespace Comparison in a Part Selector

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -947,6 +947,9 @@ void Converter<PartSelector>::operator()(xml_h element) const {
            "+++ PartSelector for %s path: %s",
            specParName.c_str(),
            path.c_str());
+  if (path.substr(0, 3) == std::string(".*:")) {
+    path = path.substr(3);
+  }
   registry.specpars[specParName].paths.emplace_back(path);
 }
 

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -476,26 +476,59 @@ std::string_view DDFilteredView::get<string_view>(const string& key) const {
   DDSpecParRefs refs;
   registry_->filter(refs, key, "");
   int level = it_.back().GetLevel();
-  for_each(begin(refs), end(refs), [&](auto const& i) {
+  for(auto const& i : refs) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
       auto const& names = split(j, "/");
       int count = names.size();
       bool flag = false;
       for (int nit = level; count > 0 and nit > 0; --nit) {
-        std::string_view name = noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName());
-        if (!regex_match(std::string(name.data(), name.size()), regex(std::string(names[--count])))) {
-          flag = false;
-          break;
+	std::string_view name = it_.back().GetNode(nit)->GetVolume()->GetName();
+        auto refname = names[--count];
+        auto rpos = refname.find(":");
+        if (rpos == refname.npos) {
+          name = noNamespace(name);
         } else {
-          flag = true;
+	  if (name.find(":") == name.npos) {
+	    refname.remove_prefix(rpos + 1);
+	  }
         }
+	auto cpos = refname.find("[");
+	if ( cpos != refname.npos) {
+	  if (std::stoi(std::string(refname.substr(cpos + 1, refname.find("]")))) == copyNum()) {
+	    refname.remove_suffix(refname.size() - cpos);
+	    flag = true;
+	    continue;
+	  } else {
+	    flag = false;
+	    break;
+	  }
+	}
+	if( !dd4hep::dd::isRegex(refname) ) {
+	  if(!dd4hep::dd::compareEqual(name, refname)) {
+	    flag = false;
+	    break;
+	  }
+	  else {
+	    flag = true;
+	    continue;
+	  }
+	} else {
+	  if (!regex_match(std::string(name.data(), name.size()), regex(std::string(refname)))) {
+	    flag = false;
+	    break;
+	  } else {
+	    flag = true;
+	    continue;
+	  }
+	}
       }
       return flag;
     });
     if (k != end(i->paths)) {
       result = i->strValue(key);
+      return result;
     }
-  });
+  }
 
   return result;
 }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -617,8 +617,7 @@ const ExpandedNodes& DDFilteredView::history() {
   for (int nit = level; nit > 0; --nit) {
     for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
-        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()),
-                        *begin(split(j, "/"))) and
+        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), *begin(split(j, "/"))) and
                 (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset")));
       });
       if (k != end(i.second.paths)) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -478,7 +478,7 @@ std::string_view DDFilteredView::get<string_view>(const string& key) const {
   int level = it_.back().GetLevel();
   for_each(begin(refs), end(refs), [&](auto const& i) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
-      auto const& names = split(realTopName(j), "/");
+      auto const& names = split(j, "/");
       int count = names.size();
       bool flag = false;
       for (int nit = level; count > 0 and nit > 0; --nit) {
@@ -618,7 +618,7 @@ const ExpandedNodes& DDFilteredView::history() {
     for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
         return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()),
-                        *begin(split(realTopName(j), "/"))) and
+                        *begin(split(j, "/"))) and
                 (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset")));
       });
       if (k != end(i.second.paths)) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -476,51 +476,50 @@ std::string_view DDFilteredView::get<string_view>(const string& key) const {
   DDSpecParRefs refs;
   registry_->filter(refs, key, "");
   int level = it_.back().GetLevel();
-  for(auto const& i : refs) {
+  for (auto const& i : refs) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
       auto const& names = split(j, "/");
       int count = names.size();
       bool flag = false;
       for (int nit = level; count > 0 and nit > 0; --nit) {
-	std::string_view name = it_.back().GetNode(nit)->GetVolume()->GetName();
+        std::string_view name = it_.back().GetNode(nit)->GetVolume()->GetName();
         auto refname = names[--count];
         auto rpos = refname.find(":");
         if (rpos == refname.npos) {
           name = noNamespace(name);
         } else {
-	  if (name.find(":") == name.npos) {
-	    refname.remove_prefix(rpos + 1);
-	  }
+          if (name.find(":") == name.npos) {
+            refname.remove_prefix(rpos + 1);
+          }
         }
-	auto cpos = refname.find("[");
-	if ( cpos != refname.npos) {
-	  if (std::stoi(std::string(refname.substr(cpos + 1, refname.find("]")))) == copyNum()) {
-	    refname.remove_suffix(refname.size() - cpos);
-	    flag = true;
-	    continue;
-	  } else {
-	    flag = false;
-	    break;
-	  }
-	}
-	if( !dd4hep::dd::isRegex(refname) ) {
-	  if(!dd4hep::dd::compareEqual(name, refname)) {
-	    flag = false;
-	    break;
-	  }
-	  else {
-	    flag = true;
-	    continue;
-	  }
-	} else {
-	  if (!regex_match(std::string(name.data(), name.size()), regex(std::string(refname)))) {
-	    flag = false;
-	    break;
-	  } else {
-	    flag = true;
-	    continue;
-	  }
-	}
+        auto cpos = refname.find("[");
+        if (cpos != refname.npos) {
+          if (std::stoi(std::string(refname.substr(cpos + 1, refname.find("]")))) == copyNum()) {
+            refname.remove_suffix(refname.size() - cpos);
+            flag = true;
+            continue;
+          } else {
+            flag = false;
+            break;
+          }
+        }
+        if (!dd4hep::dd::isRegex(refname)) {
+          if (!dd4hep::dd::compareEqual(name, refname)) {
+            flag = false;
+            break;
+          } else {
+            flag = true;
+            continue;
+          }
+        } else {
+          if (!regex_match(std::string(name.data(), name.size()), regex(std::string(refname)))) {
+            flag = false;
+            break;
+          } else {
+            flag = true;
+            continue;
+          }
+        }
       }
       return flag;
     });

--- a/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
@@ -27,7 +27,7 @@ public:
 private:
   void printMe(const cms::DDFilteredView&);
   std::string fileName_;
-  std::vector<int> refPos_{0, 0, 4, 2, 2, 1};
+  std::vector<int> refPos_{0, 0, 6, 2, 2};
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilteredViewGoTo);
@@ -49,12 +49,22 @@ void testDDFilteredViewGoTo::checkFilteredView() {
     if (count == 45) {
       testPos = fview.navPos();
     }
-    if (count == 100) {
+    if (count == 1000) {
       break;
     }
     count++;
   }
 
+  // world_volume/OCMS_1/CMSE_1/Tracker_1/PixelBarrel_1/pixbarlayer0:PixelBarrelLayer0_1/PixelBarrelLadderFull0_6/PixelBarrelModuleBoxFull_1/PixelBarrelModuleFullPlus_4/PixelBarrelSensorFull_1/PixelBarrelActiveFull0_1
+  //
+  std::vector<int> activeVol{0, 0, 6, 2, 93, 12, 1, 7, 1, 0};
+  fview.goTo(activeVol);
+  printMe(fview);
+  double radLength = fview.get<double>("TrackerRadLength");
+  double xi = fview.get<double>("TrackerXi");
+  std::cout << "TrackerRadLength = " << radLength
+	    << "\nTrackerXi = " << xi << "\n";
+  
   std::cout << "\n==== Let's go to #45\n";
   fview.goTo(testPos);
   printMe(fview);
@@ -70,7 +80,7 @@ void testDDFilteredViewGoTo::checkFilteredView() {
 
   // Start with Tracker
   std::cout << "\n==== Let's go to Tracker\n";
-  fview.goTo({0, 0, 4});
+  fview.goTo({0, 0, 6});
   CPPUNIT_ASSERT(fview.name() == "Tracker");
   printMe(fview);
 
@@ -107,7 +117,7 @@ void testDDFilteredViewGoTo::checkFilteredView() {
   printMe(fview);
 
   std::cout << "\n==== Let's do it again, go to Tracker\n";
-  fview.goTo({0, 0, 4});
+  fview.goTo({0, 0, 6});
   CPPUNIT_ASSERT(fview.name() == "Tracker");
   printMe(fview);
 

--- a/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
@@ -62,9 +62,8 @@ void testDDFilteredViewGoTo::checkFilteredView() {
   printMe(fview);
   double radLength = fview.get<double>("TrackerRadLength");
   double xi = fview.get<double>("TrackerXi");
-  std::cout << "TrackerRadLength = " << radLength
-	    << "\nTrackerXi = " << xi << "\n";
-  
+  std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
+
   std::cout << "\n==== Let's go to #45\n";
   fview.goTo(testPos);
   printMe(fview);


### PR DESCRIPTION
#### PR description:

Addresses https://github.com/cms-sw/cmssw/issues/31579 issue

For example, see `DDFilteredView.goto.cppunit.cc` where access to a current `FilteredView` `Node`
```c++
  // world_volume/OCMS_1/CMSE_1/Tracker_1/PixelBarrel_1/pixbarlayer0:PixelBarrelLayer0_1/PixelBarrelLadderFull0_6/PixelBarrelModuleBoxFull_1/PixelBarrelModuleFullPlus_4/PixelBarrelSensorFull_1/PixelBarrelActiveFull0_1
  //
  std::vector<int> activeVol{0, 0, 6, 2, 93, 12, 1, 7, 1, 0};
  fview.goTo(activeVol);
  printMe(fview);
  double radLength = fview.get<double>("TrackerRadLength");
  double xi = fview.get<double>("TrackerXi");
  std::cout << "TrackerRadLength = " << radLength
	    << "\nTrackerXi = " << xi << "\n";

```
gives
```bash
TrackerRadLength = 0.03142
TrackerXi = 6.24526e-05

```
@ghugo83 , @vargasa - FYI

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
