### PR TITLE
Add GEM to muon alignment module

### DIFF
--- a/Alignment/CommonAlignment/interface/AlignableObjectId.h
+++ b/Alignment/CommonAlignment/interface/AlignableObjectId.h
@@ -7,6 +7,7 @@
 class TrackerGeometry;
 class DTGeometry;
 class CSCGeometry;
+class GEMGeometry;
 
 /// Allows conversion between type and name, and vice-versa
 class AlignableObjectId {
@@ -15,7 +16,7 @@ public:
   enum class Geometry { RunI, PhaseI, PhaseII, General, Unspecified };
 
   AlignableObjectId(Geometry);
-  AlignableObjectId(const TrackerGeometry*, const DTGeometry*, const CSCGeometry*);
+  AlignableObjectId(const TrackerGeometry*, const DTGeometry*, const CSCGeometry*, const GEMGeometry*);
   AlignableObjectId(const AlignableObjectId&) = default;
   AlignableObjectId& operator=(const AlignableObjectId&) = default;
   AlignableObjectId(AlignableObjectId&&) = default;
@@ -43,7 +44,7 @@ public:
 
 private:
   static Geometry trackerGeometry(const TrackerGeometry*);
-  static Geometry muonGeometry(const DTGeometry*, const CSCGeometry*);
+  static Geometry muonGeometry(const DTGeometry*, const CSCGeometry*, const GEMGeometry*);
 
   const entry* entries_{nullptr};
   Geometry geometry_{Geometry::Unspecified};

--- a/Alignment/CommonAlignment/interface/StructureType.h
+++ b/Alignment/CommonAlignment/interface/StructureType.h
@@ -81,6 +81,12 @@ namespace align {
     AlignableCSCRing,
     AlignableCSCChamber,
     AlignableCSCLayer,  // = 110
+    AlignableGEMEndcap,
+    AlignableGEMStation,
+    AlignableGEMRing,
+    AlignableGEMSuperChamber,
+    AlignableGEMChamber,
+    AlignableGEMEtaPartition,
     AlignableMuon,
 
     Detector,  // = 112 (what for?)

--- a/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
+++ b/Alignment/CommonAlignment/src/AlignableCompositeBuilder.cc
@@ -18,7 +18,7 @@ AlignableCompositeBuilder ::AlignableCompositeBuilder(const TrackerTopology* tra
                                                       const TrackerGeometry* trackerGeometry,
                                                       const AlignableIndexer& alignableIndexer)
     : trackerTopology_(trackerTopology),
-      alignableObjectId_(trackerGeometry, nullptr, nullptr),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr, nullptr),
       alignableIndexer_(alignableIndexer) {}
 
 //_____________________________________________________________________________

--- a/Alignment/CommonAlignment/src/AlignableObjectId.cc
+++ b/Alignment/CommonAlignment/src/AlignableObjectId.cc
@@ -135,6 +135,12 @@ namespace {
                                                       {align::AlignableCSCRing, "CSCRing"},
                                                       {align::AlignableCSCChamber, "CSCChamber"},
                                                       {align::AlignableCSCLayer, "CSCLayer"},
+                                                      {align::AlignableGEMEndcap, "GEMEndcap"},
+                                                      {align::AlignableGEMStation, "GEMStation"},
+                                                      {align::AlignableGEMRing, "GEMRing"},
+                                                      {align::AlignableGEMSuperChamber, "GEMSuperChamber"},
+                                                      {align::AlignableGEMChamber, "GEMChamber"},
+                                                      {align::AlignableGEMEtaPartition, "GEMEtaPartition"},
                                                       {align::AlignableMuon, "Muon"},
 
                                                       {align::BeamSpot, "BeamSpot"},
@@ -201,6 +207,12 @@ namespace {
                                                        {align::AlignableCSCRing, "CSCRing"},
                                                        {align::AlignableCSCChamber, "CSCChamber"},
                                                        {align::AlignableCSCLayer, "CSCLayer"},
+                                                       {align::AlignableGEMEndcap, "GEMEndcap"},
+                                                       {align::AlignableGEMStation, "GEMStation"},
+                                                       {align::AlignableGEMRing, "GEMRing"},
+                                                       {align::AlignableGEMSuperChamber, "GEMSuperChamber"},
+                                                       {align::AlignableGEMChamber, "GEMChamber"},
+                                                       {align::AlignableGEMEtaPartition, "GEMEtaPartition"},
                                                        {align::AlignableMuon, "Muon"},
 
                                                        {align::BeamSpot, "BeamSpot"},
@@ -246,8 +258,9 @@ AlignableObjectId ::AlignableObjectId(AlignableObjectId::Geometry geometry) : ge
 //_____________________________________________________________________________
 AlignableObjectId ::AlignableObjectId(const TrackerGeometry *tracker,
                                       const DTGeometry *muonDt,
-                                      const CSCGeometry *muonCsc)
-    : AlignableObjectId(commonGeometry(trackerGeometry(tracker), muonGeometry(muonDt, muonCsc))) {}
+                                      const CSCGeometry *muonCsc,
+                                      const GEMGeometry *muonGem)
+    : AlignableObjectId(commonGeometry(trackerGeometry(tracker), muonGeometry(muonDt, muonCsc, muonGem))) {}
 
 //_____________________________________________________________________________
 align::StructureType AlignableObjectId::nameToType(const std::string &name) const { return stringToId(name.c_str()); }
@@ -299,7 +312,9 @@ AlignableObjectId::Geometry AlignableObjectId ::trackerGeometry(const TrackerGeo
   }
 }
 
-AlignableObjectId::Geometry AlignableObjectId ::muonGeometry(const DTGeometry *, const CSCGeometry *) {
+AlignableObjectId::Geometry AlignableObjectId ::muonGeometry(const DTGeometry *,
+                                                             const CSCGeometry *,
+                                                             const GEMGeometry *) {
   // muon alignment structure types are identical for all kinds of geometries
   return Geometry::General;
 }

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentProducerBase.h
@@ -51,6 +51,7 @@
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
@@ -114,6 +115,7 @@ protected:
   std::shared_ptr<TrackerGeometry> trackerGeometry_;
   edm::ESHandle<DTGeometry> muonDTGeometry_;
   edm::ESHandle<CSCGeometry> muonCSCGeometry_;
+  edm::ESHandle<GEMGeometry> muonGEMGeometry_;
   const bool doTracker_, doMuon_, useExtras_;
 
   /// Map with tracks/trajectories

--- a/Alignment/MuonAlignment/BuildFile.xml
+++ b/Alignment/MuonAlignment/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DataFormats/GeometryCommonDetAlgo"/>
 <use name="Geometry/DTGeometry"/>
 <use name="Geometry/CSCGeometry"/>
+<use name="Geometry/GEMGeometry"/>
 <use name="Geometry/CommonTopologies"/>
 <use name="Geometry/Records"/>
 <use name="FWCore/Framework"/>

--- a/Alignment/MuonAlignment/interface/AlignableGEMChamber.h
+++ b/Alignment/MuonAlignment/interface/AlignableGEMChamber.h
@@ -1,0 +1,27 @@
+#ifndef Alignment_MuonAlignment_AlignableGEMChamber_H
+#define Alignment_MuonAlignment_AlignableGEMChamber_H
+
+/* \class AlignableGEMChamber
+ * \author Hyunyong Kim - TAMU
+ */
+
+#include <iosfwd>
+#include <iostream>
+#include <vector>
+
+#include "Alignment/CommonAlignment/interface/StructureType.h"
+#include "Alignment/CommonAlignment/interface/AlignableDet.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+
+class AlignableGEMChamber : public AlignableDet {
+public:
+  friend std::ostream& operator<<(std::ostream&, const AlignableGEMChamber&);
+
+  AlignableGEMChamber(const GeomDet* geomDet);
+
+  void update(const GeomDet* geomDet);
+};
+
+#endif

--- a/Alignment/MuonAlignment/interface/AlignableGEMEndcap.h
+++ b/Alignment/MuonAlignment/interface/AlignableGEMEndcap.h
@@ -1,0 +1,42 @@
+#ifndef Alignment_MuonAlignment_AlignableGEMEndcap_H
+#define Alignment_MuonAlignment_AlignableGEMEndcap_H
+
+/* \class AlignableGEMEndcap
+ * \author Hyunyong Kim - TAMU
+ */
+
+#include "Alignment/CommonAlignment/interface/Utilities.h"
+#include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+#include "Alignment/CommonAlignment/interface/AlignableSurface.h"
+
+#include "Alignment/MuonAlignment/interface/AlignableGEMStation.h"
+
+#include <vector>
+
+class GeomDet;
+
+class AlignableGEMEndcap : public AlignableComposite {
+public:
+  AlignableGEMEndcap(const std::vector<AlignableGEMStation*>& GEMStations);
+
+  PositionType computePosition();
+
+  RotationType computeOrientation();
+
+  AlignableSurface computeSurface();
+
+  AlignableGEMStation& station(int i);
+
+  friend std::ostream& operator<<(std::ostream&, const AlignableGEMEndcap&);
+
+  void dump(void) const override;
+
+  Alignments* alignments() const override;
+
+  AlignmentErrorsExtended* alignmentErrors() const override;
+
+private:
+  std::vector<AlignableGEMStation*> theGEMStations;
+};
+
+#endif

--- a/Alignment/MuonAlignment/interface/AlignableGEMRing.h
+++ b/Alignment/MuonAlignment/interface/AlignableGEMRing.h
@@ -1,0 +1,36 @@
+#ifndef Alignment_MuonAlignment_AlignableGEMRing_H
+#define Alignment_MuonAlignment_AlignableGEMRing_H
+
+/* \class AlignableGEMRing
+ * \author Hyunyong Kim - TAMU
+ */
+
+#include "Alignment/CommonAlignment/interface/Utilities.h"
+#include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+#include "Alignment/CommonAlignment/interface/AlignableSurface.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMSuperChamber.h"
+#include <vector>
+
+class GeomDet;
+
+class AlignableGEMRing : public AlignableComposite {
+public:
+  AlignableGEMRing(const std::vector<AlignableGEMSuperChamber*>& GEMSuperChambers);
+
+  PositionType computePosition();
+
+  RotationType computeOrientation();
+
+  AlignableSurface computeSurface();
+
+  AlignableGEMSuperChamber& superChamber(int i);
+
+  friend std::ostream& operator<<(std::ostream&, const AlignableGEMRing&);
+
+  void dump(void) const override;
+
+private:
+  std::vector<AlignableGEMSuperChamber*> theGEMSuperChambers;
+};
+
+#endif

--- a/Alignment/MuonAlignment/interface/AlignableGEMStation.h
+++ b/Alignment/MuonAlignment/interface/AlignableGEMStation.h
@@ -1,0 +1,39 @@
+#ifndef Alignment_MuonAlignment_AlignableGEMStation_H
+#define Alignment_MuonAlignment_AlignableGEMStation_H
+
+/* \class AlignableGEMRing
+ * \author Hyunyong Kim - TAMU
+ */
+
+#include "Alignment/CommonAlignment/interface/Utilities.h"
+#include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+#include "Alignment/CommonAlignment/interface/AlignableSurface.h"
+
+#include "Alignment/MuonAlignment/interface/AlignableGEMRing.h"
+
+#include <vector>
+
+class GeomDet;
+class AlignableGEMRing;
+
+class AlignableGEMStation : public AlignableComposite {
+public:
+  AlignableGEMStation(const std::vector<AlignableGEMRing*>& GEMRings);
+
+  PositionType computePosition();
+
+  RotationType computeOrientation();
+
+  AlignableSurface computeSurface();
+
+  AlignableGEMRing& ring(int i);
+
+  friend std::ostream& operator<<(std::ostream&, const AlignableGEMStation&);
+
+  void dump(void) const override;
+
+private:
+  std::vector<AlignableGEMRing*> theGEMRings;
+};
+
+#endif

--- a/Alignment/MuonAlignment/interface/AlignableGEMSuperChamber.h
+++ b/Alignment/MuonAlignment/interface/AlignableGEMSuperChamber.h
@@ -1,0 +1,27 @@
+#ifndef Alignment_MuonAlignment_AlignableGEMSuperChamber_H
+#define Alignment_MuonAlignment_AlignableGEMSuperChamber_H
+
+/* \class AlignableGEMSuperChamber
+ * \author Hyunyong Kim - TAMU
+ */
+
+#include <iosfwd>
+#include <iostream>
+#include <vector>
+
+#include "Alignment/CommonAlignment/interface/StructureType.h"
+#include "Alignment/CommonAlignment/interface/AlignableDet.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Alignment/CommonAlignment/interface/AlignableComposite.h"
+
+class AlignableGEMSuperChamber : public AlignableDet {
+public:
+  friend std::ostream& operator<<(std::ostream&, const AlignableGEMSuperChamber&);
+
+  AlignableGEMSuperChamber(const GeomDet* geomDet);
+
+  void update(const GeomDet* geomDet);
+};
+
+#endif

--- a/Alignment/MuonAlignment/interface/AlignableMuon.h
+++ b/Alignment/MuonAlignment/interface/AlignableMuon.h
@@ -17,6 +17,7 @@
 #include "Alignment/CommonAlignment/interface/AlignableObjectId.h"
 
 class CSCGeometry;
+class GEMGeometry;
 
 // Classes that will be used to construct the muon
 class AlignableDTBarrel;
@@ -27,20 +28,24 @@ class AlignableCSCEndcap;
 class AlignableCSCStation;
 class AlignableCSCRing;
 class AlignableCSCChamber;
+class AlignableGEMEndcap;
+class AlignableGEMStation;
+class AlignableGEMRing;
+class AlignableGEMSuperChamber;
 
 /// Constructor of the full muon geometry.
 
 class AlignableMuon : public AlignableComposite {
 public:
   /// Constructor from geometries
-  AlignableMuon(const DTGeometry*, const CSCGeometry*);
+  AlignableMuon(const DTGeometry*, const CSCGeometry*, const GEMGeometry*);
 
   /// Destructor
   ~AlignableMuon() override;
 
   /// Updater using DTGeometry and CSCGeometry.
   /// The given geometries have to match the current ones.
-  void update(const DTGeometry*, const CSCGeometry*);
+  void update(const DTGeometry*, const CSCGeometry*, const GEMGeometry*);
 
   /// Return all components
   const align::Alignables& components() const final { return theMuonComponents; }
@@ -60,6 +65,12 @@ public:
   align::Alignables CSCStations();
   align::Alignables CSCRings();
   align::Alignables CSCEndcaps();
+  align::Alignables GEMEtaPartitions();
+  align::Alignables GEMChambers();
+  align::Alignables GEMSuperChambers();
+  align::Alignables GEMStations();
+  align::Alignables GEMRings();
+  align::Alignables GEMEndcaps();
 
   /// Get DT alignments sorted by DetId
   Alignments* dtAlignments();
@@ -70,8 +81,12 @@ public:
   /// Get CSC alignments sorted by DetId
   Alignments* cscAlignments();
 
+  Alignments* gemAlignments();
+
   /// Get CSC alignment errors sorted by DetId
   AlignmentErrorsExtended* cscAlignmentErrorsExtended();
+
+  AlignmentErrorsExtended* gemAlignmentErrorsExtended();
 
   /// Return muon alignable object ID provider derived from the muon system geometry
   const AlignableObjectId& objectIdProvider() const { return alignableObjectId_; }
@@ -100,6 +115,8 @@ private:
   /// Build muon end caps
   void buildCSCEndcap(const CSCGeometry*, bool update = false);
 
+  void buildGEMEndcap(const GEMGeometry*, bool update = false);
+
   /// Set mothers recursively
   void recursiveSetMothers(Alignable* alignable);
 
@@ -116,6 +133,11 @@ private:
   std::vector<AlignableCSCStation*> theCSCStations;
   std::vector<AlignableCSCRing*> theCSCRings;
   std::vector<AlignableCSCEndcap*> theCSCEndcaps;
+
+  std::vector<AlignableGEMSuperChamber*> theGEMSuperChambers;
+  std::vector<AlignableGEMStation*> theGEMStations;
+  std::vector<AlignableGEMRing*> theGEMRings;
+  std::vector<AlignableGEMEndcap*> theGEMEndcaps;
 
   align::Alignables theMuonComponents;
 };

--- a/Alignment/MuonAlignment/interface/MuonAlignment.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignment.h
@@ -52,6 +52,7 @@ public:
 
   void saveDTtoDB();
   void saveCSCtoDB();
+  void saveGEMtoDB();
   void saveToDB();
 
 private:
@@ -60,6 +61,7 @@ private:
 
   std::string theDTAlignRecordName, theDTErrorRecordName;
   std::string theCSCAlignRecordName, theCSCErrorRecordName;
+  std::string theGEMAlignRecordName, theGEMErrorRecordName;
   std::string theDTSurveyRecordName, theDTSurveyErrorRecordName;
   std::string theCSCSurveyRecordName, theCSCSurveyErrorRecordName;
 

--- a/Alignment/MuonAlignment/interface/MuonAlignment.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignment.h
@@ -13,9 +13,10 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
-#include <FWCore/Framework/interface/Frameworkfwd.h>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Alignment/CommonAlignment/interface/AlignableNavigator.h"
 #include "Alignment/MuonAlignment/interface/MuonAlignmentInputMethod.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 class MuonAlignment {
 public:
@@ -64,6 +65,10 @@ private:
   std::string theGEMAlignRecordName, theGEMErrorRecordName;
   std::string theDTSurveyRecordName, theDTSurveyErrorRecordName;
   std::string theCSCSurveyRecordName, theCSCSurveyErrorRecordName;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 
   align::Scalars displacements;
 

--- a/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
+++ b/Alignment/MuonAlignment/interface/MuonAlignmentInputDB.h
@@ -29,7 +29,8 @@
 class MuonAlignmentInputDB : public MuonAlignmentInputMethod {
 public:
   MuonAlignmentInputDB();
-  MuonAlignmentInputDB(std::string dtLabel, std::string cscLabel, std::string idealLabel, bool getAPEs);
+  MuonAlignmentInputDB(
+      std::string dtLabel, std::string cscLabel, std::string gemLabel, std::string idealLabel, bool getAPEs);
   ~MuonAlignmentInputDB() override;
 
   // ---------- const member functions ---------------------
@@ -47,7 +48,7 @@ private:
 
   // ---------- member data --------------------------------
 
-  std::string m_dtLabel, m_cscLabel, idealGeometryLabel;
+  std::string m_dtLabel, m_cscLabel, m_gemLabel, idealGeometryLabel;
   bool m_getAPEs;
 };
 

--- a/Alignment/MuonAlignment/interface/MuonScenarioBuilder.h
+++ b/Alignment/MuonAlignment/interface/MuonScenarioBuilder.h
@@ -33,6 +33,8 @@ public:
   /// this special method allows to move a CSCsector by a same amount
   void moveCSCSectors(const edm::ParameterSet& scenario);
 
+  void moveGEMSectors(const edm::ParameterSet& scenario);
+
   /// this special method allows to move the complete muon system by a same amount
   void moveMuon(const edm::ParameterSet& scenario);
 

--- a/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryDBConverter.cc
@@ -54,7 +54,7 @@ private:
   bool m_done;
   std::string m_input, m_output;
 
-  std::string m_dtLabel, m_cscLabel;
+  std::string m_dtLabel, m_cscLabel, m_gemLabel;
   double m_shiftErr, m_angleErr;
   std::string m_fileName;
   bool m_getAPEs;
@@ -101,6 +101,7 @@ MuonGeometryDBConverter::MuonGeometryDBConverter(const edm::ParameterSet &iConfi
   else if (m_input == std::string("db")) {
     m_dtLabel = iConfig.getParameter<std::string>("dtLabel");
     m_cscLabel = iConfig.getParameter<std::string>("cscLabel");
+    m_gemLabel = iConfig.getParameter<std::string>("gemLabel");
     m_shiftErr = iConfig.getParameter<double>("shiftErr");
     m_angleErr = iConfig.getParameter<double>("angleErr");
     m_getAPEs = iConfig.getParameter<bool>("getAPEs");
@@ -109,6 +110,7 @@ MuonGeometryDBConverter::MuonGeometryDBConverter(const edm::ParameterSet &iConfi
   else if (m_input == std::string("surveydb")) {
     m_dtLabel = iConfig.getParameter<std::string>("dtLabel");
     m_cscLabel = iConfig.getParameter<std::string>("cscLabel");
+    m_gemLabel = iConfig.getParameter<std::string>("gemLabel");
   }
 
   else if (m_input == std::string("scenario")) {
@@ -159,7 +161,7 @@ void MuonGeometryDBConverter::analyze(const edm::Event &iEvent, const edm::Event
     }
 
     else if (m_input == std::string("db")) {
-      MuonAlignmentInputDB inputMethod(m_dtLabel, m_cscLabel, idealGeometryLabelForInputDB, m_getAPEs);
+      MuonAlignmentInputDB inputMethod(m_dtLabel, m_cscLabel, m_gemLabel, idealGeometryLabelForInputDB, m_getAPEs);
       muonAlignment = new MuonAlignment(iSetup, inputMethod);
       if (m_getAPEs) {
         muonAlignment->copyAlignmentToSurvey(m_shiftErr, m_angleErr);
@@ -222,6 +224,7 @@ void MuonGeometryDBConverter::fillDescriptions(edm::ConfigurationDescriptions &d
   desc.add<std::string>("input", "ideal");
   desc.add<std::string>("dtLabel", "");
   desc.add<std::string>("cscLabel", "");
+  desc.add<std::string>("gemLabel", "");
   desc.add<double>("shiftErr", 1000.0);
   desc.add<double>("angleErr", 6.28);
   desc.add<bool>("getAPEs", true);

--- a/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
@@ -56,7 +56,10 @@ private:
   std::string theDTAlignRecordName, theDTErrorRecordName;
   std::string theCSCAlignRecordName, theCSCErrorRecordName;
   std::string theGEMAlignRecordName, theGEMErrorRecordName;
-  std::string theIdealGeometryLabel;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 
   Alignments* dt_Alignments;
   AlignmentErrorsExtended* dt_AlignmentErrorsExtended;
@@ -76,7 +79,9 @@ MuonMisalignedProducer::MuonMisalignedProducer(const edm::ParameterSet& p)
       theCSCErrorRecordName("CSCAlignmentErrorExtendedRcd"),
       theGEMAlignRecordName("GEMAlignmentRcd"),
       theGEMErrorRecordName("GEMAlignmentErrorExtendedRcd"),
-      theIdealGeometryLabel("idealForMuonMisalignedProducer") {}
+      esTokenDT_(esConsumes(edm::ESInputTag("", "idealForMuonMisalignedProducer"))),
+      esTokenCSC_(esConsumes(edm::ESInputTag("", "idealForMuonMisalignedProducer"))),
+      esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForMuonMisalignedProducer"))) {}
 
 //__________________________________________________________________________________________________
 MuonMisalignedProducer::~MuonMisalignedProducer() {}
@@ -85,12 +90,9 @@ MuonMisalignedProducer::~MuonMisalignedProducer() {}
 void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
   edm::LogInfo("MisalignedMuon") << "Producer called";
   // Create the Muon geometry from ideal geometry
-  edm::ESHandle<DTGeometry> theDTGeometry;
-  edm::ESHandle<CSCGeometry> theCSCGeometry;
-  edm::ESHandle<GEMGeometry> theGEMGeometry;
-  eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theDTGeometry);
-  eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theCSCGeometry);
-  eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theGEMGeometry);
+  edm::ESHandle<DTGeometry> theDTGeometry = eventSetup.getHandle(esTokenDT_);
+  edm::ESHandle<CSCGeometry> theCSCGeometry = eventSetup.getHandle(esTokenCSC_);
+  edm::ESHandle<GEMGeometry> theGEMGeometry = eventSetup.getHandle(esTokenGEM_);
 
   // Create the alignable hierarchy
   AlignableMuon* theAlignableMuon = new AlignableMuon(&(*theDTGeometry), &(*theCSCGeometry), &(*theGEMGeometry));

--- a/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
@@ -110,13 +110,13 @@ void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSe
   gem_AlignmentErrorsExtended = theAlignableMuon->gemAlignmentErrorsExtended();
 
   // Misalign the EventSetup geometry
-  GeometryAligner aligner;
+  /* GeometryAligner aligner;
   aligner.applyAlignments<DTGeometry>(&(*theDTGeometry), dt_Alignments, dt_AlignmentErrorsExtended, AlignTransform());
   aligner.applyAlignments<CSCGeometry>(
       &(*theCSCGeometry), csc_Alignments, csc_AlignmentErrorsExtended, AlignTransform());
   aligner.applyAlignments<GEMGeometry>(
       &(*theGEMGeometry), gem_Alignments, gem_AlignmentErrorsExtended, AlignTransform());
-
+  */
   // Write alignments to DB
   if (theSaveToDB)
     this->saveToDB();

--- a/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
+++ b/Alignment/MuonAlignment/plugins/MuonMisalignedProducer.cc
@@ -26,12 +26,15 @@
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include "Alignment/MuonAlignment/interface/MuonScenarioBuilder.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include <memory>
+
+#include <iostream>
 
 class MuonMisalignedProducer : public edm::one::EDAnalyzer<> {
 public:
@@ -52,12 +55,15 @@ private:
 
   std::string theDTAlignRecordName, theDTErrorRecordName;
   std::string theCSCAlignRecordName, theCSCErrorRecordName;
+  std::string theGEMAlignRecordName, theGEMErrorRecordName;
   std::string theIdealGeometryLabel;
 
   Alignments* dt_Alignments;
   AlignmentErrorsExtended* dt_AlignmentErrorsExtended;
   Alignments* csc_Alignments;
   AlignmentErrorsExtended* csc_AlignmentErrorsExtended;
+  Alignments* gem_Alignments;
+  AlignmentErrorsExtended* gem_AlignmentErrorsExtended;
 };
 
 //__________________________________________________________________________________________________
@@ -68,6 +74,8 @@ MuonMisalignedProducer::MuonMisalignedProducer(const edm::ParameterSet& p)
       theDTErrorRecordName("DTAlignmentErrorExtendedRcd"),
       theCSCAlignRecordName("CSCAlignmentRcd"),
       theCSCErrorRecordName("CSCAlignmentErrorExtendedRcd"),
+      theGEMAlignRecordName("GEMAlignmentRcd"),
+      theGEMErrorRecordName("GEMAlignmentErrorExtendedRcd"),
       theIdealGeometryLabel("idealForMuonMisalignedProducer") {}
 
 //__________________________________________________________________________________________________
@@ -79,11 +87,13 @@ void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSe
   // Create the Muon geometry from ideal geometry
   edm::ESHandle<DTGeometry> theDTGeometry;
   edm::ESHandle<CSCGeometry> theCSCGeometry;
+  edm::ESHandle<GEMGeometry> theGEMGeometry;
   eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theDTGeometry);
   eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theCSCGeometry);
+  eventSetup.get<MuonGeometryRecord>().get(theIdealGeometryLabel, theGEMGeometry);
 
   // Create the alignable hierarchy
-  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*theDTGeometry), &(*theCSCGeometry));
+  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*theDTGeometry), &(*theCSCGeometry), &(*theGEMGeometry));
 
   // Create misalignment scenario
   MuonScenarioBuilder scenarioBuilder(theAlignableMuon);
@@ -94,13 +104,16 @@ void MuonMisalignedProducer::analyze(const edm::Event& event, const edm::EventSe
   dt_AlignmentErrorsExtended = theAlignableMuon->dtAlignmentErrorsExtended();
   csc_Alignments = theAlignableMuon->cscAlignments();
   csc_AlignmentErrorsExtended = theAlignableMuon->cscAlignmentErrorsExtended();
+  gem_Alignments = theAlignableMuon->gemAlignments();
+  gem_AlignmentErrorsExtended = theAlignableMuon->gemAlignmentErrorsExtended();
 
   // Misalign the EventSetup geometry
   GeometryAligner aligner;
-
   aligner.applyAlignments<DTGeometry>(&(*theDTGeometry), dt_Alignments, dt_AlignmentErrorsExtended, AlignTransform());
   aligner.applyAlignments<CSCGeometry>(
       &(*theCSCGeometry), csc_Alignments, csc_AlignmentErrorsExtended, AlignTransform());
+  aligner.applyAlignments<GEMGeometry>(
+      &(*theGEMGeometry), gem_Alignments, gem_AlignmentErrorsExtended, AlignTransform());
 
   // Write alignments to DB
   if (theSaveToDB)
@@ -125,6 +138,9 @@ void MuonMisalignedProducer::saveToDB(void) {
   poolDbService->writeOne<Alignments>(&(*csc_Alignments), poolDbService->beginOfTime(), theCSCAlignRecordName);
   poolDbService->writeOne<AlignmentErrorsExtended>(
       &(*csc_AlignmentErrorsExtended), poolDbService->beginOfTime(), theCSCErrorRecordName);
+  poolDbService->writeOne<Alignments>(&(*gem_Alignments), poolDbService->beginOfTime(), theGEMAlignRecordName);
+  poolDbService->writeOne<AlignmentErrorsExtended>(
+      &(*gem_AlignmentErrorsExtended), poolDbService->beginOfTime(), theGEMErrorRecordName);
 }
 //____________________________________________________________________________________________
 DEFINE_FWK_MODULE(MuonMisalignedProducer);

--- a/Alignment/MuonAlignment/src/AlignableGEMChamber.cc
+++ b/Alignment/MuonAlignment/src/AlignableGEMChamber.cc
@@ -1,0 +1,41 @@
+/* AlignableGEMChamber
+ * \author Hyunyong Kim - TAMU
+ */
+#include "Alignment/MuonAlignment/interface/AlignableGEMChamber.h"
+
+AlignableGEMChamber::AlignableGEMChamber(const GeomDet* geomDet) : AlignableDet(geomDet) {
+  theStructureType = align::AlignableGEMChamber;
+  theSurface = geomDet->surface();
+}
+
+void AlignableGEMChamber::update(const GeomDet* geomDet) {
+  AlignableDet::update(geomDet);
+  theSurface = geomDet->surface();
+}
+
+std::ostream& operator<<(std::ostream& os, const AlignableGEMChamber& r) {
+  const auto& theDets = r.components();
+
+  os << "    This GEMChamber contains " << theDets.size() << " units" << std::endl;
+  os << "    position = " << r.globalPosition() << std::endl;
+  os << "    (phi, r, z)= (" << r.globalPosition().phi() << "," << r.globalPosition().perp() << ","
+     << r.globalPosition().z();
+  os << "), orientation:" << std::endl << r.globalRotation() << std::endl;
+
+  os << "    total displacement and rotation: " << r.displacement() << std::endl;
+  os << r.rotation() << std::endl;
+
+  for (const auto& idet : theDets) {
+    const auto& comp = idet->components();
+
+    for (unsigned int i = 0; i < comp.size(); ++i) {
+      os << "     Det position, phi, r: " << comp[i]->globalPosition() << " , " << comp[i]->globalPosition().phi()
+         << " , " << comp[i]->globalPosition().perp() << std::endl;
+      os << "     local  position, phi, r: " << r.surface().toLocal(comp[i]->globalPosition()) << " , "
+         << r.surface().toLocal(comp[i]->globalPosition()).phi() << " , "
+         << r.surface().toLocal(comp[i]->globalPosition()).perp() << std::endl;
+    }
+  }
+
+  return os;
+}

--- a/Alignment/MuonAlignment/src/AlignableGEMEndcap.cc
+++ b/Alignment/MuonAlignment/src/AlignableGEMEndcap.cc
@@ -1,0 +1,92 @@
+/* AlignableGEMEndcap
+ * \author Hyunyong Kim - TAMU
+ */
+#include <memory>
+
+#include "Alignment/MuonAlignment/interface/AlignableGEMEndcap.h"
+#include "CondFormats/Alignment/interface/Alignments.h"
+#include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+AlignableGEMEndcap::AlignableGEMEndcap(const std::vector<AlignableGEMStation*>& GEMStations)
+    : AlignableComposite(GEMStations[0]->id(), align::AlignableGEMEndcap) {
+  theGEMStations.insert(theGEMStations.end(), GEMStations.begin(), GEMStations.end());
+
+  for (const auto& station : GEMStations) {
+    const auto mother = station->mother();
+    this->addComponent(station);
+    station->setMother(mother);
+  }
+
+  setSurface(computeSurface());
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
+}
+
+AlignableGEMStation& AlignableGEMEndcap::station(int i) {
+  if (i >= size())
+    throw cms::Exception("LogicError") << "Station index (" << i << ") out of range";
+
+  return *theGEMStations[i];
+}
+
+AlignableSurface AlignableGEMEndcap::computeSurface() {
+  return AlignableSurface(computePosition(), computeOrientation());
+}
+
+AlignableGEMEndcap::PositionType AlignableGEMEndcap::computePosition() {
+  float zz = 0.;
+
+  for (std::vector<AlignableGEMStation*>::iterator ilayer = theGEMStations.begin(); ilayer != theGEMStations.end();
+       ilayer++)
+    zz += (*ilayer)->globalPosition().z();
+
+  zz /= static_cast<float>(theGEMStations.size());
+
+  return PositionType(0.0, 0.0, zz);
+}
+
+AlignableGEMEndcap::RotationType AlignableGEMEndcap::computeOrientation() { return RotationType(); }
+
+std::ostream& operator<<(std::ostream& os, const AlignableGEMEndcap& b) {
+  os << "This EndCap contains " << b.theGEMStations.size() << " GEM stations" << std::endl;
+  os << "(phi, r, z) =  (" << b.globalPosition().phi() << "," << b.globalPosition().perp() << ","
+     << b.globalPosition().z();
+  os << "),  orientation:" << std::endl << b.globalRotation() << std::endl;
+  return os;
+}
+
+void AlignableGEMEndcap::dump(void) const {
+  edm::LogInfo("AlignableDump") << (*this);
+  for (std::vector<AlignableGEMStation*>::const_iterator iLayer = theGEMStations.begin();
+       iLayer != theGEMStations.end();
+       iLayer++)
+    (*iLayer)->dump();
+}
+
+Alignments* AlignableGEMEndcap::alignments(void) const {
+  Alignments* m_alignments = new Alignments();
+
+  for (const auto& i : this->components()) {
+    std::unique_ptr<Alignments> tmpAlignments{i->alignments()};
+    std::copy(tmpAlignments->m_align.begin(), tmpAlignments->m_align.end(), std::back_inserter(m_alignments->m_align));
+  }
+
+  std::sort(m_alignments->m_align.begin(), m_alignments->m_align.end());
+
+  return m_alignments;
+}
+
+AlignmentErrorsExtended* AlignableGEMEndcap::alignmentErrors(void) const {
+  AlignmentErrorsExtended* m_alignmentErrors = new AlignmentErrorsExtended();
+
+  for (const auto& i : this->components()) {
+    std::unique_ptr<AlignmentErrorsExtended> tmpAlignmentErrorsExtended{i->alignmentErrors()};
+    std::copy(tmpAlignmentErrorsExtended->m_alignError.begin(),
+              tmpAlignmentErrorsExtended->m_alignError.end(),
+              std::back_inserter(m_alignmentErrors->m_alignError));
+  }
+
+  std::sort(m_alignmentErrors->m_alignError.begin(), m_alignmentErrors->m_alignError.end());
+
+  return m_alignmentErrors;
+}

--- a/Alignment/MuonAlignment/src/AlignableGEMRing.cc
+++ b/Alignment/MuonAlignment/src/AlignableGEMRing.cc
@@ -1,0 +1,61 @@
+/* AlignableGEMRing
+ * \author Hyunyong Kim - TAMU
+ */
+#include "Alignment/MuonAlignment/interface/AlignableGEMRing.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+AlignableGEMRing::AlignableGEMRing(const std::vector<AlignableGEMSuperChamber*>& GEMSuperChambers)
+    : AlignableComposite(GEMSuperChambers[0]->id(), align::AlignableGEMRing) {
+  theGEMSuperChambers.insert(theGEMSuperChambers.end(), GEMSuperChambers.begin(), GEMSuperChambers.end());
+
+  for (const auto& chamber : GEMSuperChambers) {
+    const auto mother = chamber->mother();
+    this->addComponent(chamber);
+    chamber->setMother(mother);
+  }
+
+  setSurface(computeSurface());
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
+}
+
+AlignableGEMSuperChamber& AlignableGEMRing::superChamber(int i) {
+  if (i >= size())
+    throw cms::Exception("LogicError") << "GEM Super Chamber index (" << i << ") out of range";
+
+  return *theGEMSuperChambers[i];
+}
+
+AlignableSurface AlignableGEMRing::computeSurface() {
+  return AlignableSurface(computePosition(), computeOrientation());
+}
+
+AlignableGEMRing::PositionType AlignableGEMRing::computePosition() {
+  float zz = 0.;
+
+  for (std::vector<AlignableGEMSuperChamber*>::iterator ichamber = theGEMSuperChambers.begin();
+       ichamber != theGEMSuperChambers.end();
+       ichamber++)
+    zz += (*ichamber)->globalPosition().z();
+
+  zz /= static_cast<float>(theGEMSuperChambers.size());
+
+  return PositionType(0.0, 0.0, zz);
+}
+
+AlignableGEMRing::RotationType AlignableGEMRing::computeOrientation() { return RotationType(); }
+
+std::ostream& operator<<(std::ostream& os, const AlignableGEMRing& b) {
+  os << "This GEM Ring contains " << b.theGEMSuperChambers.size() << " GEM Super chambers" << std::endl;
+  os << "(phi, r, z) =  (" << b.globalPosition().phi() << "," << b.globalPosition().perp() << ","
+     << b.globalPosition().z();
+  os << "),  orientation:" << std::endl << b.globalRotation() << std::endl;
+  return os;
+}
+
+void AlignableGEMRing::dump(void) const {
+  edm::LogInfo("AlignableDump") << (*this);
+  for (std::vector<AlignableGEMSuperChamber*>::const_iterator iChamber = theGEMSuperChambers.begin();
+       iChamber != theGEMSuperChambers.end();
+       iChamber++)
+    edm::LogInfo("AlignableDump") << (**iChamber);
+}

--- a/Alignment/MuonAlignment/src/AlignableGEMStation.cc
+++ b/Alignment/MuonAlignment/src/AlignableGEMStation.cc
@@ -1,0 +1,57 @@
+/* AlignableGEMStation
+ * \author Hyunyong Kim - TAMU
+ */
+#include "Alignment/MuonAlignment/interface/AlignableGEMStation.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+AlignableGEMStation::AlignableGEMStation(const std::vector<AlignableGEMRing*>& GEMRings)
+    : AlignableComposite(GEMRings[0]->id(), align::AlignableGEMStation) {
+  theGEMRings.insert(theGEMRings.end(), GEMRings.begin(), GEMRings.end());
+
+  for (const auto& ring : GEMRings) {
+    const auto mother = ring->mother();
+    this->addComponent(ring);
+    ring->setMother(mother);
+  }
+
+  setSurface(computeSurface());
+  compConstraintType_ = Alignable::CompConstraintType::POSITION_Z;
+}
+
+AlignableGEMRing& AlignableGEMStation::ring(int i) {
+  if (i >= size())
+    throw cms::Exception("LogicError") << "GEM Ring index (" << i << ") out of range";
+
+  return *theGEMRings[i];
+}
+
+AlignableSurface AlignableGEMStation::computeSurface() {
+  return AlignableSurface(computePosition(), computeOrientation());
+}
+
+AlignableGEMStation::PositionType AlignableGEMStation::computePosition() {
+  float zz = 0.;
+
+  for (std::vector<AlignableGEMRing*>::iterator ilayer = theGEMRings.begin(); ilayer != theGEMRings.end(); ilayer++)
+    zz += (*ilayer)->globalPosition().z();
+
+  zz /= static_cast<float>(theGEMRings.size());
+
+  return PositionType(0.0, 0.0, zz);
+}
+
+AlignableGEMStation::RotationType AlignableGEMStation::computeOrientation() { return RotationType(); }
+
+std::ostream& operator<<(std::ostream& os, const AlignableGEMStation& b) {
+  os << "This GEM Station contains " << b.theGEMRings.size() << " GEM rings" << std::endl;
+  os << "(phi, r, z) =  (" << b.globalPosition().phi() << "," << b.globalPosition().perp() << ","
+     << b.globalPosition().z();
+  os << "),  orientation:" << std::endl << b.globalRotation() << std::endl;
+  return os;
+}
+
+void AlignableGEMStation::dump(void) const {
+  edm::LogInfo("AlignableDump") << (*this);
+  for (std::vector<AlignableGEMRing*>::const_iterator iRing = theGEMRings.begin(); iRing != theGEMRings.end(); iRing++)
+    edm::LogInfo("AlignableDump") << (**iRing);
+}

--- a/Alignment/MuonAlignment/src/AlignableGEMSuperChamber.cc
+++ b/Alignment/MuonAlignment/src/AlignableGEMSuperChamber.cc
@@ -1,0 +1,46 @@
+/* AlignableGEMSuperChamber
+ * \author Hyunyong Kim - TAMU
+ */
+#include "Alignment/MuonAlignment/interface/AlignableGEMSuperChamber.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMChamber.h"
+
+AlignableGEMSuperChamber::AlignableGEMSuperChamber(const GeomDet* geomDet) : AlignableDet(geomDet, false) {
+  theStructureType = align::AlignableGEMSuperChamber;
+  const std::vector<const GeomDet*>& geomDets = geomDet->components();
+  for (std::vector<const GeomDet*>::const_iterator idet = geomDets.begin(); idet != geomDets.end(); ++idet) {
+    addComponent(new AlignableGEMChamber(*idet));
+  }
+  this->theSurface = geomDet->surface();
+}
+
+void AlignableGEMSuperChamber::update(const GeomDet* geomDet) {
+  AlignableDet::update(geomDet);
+  theSurface = geomDet->surface();
+}
+
+std::ostream& operator<<(std::ostream& os, const AlignableGEMSuperChamber& r) {
+  const auto& theDets = r.components();
+
+  os << "    This GEMSuperChamber contains " << theDets.size() << " units" << std::endl;
+  os << "    position = " << r.globalPosition() << std::endl;
+  os << "    (phi, r, z)= (" << r.globalPosition().phi() << "," << r.globalPosition().perp() << ","
+     << r.globalPosition().z();
+  os << "), orientation:" << std::endl << r.globalRotation() << std::endl;
+
+  os << "    total displacement and rotation: " << r.displacement() << std::endl;
+  os << r.rotation() << std::endl;
+
+  for (const auto& idet : theDets) {
+    const auto& comp = idet->components();
+
+    for (unsigned int i = 0; i < comp.size(); ++i) {
+      os << "     Det position, phi, r: " << comp[i]->globalPosition() << " , " << comp[i]->globalPosition().phi()
+         << " , " << comp[i]->globalPosition().perp() << std::endl;
+      os << "     local  position, phi, r: " << r.surface().toLocal(comp[i]->globalPosition()) << " , "
+         << r.surface().toLocal(comp[i]->globalPosition()).phi() << " , "
+         << r.surface().toLocal(comp[i]->globalPosition()).perp() << std::endl;
+    }
+  }
+
+  return os;
+}

--- a/Alignment/MuonAlignment/src/AlignableMuon.cc
+++ b/Alignment/MuonAlignment/src/AlignableMuon.cc
@@ -295,7 +295,6 @@ void AlignableMuon::buildGEMEndcap(const GEMGeometry* pGEM, bool update) {
       int iri = 1;
       int iChamber{0};
       auto vc = pGEM->superChambers();
-      sort(vc.begin(), vc.end(), [](const GEMSuperChamber* a, const GEMSuperChamber* b) { return a->id() < b->id(); });
       for (const auto& det : vc) {
         GEMDetId gemId = det->id();
         int ec = gemId.region();
@@ -601,6 +600,7 @@ Alignments* AlignableMuon::gemAlignments(void) {
   Alignments* tmpAlignments = new Alignments();
   std::copy(gemEndCap1->m_align.begin(), gemEndCap1->m_align.end(), back_inserter(tmpAlignments->m_align));
   std::copy(gemEndCap2->m_align.begin(), gemEndCap2->m_align.end(), back_inserter(tmpAlignments->m_align));
+  std::sort(tmpAlignments->m_align.begin(), tmpAlignments->m_align.end());
 
   return tmpAlignments;
 }
@@ -617,6 +617,7 @@ AlignmentErrorsExtended* AlignableMuon::gemAlignmentErrorsExtended(void) {
   std::copy(gemEndCap2Errors->m_alignError.begin(),
             gemEndCap2Errors->m_alignError.end(),
             back_inserter(tmpAlignmentErrorsExtended->m_alignError));
+  std::sort(tmpAlignmentErrorsExtended->m_alignError.begin(), tmpAlignmentErrorsExtended->m_alignError.end());
 
   return tmpAlignmentErrorsExtended;
 }

--- a/Alignment/MuonAlignment/src/AlignableMuon.cc
+++ b/Alignment/MuonAlignment/src/AlignableMuon.cc
@@ -288,9 +288,9 @@ void AlignableMuon::buildGEMEndcap(const GEMGeometry* pGEM, bool update) {
 
     for (int ist = 0; ist < 3; ist++) {
       if (ist == 0)
-        continue; //Run3 GEM dosen't have ME0
+        continue;  //Run3 GEM dosen't have ME0
       if (ist == 2)
-        continue; //Run3 GEM dosen't have GE2/1
+        continue;  //Run3 GEM dosen't have GE2/1
       std::vector<AlignableGEMSuperChamber*> tmpGEMSuperChambersInRing;
       int iri = 1;
       int iChamber{0};

--- a/Alignment/MuonAlignment/src/AlignableMuon.cc
+++ b/Alignment/MuonAlignment/src/AlignableMuon.cc
@@ -11,29 +11,39 @@
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
 #include "Geometry/DTGeometry/interface/DTChamber.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 #include <Geometry/DTGeometry/interface/DTLayer.h>
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
-
-// Muon  components
-#include "Alignment/MuonAlignment/interface/AlignableDTChamber.h"
-#include "Alignment/MuonAlignment/interface/AlignableCSCChamber.h"
-#include "Alignment/MuonAlignment/interface/AlignableDTStation.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Alignment/MuonAlignment/interface/AlignableCSCStation.h"
-#include "Alignment/MuonAlignment/interface/AlignableDTWheel.h"
+// Muon  components
 #include "Alignment/MuonAlignment/interface/AlignableDTBarrel.h"
+#include "Alignment/MuonAlignment/interface/AlignableDTStation.h"
+#include "Alignment/MuonAlignment/interface/AlignableDTWheel.h"
+#include "Alignment/MuonAlignment/interface/AlignableDTChamber.h"
 #include "Alignment/MuonAlignment/interface/AlignableCSCEndcap.h"
+#include "Alignment/MuonAlignment/interface/AlignableCSCStation.h"
+#include "Alignment/MuonAlignment/interface/AlignableCSCRing.h"
+#include "Alignment/MuonAlignment/interface/AlignableCSCChamber.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMEndcap.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMStation.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMRing.h"
+#include "Alignment/MuonAlignment/interface/AlignableGEMSuperChamber.h"
+
+#include <iostream>
 
 //--------------------------------------------------------------------------------------------------
-AlignableMuon::AlignableMuon(const DTGeometry* dtGeometry, const CSCGeometry* cscGeometry)
+AlignableMuon::AlignableMuon(const DTGeometry* dtGeometry,
+                             const CSCGeometry* cscGeometry,
+                             const GEMGeometry* gemGeometry)
     : AlignableComposite(0, align::AlignableMuon),  // cannot yet set id, use 0
-      alignableObjectId_(nullptr, dtGeometry, cscGeometry) {
+      alignableObjectId_(nullptr, dtGeometry, cscGeometry, gemGeometry) {
   // Build the muon barrel
   buildDTBarrel(dtGeometry);
 
   // Build the muon end caps
   buildCSCEndcap(cscGeometry);
+  buildGEMEndcap(gemGeometry);
 
   // Set links to mothers recursively
   recursiveSetMothers(this);
@@ -52,12 +62,15 @@ AlignableMuon::~AlignableMuon() {
 }
 
 //------------------------------------------------------------------------------
-void AlignableMuon::update(const DTGeometry* dtGeometry, const CSCGeometry* cscGeometry) {
+void AlignableMuon::update(const DTGeometry* dtGeometry,
+                           const CSCGeometry* cscGeometry,
+                           const GEMGeometry* gemGeometry) {
   // update the muon barrel
   buildDTBarrel(dtGeometry, /* update = */ true);
 
   // update the muon end caps
   buildCSCEndcap(cscGeometry, /* update = */ true);
+  buildGEMEndcap(gemGeometry, /* update = */ true);
 
   edm::LogInfo("Alignment") << "@SUB=AlignableMuon::update"
                             << "Updating alignable muon objects DONE";
@@ -267,6 +280,64 @@ void AlignableMuon::buildCSCEndcap(const CSCGeometry* pCSC, bool update) {
 }
 
 //--------------------------------------------------------------------------------------------------
+void AlignableMuon::buildGEMEndcap(const GEMGeometry* pGEM, bool update) {
+  LogDebug("Position") << "Constructing AlignableGEMEndcap";
+  std::vector<AlignableGEMStation*> tmpGEMStationsInEndcap;
+  for (int iec = -1; iec < 2; iec = iec + 2) {
+    std::vector<AlignableGEMRing*> tmpGEMRingsInStation;
+
+    for (int ist = 0; ist < 3; ist++) {
+      if (ist == 0)
+        continue; //Run3 GEM dosen't have ME0
+      if (ist == 2)
+        continue; //Run3 GEM dosen't have GE2/1
+      std::vector<AlignableGEMSuperChamber*> tmpGEMSuperChambersInRing;
+      int iri = 1;
+      int iChamber{0};
+      auto vc = pGEM->superChambers();
+      sort(vc.begin(), vc.end(), [](const GEMSuperChamber* a, const GEMSuperChamber* b) { return a->id() < b->id(); });
+      for (const auto& det : vc) {
+        GEMDetId gemId = det->id();
+        int ec = gemId.region();
+        int st = gemId.station();
+        int ri = gemId.ring();
+
+        if (iec == ec && ist == st && iri == ri) {
+          if (update) {
+            theGEMEndcaps[iec == -1 ? 0 : 1]->station(ist - 1).ring(iri - 1).superChamber(iChamber).update(det);
+          } else {
+            AlignableGEMSuperChamber* tmpGEMSuperChamber = new AlignableGEMSuperChamber(det);
+            tmpGEMSuperChambersInRing.push_back(tmpGEMSuperChamber);
+          }
+          ++iChamber;
+        }
+      }
+      if (!update) {
+        if (!tmpGEMSuperChambersInRing.empty()) {
+          theGEMSuperChambers.insert(
+              theGEMSuperChambers.end(), tmpGEMSuperChambersInRing.begin(), tmpGEMSuperChambersInRing.end());
+          AlignableGEMRing* tmpGEMRing = new AlignableGEMRing(tmpGEMSuperChambersInRing);
+          tmpGEMRingsInStation.push_back(tmpGEMRing);
+          tmpGEMSuperChambersInRing.clear();
+        }
+      }
+      if (!update) {
+        AlignableGEMStation* tmpGEMStation = new AlignableGEMStation(tmpGEMRingsInStation);
+        theGEMRings.insert(theGEMRings.end(), tmpGEMRingsInStation.begin(), tmpGEMRingsInStation.end());
+        tmpGEMStationsInEndcap.push_back(tmpGEMStation);
+        tmpGEMRingsInStation.clear();
+      }
+    }
+    if (!update) {
+      AlignableGEMEndcap* tmpEndcap = new AlignableGEMEndcap(tmpGEMStationsInEndcap);
+      theGEMStations.insert(theGEMStations.end(), tmpGEMStationsInEndcap.begin(), tmpGEMStationsInEndcap.end());
+      theGEMEndcaps.push_back(tmpEndcap);
+      tmpGEMStationsInEndcap.clear();
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
 align::Alignables AlignableMuon::DTLayers() {
   align::Alignables result;
 
@@ -373,6 +444,71 @@ align::Alignables AlignableMuon::CSCEndcaps() {
 }
 
 //__________________________________________________________________________________________________
+align::Alignables AlignableMuon::GEMEtaPartitions() {
+  align::Alignables result;
+  align::Alignables superChambers = GEMSuperChambers();
+  for (align::Alignables::const_iterator superChamberIter = superChambers.begin();
+       superChamberIter != superChambers.end();
+       ++superChamberIter) {
+    align::Alignables chambers = (*superChamberIter)->components();
+    for (align::Alignables::const_iterator chamberIter = chambers.begin(); chamberIter != chambers.end();
+         ++chamberIter) {
+      align::Alignables etaPartitions = (*chamberIter)->components();
+      for (align::Alignables::const_iterator etaPartitionIter = etaPartitions.begin();
+           etaPartitionIter != etaPartitions.end();
+           ++etaPartitionIter) {
+        result.push_back(*etaPartitionIter);
+      }
+    }
+  }
+  return result;
+}
+
+//__________________________________________________________________________________________________
+align::Alignables AlignableMuon::GEMChambers() {
+  align::Alignables result;
+  align::Alignables superChambers = GEMSuperChambers();
+  for (align::Alignables::const_iterator superChamberIter = superChambers.begin();
+       superChamberIter != superChambers.end();
+       ++superChamberIter) {
+    align::Alignables chambers = (*superChamberIter)->components();
+    for (align::Alignables::const_iterator chamberIter = chambers.begin(); chamberIter != chambers.end();
+         ++chamberIter) {
+      result.push_back(*chamberIter);
+    }
+  }
+  return result;
+}
+
+//__________________________________________________________________________________________________
+align::Alignables AlignableMuon::GEMSuperChambers() {
+  align::Alignables result;
+  copy(theGEMSuperChambers.begin(), theGEMSuperChambers.end(), back_inserter(result));
+  return result;
+}
+
+//__________________________________________________________________________________________________
+align::Alignables AlignableMuon::GEMRings() {
+  align::Alignables result;
+  copy(theGEMRings.begin(), theGEMRings.end(), back_inserter(result));
+  return result;
+}
+
+//__________________________________________________________________________________________________
+align::Alignables AlignableMuon::GEMStations() {
+  align::Alignables result;
+  copy(theGEMStations.begin(), theGEMStations.end(), back_inserter(result));
+  return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+align::Alignables AlignableMuon::GEMEndcaps() {
+  align::Alignables result;
+  copy(theGEMEndcaps.begin(), theGEMEndcaps.end(), back_inserter(result));
+  return result;
+}
+
+//__________________________________________________________________________________________________
 void AlignableMuon::recursiveSetMothers(Alignable* alignable) {
   for (const auto& iter : alignable->components()) {
     iter->setMother(alignable);
@@ -453,6 +589,33 @@ AlignmentErrorsExtended* AlignableMuon::cscAlignmentErrorsExtended(void) {
             back_inserter(tmpAlignmentErrorsExtended->m_alignError));
   std::copy(cscEndCap2Errors->m_alignError.begin(),
             cscEndCap2Errors->m_alignError.end(),
+            back_inserter(tmpAlignmentErrorsExtended->m_alignError));
+
+  return tmpAlignmentErrorsExtended;
+}
+
+//__________________________________________________________________________________________________
+Alignments* AlignableMuon::gemAlignments(void) {
+  Alignments* gemEndCap1 = this->GEMEndcaps().front()->alignments();
+  Alignments* gemEndCap2 = this->GEMEndcaps().back()->alignments();
+  Alignments* tmpAlignments = new Alignments();
+  std::copy(gemEndCap1->m_align.begin(), gemEndCap1->m_align.end(), back_inserter(tmpAlignments->m_align));
+  std::copy(gemEndCap2->m_align.begin(), gemEndCap2->m_align.end(), back_inserter(tmpAlignments->m_align));
+
+  return tmpAlignments;
+}
+//__________________________________________________________________________________________________
+AlignmentErrorsExtended* AlignableMuon::gemAlignmentErrorsExtended(void) {
+  // Retrieve muon endcaps alignment errors
+  AlignmentErrorsExtended* gemEndCap1Errors = this->GEMEndcaps().front()->alignmentErrors();
+  AlignmentErrorsExtended* gemEndCap2Errors = this->GEMEndcaps().back()->alignmentErrors();
+  AlignmentErrorsExtended* tmpAlignmentErrorsExtended = new AlignmentErrorsExtended();
+
+  std::copy(gemEndCap1Errors->m_alignError.begin(),
+            gemEndCap1Errors->m_alignError.end(),
+            back_inserter(tmpAlignmentErrorsExtended->m_alignError));
+  std::copy(gemEndCap2Errors->m_alignError.begin(),
+            gemEndCap2Errors->m_alignError.end(),
             back_inserter(tmpAlignmentErrorsExtended->m_alignError));
 
   return tmpAlignmentErrorsExtended;

--- a/Alignment/MuonAlignment/src/MuonAlignment.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignment.cc
@@ -9,9 +9,6 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 
-// Muon geom
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-
 // Alignment
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignmentErrorsExtended.h"
@@ -46,12 +43,9 @@ void MuonAlignment::init() {
 MuonAlignment::MuonAlignment(const edm::EventSetup& iSetup) {
   init();
 
-  edm::ESHandle<DTGeometry> dtGeometry;
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(gemGeometry);
+  edm::ESHandle<DTGeometry> dtGeometry = iSetup.getHandle(esTokenDT_);
+  edm::ESHandle<CSCGeometry> cscGeometry = iSetup.getHandle(esTokenCSC_);
+  edm::ESHandle<GEMGeometry> gemGeometry = iSetup.getHandle(esTokenGEM_);
 
   theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
   theAlignableNavigator = new AlignableNavigator(theAlignableMuon);

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputDB.cc
@@ -20,10 +20,12 @@
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentErrorExtendedRcd.h"
 #include "CondFormats/AlignmentRecord/interface/CSCAlignmentRcd.h"
 #include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
+#include "CondFormats/AlignmentRecord/interface/GEMAlignmentRcd.h"
+#include "CondFormats/AlignmentRecord/interface/GEMAlignmentErrorExtendedRcd.h"
 #include "Geometry/CommonTopologies/interface/GeometryAligner.h"
 #include "CondFormats/Alignment/interface/DetectorGlobalPosition.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
-
+#include "Geometry/GEMGeometry/interface/GEMGeometry.h"
 //
 // constants, enums and typedefs
 //
@@ -36,13 +38,15 @@
 // constructors and destructor
 //
 MuonAlignmentInputDB::MuonAlignmentInputDB()
-    : m_dtLabel(""), m_cscLabel(""), idealGeometryLabel("idealForInputDB"), m_getAPEs(false) {}
+    : m_dtLabel(""), m_cscLabel(""), m_gemLabel(""), idealGeometryLabel("idealForInputDB"), m_getAPEs(false) {}
 
-MuonAlignmentInputDB::MuonAlignmentInputDB(std::string dtLabel,
-                                           std::string cscLabel,
-                                           std::string idealLabel,
-                                           bool getAPEs)
-    : m_dtLabel(dtLabel), m_cscLabel(cscLabel), idealGeometryLabel(idealLabel), m_getAPEs(getAPEs) {}
+MuonAlignmentInputDB::MuonAlignmentInputDB(
+    std::string dtLabel, std::string cscLabel, std::string gemLabel, std::string idealLabel, bool getAPEs)
+    : m_dtLabel(dtLabel),
+      m_cscLabel(cscLabel),
+      m_gemLabel(gemLabel),
+      idealGeometryLabel(idealLabel),
+      m_getAPEs(getAPEs) {}
 
 // MuonAlignmentInputDB::MuonAlignmentInputDB(const MuonAlignmentInputDB& rhs)
 // {
@@ -70,22 +74,28 @@ MuonAlignmentInputDB::~MuonAlignmentInputDB() {}
 AlignableMuon* MuonAlignmentInputDB::newAlignableMuon(const edm::EventSetup& iSetup) const {
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
 
   edm::ESHandle<Alignments> dtAlignments;
   edm::ESHandle<AlignmentErrorsExtended> dtAlignmentErrorsExtended;
   edm::ESHandle<Alignments> cscAlignments;
   edm::ESHandle<AlignmentErrorsExtended> cscAlignmentErrorsExtended;
+  edm::ESHandle<Alignments> gemAlignments;
+  edm::ESHandle<AlignmentErrorsExtended> gemAlignmentErrorsExtended;
   edm::ESHandle<Alignments> globalPositionRcd;
 
   iSetup.get<DTAlignmentRcd>().get(m_dtLabel, dtAlignments);
   iSetup.get<CSCAlignmentRcd>().get(m_cscLabel, cscAlignments);
+  iSetup.get<GEMAlignmentRcd>().get(m_gemLabel, gemAlignments);
   iSetup.get<GlobalPositionRcd>().get(globalPositionRcd);
 
   if (m_getAPEs) {
     iSetup.get<DTAlignmentErrorExtendedRcd>().get(m_dtLabel, dtAlignmentErrorsExtended);
     iSetup.get<CSCAlignmentErrorExtendedRcd>().get(m_cscLabel, cscAlignmentErrorsExtended);
+    iSetup.get<GEMAlignmentErrorExtendedRcd>().get(m_gemLabel, gemAlignmentErrorsExtended);
 
     GeometryAligner aligner;
     aligner.applyAlignments<DTGeometry>(&(*dtGeometry),
@@ -96,8 +106,13 @@ AlignableMuon* MuonAlignmentInputDB::newAlignableMuon(const edm::EventSetup& iSe
                                          &(*cscAlignments),
                                          &(*cscAlignmentErrorsExtended),
                                          align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Muon)));
+    aligner.applyAlignments<GEMGeometry>(&(*gemGeometry),
+                                         &(*gemAlignments),
+                                         &(*gemAlignmentErrorsExtended),
+                                         align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Muon)));
+
   } else {
-    AlignmentErrorsExtended dtAlignmentErrorsExtended2, cscAlignmentErrorsExtended2;
+    AlignmentErrorsExtended dtAlignmentErrorsExtended2, cscAlignmentErrorsExtended2, gemAlignmentErrorsExtended2;
 
     for (std::vector<AlignTransform>::const_iterator i = dtAlignments->m_align.begin();
          i != dtAlignments->m_align.end();
@@ -113,6 +128,13 @@ AlignableMuon* MuonAlignmentInputDB::newAlignableMuon(const edm::EventSetup& iSe
       AlignTransformErrorExtended empty_error(empty_matrix, i->rawId());
       cscAlignmentErrorsExtended2.m_alignError.push_back(empty_error);
     }
+    for (std::vector<AlignTransform>::const_iterator i = gemAlignments->m_align.begin();
+         i != gemAlignments->m_align.end();
+         ++i) {
+      CLHEP::HepSymMatrix empty_matrix(3, 0);
+      AlignTransformErrorExtended empty_error(empty_matrix, i->rawId());
+      gemAlignmentErrorsExtended2.m_alignError.push_back(empty_error);
+    }
 
     GeometryAligner aligner;
     aligner.applyAlignments<DTGeometry>(&(*dtGeometry),
@@ -123,9 +145,13 @@ AlignableMuon* MuonAlignmentInputDB::newAlignableMuon(const edm::EventSetup& iSe
                                          &(*cscAlignments),
                                          &(cscAlignmentErrorsExtended2),
                                          align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Muon)));
+    aligner.applyAlignments<GEMGeometry>(&(*gemGeometry),
+                                         &(*gemAlignments),
+                                         &(gemAlignmentErrorsExtended2),
+                                         align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Muon)));
   }
 
-  return new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  return new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 }
 
 //

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputMethod.cc
@@ -62,9 +62,11 @@ MuonAlignmentInputMethod::~MuonAlignmentInputMethod() {}
 AlignableMuon* MuonAlignmentInputMethod::newAlignableMuon(const edm::EventSetup& iSetup) const {
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
-  return new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
+  return new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 }
 
 //

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputSurveyDB.cc
@@ -68,8 +68,10 @@ MuonAlignmentInputSurveyDB::~MuonAlignmentInputSurveyDB() {}
 AlignableMuon* MuonAlignmentInputSurveyDB::newAlignableMuon(const edm::EventSetup& iSetup) const {
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
 
   edm::ESHandle<Alignments> dtSurvey;
   edm::ESHandle<SurveyErrors> dtSurveyError;
@@ -80,7 +82,7 @@ AlignableMuon* MuonAlignmentInputSurveyDB::newAlignableMuon(const edm::EventSetu
   iSetup.get<CSCSurveyRcd>().get(m_cscLabel, cscSurvey);
   iSetup.get<CSCSurveyErrorExtendedRcd>().get(m_cscLabel, cscSurveyError);
 
-  AlignableMuon* output = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon* output = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
   unsigned int theSurveyIndex = 0;
   const Alignments* theSurveyValues = &*dtSurvey;

--- a/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentInputXML.cc
@@ -256,15 +256,17 @@ void MuonAlignmentInputXML::fillAliToIdeal(std::map<Alignable *, Alignable *> &a
 AlignableMuon *MuonAlignmentInputXML::newAlignableMuon(const edm::EventSetup &iSetup) const {
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
 
-  AlignableMuon *alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon *alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
   std::map<unsigned int, Alignable *> alignableNavigator;  // real AlignableNavigators don't have const methods
   recursiveGetId(alignableNavigator, alignableMuon->DTBarrel());
   recursiveGetId(alignableNavigator, alignableMuon->CSCEndcaps());
 
-  AlignableMuon *ideal_alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon *ideal_alignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
   std::map<unsigned int, Alignable *> ideal_alignableNavigator;  // real AlignableNavigators don't have const methods
   recursiveGetId(ideal_alignableNavigator, ideal_alignableMuon->DTBarrel());
   recursiveGetId(ideal_alignableNavigator, ideal_alignableMuon->CSCEndcaps());

--- a/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
+++ b/Alignment/MuonAlignment/src/MuonAlignmentOutputXML.cc
@@ -121,10 +121,12 @@ void MuonAlignmentOutputXML::write(AlignableMuon *alignableMuon, const edm::Even
   if (m_relativeto == 1) {
     edm::ESHandle<DTGeometry> dtGeometry;
     edm::ESHandle<CSCGeometry> cscGeometry;
+    edm::ESHandle<GEMGeometry> gemGeometry;
     iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
     iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
+    iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
 
-    AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry));
+    AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
     align::Alignables ideal_barrels = ideal_alignableMuon.DTBarrel();
     align::Alignables ideal_endcaps = ideal_alignableMuon.CSCEndcaps();

--- a/Alignment/MuonAlignment/test/TestMuonHierarchy.cpp
+++ b/Alignment/MuonAlignment/test/TestMuonHierarchy.cpp
@@ -52,10 +52,12 @@ void TestMuonHierarchy::analyze(const edm::Event&, const edm::EventSetup& setup)
   edm::LogInfo("MuonHierarchy") << "Starting!";
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   setup.get<MuonGeometryRecord>().get(dtGeometry);
   setup.get<MuonGeometryRecord>().get(cscGeometry);
+  setup.get<MuonGeometryRecord>().get(gemGeometry);
 
-  alignableMuon_ = std::make_unique<AlignableMuon>(&(*dtGeometry), &(*cscGeometry));
+  alignableMuon_ = std::make_unique<AlignableMuon>(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
   leaders_ = "";
   blank_ = "   ";   // These two...

--- a/Alignment/MuonAlignment/test/TestMuonHierarchy.cpp
+++ b/Alignment/MuonAlignment/test/TestMuonHierarchy.cpp
@@ -46,16 +46,17 @@ private:
 
   std::unique_ptr<AlignableMuon> alignableMuon_;
   std::string leaders_, blank_, filled_;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 };
 
 void TestMuonHierarchy::analyze(const edm::Event&, const edm::EventSetup& setup) {
   edm::LogInfo("MuonHierarchy") << "Starting!";
-  edm::ESHandle<DTGeometry> dtGeometry;
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  edm::ESHandle<GEMGeometry> gemGeometry;
-  setup.get<MuonGeometryRecord>().get(dtGeometry);
-  setup.get<MuonGeometryRecord>().get(cscGeometry);
-  setup.get<MuonGeometryRecord>().get(gemGeometry);
+  edm::ESHandle<DTGeometry> dtGeometry = setup.getHandle(esTokenDT_);
+  edm::ESHandle<CSCGeometry> cscGeometry = setup.getHandle(esTokenCSC_);
+  edm::ESHandle<GEMGeometry> gemGeometry = setup.getHandle(esTokenGEM_);
 
   alignableMuon_ = std::make_unique<AlignableMuon>(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 

--- a/Alignment/MuonAlignment/test/TestReader.cpp
+++ b/Alignment/MuonAlignment/test/TestReader.cpp
@@ -107,10 +107,12 @@ void TestMuonReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   // first, get chamber alignables from ideal geometry:
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
 
-  AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
   const auto& ideal_barrels = ideal_alignableMuon.DTBarrel();
   const auto& ideal_endcaps = ideal_alignableMuon.CSCEndcaps();

--- a/Alignment/MuonAlignment/test/TestReader.cpp
+++ b/Alignment/MuonAlignment/test/TestReader.cpp
@@ -59,7 +59,10 @@ private:
   TFile* theFile;
   float x, y, z, phi, theta, length, thick, width;
   TRotMatrix* rot;
-  std::string idealGeometryLabel;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 };
 
 //
@@ -77,7 +80,9 @@ TestMuonReader::TestMuonReader(const edm::ParameterSet& iConfig)
       thick(0.),
       width(0.),
       rot(0),
-      idealGeometryLabel("idealForTestReader") {}
+      esTokenDT_(esConsumes(edm::ESInputTag("", "idealForTestReader"))),
+      esTokenCSC_(esConsumes(edm::ESInputTag("", "idealForTestReader"))),
+      esTokenGEM_(esConsumes(edm::ESInputTag("", "idealForTestReader"))) {}
 
 TestMuonReader::~TestMuonReader() {}
 
@@ -105,12 +110,9 @@ align::EulerAngles TestMuonReader::toPhiXYZ(const align::RotationType& rot) {
 
 void TestMuonReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // first, get chamber alignables from ideal geometry:
-  edm::ESHandle<DTGeometry> dtGeometry;
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(idealGeometryLabel, gemGeometry);
+  edm::ESHandle<DTGeometry> dtGeometry = iSetup.getHandle(esTokenDT_);
+  edm::ESHandle<CSCGeometry> cscGeometry = iSetup.getHandle(esTokenCSC_);
+  edm::ESHandle<GEMGeometry> gemGeometry = iSetup.getHandle(esTokenGEM_);
 
   AlignableMuon ideal_alignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 

--- a/Alignment/MuonAlignment/test/TestRotation.cpp
+++ b/Alignment/MuonAlignment/test/TestRotation.cpp
@@ -107,10 +107,12 @@ void TestRotation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   //
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(gemGeometry);
 
-  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
   // Apply alignment
 

--- a/Alignment/MuonAlignment/test/TestRotation.cpp
+++ b/Alignment/MuonAlignment/test/TestRotation.cpp
@@ -52,8 +52,9 @@ private:
   float x, y, z, phi, theta, length, thick, width;
   TRotMatrix* dir;
 
-  //  typedef Surface::RotationType    RotationType;
-  //  typedef Surface::PositionType    PositionType;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> esTokenDT_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> esTokenCSC_;
+  edm::ESGetToken<GEMGeometry, MuonGeometryRecord> esTokenGEM_;
 };
 
 //
@@ -105,12 +106,9 @@ void TestRotation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   //
   // Retrieve ideal geometry from event setup
   //
-  edm::ESHandle<DTGeometry> dtGeometry;
-  edm::ESHandle<CSCGeometry> cscGeometry;
-  edm::ESHandle<GEMGeometry> gemGeometry;
-  iSetup.get<MuonGeometryRecord>().get(dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(cscGeometry);
-  iSetup.get<MuonGeometryRecord>().get(gemGeometry);
+  edm::ESHandle<DTGeometry> dtGeometry = iSetup.getHandle(esTokenDT_);
+  edm::ESHandle<CSCGeometry> cscGeometry = iSetup.getHandle(esTokenCSC_);
+  edm::ESHandle<GEMGeometry> gemGeometry = iSetup.getHandle(esTokenGEM_);
 
   AlignableMuon* theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 

--- a/Alignment/MuonAlignment/test/TestTranslation.cpp
+++ b/Alignment/MuonAlignment/test/TestTranslation.cpp
@@ -109,10 +109,12 @@ void TestTranslation::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   //
   edm::ESHandle<DTGeometry> dtGeometry;
   edm::ESHandle<CSCGeometry> cscGeometry;
+  edm::ESHandle<GEMGeometry> gemGeometry;
   iSetup.get<MuonGeometryRecord>().get(dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+  iSetup.get<MuonGeometryRecord>().get(gemGeometry);
 
-  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+  AlignableMuon* theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
 
   // Apply  alignment
   for (const auto& iter : theAlignableMuon->DTChambers())

--- a/Alignment/MuonAlignment/test/convertSQLitetoXML_cfg.py
+++ b/Alignment/MuonAlignment/test/convertSQLitetoXML_cfg.py
@@ -1,0 +1,127 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("CONVERT")
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.load("Configuration.Geometry.GeometryIdeal_cff")
+process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+
+process.DTGeometryAlInputDB = cms.ESProducer("DTGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputDB'),
+    applyAlignment = cms.bool(False), 
+    alignmentsLabel = cms.string(''),
+    fromDDD = cms.bool(True)
+)
+
+process.CSCGeometryAlInputDB = cms.ESProducer("CSCGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputDB'),
+    debugV = cms.untracked.bool(False),
+    useGangedStripsInME1a = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    useOnlyWiresInME1a = cms.bool(False),
+    useRealWireGeometry = cms.bool(True),
+    useCentreTIOffsets = cms.bool(False),
+    applyAlignment = cms.bool(False), 
+    fromDDD = cms.bool(True),
+    fromDD4hep = cms.bool(False)
+)
+
+process.GEMGeometryAlInputDB = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputDB'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
+
+process.DTGeometryAlOutputXML = cms.ESProducer("DTGeometryESModule",
+    appendToDataLabel = cms.string('idealForOutputXML'),
+    applyAlignment = cms.bool(False), 
+    alignmentsLabel = cms.string(''),
+    fromDDD = cms.bool(True)
+)
+
+process.CSCGeometryAlOutputXML = cms.ESProducer("CSCGeometryESModule",
+    appendToDataLabel = cms.string('idealForOutputXML'),
+    debugV = cms.untracked.bool(False),
+    useGangedStripsInME1a = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    useOnlyWiresInME1a = cms.bool(False),
+    useRealWireGeometry = cms.bool(True),
+    useCentreTIOffsets = cms.bool(False),
+    applyAlignment = cms.bool(False), 
+    fromDDD = cms.bool(True),
+    fromDD4hep = cms.bool(False)
+)
+
+process.GEMGeometryAlOutputXML = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForOutputXML'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
+
+process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDBSetup,
+    connect = cms.string("sqlite_file:Alignments.db"),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('DTAlignmentRcd'),
+        tag = cms.string('DT100InversepbScenario')
+    ),
+        cms.PSet(
+            record = cms.string('DTAlignmentErrorExtendedRcd'),
+            tag = cms.string('DT100InversepbScenarioErrors')
+        ),
+        cms.PSet(
+            record = cms.string('CSCAlignmentRcd'),
+            tag = cms.string('CSC100InversepbScenario')
+        ),
+        cms.PSet(
+            record = cms.string('CSCAlignmentErrorExtendedRcd'),
+            tag = cms.string('CSC100InversepbScenarioErrors')
+        ),
+        cms.PSet(
+            record = cms.string('GEMAlignmentRcd'),
+            tag = cms.string('GEM')
+        ),
+        cms.PSet(
+            record = cms.string('GEMAlignmentErrorExtendedRcd'),
+            tag = cms.string('test')
+        )))
+process.inertGlobalPositionRcd = cms.ESSource("PoolDBESSource",
+    process.CondDBSetup,
+    connect = cms.string("sqlite_file:inertGlobalPositionRcd.StdTags.746p3.DBv2.db"),
+    toGet = cms.VPSet(cms.PSet(record = cms.string("GlobalPositionRcd"), tag = cms.string("inertGlobalPositionRcd"))))
+process.MuonGeometryDBConverter = cms.EDAnalyzer("MuonGeometryDBConverter",
+    input = cms.string("db"),
+    dtLabel = cms.string(""),
+    cscLabel = cms.string(""),
+    gemLabel = cms.string(""),
+    shiftErr = cms.double(1000.),
+    angleErr = cms.double(6.28),
+    getAPEs = cms.bool(True),
+    output = cms.string("xml"),
+    outputXML = cms.PSet(
+        fileName = cms.string("REPLACEME.xml"),
+        relativeto = cms.string("ideal"),
+        survey = cms.bool(False),
+        rawIds = cms.bool(False),
+        eulerAngles = cms.bool(False),
+        precision = cms.int32(10),
+        suppressDTBarrel = cms.untracked.bool(True),
+        suppressDTWheels = cms.untracked.bool(True),
+        suppressDTStations = cms.untracked.bool(True),
+        suppressDTChambers = cms.untracked.bool(False),
+        suppressDTSuperLayers = cms.untracked.bool(False),
+        suppressDTLayers = cms.untracked.bool(False),
+        suppressCSCEndcaps = cms.untracked.bool(True),
+        suppressCSCStations = cms.untracked.bool(True),
+        suppressCSCRings = cms.untracked.bool(True),
+        suppressCSCChambers = cms.untracked.bool(False),
+        suppressCSCLayers = cms.untracked.bool(False)))
+
+process.Path = cms.Path(process.MuonGeometryDBConverter)

--- a/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
+++ b/Alignment/MuonAlignment/test/muonGeometryDBConverter_cfg.py
@@ -28,7 +28,8 @@ options.parseArguments()
 # setting up the process
 process = cms.Process("CONVERT")
 process.load("Configuration.StandardSequences.MagneticField_cff")
-process.load("Configuration.Geometry.GeometryIdeal_cff")
+process.load("Geometry.MuonCommonData.muonIdealGeometryXML_cfi")
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Alignment.MuonAlignment.muonGeometryDBConverter_cfi")
@@ -53,6 +54,14 @@ process.CSCGeometryAlInputMethod = cms.ESProducer("CSCGeometryESModule",
     fromDD4hep = cms.bool(False)
 )
 
+process.GEMGeometryAlInputMethod = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputMethod'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
+
 process.DTGeometryAlInputDB = cms.ESProducer("DTGeometryESModule",
     appendToDataLabel = cms.string('idealForInputDB'),
     applyAlignment = cms.bool(False),
@@ -71,6 +80,14 @@ process.CSCGeometryAlInputDB = cms.ESProducer("CSCGeometryESModule",
     applyAlignment = cms.bool(False),
     fromDDD = cms.bool(True),
     fromDD4hep = cms.bool(False)
+)
+
+process.GEMGeometryAlInputDB = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputDB'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
 )
 
 process.DTGeometryAlOutputXML = cms.ESProducer("DTGeometryESModule",
@@ -93,6 +110,14 @@ process.CSCGeometryAlOutputXML = cms.ESProducer("CSCGeometryESModule",
     fromDD4hep = cms.bool(False)
 )
 
+process.GEMGeometryAlOutputXML = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForOutputXML'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
+
 process.DTGeometryAlInputXML = cms.ESProducer("DTGeometryESModule",
     appendToDataLabel = cms.string('idealForInputXML'),
     applyAlignment = cms.bool(False),
@@ -113,8 +138,13 @@ process.CSCGeometryAlInputXML = cms.ESProducer("CSCGeometryESModule",
     fromDD4hep = cms.bool(False)
 )
 
-
-
+process.GEMGeometryAlInputXML = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForInputXML'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
 ################################################################################
 # parameters to configure:
 from Configuration.AlCa.GlobalTag import GlobalTag
@@ -135,7 +165,13 @@ if options.input == "db":
                   tag = cms.string("CSCAlignmentRcd")),
          cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
                   record = cms.string("CSCAlignmentErrorExtendedRcd"),
-                  tag = cms.string("CSCAlignmentErrorExtendedRcd"))
+                  tag = cms.string("CSCAlignmentErrorExtendedRcd")),
+         cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("GEMAlignmentRcd"),
+                  tag = cms.string("GEMAlignmentRcd")),
+         cms.PSet(connect = cms.string("sqlite_file:"+options.inputFile),
+                  record = cms.string("GEMAlignmentErrorExtendedRcd"),
+                  tag = cms.string("GEMAlignmentErrorExtendedRcd"))
         ])
 elif options.input == "xml":
     process.muonGeometryDBConverter.fileName = options.inputFile
@@ -154,6 +190,10 @@ if options.output == "db":
                      tag = cms.string("CSCAlignmentRcd")),
             cms.PSet(record = cms.string("CSCAlignmentErrorExtendedRcd"),
                      tag = cms.string("CSCAlignmentErrorExtendedRcd")),
+            cms.PSet(record = cms.string("GEMAlignmentRcd"),
+                     tag = cms.string("GEMAlignmentRcd")),
+            cms.PSet(record = cms.string("GEMAlignmentErrorExtendedRcd"),
+                     tag = cms.string("GEMAlignmentErrorExtendedRcd"))
         )
     )
     process.PoolDBOutputService.connect = "sqlite_file:"+options.outputFile

--- a/Alignment/MuonAlignment/test/test-misalign_cfg.py
+++ b/Alignment/MuonAlignment/test/test-misalign_cfg.py
@@ -4,10 +4,9 @@ process = cms.Process("TEST")
 # -- Load default module/services configurations -- //
 # Message logger service
 process.load("FWCore.MessageService.MessageLogger_cfi")
-
-# Ideal DT & CSC geometry 
 process.load("Geometry.MuonCommonData.muonIdealGeometryXML_cfi")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
 
 # Misalignment example scenario producer
 import Alignment.MuonAlignment.Scenarios_cff as _MuonScenarios
@@ -19,11 +18,6 @@ process.MisalignedMuon = cms.EDAnalyzer("MuonMisalignedProducer",
                                         _MuonScenarios.ExampleScenario,
                                         saveToDbase = cms.untracked.bool(True)
                                         )
-
-# or standard stuff 
-# Reco geometry producer
-#process.load("Geometry.DTGeometry.dtGeometry_cfi")
-#process.load("Geometry.CSCGeometry.cscGeometry_cfi")
 
 process.MisalignedMuon.scenario = _MuonScenarios.Muon100InversepbScenario
 process.maxEvents = cms.untracked.PSet(
@@ -52,6 +46,14 @@ process.CSCGeometryMisalignedMuonProducer = cms.ESProducer("CSCGeometryESModule"
     fromDD4hep = cms.bool(False)
 )
 
+process.GEMGeometryMisalignedMuonProducer = cms.ESProducer("GEMGeometryESModule",
+    appendToDataLabel = cms.string('idealForMuonMisalignedProducer'),
+    fromDDD = cms.bool(True),
+    fromDD4Hep = cms.bool(False),
+    alignmentsLabel = cms.string(''),
+    applyAlignment = cms.bool(False)
+)
+
 
 # Database output service if you want to store soemthing in MisalignedMuon
 from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
@@ -72,7 +74,16 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
         cms.PSet(
             record = cms.string('CSCAlignmentErrorExtendedRcd'),
             tag = cms.string('CSC100InversepbScenarioErrors')
+        ),
+        cms.PSet(
+            record = cms.string('GEMAlignmentRcd'),
+            tag = cms.string('GEM')
+        ), 
+        cms.PSet(
+            record = cms.string('GEMAlignmentErrorExtendedRcd'),
+            tag = cms.string('test')
         )),
+
     connect = cms.string('sqlite_file:Alignments.db')
 )
 
@@ -80,7 +91,8 @@ process.prod = cms.EDAnalyzer("TestMisalign",
     fileName = cms.untracked.string('misaligment.root')
 )
 
-process.p1 = cms.Path(process.MisalignedMuon+process.prod)
+#process.p1 = cms.Path(process.MisalignedMuon+process.prod)
+process.p1 = cms.Path(process.MisalignedMuon)
 process.MessageLogger.cout = cms.untracked.PSet(
     threshold = cms.untracked.string('INFO'),
     default = cms.untracked.PSet(

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
@@ -162,10 +162,12 @@ void SurveyInputCSCfromPins::analyze(const edm::Event &, const edm::EventSetup &
 
     edm::ESHandle<DTGeometry> dtGeometry;
     edm::ESHandle<CSCGeometry> cscGeometry;
+    edm::ESHandle<GEMGeometry> gemGeometry;
     iSetup.get<MuonGeometryRecord>().get(dtGeometry);
     iSetup.get<MuonGeometryRecord>().get(cscGeometry);
+    iSetup.get<MuonGeometryRecord>().get(gemGeometry);
 
-    AlignableMuon *theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry));
+    AlignableMuon *theAlignableMuon = new AlignableMuon(&(*dtGeometry), &(*cscGeometry), &(*gemGeometry));
     AlignableNavigator *theAlignableNavigator = new AlignableNavigator(theAlignableMuon);
 
     const auto &theEndcaps = theAlignableMuon->CSCEndcaps();

--- a/Alignment/TrackerAlignment/src/AlignableTracker.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTracker.cc
@@ -16,7 +16,7 @@ AlignableTracker ::AlignableTracker(const TrackerGeometry* trackerGeometry, cons
       AlignableComposite(0, align::Tracker, RotationType()),
       tTopo_(trackerTopology),
       trackerNameSpace_(trackerTopology),
-      alignableObjectId_(trackerGeometry, nullptr, nullptr) {
+      alignableObjectId_(trackerGeometry, nullptr, nullptr, nullptr) {
   AlignableTrackerBuilder builder(trackerGeometry, trackerTopology);
   builder.buildAlignables(this);
   trackerNameSpace_ = builder.trackerNameSpace();

--- a/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
+++ b/Alignment/TrackerAlignment/src/AlignableTrackerBuilder.cc
@@ -25,7 +25,7 @@ AlignableTrackerBuilder ::AlignableTrackerBuilder(const TrackerGeometry* tracker
                                                   const TrackerTopology* trackerTopology)
     : trackerGeometry_(trackerGeometry),
       trackerTopology_(trackerTopology),
-      alignableObjectId_(trackerGeometry, nullptr, nullptr),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr, nullptr),
       alignableMap_(nullptr),
       trackerAlignmentLevelBuilder_(trackerTopology, trackerGeometry) {
   std::ostringstream ss;

--- a/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
+++ b/Alignment/TrackerAlignment/src/TrackerAlignmentLevelBuilder.cc
@@ -17,7 +17,7 @@
 TrackerAlignmentLevelBuilder ::TrackerAlignmentLevelBuilder(const TrackerTopology* trackerTopology,
                                                             const TrackerGeometry* trackerGeometry)
     : trackerTopology_(trackerTopology),
-      alignableObjectId_(trackerGeometry, nullptr, nullptr),
+      alignableObjectId_(trackerGeometry, nullptr, nullptr, nullptr),
       trackerNameSpace_(trackerTopology) {}
 
 //_____________________________________________________________________________

--- a/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
+++ b/Alignment/TrackerAlignment/test/TrackerGeometryAnalyzer.cc
@@ -78,7 +78,7 @@ void TrackerGeometryAnalyzer ::setTrackerGeometry(const edm::EventSetup& setup) 
 
   TrackerGeomBuilderFromGeometricDet trackerGeometryBuilder;
   trackerGeometry = trackerGeometryBuilder.build(&(*geometricDet), *trackerParams, trackerTopology);
-  alignableObjectId_ = AlignableObjectId{trackerGeometry, nullptr, nullptr};
+  alignableObjectId_ = AlignableObjectId{trackerGeometry, nullptr, nullptr, nullptr};
 }
 
 //_____________________________________________________________________________

--- a/Geometry/CommonTopologies/interface/GeometryAligner.h
+++ b/Geometry/CommonTopologies/interface/GeometryAligner.h
@@ -70,21 +70,18 @@ void GeometryAligner::applyAlignments(const C* geometry,
   const AlignTransform::Rotation inverseGlobalRotation = globalRotation.inverse();
 
   // Parallel loop on alignments, alignment errors and geomdets
-  std::vector<AlignTransform>::const_iterator iAlign = alignments->m_align.begin();
   std::vector<AlignTransformErrorExtended>::const_iterator iAlignError = alignmentErrors->m_alignError.begin();
   //copy  geometry->theMap to a real map to order it....
   std::map<unsigned int, GeomDet const*> theMap;
   std::copy(geometry->theMap.begin(), geometry->theMap.end(), std::inserter(theMap, theMap.begin()));
   unsigned int nAPE = 0;
-  for (auto iPair = theMap.begin(); iPair != theMap.end(); ++iPair, ++iAlign, ++iAlignError) {
+  for (auto iAlign = alignments->m_align.begin(); iAlign != alignments->m_align.end(); ++iAlign, ++iAlignError) {
     // Check DetIds
-    if ((*iPair).first != (*iAlign).rawId())
-      throw cms::Exception("GeometryMismatch") << "DetId mismatch between geometry (rawId=" << (*iPair).first
-                                               << ") and alignments (rawId=" << (*iAlign).rawId();
+    if (theMap.find((*iAlign).rawId()) == theMap.end())
+      throw cms::Exception("GeometryMismatch") << "Can't find rawId=" << (*iAlign).rawId();
 
-    if ((*iPair).first != (*iAlignError).rawId())
-      throw cms::Exception("GeometryMismatch") << "DetId mismatch between geometry (rawId=" << (*iPair).first
-                                               << ") and alignment errors (rawId=" << (*iAlignError).rawId();
+    if (theMap.find((*iAlignError).rawId()) == theMap.end())
+      throw cms::Exception("GeometryMismatch") << "Can't find rawId=" << (*iAlignError).rawId();
 
     // Apply global correction
     CLHEP::Hep3Vector positionHep = globalRotation * CLHEP::Hep3Vector((*iAlign).translation()) + globalShift;
@@ -101,7 +98,7 @@ void GeometryAligner::applyAlignments(const C* geometry,
                                    rotationHep.zx(),
                                    rotationHep.zy(),
                                    rotationHep.zz());
-    GeomDet* iGeomDet = const_cast<GeomDet*>((*iPair).second);
+    GeomDet* iGeomDet = const_cast<GeomDet*>(theMap[(*iAlign).rawId()]);
     this->setGeomDetPosition(*iGeomDet, position, rotation);
 
     // Alignment Position Error only if non-zero to save memory


### PR DESCRIPTION
#### PR description:

- Add GEM to AlignableMuon
- Other submodules (DB converters) will be done later 
- To test and develop muon alignment include GEM, we need to update the MuonAlignment module first

#### PR validation:

- Muon scenario builder created the GEM SQLite DB file correctly
