### PR TITLE
[10_6_X] ParticleNetAK4 jet tagger

### DIFF
--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -45,8 +45,10 @@ supportedBtagInfos = [
   , 'pfDeepDoubleXTagInfos'
     # DeepBoostedJet tag infos
   , 'pfDeepBoostedJetTagInfos'
-    # ParticleNet tag infos
+    # ParticleNet (AK8) tag infos
   , 'pfParticleNetTagInfos'
+    # ParticleNet (AK4) tag infos
+  , 'pfParticleNetAK4TagInfos'
     # HiggsInteractionNet tag infos
   , 'pfHiggsInteractionNetTagInfos'
   ]
@@ -240,7 +242,7 @@ for disc in _pfMassDecorrelatedDeepBoostedJetTagsMetaDiscrs:
 # -----------------------------------
 
 # -----------------------------------
-# setup ParticleNet
+# setup ParticleNet AK8
 from RecoBTag.ONNXRuntime.pfParticleNet_cff import _pfParticleNetJetTagsProbs, _pfParticleNetJetTagsMetaDiscrs, \
     _pfMassDecorrelatedParticleNetJetTagsProbs, _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs
 # update supportedBtagDiscr
@@ -252,8 +254,22 @@ for disc in _pfParticleNetJetTagsMetaDiscrs:
 for disc in _pfMassDecorrelatedParticleNetJetTagsMetaDiscrs:
     supportedMetaDiscr[disc] = _pfMassDecorrelatedParticleNetJetTagsProbs
 # -----------------------------------
+
+# -----------------------------------
+# setup ParticleNet AK4
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsProbs, _pfParticleNetAK4JetTagsMetaDiscrs
+# update supportedBtagDiscr
+for disc in _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs:
+    supportedBtagDiscr[disc] = [["pfParticleNetAK4TagInfos"]]
+# update supportedMetaDiscr
+for disc in _pfParticleNetAK4JetTagsMetaDiscrs:
+    supportedMetaDiscr[disc] = _pfParticleNetAK4JetTagsProbs
+# -----------------------------------
+
+# -----------------------------------
 # setup HiggsInteractionNet
 from RecoBTag.ONNXRuntime.pfHiggsInteractionNet_cff import _pfHiggsInteractionNetTagsProbs
 # update supportedBtagDiscr 
 for disc in _pfHiggsInteractionNetTagsProbs:
     supportedBtagDiscr[disc] = [["pfHiggsInteractionNetTagInfos"]]
+# -----------------------------------

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -49,6 +49,7 @@ supportedBtagInfos = [
   , 'pfParticleNetTagInfos'
     # ParticleNet (AK4) tag infos
   , 'pfParticleNetAK4TagInfos'
+  , 'pfNegativeParticleNetAK4TagInfos'
     # HiggsInteractionNet tag infos
   , 'pfHiggsInteractionNetTagInfos'
   ]
@@ -264,6 +265,11 @@ for disc in _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs:
 # update supportedMetaDiscr
 for disc in _pfParticleNetAK4JetTagsMetaDiscrs:
     supportedMetaDiscr[disc] = _pfParticleNetAK4JetTagsProbs
+# -----------------------------------
+# setup Negative ParticleNet AK4
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfNegativeParticleNetAK4JetTagsProbs
+for disc in _pfNegativeParticleNetAK4JetTagsProbs:
+    supportedBtagDiscr[disc] = [["pfNegativeParticleNetAK4TagInfos"]]
 # -----------------------------------
 
 # -----------------------------------

--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -9,6 +9,7 @@ def applyDeepBtagging( process, postfix="" ) :
     from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
+    from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll as pfParticleNetAK4JetTagsAll
 
     # update slimmed jets to include DeepFlavour (keep same name)
     # make clone for DeepFlavour-less slimmed jets, so output name is preserved
@@ -31,7 +32,7 @@ def applyDeepBtagging( process, postfix="" ) :
           'pfDeepFlavourJetTags:probc',
           'pfDeepFlavourJetTags:probuds',
           'pfDeepFlavourJetTags:probg',
-       ],
+       ] + pfParticleNetAK4JetTagsAll,
        postfix = 'SlimmedDeepFlavour'+postfix,
        printWarning = False
     )

--- a/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applyDeepBtagging_cff.py
@@ -9,11 +9,23 @@ def applyDeepBtagging( process, postfix="" ) :
     from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
+    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
     from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll as pfParticleNetAK4JetTagsAll
 
     # update slimmed jets to include DeepFlavour (keep same name)
     # make clone for DeepFlavour-less slimmed jets, so output name is preserved
     addToProcessAndTask('slimmedJetsNoDeepFlavour', process.slimmedJets.clone(), process, task)
+    _btagDiscriminatorsAK4 = cms.PSet( names = cms.vstring(
+         'pfDeepFlavourJetTags:probb',
+         'pfDeepFlavourJetTags:probbb',
+         'pfDeepFlavourJetTags:problepb',
+         'pfDeepFlavourJetTags:probc',
+         'pfDeepFlavourJetTags:probuds',
+         'pfDeepFlavourJetTags:probg',
+      )
+    )
+    run2_miniAOD_UL.toModify(_btagDiscriminatorsAK4,
+                             names = _btagDiscriminatorsAK4.names + pfParticleNetAK4JetTagsAll)
     updateJetCollection(
        process,
        jetSource = cms.InputTag('slimmedJetsNoDeepFlavour'),
@@ -25,14 +37,7 @@ def applyDeepBtagging( process, postfix="" ) :
        muSource = cms.InputTag('slimmedMuons'),
        elSource = cms.InputTag('slimmedElectrons'),
        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-       btagDiscriminators = [
-          'pfDeepFlavourJetTags:probb',
-          'pfDeepFlavourJetTags:probbb',
-          'pfDeepFlavourJetTags:problepb',
-          'pfDeepFlavourJetTags:probc',
-          'pfDeepFlavourJetTags:probuds',
-          'pfDeepFlavourJetTags:probg',
-       ] + pfParticleNetAK4JetTagsAll,
+       btagDiscriminators = _btagDiscriminatorsAK4.names.value(),
        postfix = 'SlimmedDeepFlavour'+postfix,
        printWarning = False
     )
@@ -65,7 +70,6 @@ def applyDeepBtagging( process, postfix="" ) :
         'pfMassIndependentDeepDoubleCvBJetTags:probHcc',
         ) + pfDeepBoostedJetTagsAll
     )
-    from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
     run2_miniAOD_UL.toModify(_btagDiscriminators,
                              names = _btagDiscriminators.names + pfParticleNetJetTagsAll + pfHiggsInteractionNetTagsProbs)
     updateJetCollection(

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -691,6 +691,30 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                       ),
                                     process, task)
 
+            if 'ParticleNetAK4TagInfos' in btagInfo:
+                # TODO: add negative tag
+                if pfCandidates.value() == 'packedPFCandidates':
+                    # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
+                    puppi_value_map = ""
+                    vertex_associator = ""
+                elif pfCandidates.value() == 'particleFlow':
+                    raise ValueError("Running pfDeepBoostedJetTagInfos with reco::PFCandidates is currently not supported.")
+                    # case 2: running on new jet collection whose daughters are PFCandidates (e.g., cluster jets in RECO/AOD)
+                    puppi_value_map = "puppi"
+                    vertex_associator = "primaryVertexAssociation:original"
+                else:
+                    raise ValueError("Invalid pfCandidates collection: %s." % pfCandidates.value())
+                addToProcessAndTask(btagPrefix+btagInfo+labelName+postfix,
+                                    btag.pfParticleNetAK4TagInfos.clone(
+                                      jets = jetSource,
+                                      vertices = pvSource,
+                                      secondary_vertices = svSource,
+                                      pf_candidates = pfCandidates,
+                                      puppi_value_map = puppi_value_map,
+                                      vertex_associator = vertex_associator,
+                                      ),
+                                    process, task)
+
             acceptedTagInfos.append(btagInfo)
         elif hasattr(toptag, btagInfo) :
             acceptedTagInfos.append(btagInfo)

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -327,7 +327,11 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
     runNegativeVertexing = False
     runNegativeCvsLVertexing = False
     for btagInfo in requiredTagInfos:
-        if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeTagInfos' or btagInfo == 'pfNegativeDeepFlavourTagInfos':
+        if btagInfo in (
+            'pfInclusiveSecondaryVertexFinderNegativeTagInfos',
+            'pfNegativeDeepFlavourTagInfos',
+            'pfNegativeParticleNetAK4TagInfos',
+            ):
             runNegativeVertexing = True
         if btagInfo == 'pfInclusiveSecondaryVertexFinderNegativeCvsLTagInfos':
             runNegativeCvsLVertexing = True
@@ -692,7 +696,15 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     process, task)
 
             if 'ParticleNetAK4TagInfos' in btagInfo:
-                # TODO: add negative tag
+                if btagInfo == 'pfNegativeParticleNetAK4TagInfos':
+                    secondary_vertices = btagPrefix + \
+                        'inclusiveCandidateNegativeSecondaryVertices' + labelName + postfix
+                    flip_ip_sign = True
+                    sip3dSigMax = 10
+                else:
+                    secondary_vertices = svSource
+                    flip_ip_sign = False
+                    sip3dSigMax = -1
                 if pfCandidates.value() == 'packedPFCandidates':
                     # case 1: running over jets whose daughters are PackedCandidates (only via updateJetCollection for now)
                     puppi_value_map = ""
@@ -708,10 +720,12 @@ def setupBTagging(process, jetSource, pfCandidates, explicitJTA, pvSource, svSou
                                     btag.pfParticleNetAK4TagInfos.clone(
                                       jets = jetSource,
                                       vertices = pvSource,
-                                      secondary_vertices = svSource,
+                                      secondary_vertices = secondary_vertices,
                                       pf_candidates = pfCandidates,
                                       puppi_value_map = puppi_value_map,
                                       vertex_associator = vertex_associator,
+                                      flip_ip_sign = flip_ip_sign,
+                                      sip3dSigMax = sip3dSigMax,
                                       ),
                                     process, task)
 

--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -12,6 +12,7 @@ from RecoBTag.ONNXRuntime.pfDeepDoubleX_cff import *
 from RecoBTag.ONNXRuntime.pfDeepBoostedJet_cff import *
 from RecoBTag.ONNXRuntime.pfHiggsInteractionNet_cff import *
 from RecoBTag.ONNXRuntime.pfParticleNet_cff import *
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import *
 from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import *
 
 legacyBTaggingTask = cms.Task(

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4DiscriminatorsJetTags_cfi.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4DiscriminatorsJetTags_cfi.py
@@ -1,0 +1,59 @@
+import FWCore.ParameterSet.Config as cms
+
+pfParticleNetAK4DiscriminatorsJetTags = cms.EDProducer(
+   'BTagProbabilityToDiscriminator',
+   discriminators = cms.VPSet(
+      cms.PSet(
+         name = cms.string('BvsAll'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            ),
+         denominator=cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+         ),
+      ),
+      cms.PSet(
+         name = cms.string('CvsL'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('CvsB'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probb'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probbb'),
+            ),
+         ),
+      cms.PSet(
+         name = cms.string('QvsG'),
+         numerator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            ),
+         denominator = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags', 'probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags', 'probg'),
+            ),
+         ),
+
+      )
+   )

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -34,3 +34,19 @@ _pfParticleNetAK4JetTagsMetaDiscrs = ['pfParticleNetAK4DiscriminatorsJetTags:' +
                                       for disc in pfParticleNetAK4DiscriminatorsJetTags.discriminators]
 
 _pfParticleNetAK4JetTagsAll = _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs
+
+
+# === Negative tags ===
+pfNegativeParticleNetAK4TagInfos = pfParticleNetAK4TagInfos.clone(
+    flip_ip_sign = True,
+    sip3dSigMax = 10,
+    secondary_vertices = 'inclusiveCandidateNegativeSecondaryVertices',
+)
+
+pfNegativeParticleNetAK4JetTags = pfParticleNetAK4JetTags.clone(
+    src = 'pfNegativeParticleNetAK4TagInfos',
+)
+
+# probs
+_pfNegativeParticleNetAK4JetTagsProbs = ['pfNegativeParticleNetAK4JetTags:' + flav_name 
+                                         for flav_name in pfNegativeParticleNetAK4JetTags.flav_names]

--- a/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfParticleNetAK4_cff.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.FeatureTools.pfDeepBoostedJetTagInfos_cfi import pfDeepBoostedJetTagInfos
+from RecoBTag.ONNXRuntime.boostedJetONNXJetTagsProducer_cfi import boostedJetONNXJetTagsProducer
+from RecoBTag.ONNXRuntime.pfParticleNetAK4DiscriminatorsJetTags_cfi import pfParticleNetAK4DiscriminatorsJetTags
+
+pfParticleNetAK4TagInfos = pfDeepBoostedJetTagInfos.clone(
+    jet_radius = 0.4,
+    min_jet_pt = 15,
+    min_puppi_wgt = -1,
+    use_puppiP4 = False,
+)
+
+pfParticleNetAK4JetTags = boostedJetONNXJetTagsProducer.clone(
+    src = 'pfParticleNetAK4TagInfos',
+    preprocess_json = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/preprocess.json',
+    model_path = 'RecoBTag/Combined/data/ParticleNetAK4/CHS/V00/particle-net.onnx',
+    flav_names = ["probb",  "probbb",  "probc",   "probcc",  "probuds", "probg", "probundef", "probpu"],
+)
+
+from CommonTools.PileupAlgos.Puppi_cff import puppi
+from PhysicsTools.PatAlgos.slimming.primaryVertexAssociation_cfi import primaryVertexAssociation
+
+# This task is not used, useful only if we run it from RECO jets (RECO/AOD)
+pfParticleNetAK4Task = cms.Task(puppi, primaryVertexAssociation, pfParticleNetAK4TagInfos,
+                                pfParticleNetAK4JetTags, pfParticleNetAK4DiscriminatorsJetTags)
+
+# declare all the discriminators
+# probs
+_pfParticleNetAK4JetTagsProbs = ['pfParticleNetAK4JetTags:' + flav_name
+                                 for flav_name in pfParticleNetAK4JetTags.flav_names]
+# meta-taggers
+_pfParticleNetAK4JetTagsMetaDiscrs = ['pfParticleNetAK4DiscriminatorsJetTags:' + disc.name.value()
+                                      for disc in pfParticleNetAK4DiscriminatorsJetTags.discriminators]
+
+_pfParticleNetAK4JetTagsAll = _pfParticleNetAK4JetTagsProbs + _pfParticleNetAK4JetTagsMetaDiscrs

--- a/RecoBTag/ONNXRuntime/test/test_particle_net_ak4_cfg.py
+++ b/RecoBTag/ONNXRuntime/test/test_particle_net_ak4_cfg.py
@@ -1,0 +1,76 @@
+import FWCore.ParameterSet.Config as cms
+from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask
+
+from FWCore.ParameterSet.VarParsing import VarParsing
+options = VarParsing('analysis')
+options.inputFiles = '/store/mc/RunIISummer19UL17MiniAOD/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v4/30000/FFA0194D-1BBC-EF4F-9B8F-8FBED2C62FC8.root'
+options.maxEvents = 1000
+options.parseArguments()
+
+process = cms.Process("PATtest")
+
+## MessageLogger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+
+## Options and Output Report
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+## Source
+process.source = cms.Source("PoolSource",
+    fileNames=cms.untracked.vstring(options.inputFiles)
+)
+## Maximal Number of Events
+process.maxEvents = cms.untracked.PSet(input=cms.untracked.int32(options.maxEvents))
+
+## Geometry and Detector Conditions (needed for a few patTuple production steps)
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic')
+process.load("Configuration.StandardSequences.MagneticField_cff")
+
+## Output Module Configuration (expects a path 'p')
+from PhysicsTools.PatAlgos.patEventContent_cff import patEventContentNoCleaning
+process.out = cms.OutputModule("PoolOutputModule",
+                               fileName = cms.untracked.string('patTuple.root'),
+                               ## save only events passing the full path
+                               #SelectEvents = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
+                               ## save PAT output; you need a '*' to unpack the list of commands
+                               ## 'patEventContent'
+                               outputCommands = cms.untracked.vstring('drop *', *patEventContentNoCleaning )
+                               )
+
+patAlgosToolsTask = getPatAlgosToolsTask(process)
+process.outpath = cms.EndPath(process.out, patAlgosToolsTask)
+
+## and add them to the event content
+from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import _pfParticleNetAK4JetTagsAll as pfParticleNetAK4JetTagsAll
+
+updateJetCollection(
+   process,
+   jetSource = cms.InputTag('slimmedJets'),
+   pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+   svSource = cms.InputTag('slimmedSecondaryVertices'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+   btagDiscriminators = [
+          'pfDeepFlavourJetTags:probb',
+          'pfDeepFlavourJetTags:probbb',
+          'pfDeepFlavourJetTags:problepb',
+          'pfDeepFlavourJetTags:probc',
+          'pfDeepFlavourJetTags:probuds',
+          'pfDeepFlavourJetTags:probg',
+       ] + pfParticleNetAK4JetTagsAll
+   )
+
+from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
+process.out.outputCommands.append('keep *_slimmedJets*_*_*')
+process.out.outputCommands.append('keep *_offlineSlimmedPrimaryVertices*_*_*')
+process.out.outputCommands.append('keep *_slimmedSecondaryVertices*_*_*')
+process.out.outputCommands.append('keep *_selectedPatJets*_*_*')
+process.out.outputCommands.append('keep *_selectedUpdatedPatJets*_*_*')
+process.out.outputCommands.append('keep *_updatedPatJets*_*_*')
+
+process.out.fileName = 'test_particle_net_ak4_MINIAODSIM.root'


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-sw/cmssw/pull/31570. 
The addition of the ParticleNetAK4 discriminants to miniAOD is controlled by the `run2_miniAOD_UL` modifier in this backport.

Needs cms-data/RecoBTag-Combined#35.


FYI @camclean @alefisico