### PR TITLE
Update PPS tags in Run 2 offline GTs for re-miniAOD

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,13 +26,13 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v3',
+    'run1_data'         :   '112X_dataRun2_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v3',
+    'run2_data'         :   '112X_dataRun2_v4',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v3',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v4',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v3',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v4',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '110X_dataRun2_PromptLike_HI_v10',
     # GlobalTag for Run1 HLT: it points to the online GT


### PR DESCRIPTION
#### PR description:

This PR updates two PPS records, `CTPPSOpticsRcd` and `RPRealAlignmentRecord` as described in a [presentation](https://indico.cern.ch/event/919920/#23-pps-update-for-run-2-re-min) in the May 18, 2020 AlCaDB meeting.

It also removes an obsolete record `L1TMuonEndcapParamsRcd` from the GT (the record with a capital 'C' in EndCap remains), which is purely technical. Once this record is removed from all GTs in production, it can be removed from CMSSW.

The GT diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_v3/112X_dataRun2_v4

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HEfail_v3/112X_dataRun2_HEfail_v4

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_relval_v3/112X_dataRun2_relval_v4


#### PR validation:

Please see the [presentation](https://indico.cern.ch/event/919920/#23-pps-update-for-run-2-re-min) in the May 18, 2020 AlCaDB meeting for details. In addition, a technical test was performed:

`runTheMatrix.py -l limited,136.8642,136.72411 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 106X for use in the Run 2 re-miniAOD.