### PR TITLE
[DD4hep] Filtered View Performance - Step 3

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDCompactView.h
+++ b/DetectorDescription/DDCMS/interface/DDCompactView.h
@@ -35,6 +35,11 @@ namespace cms {
     template <typename T>
     std::vector<T> getVector(const std::string&) const;
 
+    template <typename T>
+    T const& get(const std::string&) const;
+    template <typename T>
+    T const& get(const std::string&, const std::string&) const;
+
   private:
     const cms::DDDetector& m_det;
   };

--- a/DetectorDescription/DDCMS/interface/DDDetector.h
+++ b/DetectorDescription/DDCMS/interface/DDDetector.h
@@ -1,6 +1,7 @@
 #ifndef DetectorDescription_DDCMS_DDDetector_h
 #define DetectorDescription_DDCMS_DDDetector_h
 
+#include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
 #include <DD4hep/Detector.h>
 #include <DD4hep/SpecParRegistry.h>
 #include <string>
@@ -13,7 +14,7 @@ namespace cms {
     explicit DDDetector(const std::string&, const std::string&, bool bigXML = false);
     DDDetector() = delete;
 
-    dd4hep::VectorsMap const& vectors() const { return m_vectors; }
+    cms::DDVectorsMap const& vectors() const { return m_vectors; }
 
     dd4hep::PartSelectionMap const& partsels() const { return m_partsels; }
 
@@ -38,7 +39,7 @@ namespace cms {
     void processXML(const std::string&);
 
     dd4hep::Detector* m_description = nullptr;
-    dd4hep::VectorsMap m_vectors;
+    cms::DDVectorsMap m_vectors;
     dd4hep::PartSelectionMap m_partsels;
     dd4hep::SpecParRegistry m_specpars;
     const std::string m_tag;

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -192,6 +192,36 @@ namespace cms {
     template <typename T>
     T get(const std::string&);
 
+    //! extract attribute value for current Node
+    //  keep the maespace for comparison
+    //  assume there are no regular expressions
+    template <typename T>
+    std::vector<T> getValuesNS(const std::string& key) {
+      DDSpecParRefs refs;
+      registry_->filter(refs, key);
+
+      std::string path = this->path();
+      for (const auto& specPar : refs) {
+        for (const auto& part : specPar->paths) {
+          bool flag(true);
+          std::size_t from = 0;
+          for (auto name : dd4hep::dd::split(part, "/")) {
+            auto const& to = path.find(name, from);
+            if (to == std::string::npos) {
+              flag = false;
+              break;
+            } else {
+              from = to;
+            }
+          }
+          if (flag) {
+            return specPar->value<std::vector<T>>(key);
+          }
+        }
+      }
+      return std::vector<T>();
+    }
+
     //! extract another value from the same SpecPar
     //  call get<double> first to find a relevant one
     double getNextValue(const std::string&) const;

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -20,11 +20,11 @@
 //
 #include "DetectorDescription/DDCMS/interface/DDSolidShapes.h"
 #include "DetectorDescription/DDCMS/interface/ExpandedNodes.h"
+#include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
 #include <DD4hep/Filter.h>
 #include <DD4hep/SpecParRegistry.h>
 #include <DD4hep/Volumes.h>
 #include <memory>
-#include <tuple>
 #include <vector>
 
 namespace cms {
@@ -50,7 +50,6 @@ namespace cms {
   using DDSpecPar = dd4hep::SpecPar;
   using DDSpecParRefs = dd4hep::SpecParRefs;
   using DDSpecParRegistry = dd4hep::SpecParRegistry;
-  using DDVectorsMap = dd4hep::VectorsMap;
   using Iterator = TGeoIterator;
   using Node = TGeoNode;
   using Translation = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
@@ -252,6 +251,7 @@ namespace cms {
     const DDSpecPar* find(const std::string&) const;
     void filter(DDSpecParRefs&, const std::string&) const;
     const std::string_view front(const std::string_view) const;
+    const std::string_view back(const std::string_view) const;
 
     ExpandedNodes nodes_;
     std::vector<Iterator> it_;

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -228,12 +228,12 @@ namespace cms {
     void findSpecPar(T const& first, Ts const&... rest) {
       currentSpecPar_ = find(first);
       if constexpr (sizeof...(rest) > 0) {
-	  // this line will only be instantiated if there are further
-	  // arguments. if rest... is empty, there will be no call to
-	  // findSpecPar(next).
-	  if (currentSpecPar_ == nullptr)
-	    findSpecPar(rest...);
-    	}
+        // this line will only be instantiated if there are further
+        // arguments. if rest... is empty, there will be no call to
+        // findSpecPar(next).
+        if (currentSpecPar_ == nullptr)
+          findSpecPar(rest...);
+      }
     }
 
   private:
@@ -252,7 +252,7 @@ namespace cms {
     const DDSpecPar* find(const std::string&) const;
     void filter(DDSpecParRefs&, const std::string&) const;
     const std::string_view front(const std::string_view) const;
-				 
+
     ExpandedNodes nodes_;
     std::vector<Iterator> it_;
     std::vector<std::unique_ptr<Filter>> filters_;

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -250,8 +250,8 @@ namespace cms {
     //  the registry
     const DDSpecPar* find(const std::string&) const;
     void filter(DDSpecParRefs&, const std::string&) const;
-    const std::string_view front(const std::string_view) const;
-    const std::string_view back(const std::string_view) const;
+    std::string_view front(const std::string_view) const;
+    std::string_view back(const std::string_view) const;
 
     ExpandedNodes nodes_;
     std::vector<Iterator> it_;

--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -222,6 +222,20 @@ namespace cms {
     //! print Filter paths and selections
     void printFilter() const;
 
+    //! find a current Node SpecPar that has at least
+    //  one of the attributes
+    template <class T, class... Ts>
+    void findSpecPar(T const& first, Ts const&... rest) {
+      currentSpecPar_ = find(first);
+      if constexpr (sizeof...(rest) > 0) {
+	  // this line will only be instantiated if there are further
+	  // arguments. if rest... is empty, there will be no call to
+	  // findSpecPar(next).
+	  if (currentSpecPar_ == nullptr)
+	    findSpecPar(rest...);
+    	}
+    }
+
   private:
     bool accept(std::string_view);
     int nodeCopyNo(const std::string_view) const;
@@ -236,7 +250,9 @@ namespace cms {
     //  speeding up avoiding the same search over
     //  the registry
     const DDSpecPar* find(const std::string&) const;
-
+    void filter(DDSpecParRefs&, const std::string&) const;
+    const std::string_view front(const std::string_view) const;
+				 
     ExpandedNodes nodes_;
     std::vector<Iterator> it_;
     std::vector<std::unique_ptr<Filter>> filters_;

--- a/DetectorDescription/DDCMS/interface/DDNamespace.h
+++ b/DetectorDescription/DDCMS/interface/DDNamespace.h
@@ -5,13 +5,13 @@
 #include "DD4hep/Objects.h"
 #include "DD4hep/Shapes.h"
 #include "DD4hep/Volumes.h"
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
+#include <unordered_map>
+#include <vector>
 
 namespace cms {
 
   class DDParsingContext;
-  using DDVectorsMap = tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<double>>;
+  using DDVectorsMap = std::unordered_map<std::string, std::vector<double>>;
 
   class DDNamespace {
   public:

--- a/DetectorDescription/DDCMS/interface/DDPlugins.h
+++ b/DetectorDescription/DDCMS/interface/DDPlugins.h
@@ -7,23 +7,20 @@
 
 namespace dd4hep {
 
-  class SensitiveDetector;
-
   template <typename T>
   class DDCMSDetElementFactory : public dd4hep::PluginFactoryBase {
   public:
     static long create(dd4hep::Detector& detector,
                        cms::DDParsingContext& context,
-                       dd4hep::xml::Handle_t element,
-                       dd4hep::SensitiveDetector& sensitive);
+                       dd4hep::xml::Handle_t element);
   };
 }  // namespace dd4hep
 
 namespace {
   template <typename P, typename S>
   class Factory;
-  DD4HEP_PLUGIN_FACTORY_ARGS_4(long, dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*, dd4hep::SensitiveDetector*) {
-    return dd4hep::DDCMSDetElementFactory<P>::create(*a0, *a1, *a2, *a3);
+  DD4HEP_PLUGIN_FACTORY_ARGS_3(long, dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*) {
+    return dd4hep::DDCMSDetElementFactory<P>::create(*a0, *a1, *a2);
   }
 }  // namespace
 
@@ -31,12 +28,12 @@ namespace {
   DD4HEP_OPEN_PLUGIN(dd4hep, ddcms_det_element_##name) {                                                              \
     typedef DDCMSDetElementFactory<ddcms_det_element_##name> _IMP;                                                    \
     template <>                                                                                                       \
-    long _IMP::create(dd4hep::Detector& d, cms::DDParsingContext& c, xml::Handle_t e, dd4hep::SensitiveDetector& h) { \
-      return func(d, c, e, h);                                                                                        \
+    long _IMP::create(dd4hep::Detector& d, cms::DDParsingContext& c, xml::Handle_t e) {                               \
+      return func(d, c, e);                                                                                           \
     }                                                                                                                 \
     DD4HEP_PLUGINSVC_FACTORY(ddcms_det_element_##name,                                                                \
                              name,                                                                                    \
-                             long(dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*, dd4hep::SensitiveDetector*), \
+                             long(dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*),                             \
                              __LINE__)                                                                                \
   }
 

--- a/DetectorDescription/DDCMS/interface/DDPlugins.h
+++ b/DetectorDescription/DDCMS/interface/DDPlugins.h
@@ -10,9 +10,7 @@ namespace dd4hep {
   template <typename T>
   class DDCMSDetElementFactory : public dd4hep::PluginFactoryBase {
   public:
-    static long create(dd4hep::Detector& detector,
-                       cms::DDParsingContext& context,
-                       dd4hep::xml::Handle_t element);
+    static long create(dd4hep::Detector& detector, cms::DDParsingContext& context, dd4hep::xml::Handle_t element);
   };
 }  // namespace dd4hep
 
@@ -24,17 +22,15 @@ namespace {
   }
 }  // namespace
 
-#define DECLARE_DDCMS_DETELEMENT(name, func)                                                                          \
-  DD4HEP_OPEN_PLUGIN(dd4hep, ddcms_det_element_##name) {                                                              \
-    typedef DDCMSDetElementFactory<ddcms_det_element_##name> _IMP;                                                    \
-    template <>                                                                                                       \
-    long _IMP::create(dd4hep::Detector& d, cms::DDParsingContext& c, xml::Handle_t e) {                               \
-      return func(d, c, e);                                                                                           \
-    }                                                                                                                 \
-    DD4HEP_PLUGINSVC_FACTORY(ddcms_det_element_##name,                                                                \
-                             name,                                                                                    \
-                             long(dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*),                             \
-                             __LINE__)                                                                                \
+#define DECLARE_DDCMS_DETELEMENT(name, func)                                                                   \
+  DD4HEP_OPEN_PLUGIN(dd4hep, ddcms_det_element_##name) {                                                       \
+    typedef DDCMSDetElementFactory<ddcms_det_element_##name> _IMP;                                             \
+    template <>                                                                                                \
+    long _IMP::create(dd4hep::Detector& d, cms::DDParsingContext& c, xml::Handle_t e) {                        \
+      return func(d, c, e);                                                                                    \
+    }                                                                                                          \
+    DD4HEP_PLUGINSVC_FACTORY(                                                                                  \
+        ddcms_det_element_##name, name, long(dd4hep::Detector*, cms::DDParsingContext*, ns::xml_h*), __LINE__) \
   }
 
 #endif

--- a/DetectorDescription/DDCMS/interface/DDVectorRegistry.h
+++ b/DetectorDescription/DDCMS/interface/DDVectorRegistry.h
@@ -7,7 +7,7 @@
 
 namespace cms {
   using DDVectorsMap = std::unordered_map<std::string, std::vector<double>>;
-  
+
   struct DDVectorRegistry {
     DDVectorsMap vectors;
   };

--- a/DetectorDescription/DDCMS/interface/DDVectorRegistry.h
+++ b/DetectorDescription/DDCMS/interface/DDVectorRegistry.h
@@ -2,12 +2,14 @@
 #define DETECTOR_DESCRIPTION_DD_VECTOR_REGISTRY_H
 
 #include <string>
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
+#include <unordered_map>
+#include <vector>
 
 namespace cms {
+  using DDVectorsMap = std::unordered_map<std::string, std::vector<double>>;
+  
   struct DDVectorRegistry {
-    tbb::concurrent_unordered_map<std::string, tbb::concurrent_vector<double> > vectors;
+    DDVectorsMap vectors;
   };
 }  // namespace cms
 

--- a/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
+++ b/DetectorDescription/DDCMS/plugins/DDVectorRegistryESProducer.cc
@@ -31,9 +31,14 @@
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DD4hep/Detector.h"
 
+#include <unordered_map>
+#include <vector>
+
 using namespace std;
 using namespace cms;
 using namespace edm;
+
+using DDVectorsMap = std::unordered_map<std::string, std::vector<double>>;
 
 class DDVectorRegistryESProducer : public edm::ESProducer {
 public:
@@ -62,7 +67,7 @@ void DDVectorRegistryESProducer::fillDescriptions(edm::ConfigurationDescriptions
 
 DDVectorRegistryESProducer::ReturnType DDVectorRegistryESProducer::produce(const DDVectorRegistryRcd& iRecord) {
   LogDebug("Geometry") << "DDVectorRegistryESProducer::produce\n";
-  const dd4hep::VectorsMap& registry = iRecord.get(m_token).vectors();
+  const auto& registry = iRecord.get(m_token).vectors();
 
   auto product = std::make_unique<DDVectorRegistry>();
   product->vectors.insert(registry.begin(), registry.end());

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDAngular.cc
@@ -20,7 +20,7 @@ namespace {
   }
 }  // namespace
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
 

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -28,7 +28,7 @@
 #include <vector>
 #include <unordered_map>
 #include <utility>
-#include <tbb/concurrent_vector.h>
+//#include <tbb/concurrent_vector.h>
 
 using namespace std;
 using namespace dd4hep;
@@ -1676,7 +1676,7 @@ void Converter<DDLVector>::operator()(xml_h element) const {
   try {
     std::vector<double> results = splitNumeric(val);
     registry->insert(
-        {name, tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
+		     {name, results});//tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
   } catch (const exception& e) {
     printout(INFO,
              "DD4CMS",
@@ -1844,8 +1844,8 @@ static long load_dddefinition(Detector& det, xml_h element) {
               result.emplace_back(dd4hep::_toDouble(i));
             }
             registry->insert(
-                {it->first,
-                 tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
+			     {it->first, result });
+	    //                 tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
             // All components are resolved
             it = context.unresolvedVectors.erase(it);
           }

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -28,7 +28,6 @@
 #include <vector>
 #include <unordered_map>
 #include <utility>
-//#include <tbb/concurrent_vector.h>
 
 using namespace std;
 using namespace dd4hep;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -1675,7 +1675,8 @@ void Converter<DDLVector>::operator()(xml_h element) const {
            val.c_str());
   try {
     std::vector<double> results = splitNumeric(val);
-    registry->insert({name, tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
+    registry->insert(
+        {name, tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
   } catch (const exception& e) {
     printout(INFO,
              "DD4CMS",
@@ -1842,7 +1843,9 @@ static long load_dddefinition(Detector& det, xml_h element) {
             for (const auto& i : it->second) {
               result.emplace_back(dd4hep::_toDouble(i));
             }
-            registry->insert({it->first, tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
+            registry->insert(
+                {it->first,
+                 tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
             // All components are resolved
             it = context.unresolvedVectors.erase(it);
           }

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -1676,7 +1676,8 @@ void Converter<DDLVector>::operator()(xml_h element) const {
   try {
     std::vector<double> results = splitNumeric(val);
     registry->insert(
-		     {name, results});//tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
+        {name,
+         results});  //tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(results.begin(), results.end())});
   } catch (const exception& e) {
     printout(INFO,
              "DD4CMS",
@@ -1843,9 +1844,8 @@ static long load_dddefinition(Detector& det, xml_h element) {
             for (const auto& i : it->second) {
               result.emplace_back(dd4hep::_toDouble(i));
             }
-            registry->insert(
-			     {it->first, result });
-	    //                 tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
+            registry->insert({it->first, result});
+            //                 tbb::concurrent_vector<double, tbb::cache_aligned_allocator<double>>(begin(result), end(result))});
             // All components are resolved
             it = context.unresolvedVectors.erase(it);
           }

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -509,7 +509,7 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
                "+++ Compared to XML values: Atomic weight %g, Atomic number %u",
                atomicWeight,
                atomicNumber);
-      static constexpr double const& weightTolerance = 1.0e-6;
+      static constexpr double const weightTolerance = 1.0e-6;
       if (atomicNumber != elt->Z() ||
           (std::abs(atomicWeight - elt->A()) > (weightTolerance * (atomicWeight + elt->A()))))
         newMatDef = true;

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -25,9 +25,9 @@
 #include <iostream>
 #include <iomanip>
 #include <map>
+#include <vector>
+#include <unordered_map>
 #include <utility>
-#include "tbb/concurrent_unordered_map.h"
-#include "tbb/concurrent_vector.h"
 
 using namespace std;
 using namespace dd4hep;
@@ -50,8 +50,8 @@ namespace dd4hep {
     class DDLConstant;
 
     struct DDRegistry {
-      tbb::concurrent_vector<xml::Document> includes;
-      tbb::concurrent_unordered_map<std::string, std::string> unresolvedConst, allConst, originalConst;
+      std::vector<xml::Document> includes;
+      std::unordered_map<std::string, std::string> unresolvedConst, allConst, originalConst;
     };
 
     class MaterialSection;
@@ -101,8 +101,6 @@ namespace dd4hep {
     class PartSelector;
     class Parameter;
 
-    class vissection;
-    class vis;
     class debug;
   }  // namespace
 
@@ -132,13 +130,6 @@ namespace dd4hep {
   void Converter<DDLConstant>::operator()(xml_h element) const;
   template <>
   void Converter<DDRegistry>::operator()(xml_h element) const;
-
-  /// Converter for <VisSection/> tags
-  template <>
-  void Converter<vissection>::operator()(xml_h element) const;
-  /// Convert compact visualization attributes
-  template <>
-  void Converter<vis>::operator()(xml_h element) const;
 
   /// Converter for <MaterialSection/> tags
   template <>
@@ -279,13 +270,6 @@ void Converter<ConstantsSection>::operator()(xml_h element) const {
   xml_coll_t(element, DD_CMU(Vector)).for_each(Converter<DDLVector>(description, context, optional));
 }
 
-/// Converter for <VisSection/> tags
-template <>
-void Converter<vissection>::operator()(xml_h element) const {
-  cms::DDNamespace ns(_param<cms::DDParsingContext>(), element);
-  xml_coll_t(element, DD_CMU(vis)).for_each(Converter<vis>(description, ns.context(), optional));
-}
-
 /// Converter for <MaterialSection/> tags
 template <>
 void Converter<MaterialSection>::operator()(xml_h element) const {
@@ -347,7 +331,6 @@ template <>
 void Converter<SolidSection>::operator()(xml_h element) const {
   cms::DDNamespace ns(_param<cms::DDParsingContext>(), element);
   for (xml_coll_t solid(element, _U(star)); solid; ++solid) {
-    string tag = solid.tag();
     using cms::hash;
     switch (hash(solid.tag())) {
       case hash("Box"):
@@ -411,7 +394,7 @@ void Converter<SolidSection>::operator()(xml_h element) const {
         Converter<DDLShapeless>(description, ns.context(), optional)(solid);
         break;
       default:
-        throw std::runtime_error("Request to process unknown shape '" + xml_dim_t(solid).nameStr() + "' [" + tag + "]");
+        throw std::runtime_error("Request to process unknown shape '" + xml_dim_t(solid).nameStr() + "' [" + solid.tag() + "]");
         break;
     }
   }
@@ -466,59 +449,6 @@ void Converter<DDLConstant>::operator()(xml_h element) const {
   res->allConst[real] = val;
   res->originalConst[real] = val;
   res->unresolvedConst[real] = val;
-}
-
-/** Convert compact visualization attribute to Detector visualization attribute
- *
- *  <vis name="SiVertexBarrelModuleVis"
- *       alpha="1.0" r="1.0" g="0.75" b="0.76"
- *       drawingStyle="wireframe"
- *       showDaughters="false"
- *       visible="true"/>
- */
-template <>
-void Converter<vis>::operator()(xml_h e) const {
-  cms::DDNamespace ns(_param<cms::DDParsingContext>());
-  VisAttr attr(e.attr<string>(_U(name)));
-  float red = e.hasAttr(_U(r)) ? e.attr<float>(_U(r)) : 1.0f;
-  float green = e.hasAttr(_U(g)) ? e.attr<float>(_U(g)) : 1.0f;
-  float blue = e.hasAttr(_U(b)) ? e.attr<float>(_U(b)) : 1.0f;
-
-  printout(ns.context()->debug_visattr ? ALWAYS : DEBUG,
-           "Compact",
-           "++ Converting VisAttr  structure: %-16s. R=%.3f G=%.3f B=%.3f",
-           attr.name(),
-           red,
-           green,
-           blue);
-  attr.setColor(red, green, blue);
-  if (e.hasAttr(_U(alpha)))
-    attr.setAlpha(e.attr<float>(_U(alpha)));
-  if (e.hasAttr(_U(visible)))
-    attr.setVisible(e.attr<bool>(_U(visible)));
-  if (e.hasAttr(_U(lineStyle))) {
-    string ls = e.attr<string>(_U(lineStyle));
-    if (ls == "unbroken")
-      attr.setLineStyle(VisAttr::SOLID);
-    else if (ls == "broken")
-      attr.setLineStyle(VisAttr::DASHED);
-  } else {
-    attr.setLineStyle(VisAttr::SOLID);
-  }
-  if (e.hasAttr(_U(drawingStyle))) {
-    string ds = e.attr<string>(_U(drawingStyle));
-    if (ds == "wireframe")
-      attr.setDrawingStyle(VisAttr::WIREFRAME);
-    else if (ds == "solid")
-      attr.setDrawingStyle(VisAttr::SOLID);
-  } else {
-    attr.setDrawingStyle(VisAttr::SOLID);
-  }
-  if (e.hasAttr(_U(showDaughters)))
-    attr.setShowDaughters(e.attr<bool>(_U(showDaughters)));
-  else
-    attr.setShowDaughters(true);
-  description.addVisAttribute(attr);
 }
 
 /// Converter for <DDLElementaryMaterial/> tags
@@ -577,7 +507,7 @@ void Converter<DDLElementaryMaterial>::operator()(xml_h element) const {
                "+++ Compared to XML values: Atomic weight %g, Atomic number %u",
                atomicWeight,
                atomicNumber);
-      static const double weightTolerance = 1.0e-6;
+      static constexpr double const& weightTolerance = 1.0e-6;
       if (atomicNumber != elt->Z() ||
           (std::abs(atomicWeight - elt->A()) > (weightTolerance * (atomicWeight + elt->A()))))
         newMatDef = true;
@@ -981,7 +911,7 @@ void Converter<Parameter>::operator()(xml_h element) const {
 
   size_t idx = value.find('[');
   if (idx == string::npos || type == "string") {
-    registry.specpars[specParName].spars[name].emplace_back(value);
+    registry.specpars[specParName].spars[name].emplace_back(std::move(value));
     return;
   }
 
@@ -1657,17 +1587,14 @@ void Converter<DDLAlgorithm>::operator()(xml_h element) const {
   }
 
   size_t idx;
-  SensitiveDetector sd;
   string type = "DDCMS_" + ns.realName(name);
   while ((idx = type.find(NAMESPACE_SEP)) != string::npos)
     type[idx] = '_';
 
-  // SensitiveDetector and Segmentation currently are undefined. Let's keep it like this
-  // until we found something better.....
   printout(
       ns.context()->debug_algorithms ? ALWAYS : DEBUG, "DD4CMS", "+++ Start executing algorithm %s....", type.c_str());
 
-  long ret = PluginService::Create<long>(type, &description, ns.context(), &element, &sd);
+  long ret = PluginService::Create<long>(type, &description, ns.context(), &element);
   if (ret == s_executed) {
     printout(ns.context()->debug_algorithms ? ALWAYS : DEBUG,
              "DD4CMS",
@@ -1707,8 +1634,8 @@ namespace {
     return output;
   }
 
-  tbb::concurrent_vector<double> splitNumeric(const string& str, const string& delims = ",") {
-    tbb::concurrent_vector<double> output;
+  std::vector<double> splitNumeric(const string& str, const string& delims = ",") {
+    std::vector<double> output;
 
     for_each_token(cbegin(str), cend(str), cbegin(delims), cend(delims), [&output](auto first, auto second) {
       if (first != second) {
@@ -1745,8 +1672,8 @@ void Converter<DDLVector>::operator()(xml_h element) const {
            nEntries.c_str(),
            val.c_str());
   try {
-    tbb::concurrent_vector<double> results = splitNumeric(val);
-    registry->insert({name, results});
+    std::vector<double> results = splitNumeric(val);
+    registry->insert({name, tbb::concurrent_vector(results.begin(), results.end()) });
   } catch (const exception& e) {
     printout(INFO,
              "DD4CMS",
@@ -1830,7 +1757,7 @@ void Converter<DDRegistry>::operator()(xml_h /* element */) const {
                  n.c_str(),
                  res->originalConst[n].c_str());
         ns.addConstantNS(n, v, "number");
-        res->unresolvedConst.unsafe_erase(n);
+        res->unresolvedConst.erase(n);
         break;
       }
     }
@@ -1888,7 +1815,6 @@ static long load_dddefinition(Detector& det, xml_h element) {
       print_doc((doc = dddef.document()).root());
       xml_coll_t(dddef, DD_CMU(DisabledAlgo)).for_each(Converter<disabled_algo>(det, &context, &res));
       xml_coll_t(dddef, DD_CMU(ConstantsSection)).for_each(Converter<ConstantsSection>(det, &context, &res));
-      xml_coll_t(dddef, DD_CMU(VisSection)).for_each(Converter<vissection>(det, &context));
       xml_coll_t(dddef, DD_CMU(RotationSection)).for_each(Converter<RotationSection>(det, &context));
       xml_coll_t(dddef, DD_CMU(MaterialSection)).for_each(Converter<MaterialSection>(det, &context));
 
@@ -1910,12 +1836,11 @@ static long load_dddefinition(Detector& det, xml_h element) {
 
         while (!context.unresolvedVectors.empty()) {
           for (auto it = context.unresolvedVectors.begin(); it != context.unresolvedVectors.end();) {
-            auto const& name = it->first;
-            tbb::concurrent_vector<double> result;
+	    std::vector<double> result;
             for (const auto& i : it->second) {
               result.emplace_back(dd4hep::_toDouble(i));
             }
-            registry->insert({name, result});
+            registry->insert({it->first, tbb::concurrent_vector(begin(result), end(result))});
             // All components are resolved
             it = context.unresolvedVectors.erase(it);
           }

--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDLinear.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDLinear.cc
@@ -12,7 +12,7 @@ using namespace cms_units::operators;
 
 using DD3Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestSpecPars.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestSpecPars.cc
@@ -32,15 +32,18 @@ void DDTestSpecPars::analyze(const Event&, const EventSetup& iEventSetup) {
   LogVerbatim("Geometry").log([&registry](auto& log) {
     log << "DD SpecPar Registry size: " << registry->specpars.size();
     for (const auto& i : registry->specpars) {
-      log << " " << i.first << " => ";
+      log << " " << i.first << " == " << std::string({i.second.name.data(), i.second.name.size()}) << " =>";
+      log << "\npaths:\n";
       for (const auto& k : i.second.paths)
         log << k << ", ";
+      log << "\nstring parameters:\n";
       for (const auto& l : i.second.spars) {
-        log << l.first << " => ";
+        log << l.first << " == " << i.second.strValue(l.first) << " = ";
         for (const auto& il : l.second) {
           log << il << ", ";
         }
       }
+      log << "\nnumeric parameters\n";
       for (const auto& m : i.second.numpars) {
         log << m.first << " => ";
         for (const auto& im : m.second) {

--- a/DetectorDescription/DDCMS/plugins/test/DDTestVectorAlgo.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestVectorAlgo.cc
@@ -6,7 +6,7 @@ using namespace std;
 using namespace dd4hep;
 using namespace cms;
 
-static long algorithm(Detector&, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector&) {
+static long algorithm(Detector&, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   vector<string> materials = args.vecStr("MaterialNames");

--- a/DetectorDescription/DDCMS/src/DDCompactView.cc
+++ b/DetectorDescription/DDCMS/src/DDCompactView.cc
@@ -11,8 +11,8 @@ std::vector<int> cms::DDCompactView::getVector<int>(const std::string& key) cons
   const auto& vmap = this->detector()->vectors();
   for (auto const& it : vmap) {
     if (dd4hep::dd::noNamespace(it.first) == key) {
-      std::transform(it.second.begin(), it.second.end(), std::back_inserter(result),
-		     [](int n) -> int { return (int)n; });
+      std::transform(
+          it.second.begin(), it.second.end(), std::back_inserter(result), [](int n) -> int { return (int)n; });
       return result;
     }
   }
@@ -38,17 +38,18 @@ std::vector<double> const& cms::DDCompactView::get<std::vector<double>>(const st
       return it.second;
     }
   }
-  throw cms::Exception("DDError") << "no vector<double> with name " << key; 
+  throw cms::Exception("DDError") << "no vector<double> with name " << key;
 }
 
 template <>
-tbb::concurrent_vector<double> const& cms::DDCompactView::get<tbb::concurrent_vector<double>>(const std::string& name, const std::string& key) const {
+tbb::concurrent_vector<double> const& cms::DDCompactView::get<tbb::concurrent_vector<double>>(
+    const std::string& name, const std::string& key) const {
   const auto& spec = specpars().specPar(name);
-  if(spec != nullptr) {
+  if (spec != nullptr) {
     auto const& nitem = spec->numpars.find(key);
     if (nitem != end(spec->numpars)) {
       return nitem->second;
     }
   }
-  throw cms::Exception("DDError") << "no SpecPar with name " << name << " and vector<double> key " << key; 
+  throw cms::Exception("DDError") << "no SpecPar with name " << name << " and vector<double> key " << key;
 }

--- a/DetectorDescription/DDCMS/src/DDCompactView.cc
+++ b/DetectorDescription/DDCMS/src/DDCompactView.cc
@@ -1,18 +1,19 @@
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include <DD4hep/Filter.h>
 
 #include <cmath>
+#include "tbb/concurrent_vector.h"
 
 template <>
 std::vector<int> cms::DDCompactView::getVector<int>(const std::string& key) const {
-  const dd4hep::VectorsMap& vmap = this->detector()->vectors();
   std::vector<int> result;
+  const auto& vmap = this->detector()->vectors();
   for (auto const& it : vmap) {
     if (dd4hep::dd::noNamespace(it.first) == key) {
-      for (const auto& i : it.second) {
-        result.emplace_back(std::round(i));
-      }
-      break;
+      std::transform(it.second.begin(), it.second.end(), std::back_inserter(result),
+		     [](int n) -> int { return (int)n; });
+      return result;
     }
   }
   return result;
@@ -20,16 +21,34 @@ std::vector<int> cms::DDCompactView::getVector<int>(const std::string& key) cons
 
 template <>
 std::vector<double> cms::DDCompactView::getVector<double>(const std::string& key) const {
-  const dd4hep::VectorsMap& vmap = this->detector()->vectors();
-  std::vector<double> result;
-
+  const auto& vmap = this->detector()->vectors();
   for (auto const& it : vmap) {
     if (dd4hep::dd::noNamespace(it.first) == key) {
-      for (const auto& i : it.second) {
-        result.emplace_back(i);
-      }
-      break;
+      return it.second;
     }
   }
-  return result;
+  return std::vector<double>();
+}
+
+template <>
+std::vector<double> const& cms::DDCompactView::get<std::vector<double>>(const std::string& key) const {
+  const auto& vmap = this->detector()->vectors();
+  for (auto const& it : vmap) {
+    if (dd4hep::dd::noNamespace(it.first) == key) {
+      return it.second;
+    }
+  }
+  throw cms::Exception("DDError") << "no vector<double> with name " << key; 
+}
+
+template <>
+tbb::concurrent_vector<double> const& cms::DDCompactView::get<tbb::concurrent_vector<double>>(const std::string& name, const std::string& key) const {
+  const auto& spec = specpars().specPar(name);
+  if(spec != nullptr) {
+    auto const& nitem = spec->numpars.find(key);
+    if (nitem != end(spec->numpars)) {
+      return nitem->second;
+    }
+  }
+  throw cms::Exception("DDError") << "no SpecPar with name " << name << " and vector<double> key " << key; 
 }

--- a/DetectorDescription/DDCMS/src/DDDetector.cc
+++ b/DetectorDescription/DDCMS/src/DDDetector.cc
@@ -12,7 +12,7 @@ namespace cms {
 
   DDDetector::DDDetector(const std::string& tag, const std::string& fileName, bool bigXML) : m_tag(tag) {
     m_description = &dd4hep::Detector::getInstance(tag);
-    m_description->addExtension<dd4hep::VectorsMap>(&m_vectors);
+    m_description->addExtension<cms::DDVectorsMap>(&m_vectors);
     m_description->addExtension<dd4hep::PartSelectionMap>(&m_partsels);
     m_description->addExtension<dd4hep::SpecParRegistry>(&m_specpars);
     if (bigXML)

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -176,7 +176,7 @@ void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
       });
       if (filter == end(filters_)) {
         filters_.emplace_back(unique_ptr<Filter>(
-	     new Filter{{front(j)},
+            new Filter{{front(j)},
                        {std::regex(std::string("^").append({front(j).data(), front(j).size()}).append("$"))},
                        nullptr,
                        nullptr,
@@ -422,7 +422,7 @@ bool DDFilteredView::parent() {
 
 bool DDFilteredView::next(int type) {
   currentSpecPar_ = nullptr;
-  
+
   if (it_.empty())
     return false;
   it_.back().SetType(type);
@@ -436,7 +436,7 @@ bool DDFilteredView::next(int type) {
 
 void DDFilteredView::down() {
   currentSpecPar_ = nullptr;
-  
+
   if (it_.empty() or currentFilter_ == nullptr)
     return;
   it_.emplace_back(Iterator(it_.back()));
@@ -447,7 +447,7 @@ void DDFilteredView::down() {
 
 void DDFilteredView::up() {
   currentSpecPar_ = nullptr;
-  
+
   if (it_.size() > 1 and currentFilter_ != nullptr) {
     it_.pop_back();
     it_.back().SetType(0);
@@ -506,12 +506,12 @@ std::string_view DDFilteredView::get<string_view>(const string& key) {
 template <>
 double DDFilteredView::get<double>(const string& key) {
   double result(0.0);
-  
+
   currentSpecPar_ = find(key);
   if (currentSpecPar_ != nullptr) {
-    result = getNextValue(key); 
+    result = getNextValue(key);
   }
-  
+
   return result;
 }
 
@@ -577,7 +577,7 @@ const int DDFilteredView::level() const {
 bool DDFilteredView::goTo(const nav_type& newpos) {
   bool result(false);
   currentSpecPar_ = nullptr;
- 
+
   // save the current position
   it_.emplace_back(Iterator(it_.back().GetTopVolume()));
   Node* node = nullptr;
@@ -623,9 +623,9 @@ const ExpandedNodes& DDFilteredView::history() {
   for (int nit = level; nit > 0; --nit) {
     for (auto const& i : registry_->specpars) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
-	  return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), front(j))) and
-	  (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset"));
-	});
+        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), front(j))) and
+               (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset"));
+      });
       if (k != end(i.second.paths)) {
         nodes_.tags.emplace_back(i.second.dblValue("CopyNoTag"));
         nodes_.offsets.emplace_back(i.second.dblValue("CopyNoOffset"));
@@ -638,7 +638,6 @@ const ExpandedNodes& DDFilteredView::history() {
 }
 
 const DDSpecPar* DDFilteredView::find(const std::string& key) const {
-  
   DDSpecParRefs refs;
   filter(refs, key);
 
@@ -701,7 +700,6 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
   return nullptr;
 }
 
-
 void DDFilteredView::filter(DDSpecParRefs& refs, const std::string& key) const {
   for (auto const& it : registry_->specpars) {
     if (it.second.hasValue(key) || (it.second.spars.find(key) != end(it.second.spars))) {
@@ -719,11 +717,11 @@ const std::string_view DDFilteredView::front(const std::string_view path) const 
     }
     return path.substr(lpos, rpos);
   }
-  
+
   // throw cms::Exception("Filtered View") << "Path must start with '//'  " << path;
   return path;
 }
-  
+
 double DDFilteredView::getNextValue(const std::string& key) const {
   double result(0.0);
 
@@ -734,7 +732,7 @@ double DDFilteredView::getNextValue(const std::string& key) const {
     } else if (currentSpecPar_->hasValue(key)) {
       auto const& nitem = currentSpecPar_->numpars.find(key);
       if (nitem != end(currentSpecPar_->numpars)) {
-	result = nitem->second[0];
+        result = nitem->second[0];
       }
     }
   }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -723,6 +723,15 @@ const std::string_view DDFilteredView::front(const std::string_view path) const 
   return path;
 }
 
+const std::string_view DDFilteredView::back(const std::string_view path) const {
+  if (auto const& lpos = path.rfind('/') != path.npos) {
+    return path.substr(lpos, path.size());
+  }
+
+  // throw cms::Exception("Filtered View") << "Path must start with '//'  " << path;
+  return path;
+}
+
 double DDFilteredView::getNextValue(const std::string& key) const {
   double result(0.0);
 

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -166,8 +166,9 @@ void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
   }
   for (const auto& i : specs) {
     for (const auto& j : i->paths) {
+      auto const& firstTok = front(j);
       auto const& filter = find_if(begin(filters_), end(filters_), [&](auto const& f) {
-        auto const& k = find_if(begin(f->skeys), end(f->skeys), [&](auto const& p) { return front(j) == p; });
+        auto const& k = find_if(begin(f->skeys), end(f->skeys), [&](auto const& p) { return firstTok == p; });
         if (k != end(f->skeys)) {
           currentFilter_ = f.get();
           return true;
@@ -176,8 +177,8 @@ void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
       });
       if (filter == end(filters_)) {
         filters_.emplace_back(unique_ptr<Filter>(
-            new Filter{{front(j)},
-                       {std::regex(std::string("^").append({front(j).data(), front(j).size()}).append("$"))},
+            new Filter{{firstTok},
+                       {std::regex(std::string("^").append({firstTok.data(), firstTok.size()}).append("$"))},
                        nullptr,
                        nullptr,
                        i}));
@@ -715,7 +716,7 @@ const std::string_view DDFilteredView::front(const std::string_view path) const 
     if (rpos == path.npos) {
       rpos = path.size();
     }
-    return path.substr(lpos, rpos);
+    return path.substr(lpos, rpos - lpos);
   }
 
   // throw cms::Exception("Filtered View") << "Path must start with '//'  " << path;

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -643,6 +643,7 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
   filter(refs, key);
 
   int level = it_.back().GetLevel();
+
   for (auto const& i : refs) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
       auto topos = j.size();
@@ -650,6 +651,7 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
       bool flag = false;
       for (int nit = level; frompos - 1 <= topos and nit > 0; --nit) {
         std::string_view name = it_.back().GetNode(nit)->GetVolume()->GetName();
+        const int copyNum = it_.back().GetNode(nit)->GetNumber();
         std::string_view refname{&j[frompos + 1], topos - frompos - 1};
         topos = frompos;
         frompos = j.substr(0, topos).rfind('/');
@@ -664,10 +666,9 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
         }
         auto cpos = refname.rfind('[');
         if (cpos != refname.npos) {
-          if (std::stoi(std::string(refname.substr(cpos + 1, refname.rfind(']')))) == copyNum()) {
+          if (std::stoi(std::string(refname.substr(cpos + 1, refname.rfind(']')))) == copyNum) {
             refname.remove_suffix(refname.size() - cpos);
             flag = true;
-            continue;
           } else {
             flag = false;
             break;
@@ -679,7 +680,6 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
             break;
           } else {
             flag = true;
-            continue;
           }
         } else {
           if (!regex_match(std::string(name.data(), name.size()), regex(std::string(refname)))) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -709,7 +709,7 @@ void DDFilteredView::filter(DDSpecParRefs& refs, const std::string& key) const {
   }
 }
 
-const std::string_view DDFilteredView::front(const std::string_view path) const {
+std::string_view DDFilteredView::front(const std::string_view path) const {
   auto const& lpos = path.find_first_not_of('/');
   if (lpos != path.npos) {
     auto rpos = path.find_first_of('/', lpos);
@@ -723,7 +723,7 @@ const std::string_view DDFilteredView::front(const std::string_view path) const 
   return path;
 }
 
-const std::string_view DDFilteredView::back(const std::string_view path) const {
+std::string_view DDFilteredView::back(const std::string_view path) const {
   if (auto const& lpos = path.rfind('/') != path.npos) {
     return path.substr(lpos, path.size());
   }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -158,15 +158,16 @@ void DDFilteredView::rot(dd4hep::Rotation3D& matrixOut) const {
 }
 
 void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
+  currentSpecPar_ = nullptr;
+
   if (!filters_.empty()) {
     filters_.clear();
     filters_.shrink_to_fit();
   }
   for (const auto& i : specs) {
     for (const auto& j : i->paths) {
-      vector<string_view> toks = split(j, "/");
       auto const& filter = find_if(begin(filters_), end(filters_), [&](auto const& f) {
-        auto const& k = find_if(begin(f->skeys), end(f->skeys), [&](auto const& p) { return toks.front() == p; });
+        auto const& k = find_if(begin(f->skeys), end(f->skeys), [&](auto const& p) { return front(j) == p; });
         if (k != end(f->skeys)) {
           currentFilter_ = f.get();
           return true;
@@ -175,8 +176,8 @@ void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
       });
       if (filter == end(filters_)) {
         filters_.emplace_back(unique_ptr<Filter>(
-            new Filter{{toks.front()},
-                       {std::regex(std::string("^").append({toks.front().data(), toks.front().size()}).append("$"))},
+	     new Filter{{front(j)},
+                       {std::regex(std::string("^").append({front(j).data(), front(j).size()}).append("$"))},
                        nullptr,
                        nullptr,
                        i}));
@@ -186,6 +187,7 @@ void DDFilteredView::mergedSpecifics(DDSpecParRefs const& specs) {
         }
       }
       // all next levels
+      vector<string_view> toks = split(j, "/");
       for (size_t pos = 1; pos < toks.size(); ++pos) {
         if (currentFilter_->next != nullptr) {
           currentFilter_ = currentFilter_->next.get();
@@ -217,6 +219,8 @@ void DDFilteredView::printFilter() const {
 }
 
 bool DDFilteredView::firstChild() {
+  currentSpecPar_ = nullptr;
+
   if (it_.empty()) {
     LogVerbatim("DDFilteredView") << "Iterator vector has zero size.";
     return false;
@@ -291,6 +295,8 @@ bool DDFilteredView::match(const std::string& path, const std::vector<std::pair<
 }
 
 std::vector<std::vector<Node*>> DDFilteredView::children(const std::string& selectPath) {
+  currentSpecPar_ = nullptr;
+
   std::vector<std::vector<Node*>> paths;
   if (it_.empty()) {
     LogVerbatim("DDFilteredView") << "Iterator vector has zero size.";
@@ -325,6 +331,8 @@ std::vector<std::vector<Node*>> DDFilteredView::children(const std::string& sele
 }
 
 bool DDFilteredView::firstSibling() {
+  currentSpecPar_ = nullptr;
+
   assert(node_);
   if (it_.empty() or currentFilter_ == nullptr)
     return false;
@@ -349,6 +357,8 @@ bool DDFilteredView::firstSibling() {
 }
 
 bool DDFilteredView::nextSibling() {
+  currentSpecPar_ = nullptr;
+
   assert(node_);
   if (it_.empty() or currentFilter_ == nullptr)
     return false;
@@ -370,6 +380,8 @@ bool DDFilteredView::nextSibling() {
 }
 
 bool DDFilteredView::sibling() {
+  currentSpecPar_ = nullptr;
+
   if (it_.empty() or currentFilter_ == nullptr)
     return false;
   it_.back().SetType(1);
@@ -384,6 +396,8 @@ bool DDFilteredView::sibling() {
 }
 
 bool DDFilteredView::checkChild() {
+  currentSpecPar_ = nullptr;
+
   if (it_.empty() or currentFilter_ == nullptr)
     return false;
   it_.back().SetType(1);
@@ -397,6 +411,7 @@ bool DDFilteredView::checkChild() {
 }
 
 bool DDFilteredView::parent() {
+  currentSpecPar_ = nullptr;
   if (it_.empty() or currentFilter_ == nullptr)
     return false;
   up();
@@ -406,6 +421,8 @@ bool DDFilteredView::parent() {
 }
 
 bool DDFilteredView::next(int type) {
+  currentSpecPar_ = nullptr;
+  
   if (it_.empty())
     return false;
   it_.back().SetType(type);
@@ -418,6 +435,8 @@ bool DDFilteredView::next(int type) {
 }
 
 void DDFilteredView::down() {
+  currentSpecPar_ = nullptr;
+  
   if (it_.empty() or currentFilter_ == nullptr)
     return;
   it_.emplace_back(Iterator(it_.back()));
@@ -427,6 +446,8 @@ void DDFilteredView::down() {
 }
 
 void DDFilteredView::up() {
+  currentSpecPar_ = nullptr;
+  
   if (it_.size() > 1 and currentFilter_ != nullptr) {
     it_.pop_back();
     it_.back().SetType(0);
@@ -485,9 +506,12 @@ std::string_view DDFilteredView::get<string_view>(const string& key) {
 template <>
 double DDFilteredView::get<double>(const string& key) {
   double result(0.0);
-  std::string_view tmpStrV = get<std::string_view>(key);
-  if (!tmpStrV.empty())
-    result = dd4hep::_toDouble({tmpStrV.data(), tmpStrV.size()});
+  
+  currentSpecPar_ = find(key);
+  if (currentSpecPar_ != nullptr) {
+    result = getNextValue(key); 
+  }
+  
   return result;
 }
 
@@ -552,7 +576,8 @@ const int DDFilteredView::level() const {
 
 bool DDFilteredView::goTo(const nav_type& newpos) {
   bool result(false);
-
+  currentSpecPar_ = nullptr;
+ 
   // save the current position
   it_.emplace_back(Iterator(it_.back().GetTopVolume()));
   Node* node = nullptr;
@@ -593,30 +618,30 @@ const ExpandedNodes& DDFilteredView::history() {
   nodes_.tags.clear();
   nodes_.offsets.clear();
   nodes_.copyNos.clear();
-  bool result(false);
 
   int level = it_.back().GetLevel();
   for (int nit = level; nit > 0; --nit) {
-    for_each(begin(registry_->specpars), end(registry_->specpars), [&](auto const& i) {
+    for (auto const& i : registry_->specpars) {
       auto k = find_if(begin(i.second.paths), end(i.second.paths), [&](auto const& j) {
-        return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), *begin(split(j, "/"))) and
-                (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset")));
-      });
+	  return (isMatch(noNamespace(it_.back().GetNode(nit)->GetVolume()->GetName()), front(j))) and
+	  (i.second.hasValue("CopyNoTag") or i.second.hasValue("CopyNoOffset"));
+	});
       if (k != end(i.second.paths)) {
         nodes_.tags.emplace_back(i.second.dblValue("CopyNoTag"));
         nodes_.offsets.emplace_back(i.second.dblValue("CopyNoOffset"));
         nodes_.copyNos.emplace_back(it_.back().GetNode(nit)->GetNumber());
-        result = true;
       }
-    });
+    }
   }
 
   return nodes_;
 }
 
 const DDSpecPar* DDFilteredView::find(const std::string& key) const {
+  
   DDSpecParRefs refs;
-  registry_->filter(refs, key, "");
+  filter(refs, key);
+
   int level = it_.back().GetLevel();
   for (auto const& i : refs) {
     auto k = find_if(begin(i->paths), end(i->paths), [&](auto const& j) {
@@ -676,15 +701,42 @@ const DDSpecPar* DDFilteredView::find(const std::string& key) const {
   return nullptr;
 }
 
+
+void DDFilteredView::filter(DDSpecParRefs& refs, const std::string& key) const {
+  for (auto const& it : registry_->specpars) {
+    if (it.second.hasValue(key) || (it.second.spars.find(key) != end(it.second.spars))) {
+      refs.emplace_back(&it.second);
+    }
+  }
+}
+
+const std::string_view DDFilteredView::front(const std::string_view path) const {
+  auto const& lpos = path.find_first_not_of('/');
+  if (lpos != path.npos) {
+    auto rpos = path.find_first_of('/', lpos);
+    if (rpos == path.npos) {
+      rpos = path.size();
+    }
+    return path.substr(lpos, rpos);
+  }
+  
+  // throw cms::Exception("Filtered View") << "Path must start with '//'  " << path;
+  return path;
+}
+  
 double DDFilteredView::getNextValue(const std::string& key) const {
   double result(0.0);
-  std::string_view tmpresult;
 
   if (currentSpecPar_ != nullptr) {
-    tmpresult = currentSpecPar_->strValue(key);
-  }
-  if (!tmpresult.empty()) {
-    result = dd4hep::_toDouble({tmpresult.data(), tmpresult.size()});
+    std::string_view svalue = currentSpecPar_->strValue(key);
+    if (!svalue.empty()) {
+      result = dd4hep::_toDouble({svalue.data(), svalue.size()});
+    } else if (currentSpecPar_->hasValue(key)) {
+      auto const& nitem = currentSpecPar_->numpars.find(key);
+      if (nitem != end(currentSpecPar_->numpars)) {
+	result = nitem->second[0];
+      }
+    }
   }
 
   return result;

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -9,6 +9,11 @@
   <use name="dd4hep"/>
 </bin>
 
+<bin name="testDD4hepFilteredViewGet" file="DDFilteredView.get.cppunit.cc,testRunner.cpp">
+  <use name="DetectorDescription/DDCMS"/>
+  <use name="dd4hep"/>
+</bin>
+
 <bin name="testDD4hepFilteredViewGoTo" file="DDFilteredView.goto.cppunit.cc,testRunner.cpp">
   <use name="DetectorDescription/DDCMS"/>
   <use name="dd4hep"/>

--- a/DetectorDescription/DDCMS/test/BuildFile.xml
+++ b/DetectorDescription/DDCMS/test/BuildFile.xml
@@ -14,6 +14,11 @@
   <use name="dd4hep"/>
 </bin>
 
+<bin name="testDD4hepFilteredViewFind" file="DDFilteredView.find.cppunit.cc,testRunner.cpp">
+  <use name="DetectorDescription/DDCMS"/>
+  <use name="dd4hep"/>
+</bin>
+
 <bin name="testDD4hepCompactView" file="DDCompactView.cppunit.cc,testRunner.cpp">
   <use name="DetectorDescription/DDCMS"/>
   <use name="dd4hep"/>

--- a/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
@@ -1,0 +1,185 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "DD4hep/Detector.h"
+
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+using namespace cms;
+
+class testDDFilteredViewFind : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testDDFilteredViewFind);
+  CPPUNIT_TEST(checkFilteredView);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override;
+  void tearDown() override {}
+  void checkFilteredView();
+
+private:
+  void printMe(const cms::DDFilteredView&);
+  double refRadLength_ = 0.03142;
+  double refXi_ = 6.24526e-05;
+  int refCopyNoTag_ = 1000;
+  int refCopyNoOffset_ = 100;
+  int refCopyNo_ = 1;
+  std::string fileName_;
+  std::vector<int> refPos_{0, 0, 6, 2, 2};
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilteredViewFind);
+
+void testDDFilteredViewFind::setUp() {
+  fileName_ = edm::FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml").fullPath();
+}
+
+void testDDFilteredViewFind::checkFilteredView() {
+  std::unique_ptr<DDDetector> det = std::make_unique<DDDetector>("DUMMY", fileName_);
+  DDFilteredView fview(det.get(), det->description()->worldVolume());
+
+  int count = 1;
+  auto testPos = fview.navPos();
+  while (fview.next(0)) {
+    std::cout << "#" << count << ": ";
+    printMe(fview);
+
+    if (count == 45) {
+      testPos = fview.navPos();
+    }
+    if (count == 50) {
+      break;
+    }
+    count++;
+  }
+
+  // world_volume/OCMS_1/CMSE_1/Tracker_1/PixelBarrel_1/pixbarlayer0:PixelBarrelLayer0_1/PixelBarrelLadderFull0_6/PixelBarrelModuleBoxFull_1/PixelBarrelModuleFullPlus_4/PixelBarrelSensorFull_1/PixelBarrelActiveFull0_1
+  //
+  std::vector<int> activeVol{0, 0, 6, 2, 93, 12, 1, 7, 1, 0};
+  fview.goTo(activeVol);
+  printMe(fview);
+  fview.findSpecPar("TrackerRadLength", "TrackerXi");
+  
+  double radLength = fview.getNextValue("TrackerRadLength");
+  double xi = fview.getNextValue("TrackerXi");
+  CPPUNIT_ASSERT(radLength == refRadLength_);
+  CPPUNIT_ASSERT(xi == refXi_);
+
+  std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
+
+  std::cout << "\n==== Let's go to #45\n";
+  fview.goTo(testPos);
+  printMe(fview);
+
+  int i = 0;
+  for (auto it : fview.navPos()) {
+    CPPUNIT_ASSERT(it == testPos[i++]);
+  }
+  i = 0;
+  for (auto it : testPos) {
+    CPPUNIT_ASSERT(it == refPos_[i++]);
+  }
+
+  // Start with Muon
+  std::cout << "\n==== Let's go to Muon\n";
+  fview.goTo({0, 0, 8});
+  printMe(fview);
+
+  CPPUNIT_ASSERT(fview.name() == "MUON");
+
+  // Go to the first daughter
+  fview.next(0);
+  printMe(fview);
+
+  // Use it as an escape level
+  int startLevel = fview.level();
+
+  count = 1;
+
+  do {
+    std::cout << "#" << count++ << ": ";
+    std::cout << "started at level " << startLevel << "\n";
+    printMe(fview);
+
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  std::cout << "\n==== Continue iteration\n";
+
+  count = 1;
+  fview.next(0);
+  startLevel = fview.level();
+  printMe(fview);
+
+  do {
+    std::cout << "#" << count++;
+    std::cout << " started at level " << startLevel << ":\n";
+    printMe(fview);
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  fview.next(0);
+  printMe(fview);
+
+  std::cout << "\n==== Let's do it again, go to Muon\n";
+  fview.goTo({0, 0, 8});
+  printMe(fview);
+  CPPUNIT_ASSERT(fview.name() == "MUON");
+
+  // Go to the first daughter
+  fview.next(0);
+  printMe(fview);
+
+  // Use it as an escape level
+  startLevel = fview.level();
+
+  count = 1;
+
+  do {
+    std::cout << "#" << count++ << ": ";
+    std::cout << "started at level " << startLevel << "\n";
+    printMe(fview);
+
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  fview.goTo({0, 0, 8, 0});
+  printMe(fview);
+  fview.findSpecPar("CopyNoTag", "CopyNoOffset");
+
+  auto tag = fview.getNextValue("CopyNoTag");
+  auto offset = fview.getNextValue("CopyNoOffset");
+  std::cout << "CopyNoTag = " << tag << "\n";
+  std::cout << "CopyNoOffset = " << fview.getNextValue("CopyNoOffset") << "\n";
+  CPPUNIT_ASSERT(refCopyNoTag_ == tag);
+  CPPUNIT_ASSERT(refCopyNoOffset_ == offset);
+  
+  const auto& nodes = fview.history();
+  int ctr(0);
+  for(const auto& t : nodes.tags) {
+    std::cout << t << ": " << nodes.offsets[ctr] << ", " << nodes.copyNos[ctr] << "\n";
+    CPPUNIT_ASSERT(refCopyNoTag_ == t);
+    CPPUNIT_ASSERT(refCopyNoOffset_ == nodes.offsets[ctr]);
+    CPPUNIT_ASSERT(refCopyNo_ == nodes.copyNos[ctr]);
+    ctr++;
+  }
+}
+
+void testDDFilteredViewFind::printMe(const cms::DDFilteredView& fview) {
+  std::cout << ">>> " << fview.level() << " level: " << fview.name() << " is a "
+            << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
+  std::cout << "Full path to it is " << fview.path() << "\n";
+
+  auto copies = fview.copyNos();
+  std::cout << "    copy Nos: ";
+  std::for_each(copies.rbegin(), copies.rend(), [](const auto& it) { std::cout << it << ", "; });
+  std::cout << "\n    levels  : ";
+  for (auto it : fview.navPos()) {
+    std::cout << it << ", ";
+  }
+  std::cout << "\n";
+}

--- a/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
@@ -66,7 +66,7 @@ void testDDFilteredViewFind::checkFilteredView() {
   fview.goTo(activeVol);
   printMe(fview);
   fview.findSpecPar("TrackerRadLength", "TrackerXi");
-  
+
   double radLength = fview.getNextValue("TrackerRadLength");
   double xi = fview.getNextValue("TrackerXi");
   CPPUNIT_ASSERT(radLength == refRadLength_);
@@ -157,10 +157,10 @@ void testDDFilteredViewFind::checkFilteredView() {
   std::cout << "CopyNoOffset = " << fview.getNextValue("CopyNoOffset") << "\n";
   CPPUNIT_ASSERT(refCopyNoTag_ == tag);
   CPPUNIT_ASSERT(refCopyNoOffset_ == offset);
-  
+
   const auto& nodes = fview.history();
   int ctr(0);
-  for(const auto& t : nodes.tags) {
+  for (const auto& t : nodes.tags) {
     std::cout << t << ": " << nodes.offsets[ctr] << ", " << nodes.copyNos[ctr] << "\n";
     CPPUNIT_ASSERT(refCopyNoTag_ == t);
     CPPUNIT_ASSERT(refCopyNoOffset_ == nodes.offsets[ctr]);

--- a/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
@@ -1,0 +1,188 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+#include "DetectorDescription/DDCMS/interface/DDDetector.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "DD4hep/Detector.h"
+
+#include <string>
+#include <memory>
+#include <vector>
+
+#include "cppunit/TestAssert.h"
+#include "cppunit/TestFixture.h"
+
+using namespace cms;
+
+class testDDFilteredViewGet : public CppUnit::TestFixture {
+  CPPUNIT_TEST_SUITE(testDDFilteredViewGet);
+  CPPUNIT_TEST(checkFilteredView);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override;
+  void tearDown() override {}
+  void checkFilteredView();
+
+private:
+  void printMe(const cms::DDFilteredView&);
+  double refRadLength_ = 0.03142;
+  double refXi_ = 6.24526e-05;
+  int refCopyNoTag_ = 1000;
+  int refCopyNoOffset_ = 100;
+  int refCopyNo_ = 1;
+  std::string fileName_;
+  std::vector<int> refPos_{0, 0, 6, 2, 2};
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(testDDFilteredViewGet);
+
+void testDDFilteredViewGet::setUp() {
+  fileName_ = edm::FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml").fullPath();
+}
+
+void testDDFilteredViewGet::checkFilteredView() {
+  std::unique_ptr<DDDetector> det = std::make_unique<DDDetector>("DUMMY", fileName_);
+  DDFilteredView fview(det.get(), det->description()->worldVolume());
+
+  int count = 1;
+  auto testPos = fview.navPos();
+  while (fview.next(0)) {
+    std::cout << "#" << count << ": ";
+    printMe(fview);
+
+    if (count == 45) {
+      testPos = fview.navPos();
+    }
+    if (count == 50) {
+      break;
+    }
+    count++;
+  }
+
+  // world_volume/OCMS_1/CMSE_1/Tracker_1/PixelBarrel_1/pixbarlayer0:PixelBarrelLayer0_1/PixelBarrelLadderFull0_6/PixelBarrelModuleBoxFull_1/PixelBarrelModuleFullPlus_4/PixelBarrelSensorFull_1/PixelBarrelActiveFull0_1
+  //
+  std::vector<int> activeVol{0, 0, 6, 2, 93, 12, 1, 7, 1, 0};
+  fview.goTo(activeVol);
+  printMe(fview);
+  fview.findSpecPar("TrackerRadLength", "TrackerXi");
+
+  double radLength = fview.getNextValue("TrackerRadLength");
+  double xi = fview.getNextValue("TrackerXi");
+  CPPUNIT_ASSERT(radLength == refRadLength_);
+  CPPUNIT_ASSERT(xi == refXi_);
+
+  std::cout << "TrackerRadLength = " << radLength << "\nTrackerXi = " << xi << "\n";
+  auto vals = fview.getValuesNS<std::string>("TrackerRadLength");
+  for (auto i : vals)
+    std::cout << "TrackerRadLength = " << i << "\n";
+
+  std::cout << "\n==== Let's go to #45\n";
+  fview.goTo(testPos);
+  printMe(fview);
+
+  int i = 0;
+  for (auto it : fview.navPos()) {
+    CPPUNIT_ASSERT(it == testPos[i++]);
+  }
+  i = 0;
+  for (auto it : testPos) {
+    CPPUNIT_ASSERT(it == refPos_[i++]);
+  }
+
+  // Start with Muon
+  std::cout << "\n==== Let's go to Muon\n";
+  fview.goTo({0, 0, 8});
+  printMe(fview);
+
+  CPPUNIT_ASSERT(fview.name() == "MUON");
+
+  // Go to the first daughter
+  fview.next(0);
+  printMe(fview);
+
+  // Use it as an escape level
+  int startLevel = fview.level();
+
+  count = 1;
+
+  do {
+    std::cout << "#" << count++ << ": ";
+    std::cout << "started at level " << startLevel << "\n";
+    printMe(fview);
+
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  std::cout << "\n==== Continue iteration\n";
+
+  count = 1;
+  fview.next(0);
+  startLevel = fview.level();
+  printMe(fview);
+
+  do {
+    std::cout << "#" << count++;
+    std::cout << " started at level " << startLevel << ":\n";
+    printMe(fview);
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  fview.next(0);
+  printMe(fview);
+
+  std::cout << "\n==== Let's do it again, go to Muon\n";
+  fview.goTo({0, 0, 8});
+  printMe(fview);
+  CPPUNIT_ASSERT(fview.name() == "MUON");
+
+  // Go to the first daughter
+  fview.next(0);
+  printMe(fview);
+
+  // Use it as an escape level
+  startLevel = fview.level();
+
+  count = 1;
+
+  do {
+    std::cout << "#" << count++ << ": ";
+    std::cout << "started at level " << startLevel << "\n";
+    printMe(fview);
+
+  } while (fview.next(0) && fview.level() < startLevel);
+
+  fview.goTo({0, 0, 8, 0});
+  printMe(fview);
+  fview.findSpecPar("CopyNoTag", "CopyNoOffset");
+
+  auto tag = fview.getNextValue("CopyNoTag");
+  auto offset = fview.getNextValue("CopyNoOffset");
+  std::cout << "CopyNoTag = " << tag << "\n";
+  std::cout << "CopyNoOffset = " << fview.getNextValue("CopyNoOffset") << "\n";
+  CPPUNIT_ASSERT(refCopyNoTag_ == tag);
+  CPPUNIT_ASSERT(refCopyNoOffset_ == offset);
+
+  const auto& nodes = fview.history();
+  int ctr(0);
+  for (const auto& t : nodes.tags) {
+    std::cout << t << ": " << nodes.offsets[ctr] << ", " << nodes.copyNos[ctr] << "\n";
+    CPPUNIT_ASSERT(refCopyNoTag_ == t);
+    CPPUNIT_ASSERT(refCopyNoOffset_ == nodes.offsets[ctr]);
+    CPPUNIT_ASSERT(refCopyNo_ == nodes.copyNos[ctr]);
+    ctr++;
+  }
+}
+
+void testDDFilteredViewGet::printMe(const cms::DDFilteredView& fview) {
+  std::cout << ">>> " << fview.level() << " level: " << fview.name() << " is a "
+            << cms::dd::name(cms::DDSolidShapeMap, fview.shape()) << "\n";
+  std::cout << "Full path to it is " << fview.path() << "\n";
+
+  auto copies = fview.copyNos();
+  std::cout << "    copy Nos: ";
+  std::for_each(copies.rbegin(), copies.rend(), [](const auto& it) { std::cout << it << ", "; });
+  std::cout << "\n    levels  : ";
+  for (auto it : fview.navPos()) {
+    std::cout << it << ", ";
+  }
+  std::cout << "\n";
+}

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
@@ -473,8 +473,8 @@ namespace {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   BenchmarkGrd counter("DDEcalBarrelNewAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
@@ -471,10 +471,7 @@ namespace {
   }
 }  // namespace
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   BenchmarkGrd counter("DDEcalBarrelNewAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalEndcapAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalEndcapAlgo.cc
@@ -93,8 +93,8 @@ namespace {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   BenchmarkGrd counter("DDEcalEndcapAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalEndcapAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalEndcapAlgo.cc
@@ -91,10 +91,7 @@ namespace {
   }
 }  // namespace
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   BenchmarkGrd counter("DDEcalEndcapAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalPreshowerAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalPreshowerAlgo.cc
@@ -79,10 +79,7 @@ namespace {
   };
 }  // namespace
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   BenchmarkGrd counter("DDEcalPreshowerAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalPreshowerAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalPreshowerAlgo.cc
@@ -81,8 +81,8 @@ namespace {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   BenchmarkGrd counter("DDEcalPreshowerAlgo");
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);

--- a/Geometry/ForwardCommonData/plugins/dd4hep/DDBHMAngular.cc
+++ b/Geometry/ForwardCommonData/plugins/dd4hep/DDBHMAngular.cc
@@ -9,8 +9,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   int units = args.value<int>("number");

--- a/Geometry/ForwardCommonData/plugins/dd4hep/DDBHMAngular.cc
+++ b/Geometry/ForwardCommonData/plugins/dd4hep/DDBHMAngular.cc
@@ -7,10 +7,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   int units = args.value<int>("number");

--- a/Geometry/ForwardCommonData/plugins/dd4hep/DDTotemAngular.cc
+++ b/Geometry/ForwardCommonData/plugins/dd4hep/DDTotemAngular.cc
@@ -8,10 +8,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   double startAngle = args.value<double>("startAngle");

--- a/Geometry/ForwardCommonData/plugins/dd4hep/DDTotemAngular.cc
+++ b/Geometry/ForwardCommonData/plugins/dd4hep/DDTotemAngular.cc
@@ -10,8 +10,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   double startAngle = args.value<double>("startAngle");

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
@@ -17,8 +17,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.00001;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDAHcalModuleAlgo.cc
@@ -15,10 +15,7 @@
 //#define EDM_ML_DEBUG
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.00001;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalCell.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalCell.cc
@@ -7,8 +7,7 @@
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHGCalCell.h

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalCell.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalCell.cc
@@ -5,9 +5,7 @@
 
 //#define EDM_ML_DEBUG
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHGCalCell.h

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
@@ -407,8 +407,7 @@ struct HGCalEEAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HGCalEEAlgo eealgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEAlgo.cc
@@ -405,9 +405,7 @@ struct HGCalEEAlgo {
   }
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HGCalEEAlgo eealgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEFileAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEFileAlgo.cc
@@ -396,9 +396,7 @@ struct HGCalEEFileAlgo {
   double alpha_, cosAlpha_;
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HGCalEEFileAlgo eealgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEFileAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalEEFileAlgo.cc
@@ -398,8 +398,7 @@ struct HGCalEEFileAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HGCalEEFileAlgo eealgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEAlgo.cc
@@ -580,8 +580,7 @@ struct HGCalHEAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HGCalHEAlgo healgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEAlgo.cc
@@ -578,9 +578,7 @@ struct HGCalHEAlgo {
   static constexpr double tol2_ = 0.00001;
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HGCalHEAlgo healgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEFileAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEFileAlgo.cc
@@ -594,9 +594,7 @@ struct HGCalHEFileAlgo {
   double alpha_, cosAlpha_;
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HGCalHEFileAlgo healgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEFileAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalHEFileAlgo.cc
@@ -596,8 +596,7 @@ struct HGCalHEFileAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HGCalHEFileAlgo healgo(ctxt, e);
   return cms::s_executed;
 }

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModule.cc
@@ -23,8 +23,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.01;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModule.cc
@@ -21,10 +21,7 @@
 #endif
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.01;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModuleAlgo.cc
@@ -23,8 +23,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.01;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModuleAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalModuleAlgo.cc
@@ -21,10 +21,7 @@
 #endif
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol = 0.01;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
@@ -9,8 +9,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string motherName = args.parentName();

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalNoTaperEndcap.cc
@@ -7,10 +7,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string motherName = args.parentName();

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc
@@ -14,10 +14,7 @@
 #endif
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol2 = 0.00001;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModule.cc
@@ -16,8 +16,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   static constexpr double tol2 = 0.00001;

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
@@ -186,10 +186,7 @@ namespace DDHGCalGeom {
   }
 }  // namespace DDHGCalGeom
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalTBModuleX.cc
@@ -188,8 +188,8 @@ namespace DDHGCalGeom {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer.cc
@@ -10,8 +10,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string nsName = static_cast<std::string>(ns.name());

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer.cc
@@ -8,10 +8,7 @@
 
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string nsName = static_cast<std::string>(ns.name());

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer8.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer8.cc
@@ -15,8 +15,8 @@
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string motherName = args.parentName();

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer8.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWafer8.cc
@@ -13,10 +13,7 @@
 
 //#define EDM_ML_DEBUG
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string motherName = args.parentName();

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
@@ -7,10 +7,7 @@
 //#define EDM_ML_DEBUG
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
+++ b/Geometry/HGCalCommonData/plugins/dd4hep/DDHGCalWaferAlgo.cc
@@ -9,8 +9,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
@@ -8,8 +8,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHCalAngular.h

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalAngular.cc
@@ -6,10 +6,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHCalAngular.h

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalBarrelAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalBarrelAlgo.cc
@@ -977,9 +977,7 @@ struct HcalBarrelAlgo {
   }
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HcalBarrelAlgo hcalbarrelalgo(ctxt, e);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalBarrelAlgo construction";

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalBarrelAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalBarrelAlgo.cc
@@ -979,8 +979,7 @@ struct HcalBarrelAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HcalBarrelAlgo hcalbarrelalgo(ctxt, e);
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("HCalGeom") << "<<== End of DDHCalBarrelAlgo construction";

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
@@ -979,8 +979,7 @@ struct HCalEndcapAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HCalEndcapAlgo hcalendcapalgo(ctxt, e);
   return 1;
 }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapAlgo.cc
@@ -977,9 +977,7 @@ struct HCalEndcapAlgo {
   }
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HCalEndcapAlgo hcalendcapalgo(ctxt, e);
   return 1;
 }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -582,9 +582,7 @@ struct HCalEndcapModuleAlgo {
   }
 };
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   HCalEndcapModuleAlgo hcalendcapalgo(ctxt, e);
   return 1;
 }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalEndcapModuleAlgo.cc
@@ -584,8 +584,7 @@ struct HCalEndcapModuleAlgo {
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
   HCalEndcapModuleAlgo hcalendcapalgo(ctxt, e);
   return 1;
 }

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
@@ -7,10 +7,7 @@
 
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalFibreBundle.cc
@@ -9,8 +9,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalForwardAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalForwardAlgo.cc
@@ -7,10 +7,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalForwardAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalForwardAlgo.cc
@@ -9,8 +9,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
@@ -8,8 +8,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHCalLinearXY.h

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalLinearXY.cc
@@ -6,10 +6,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section of original DDHCalLinearXY.h

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
@@ -7,10 +7,7 @@
 
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBCableAlgo.cc
@@ -9,8 +9,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
@@ -6,10 +6,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTBZposAlgo.cc
@@ -8,8 +8,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
@@ -6,10 +6,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalTestBeamAlgo.cc
@@ -8,8 +8,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalXtalAlgo.cc
@@ -6,10 +6,7 @@
 //#define EDM_ML_DEBUG
 using namespace geant_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalAlgo/plugins/dd4hep/DDHCalXtalAlgo.cc
+++ b/Geometry/HcalAlgo/plugins/dd4hep/DDHCalXtalAlgo.cc
@@ -8,8 +8,8 @@ using namespace geant_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   // Header section

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -152,22 +152,22 @@ bool HcalParametersFromDD::build(const cms::DDCompactView& cpv, HcalParameters& 
   php.dzVcal = geom->getConstDzHF();
   geom->getConstRHO(php.rHO);
 
-  php.phioff = cpv.getVector<double>("phioff");
-  php.etaTable = cpv.getVector<double>("etaTable");
-  php.rTable = cpv.getVector<double>("rTable");
-  php.phibin = cpv.getVector<double>("phibin");
-  php.phitable = cpv.getVector<double>("phitable");
+  php.phioff = cpv.get<std::vector<double>>("phioff");
+  php.etaTable = cpv.get<std::vector<double>>("etaTable");
+  php.rTable = cpv.get<std::vector<double>>("rTable");
+  php.phibin = cpv.get<std::vector<double>>("phibin");
+  php.phitable = cpv.get<std::vector<double>>("phitable");
   php.etaMin = cpv.getVector<int>("etaMin");
   php.etaMax = cpv.getVector<int>("etaMax");
-  php.etaRange = cpv.getVector<double>("etaRange");
-  php.gparHF = cpv.getVector<double>("gparHF");
+  php.etaRange = cpv.get<std::vector<double>>("etaRange");
+  php.gparHF = cpv.get<std::vector<double>>("gparHF");
   php.noff = cpv.getVector<int>("noff");
-  php.Layer0Wt = cpv.getVector<double>("Layer0Wt");
-  php.HBGains = cpv.getVector<double>("HBGains");
+  php.Layer0Wt = cpv.get<std::vector<double>>("Layer0Wt");
+  php.HBGains = cpv.get<std::vector<double>>("HBGains");
   php.HBShift = cpv.getVector<int>("HBShift");
-  php.HEGains = cpv.getVector<double>("HEGains");
+  php.HEGains = cpv.get<std::vector<double>>("HEGains");
   php.HEShift = cpv.getVector<int>("HEShift");
-  php.HFGains = cpv.getVector<double>("HFGains");
+  php.HFGains = cpv.get<std::vector<double>>("HFGains");
   php.HFShift = cpv.getVector<int>("HFShift");
   php.maxDepth = cpv.getVector<int>("MaxDepth");
 

--- a/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalCommonData/src/HcalParametersFromDD.cc
@@ -186,10 +186,10 @@ bool HcalParametersFromDD::build(const cms::DDCompactView& cpv, HcalParameters& 
   const cms::DDFilter filter("OnlyForHcalRecNumbering", "HCAL");
   cms::DDFilteredView fv(cpv, filter);
 
-  std::vector<std::string> tempS = fv.get<std::vector<std::string> >("hcal", "TopologyMode");
+  std::vector<std::string> tempS = fv.get<std::vector<std::string>>("hcal", "TopologyMode");
   std::string sv = (!tempS.empty()) ? tempS[0] : "HcalTopologyMode::SLHC";
   int topoMode = getTopologyMode(sv, true);
-  tempS = fv.get<std::vector<std::string> >("hcal", "TriggerMode");
+  tempS = fv.get<std::vector<std::string>>("hcal", "TriggerMode");
   sv = (!tempS.empty()) ? tempS[0] : "HcalTopologyMode::TriggerMode_2021";
   int trigMode = getTopologyMode(sv, false);
   php.topologyMode = ((trigMode & 0xFF) << 8) | (topoMode & 0xFF);

--- a/Geometry/MTDCommonData/plugins/dd4hep/DDMTDLinear.cc
+++ b/Geometry/MTDCommonData/plugins/dd4hep/DDMTDLinear.cc
@@ -13,7 +13,7 @@ using namespace cms_units::operators;
 
 using DD3Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double> >;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -7,10 +7,7 @@ using namespace cms_units::operators;
 
 //#define EDM_ML_DEBUG
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDGEMAngular.cc
@@ -9,8 +9,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -7,8 +7,8 @@ using namespace cms_units::operators;
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& context,
-                      xml_h element,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h element) {
+
   cms::DDNamespace ns(context, element, true);
   cms::DDAlgoArguments args(context, element);
 

--- a/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
+++ b/Geometry/MuonCommonData/plugins/dd4hep/DDMuonAngular.cc
@@ -5,10 +5,7 @@
 
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& context,
-                      xml_h element) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& context, xml_h element) {
   cms::DDNamespace ns(context, element, true);
   cms::DDAlgoArguments args(context, element);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
@@ -8,8 +8,8 @@ using namespace cms_units::operators;  // _deg and convertRadToDeg
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDCutTubsFromPoints.cc
@@ -6,10 +6,7 @@
 
 using namespace cms_units::operators;  // _deg and convertRadToDeg
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& description, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& description, cms::DDParsingContext& ctxt, xml_h e) {
   PlacedVolume pv;
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerUpgradeAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixBarLayerUpgradeAlgo.cc
@@ -5,7 +5,7 @@
 
 using namespace cms_units::operators;
 
-static long algorithm(dd4hep::Detector&, cms::DDParsingContext& ctxt, xml_h e, dd4hep::SensitiveDetector&) {
+static long algorithm(dd4hep::Detector&, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
   std::string parentName = args.parentName();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
@@ -14,10 +14,7 @@
 
 using namespace cms_units::operators;  // _deg and convertRadToDeg
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixFwdDiskAlgo.cc
@@ -16,8 +16,8 @@ using namespace cms_units::operators;  // _deg and convertRadToDeg
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixPhase1FwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixPhase1FwdDiskAlgo.cc
@@ -15,8 +15,8 @@ using namespace cms_units::operators;  // _deg and convertRadToDeg
 
 static long algorithm(dd4hep::Detector& /* description */,
                       cms::DDParsingContext& ctxt,
-                      xml_h e,
-                      dd4hep::SensitiveDetector& /* sens */) {
+                      xml_h e) {
+
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDPixPhase1FwdDiskAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDPixPhase1FwdDiskAlgo.cc
@@ -13,10 +13,7 @@
 
 using namespace cms_units::operators;  // _deg and convertRadToDeg
 
-static long algorithm(dd4hep::Detector& /* description */,
-                      cms::DDParsingContext& ctxt,
-                      xml_h e) {
-
+static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECCoolAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECCoolAlgo.cc
@@ -11,7 +11,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   int startCopyNo = args.find("StartCopyNo") ? args.value<int>("StartCopyNo") : 1;

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECModuleAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECOptoHybAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECOptoHybAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   int startCopyNo = args.value<int>("StartCopyNo");

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECPhiAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECPhiAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTECPhiAltAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTECPhiAltAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
@@ -8,10 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */,
-                      cms::DDParsingContext& context,
-                      xml_h element) {
-
+static long algorithm(Detector& /* description */, cms::DDParsingContext& context, xml_h element) {
   using VecDouble = vector<double>;
 
   cms::DDNamespace ns(context, element, true);

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIBLayerAlgo.cc
@@ -10,8 +10,8 @@ using namespace cms_units::operators;
 
 static long algorithm(Detector& /* description */,
                       cms::DDParsingContext& context,
-                      xml_h element,
-                      SensitiveDetector& /* sens */) {
+                      xml_h element) {
+
   using VecDouble = vector<double>;
 
   cms::DDNamespace ns(context, element, true);

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDAxialCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDAxialCableAlgo.cc
@@ -16,7 +16,7 @@ using namespace cms;
 using namespace cms_units::operators;
 
 namespace {
-  long algorithm(dd4hep::Detector &description, cms::DDParsingContext &ctxt, xml_h e, SensitiveDetector & /* sens */) {
+  long algorithm(dd4hep::Detector &description, cms::DDParsingContext &ctxt, xml_h e) {
     cms::DDNamespace ns(ctxt, e, true);
     cms::DDAlgoArguments args(ctxt, e);
 

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDModuleAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDModuleAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   string mother = args.parentName();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDModulePosAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDModulePosAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   string parentName = args.parentName();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTIDRingAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBAxCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBAxCableAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   vector<string> sectorNumber = args.vecStr("SectorNumber");          // Id. Number of the sectors

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBRadCableAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBRadCableAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   double diskDz = args.dble("DiskDz");                   // Disk  thickness

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBRodAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTOBRodAlgo.cc
@@ -6,7 +6,7 @@ using namespace std;
 using namespace dd4hep;
 using namespace cms;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   string parentName = args.parentName();

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerAngular.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerAngular.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   // Header section of original DDTrackerAngular.h

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerLinear.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerLinear.cc
@@ -6,7 +6,7 @@ using namespace std;
 using namespace dd4hep;
 using namespace cms;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   int startcn = args.find("StartCopyNo") ? args.value<int>("StartCopyNo") : 1;

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerPhiAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerPhiAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerPhiAltAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerPhiAltAlgo.cc
@@ -8,7 +8,7 @@ using namespace dd4hep;
 using namespace cms;
 using namespace cms_units::operators;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerRingAlgo.cc
@@ -9,7 +9,7 @@ using namespace cms;
 using namespace cms_units::operators;
 
 namespace {
-  long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+  long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
     DDNamespace ns(ctxt, e, true);
     DDAlgoArguments args(ctxt, e);
     Volume mother = ns.volume(args.parentName());

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerXYZPosAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerXYZPosAlgo.cc
@@ -6,7 +6,7 @@ using namespace std;
 using namespace dd4hep;
 using namespace cms;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   int startCopyNo = args.find("StartCopyNo") ? args.value<int>("StartCopyNo") : 1;

--- a/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerZPosAlgo.cc
+++ b/Geometry/TrackerCommonData/plugins/dd4hep/DDTrackerZPosAlgo.cc
@@ -7,7 +7,7 @@ using namespace std;
 using namespace dd4hep;
 using namespace cms;
 
-static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e, SensitiveDetector& /* sens */) {
+static long algorithm(Detector& /* description */, cms::DDParsingContext& ctxt, xml_h e) {
   cms::DDNamespace ns(ctxt, e, true);
   DDAlgoArguments args(ctxt, e);
   int startCopyNo = args.find("StartCopyNo") ? args.value<int>("StartCopyNo") : 1;

--- a/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
@@ -24,7 +24,7 @@ bool TrackerParametersFromDD::build(const DDCompactView* cvp, PTrackerParameters
 }
 
 bool TrackerParametersFromDD::build(const cms::DDCompactView* cvp, PTrackerParameters& ptp) {
-  dd4hep::VectorsMap vmap = cvp->detector()->vectors();
+  const auto& vmap = cvp->detector()->vectors();
   for (int subdet = 1; subdet <= 6; ++subdet) {
     std::stringstream sstm;
     sstm << "Subdetector" << subdet;


### PR DESCRIPTION
#### PR description:

* Unite an API for retrieving an attribute value from a `SpecPar` whether it's a string or numeric
* Add a `find` method to allow a `SpecPar` caching defined by a parameter pack of attributes, subsequent calls to `getNextValue` will not perform a search in the SpecPar registry:
```c++
  fview.findSpecPar("TrackerRadLength", "TrackerXi");
  
  double radLength = fview.getNextValue("TrackerRadLength");
  double xi = fview.getNextValue("TrackerXi");

```
I should probably rename `getNextValue` to `getValueOf`
* Make sure that current `SpecPar` cache is invalidated on iteration
* Add a unit test for `find`
* Test replacing `split` with a sliding window on Hcal where all part selectors have a single name in the path:
```xml
//HBS.* //HTS.* //HES.* //HVQF //HCal //HBS.* //HTS.* //HEScintillator.* //HVQX //VcalElecCathode //FibreBundle.* //VcalFibreBundleL.* //VcalFibreBundleR.* //CALO //MBAT //MBBT.* //VCAL
``` 
this PR vs CMSSW_11_2_X_2020-10-03-1100 IB:
```diff
194,202c234,242
<  - Min event:   185.589
<  - Max event:   185.589
<  - Avg event:   185.589
<  - Total loop:  185.59
<  - Total init:  4.00237
<  - Total job:   189.594
<  - EventSetup Lock:   0
<  - EventSetup Get:   0
<  Event Throughput: 0.00538822 ev/s
---
>  - Min event:   188.521
>  - Max event:   188.521
>  - Avg event:   188.521
>  - Total loop:  188.523
>  - Total init:  13.8746
>  - Total job:   202.399
>  - EventSetup Lock:   4.76837e-06
>  - EventSetup Get:   199.737
>  Event Throughput: 0.00530439 ev/s
204,205c244,245
<  - Total loop:  185.408
<  - Total init:  2.09542
---
>  - Total loop:  186.369
>  - Total init:  1.61794
207c247
<  - Total job:   187.504
---
>  - Total job:   187.988

```

* Remove unused `Vis` and `VisSection` processing
* Remove unused `dd4hep::SensitiveDetector` and its reference passed to the Algorithms 
* Replace the `tbb` containers with the `std` ones where concurrent processing is not expected 

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
