### PR TITLE
move std dictionaries to DataFormats/StdDictionaries

### DIFF
--- a/CondFormats/Common/src/classes_def.xml
+++ b/CondFormats/Common/src/classes_def.xml
@@ -9,9 +9,6 @@
  <class name="FileBlobCollection" class_version="0"/>
  <class name="edm::Wrapper<FileBlobCollection>" class_version="0"/>
 
- <class name="std::pair <const std::string, unsigned long long>" />
- <class name="std::map <std::string, unsigned long long>" />
-
  <class name="MultiFileBlob" class_version="0">
    <field name="blob" mapping="blob"/>
    <field name="positions" mapping="blob"/>
@@ -28,9 +25,6 @@
 
 
  <class name="cond::BaseKeyed"/>
-
-  <class name="std::map<unsigned long long,unsigned long long>"/>
-  <class name="std::map<unsigned long long,unsigned long long>::value_type" />
 
  <class name="ConfObject"/>
 

--- a/DataFormats/StdDictionaries/src/classes_def_map.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_map.xml
@@ -38,4 +38,9 @@
  <class name="std::map<unsigned short,float>"/>
  <class name="std::map<unsigned short,std::vector<unsigned short> >"/>
  <class name="std::map<unsigned short,unsigned short>"/>
+
+ <class name="std::map<unsigned long long,unsigned long long>"/>
+ <class name="std::map<unsigned long long,unsigned long long>::value_type" />
+ <class name="std::map <std::string, unsigned long long>" />
+
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_def_pair.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_pair.xml
@@ -68,4 +68,5 @@
  <class name="std::pair<unsigned short,float>"/>
  <class name="std::pair<unsigned short,std::vector<unsigned short> >"/>
  <class name="std::pair<unsigned short,unsigned short>"/>
+ <class name="std::pair <const std::string, unsigned long long>" />
 </lcgdict>


### PR DESCRIPTION
Dictionaries that can not be found in modules IB as they are declared in a non-standard place. This PR just moves them to the nominal package for dictionaries of std types.