### PR TITLE
Fix range of Pixel Phase1 digi Validation histos

### DIFF
--- a/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
+++ b/Validation/SiPixelPhase1DigisV/python/SiPixelPhase1DigisV_cfi.py
@@ -7,8 +7,8 @@ SiPixelPhase1DigisADC = DefaultHisto.clone(
   title = "Digi ADC values",
   xlabel = "ADC counts",
   range_min = 0,
-  range_max = 300,
-  range_nbins = 300,
+  range_max = 256,
+  range_nbins = 256,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),
@@ -43,8 +43,8 @@ SiPixelPhase1DigisRows = DefaultHisto.clone(
   title = "Digi Rows",
   xlabel = "Row",
   range_min = 0,
-  range_max = 200,
-  range_nbins = 200,
+  range_max = 180,
+  range_nbins = 180,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),
@@ -58,8 +58,8 @@ SiPixelPhase1DigisColumns = DefaultHisto.clone(
   title = "Digi Columns",
   xlabel = "Column",
   range_min = 0,
-  range_max = 300,
-  range_nbins = 300,
+  range_max = 420,
+  range_nbins = 420,
   topFolderName = "PixelPhase1V/Digis",
   specs = VPSet(
     Specification().groupBy("PXBarrel/PXLayer").save(),


### PR DESCRIPTION
#### PR description:

This PR fixes the histogram ranges in the DQM/SiPixelPhase1DigisV package - digi row, adc, col  histogram axis ranges).

#### PR validation:
This was validated using wf 11634.0.
#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NO