### PR TITLE
SonicTriton tests with Singularity

### DIFF
--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -1,7 +1,7 @@
 # SONIC TritonClient tests
 
-A test producer `TritonImageProducer` is available.
-It generates an arbitrary image for ResNet50 inference and prints the resulting classifications.
+Test producers `TritonImageProducer` and `TritonGraphProducer` are available.
+They generate arbitrary inputs for inference (with ResNet50 or Graph Attention Network, respectively) and print the resulting output.
 
 To run the tests, a local Triton server can be started using Docker.
 (This may require superuser permission.)
@@ -13,14 +13,11 @@ First, the relevant data should be downloaded from Nvidia:
 
 Execute this Docker command to launch the local server:
 ```bash
-docker run -d --rm --name tritonserver \
+docker run -d --name tritonserver \
   --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
   -p8000:8000 -p8001:8001 -p8002:8002 \
   -v${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models:/models \
-  -v${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/lib:/inputlib \
-  -e LD_LIBRARY_PATH="/opt/tritonserver/lib/pytorch:/usr/local/cuda/compat/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
-  -e LD_PRELOAD="/inputlib/libtorchscatter.so /inputlib/libtorchsparse.so" \
-  nvcr.io/nvidia/tritonserver:20.06-v1-py3 tritonserver --model-repository=/models
+  fastml/triton-torchgeo:20.06-v1-py3-geometric tritonserver --model-repository=/models
 ```
 
 If the machine has Nvidia GPUs, the flag `--gpus all` can be added to the command.

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -3,13 +3,37 @@
 Test producers `TritonImageProducer` and `TritonGraphProducer` are available.
 They generate arbitrary inputs for inference (with ResNet50 or Graph Attention Network, respectively) and print the resulting output.
 
-To run the tests, a local Triton server can be started using Docker.
-(This may require superuser permission.)
+To run the tests, a local Triton server can be started using Singularity or Docker.
+The default local server address is `0.0.0.0`.
+(In either case, to get more debugging information from the server, the flags `--log-verbose=1 --log-error=1 --log-info=1`
+can be added to the end of the command that includes `tritonserver`.)
 
 First, the relevant data should be downloaded from Nvidia:
 ```
 ./fetch_model.sh
 ```
+
+## Singularity instructions
+
+Using Singularity should not require superuser permissions.
+
+Execute these Singularity commands to start the instance in the background and then activate the server:
+```bash
+singularity instance start \
+  -B /dev/shm:/run/shm -B ${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models:/models \
+  /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.06-v1-py3-geometric/ triton_server_instance
+singularity run instance://triton_server_instance \
+  tritonserver --model-repository=/models
+```
+
+(Some operating systems may have `/run/shm` rather than `/dev/shm`.)
+
+If the machine has Nvidia GPUs, the flag `--nv` can be added to the command.
+Otherwise, the server will perform inference using the CPU (slower).
+
+## Docker instructions
+
+Using Docker may require superuser permissions.
 
 Execute this Docker command to launch the local server:
 ```bash
@@ -23,10 +47,7 @@ docker run -d --name tritonserver \
 If the machine has Nvidia GPUs, the flag `--gpus all` can be added to the command.
 Otherwise, the server will perform inference using the CPU (slower).
 
-To get more debugging information from the server, the flags `--log-verbose=1 --log-error=1 --log-info=1`
-can be added to the end of the command.
-
-The default local server address is `0.0.0.0`.
+## Test commands
 
 Run the image test:
 ```

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -23,8 +23,9 @@ The server can be managed with the `triton` script (using Singularity with CPU b
 The script has the following options:
 * `-d`: use Docker instead of Singularity
 * `-g`: use GPU instead of CPU
+* `-n`: name of container instance (default: triton_server_instance)
 * `-v`: (verbose) start: activate server debugging info; stop: keep server logs
-* `-w`: maximum time to wait for server to start (default: 30 seconds)
+* `-w`: maximum time to wait for server to start (default: 60 seconds)
 * `-h`: print help message and exit
 
 ## Test commands
@@ -38,3 +39,8 @@ Run the graph test:
 ```
 cmsRun tritonTest_cfg.py maxEvents=1 producer=TritonGraphProducer
 ```
+
+## Caveats
+
+* Local CPU server requires support for AVX instructions.
+* Multiple users cannot run servers on the same GPU (e.g. on a shared node).

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -3,49 +3,28 @@
 Test producers `TritonImageProducer` and `TritonGraphProducer` are available.
 They generate arbitrary inputs for inference (with ResNet50 or Graph Attention Network, respectively) and print the resulting output.
 
-To run the tests, a local Triton server can be started using Singularity or Docker.
+To run the tests, a local Triton server can be started using Singularity (default, should not require superuser permission)
+or Docker (may require superuser permission).
+The server can utilize the local CPU (support for AVX instructions required) or a local Nvidia GPU, if one is available.
 The default local server address is `0.0.0.0`.
-(In either case, to get more debugging information from the server, the flags `--log-verbose=1 --log-error=1 --log-info=1`
-can be added to the end of the command that includes `tritonserver`.)
 
 First, the relevant data should be downloaded from Nvidia:
 ```
 ./fetch_model.sh
 ```
 
-## Singularity instructions
-
-Using Singularity should not require superuser permissions.
-
-Execute these Singularity commands to start the instance in the background and then activate the server:
-```bash
-singularity instance start \
-  -B /dev/shm:/run/shm -B ${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models:/models \
-  /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.06-v1-py3-geometric/ triton_server_instance
-singularity run instance://triton_server_instance \
-  tritonserver --model-repository=/models
+The server can be managed with the `triton` script (using Singularity with CPU by default):
+```
+./triton start
+[run test commands]
+./triton stop
 ```
 
-(Some operating systems may have `/run/shm` rather than `/dev/shm`.)
-
-If the machine has Nvidia GPUs, the flag `--nv` can be added to the command.
-Otherwise, the server will perform inference using the CPU (slower).
-
-## Docker instructions
-
-Using Docker may require superuser permissions.
-
-Execute this Docker command to launch the local server:
-```bash
-docker run -d --name tritonserver \
-  --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
-  -p8000:8000 -p8001:8001 -p8002:8002 \
-  -v${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models:/models \
-  fastml/triton-torchgeo:20.06-v1-py3-geometric tritonserver --model-repository=/models
-```
-
-If the machine has Nvidia GPUs, the flag `--gpus all` can be added to the command.
-Otherwise, the server will perform inference using the CPU (slower).
+The script has the following options:
+* `-d`: use Docker instead of Singularity
+* `-g`: use GPU instead of CPU
+* `-v`: (verbose) start: activate server debugging info; stop: keep server logs
+* `-h`: print help message and exit
 
 ## Test commands
 

--- a/HeterogeneousCore/SonicTriton/test/README.md
+++ b/HeterogeneousCore/SonicTriton/test/README.md
@@ -24,6 +24,7 @@ The script has the following options:
 * `-d`: use Docker instead of Singularity
 * `-g`: use GPU instead of CPU
 * `-v`: (verbose) start: activate server debugging info; stop: keep server logs
+* `-w`: maximum time to wait for server to start (default: 30 seconds)
 * `-h`: print help message and exit
 
 ## Test commands

--- a/HeterogeneousCore/SonicTriton/test/fetch_model.sh
+++ b/HeterogeneousCore/SonicTriton/test/fetch_model.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# borrowed from https://github.com/NVIDIA/triton-inference-server/tree/master/docs/examples
+# borrowed from https://github.com/triton-inference-server/server/tree/master/docs/examples
 
-TRITON_VERSION=$(scram tool info triton-inference-server | grep "Version : " | cut -d' ' -f3)
+TRITON_REPO="https://github.com/triton-inference-server/server"
+TRITON_VERSION=$(scram tool info triton-inference-server | grep "Version : " | cut -d' ' -f3 | cut -d'-' -f1)
 
 TEST_DIR=`pwd`
 
@@ -11,28 +12,20 @@ cd $TEST_DIR
 mkdir -p $MODEL_DIR
 cd $MODEL_DIR
 
-curl -O -L https://github.com/NVIDIA/triton-inference-server/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/config.pbtxt
-curl -O -L https://github.com/NVIDIA/triton-inference-server/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/resnet50_labels.txt
+curl -O -L ${TRITON_REPO}/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/config.pbtxt
+curl -O -L ${TRITON_REPO}/raw/v${TRITON_VERSION}/docs/examples/model_repository/resnet50_netdef/resnet50_labels.txt
 
 mkdir -p 1
 
 curl -o 1/model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/predict_net.pb
 curl -o 1/init_model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/init_net.pb
 
+GAT_REPO="https://github.com/lgray/triton-torchgeo-gat-example/raw/cmssw_20.06-v1-py3"
 GAT_DIR=${TEST_DIR}/../data/models/gat_test
 cd $TEST_DIR
 mkdir -p $GAT_DIR
 cd $GAT_DIR
 
-curl -O -L https://github.com/lgray/triton-torchgeo-gat-example/raw/cmssw_20.06-v1-py3/artifacts/models/gat_test/config.pbtxt
+curl -O -L ${GAT_REPO}/artifacts/models/gat_test/config.pbtxt
 mkdir -p 1
-curl -o 1/model.pt -L https://github.com/lgray/triton-torchgeo-gat-example/raw/cmssw_20.06-v1-py3/artifacts/models/gat_test/1/model.pt
-
-TORCH_DIR=${TEST_DIR}/../data/lib/
-cd $TEST_DIR
-mkdir -p $TORCH_DIR
-cd $TORCH_DIR
-
-for lib in libtorchcluster.so libtorchscatter.so libtorchsparse.so libtorchsplineconv.so; do
-  curl -O -L https://github.com/lgray/triton-torchgeo-gat-example/raw/cmssw_20.06-v1-py3/artifacts/lib/$lib
-done
+curl -o 1/model.pt -L ${GAT_REPO}/artifacts/models/gat_test/1/model.pt

--- a/HeterogeneousCore/SonicTriton/test/fetch_model.sh
+++ b/HeterogeneousCore/SonicTriton/test/fetch_model.sh
@@ -20,12 +20,35 @@ mkdir -p 1
 curl -o 1/model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/predict_net.pb
 curl -o 1/init_model.netdef http://download.caffe2.ai.s3.amazonaws.com/models/resnet50/init_net.pb
 
-GAT_REPO="https://github.com/lgray/triton-torchgeo-gat-example/raw/cmssw_20.06-v1-py3"
 GAT_DIR=${TEST_DIR}/../data/models/gat_test
 cd $TEST_DIR
 mkdir -p $GAT_DIR
 cd $GAT_DIR
 
-curl -O -L ${GAT_REPO}/artifacts/models/gat_test/config.pbtxt
+cat << EOF > config.pbtxt
+name: "gat_test"
+platform: "pytorch_libtorch"
+max_batch_size: 0
+input [
+  {
+    name: "x__0"
+    data_type: TYPE_FP32
+    dims: [ -1, 1433 ]
+  },
+  {
+    name: "edgeindex__1"
+    data_type: TYPE_INT64
+    dims: [ 2, -1 ]
+  }
+]
+output [
+  {
+    name: "logits__0"
+    data_type: TYPE_FP32
+    dims: [ -1, 7 ]
+  }
+]
+EOF
+
 mkdir -p 1
-curl -o 1/model.pt -L ${GAT_REPO}/artifacts/models/gat_test/1/model.pt
+cp /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.06-v1-py3-geometric/torch_geometric/examples/model.pt 1/model.pt

--- a/HeterogeneousCore/SonicTriton/test/triton
+++ b/HeterogeneousCore/SonicTriton/test/triton
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-WTIME=30
+# defaults
+USEDOCKER=""
+GPU=""
+VERBOSE=""
+WTIME=60
+SERVER=triton_server_instance
+
 usage() {
 	ECHO="echo -e"
 	$ECHO "triton [options] [start|stop]"
@@ -8,6 +14,7 @@ usage() {
 	$ECHO "Options:"
 	$ECHO "-d        \t use Docker instead of Singularity"
 	$ECHO "-g        \t use GPU instead of CPU"
+	$ECHO "-n        \t name of container instance (default: ${SERVER})"
 	$ECHO "-v        \t (verbose) start: activate server debugging info; stop: keep server logs"
 	$ECHO "-w        \t maximum time to wait for server to start (default: ${WTIME} seconds)"
 	$ECHO "-h        \t print this message and exit"
@@ -18,18 +25,13 @@ usage() {
 	exit $1
 }
 
-# defaults
-USEDOCKER=""
-GPU=""
-VERBOSE=""
-
 # check shm locations
 SHM=/dev/shm
 if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "dgvhw:" opt; do
+while getopts "dgvhw:n:" opt; do
 	case "$opt" in
 		d) USEDOCKER=true
 		;;
@@ -40,6 +42,8 @@ while getopts "dgvhw:" opt; do
 		h) usage 0
 		;;
 		w) WTIME="$OPTARG"
+		;;
+		n) SERVER="$OPTARG"
 		;;
 	esac
 done
@@ -54,7 +58,6 @@ fi
 DOCKER="sudo docker"
 IMAGE=fastml/triton-torchgeo:20.06-v1-py3-geometric
 MODELS=${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models
-SERVER=triton_server_instance
 LOG=log_triton_server.log
 LIB=lib
 STARTED_INDICATOR="Started GRPCService"
@@ -83,6 +86,7 @@ start_singularity(){
 
 	START_EXIT=$?
 	if [ "$START_EXIT" -ne 0 ]; then
+		rm -rf ${LIB}
 		return "$START_EXIT"
 	fi
 
@@ -121,7 +125,7 @@ wait_server(){
 	while ! $WAIT_COND >& /dev/null; do
 		if [ "$COUNT" -gt "$WTIME" ]; then
 			echo "timed out waiting for server to start"
-			$STOP_FN
+			VERBOSE=true $STOP_FN
 			exit 1
 		else
 			COUNT=$(($COUNT + 1))

--- a/HeterogeneousCore/SonicTriton/test/triton
+++ b/HeterogeneousCore/SonicTriton/test/triton
@@ -117,14 +117,6 @@ test_singularity(){
 }
 
 wait_server(){
-	if [ -n "$USEDOCKER" ]; then
-		WAIT_COND=test_docker
-		STOP_FN=stop_docker
-	else
-		WAIT_COND=test_singularity
-		STOP_FN=stop_singularity
-	fi
-
 	COUNT=0
 	while ! $WAIT_COND >& /dev/null; do
 		if [ "$COUNT" -gt "$WTIME" ]; then
@@ -146,6 +138,7 @@ if [ -n "$USEDOCKER" ]; then
 		EXTRA="--gpus all"
 	fi
 	START_FN=start_docker
+	WAIT_COND=test_docker
 	STOP_FN=stop_docker
 	PROG_NAME=Docker
 else
@@ -153,6 +146,7 @@ else
 		EXTRA="--nv"
 	fi
 	START_FN=start_singularity
+	WAIT_COND=test_singularity
 	STOP_FN=stop_singularity
 	PROG_NAME=Singularity
 fi

--- a/HeterogeneousCore/SonicTriton/test/triton
+++ b/HeterogeneousCore/SonicTriton/test/triton
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+WTIME=30
 usage() {
 	ECHO="echo -e"
 	$ECHO "triton [options] [start|stop]"
@@ -8,6 +9,7 @@ usage() {
 	$ECHO "-d        \t use Docker instead of Singularity"
 	$ECHO "-g        \t use GPU instead of CPU"
 	$ECHO "-v        \t (verbose) start: activate server debugging info; stop: keep server logs"
+	$ECHO "-w        \t maximum time to wait for server to start (default: ${WTIME} seconds)"
 	$ECHO "-h        \t print this message and exit"
 	$ECHO
 	$ECHO "Operations:"
@@ -27,7 +29,7 @@ if [ -e /run/shm ]; then
 	SHM=/run/shm
 fi
 
-while getopts "dgvh" opt; do
+while getopts "dgvhw:" opt; do
 	case "$opt" in
 		d) USEDOCKER=true
 		;;
@@ -36,6 +38,8 @@ while getopts "dgvh" opt; do
 		v) VERBOSE="--log-verbose=1 --log-error=1 --log-info=1"
 		;;
 		h) usage 0
+		;;
+		w) WTIME="$OPTARG"
 		;;
 	esac
 done
@@ -53,53 +57,114 @@ MODELS=${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models
 SERVER=triton_server_instance
 LOG=log_triton_server.log
 LIB=lib
+STARTED_INDICATOR="Started GRPCService"
+EXTRA=""
+
+start_docker(){
+	$DOCKER run -d --name ${SERVER} \
+		--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
+		-p8000:8000 -p8001:8001 -p8002:8002 $EXTRA \
+		-v${MODELS}:/models \
+		${IMAGE} tritonserver --model-repository=/models $VERBOSE
+}
+
+start_singularity(){
+	# triton server image may need to modify contents of opt/tritonserver/lib/
+	# but cvmfs is read-only
+	# -> make a writable local directory with the same contents
+	mkdir ${LIB}
+	ln -s /cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE}/opt/tritonserver/lib/* ${LIB}/
+
+	# start instance
+	# need to bind /cvmfs for above symlinks to work inside container
+	singularity instance start \
+		-B ${SHM}:/run/shm -B ${MODELS}:/models -B ${LIB}:/opt/tritonserver/lib -B /cvmfs $EXTRA \
+		/cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE} ${SERVER}
+
+	START_EXIT=$?
+	if [ "$START_EXIT" -ne 0 ]; then
+		return "$START_EXIT"
+	fi
+
+	# run the actual server
+	singularity run instance://${SERVER} \
+		tritonserver --model-repository=/models $VERBOSE >& ${LOG} &
+}
+
+stop_docker(){
+	# keep log
+	if [ -n "$VERBOSE" ]; then $DOCKER logs ${SERVER} >& ${LOG}; fi
+
+	$DOCKER stop ${SERVER}
+	$DOCKER rm ${SERVER}
+}
+
+stop_singularity(){
+	singularity instance stop ${SERVER}
+
+	# cleanup
+	rm -rf ${LIB}
+	if [ -z "$VERBOSE" ]; then rm ${LOG}; fi
+}
+
+test_docker(){
+	# docker logs print to stderr
+	${DOCKER} logs ${SERVER} |& grep "$STARTED_INDICATOR"
+}
+
+test_singularity(){
+	grep "$STARTED_INDICATOR" $LOG
+}
+
+wait_server(){
+	if [ -n "$USEDOCKER" ]; then
+		WAIT_COND=test_docker
+		STOP_FN=stop_docker
+	else
+		WAIT_COND=test_singularity
+		STOP_FN=stop_singularity
+	fi
+
+	COUNT=0
+	while ! $WAIT_COND >& /dev/null; do
+		if [ "$COUNT" -gt "$WTIME" ]; then
+			echo "timed out waiting for server to start"
+			$STOP_FN
+			exit 1
+		else
+			COUNT=$(($COUNT + 1))
+			sleep 1
+		fi
+	done
+
+	echo "server is ready!"
+	exit 0
+}
 
 if [ -n "$USEDOCKER" ]; then
-	EXTRA=""
 	if [ -n "$GPU" ]; then
 		EXTRA="--gpus all"
 	fi
-
-	if [ "$OP" == start ]; then
-		$DOCKER run -d --name ${SERVER} \
-			--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
-			-p8000:8000 -p8001:8001 -p8002:8002 $EXTRA \
-			-v${MODELS}:/models \
-			${IMAGE} tritonserver --model-repository=/models $VERBOSE
-	else
-		# keep log
-		if [ -n "$VERBOSE" ]; then docker logs ${SERVER} >& ${LOG}; fi
-
-		$DOCKER stop ${SERVER}
-		$DOCKER rm ${SERVER}
-	fi
+	START_FN=start_docker
+	STOP_FN=stop_docker
+	PROG_NAME=Docker
 else
-	EXTRA=""
 	if [ -n "$GPU" ]; then
 		EXTRA="--nv"
 	fi
+	START_FN=start_singularity
+	STOP_FN=stop_singularity
+	PROG_NAME=Singularity
+fi
 
-	if [ "$OP" == start ]; then
-		# triton server image may need to modify contents of opt/tritonserver/lib/
-		# but cvmfs is read-only
-		# -> make a writable local directory with the same contents
-		mkdir ${LIB}
-		ln -s /cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE}/opt/tritonserver/lib/* ${LIB}/
-
-		# start instance
-		# need to bind /cvmfs for above symlinks to work inside container
-		singularity instance start \
-			-B ${SHM}:/run/shm -B ${MODELS}:/models -B ${LIB}:/opt/tritonserver/lib -B /cvmfs $EXTRA \
-			/cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE} ${SERVER}
-
-		# run the actual server
-		singularity run instance://${SERVER} \
-			tritonserver --model-repository=/models $VERBOSE >& ${LOG} &
-	else
-		singularity instance stop ${SERVER}
-
-		# cleanup
-		rm -rf ${LIB}
-		if [ -z "$VERBOSE" ]; then rm ${LOG}; fi
+if [ "$OP" == start ]; then
+	$START_FN
+	START_EXIT=$?
+	if [ "$START_EXIT" -ne 0 ]; then
+		echo "Error from $PROG_NAME"
+		exit "$START_EXIT"
 	fi
+	wait_server
+else
+	$STOP_FN
 fi

--- a/HeterogeneousCore/SonicTriton/test/triton
+++ b/HeterogeneousCore/SonicTriton/test/triton
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+usage() {
+	ECHO="echo -e"
+	$ECHO "triton [options] [start|stop]"
+	$ECHO
+	$ECHO "Options:"
+	$ECHO "-d        \t use Docker instead of Singularity"
+	$ECHO "-g        \t use GPU instead of CPU"
+	$ECHO "-v        \t (verbose) start: activate server debugging info; stop: keep server logs"
+	$ECHO "-h        \t print this message and exit"
+	$ECHO
+	$ECHO "Operations:"
+	$ECHO "start    \t start server"
+	$ECHO "stop    \t stop server"
+	exit $1
+}
+
+# defaults
+USEDOCKER=""
+GPU=""
+VERBOSE=""
+
+# check shm locations
+SHM=/dev/shm
+if [ -e /run/shm ]; then
+	SHM=/run/shm
+fi
+
+while getopts "dgvh" opt; do
+	case "$opt" in
+		d) USEDOCKER=true
+		;;
+		g) GPU=true
+		;;
+		v) VERBOSE="--log-verbose=1 --log-error=1 --log-info=1"
+		;;
+		h) usage 0
+		;;
+	esac
+done
+
+shift $(($OPTIND - 1))
+OP=$1
+
+if [ "$OP" != start ] && [ "$OP" != stop ]; then
+	usage 1
+fi
+
+DOCKER="sudo docker"
+IMAGE=fastml/triton-torchgeo:20.06-v1-py3-geometric
+MODELS=${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models
+SERVER=triton_server_instance
+LOG=log_triton_server.log
+LIB=lib
+
+if [ -n "$USEDOCKER" ]; then
+	EXTRA=""
+	if [ -n "$GPU" ]; then
+		EXTRA="--gpus all"
+	fi
+
+	if [ "$OP" == start ]; then
+		$DOCKER run -d --name ${SERVER} \
+			--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
+			-p8000:8000 -p8001:8001 -p8002:8002 $EXTRA \
+			-v${MODELS}:/models \
+			${IMAGE} tritonserver --model-repository=/models $VERBOSE
+	else
+		# keep log
+		if [ -n "$VERBOSE" ]; then docker logs ${SERVER} >& ${LOG}; fi
+
+		$DOCKER stop ${SERVER}
+		$DOCKER rm ${SERVER}
+	fi
+else
+	EXTRA=""
+	if [ -n "$GPU" ]; then
+		EXTRA="--nv"
+	fi
+
+	if [ "$OP" == start ]; then
+		# triton server image may need to modify contents of opt/tritonserver/lib/
+		# but cvmfs is read-only
+		# -> make a writable local directory with the same contents
+		mkdir ${LIB}
+		ln -s /cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE}/opt/tritonserver/lib/* ${LIB}/
+
+		# start instance
+		# need to bind /cvmfs for above symlinks to work inside container
+		singularity instance start \
+			-B ${SHM}:/run/shm -B ${MODELS}:/models -B ${LIB}:/opt/tritonserver/lib -B /cvmfs $EXTRA \
+			/cvmfs/unpacked.cern.ch/registry.hub.docker.com/${IMAGE} ${SERVER}
+
+		# run the actual server
+		singularity run instance://${SERVER} \
+			tritonserver --model-repository=/models $VERBOSE >& ${LOG} &
+	else
+		singularity instance stop ${SERVER}
+
+		# cleanup
+		rm -rf ${LIB}
+		if [ -z "$VERBOSE" ]; then rm ${LOG}; fi
+	fi
+fi


### PR DESCRIPTION
#### PR description:

SonicTriton tests can now run on either Singularity or Docker. This makes the test setup more accessible (since Docker typically requires superuser permission). An augmented Docker image with PyTorch libraries included is now hosted on DockerHub at https://hub.docker.com/repository/docker/fastml/triton-torchgeo, while the Singularity version of that image is automatically generated and hosted on `/cvmfs/unpacked.cern.ch` thanks to https://gitlab.cern.ch/unpacked/sync.

A unified script `triton` is introduced to handle the server for both the Docker and Singularity cases. It also handles using GPU instead of CPU, verbosity, waiting for the server to actually start, and other details. The documentation is updated accordingly.

(This PR also fixes some alarmingly fast link rot in the tests... hopefully Nvidia is done renaming the triton inference server repository.)

#### PR validation:

Tested on several different machines, and had some other users test as well.