### PR TITLE
Partially fix CLCT position bias after CCLUT (CCLUT-8)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -74,13 +74,18 @@ public:
   /// set the slope
   void setSlope(const uint16_t slope);
 
+  /// slope in number of half-strips/layer
+  float getFractionalSlope(const uint16_t slope = 5) const;
+
   /// return striptype
   uint16_t getStripType() const { return striptype_; }
 
   /// set stripType
   void setStripType(const uint16_t stripType) { striptype_ = stripType; }
 
-  /// return bend (left or right)
+  /// return bending
+  /// 0: left-bending (negative delta-strip)
+  /// 1: right-bending (positive delta-strip)
   uint16_t getBend() const { return bend_; }
 
   /// set bend

--- a/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h
@@ -21,7 +21,7 @@ public:
   enum LCTKeyStripMasks { kEightStripMask = 0x1, kQuartStripMask = 0x1, kHalfStripMask = 0xff };
   enum LCTKeyStripShifts { kEightStripShift = 9, kQuartStripShift = 8, kHalfStripShift = 0 };
   // temporary to facilitate CCLUT-EMTF/OMTF integration studies
-  enum LCTPatternMasks { kRun3SlopeMask = 0x1f, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
+  enum LCTPatternMasks { kRun3SlopeMask = 0xf, kRun3PatternMask = 0x7, kLegacyPatternMask = 0xf };
   enum LCTPatternShifts { kRun3SlopeShift = 7, kRun3PatternShift = 4, kLegacyPatternShift = 0 };
   enum class Version { Legacy = 0, Run3 };
 

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -115,6 +115,21 @@ void CSCCLCTDigi::setSlope(const uint16_t slope) {
   setDataWord(slope, pattern_, kRun3SlopeShift, kRun3SlopeMask);
 }
 
+// slope in number of half-strips/layer
+float CSCCLCTDigi::getFractionalSlope(const uint16_t nBits) const {
+  if (isRun3()) {
+    const float minSlope = 0;
+    const float maxSlope = 2.5;
+    const int range = pow(2, nBits);
+    const float deltaSlope = (maxSlope - minSlope) / range;
+    const float slopeValue = minSlope + deltaSlope * getSlope();
+    return (2 * getBend() - 1) * slopeValue;
+  } else {
+    int slope[11] = {0, 0, -8, 8, -6, 6, -4, 4, -2, 2, 0};
+    return float(slope[getPattern()] / 5.);
+  }
+}
+
 uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
   // 10-bit case for strip data word
   if (compCode_ != -1 and n == 8) {
@@ -132,9 +147,9 @@ uint16_t CSCCLCTDigi::getKeyStrip(const uint16_t n) const {
 
 /// return the fractional strip (middle of the strip)
 float CSCCLCTDigi::getFractionalStrip(const uint16_t n) const {
-  if (n == 8) {
+  if (compCode_ != -1 and n == 8) {
     return 0.125f * (getKeyStrip(n) + 0.5);
-  } else if (n == 4) {
+  } else if (compCode_ != -1 and n == 4) {
     return 0.25f * (getKeyStrip(n) + 0.5);
   } else {
     return 0.5f * (getKeyStrip(n) + 0.5);

--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCCathodeLCTProcessor.h
@@ -158,7 +158,7 @@ protected:
   int calculateComparatorCode(const std::array<std::array<int, 3>, 6>& halfStripPattern) const;
 
   // sets the 1/4 and 1/8 strip bits given a floating point position offset
-  void assignPositionCC(const unsigned offset, uint16_t& halfstrip, bool& quartstrip, bool& eightstrip) const;
+  void assignPositionCC(const unsigned offset, std::tuple<uint16_t, bool, bool>& returnValue) const;
 
   // runs the CCLUT procedure
   void runCCLUT(CSCCLCTDigi& digi) const;

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -489,9 +489,6 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
                                                    int trknmb) const {
   // CLCT pattern number
   unsigned int pattern = encodePattern(cLCT.getPattern());
-  if (use_run3_patterns_ and use_comparator_codes_) {
-    pattern = cLCT.getSlope();
-  }
 
   // LCT quality number
   unsigned int quality;

--- a/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
+++ b/L1Trigger/CSCTriggerPrimitives/test/macros/CCLUTLinearFitWriter.cpp
@@ -130,7 +130,8 @@ void writeHeaderPosOffsetLUT(ofstream& file);
 void writeHeaderSlopeLUT(ofstream& file);
 unsigned firmwareWord(const unsigned quality, const unsigned slope, const unsigned offset);
 void setDataWord(unsigned& word, const unsigned newWord, const unsigned shift, const unsigned mask);
-unsigned assign(const float fvalue, const float fmin, const float fmax, const unsigned nbits);
+unsigned assignPosition(const float fvalue, const float fmin, const float fmax, const unsigned nbits);
+unsigned assignBending(const float fvalue, const float fmin, const float fmax, const unsigned nbits);
 
 int CCLUTLinearFitWriter(unsigned N_LAYER_REQUIREMENT = 3) {
   //all the patterns we will fit
@@ -340,10 +341,16 @@ int CCLUTLinearFitWriter(unsigned N_LAYER_REQUIREMENT = 3) {
       const float fmaxOffset = 2;
       const float fminOffset = -1.75;
       const float fmaxSlope = 2.5;
-      const float fminSlope = -2.5;
+      const float fminSlope = 0;
 
-      const unsigned offset_bin = assign(offset, fminOffset, fmaxOffset, 4);
-      const unsigned slope_bin = assign(slope, fminSlope, fmaxSlope, 5);
+      // negative bending -> 0
+      // positive bending -> 1
+      const bool slope_sign(slope >= 0);
+
+      const unsigned offset_bin = assignPosition(offset, fminOffset, fmaxOffset, 4);
+      unsigned slope_bin = assignBending(std::abs(slope), fminSlope, fmaxSlope, 4);
+      if (slope_sign)
+        slope_bin += 16;
       const unsigned fwword = firmwareWord(0, slope_bin, offset_bin);
 
       // write to output files
@@ -496,7 +503,7 @@ void writeHeaderSlopeLUT(ofstream& file) {
        << "#<header> v1.0 12 32 </header>\n";
 }
 
-unsigned assign(const float fvalue, const float fmin, const float fmax, const unsigned nbits) {
+unsigned assignPosition(const float fvalue, const float fmin, const float fmax, const unsigned nbits) {
   bool debug;
   unsigned value = 0;
   const unsigned range = pow(2, nbits);
@@ -509,7 +516,28 @@ unsigned assign(const float fvalue, const float fmin, const float fmax, const un
   } else if (fvalue <= fmin) {
     value = minValue;
   } else {
-    value = int(std::floor((fvalue - fmin) / fdelta));
+    value = std::min(unsigned(std::ceil((fvalue - fmin) / fdelta)), maxValue);
+  }
+  if (debug)
+    std::cout << "fvalue " << fvalue << " " << fmin << " " << fmax << " " << nbits << " " << value << std::endl;
+
+  return value;
+}
+
+unsigned assignBending(const float fvalue, const float fmin, const float fmax, const unsigned nbits) {
+  bool debug;
+  unsigned value = 0;
+  const unsigned range = pow(2, nbits);
+  const unsigned minValue = 0;
+  const unsigned maxValue = range - 1;
+  const double fdelta = (fmax - fmin) / range;
+
+  if (fvalue >= fmax) {
+    value = maxValue;
+  } else if (fvalue <= fmin) {
+    value = minValue;
+  } else {
+    value = std::min(unsigned(std::floor((fvalue - fmin) / fdelta)), maxValue);
   }
   if (debug)
     std::cout << "fvalue " << fvalue << " " << fmin << " " << fmax << " " << nbits << " " << value << std::endl;
@@ -520,11 +548,12 @@ unsigned assign(const float fvalue, const float fmin, const float fmax, const un
 unsigned firmwareWord(const unsigned quality, const unsigned slope, const unsigned offset) {
   /* construct fw dataword:
      [8:0] is quality (set all to 0 for now)
-     [13, 9] is slope
+     [12:9] is slope value
+     [13] is slope sign
      [17:14] is offset
   */
   enum Masks { OffsetMask = 0xf, SlopeMask = 0x1f, QualityMask = 0x1ff };
-  enum Shifts { OffsetShift = 13, SlopeShift = 9, QualityShift = 0 };
+  enum Shifts { OffsetShift = 14, SlopeShift = 9, QualityShift = 0 };
 
   unsigned fwword = 0;
   setDataWord(fwword, quality, QualityShift, QualityMask);

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -13,7 +13,7 @@ GEMDigiMatcher::GEMDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   maxBXDigi_ = gemDigi.getParameter<int>("maxBX");
   matchDeltaStrip_ = gemDigi.getParameter<int>("matchDeltaStrip");
   verboseDigi_ = gemDigi.getParameter<int>("verbose");
-  matchToSimLink_ = gemDigi.getParameter<int>("matchToSimLink");
+  matchToSimLink_ = gemDigi.getParameter<bool>("matchToSimLink");
 
   const auto& gemPad = pset.getParameterSet("gemPadDigi");
   minBXPad_ = gemPad.getParameter<int>("minBX");

--- a/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
+++ b/Validation/MuonGEMDigis/src/GEMDigiMatcher.cc
@@ -33,7 +33,9 @@ GEMDigiMatcher::GEMDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
   // make a new simhits matcher
   muonSimHitMatcher_.reset(new GEMSimHitMatcher(pset, std::move(iC)));
 
-  gemSimLinkToken_ = iC.consumes<edm::DetSetVector<GEMDigiSimLink>>(gemSimLink.getParameter<edm::InputTag>("inputTag"));
+  if (matchToSimLink_)
+    gemSimLinkToken_ =
+        iC.consumes<edm::DetSetVector<GEMDigiSimLink>>(gemSimLink.getParameter<edm::InputTag>("inputTag"));
   gemDigiToken_ = iC.consumes<GEMDigiCollection>(gemDigi.getParameter<edm::InputTag>("inputTag"));
   gemPadToken_ = iC.consumes<GEMPadDigiCollection>(gemPad.getParameter<edm::InputTag>("inputTag"));
   gemClusterToken_ = iC.consumes<GEMPadDigiClusterCollection>(gemCluster.getParameter<edm::InputTag>("inputTag"));
@@ -45,7 +47,8 @@ GEMDigiMatcher::GEMDigiMatcher(const edm::ParameterSet& pset, edm::ConsumesColle
 void GEMDigiMatcher::init(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   muonSimHitMatcher_->init(iEvent, iSetup);
 
-  iEvent.getByToken(gemSimLinkToken_, gemDigisSLH_);
+  if (matchToSimLink_)
+    iEvent.getByToken(gemSimLinkToken_, gemDigisSLH_);
   iEvent.getByToken(gemDigiToken_, gemDigisH_);
   iEvent.getByToken(gemPadToken_, gemPadsH_);
   iEvent.getByToken(gemClusterToken_, gemClustersH_);
@@ -73,7 +76,8 @@ void GEMDigiMatcher::match(const SimTrack& t, const SimVertex& v) {
     return;
 
   // now match the digis
-  matchDigisSLToSimTrack(gemDigisSL);
+  if (matchToSimLink_)
+    matchDigisSLToSimTrack(gemDigisSL);
   matchDigisToSimTrack(gemDigis);
   matchPadsToSimTrack(gemPads);
   matchClustersToSimTrack(gemClusters);

--- a/Validation/MuonHits/interface/CSCSimHitMatcher.h
+++ b/Validation/MuonHits/interface/CSCSimHitMatcher.h
@@ -55,6 +55,7 @@ public:
 
   // local bending in a CSC chamber
   float LocalBendingInChamber(unsigned int detid) const;
+  void fitHitsInChamber(unsigned int detid, float& mean, float& slope) const;
 
   // calculate average strip number for a provided collection of simhits
   float simHitsMeanStrip(const edm::PSimHitContainer& sim_hits) const;

--- a/Validation/MuonHits/interface/MuonSimHitMatcher.h
+++ b/Validation/MuonHits/interface/MuonSimHitMatcher.h
@@ -66,6 +66,8 @@ public:
   // calculate the average position at the second station
   GlobalPoint simHitsMeanPositionStation(int n) const;
 
+  const TrackingGeometry* geometry() { return geometry_; }
+
 protected:
   std::vector<unsigned int> getIdsOfSimTrackShower(unsigned trk_id,
                                                    const edm::SimTrackContainer& simTracks,


### PR DESCRIPTION
#### PR description:

In recent studies, a bias was found in the 1/2-strip, 1/4-strip and 1/8-strip positions of about 0.17. The bias has now been eliminated for the 1/2 position. A bias of < 0.1 strip remains for the 1/4 and 1/8 strip positions (this may be due to how we define the 1/n-strip position: center or middle). New LUTs provided here: https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives/pull/3.

#### PR validation:

Tested with ```/RelValSingleMuPt10/CMSSW_11_0_0-110X_mcRun4_realistic_v2_2026D49noPU-v1/GEN-SIM-DIGI-RAW``` and ```/RelValSingleMuFlatPt2To100/CMSSW_11_0_0-110X_mcRun4_realistic_v2_2026D49noPU-v1/GEN-SIM-DIGI-RAW```

Most recent presentation summarizing the results https://indico.cern.ch/event/965106/contributions/4062917/attachments/2122267/3572271/CSCResolutionNewPatterns_SD_20201014.pdf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 Please pick-up the new .mem files from https://github.com/cms-data/L1Trigger-CSCTriggerPrimitives.