### PR TITLE
use standard libuuid functions, add binary uuid option

### DIFF
--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -57,7 +57,7 @@ namespace edm {
         processHistoryRegistry_(new ProcessHistoryRegistry),
         branchIDListHelper_(desc.branchIDListHelper_),
         thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
-        processGUID_(createGlobalIdentifier()),
+        processGUID_(createGlobalIdentifier(true)),
         time_(),
         newRun_(true),
         newLumi_(true),

--- a/FWCore/Utilities/interface/GlobalIdentifier.h
+++ b/FWCore/Utilities/interface/GlobalIdentifier.h
@@ -3,7 +3,7 @@
 
 #include <string>
 namespace edm {
-  std::string createGlobalIdentifier();
+  std::string createGlobalIdentifier(bool binary = false);
 }
 
 #endif

--- a/FWCore/Utilities/src/GlobalIdentifier.cc
+++ b/FWCore/Utilities/src/GlobalIdentifier.cc
@@ -2,8 +2,8 @@
 #include "Guid.h"
 
 namespace edm {
-  std::string createGlobalIdentifier() {
+  std::string createGlobalIdentifier(bool binary) {
     Guid guid;
-    return guid.toString();
+    return binary ? guid.toBinary() : guid.toString();
   }
 }  // namespace edm

--- a/FWCore/Utilities/src/Guid.cc
+++ b/FWCore/Utilities/src/Guid.cc
@@ -10,72 +10,45 @@
 //
 //      ====================================================================
 #include "Guid.h"
-#include <cassert>
-#include <cstdio>
 #include <cstring>
-#include <cstdlib>
-#include <string>
-#include <fmt/format.h>
-#include "uuid/uuid.h"
+#include <cassert>
 
 namespace edm {
-  constexpr char const* const fmt_Guid = "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}";
   /// Initialize a new Guid
-  void Guid::init() {
-    uuid_t me_;
-    ::uuid_generate_random(me_);
-    unsigned int* d1 = reinterpret_cast<unsigned int*>(me_);
-    unsigned short* d2 = reinterpret_cast<unsigned short*>(me_ + 4);
-    unsigned short* d3 = reinterpret_cast<unsigned short*>(me_ + 6);
-    Data1 = *d1;
-    Data2 = *d2;
-    Data3 = *d3;
-    for (int i = 0; i < 8; ++i) {
-      Data4[i] = me_[i + 8];
+  void Guid::init(bool usetime) {
+    if (usetime) {
+      ::uuid_generate_time(data_);
+    } else {
+      // uuid_generate() defaults to uuid_generate_random() if /dev/urandom
+      // is available; if /dev/urandom is not available, then it is better
+      // to let uuid_generate() choose the best fallback rather than forcing
+      // use of an inferior source of randomness
+      ::uuid_generate(data_);
     }
   }
 
+  std::string const Guid::toBinary() const {
+    return std::string(reinterpret_cast<const char*>(data_), sizeof(data_));
+  }
+
+  Guid const& Guid::fromBinary(std::string const& source) {
+    assert(source.size() == sizeof(data_));
+    std::memcpy(data_, source.data(), sizeof(data_));
+    return *this;
+  }
+
   std::string const Guid::toString() const {
-    return fmt::format(
-        fmt_Guid, Data1, Data2, Data3, Data4[0], Data4[1], Data4[2], Data4[3], Data4[4], Data4[5], Data4[6], Data4[7]);
+    char out[UUID_STR_LEN];
+    ::uuid_unparse(data_, out);
+    return std::string(out);
   }
 
   // fromString is used only in a unit test, so performance is not critical.
   Guid const& Guid::fromString(std::string const& source) {
-    char const dash = '-';
-    size_t const iSize = 8;
-    size_t const sSize = 4;
-    size_t const cSize = 2;
-    size_t offset = 0;
-    Data1 = strtol(source.substr(offset, iSize).c_str(), nullptr, 16);
-    offset += iSize;
-    assert(dash == source[offset++]);
-    Data2 = strtol(source.substr(offset, sSize).c_str(), nullptr, 16);
-    offset += sSize;
-    assert(dash == source[offset++]);
-    Data3 = strtol(source.substr(offset, sSize).c_str(), nullptr, 16);
-    offset += sSize;
-    assert(dash == source[offset++]);
-    Data4[0] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[1] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    assert(dash == source[offset++]);
-    Data4[2] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[3] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[4] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[5] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[6] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    Data4[7] = strtol(source.substr(offset, cSize).c_str(), nullptr, 16);
-    offset += cSize;
-    assert(source.size() == offset);
+    auto err = ::uuid_parse(source.c_str(), data_);
+    assert(err == 0);
     return *this;
   }
 
-  bool Guid::operator<(Guid const& g) const { return ::memcmp(&g.Data1, &Data1, 16) < 0; }
+  bool Guid::operator<(Guid const& g) const { return ::uuid_compare(data_, g.data_) < 0; }
 }  // namespace edm

--- a/FWCore/Utilities/src/Guid.cc
+++ b/FWCore/Utilities/src/Guid.cc
@@ -27,9 +27,7 @@ namespace edm {
     }
   }
 
-  std::string const Guid::toBinary() const {
-    return std::string(reinterpret_cast<const char*>(data_), sizeof(data_));
-  }
+  std::string const Guid::toBinary() const { return std::string(reinterpret_cast<const char*>(data_), sizeof(data_)); }
 
   Guid const& Guid::fromBinary(std::string const& source) {
     assert(source.size() == sizeof(data_));

--- a/FWCore/Utilities/src/Guid.h
+++ b/FWCore/Utilities/src/Guid.h
@@ -1,6 +1,7 @@
 #ifndef FWCOre_Utilities_Guid_h
 #define FWCOre_Utilities_Guid_h
 
+#include "uuid/uuid.h"
 #include <string>
 
 /*
@@ -19,34 +20,25 @@ namespace edm {
     * @author   Zhen Xie         Include DCE implementation for linux
     * @version  1.1
     * @date     03/09/2002
+    *
+    * Simplified by Dan Riley for CMS to use standard libuuid functions
     */
   class Guid {  // size is 16
   public:
-    unsigned int Data1;
-    unsigned short Data2;
-    unsigned short Data3;
-    unsigned char Data4[8];
-
     /// Standard constructor (With initializaton)
     Guid() { init(); }
     /// Standard constructor (With initialization)
-    explicit Guid(bool) { init(); }
+    explicit Guid(bool usetime) { init(usetime); }
     /// Constructor for Guid from char*
-    explicit Guid(char const* s) { fromString(s); }
+    explicit Guid(char const* s, bool binary = false) { binary ? fromBinary(s) : fromString(s); }
     /// Constructor for Guid from string
-    explicit Guid(std::string const& s) { fromString(s); }
+    explicit Guid(std::string const& s, bool binary = false) { binary ? fromBinary(s) : fromString(s); }
     /// Copy constructor
     Guid(Guid const& c) { *this = c; }
     /// Assignment operator
     Guid& operator=(Guid const& g) {
       if (this != &g) {
-        Data1 = g.Data1;
-        Data2 = g.Data2;
-        Data3 = g.Data3;
-        unsigned int* p = reinterpret_cast<unsigned int*>(&Data4[0]);
-        unsigned int const* q = reinterpret_cast<unsigned int const*>(&g.Data4[0]);
-        *(p + 1) = *(q + 1);
-        *p = *q;
+        ::uuid_copy(data_, g.data_);
       }
       return *this;
     }
@@ -55,27 +47,24 @@ namespace edm {
     /// Equality operator
     bool operator==(Guid const& g) const {
       if (this != &g) {
-        if (Data1 != g.Data1)
-          return false;
-        if (Data2 != g.Data2)
-          return false;
-        if (Data3 != g.Data3)
-          return false;
-        unsigned int const* p = reinterpret_cast<unsigned int const*>(&Data4[0]);
-        unsigned int const* q = reinterpret_cast<unsigned int const*>(&g.Data4[0]);
-        return *p == *q && *(p + 1) == *(q + 1);
+        return ::uuid_compare(data_, g.data_) == 0;
       }
       return true;
     }
     /// Non-equality operator
     bool operator!=(Guid const& g) const { return !(this->operator==(g)); }
-    /// Automatic conversion from string reprentation
+    /// conversion to binary string reprentation
+    std::string const toBinary() const;
+    /// conversion from binary string representation
+    Guid const& fromBinary(std::string const& s);
+    /// conversion to formatted string reprentation
     std::string const toString() const;
-    /// Automatic conversion to string representation
+    /// conversion from formatted string representation
     Guid const& fromString(std::string const& s);
-    /// initialize a new Guid
   private:
-    void init();
+    /// initialize a new Guid
+    void init(bool usetime = false);
+    uuid_t data_;
   };
 }  // namespace edm
 #endif

--- a/FWCore/Utilities/src/Guid.h
+++ b/FWCore/Utilities/src/Guid.h
@@ -61,6 +61,7 @@ namespace edm {
     std::string const toString() const;
     /// conversion from formatted string representation
     Guid const& fromString(std::string const& s);
+
   private:
     /// initialize a new Guid
     void init(bool usetime = false);

--- a/FWCore/Utilities/test/Guid_t.cpp
+++ b/FWCore/Utilities/test/Guid_t.cpp
@@ -6,14 +6,31 @@
 
 int main() {
   edm::Guid guid;
-  std::string guidString = guid.toString();
-  edm::Guid guid2;
-  guid2.fromString(guidString);
+
+  auto guidString = guid.toString();
+  edm::Guid guid2(guidString, false);
   edm::Guid guid3(guid2);
+
+  auto guidBinary = guid.toBinary();
+  edm::Guid guid4(guidBinary, true);
+
   assert(guid == guid2);
   assert(guid == guid3);
-  std::string guidString2 = guid2.toString();
-  std::string guidString3 = guid3.toString();
+  assert(guid == guid4);
+
+  auto guidString2 = guid2.toString();
+  auto guidString3 = guid3.toString();
+  auto guidString4 = guid4.toString();
+
   assert(guidString2 == guidString);
   assert(guidString3 == guidString);
+  assert(guidString4 == guidString);
+
+  auto guidBinary2 = guid2.toBinary();
+  auto guidBinary3 = guid3.toBinary();
+  auto guidBinary4 = guid4.toBinary();
+
+  assert(guidBinary2 == guidBinary);
+  assert(guidBinary3 == guidBinary);
+  assert(guidBinary4 == guidBinary);
 }

--- a/FWCore/Utilities/test/Guid_t.cpp
+++ b/FWCore/Utilities/test/Guid_t.cpp
@@ -33,4 +33,11 @@ int main() {
   assert(guidBinary2 == guidBinary);
   assert(guidBinary3 == guidBinary);
   assert(guidBinary4 == guidBinary);
+
+  edm::Guid otherGuid;
+  assert(otherGuid != guid);
+
+  edm::Guid otherBinaryGuid{ otherGuid.toBinary(), true };
+  assert(otherBinaryGuid == otherGuid);
+  assert(otherBinaryGuid != guid4);
 }

--- a/FWCore/Utilities/test/Guid_t.cpp
+++ b/FWCore/Utilities/test/Guid_t.cpp
@@ -37,7 +37,7 @@ int main() {
   edm::Guid otherGuid;
   assert(otherGuid != guid);
 
-  edm::Guid otherBinaryGuid{ otherGuid.toBinary(), true };
+  edm::Guid otherBinaryGuid{otherGuid.toBinary(), true};
   assert(otherBinaryGuid == otherGuid);
   assert(otherBinaryGuid != guid4);
 }

--- a/PhysicsTools/Utilities/plugins/PileUpFilter.cc
+++ b/PhysicsTools/Utilities/plugins/PileUpFilter.cc
@@ -9,8 +9,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-//#include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 


### PR DESCRIPTION
#### PR description:

The EDM Guid class was derived from POOL source that apparently dates back to the COM/DCE days before UUIDs were standardized and before the general availability of libuuid.  Most of the functionality of the Guid class is now available from libuuid.  This PR

1) Replaces most of Guid.cc with calls to libuuid (we're linking to it, we might as well use it).
2) Changes the internal representation of the Guid class to the libuuid uuid_t type.
3) Adds an option to load and store an edm Guid as a 16 byte binary string instead of the 32 byte printable representation normally used (std::string can contain null characters so long as c_str() isn't called).
4) Adds an option to use ::uuid_generate_time() to generate UUIDs, and defaults to ::uuid_generate() instead of ::uuid_generate_random().  uuid_generate() defaults to uuid_generate_random(), but has better fallback behavior in the (unlikely) event that /dev/urandom is unavailable.
5) Uses the binary representation for the ProcessGUID stored with every event in the EventAuxiliary record.  An audit of the code shows that we never print the ProcessGUID nor do we otherwise rely on the string representation.
6) Reverses the sense of the '<' comparison operator to match the standard definition (it could probably be removed--I don't think we ever use it).

#### PR validation:

A standard limited matrix was run, and the Guid unit test was updated to test the new functionality.