### PR TITLE
Add ntracks associated to each SV

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -589,6 +589,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('x', 'x', 20, -0.5, 0.5, 'secondary vertex X position, in cm'),
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
+                Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -31,7 +31,7 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
         z   = Var("position().z()", float, doc = "secondary vertex Z position, in cm",precision=14),
         ndof    = Var("vertexNdof()", float, doc = "number of degrees of freedom",precision=8),
         chi2    = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
-        ntracks = Var("numberOfDaughters()", int, doc = "number of tracks"),
+        ntracks = Var("numberOfDaughters()", "uint8", doc = "number of tracks"),
     ),
 )
 svCandidateTable.variables.pt.precision=10

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -29,8 +29,9 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
         x   = Var("position().x()", float, doc = "secondary vertex X position, in cm",precision=10),
         y   = Var("position().y()", float, doc = "secondary vertex Y position, in cm",precision=10),
         z   = Var("position().z()", float, doc = "secondary vertex Z position, in cm",precision=14),
-        ndof   = Var("vertexNdof()", float, doc = "number of degrees of freedom",precision=8),
-        chi2   = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
+        ndof    = Var("vertexNdof()", float, doc = "number of degrees of freedom",precision=8),
+        chi2    = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
+        ntracks = Var("numberOfDaughters()", int, doc = "number of tracks"),
     ),
 )
 svCandidateTable.variables.pt.precision=10


### PR DESCRIPTION
**PR description:**

Add the number of tracks associated to each SV
Necessary for the soft b-tagging algorithm developed int the context of SUS-16-049 and is been used in multiple other analyses [e.g., SUS-16-032, SUS-19-009, SUS-19-010, HIG-18-026,..]

Also: Necessary for the calibration of the bb/cc component of various boosted jet taggers [e.g, DeepAK8/DeepAK15/ParticleNet..]   

**PR validation:**

produced a test file:
`cmsDriver.py test_nanoTuples_mc2017 -n 10 --mc --eventcontent NANOAODSIM --datatier NANOAODSIM --conditions auto:phase1_2017_realistic --step NANO --nThreads 1 --era Run2_2017,run2_nanoAOD_106Xv1 --filein /store/mc/RunIISummer19UL17MiniAOD/TTToSemiLeptonic_TuneCP5CR2_13TeV-powheg-pythia8/MINIAODSIM/106X_mc2017_realistic_v6-v1/10000/466694A9-3806-624C-87A0-97C8379FAD23.root --fileout file:nano_mc2017.root --customise_commands "process.options.wantSummary = cms.untracked.bool(True)"`
