### PR TITLE
Use akCs4PFJets for candidate-based tagInfos for HI workflows

### DIFF
--- a/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
+++ b/DQMOffline/RecoB/python/dqmAnalyzer_cff.py
@@ -43,6 +43,10 @@ newpatJetGenJetMatch = patJetGenJetMatch.clone(
     resolveAmbiguities = cms.bool(True)
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(newpatJetGenJetMatch, src = "akCs4PFJets")
+
 # Module execution for MC
 from Validation.RecoB.bTagAnalysis_cfi import *
 bTagValidation.jetMCSrc = 'myak4JetFlavourInfos'

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -15,13 +15,13 @@ cleanedPartons = hiPartons.clone(
     src = 'allPartons',
     )
 
-ak4HiCleanedGenJets = heavyIonCleanedGenJets.clone(src = "ak4HiGenJets")
+ak4HiGenJetsCleaned = heavyIonCleanedGenJets.clone(src = "ak4HiGenJets")
 
 cleanedGenJetsTask = cms.Task(
     genParticlesForJets,
     cleanedPartons,
     ak4HiGenJets,
-    ak4HiCleanedGenJets
+    ak4HiGenJetsCleaned
 )
 
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, pfEmptyCollection, ak4PFJetsForFlow, hiPuRho, hiFJRhoFlowModulation, akCs4PFJets

--- a/RecoBTag/ImpactParameter/python/pfImpactParameterTagInfos_cfi.py
+++ b/RecoBTag/ImpactParameter/python/pfImpactParameterTagInfos_cfi.py
@@ -19,3 +19,7 @@ pfImpactParameterTagInfos = cms.EDProducer("CandIPProducer",
     candidates = cms.InputTag("particleFlow"),
     maxDeltaR = cms.double(0.4)
 )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(pfImpactParameterTagInfos, jets = "akCs4PFJets")

--- a/RecoBTag/SoftLepton/python/softPFElectronTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softPFElectronTagInfos_cfi.py
@@ -7,3 +7,7 @@ softPFElectronsTagInfos = cms.EDProducer("SoftPFElectronTagInfoProducer",
     DeltaRElectronJet=cms.double(0.4),
     MaxSip3Dsig=cms.double(200)
 )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(softPFElectronsTagInfos, jets = "akCs4PFJets")

--- a/RecoBTag/SoftLepton/python/softPFMuonTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softPFMuonTagInfos_cfi.py
@@ -11,3 +11,7 @@ softPFMuonsTagInfos = cms.EDProducer("SoftPFMuonTagInfoProducer",
   filterRatio2      = cms.double(0.7),
   filterPromptMuons = cms.bool(False)
 )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(softPFMuonsTagInfos, jets = "akCs4PFJets")


### PR DESCRIPTION
#### PR description:

Update candidate based tagInfos to use HI jet collection (akCs4PFJets) in HI workflows. 
This fixes an issue created in #30898, which is causing crashes in several HI workflows ( #31670 ).
The issue is that the b-tagging validation clones the 'patJets', but changes from the track-based tagInfos that we use to the candidate-based ones used nowadays in pp.  
The solution is to update the candidate-based tagInfos to use akCs4PFJets, which was anyway on the to-do list for Run 3, when we plan update to those in the HI b-tagging sequence.  This issue was spotted running wfs like 158.1.

There was also a trivial change to the name of the cleaned heavy ion genJet module, which had a conflict (affected wf 150, for example).  

#### PR validation:

Tested on wf 150, 158.1 and 158.01.  Please test on the other wfs identified in #31670


#### if this PR is a backport please specify the original PR and why you need to backport that PR:


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
