### PR TITLE
Clean BuildFiles in DetectorDescription

### DIFF
--- a/DetectorDescription/DDCMS/BuildFile.xml
+++ b/DetectorDescription/DDCMS/BuildFile.xml
@@ -1,7 +1,5 @@
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
-<use name="Geometry/MuonNumbering"/>
 <use name="dd4hep"/>
 <use name="rootmath"/>
 <use name="rootgeom"/>

--- a/DetectorDescription/DDCMS/plugins/BuildFile.xml
+++ b/DetectorDescription/DDCMS/plugins/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="dd4hep"/>
 <use name="DetectorDescription/DDCMS"/>

--- a/DetectorDescription/Parser/BuildFile.xml
+++ b/DetectorDescription/Parser/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DetectorDescription/Core"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/PluginManager"/>
 <use name="FWCore/Utilities"/>
 <use name="Utilities/Xerces"/>
 <use name="boost"/>

--- a/DetectorDescription/Parser/test/BuildFile.xml
+++ b/DetectorDescription/Parser/test/BuildFile.xml
@@ -5,7 +5,6 @@
 
 <bin name="testmat" file="testmat.cpp">
   <use name="DetectorDescription/Parser"/>
-  <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSetReader"/>
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>

--- a/DetectorDescription/RegressionTest/test/BuildFile.xml
+++ b/DetectorDescription/RegressionTest/test/BuildFile.xml
@@ -122,7 +122,6 @@
   <use name="DetectorDescription/RegressionTest"/>
   <use name="DetectorDescription/Parser"/>
   <use name="xerces-c"/>
-  <use name="FWCore/Framework"/>
   <use name="FWCore/Utilities"/>
   <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>

--- a/ElectroWeakAnalysis/ZEE/BuildFile.xml
+++ b/ElectroWeakAnalysis/ZEE/BuildFile.xml
@@ -9,8 +9,6 @@
 <use name="MagneticField/Records"/>
 <use name="MagneticField/Engine"/>
 <use name="RecoEcal/EgammaCoreTools"/>
-<use name="RecoEgamma/EgammaTools"/>
-<use name="RecoLocalCalo/EcalRecAlgos"/>
 <use name="HLTrigger/HLTcore"/>
 <use name="root"/>
 <use name="rootmath"/>

--- a/Geometry/HcalAlgo/plugins/BuildFile.xml
+++ b/Geometry/HcalAlgo/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 </library>
 
 <library name="DD4hep_GeometryHcalAlgoPlugins" file="dd4hep/*.cc">
+  <use name="DetectorDescription/Core"/>
   <use name="DetectorDescription/DDCMS"/>
   <use name="dd4hep"/>
   <lib name="Geom"/>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31590).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
