### PR TITLE
Clean more BuildFiles in DataFormats

### DIFF
--- a/DataFormats/L1GlobalCaloTrigger/test/BuildFile.xml
+++ b/DataFormats/L1GlobalCaloTrigger/test/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="DataFormats/L1CaloTrigger"/>
 <use name="DataFormats/L1GlobalCaloTrigger"/>
 <bin name="testL1GlobalCaloRegionDetId" file="testL1GlobalCaloRegionDetId.cpp">
 </bin>

--- a/DataFormats/L1GlobalTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalTrigger/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Provenance"/>
-<use name="DataFormats/StdDictionaries"/>
 <use name="DataFormats/L1GlobalMuonTrigger"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>

--- a/DataFormats/L1TCalorimeter/BuildFile.xml
+++ b/DataFormats/L1TCalorimeter/BuildFile.xml
@@ -1,5 +1,3 @@
-<use name="DataFormats/Candidate"/>
-<use name="DataFormats/Common"/>
 <use name="DataFormats/L1Trigger"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/L1TCalorimeterPhase2/BuildFile.xml
+++ b/DataFormats/L1TCalorimeterPhase2/BuildFile.xml
@@ -1,7 +1,3 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/PluginManager"/>
-<use name="FWCore/ParameterSet"/>
-<use name="DataFormats/Candidate"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="rootrflx"/>
 <export>

--- a/DataFormats/L1TGlobal/BuildFile.xml
+++ b/DataFormats/L1TGlobal/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1Trigger"/>
 <export>

--- a/DataFormats/L1TMuon/BuildFile.xml
+++ b/DataFormats/L1TMuon/BuildFile.xml
@@ -2,10 +2,8 @@
   <lib name="1"/>
 </export>
 <use name="DataFormats/CSCDigi"/>
-<use name="DataFormats/L1DTTrackFinder"/>
 <use name="DataFormats/GEMDigi"/>
 <use name="DataFormats/MuonDetId"/>
-<use name="DataFormats/L1CSCTrackFinder"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/Candidate"/>
 <use name="rootrflx"/>

--- a/GeometryReaders/XMLIdealGeometryESSource/BuildFile.xml
+++ b/GeometryReaders/XMLIdealGeometryESSource/BuildFile.xml
@@ -5,6 +5,5 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
 <use name="CondFormats/Common"/>
-<use name="CondFormats/GeometryObjects"/>
 <use name="MagneticField/Records"/>
 <flags EDM_PLUGIN="1"/>

--- a/HLTriggerOffline/Btag/BuildFile.xml
+++ b/HLTriggerOffline/Btag/BuildFile.xml
@@ -1,3 +1,5 @@
-<use name="DQMOffline/RecoB"/>
+<use name="DataFormats/BTauReco"/>
+<use name="DQMServices/Core"/>
 <use name="HLTrigger/HLTcore"/>
+<use name="rootgraphics"/>
 <flags EDM_PLUGIN="1"/>

--- a/L1Trigger/L1TMuon/BuildFile.xml
+++ b/L1Trigger/L1TMuon/BuildFile.xml
@@ -4,6 +4,7 @@
   <use name="root"/>
   <use name="xerces-c"/>
 </export>
+<use name="DataFormats/L1DTTrackFinder"/>
 <use name="DataFormats/L1TMuon"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/RPCRecHit"/>

--- a/L1Trigger/L1TMuonOverlap/BuildFile.xml
+++ b/L1Trigger/L1TMuonOverlap/BuildFile.xml
@@ -3,6 +3,7 @@
 </export>
 <use name="xerces-c"/>
 <use name="root"/>
+<use name="DataFormats/L1DTTrackFinder"/>
 <use name="L1Trigger/RPCTrigger"/>
 <use name="DataFormats/L1TMuon"/>
 <use name="Geometry/Records"/>


### PR DESCRIPTION
#### PR description:

Another quick partially automatic BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31663).

In particular, this one gets rid of a dependency of `DataFormats/L1TCalorimeterPhase2` on the `FWCore` subsystem, which is not needed.

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.