### PR TITLE
fix MF regression test in the Py3 case

### DIFF
--- a/MagneticField/Engine/test/regression.py
+++ b/MagneticField/Engine/test/regression.py
@@ -1,4 +1,5 @@
 
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 import sys
@@ -155,10 +156,10 @@ elif options.producerType == 'fromDB' or options.producerType == 'fromDB_DD4Hep'
 
 
 else :
-    print '\nERROR: invalid producerType', producerType,'\n'
+    print('\nERROR: invalid producerType', producerType,'\n')
 
 
-print '\nRegression for MF built with', options.producerType, 'era:', options.era, 'current:', options.current,'\n'
+print('\nRegression for MF built with', options.producerType, 'era:', options.era, 'current:', options.current,'\n')
 
 
 process.testMagneticField = cms.EDAnalyzer("testMagneticField",


### PR DESCRIPTION
#### PR description:

I noticed *en passant* that the `MagneticFieldEngineTestDriver` is failing in the Py3 builds (see [log](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_2_PY3_X_2020-10-06-2300/unitTestLogs/MagneticField/Engine#/)).
This is fixed, by using the `print_function` of the `_future_` library.

#### PR validation:

I've run the unit test in the `CMSSW_11_2_PY3_X_2020-10-06-2300` with the updated file and now it run to success.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed.
