### PR TITLE
[DD4hep] PartSelector Path Namespace Fix

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -947,7 +947,7 @@ void Converter<PartSelector>::operator()(xml_h element) const {
            "+++ PartSelector for %s path: %s",
            specParName.c_str(),
            path.c_str());
-  auto npos = path.find(":");
+  auto npos = path.find(':');
   if (npos != path.npos) {
     std::string anyns{"//.*"};
     if (path.substr(0, npos) == anyns) {

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -947,8 +947,12 @@ void Converter<PartSelector>::operator()(xml_h element) const {
            "+++ PartSelector for %s path: %s",
            specParName.c_str(),
            path.c_str());
-  if (path.substr(0, 3) == std::string(".*:")) {
-    path = path.substr(3);
+  auto npos = path.find(":");
+  if (npos != path.npos) {
+    std::string anyns{"//.*"};
+    if (path.substr(0, npos) == anyns) {
+      path = string("//").append(path.substr(npos + 1));
+    }
   }
   registry.specpars[specParName].paths.emplace_back(path);
 }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -463,6 +463,7 @@ const std::vector<double> DDFilteredView::parameters() const {
 }
 
 const cms::DDSolidShape DDFilteredView::shape() const {
+  assert(node_);
   return cms::dd::value(cms::DDSolidShapeMap, std::string(node_->GetVolume()->GetShape()->GetTitle()));
 }
 


### PR DESCRIPTION
#### PR description:

When a PartSelector path namespace defines **any** namespace remove it. This is a default mode, there is no need to propagate it to the special parameters registry.

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
