### PR TITLE
Bugfix for PackedCandidateMuonSelectorProducer (HI re-miniAOD)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
@@ -94,7 +94,7 @@ void pat::PackedCandidateMuonSelectorProducer::produce(edm::Event& iEvent, const
       const auto& cand = pat::PackedCandidateRef(candidates, i);
       const auto& candTrack = candidate2PF[cand]->trackRef();
       // check if candidate and muon are compatible
-      if (candTrack.isNonnull() && muonTrack.id() == candTrack.id()) {
+      if (candTrack.isNonnull() && muonTrack == candTrack) {
         for (const auto& sel : muonSelectors_) {
           if (muon::isGoodMuon(muon, muon::selectionTypeFromString(sel)))
             candMap[sel]->push_back(cand);


### PR DESCRIPTION
#### PR description:

This PR fixes a bug introduced in PackedCandidateMuonSelectorProducer by PR https://github.com/cms-sw/cmssw/pull/30253 .

#### PR validation:

Tested using PbPb 2018 dimuon data.

@mandrenguyen 