### PR TITLE
Avoid dangling reference in edm::ConsumesCollectorWithTagESAdaptor

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -161,7 +161,7 @@ namespace edm {
         : m_consumer(std::move(iBase)), m_tag(std::move(iTag)) {}
 
     ConsumesCollector m_consumer;
-    ESInputTag const& m_tag;
+    ESInputTag const m_tag;
   };
 
   template <BranchType B>


### PR DESCRIPTION
#### PR description:

While migrating `MixingModule` to `esConsumes()` (#31061) I noticed random crashes that I traced to be caused by `edm::ConsumesCollectorWithTagESAdaptor` storing a const reference to an `edm::ESInputTag` argument that is passed by value. This PR changes the member to be stored as const object, as in other such adaptors.

#### PR validation:

The crashes disappeared.