### PR TITLE
Fix to allow concurrent processing of lumisections with ECAL DQM

### DIFF
--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -17,7 +17,10 @@ namespace edm {
 }  // namespace edm
 
 namespace ecaldqm {
-  struct NoCache {};
+  struct EcalLSCache {
+    std::map<std::string, bool> ByLumiPlotsResetSwitches;
+    bool lhcStatusSet_;
+  };
 
   class EcalDQMonitor {
   public:
@@ -41,7 +44,7 @@ namespace ecaldqm {
 
     std::vector<DQWorker *> workers_;
     std::string const moduleName_;
-    int const verbosity_;
+    const int verbosity_;
   };
 
   template <typename FuncOnWorker>

--- a/DQM/EcalCommon/interface/EcalDQMonitor.h
+++ b/DQM/EcalCommon/interface/EcalDQMonitor.h
@@ -17,6 +17,8 @@ namespace edm {
 }  // namespace edm
 
 namespace ecaldqm {
+  struct NoCache {};
+
   class EcalDQMonitor {
   public:
     EcalDQMonitor(edm::ParameterSet const &);
@@ -28,14 +30,14 @@ namespace ecaldqm {
     void ecaldqmGetSetupObjects(edm::EventSetup const &);
     void ecaldqmBeginRun(edm::Run const &, edm::EventSetup const &);
     void ecaldqmEndRun(edm::Run const &, edm::EventSetup const &);
-    void ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &);
+    void ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &) const;
     void ecaldqmEndLuminosityBlock(edm::LuminosityBlock const &, edm::EventSetup const &);
 
     template <typename FuncOnWorker>
     void executeOnWorkers_(FuncOnWorker,
                            std::string const &,
                            std::string const & = "",
-                           int = 1);  // loop over workers and capture exceptions
+                           int = 1) const;  // loop over workers and capture exceptions
 
     std::vector<DQWorker *> workers_;
     std::string const moduleName_;
@@ -46,7 +48,7 @@ namespace ecaldqm {
   void EcalDQMonitor::executeOnWorkers_(FuncOnWorker _func,
                                         std::string const &_context,
                                         std::string const &_message /* = ""*/,
-                                        int _verbThreshold /* = 1*/) {
+                                        int _verbThreshold /* = 1*/) const {
     std::for_each(workers_.begin(), workers_.end(), [&](DQWorker *worker) {
       if (verbosity_ > _verbThreshold && !_message.empty())
         edm::LogInfo("EcalDQM") << moduleName_ << ": " << _message << " @ " << worker->getName();

--- a/DQM/EcalCommon/src/EcalDQMonitor.cc
+++ b/DQM/EcalCommon/src/EcalDQMonitor.cc
@@ -112,7 +112,7 @@ namespace ecaldqm {
       edm::LogInfo("EcalDQM") << moduleName_ << "::ecaldqmEndRun";
   }
 
-  void EcalDQMonitor::ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &_lumi, edm::EventSetup const &_es) {
+  void EcalDQMonitor::ecaldqmBeginLuminosityBlock(edm::LuminosityBlock const &_lumi, edm::EventSetup const &_es) const {
     executeOnWorkers_(
         [&_lumi, &_es](DQWorker *worker) {
           if (worker->onlineMode())

--- a/DQM/EcalMonitorTasks/interface/ClusterTask.h
+++ b/DQM/EcalMonitorTasks/interface/ClusterTask.h
@@ -26,7 +26,7 @@ namespace ecaldqm {
 
     void addDependencies(DependencySet&) override;
 
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     void endEvent(edm::Event const&, edm::EventSetup const&) override;
 
     bool analyze(void const*, Collections) override;

--- a/DQM/EcalMonitorTasks/interface/DQWorkerTask.h
+++ b/DQM/EcalMonitorTasks/interface/DQWorkerTask.h
@@ -77,7 +77,7 @@ namespace ecaldqm {
 
     static void fillDescriptions(edm::ParameterSetDescription&);
 
-    virtual void beginEvent(edm::Event const&, edm::EventSetup const&) {}
+    virtual void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) {}
     virtual void endEvent(edm::Event const&, edm::EventSetup const&) {}
 
     virtual bool filterRunType(short const*) { return true; };

--- a/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
+++ b/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
@@ -15,7 +15,7 @@ namespace edm {
   class ParameterSetDescription;
 }  // namespace edm
 
-class EcalDQMonitorTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache>>,
+class EcalDQMonitorTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::EcalLSCache>>,
                           public ecaldqm::EcalDQMonitor {
 public:
   EcalDQMonitorTask(edm::ParameterSet const&);
@@ -28,8 +28,8 @@ public:
 
 private:
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
-  std::shared_ptr<ecaldqm::NoCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
-                                                               edm::EventSetup const&) const override;
+  std::shared_ptr<ecaldqm::EcalLSCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                                   edm::EventSetup const&) const override;
   void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
 

--- a/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
+++ b/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
@@ -15,7 +15,7 @@ namespace edm {
   class ParameterSetDescription;
 }  // namespace edm
 
-class EcalDQMonitorTask : public DQMOneLumiEDAnalyzer<>, public ecaldqm::EcalDQMonitor {
+class EcalDQMonitorTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache>>, public ecaldqm::EcalDQMonitor {
 public:
   EcalDQMonitorTask(edm::ParameterSet const&);
   ~EcalDQMonitorTask() override {}
@@ -27,8 +27,8 @@ public:
 
 private:
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
-  void dqmBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-  void dqmEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  std::shared_ptr<ecaldqm::NoCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+  void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
 
   typedef void (EcalDQMonitorTask::*Processor)(edm::Event const&,

--- a/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
+++ b/DQM/EcalMonitorTasks/interface/EcalDQMonitorTask.h
@@ -15,7 +15,8 @@ namespace edm {
   class ParameterSetDescription;
 }  // namespace edm
 
-class EcalDQMonitorTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache>>, public ecaldqm::EcalDQMonitor {
+class EcalDQMonitorTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache>>,
+                          public ecaldqm::EcalDQMonitor {
 public:
   EcalDQMonitorTask(edm::ParameterSet const&);
   ~EcalDQMonitorTask() override {}
@@ -27,7 +28,8 @@ public:
 
 private:
   void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
-  std::shared_ptr<ecaldqm::NoCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override;
+  std::shared_ptr<ecaldqm::NoCache> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                               edm::EventSetup const&) const override;
   void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   void analyze(edm::Event const&, edm::EventSetup const&) override;
 
@@ -42,9 +44,9 @@ private:
 
   /* DATA MEMBERS */
 
-  edm::EDGetToken collectionTokens_[ecaldqm::nCollections];            // list of EDGetTokens
-  std::vector<std::pair<Processor, ecaldqm::Collections> > schedule_;  // schedule of collections to run
-  bool allowMissingCollections_;                                       // when true, skip missing collections silently
+  edm::EDGetToken collectionTokens_[ecaldqm::nCollections];           // list of EDGetTokens
+  std::vector<std::pair<Processor, ecaldqm::Collections>> schedule_;  // schedule of collections to run
+  bool allowMissingCollections_;                                      // when true, skip missing collections silently
   int processedEvents_;
 
   /* TASK TIME PROFILING */

--- a/DQM/EcalMonitorTasks/interface/EnergyTask.h
+++ b/DQM/EcalMonitorTasks/interface/EnergyTask.h
@@ -14,8 +14,7 @@ namespace ecaldqm {
 
     bool filterRunType(short const*) override;
 
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     bool analyze(void const*, Collections) override;
 
     void runOnRecHits(EcalRecHitCollection const&);

--- a/DQM/EcalMonitorTasks/interface/IntegrityTask.h
+++ b/DQM/EcalMonitorTasks/interface/IntegrityTask.h
@@ -15,7 +15,7 @@ namespace ecaldqm {
     IntegrityTask();
     ~IntegrityTask() override {}
 
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/LaserTask.h
+++ b/DQM/EcalMonitorTasks/interface/LaserTask.h
@@ -22,7 +22,7 @@ namespace ecaldqm {
 
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/LedTask.h
+++ b/DQM/EcalMonitorTasks/interface/LedTask.h
@@ -22,7 +22,7 @@ namespace ecaldqm {
 
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
     void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/OccupancyTask.h
+++ b/DQM/EcalMonitorTasks/interface/OccupancyTask.h
@@ -15,7 +15,7 @@ namespace ecaldqm {
 
     bool filterRunType(short const*) override;
 
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/PresampleTask.h
+++ b/DQM/EcalMonitorTasks/interface/PresampleTask.h
@@ -14,13 +14,13 @@ namespace ecaldqm {
 
     bool filterRunType(short const*) override;
 
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     bool analyze(void const*, Collections) override;
 
     template <typename DigiCollection>
     void runOnDigis(DigiCollection const&);
 
   private:
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
     void setParams(edm::ParameterSet const&) override;
 
     bool doPulseMaxCheck_;

--- a/DQM/EcalMonitorTasks/interface/RawDataTask.h
+++ b/DQM/EcalMonitorTasks/interface/RawDataTask.h
@@ -17,8 +17,7 @@ namespace ecaldqm {
     void addDependencies(DependencySet&) override;
 
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
+++ b/DQM/EcalMonitorTasks/interface/SelectiveReadoutTask.h
@@ -23,7 +23,7 @@ namespace ecaldqm {
     void addDependencies(DependencySet&) override;
 
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 

--- a/DQM/EcalMonitorTasks/interface/TimingTask.h
+++ b/DQM/EcalMonitorTasks/interface/TimingTask.h
@@ -20,8 +20,7 @@ namespace ecaldqm {
     void runOnUncalibRecHits(EcalUncalibratedRecHitCollection const&);
 
   private:
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
     void setParams(edm::ParameterSet const&) override;
 
     std::vector<int> bxBinEdges_;

--- a/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
+++ b/DQM/EcalMonitorTasks/interface/TrigPrimTask.h
@@ -24,8 +24,7 @@ namespace ecaldqm {
     void addDependencies(DependencySet&) override;
 
     void beginRun(edm::Run const&, edm::EventSetup const&) override;
-    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-    void beginEvent(edm::Event const&, edm::EventSetup const&) override;
+    void beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) override;
 
     bool analyze(void const*, Collections) override;
 
@@ -60,7 +59,6 @@ namespace ecaldqm {
 
     edm::InputTag lhcStatusInfoCollectionTag_;
     edm::EDGetTokenT<TCDSRecord> lhcStatusInfoRecordToken_;
-    bool lhcStatusSet_;
   };
 
   inline bool TrigPrimTask::analyze(void const* _p, Collections _collection) {

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -25,7 +25,7 @@
 #include <sstream>
 
 EcalDQMonitorTask::EcalDQMonitorTask(edm::ParameterSet const& _ps)
-    : DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache> >(),
+    : DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::EcalLSCache>>(),
       ecaldqm::EcalDQMonitor(_ps),
       schedule_(),
       allowMissingCollections_(_ps.getUntrackedParameter<bool>("allowMissingCollections")),
@@ -119,10 +119,19 @@ void EcalDQMonitorTask::dqmEndRun(edm::Run const& _run, edm::EventSetup const& _
   executeOnWorkers_([](ecaldqm::DQWorker* worker) { worker->releaseMEs(); }, "releaseMEs", "releasing histograms");
 }
 
-std::shared_ptr<ecaldqm::NoCache> EcalDQMonitorTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& _lumi,
-                                                                                edm::EventSetup const& _es) const {
+std::shared_ptr<ecaldqm::EcalLSCache> EcalDQMonitorTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& _lumi,
+                                                                                    edm::EventSetup const& _es) const {
+  std::shared_ptr<ecaldqm::EcalLSCache> tmpCache = std::make_shared<ecaldqm::EcalLSCache>();
+  executeOnWorkers_(
+      [&tmpCache](ecaldqm::DQWorker* worker) { (tmpCache->ByLumiPlotsResetSwitches)[worker->getName()] = true; },
+      "globalBeginLuminosityBlock");
+  if (this->verbosity_ > 2)
+    edm::LogInfo("EcalDQM") << "Set LS cache.";
+
+  // Reset lhcStatusSet_ to false at the beginning of each LS; when LHC status is set in some event this variable will be set to tru
+  tmpCache->lhcStatusSet_ = false;
   ecaldqmBeginLuminosityBlock(_lumi, _es);
-  return nullptr;
+  return tmpCache;
 }
 
 void EcalDQMonitorTask::globalEndLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) {
@@ -187,13 +196,18 @@ void EcalDQMonitorTask::analyze(edm::Event const& _evt, edm::EventSetup const& _
   ++processedEvents_;
 
   // start event processing
+  auto lumiCache = luminosityBlockCache(_evt.getLuminosityBlock().index());
   executeOnWorkers_(
-      [&_evt, &_es, &enabledTasks](ecaldqm::DQWorker* worker) {
+      [&_evt, &_es, &enabledTasks, &lumiCache](ecaldqm::DQWorker* worker) {
         if (enabledTasks.find(worker) != enabledTasks.end()) {
           if (worker->onlineMode())
             worker->setTime(time(nullptr));
           worker->setEventNumber(_evt.id().event());
-          static_cast<ecaldqm::DQWorkerTask*>(worker)->beginEvent(_evt, _es);
+          bool ByLumiResetSwitch = (lumiCache->ByLumiPlotsResetSwitches).at(worker->getName());
+          bool lhcStatusSet = lumiCache->lhcStatusSet_;
+          static_cast<ecaldqm::DQWorkerTask*>(worker)->beginEvent(_evt, _es, ByLumiResetSwitch, lhcStatusSet);
+          (lumiCache->ByLumiPlotsResetSwitches)[worker->getName()] = false;
+          lumiCache->lhcStatusSet_ = lhcStatusSet;
         }
       },
       "beginEvent");

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -119,7 +119,8 @@ void EcalDQMonitorTask::dqmEndRun(edm::Run const& _run, edm::EventSetup const& _
   executeOnWorkers_([](ecaldqm::DQWorker* worker) { worker->releaseMEs(); }, "releaseMEs", "releasing histograms");
 }
 
-std::shared_ptr<ecaldqm::NoCache> EcalDQMonitorTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) const {
+std::shared_ptr<ecaldqm::NoCache> EcalDQMonitorTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& _lumi,
+                                                                                edm::EventSetup const& _es) const {
   ecaldqmBeginLuminosityBlock(_lumi, _es);
   return nullptr;
 }

--- a/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
+++ b/DQM/EcalMonitorTasks/plugins/EcalDQMonitorTask.cc
@@ -25,7 +25,7 @@
 #include <sstream>
 
 EcalDQMonitorTask::EcalDQMonitorTask(edm::ParameterSet const& _ps)
-    : DQMOneLumiEDAnalyzer(),
+    : DQMOneEDAnalyzer<edm::LuminosityBlockCache<ecaldqm::NoCache> >(),
       ecaldqm::EcalDQMonitor(_ps),
       schedule_(),
       allowMissingCollections_(_ps.getUntrackedParameter<bool>("allowMissingCollections")),
@@ -119,11 +119,12 @@ void EcalDQMonitorTask::dqmEndRun(edm::Run const& _run, edm::EventSetup const& _
   executeOnWorkers_([](ecaldqm::DQWorker* worker) { worker->releaseMEs(); }, "releaseMEs", "releasing histograms");
 }
 
-void EcalDQMonitorTask::dqmBeginLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) {
+std::shared_ptr<ecaldqm::NoCache> EcalDQMonitorTask::globalBeginLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) const {
   ecaldqmBeginLuminosityBlock(_lumi, _es);
+  return nullptr;
 }
 
-void EcalDQMonitorTask::dqmEndLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) {
+void EcalDQMonitorTask::globalEndLuminosityBlock(edm::LuminosityBlock const& _lumi, edm::EventSetup const& _es) {
   ecaldqmEndLuminosityBlock(_lumi, _es);
 
   if (lastResetTime_ != 0 && (time(nullptr) - lastResetTime_) / 3600. > resetInterval_) {

--- a/DQM/EcalMonitorTasks/src/ClusterTask.cc
+++ b/DQM/EcalMonitorTasks/src/ClusterTask.cc
@@ -74,7 +74,7 @@ namespace ecaldqm {
     _dependencies.push_back(Dependency(kEESuperCluster, kEERecHit));
   }
 
-  void ClusterTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es) {
+  void ClusterTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es, bool const&, bool&) {
     if (!doExtra_)
       return;
 

--- a/DQM/EcalMonitorTasks/src/EnergyTask.cc
+++ b/DQM/EcalMonitorTasks/src/EnergyTask.cc
@@ -26,9 +26,10 @@ namespace ecaldqm {
     return false;
   }
 
-  void EnergyTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Reset by LS plots at beginning of every LS
-    MEs_.at("HitMapAllByLumi").reset();
+  void EnergyTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es, bool const& ByLumiResetSwitch, bool&) {
+    if (ByLumiResetSwitch) {
+      MEs_.at("HitMapAllByLumi").reset();
+    }
   }
 
   void EnergyTask::runOnRecHits(EcalRecHitCollection const& _hits) {

--- a/DQM/EcalMonitorTasks/src/IntegrityTask.cc
+++ b/DQM/EcalMonitorTasks/src/IntegrityTask.cc
@@ -6,10 +6,14 @@
 namespace ecaldqm {
   IntegrityTask::IntegrityTask() : DQWorkerTask() {}
 
-  void IntegrityTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Reset by LS plots at beginning of every LS
-    MEs_.at("MapByLumi").reset();
-    MEs_.at("ByLumi").reset();
+  void IntegrityTask::beginEvent(edm::Event const& _evt,
+                                 edm::EventSetup const& _es,
+                                 bool const& ByLumiResetSwitch,
+                                 bool&) {
+    if (ByLumiResetSwitch) {
+      MEs_.at("MapByLumi").reset();
+      MEs_.at("ByLumi").reset();
+    }
   }
 
   template <typename IDCollection>

--- a/DQM/EcalMonitorTasks/src/LaserTask.cc
+++ b/DQM/EcalMonitorTasks/src/LaserTask.cc
@@ -60,7 +60,7 @@ namespace ecaldqm {
       emptyLS_ = -1;
   }
 
-  void LaserTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&) { pnAmp_.clear(); }
+  void LaserTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&, bool const&, bool&) { pnAmp_.clear(); }
 
   void LaserTask::runOnRawData(EcalRawDataCollection const& _rawData) {
     MESet& meCalibStatus(MEs_.at("CalibStatus"));

--- a/DQM/EcalMonitorTasks/src/LedTask.cc
+++ b/DQM/EcalMonitorTasks/src/LedTask.cc
@@ -61,7 +61,7 @@ namespace ecaldqm {
       emptyLS_ = -1;
   }
 
-  void LedTask::beginEvent(edm::Event const&, edm::EventSetup const&) { pnAmp_.clear(); }
+  void LedTask::beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) { pnAmp_.clear(); }
 
   void LedTask::runOnRawData(EcalRawDataCollection const& _rawData) {
     MESet& meCalibStatus(MEs_.at("CalibStatus"));

--- a/DQM/EcalMonitorTasks/src/OccupancyTask.cc
+++ b/DQM/EcalMonitorTasks/src/OccupancyTask.cc
@@ -25,11 +25,15 @@ namespace ecaldqm {
     return false;
   }
 
-  void OccupancyTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Reset by LS plots at beginning of every LS
-    MEs_.at("DigiAllByLumi").reset();
-    MEs_.at("TPDigiThrAllByLumi").reset();
-    MEs_.at("RecHitThrAllByLumi").reset();
+  void OccupancyTask::beginEvent(edm::Event const& _evt,
+                                 edm::EventSetup const& _es,
+                                 bool const& ByLumiResetSwitch,
+                                 bool&) {
+    if (ByLumiResetSwitch) {
+      MEs_.at("DigiAllByLumi").reset();
+      MEs_.at("TPDigiThrAllByLumi").reset();
+      MEs_.at("RecHitThrAllByLumi").reset();
+    }
   }
 
   void OccupancyTask::runOnRawData(EcalRawDataCollection const& _dcchs) {

--- a/DQM/EcalMonitorTasks/src/PresampleTask.cc
+++ b/DQM/EcalMonitorTasks/src/PresampleTask.cc
@@ -28,13 +28,18 @@ namespace ecaldqm {
     return false;
   }
 
-  void PresampleTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Fill separate MEs with only 10 LSs worth of stats
-    // Used to correctly fill Presample Trend plots:
-    // 1 pt:10 LS in Trend plots
-    mePedestalByLS = &MEs_.at("PedestalByLS");
-    if (timestamp_.iLumi % 10 == 0)
-      mePedestalByLS->reset();
+  void PresampleTask::beginEvent(edm::Event const& _evt,
+                                 edm::EventSetup const& _es,
+                                 bool const& ByLumiResetSwitch,
+                                 bool&) {
+    if (ByLumiResetSwitch) {
+      // Fill separate MEs with only 10 LSs worth of stats
+      // Used to correctly fill Presample Trend plots:
+      // 1 pt:10 LS in Trend plots
+      mePedestalByLS = &MEs_.at("PedestalByLS");
+      if (timestamp_.iLumi % 10 == 0)
+        mePedestalByLS->reset();
+    }
   }
 
   template <typename DigiCollection>

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -20,19 +20,17 @@ namespace ecaldqm {
 
   void RawDataTask::beginRun(edm::Run const& _run, edm::EventSetup const&) { runNumber_ = _run.run(); }
 
-  void RawDataTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Reset by LS plots at beginning of every LS
-    MEs_.at("DesyncByLumi").reset();
-    MEs_.at("FEByLumi").reset();
-    MEs_.at("FEStatusErrMapByLumi").reset();
-  }
-
-  void RawDataTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&) {
+  void RawDataTask::beginEvent(edm::Event const& _evt, edm::EventSetup const&, bool const& ByLumiResetSwitch, bool&) {
     orbit_ = _evt.orbitNumber() & 0xffffffff;
     bx_ = _evt.bunchCrossing() & 0xfff;
     triggerType_ = _evt.experimentType() & 0xf;
     l1A_ = 0;
     feL1Offset_ = _evt.isRealData() ? 1 : 0;
+    if (ByLumiResetSwitch) {
+      MEs_.at("DesyncByLumi").reset();
+      MEs_.at("FEByLumi").reset();
+      MEs_.at("FEStatusErrMapByLumi").reset();
+    }
   }
 
   void RawDataTask::runOnSource(FEDRawDataCollection const& _fedRaw) {

--- a/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
+++ b/DQM/EcalMonitorTasks/src/SelectiveReadoutTask.cc
@@ -59,7 +59,7 @@ namespace ecaldqm {
     }
   }
 
-  void SelectiveReadoutTask::beginEvent(edm::Event const&, edm::EventSetup const&) {
+  void SelectiveReadoutTask::beginEvent(edm::Event const&, edm::EventSetup const&, bool const&, bool&) {
     flags_.assign(nRU, -1);
     suppressed_.clear();
   }

--- a/DQM/EcalMonitorTasks/src/TimingTask.cc
+++ b/DQM/EcalMonitorTasks/src/TimingTask.cc
@@ -47,19 +47,15 @@ namespace ecaldqm {
     return false;
   }
 
-  void TimingTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Fill separate MEs with only 10 LSs worth of stats
-    // Used to correctly fill Presample Trend plots:
-    // 1 pt:10 LS in Trend plots
-    meTimeMapByLS = &MEs_.at("TimeMapByLS");
-    if (timestamp_.iLumi % 10 == 0)
-      meTimeMapByLS->reset();
-  }
-
-  void TimingTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es) {
+  void TimingTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es, bool const& ByLumiResetSwitch, bool&) {
     using namespace std;
     std::vector<int>::iterator pBin = std::upper_bound(bxBinEdges_.begin(), bxBinEdges_.end(), _evt.bunchCrossing());
     bxBin_ = static_cast<int>(pBin - bxBinEdges_.begin()) - 0.5;
+    if (ByLumiResetSwitch) {
+      meTimeMapByLS = &MEs_.at("TimeMapByLS");
+      if (timestamp_.iLumi % 10 == 0)
+        meTimeMapByLS->reset();
+    }
   }
 
   void TimingTask::runOnRecHits(EcalRecHitCollection const& _hits, Collections _collection) {

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -24,8 +24,7 @@ namespace ecaldqm {
         bxBinEdges_{{1, 271, 541, 892, 1162, 1432, 1783, 2053, 2323, 2674, 2944, 3214, 3446, 3490, 3491, 3565}},
         bxBin_(0.),
         towerReadouts_(),
-        lhcStatusInfoCollectionTag_(),
-        lhcStatusSet_(false) {}
+        lhcStatusInfoCollectionTag_() {}
 
   void TrigPrimTask::setParams(edm::ParameterSet const& _params) {
     runOnEmul_ = _params.getUntrackedParameter<bool>("runOnEmul");
@@ -54,30 +53,29 @@ namespace ecaldqm {
     _es.get<EcalTPGStripStatusRcd>().get(StripStatusRcd);
   }
 
-  void TrigPrimTask::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-    // Reset by LS plots at beginning of every LS
-    MEs_.at("EtSummaryByLumi").reset();
-    MEs_.at("TTFlags4ByLumi").reset();
-    MEs_.at("LHCStatusByLumi").reset(-1);
-
-    // Reset lhcStatusSet_ to false at the beginning of each LS; when LHC status is set in some event this variable will be set to true
-    lhcStatusSet_ = false;
-  }
-
-  void TrigPrimTask::beginEvent(edm::Event const& _evt, edm::EventSetup const& _es) {
+  void TrigPrimTask::beginEvent(edm::Event const& _evt,
+                                edm::EventSetup const& _es,
+                                bool const& ByLumiResetSwitch,
+                                bool& lhcStatusSet) {
     using namespace std;
 
     towerReadouts_.clear();
 
-    if (!lhcStatusSet_) {
+    if (!lhcStatusSet) {
       // Update LHC status once each LS
       MESet& meLHCStatusByLumi(static_cast<MESet&>(MEs_.at("LHCStatusByLumi")));
       edm::Handle<TCDSRecord> tcdsData;
       _evt.getByToken(lhcStatusInfoRecordToken_, tcdsData);
       if (tcdsData.isValid()) {
         meLHCStatusByLumi.fill(double(tcdsData->getBST().getBeamMode()));
-        lhcStatusSet_ = true;
+        lhcStatusSet = true;
       }
+    }
+
+    if (ByLumiResetSwitch) {
+      MEs_.at("EtSummaryByLumi").reset();
+      MEs_.at("TTFlags4ByLumi").reset();
+      MEs_.at("LHCStatusByLumi").reset(-1);
     }
 
     realTps_ = nullptr;

--- a/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
+++ b/DQM/EcalMonitorTasks/src/TrigPrimTask.cc
@@ -61,6 +61,12 @@ namespace ecaldqm {
 
     towerReadouts_.clear();
 
+    if (ByLumiResetSwitch) {
+      MEs_.at("EtSummaryByLumi").reset();
+      MEs_.at("TTFlags4ByLumi").reset();
+      MEs_.at("LHCStatusByLumi").reset(-1);
+    }
+
     if (!lhcStatusSet) {
       // Update LHC status once each LS
       MESet& meLHCStatusByLumi(static_cast<MESet&>(MEs_.at("LHCStatusByLumi")));
@@ -70,12 +76,6 @@ namespace ecaldqm {
         meLHCStatusByLumi.fill(double(tcdsData->getBST().getBeamMode()));
         lhcStatusSet = true;
       }
-    }
-
-    if (ByLumiResetSwitch) {
-      MEs_.at("EtSummaryByLumi").reset();
-      MEs_.at("TTFlags4ByLumi").reset();
-      MEs_.at("LHCStatusByLumi").reset(-1);
     }
 
     realTps_ = nullptr;


### PR DESCRIPTION
Change DQMOneLumiEDAnalyzer to DQMOneEDAnalyzer to allow concurrent processing of lumisections.

#### PR description:

This PR is meant to allow concurrent processing of lumisections with ECAL included in the workflow. This is done by changing the class from which the tasks inherit from DQMOneLumiEDAnalyzer to DQMOneEDAnalyzer.

No changes are expected in the output.

This PR supersedes earlier ECAL PR 30187 (https://github.com/cms-sw/cmssw/pull/30187).

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

The standard suite of tests was run: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->
Not a backport.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
