### PR TITLE
Energy threshold update for new MTD geometry

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C11_etlV4_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11_etlV4_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+
+Phase2C11_etlV4 = cms.ModifierChain(Phase2C11, phase2_etlV4)

--- a/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+ 
+phase2_etlV4 =  cms.Modifier()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -42,6 +42,7 @@ class Eras (object):
                  'Phase2C9_dd4hep',
                  'Phase2C10_dd4hep',
                  'Phase2C11_dd4hep',
+                 'Phase2C11_etlV4',
                  'Phase2C12_dd4hep',
         ]
 

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -24,13 +24,13 @@ public:
 
   /// make the rec hit
   FTLRecHit makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags) const final;
-  static constexpr int topologycode1Disk = 4;
 
 private:
   std::vector<double> thresholdToKeep_;
   double calibration_;
   const MTDTimeCalib* time_calib_;
-  const MTDTopology* topology;
+  const MTDTopology* topology_;
+  static constexpr int topologycode1Disk_ = 4;
 };
 
 void MTDRecHitAlgo::getEventSetup(const edm::EventSetup& es) {
@@ -39,7 +39,7 @@ void MTDRecHitAlgo::getEventSetup(const edm::EventSetup& es) {
   time_calib_ = pTC.product();
   edm::ESHandle<MTDTopology> topologyHandle;
   es.get<MTDTopologyRcd>().get(topologyHandle);
-  topology = topologyHandle.product();
+  topology_ = topologyHandle.product();
 }
 
 FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32_t& flags) const {
@@ -51,7 +51,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
 
   // MTD topology
   unsigned int index_topology = 0;  //1Disks geometry
-  if (topology->getMTDTopologyMode() > topologycode1Disk)
+  if (topology_->getMTDTopologyMode() > topologycode1Disk_)
     index_topology = 1;  //2Disk geometry
 
   /// position and positionError in unit cm

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -94,7 +94,6 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
 
   // Now fill flags
   // all rechits from the digitizer are "good" at present
-     std::cout << "threshold 1D: 0.0425    threshold2D: 0.005  ----> "<< thresholdToKeep_[index_topology] << std::endl;
      if (energy > thresholdToKeep_[index_topology]) {
        flags = FTLRecHit::kGood;
        rh.setFlag(flags);

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -30,7 +30,6 @@ private:
   double calibration_;
   const MTDTimeCalib* time_calib_;
   const MTDTopology* topology_;
-  static constexpr int topologycode1Disk_ = 4;
 };
 
 void MTDRecHitAlgo::getEventSetup(const edm::EventSetup& es) {
@@ -51,7 +50,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
 
   // MTD topology
   unsigned int index_topology = 0;  //1Disks geometry
-  if (topology_->getMTDTopologyMode() > topologycode1Disk_)
+  if (topology_->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
     index_topology = 1;  //2Disk geometry
 
   /// position and positionError in unit cm

--- a/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
+++ b/RecoLocalFastTime/FTLCommonAlgos/plugins/MTDRecHitAlgo.cc
@@ -5,7 +5,7 @@
 
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
 #include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
-#include<iostream>
+#include <iostream>
 
 class MTDRecHitAlgo : public MTDRecHitAlgoBase {
 public:
@@ -50,8 +50,9 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
   float time = 0.;
 
   // MTD topology
-  unsigned int index_topology = 0; //1Disks geometry
-  if ( topology->getMTDTopologyMode() > topologycode1Disk ) index_topology = 1; //2Disk geometry
+  unsigned int index_topology = 0;  //1Disks geometry
+  if (topology->getMTDTopologyMode() > topologycode1Disk)
+    index_topology = 1;  //2Disk geometry
 
   /// position and positionError in unit cm
   float position = -1.f;
@@ -85,7 +86,7 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
   }
 
   // --- Energy calibration: for the time being this is just a conversion pC --> MeV
-     energy *= calibration_;
+  energy *= calibration_;
 
   // --- Time calibration: for the time being just removes a time offset in BTL
   time += time_calib_->getTimeCalib(uRecHit.id());
@@ -94,13 +95,13 @@ FTLRecHit MTDRecHitAlgo::makeRecHit(const FTLUncalibratedRecHit& uRecHit, uint32
 
   // Now fill flags
   // all rechits from the digitizer are "good" at present
-     if (energy > thresholdToKeep_[index_topology]) {
-       flags = FTLRecHit::kGood;
-       rh.setFlag(flags);
-     } else {
-       flags = FTLRecHit::kKilled;
-       rh.setFlag(flags);
-     }
+  if (energy > thresholdToKeep_[index_topology]) {
+    flags = FTLRecHit::kGood;
+    rh.setFlag(flags);
+  } else {
+    flags = FTLRecHit::kKilled;
+    rh.setFlag(flags);
+  }
 
   return rh;
 }

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -2,17 +2,20 @@ import FWCore.ParameterSet.Config as cms
 
 _barrelAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
-    thresholdToKeep = cms.vdouble(1., 1.),          # MeV
+    thresholdToKeep = cms.double(1.),          # MeV
     calibrationConstant = cms.double(0.03125), # MeV/pC
 )
 
 
 _endcapAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
-    thresholdToKeep = cms.vdouble(0.0425, 0.005),    # MeV
+    thresholdToKeep = cms.double(0.0425),    # MeV
     calibrationConstant = cms.double(0.085), # MeV/MIP
 )
 
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005 )
+phase2_etlV4.toModify(_endcapAlgo, calibrationConstant = 0.001 )
 
 mtdRecHits = cms.EDProducer(
     "MTDRecHitProducer",
@@ -23,3 +26,5 @@ mtdRecHits = cms.EDProducer(
     BarrelHitsName = cms.string('FTLBarrel'),
     EndcapHitsName = cms.string('FTLEndcap'),
 )
+
+

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -3,14 +3,14 @@ import FWCore.ParameterSet.Config as cms
 _barrelAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
     thresholdToKeep = cms.vdouble(1., 1.),          # MeV
-    calibrationConstant = cms.vdouble(0.03125, 0.03125), # MeV/pC
+    calibrationConstant = cms.double(0.03125), # MeV/pC
 )
 
 
 _endcapAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
     thresholdToKeep = cms.vdouble(0.0425, 0.005),    # MeV
-    calibrationConstant = cms.vdouble(0.085, 0.01), # MeV/MIP
+    calibrationConstant = cms.double(0.085), # MeV/MIP
 )
 
 

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -2,15 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 _barrelAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
-    thresholdToKeep = cms.double(1.),          # MeV
-    calibrationConstant = cms.double(0.03125), # MeV/pC
+    thresholdToKeep = cms.vdouble(1., 1.),          # MeV
+    calibrationConstant = cms.vdouble(0.03125, 0.03125), # MeV/pC
 )
 
 
 _endcapAlgo = cms.PSet(
     algoName = cms.string("MTDRecHitAlgo"),
-    thresholdToKeep = cms.double(0.0425),    # MeV
-    calibrationConstant = cms.double(0.085), # MeV/MIP
+    thresholdToKeep = cms.vdouble(0.0425, 0.005),    # MeV
+    calibrationConstant = cms.vdouble(0.085, 0.01), # MeV/MIP
 )
 
 

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -84,6 +84,9 @@ _endcap_MTDDigitizer = cms.PSet(
         )
 )
 
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+phase2_etlV4.toModify(_endcap_MTDDigitizer.DeviceSimulation, meVPerMIP = 0.001 )
+
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 for _m in [_barrel_MTDDigitizer, _endcap_MTDDigitizer]:
     premix_stage1.toModify(_m, premixStage1 = True)


### PR DESCRIPTION
#### PR description:

The energy threshold parameter used in the MTDRecHitAlgo plugin has been modified in order to discriminate between the two different MTD ETL geometries (with one ETL disk and two ETL disks). The two MTD ETL geometries are identified via the MTDTopologyMode.

#### PR validation:

The new code has been tested in the release CMSSW_11_2_0_pre6.


