### PR TITLE
Fix issue with Strip CalibTree production and improve unit tests

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -4,7 +4,6 @@
 <use name="DataFormats/SiStripDetId"/>
 <use name="DataFormats/Scalers"/>
 <use name="DataFormats/OnlineMetaData"/>
-<use name="SimDataFormats/TrackingAnalysis"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ServiceRegistry"/>

--- a/CalibTracker/SiStripCommon/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
 <use name="RecoLocalTracker/SiStripClusterizer"/>
+<use name="SimDataFormats/TrackingAnalysis"/>
 <library file="*.cc" name="CalibTrackerSiStripCommonPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.cc
@@ -8,6 +8,8 @@
 #include <TBranch.h>
 
 ShallowTree::ShallowTree(const edm::ParameterSet& iConfig) {
+  usesResource(TFileService::kSharedResource);
+
   //int compSettings= iConfig.getParameter<int>("CompressionSettings",-1);
   int compSettings = iConfig.getUntrackedParameter<int>("CompressionSettings", -1);
   if (compSettings > 0)
@@ -194,5 +196,3 @@ ShallowTree::TypedBranchConnector<T>::TypedBranchConnector(edm::BranchDescriptio
     tree->Branch(pin.c_str(), &object_ptr_);
   }  //vector<type>
 }
-
-void ShallowTree::beginJob() {}

--- a/CalibTracker/SiStripCommon/plugins/ShallowTree.h
+++ b/CalibTracker/SiStripCommon/plugins/ShallowTree.h
@@ -19,7 +19,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -30,11 +30,9 @@
 #include <vector>
 #include <TTree.h>
 
-class ShallowTree : public edm::EDAnalyzer {
+class ShallowTree : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 private:
-  void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
-  void endJob() override {}
 
   template <class T>
   void eat(edm::BranchDescription const* desc) {

--- a/CalibTracker/SiStripCommon/test/test_all.sh
+++ b/CalibTracker/SiStripCommon/test/test_all.sh
@@ -4,4 +4,4 @@ function die { echo $1: status $2 ; exit $2; }
 
 echo "TESTING CalibTracker/SiStripCommon ..."
 cmsRun ${LOCAL_TEST_DIR}/test_all_cfg.py || die "Failure running test_CalibTrackerSiStripCommon_cfg.py" $? 
-cmsRun ${LOCAL_TEST_DIR}/testProduceCalibrationTree_cfg.py maxEvents=1 || die "Failure running produceCalibrationTree_template_cfg.py" $?
+cmsRun ${LOCAL_TEST_DIR}/testProduceCalibrationTree_cfg.py maxEvents=10 unitTest=True || die "Failure running produceCalibrationTree_template_cfg.py" $?


### PR DESCRIPTION
#### PR description:

After integration of PR https://github.com/cms-sw/cmssw/pull/31002 I noticed that the production of Strip calibTrees was substantially slowed down and identified the motivation in the migration of `ShallowGainCalibration` from a `stream` to `global`. 
I revert in this PR part of the changes (commit 2c77c10) leading to the slow-down.
Additionally:
- I address the comment https://github.com/cms-sw/cmssw/pull/31002#discussion_r495831968 about the content of the `plugins/BuildFile.xml` of that package (commit: 7f83ffc)
- improve the unit test, in order to to run multi-threaded (but not yet using concurrent lumis), setting same compression settings as used in production and removing few missing trigger errors currently present in the IBs (see e.g. [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_2_X_2020-10-01-1100/unitTestLogs/CalibTracker/SiStripCommon#/71)) in commit 3da8316 
- make `ShallowTree` an `edm::one::EDAnalyzer` (commit 4671911)

#### PR validation:

Tested in `CMSSW_11_2_X_2020-09-30-1100` using:
```
 cmsRun testProduceCalibrationTree_cfg.py inputFiles="/store/express/Run2018D/StreamExpress/ALCARECO/SiStripCalMinBias-Express-v1/000/323/492/00000/ED5EFF5C-1B7B-564D-974B-15499A1B7D4E.root" inputCollection="ALCARECOSiStripCalMinBias" conditionGT="101X_dataRun2_Express_v8"
```
I get:

```
TimeReport> Time report complete in 360.07 seconds
 Time Summary: 
 - Min event:   0.444757
 - Max event:   21.3634
 - Avg event:   1.96364
 - Total loop:  330.235
 - Total init:  29.7974
 - Total job:   360.07
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 2.01372 ev/s
 CPU Summary: 
 - Total loop:  1286.18
 - Total init:  11.6651
 - Total extra: 0
 - Total job:   1297.95
 Processing Summary: 
 - Number of Events:  665
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
```

while with this branch:

```
TimeReport> Time report complete in 76.3658 seconds
 Time Summary: 
 - Min event:   0.0435982
 - Max event:   21.6353
 - Avg event:   0.271647
 - Total loop:  50.1936
 - Total init:  26.1378
 - Total job:   76.3658
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 13.2487 ev/s
 CPU Summary: 
 - Total loop:  144.93
 - Total init:  11.4757
 - Total extra: 0
 - Total job:   156.509
 Processing Summary: 
 - Number of Events:  665
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.
