### PR TITLE
[102X] NanoAOD: add flag to keep all PS weights

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -398,8 +398,8 @@ public:
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
       if (keepAllPSWeights_) {
-        for (std::size_t i = 2; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i]) / nominal;
+        for (std::size_t i = 0; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i + 2]) / nominal;
         }
         psWeightDocStr = "All PS weights (w_var / w_nominal)";
       } else {
@@ -525,8 +525,8 @@ public:
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
       if (keepAllPSWeights_) {
-        for (std::size_t i = 2; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i]) / nominal;
+        for (std::size_t i = 0; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i + 2]) / nominal;
         }
         psWeightDocStr = "All PS weights (w_var / w_nominal)";
       } else {
@@ -952,7 +952,7 @@ public:
           }
         } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
                    line.find("fsr") != std::string::npos) {
-          if (keepAllPSWeights_ || line.find("Def") != std::string::npos) {
+          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos || line.find("Def") != std::string::npos) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           }
         }

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -461,9 +461,8 @@ public:
     const std::vector<unsigned int>& psWeightIDs = weightChoice->psWeightIDs;
 
     auto weights = genProd.weights();
-    double w0 = weights.at(1);
-    double originalXWGTUP = weights.at(1);
-    ;
+    double w0 = (weights.size() > 1) ? weights.at(1) : 1.;
+    double originalXWGTUP = (weights.size() > 1) ? weights.at(1) : 1.;
 
     std::vector<double> wScale, wPDF, wPS;
     for (auto id : scaleWeightIDs)

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -14,6 +14,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "boost/algorithm/string.hpp"
 
+#include <memory>
+
 #include <vector>
 #include <unordered_map>
 #include <iostream>
@@ -193,7 +195,7 @@ namespace {
   };
 
   float stof_fortrancomp(const std::string& str) {
-    std::string::size_type match = str.find("d");
+    std::string::size_type match = str.find('d');
     if (match != std::string::npos) {
       std::string pre = str.substr(0, match);
       std::string post = str.substr(match + 1);
@@ -321,17 +323,17 @@ public:
       const DynamicWeightChoiceGenInfo* weightChoice = &(streamCache(id)->weightChoice);
       fillLHEPdfWeightTablesFromGenInfo(
           counter, weightChoice, weight, *genInfo, lheScaleTab, lhePdfTab, lheNamedTab, genPSTab);
-      lheRwgtTab.reset(new nanoaod::FlatTable(1, "LHEReweightingWeights", true));
+      lheRwgtTab = std::make_unique<nanoaod::FlatTable>(1, "LHEReweightingWeights", true);
       //lheNamedTab.reset(new nanoaod::FlatTable(1, "LHENamedWeights", true));
       //genPSTab.reset(new nanoaod::FlatTable(1, "PSWeight", true));
     } else {
       // Still try to add the PS weights
       fillOnlyPSWeightTable(counter, weight, *genInfo, genPSTab);
       // make dummy values
-      lheScaleTab.reset(new nanoaod::FlatTable(1, "LHEScaleWeights", true));
-      lhePdfTab.reset(new nanoaod::FlatTable(1, "LHEPdfWeights", true));
-      lheRwgtTab.reset(new nanoaod::FlatTable(1, "LHEReweightingWeights", true));
-      lheNamedTab.reset(new nanoaod::FlatTable(1, "LHENamedWeights", true));
+      lheScaleTab = std::make_unique<nanoaod::FlatTable>(1, "LHEScaleWeights", true);
+      lhePdfTab = std::make_unique<nanoaod::FlatTable>(1, "LHEPdfWeights", true);
+      lheRwgtTab = std::make_unique<nanoaod::FlatTable>(1, "LHEReweightingWeights", true);
+      lheNamedTab = std::make_unique<nanoaod::FlatTable>(1, "LHENamedWeights", true);
       if (!hasIssuedWarning_.exchange(true)) {
         edm::LogWarning("LHETablesProducer") << "No LHEEventProduct, so there will be no LHE Tables\n";
       }
@@ -386,7 +388,11 @@ public:
         wNamed[mNamed - namedWeightIDs_.begin()] = weight.wgt / w0;
     }
 
-    std::size_t vectorSize = (genProd.weights().size() > 2) ? (keepAllPSWeights_ ? (genProd.weights().size() - 2) : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1)) : 1;
+    std::size_t vectorSize =
+        (genProd.weights().size() > 2)
+            ? (keepAllPSWeights_ ? (genProd.weights().size() - 2)
+                                 : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1))
+            : 1;
     std::vector<double> wPS(vectorSize, 1);
     std::string psWeightDocStr;
     if (vectorSize > 1) {
@@ -400,8 +406,9 @@ public:
         for (std::size_t i = 6; i < 10; i++) {
           wPS[i - 6] = (genProd.weights()[i]) / nominal;
         }
-        psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                         "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
+        psWeightDocStr =
+            "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+            "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
       }
     } else {
       psWeightDocStr = "dummy PS weight (1.0) ";
@@ -465,7 +472,8 @@ public:
       wPDF.push_back(weights.at(id) / w0);
     }
     if (!psWeightIDs.empty()) {
-      double psNom = weights.at(psWeightIDs.at(0)); // normalise PS weights by "Baseline", which should be the first entry
+      double psNom =
+          weights.at(psWeightIDs.at(0));  // normalise PS weights by "Baseline", which should be the first entry
       for (std::size_t i = 1; i < psWeightIDs.size(); i++)
         wPS.push_back(weights.at(psWeightIDs.at(i)) / psNom);
     } else
@@ -474,8 +482,9 @@ public:
     if (keepAllPSWeights_) {
       psWeightDocStr = "All PS weights (w_var / w_nominal)";
     } else {
-      psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                       "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
+      psWeightDocStr =
+          "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+          "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
     }
 
     outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
@@ -507,7 +516,11 @@ public:
                              double genWeight,
                              const GenEventInfoProduct& genProd,
                              std::unique_ptr<nanoaod::FlatTable>& outPS) const {
-    std::size_t vectorSize = (genProd.weights().size() > 2) ? (keepAllPSWeights_ ? (genProd.weights().size() - 2) : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1)) : 1;
+    std::size_t vectorSize =
+        (genProd.weights().size() > 2)
+            ? (keepAllPSWeights_ ? (genProd.weights().size() - 2)
+                                 : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1))
+            : 1;
     std::vector<double> wPS(vectorSize, 1);
     std::string psWeightDocStr;
     if (vectorSize > 1) {
@@ -521,8 +534,9 @@ public:
         for (std::size_t i = 6; i < 10; i++) {
           wPS[i - 6] = (genProd.weights()[i]) / nominal;
         }
-        psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                         "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
+        psWeightDocStr =
+            "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+            "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
       }
     } else {
       psWeightDocStr = "dummy PS weight (1.0) ";
@@ -917,7 +931,7 @@ public:
       auto weightNames = genLumiInfoHead->weightNames();
       std::unordered_map<std::string, uint32_t> knownPDFSetsFromGenInfo_;
       unsigned int weightIter = 0;
-      for (auto line : weightNames) {
+      for (const auto& line : weightNames) {
         if (std::regex_search(line, groups, scalew)) {  // scale variation
           auto id = groups.str(1);
           auto group = groups.str(2);
@@ -937,9 +951,10 @@ public:
             } else
               pdfSetWeightIDs.back().add(id, std::atoi(id.c_str()));
           }
-        } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
+        } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
+                   line.find("fsr") != std::string::npos) {
           if (keepAllPSWeights_ || line.find("Def") != std::string::npos) {
-            weightChoice->psWeightIDs.push_back(weightIter); // PS variations
+            weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           }
         }
         weightIter++;
@@ -966,7 +981,7 @@ public:
       for (const auto& pw : pdfSetWeightIDs) {
         if (pw.wids.size() == 1)
           continue;  // only consider error sets
-        for (auto wantedpdf : lhaNameToID_) {
+        for (const auto& wantedpdf : lhaNameToID_) {
           auto pdfname = wantedpdf.first;
           if (knownPDFSetsFromGenInfo_.find(pdfname) == knownPDFSetsFromGenInfo_.end())
             continue;
@@ -974,7 +989,7 @@ public:
           if (pw.lhaIDs.first != lhaid)
             continue;
           pdfDoc << pdfname;
-          for (auto x : pw.wids)
+          for (const auto& x : pw.wids)
             weightChoice->pdfWeightIDs.push_back(std::atoi(x.c_str()));
           if (maxPdfWeights_ < pw.wids.size()) {
             weightChoice->pdfWeightIDs.resize(maxPdfWeights_);  // drop some replicas
@@ -1006,7 +1021,7 @@ public:
   void globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&, CounterMap const* runCounterMap) const override {
     auto out = std::make_unique<nanoaod::MergeableCounterTable>();
 
-    for (auto x : runCounterMap->countermap) {
+    for (const auto& x : runCounterMap->countermap) {
       auto runCounter = &(x.second);
       std::string label = (!x.first.empty()) ? (std::string("_") + x.first) : "";
       std::string doclabel = (!x.first.empty()) ? (std::string(", for model label ") + x.first) : "";

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -324,8 +324,8 @@ public:
       fillLHEPdfWeightTablesFromGenInfo(
           counter, weightChoice, weight, *genInfo, lheScaleTab, lhePdfTab, lheNamedTab, genPSTab);
       lheRwgtTab = std::make_unique<nanoaod::FlatTable>(1, "LHEReweightingWeights", true);
-      //lheNamedTab.reset(new nanoaod::FlatTable(1, "LHENamedWeights", true));
-      //genPSTab.reset(new nanoaod::FlatTable(1, "PSWeight", true));
+      //lheNamedTab = std::make_unique<nanoaod::FlatTable>(1, "LHENamedWeights", true);
+      //genPSTab = std::make_unique<nanoaod::FlatTable>(1, "PSWeight", true);
     } else {
       // Still try to add the PS weights
       fillOnlyPSWeightTable(counter, weight, *genInfo, genPSTab);
@@ -413,22 +413,22 @@ public:
     } else {
       psWeightDocStr = "dummy PS weight (1.0) ";
     }
-    outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
+    outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
     outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
+    outScale = std::make_unique<nanoaod::FlatTable>(wScale.size(), "LHEScaleWeight", false);
     outScale->addColumn<float>(
         "", wScale, weightChoice->scaleWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outPdf.reset(new nanoaod::FlatTable(wPDF.size(), "LHEPdfWeight", false));
+    outPdf = std::make_unique<nanoaod::FlatTable>(wPDF.size(), "LHEPdfWeight", false);
     outPdf->addColumn<float>(
         "", wPDF, weightChoice->pdfWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outRwgt.reset(new nanoaod::FlatTable(wRwgt.size(), "LHEReweightingWeight", false));
+    outRwgt = std::make_unique<nanoaod::FlatTable>(wRwgt.size(), "LHEReweightingWeight", false);
     outRwgt->addColumn<float>(
         "", wRwgt, weightChoice->rwgtWeightDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outNamed.reset(new nanoaod::FlatTable(1, "LHEWeight", true));
+    outNamed = std::make_unique<nanoaod::FlatTable>(1, "LHEWeight", true);
     outNamed->addColumnValue<float>("originalXWGTUP",
                                     lheProd.originalXWGTUP(),
                                     "Nominal event weight in the LHE file",
@@ -482,22 +482,22 @@ public:
           "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
     }
 
-    outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
+    outScale = std::make_unique<nanoaod::FlatTable>(wScale.size(), "LHEScaleWeight", false);
     outScale->addColumn<float>(
         "", wScale, weightChoice->scaleWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outPdf.reset(new nanoaod::FlatTable(wPDF.size(), "LHEPdfWeight", false));
+    outPdf = std::make_unique<nanoaod::FlatTable>(wPDF.size(), "LHEPdfWeight", false);
     outPdf->addColumn<float>(
         "", wPDF, weightChoice->pdfWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
-    outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
+    outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
     outPS->addColumn<float>("",
                             wPS,
                             wPS.size() > 1 ? psWeightDocStr : "dummy PS weight (1.0) ",
                             nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
-    outNamed.reset(new nanoaod::FlatTable(1, "LHEWeight", true));
+    outNamed = std::make_unique<nanoaod::FlatTable>(1, "LHEWeight", true);
     outNamed->addColumnValue<float>(
         "originalXWGTUP", originalXWGTUP, "Nominal event weight in the LHE file", nanoaod::FlatTable::FloatColumn);
     /*for (unsigned int i = 0, n = wNamed.size(); i < n; ++i) {
@@ -536,7 +536,7 @@ public:
     } else {
       psWeightDocStr = "dummy PS weight (1.0) ";
     }
-    outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
+    outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
     outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
     counter->incGenOnly(genWeight);

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -414,11 +414,7 @@ public:
       psWeightDocStr = "dummy PS weight (1.0) ";
     }
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
-    outPS->addColumn<float>("",
-                            wPS,
-                            psWeightDocStr,
-                            nanoaod::FlatTable::FloatColumn,
-                            lheWeightPrecision_);
+    outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
     outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
     outScale->addColumn<float>(
@@ -541,11 +537,7 @@ public:
       psWeightDocStr = "dummy PS weight (1.0) ";
     }
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
-    outPS->addColumn<float>("",
-                            wPS,
-                            psWeightDocStr,
-                            nanoaod::FlatTable::FloatColumn,
-                            lheWeightPrecision_);
+    outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
     counter->incGenOnly(genWeight);
     counter->incPSOnly(genWeight, wPS);

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -952,7 +952,8 @@ public:
           }
         } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
                    line.find("fsr") != std::string::npos) {
-          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos || line.find("Def") != std::string::npos) {
+          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos ||
+              line.find("Def") != std::string::npos) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           }
         }

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -251,6 +251,7 @@ public:
         namedWeightLabels_(params.getParameter<std::vector<std::string>>("namedWeightLabels")),
         lheWeightPrecision_(params.getParameter<int32_t>("lheWeightPrecision")),
         maxPdfWeights_(params.getParameter<uint32_t>("maxPdfWeights")),
+        keepAllPSWeights_(params.getParameter<bool>("keepAllPSWeights")),
         debug_(params.getUntrackedParameter<bool>("debug", false)),
         debugRun_(debug_.load()),
         hasIssuedWarning_(false) {
@@ -385,20 +386,30 @@ public:
         wNamed[mNamed - namedWeightIDs_.begin()] = weight.wgt / w0;
     }
 
-    int vectorSize = (genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1;
+    std::size_t vectorSize = (genProd.weights().size() > 2) ? (keepAllPSWeights_ ? (genProd.weights().size() - 2) : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1)) : 1;
     std::vector<double> wPS(vectorSize, 1);
+    std::string psWeightDocStr;
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
-      for (unsigned int i = 6; i < 10; i++) {
-        wPS[i - 6] = (genProd.weights()[i]) / nominal;
+      if (keepAllPSWeights_) {
+        for (std::size_t i = 2; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i]) / nominal;
+        }
+        psWeightDocStr = "All PS weights (w_var / w_nominal)";
+      } else {
+        for (std::size_t i = 6; i < 10; i++) {
+          wPS[i - 6] = (genProd.weights()[i]) / nominal;
+        }
+        psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+                         "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
       }
+    } else {
+      psWeightDocStr = "dummy PS weight (1.0) ";
     }
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
     outPS->addColumn<float>("",
                             wPS,
-                            vectorSize > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                                             "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
-                                           : "dummy PS weight (1.0) ",
+                            psWeightDocStr,
                             nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
@@ -454,10 +465,18 @@ public:
       wPDF.push_back(weights.at(id) / w0);
     }
     if (!psWeightIDs.empty()) {
-      for (auto id : psWeightIDs)
-        wPS.push_back((weights.at(id)) / w0);
+      double psNom = weights.at(psWeightIDs.at(0)); // normalise PS weights by "Baseline", which should be the first entry
+      for (std::size_t i = 1; i < psWeightIDs.size(); i++)
+        wPS.push_back(weights.at(psWeightIDs.at(i)) / psNom);
     } else
       wPS.push_back(1.0);
+    std::string psWeightDocStr;
+    if (keepAllPSWeights_) {
+      psWeightDocStr = "All PS weights (w_var / w_nominal)";
+    } else {
+      psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+                       "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
+    }
 
     outScale.reset(new nanoaod::FlatTable(wScale.size(), "LHEScaleWeight", false));
     outScale->addColumn<float>(
@@ -470,9 +489,7 @@ public:
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
     outPS->addColumn<float>("",
                             wPS,
-                            wPS.size() > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                                             "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
-                                           : "dummy PS weight (1.0) ",
+                            wPS.size() > 1 ? psWeightDocStr : "dummy PS weight (1.0) ",
                             nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
@@ -490,22 +507,30 @@ public:
                              double genWeight,
                              const GenEventInfoProduct& genProd,
                              std::unique_ptr<nanoaod::FlatTable>& outPS) const {
-    int vectorSize = (genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1;
-
+    std::size_t vectorSize = (genProd.weights().size() > 2) ? (keepAllPSWeights_ ? (genProd.weights().size() - 2) : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1)) : 1;
     std::vector<double> wPS(vectorSize, 1);
+    std::string psWeightDocStr;
     if (vectorSize > 1) {
       double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
-      for (unsigned int i = 6; i < 10; i++) {
-        wPS[i - 6] = (genProd.weights()[i]) / nominal;
+      if (keepAllPSWeights_) {
+        for (std::size_t i = 2; i < vectorSize; i++) {
+          wPS[i] = (genProd.weights()[i]) / nominal;
+        }
+        psWeightDocStr = "All PS weights (w_var / w_nominal)";
+      } else {
+        for (std::size_t i = 6; i < 10; i++) {
+          wPS[i - 6] = (genProd.weights()[i]) / nominal;
+        }
+        psWeightDocStr = "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
+                         "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
       }
+    } else {
+      psWeightDocStr = "dummy PS weight (1.0) ";
     }
-
     outPS.reset(new nanoaod::FlatTable(wPS.size(), "PSWeight", false));
     outPS->addColumn<float>("",
                             wPS,
-                            vectorSize > 1 ? "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-                                             "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 "
-                                           : "dummy PS weight (1.0) ",
+                            psWeightDocStr,
                             nanoaod::FlatTable::FloatColumn,
                             lheWeightPrecision_);
 
@@ -912,9 +937,10 @@ public:
             } else
               pdfSetWeightIDs.back().add(id, std::atoi(id.c_str()));
           }
-        } else if (line.find("isrDef") != std::string::npos ||
-                   line.find("fsrDef") != std::string::npos) {  // PS variation
-          weightChoice->psWeightIDs.push_back(weightIter);
+        } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
+          if (keepAllPSWeights_ || line.find("Def") != std::string::npos) {
+            weightChoice->psWeightIDs.push_back(weightIter); // PS variations
+          }
         }
         weightIter++;
       }
@@ -1048,6 +1074,7 @@ public:
         ->setComment("output names for the namedWeightIDs (in the same order)");
     desc.add<int32_t>("lheWeightPrecision")->setComment("Number of bits in the mantissa for LHE weights");
     desc.add<uint32_t>("maxPdfWeights")->setComment("Maximum number of PDF weights to save (to crop NN replicas)");
+    desc.add<bool>("keepAllPSWeights")->setComment("Store all PS weights found");
     desc.addOptionalUntracked<bool>("debug")->setComment("dump out all LHE information for one event");
     descriptions.add("genWeightsTable", desc);
   }
@@ -1065,6 +1092,7 @@ protected:
   std::vector<std::string> namedWeightLabels_;
   int lheWeightPrecision_;
   unsigned int maxPdfWeights_;
+  bool keepAllPSWeights_;
 
   mutable std::atomic<bool> debug_, debugRun_, hasIssuedWarning_;
 };

--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -436,6 +436,13 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('z', 'z', 20, -20, 20, 'Z position of other primary vertices, excluding the main PV'),
             )
         ),
+        PSWeight = cms.PSet(
+            sels = cms.PSet(),
+            plots = cms.VPSet(
+                Plot1D('', '', 20, 0, 2, 'All PS weights (w_var / w_nominal)'),
+                Count1D('_size', 46, -0.5, 45.5, 'Number of PS weights'),
+            )
+        ),
         PV = cms.PSet(
             sels = cms.PSet(),
             plots = cms.VPSet(

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -108,6 +108,7 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),
     lheWeightPrecision = cms.int32(14),
+    keepAllPSWeights = cms.bool(False),
     maxPdfWeights = cms.uint32(150), 
     debug = cms.untracked.bool(False),
 )


### PR DESCRIPTION
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #31276 to fix nanoAOD workflows crashing in 102X because of https://github.com/cms-nanoAOD/cmssw/issues/538

@agrohsje
