### PR TITLE
Update NHitCuts_byTrackAlgo for hgcalTrack 

### DIFF
--- a/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py
@@ -7,7 +7,7 @@ hgcalTrackCollection = cms.EDProducer(
     # From GeneralTracksImporter
     useIterativeTracking = cms.bool(True),
     DPtOverPtCuts_byTrackAlgo = cms.vdouble(10.0,10.0,10.0,10.0,10.0,5.0),
-    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,32700), # the last value is nonsense
+    NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3,3),
 
     # From HGCClusterizer
     hgcalGeometryNames = cms.PSet( HGC_ECAL  = cms.string('HGCalEESensitive'),


### PR DESCRIPTION
...to be consistent as that for GeneralTracksImporter.

#### PR description:

The sixth entry of
https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFTracking/python/hgcalTrackCollection_cfi.py#L10
has been known as a nonsensical value. See: https://github.com/cms-sw/cmssw/issues/16914.
I didn't really trace all the history, but I checked how the PF output changes when we set it to a "reasonable" value which is consistent as that used for GeneralTrackImporter, and I don't see anything alarming [0].

For simPFProducer outputs, after this NHitCuts_byTrackAlgo, I see slightly smaller neutral hadron entries of low pt [1] and a very minor change in PF electrons and photons [2]. I think this is because we are including more tracks (from muonSeededStepInOut/OutIn) in the hgcalTrack collection, and consequently more HGCalHE hits are associated to tracks.

Remarks: Right now, PF muons are produced from particleFlowTmpBarrel when they are RECO muons, even if the muons are in endcap [3], and simPFProducer skips [4] muons from reco muon collection. While ticl attempts to reconstruct these endcap muons, as expected. When we switch from simPFProducer to pfTICL, it's likely that we will have to do some duplicate removal between pfTICL and particleFlowTmpBarrel at least for muons. I am hoping to address this in a follow-up PR.

[1] http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/plots/ZMM_ParticleFlow/PackedCandidates/neutralHadron/neutralHadronEta.pdf
[2] http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/plots/ZMM_ParticleFlow/PackedCandidates/electron/electronEta.pdf
http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/plots/ZMM_ParticleFlow/PackedCandidates/photon/photonEta.pdf

[3] because veto skips tracks with muonref:  https://cmssdt.cern.ch/lxr/source/RecoParticleFlow/PFProducer/plugins/importers/GeneralTracksImporterWithVeto.cc#0133
[4] https://cmssdt.cern.ch/lxr/source/RecoParticleFlow/PFSimProducer/plugins/SimPFProducer.cc#0389

#### PR validation:

Ran PF validation on ZMM with and without PU:
[0] http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/plots/
PF candidates stay almost identical, as discussed above. The "offset" plot is nearly identical:
http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/plots/OffsetStacks/stack_ZMM_NHitCuts3_ref_vs_ZMM_ref.pdf

Since https://github.com/cms-sw/cmssw/issues/16914 unexpectedly discussed about large reco muon changes, here we checked that slimmedMuons are not affected.
[5] http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/SlimmedMuonEta_ZMMNoPU.pdf
[6] http://hep.baylor.edu/hatake/PFval/val_11_2_pre6_NHitCuts_byTrackAlgo/SlimmedMuonEta_ZMMPU.pdf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

Att: @bendavid @rovere @felicepantaleo @kpedro88 