### PR TITLE
Migrate most of MixingModule and PreMixingModule to EventSetup consumes

### DIFF
--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
@@ -21,10 +21,9 @@
 class SiPixelGainCalibrationForHLTService final
     : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTRcd> {
 public:
-  explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf)
+  explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
       : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTRcd>(
-            conf){};
-  ~SiPixelGainCalibrationForHLTService() override{};
+            conf, std::move(iC)){};
 
   void calibrate(
       uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int* electron) override;

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h
@@ -23,10 +23,9 @@ class SiPixelGainCalibrationForHLTSimService
     : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,
                                                         SiPixelGainCalibrationForHLTSimRcd> {
 public:
-  explicit SiPixelGainCalibrationForHLTSimService(const edm::ParameterSet& conf)
+  explicit SiPixelGainCalibrationForHLTSimService(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
       : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT, SiPixelGainCalibrationForHLTSimRcd>(
-            conf){};
-  ~SiPixelGainCalibrationForHLTSimService() override{};
+            conf, std::move(iC)){};
 
   // column granularity
   float getPedestal(const uint32_t& detID, const int& col, const int& row) override;

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h
@@ -21,10 +21,9 @@
 class SiPixelGainCalibrationOfflineService
     : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineRcd> {
 public:
-  explicit SiPixelGainCalibrationOfflineService(const edm::ParameterSet& conf)
+  explicit SiPixelGainCalibrationOfflineService(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
       : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineRcd>(
-            conf){};
-  ~SiPixelGainCalibrationOfflineService() override{};
+            conf, std::move(iC)){};
 
   // pixel granularity
   float getPedestal(const uint32_t& detID, const int& col, const int& row) override;

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h
@@ -23,10 +23,8 @@ class SiPixelGainCalibrationOfflineSimService
     : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline,
                                                         SiPixelGainCalibrationOfflineSimRcd> {
 public:
-  explicit SiPixelGainCalibrationOfflineSimService(const edm::ParameterSet& conf)
-      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationOffline, SiPixelGainCalibrationOfflineSimRcd>(
-            conf){};
-  ~SiPixelGainCalibrationOfflineSimService() override{};
+  explicit SiPixelGainCalibrationOfflineSimService(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+      : SiPixelGainCalibrationServicePayloadGetter(conf, iC){};
 
   // pixel granularity
   float getPedestal(const uint32_t& detID, const int& col, const int& row) override;

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h
@@ -21,9 +21,9 @@
 class SiPixelGainCalibrationService
     : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration, SiPixelGainCalibrationRcd> {
 public:
-  explicit SiPixelGainCalibrationService(const edm::ParameterSet& conf)
-      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration, SiPixelGainCalibrationRcd>(conf){};
-  ~SiPixelGainCalibrationService() override{};
+  explicit SiPixelGainCalibrationService(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+      : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibration, SiPixelGainCalibrationRcd>(conf,
+                                                                                                      std::move(iC)){};
 
   // pixel granularity
   float getPedestal(const uint32_t& detID, const int& col, const int& row) override;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
@@ -9,7 +9,7 @@ namespace cms {
       : conf_(conf),
         trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
         trackerGeomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-        SiPixelGainCalibrationForHLTService_(conf),
+        SiPixelGainCalibrationForHLTService_(conf, consumesCollector()),
         filename_(conf.getParameter<std::string>("fileName")) {}
 
   void SiPixelFakeGainForHLTReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
@@ -7,7 +7,7 @@
 namespace cms {
   SiPixelFakeGainOfflineReader::SiPixelFakeGainOfflineReader(const edm::ParameterSet& conf)
       : conf_(conf),
-        SiPixelGainCalibrationOfflineService_(conf),
+        SiPixelGainCalibrationOfflineService_(conf, consumesCollector()),
         trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
         trackerGeomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
         filename_(conf.getParameter<std::string>("fileName")) {}

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.cc
@@ -9,7 +9,7 @@ namespace cms {
       : conf_(conf),
         trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
         trackerGeomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-        SiPixelGainCalibrationService_(conf),
+        SiPixelGainCalibrationService_(conf, consumesCollector()),
         filename_(conf.getParameter<std::string>("fileName")) {}
 
   void SiPixelFakeGainReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjAllPayloadsReader.h
@@ -22,11 +22,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
@@ -45,16 +45,14 @@ namespace cms {
   public:
     explicit SiPixelCondObjAllPayloadsReader(const edm::ParameterSet& iConfig);
 
-    ~SiPixelCondObjAllPayloadsReader(){};
-    virtual void beginJob();
     virtual void analyze(const edm::Event&, const edm::EventSetup&);
     virtual void endJob();
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
     //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-    SiPixelGainCalibrationServiceBase* SiPixelGainCalibrationService_;
+    std::unique_ptr<SiPixelGainCalibrationServiceBase> SiPixelGainCalibrationService_;
 
     std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;
     std::map<uint32_t, TH1F*> _TH1F_Gains_m;

--- a/CondTools/SiPixel/test/SiPixelCondObjBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelCondObjBuilder.cc
@@ -5,9 +5,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
@@ -17,8 +15,9 @@ namespace cms {
   SiPixelCondObjBuilder::SiPixelCondObjBuilder(const edm::ParameterSet& iConfig)
       : conf_(iConfig),
         appendMode_(conf_.getUntrackedParameter<bool>("appendMode", true)),
+        pddToken_(esConsumes()),
         SiPixelGainCalibration_(nullptr),
-        SiPixelGainCalibrationService_(iConfig),
+        SiPixelGainCalibrationService_(iConfig, consumesCollector()),
         recordName_(iConfig.getParameter<std::string>("record")),
         meanPed_(conf_.getParameter<double>("meanPed")),
         rmsPed_(conf_.getParameter<double>("rmsPed")),
@@ -52,8 +51,7 @@ namespace cms {
     float maxped = 255;
     SiPixelGainCalibration_ = new SiPixelGainCalibration(minped, maxped, mingain, maxgain);
 
-    edm::ESHandle<TrackerGeometry> pDD;
-    iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+    const TrackerGeometry* pDD = &iSetup.getData(pddToken_);
     edm::LogInfo("SiPixelCondObjBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
 
     for (TrackerGeometry::DetContainer::const_iterator it = pDD->dets().begin(); it != pDD->dets().end(); it++) {

--- a/CondTools/SiPixel/test/SiPixelCondObjBuilder.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjBuilder.h
@@ -22,11 +22,12 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 //#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
 #include "CondFormats/SiPixelObjects/interface/PixelIndices.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include <string>
 
 namespace cms {
@@ -43,6 +44,7 @@ namespace cms {
   private:
     edm::ParameterSet conf_;
     bool appendMode_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
     SiPixelGainCalibration* SiPixelGainCalibration_;
     SiPixelGainCalibrationService SiPixelGainCalibrationService_;
     std::string recordName_;

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTBuilder.cc
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTBuilder.cc
@@ -21,7 +21,7 @@ namespace cms {
       : conf_(iConfig),
         appendMode_(conf_.getUntrackedParameter<bool>("appendMode", true)),
         SiPixelGainCalibration_(nullptr),
-        SiPixelGainCalibrationService_(iConfig),
+        SiPixelGainCalibrationService_(iConfig, consumesCollector()),
         recordName_(iConfig.getParameter<std::string>("record")),
         meanPed_(conf_.getParameter<double>("meanPed")),
         rmsPed_(conf_.getParameter<double>("rmsPed")),

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader.cc
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader.cc
@@ -3,7 +3,6 @@
 #include "CondTools/SiPixel/test/SiPixelCondObjForHLTReader.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -12,11 +11,14 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTSimService.h"
 
 namespace cms {
-  SiPixelCondObjForHLTReader::SiPixelCondObjForHLTReader(const edm::ParameterSet& conf) : conf_(conf) {
+  SiPixelCondObjForHLTReader::SiPixelCondObjForHLTReader(const edm::ParameterSet& conf)
+      : conf_(conf), tkGeomToken_(esConsumes()) {
     if (conf_.getParameter<bool>("useSimRcd"))
-      SiPixelGainCalibrationService_ = new SiPixelGainCalibrationForHLTSimService(conf_);
+      SiPixelGainCalibrationService_ =
+          std::make_unique<SiPixelGainCalibrationForHLTSimService>(conf_, consumesCollector());
     else
-      SiPixelGainCalibrationService_ = new SiPixelGainCalibrationForHLTService(conf_);
+      SiPixelGainCalibrationService_ =
+          std::make_unique<SiPixelGainCalibrationForHLTService>(conf_, consumesCollector());
   }
 
   void SiPixelCondObjForHLTReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -37,7 +39,7 @@ namespace cms {
         << "[SiPixelCondObjForHLTReader::beginJob] End Reading CondObjForHLTects" << std::endl;
 
     // Get the Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    const TrackerGeometry* tkgeom = &iSetup.getData(tkGeomToken_);
     edm::LogInfo("SiPixelCondObjForHLTReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
     // Get the list of DetId's
@@ -194,9 +196,6 @@ namespace cms {
     std::cout << "         in FPIX " << _TH1F_Pedestals_fpix->GetMean() << " with rms "
               << _TH1F_Pedestals_fpix->GetRMS() << std::endl;
   }
-
-  // ------------ method called once each job just before starting event loop  ------------
-  void SiPixelCondObjForHLTReader::beginJob() {}
 
   // ------------ method called once each job just after ending the event loop  ------------
   void SiPixelCondObjForHLTReader::endJob() { std::cout << " ---> End job " << std::endl; }

--- a/CondTools/SiPixel/test/SiPixelCondObjForHLTReader.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjForHLTReader.h
@@ -22,11 +22,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //#include "CondFormats/SiPixelObjForHLTects/interface/SiPixelGainCalibration.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
 
 #include "TROOT.h"
@@ -40,16 +40,14 @@ namespace cms {
   public:
     explicit SiPixelCondObjForHLTReader(const edm::ParameterSet &iConfig);
 
-    ~SiPixelCondObjForHLTReader(){};
-    virtual void beginJob();
     virtual void analyze(const edm::Event &, const edm::EventSetup &);
     virtual void endJob();
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
     //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-    SiPixelGainCalibrationServiceBase *SiPixelGainCalibrationService_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
+    std::unique_ptr<SiPixelGainCalibrationServiceBase> SiPixelGainCalibrationService_;
 
     std::map<uint32_t, TH1F *> _TH1F_Pedestals_m;
     std::map<uint32_t, TH1F *> _TH1F_Gains_m;

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineBuilder.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineBuilder.h
@@ -22,11 +22,12 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 //#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h"
 #include "CondFormats/SiPixelObjects/interface/PixelIndices.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include <string>
 
 namespace cms {
@@ -34,15 +35,14 @@ namespace cms {
   public:
     explicit SiPixelCondObjOfflineBuilder(const edm::ParameterSet& iConfig);
 
-    ~SiPixelCondObjOfflineBuilder(){};
     virtual void beginJob();
     virtual void analyze(const edm::Event&, const edm::EventSetup&);
-    virtual void endJob();
     bool loadFromFile();
 
   private:
     edm::ParameterSet conf_;
     bool appendMode_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
     SiPixelGainCalibrationOffline* SiPixelGainCalibration_;
     SiPixelGainCalibrationOfflineService SiPixelGainCalibrationService_;
     std::string recordName_;

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader.cc
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader.cc
@@ -5,18 +5,20 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineSimService.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 namespace cms {
-  SiPixelCondObjOfflineReader::SiPixelCondObjOfflineReader(const edm::ParameterSet& conf) : conf_(conf) {
+  SiPixelCondObjOfflineReader::SiPixelCondObjOfflineReader(const edm::ParameterSet& conf)
+      : conf_(conf), tkGeomToken_(esConsumes()) {
     if (conf_.getParameter<bool>("useSimRcd"))
-      SiPixelGainCalibrationService_ = new SiPixelGainCalibrationOfflineSimService(conf_);
+      SiPixelGainCalibrationService_ =
+          std::make_unique<SiPixelGainCalibrationOfflineSimService>(conf_, consumesCollector());
     else
-      SiPixelGainCalibrationService_ = new SiPixelGainCalibrationOfflineService(conf_);
+      SiPixelGainCalibrationService_ =
+          std::make_unique<SiPixelGainCalibrationOfflineService>(conf_, consumesCollector());
   }
 
   void SiPixelCondObjOfflineReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -37,7 +39,7 @@ namespace cms {
         << "[SiPixelCondObjOfflineReader::beginJob] End Reading CondObjOfflineects" << std::endl;
 
     // Get the Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    const TrackerGeometry* tkgeom = &iSetup.getData(tkGeomToken_);
     edm::LogInfo("SiPixelCondObjOfflineReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
     // Get the list of DetId's
@@ -198,9 +200,6 @@ namespace cms {
     std::cout << "         in FPIX " << _TH1F_Pedestals_fpix->GetMean() << " with rms "
               << _TH1F_Pedestals_fpix->GetRMS() << std::endl;
   }
-
-  // ------------ method called once each job just before starting event loop  ------------
-  void SiPixelCondObjOfflineReader::beginJob() {}
 
   // ------------ method called once each job just after ending the event loop  ------------
   void SiPixelCondObjOfflineReader::endJob() { std::cout << " ---> End job " << std::endl; }

--- a/CondTools/SiPixel/test/SiPixelCondObjOfflineReader.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjOfflineReader.h
@@ -22,11 +22,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //#include "CondFormats/SiPixelObjOfflineects/interface/SiPixelGainCalibration.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h"
 
 #include "TROOT.h"
@@ -40,17 +40,15 @@ namespace cms {
   public:
     explicit SiPixelCondObjOfflineReader(const edm::ParameterSet &iConfig);
 
-    ~SiPixelCondObjOfflineReader(){};
-    virtual void beginJob();
     virtual void analyze(const edm::Event &, const edm::EventSetup &);
     virtual void endJob();
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
     std::string recordName_;
     //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-    SiPixelGainCalibrationServiceBase *SiPixelGainCalibrationService_;
+    std::unique_ptr<SiPixelGainCalibrationServiceBase> SiPixelGainCalibrationService_;
 
     std::map<uint32_t, TH1F *> _TH1F_Pedestals_m;
     std::map<uint32_t, TH1F *> _TH1F_Gains_m;

--- a/CondTools/SiPixel/test/SiPixelCondObjReader.cc
+++ b/CondTools/SiPixel/test/SiPixelCondObjReader.cc
@@ -3,7 +3,6 @@
 #include "CondTools/SiPixel/test/SiPixelCondObjReader.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
@@ -11,7 +10,7 @@
 
 namespace cms {
   SiPixelCondObjReader::SiPixelCondObjReader(const edm::ParameterSet& conf)
-      : conf_(conf), SiPixelGainCalibrationService_(conf) {}
+      : conf_(conf), tkGeomToken_(esConsumes()), SiPixelGainCalibrationService_(conf, consumesCollector()) {}
 
   void SiPixelCondObjReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
     //Create Subdirectories
@@ -30,7 +29,7 @@ namespace cms {
     edm::LogInfo("SiPixelCondObjReader") << "[SiPixelCondObjReader::beginJob] End Reading CondObjects" << std::endl;
 
     // Get the Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    const TrackerGeometry* tkgeom = &iSetup.getData(tkGeomToken_);
     edm::LogInfo("SiPixelCondObjReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
 
     // Get the list of DetId's

--- a/CondTools/SiPixel/test/SiPixelCondObjReader.h
+++ b/CondTools/SiPixel/test/SiPixelCondObjReader.h
@@ -22,11 +22,11 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
 
 #include "TROOT.h"
@@ -47,7 +47,7 @@ namespace cms {
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> tkGeomToken_;
     //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
     SiPixelGainCalibrationService SiPixelGainCalibrationService_;
 

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.cc
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.cc
@@ -142,8 +142,7 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
             << std::endl;
   uint32_t detid = 0;
   therootfile->cd();
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry *pDD = &iSetup.getData(pddToken_);
   edm::LogInfo("SiPixelCondObjOfflineBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
 
   int NDetid = 0;
@@ -486,7 +485,8 @@ void SiPixelGainCalibrationReadDQMFile::fillDatabase(const edm::EventSetup &iSet
 
 SiPixelGainCalibrationReadDQMFile::SiPixelGainCalibrationReadDQMFile(const edm::ParameterSet &iConfig)
     : appendMode_(iConfig.getUntrackedParameter<bool>("appendMode", true)),
-      theGainCalibrationDbInputService_(iConfig),
+      pddToken_(esConsumes()),
+      theGainCalibrationDbInputService_(iConfig, consumesCollector()),
       record_(iConfig.getUntrackedParameter<std::string>("record", "SiPixelGainCalibrationOfflineRcd")),
       gainlow_(10.),
       gainhi_(0.),

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.h
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationReadDQMFile.h
@@ -62,6 +62,7 @@ private:
   std::map<uint32_t, std::vector<std::map<int, int> > > noisyPixelsKeeper_;
 
   bool appendMode_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
   SiPixelGainCalibrationService theGainCalibrationDbInputService_;
   std::unique_ptr<TH2F> defaultGain_;
   std::unique_ptr<TH2F> defaultPed_;

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead.cc
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead.cc
@@ -21,9 +21,7 @@
 
 #include "SiPixelGainCalibrationRejectNoisyAndDead.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 
 //
@@ -58,8 +56,7 @@ void SiPixelGainCalibrationRejectNoisyAndDead::fillDatabase(const edm::EventSetu
     SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
 
   //Get list of ideal detids
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry* pDD = &iSetup.getData(pddToken_);
   edm::LogInfo("SiPixelCondObjOfflineBuilder") << " There are " << pDD->dets().size() << " detectors" << std::endl;
 
   if (record_ == "SiPixelGainCalibrationOfflineRcd") {
@@ -434,8 +431,9 @@ void SiPixelGainCalibrationRejectNoisyAndDead::getDeadPixels() {}
 
 SiPixelGainCalibrationRejectNoisyAndDead::SiPixelGainCalibrationRejectNoisyAndDead(const edm::ParameterSet& iConfig)
     : conf_(iConfig),
-      SiPixelGainCalibrationOfflineService_(iConfig),
-      SiPixelGainCalibrationForHLTService_(iConfig),
+      pddToken_(esConsumes()),
+      SiPixelGainCalibrationOfflineService_(iConfig, consumesCollector()),
+      SiPixelGainCalibrationForHLTService_(iConfig, consumesCollector()),
       noisypixellist_(iConfig.getUntrackedParameter<std::string>("noisyPixelList", "noisypixel.txt")),
       insertnoisypixelsindb_(iConfig.getUntrackedParameter<int>("insertNoisyPixelsInDB", 1)),
       record_(iConfig.getUntrackedParameter<std::string>("record", "SiPixelGainCalibrationOfflineRcd")),
@@ -451,11 +449,5 @@ void SiPixelGainCalibrationRejectNoisyAndDead::analyze(const edm::Event& iEvent,
     getNoisyPixels();
   fillDatabase(iSetup);
 }
-
-// ------------ method called once each job just before starting event loop  ------------
-void SiPixelGainCalibrationRejectNoisyAndDead::beginJob() {}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void SiPixelGainCalibrationRejectNoisyAndDead::endJob() {}
 
 //define this as a plug-in

--- a/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead.h
+++ b/CondTools/SiPixel/test/SiPixelGainCalibrationRejectNoisyAndDead.h
@@ -23,6 +23,8 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "TH2F.h"
 #include "TFile.h"
@@ -38,6 +40,7 @@ public:
 
 private:
   edm::ParameterSet conf_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pddToken_;
   SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
   //SiPixelGainCalibrationForHLTService SiPixelGainCalibrationService_;
   SiPixelGainCalibrationOffline *theGainCalibrationDbInputOffline_;
@@ -45,9 +48,7 @@ private:
   SiPixelGainCalibrationForHLTService SiPixelGainCalibrationForHLTService_;
   SiPixelGainCalibrationForHLT *theGainCalibrationDbInputForHLT_;
 
-  virtual void beginJob();
   virtual void analyze(const edm::Event &, const edm::EventSetup &);
-  virtual void endJob();
 
   std::map<int, std::vector<std::pair<int, int> > > noisypixelkeeper;
   std::map<int, std::vector<std::pair<int, int> > > insertednoisypixel;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -59,11 +59,11 @@ SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf)
 
   const auto& payloadType = conf.getParameter<std::string>("payloadType");
   if (payloadType == "HLT")
-    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationForHLTService>(conf);
+    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationForHLTService>(conf, consumesCollector());
   else if (payloadType == "Offline")
-    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationOfflineService>(conf);
+    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationOfflineService>(conf, consumesCollector());
   else if (payloadType == "Full")
-    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationService>(conf);
+    theSiPixelGainCalibration_ = std::make_unique<SiPixelGainCalibrationService>(conf, consumesCollector());
 
   //--- Make the algorithm(s) according to what the user specified
   //--- in the ParameterSet.

--- a/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h
+++ b/RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h
@@ -28,8 +28,8 @@ public:
   void suppress(const std::vector<SiStripDigi>& in,
                 std::vector<SiStripDigi>& selectedSignal,
                 uint32_t detId,
-                edm::ESHandle<SiStripNoises>&,
-                edm::ESHandle<SiStripThreshold>&);
+                const SiStripNoises&,
+                const SiStripThreshold&);
   void suppress(const std::vector<SiStripDigi>& in, std::vector<SiStripDigi>& selectedSignal, uint32_t detId);
   void suppress(const edm::DetSet<SiStripRawDigi>& in, edm::DetSet<SiStripDigi>& out);
   void suppress(const std::vector<int16_t>& in, uint16_t firstAPV, edm::DetSet<SiStripDigi>& out);

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -1,10 +1,14 @@
 #ifndef CastorDigiProducer_h
 #define CastorDigiProducer_h
 
+#include "CalibFormats/CastorObjects/interface/CastorDbRecord.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
 #include "SimCalorimetry/CastorSim/src/CastorAmplifier.h"
@@ -19,11 +23,6 @@
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 #include <vector>
-
-namespace edm {
-  class StreamID;
-  class ConsumesCollector;
-}  // namespace edm
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -54,6 +53,9 @@ private:
   void checkGeometry(const edm::EventSetup &eventSetup);
 
   edm::InputTag theHitsProducerTag;
+  const edm::ESGetToken<CastorDbService, CastorDbRecord> theConditionsToken;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theGeometryToken;
+  edm::ESWatcher<CaloGeometryRecord> theGeometryWatcher;
 
   /** Reconstruction algorithm*/
   typedef CaloTDigitizer<CastorDigitizerTraits> CastorDigitizer;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -1,9 +1,29 @@
 #ifndef SimCalorimetry_EcalSimProducers_EcalDigiProducer_h
 #define SimCalorimetry_EcalSimProducers_EcalDigiProducer_h
 
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
+#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
+#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
+#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
+#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
+#include "CondFormats/DataRecord/interface/ESGainRcd.h"
+#include "CondFormats/DataRecord/interface/ESIntercalibConstantsRcd.h"
+#include "CondFormats/DataRecord/interface/ESMIPToGeVConstantRcd.h"
+#include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
+#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
+#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
+#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
+#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
+#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
+#include "CondFormats/ESObjects/interface/ESGain.h"
+#include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
+#include "CondFormats/ESObjects/interface/ESMIPToGeVConstant.h"
+#include "CondFormats/ESObjects/interface/ESPedestals.h"
 #include "DataFormats/Math/interface/Error.h"
 #include "CalibFormats/CaloObjects/interface/CaloTSamples.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/APDShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBShape.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEShape.h"
@@ -98,6 +118,18 @@ private:
   const std::string m_EEdigiCollection;
   const std::string m_ESdigiCollection;
   const std::string m_hitsProducerTag;
+
+  const edm::ESGetToken<EcalPedestals, EcalPedestalsRcd> m_pedestalsToken;
+  const edm::ESGetToken<EcalIntercalibConstantsMC, EcalIntercalibConstantsMCRcd> m_icalToken;
+  const edm::ESGetToken<EcalLaserDbService, EcalLaserDbRecord> m_laserToken;
+  const edm::ESGetToken<EcalADCToGeVConstant, EcalADCToGeVConstantRcd> m_agcToken;
+  const edm::ESGetToken<EcalGainRatios, EcalGainRatiosRcd> m_grToken;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
+  edm::ESGetToken<ESGain, ESGainRcd> m_esGainToken;
+  edm::ESGetToken<ESMIPToGeVConstant, ESMIPToGeVConstantRcd> m_esMIPToGeVToken;
+  edm::ESGetToken<ESPedestals, ESPedestalsRcd> m_esPedestalsToken;
+  edm::ESGetToken<ESIntercalibConstants, ESIntercalibConstantsRcd> m_esMIPsToken;
+  edm::ESWatcher<CaloGeometryRecord> m_geometryWatcher;
 
   bool m_useLCcorrection;
 

--- a/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalTimeDigiProducer.h
@@ -5,8 +5,11 @@
 
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalDigitizerTraits.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
@@ -21,11 +24,8 @@ class PileUpEventPrincipal;
 class EcalTimeMapDigitizer;
 
 namespace edm {
-  class Event;
-  class EventSetup;
   template <typename T>
   class Handle;
-  class ParameterSet;
 }  // namespace edm
 
 class EcalTimeDigiProducer : public DigiAccumulatorMixMod {
@@ -49,6 +49,8 @@ private:
   const std::string m_EBdigiCollection;
   const edm::InputTag m_hitsProducerTagEB;
   const edm::EDGetTokenT<std::vector<PCaloHit>> m_hitsProducerTokenEB;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
+  edm::ESWatcher<CaloGeometryRecord> m_geometryWatcher;
 
 private:
   int m_timeLayerEB;

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -14,20 +14,9 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
 #include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 //#include "SimCalorimetry/EcalSimAlgos/interface/ESFastTDigitizer.h"
-#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbRecord.h"
-#include "CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
-#include "CondFormats/DataRecord/interface/EcalADCToGeVConstantRcd.h"
-#include "CondFormats/DataRecord/interface/EcalGainRatiosRcd.h"
-#include "CondFormats/DataRecord/interface/EcalIntercalibConstantsMCRcd.h"
-#include "CondFormats/DataRecord/interface/EcalPedestalsRcd.h"
-#include "CondFormats/EcalObjects/interface/EcalADCToGeVConstant.h"
-#include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
-#include "CondFormats/EcalObjects/interface/EcalIntercalibConstantsMC.h"
-#include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -39,19 +28,10 @@
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/ESDigitizer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-#include "CondFormats/DataRecord/interface/ESGainRcd.h"
-#include "CondFormats/DataRecord/interface/ESIntercalibConstantsRcd.h"
-#include "CondFormats/DataRecord/interface/ESMIPToGeVConstantRcd.h"
-#include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
-#include "CondFormats/ESObjects/interface/ESGain.h"
-#include "CondFormats/ESObjects/interface/ESIntercalibConstants.h"
-#include "CondFormats/ESObjects/interface/ESMIPToGeVConstant.h"
-#include "CondFormats/ESObjects/interface/ESPedestals.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
 EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params,
@@ -77,6 +57,12 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
       m_EEdigiCollection(params.getParameter<std::string>("EEdigiCollection")),
       m_ESdigiCollection(params.getParameter<std::string>("ESdigiCollection")),
       m_hitsProducerTag(params.getParameter<std::string>("hitsProducer")),
+      m_pedestalsToken(iC.esConsumes()),
+      m_icalToken(iC.esConsumes()),
+      m_laserToken(iC.esConsumes()),
+      m_agcToken(iC.esConsumes()),
+      m_grToken(iC.esConsumes()),
+      m_geometryToken(iC.esConsumes()),
       m_useLCcorrection(params.getUntrackedParameter<bool>("UseLCcorrection")),
       m_apdSeparateDigi(params.getParameter<bool>("apdSeparateDigi")),
 
@@ -160,8 +146,13 @@ EcalDigiProducer::EcalDigiProducer(const edm::ParameterSet &params, edm::Consume
     iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
   if (m_doEE)
     iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
-  if (m_doES)
+  if (m_doES) {
     iC.consumes<std::vector<PCaloHit>>(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
+    m_esGainToken = iC.esConsumes();
+    m_esMIPToGeVToken = iC.esConsumes();
+    m_esPedestalsToken = iC.esConsumes();
+    m_esMIPsToken = iC.esConsumes();
+  }
 
   const std::vector<double> ebCorMatG12 = params.getParameter<std::vector<double>>("EBCorrNoiseMatrixG12");
   const std::vector<double> eeCorMatG12 = params.getParameter<std::vector<double>>("EECorrNoiseMatrixG12");
@@ -436,18 +427,14 @@ void EcalDigiProducer::beginLuminosityBlock(edm::LuminosityBlock const &lumi, ed
 void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::EventSetup &eventSetup) {
   // Pedestals from event setup
 
-  edm::ESHandle<EcalPedestals> dbPed;
-  eventSetup.get<EcalPedestalsRcd>().get(dbPed);
-  const EcalPedestals *pedestals(dbPed.product());
+  const EcalPedestals *pedestals = &eventSetup.getData(m_pedestalsToken);
 
   m_Coder->setPedestals(pedestals);
   if (nullptr != m_APDCoder)
     m_APDCoder->setPedestals(pedestals);
 
   // Ecal Intercalibration Constants
-  edm::ESHandle<EcalIntercalibConstantsMC> pIcal;
-  eventSetup.get<EcalIntercalibConstantsMCRcd>().get(pIcal);
-  const EcalIntercalibConstantsMC *ical(pIcal.product());
+  const EcalIntercalibConstantsMC *ical = &eventSetup.getData(m_icalToken);
 
   m_Coder->setIntercalibConstants(ical);
   if (nullptr != m_APDCoder)
@@ -458,25 +445,20 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::Eve
     m_APDResponse->setIntercal(ical);
 
   // Ecal LaserCorrection Constants
-  edm::ESHandle<EcalLaserDbService> laser;
-  eventSetup.get<EcalLaserDbRecord>().get(laser);
+  const EcalLaserDbService *laser = &eventSetup.getData(m_laserToken);
   const edm::TimeValue_t eventTimeValue = event.time().value();
 
   m_EBResponse->setEventTime(eventTimeValue);
-  m_EBResponse->setLaserConstants(laser.product(), m_useLCcorrection);
+  m_EBResponse->setLaserConstants(laser, m_useLCcorrection);
 
   m_EEResponse->setEventTime(eventTimeValue);
-  m_EEResponse->setLaserConstants(laser.product(), m_useLCcorrection);
+  m_EEResponse->setLaserConstants(laser, m_useLCcorrection);
 
   // ADC -> GeV Scale
-  edm::ESHandle<EcalADCToGeVConstant> pAgc;
-  eventSetup.get<EcalADCToGeVConstantRcd>().get(pAgc);
-  const EcalADCToGeVConstant *agc = pAgc.product();
+  const EcalADCToGeVConstant *agc = &eventSetup.getData(m_agcToken);
 
   // Gain Ratios
-  edm::ESHandle<EcalGainRatios> pRatio;
-  eventSetup.get<EcalGainRatiosRcd>().get(pRatio);
-  const EcalGainRatios *gr = pRatio.product();
+  const EcalGainRatios *gr = &eventSetup.getData(m_grToken);
 
   m_Coder->setGainRatios(gr);
   if (nullptr != m_APDCoder)
@@ -514,51 +496,33 @@ void EcalDigiProducer::checkCalibrations(const edm::Event &event, const edm::Eve
   if (nullptr != m_APDCoder)
     m_APDCoder->setFullScaleEnergy(EBscale, EEscale);
 
-  if (nullptr != m_ESOldDigitizer || nullptr != m_ESDigitizer) {
+  if (m_doES) {
     // ES condition objects
-    edm::ESHandle<ESGain> hesgain;
-    edm::ESHandle<ESMIPToGeVConstant> hesMIPToGeV;
-    edm::ESHandle<ESPedestals> hesPedestals;
-    edm::ESHandle<ESIntercalibConstants> hesMIPs;
-
-    eventSetup.get<ESGainRcd>().get(hesgain);
-    eventSetup.get<ESMIPToGeVConstantRcd>().get(hesMIPToGeV);
-    eventSetup.get<ESPedestalsRcd>().get(hesPedestals);
-    eventSetup.get<ESIntercalibConstantsRcd>().get(hesMIPs);
-
-    const ESGain *esgain(hesgain.product());
-    const ESPedestals *espeds(hesPedestals.product());
-    const ESIntercalibConstants *esmips(hesMIPs.product());
-    const ESMIPToGeVConstant *esMipToGeV(hesMIPToGeV.product());
+    const ESGain *esgain = &eventSetup.getData(m_esGainToken);
+    const ESPedestals *espeds = &eventSetup.getData(m_esPedestalsToken);
+    const ESIntercalibConstants *esmips = &eventSetup.getData(m_esMIPsToken);
+    const ESMIPToGeVConstant *esMipToGeV = &eventSetup.getData(m_esMIPToGeVToken);
     const int ESGain(1.1 > esgain->getESGain() ? 1 : 2);
     const double ESMIPToGeV((1 == ESGain) ? esMipToGeV->getESValueLow() : esMipToGeV->getESValueHigh());
 
-    if (m_doES) {
-      m_ESShape.setGain(ESGain);
-      if (!m_doFastES) {
-        m_ESElectronicsSim->setGain(ESGain);
-        m_ESElectronicsSim->setPedestals(espeds);
-        m_ESElectronicsSim->setMIPs(esmips);
-        m_ESElectronicsSim->setMIPToGeV(ESMIPToGeV);
-      } else {
-        m_ESDigitizer->setGain(ESGain);
-        m_ESElectronicsSimFast->setPedestals(espeds);
-        m_ESElectronicsSimFast->setMIPs(esmips);
-        m_ESElectronicsSimFast->setMIPToGeV(ESMIPToGeV);
-      }
+    m_ESShape.setGain(ESGain);
+    if (!m_doFastES) {
+      m_ESElectronicsSim->setGain(ESGain);
+      m_ESElectronicsSim->setPedestals(espeds);
+      m_ESElectronicsSim->setMIPs(esmips);
+      m_ESElectronicsSim->setMIPToGeV(ESMIPToGeV);
+    } else {
+      m_ESDigitizer->setGain(ESGain);
+      m_ESElectronicsSimFast->setPedestals(espeds);
+      m_ESElectronicsSimFast->setMIPs(esmips);
+      m_ESElectronicsSimFast->setMIPToGeV(ESMIPToGeV);
     }
   }
 }
 
 void EcalDigiProducer::checkGeometry(const edm::EventSetup &eventSetup) {
-  // TODO find a way to avoid doing this every event
-  edm::ESHandle<CaloGeometry> hGeometry;
-  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
-
-  const CaloGeometry *pGeometry = &*hGeometry;
-
-  if (pGeometry != m_Geometry) {
-    m_Geometry = pGeometry;
+  if (m_geometryWatcher.check(eventSetup)) {
+    m_Geometry = &eventSetup.getData(m_geometryToken);
     updateGeometry();
   }
 }

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoTBCalo/EcalTBTDCReconstructor/interface/EcalTBTDCRecInfoAlgo.h"
 #include "SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h"
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
@@ -39,6 +40,7 @@ private:
   std::string m_ecalTBInfoLabel;
   std::string m_EBdigiFinalTag;
   std::string m_EBdigiTempTag;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> m_geometryToken;
 
   bool m_doPhaseShift;
   double m_thisPhaseShift;

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -7,7 +7,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EcalSimParameterMap.h"
@@ -17,7 +16,7 @@
 EcalTBDigiProducer::EcalTBDigiProducer(const edm::ParameterSet &params,
                                        edm::ProducesCollector producesCollector,
                                        edm::ConsumesCollector &iC)
-    : EcalDigiProducer(params, producesCollector, iC) {
+    : EcalDigiProducer(params, producesCollector, iC), m_geometryToken(iC.esConsumes()) {
   std::string const instance("simEcalUnsuppressedDigis");
   m_EBdigiFinalTag = params.getParameter<std::string>("EBdigiFinalCollection");
   m_EBdigiTempTag = params.getParameter<std::string>("EBdigiCollection");
@@ -63,9 +62,7 @@ EcalTBDigiProducer::~EcalTBDigiProducer() {}
 
 void EcalTBDigiProducer::initializeEvent(edm::Event const &event, edm::EventSetup const &eventSetup) {
   std::cout << "====****Entering EcalTBDigiProducer produce()" << std::endl;
-  edm::ESHandle<CaloGeometry> hGeometry;
-  eventSetup.get<CaloGeometryRecord>().get(hGeometry);
-  const std::vector<DetId> &theBarrelDets(hGeometry->getValidDetIds(DetId::Ecal, EcalBarrel));
+  const std::vector<DetId> &theBarrelDets = eventSetup.getData(m_geometryToken).getValidDetIds(DetId::Ecal, EcalBarrel);
 
   m_theTBReadout->setDetIds(theBarrelDets);
 

--- a/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
+++ b/SimCalorimetry/HGCalSimProducers/interface/HGCDigitizer.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"
@@ -11,7 +12,8 @@
 #include "SimCalorimetry/HGCalSimProducers/interface/HGCDigitizerBase.h"
 #include "DataFormats/HGCDigi/interface/HGCDigiCollections.h"
 #include "DataFormats/HGCDigi/interface/PHGCSimAccumulator.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 #include "Geometry/HcalTowerAlgo/interface/HcalGeometry.h"
 
@@ -73,12 +75,6 @@ public:
 
   std::string digiCollection() { return digiCollection_; }
 
-  /**
-      @short actions at the start/end of run
-   */
-  void beginRun(const edm::EventSetup& es);
-  void endRun();
-
 private:
   uint32_t getType() const;
   std::string hitCollection_, digiCollection_;
@@ -108,8 +104,10 @@ private:
   std::unique_ptr<HGCDigitizerBase> theDigitizer_;
 
   //geometries
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+  edm::ESWatcher<CaloGeometryRecord> geomWatcher_;
   std::unordered_set<DetId> validIds_;
-  const HGCalGeometry* gHGCal_;
+  const HGCalGeometry* gHGCal_ = nullptr;
 
   //misc switches
   uint32_t verbosity_;

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.cc
@@ -57,10 +57,4 @@ void HGCDigiProducer::accumulate(PileUpEventPrincipal const& event,
   }
 }
 
-//
-void HGCDigiProducer::beginRun(edm::Run const&, edm::EventSetup const& es) { theDigitizer_.beginRun(es); }
-
-//
-void HGCDigiProducer::endRun(edm::Run const&, edm::EventSetup const&) { theDigitizer_.endRun(); }
-
 DEFINE_DIGI_ACCUMULATOR(HGCDigiProducer);

--- a/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
+++ b/SimCalorimetry/HGCalSimProducers/plugins/HGCDigiProducer.h
@@ -29,8 +29,6 @@ public:
   void finalizeEvent(edm::Event&, edm::EventSetup const&) override;
   void accumulate(edm::Event const&, edm::EventSetup const&) override;
   void accumulate(PileUpEventPrincipal const&, edm::EventSetup const&, edm::StreamID const&) override;
-  void beginRun(edm::Run const&, edm::EventSetup const&) override;
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
   ~HGCDigiProducer() override = default;
 
 private:

--- a/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
+++ b/SimCalorimetry/HGCalSimProducers/plugins/PreMixingHGCalWorker.cc
@@ -24,9 +24,7 @@ public:
   PreMixingHGCalWorker(const PreMixingHGCalWorker&) = delete;
   PreMixingHGCalWorker& operator=(const PreMixingHGCalWorker&) = delete;
 
-  void beginRun(const edm::Run& run, const edm::EventSetup& ES) override;
-  void endRun() override;
-  void initializeEvent(const edm::Event& e, const edm::EventSetup& ES) override {}
+  void initializeEvent(const edm::Event& e, const edm::EventSetup& ES) override;
   void addSignals(const edm::Event& e, const edm::EventSetup& ES) override;
   void addPileups(const PileUpEventPrincipal&, const edm::EventSetup& ES) override;
   void put(edm::Event& e, const edm::EventSetup& ES, std::vector<PileupSummaryInfo> const& ps, int bs) override;
@@ -47,9 +45,9 @@ PreMixingHGCalWorker::PreMixingHGCalWorker(const edm::ParameterSet& ps,
   producesCollector.produces<HGCalDigiCollection>(digitizer_.digiCollection());
 }
 
-void PreMixingHGCalWorker::beginRun(const edm::Run& run, const edm::EventSetup& ES) { digitizer_.beginRun(ES); }
-
-void PreMixingHGCalWorker::endRun() { digitizer_.endRun(); }
+void PreMixingHGCalWorker::initializeEvent(const edm::Event& e, const edm::EventSetup& ES) {
+  digitizer_.initializeEvent(e, ES);
+}
 
 void PreMixingHGCalWorker::addSignals(const edm::Event& e, const edm::EventSetup& ES) {
   edm::Handle<PHGCSimAccumulator> handle;

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -2,6 +2,9 @@
 #define HcalSimProducers_HcalDigitizer_h
 
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CondFormats/DataRecord/interface/HBHEDarkeningRecord.h"
+#include "CondFormats/DataRecord/interface/HcalTimeSlewRecord.h"
 #include "CondFormats/HcalObjects/interface/HBHEDarkening.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalCalibObjects/interface/HFRecalibration.h"
@@ -34,10 +37,6 @@ class HcalBaseSignalGenerator;
 class HcalShapes;
 class PileUpEventPrincipal;
 class HcalTopology;
-
-namespace edm {
-  class ConsumesCollector;
-}
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -74,6 +73,15 @@ private:
   /// make sure the digitizer has the correct list of all cells that
   /// exist in the geometry
   void checkGeometry(const edm::EventSetup &eventSetup);
+  const edm::ESGetToken<HcalDbService, HcalDbRecord> conditionsToken_;
+  const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topoToken_;
+  edm::ESGetToken<HBHEDarkening, HBHEDarkeningRecord> m_HBDarkeningToken;
+  edm::ESGetToken<HBHEDarkening, HBHEDarkeningRecord> m_HEDarkeningToken;
+  const edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> hcalTimeSlew_delay_token_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theGeometryToken;
+  const edm::ESGetToken<HcalDDDRecConstants, HcalRecNumberingRecord> theRecNumberToken;
+  const edm::ESGetToken<HcalQIETypes, HcalQIETypesRcd> qieTypesToken_;
+  edm::ESGetToken<HcalMCParams, HcalMCParamsRcd> mcParamsToken_;
   edm::ESWatcher<CaloGeometryRecord> theGeometryWatcher_;
   edm::ESWatcher<HcalRecNumberingRecord> theRecNumberWatcher_;
   const CaloGeometry *theGeometry;

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -1,8 +1,5 @@
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h"
-#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
-#include "CondFormats/DataRecord/interface/HBHEDarkeningRecord.h"
-#include "CondFormats/DataRecord/interface/HcalTimeSlewRecord.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
@@ -11,7 +8,6 @@
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/HcalDigi/interface/HcalQIENum.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -36,7 +32,13 @@
 //#define DebugLog
 
 HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector &iC)
-    : theGeometry(nullptr),
+    : conditionsToken_(iC.esConsumes()),
+      topoToken_(iC.esConsumes()),
+      hcalTimeSlew_delay_token_(iC.esConsumes(edm::ESInputTag("", "HBHE"))),
+      theGeometryToken(iC.esConsumes()),
+      theRecNumberToken(iC.esConsumes()),
+      qieTypesToken_(iC.esConsumes()),
+      theGeometry(nullptr),
       theRecNumber(nullptr),
       theParameterMap(ps),
       theShapes(),
@@ -102,6 +104,16 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet &ps, edm::ConsumesCollector
       injectedHitsCells_(ps.getParameter<std::vector<int>>("injectTestHitsCells")) {
   iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "ZDCHITS"));
   iC.consumes<std::vector<PCaloHit>>(edm::InputTag(hitsProducer_, "HcalHits"));
+
+  if (agingFlagHB) {
+    m_HBDarkeningToken = iC.esConsumes(edm::ESInputTag("", "HB"));
+  }
+  if (agingFlagHE) {
+    m_HEDarkeningToken = iC.esConsumes(edm::ESInputTag("", "HE"));
+  }
+  if (theHOSiPMCode == 2) {
+    mcParamsToken_ = iC.esConsumes();
+  }
 
   bool doNoise = ps.getParameter<bool>("doNoise");
 
@@ -294,23 +306,22 @@ void HcalDigitizer::initializeEvent(edm::Event const &e, edm::EventSetup const &
   setup(eventSetup);
 
   // get the appropriate gains, noises, & widths for this event
-  edm::ESHandle<HcalDbService> conditions;
-  eventSetup.get<HcalDbRecord>().get(conditions);
+  const HcalDbService *conditions = &eventSetup.getData(conditionsToken_);
 
-  theShapes.setDbService(conditions.product());
+  theShapes.setDbService(conditions);
 
-  theHBHEAmplifier->setDbService(conditions.product());
-  theHFAmplifier->setDbService(conditions.product());
-  theHOAmplifier->setDbService(conditions.product());
-  theZDCAmplifier->setDbService(conditions.product());
-  theHFQIE10Amplifier->setDbService(conditions.product());
-  theHBHEQIE11Amplifier->setDbService(conditions.product());
+  theHBHEAmplifier->setDbService(conditions);
+  theHFAmplifier->setDbService(conditions);
+  theHOAmplifier->setDbService(conditions);
+  theZDCAmplifier->setDbService(conditions);
+  theHFQIE10Amplifier->setDbService(conditions);
+  theHBHEQIE11Amplifier->setDbService(conditions);
 
-  theHFQIE10ElectronicsSim->setDbService(conditions.product());
-  theHBHEQIE11ElectronicsSim->setDbService(conditions.product());
+  theHFQIE10ElectronicsSim->setDbService(conditions);
+  theHBHEQIE11ElectronicsSim->setDbService(conditions);
 
-  theCoderFactory->setDbService(conditions.product());
-  theParameterMap.setDbService(conditions.product());
+  theCoderFactory->setDbService(conditions);
+  theParameterMap.setDbService(conditions);
 
   // initialize hits
   if (theHBHEDigitizer)
@@ -424,9 +435,7 @@ void HcalDigitizer::accumulate(edm::Event const &e, edm::EventSetup const &event
   e.getByLabel(hcalTag, hcalHandle);
   isHCAL = hcalHandle.isValid() or injectTestHits_;
 
-  edm::ESHandle<HcalTopology> htopo;
-  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-  const HcalTopology *htopoP = htopo.product();
+  const HcalTopology *htopoP = &eventSetup.getData(topoToken_);
 
   accumulateCaloHits(hcalHandle, zdcHandle, 0, engine, htopoP);
 }
@@ -445,9 +454,7 @@ void HcalDigitizer::accumulate(PileUpEventPrincipal const &e,
   e.getByLabel(hcalTag, hcalHandle);
   isHCAL = hcalHandle.isValid();
 
-  edm::ESHandle<HcalTopology> htopo;
-  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-  const HcalTopology *htopoP = htopo.product();
+  const HcalTopology *htopoP = &eventSetup.getData(topoToken_);
 
   accumulateCaloHits(hcalHandle, zdcHandle, e.bunchCrossing(), engine, htopoP);
 }
@@ -557,19 +564,13 @@ void HcalDigitizer::setup(const edm::EventSetup &es) {
   checkGeometry(es);
 
   if (agingFlagHB) {
-    edm::ESHandle<HBHEDarkening> hdark;
-    es.get<HBHEDarkeningRecord>().get("HB", hdark);
-    m_HBDarkening = &*hdark;
+    m_HBDarkening = &es.getData(m_HBDarkeningToken);
   }
   if (agingFlagHE) {
-    edm::ESHandle<HBHEDarkening> hdark;
-    es.get<HBHEDarkeningRecord>().get("HE", hdark);
-    m_HEDarkening = &*hdark;
+    m_HEDarkening = &es.getData(m_HEDarkeningToken);
   }
 
-  edm::ESHandle<HcalTimeSlew> delay;
-  es.get<HcalTimeSlewRecord>().get("HBHE", delay);
-  hcalTimeSlew_delay_ = &*delay;
+  hcalTimeSlew_delay_ = &es.getData(hcalTimeSlew_delay_token_);
 
   theHBHEAmplifier->setTimeSlew(hcalTimeSlew_delay_);
   theHBHEQIE11Amplifier->setTimeSlew(hcalTimeSlew_delay_);
@@ -578,12 +579,8 @@ void HcalDigitizer::setup(const edm::EventSetup &es) {
 }
 
 void HcalDigitizer::checkGeometry(const edm::EventSetup &eventSetup) {
-  edm::ESHandle<CaloGeometry> geometry;
-  eventSetup.get<CaloGeometryRecord>().get(geometry);
-  theGeometry = &*geometry;
-  edm::ESHandle<HcalDDDRecConstants> pHRNDC;
-  eventSetup.get<HcalRecNumberingRecord>().get(pHRNDC);
-  theRecNumber = &*pHRNDC;
+  theGeometry = &eventSetup.getData(theGeometryToken);
+  theRecNumber = &eventSetup.getData(theRecNumberToken);
 
   if (theHBHEResponse)
     theHBHEResponse->setGeometry(theGeometry);
@@ -693,14 +690,10 @@ void HcalDigitizer::buildHFQIECells(const std::vector<DetId> &allCells, const ed
     return;
 
   // get the QIETypes
-  edm::ESHandle<HcalQIETypes> q;
-  eventSetup.get<HcalQIETypesRcd>().get(q);
-  edm::ESHandle<HcalTopology> htopo;
-  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-
-  HcalQIETypes qieTypes(*q.product());
+  // intentional copy
+  HcalQIETypes qieTypes = eventSetup.getData(qieTypesToken_);
   if (qieTypes.topo() == nullptr) {
-    qieTypes.setTopo(htopo.product());
+    qieTypes.setTopo(&eventSetup.getData(topoToken_));
   }
 
   for (std::vector<DetId>::const_iterator detItr = allCells.begin(); detItr != allCells.end(); ++detItr) {
@@ -733,14 +726,10 @@ void HcalDigitizer::buildHBHEQIECells(const std::vector<DetId> &allCells, const 
     return;
 
   // get the QIETypes
-  edm::ESHandle<HcalQIETypes> q;
-  eventSetup.get<HcalQIETypesRcd>().get(q);
-  edm::ESHandle<HcalTopology> htopo;
-  eventSetup.get<HcalRecNumberingRecord>().get(htopo);
-
-  HcalQIETypes qieTypes(*q.product());
+  // intentional copy
+  HcalQIETypes qieTypes = eventSetup.getData(qieTypesToken_);
   if (qieTypes.topo() == nullptr) {
-    qieTypes.setTopo(htopo.product());
+    qieTypes.setTopo(&eventSetup.getData(topoToken_));
   }
 
   for (std::vector<DetId>::const_iterator detItr = allCells.begin(); detItr != allCells.end(); ++detItr) {
@@ -782,14 +771,11 @@ void HcalDigitizer::buildHOSiPMCells(const std::vector<DetId> &allCells, const e
     // FIXME pick Zecotek or hamamatsu?
   } else if (theHOSiPMCode == 2) {
     std::vector<HcalDetId> zecotekDetIds, hamamatsuDetIds;
-    edm::ESHandle<HcalMCParams> p;
-    eventSetup.get<HcalMCParamsRcd>().get(p);
-    edm::ESHandle<HcalTopology> htopo;
-    eventSetup.get<HcalRecNumberingRecord>().get(htopo);
 
-    HcalMCParams mcParams(*p.product());
+    // intentional copy
+    HcalMCParams mcParams = eventSetup.getData(mcParamsToken_);
     if (mcParams.topo() == nullptr) {
-      mcParams.setTopo(htopo.product());
+      mcParams.setTopo(&eventSetup.getData(topoToken_));
     }
 
     for (std::vector<DetId>::const_iterator detItr = allCells.begin(); detItr != allCells.end(); ++detItr) {

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -1,10 +1,14 @@
 #ifndef SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 #define SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloHitResponse.h"
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
 #include "SimCalorimetry/HcalSimAlgos/interface/HcalAmplifier.h"
@@ -23,11 +27,6 @@
 #include <vector>
 
 class PEcalTBInfo;
-
-namespace edm {
-  class StreamID;
-  class ConsumesCollector;
-}  // namespace edm
 
 namespace CLHEP {
   class HepRandomEngine;
@@ -82,6 +81,10 @@ private:
   HBHEDigitizer *theHBHEDigitizer;
   HODigitizer *theHODigitizer;
 
+  edm::ESGetToken<HcalDbService, HcalDbRecord> conditionsToken_;
+  edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> hcalTimeSlew_delay_token_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  edm::ESWatcher<CaloGeometryRecord> geometryWatcher_;
   const CaloGeometry *theGeometry;
   std::vector<DetId> hbheCells;
   std::vector<DetId> hoCells;

--- a/SimGeneral/MixingModule/plugins/Mixing2DB.cc
+++ b/SimGeneral/MixingModule/plugins/Mixing2DB.cc
@@ -31,19 +31,7 @@ Mixing2DB::~Mixing2DB() {
 //
 
 // ------------ method called for each event  ------------
-void Mixing2DB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  using namespace edm;
-
-#ifdef THIS_IS_AN_EVENT_EXAMPLE
-  Handle<ExampleData> pIn;
-  iEvent.getByLabel("example", pIn);
-#endif
-
-#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
-  ESHandle<SetupData> pSetup;
-  iSetup.get<SetupRecord>().get(pSetup);
-#endif
-}
+void Mixing2DB::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {}
 
 // ------------ method called once each job just before starting event loop  ------------
 void Mixing2DB::beginJob() {}

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -288,6 +288,7 @@ namespace edm {
   }
 
   void MixingModule::reload(const edm::EventSetup& setup) {
+    // TODO for esConsumes migration: assume for now this function is mostly unused
     //change the basic parameters.
     edm::ESHandle<MixingModuleConfig> config;
     setup.get<MixingRcd>().get(config);

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -613,8 +613,8 @@ namespace edm {
 
     std::unique_ptr<PileupMixingContent> PileupMixing_;
 
-    PileupMixing_ = std::unique_ptr<PileupMixingContent>(new PileupMixingContent(
-        bunchCrossingList, numInteractionList, TrueInteractionList, eventInfoList, bunchSpace_));
+    PileupMixing_ = std::make_unique<PileupMixingContent>(
+        bunchCrossingList, numInteractionList, TrueInteractionList, eventInfoList, bunchSpace_);
 
     e.put(std::move(PileupMixing_));
 

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -109,6 +109,7 @@ namespace edm {
 
   public:
     void reload(const edm::EventSetup &setup) override {
+      // TODO for esConsumes migration: assume for now this function is mostly unused
       //get the required parameters from DB.
       // watch the label/tag
       edm::ESHandle<MixingModuleConfig> config;

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -50,10 +50,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 // Turn on integrity checking
 //#define DO_DEBUG_TESTING
@@ -277,6 +274,7 @@ TrackingTruthAccumulator::TrackingTruthAccumulator(const edm::ParameterSet &conf
       collectionTags_(),
       genParticleLabel_(config.getParameter<edm::InputTag>("genParticleCollection")),
       hepMCproductLabel_(config.getParameter<edm::InputTag>("HepMCProductLabel")),
+      tTopoToken_(iC.esConsumes()),
       allowDifferentProcessTypeForDifferentDetectors_(config.getParameter<bool>("allowDifferentSimHitProcesses")) {
   //
   // Make sure at least one of the merged and unmerged collections have been set
@@ -468,9 +466,7 @@ void TrackingTruthAccumulator::accumulateEvent(const T &event,
   }
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  setup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology *const tTopo = tTopoHandle.product();
+  const TrackerTopology *const tTopo = &setup.getData(tTopoToken_);
 
   // Run through the collections and work out the decay chain of each
   // track/vertex. The information in SimTrack and SimVertex only allows

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.h
@@ -1,6 +1,9 @@
 #ifndef TrackingAnalysis_TrackingTruthAccumulator_h
 #define TrackingAnalysis_TrackingTruthAccumulator_h
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
@@ -9,13 +12,6 @@
 #include <memory>  // required for std::unique_ptr
 
 // Forward declarations
-namespace edm {
-  class ParameterSet;
-  class ConsumesCollector;
-  class Event;
-  class EventSetup;
-  class StreamID;
-}  // namespace edm
 class PileUpEventPrincipal;
 class PSimHit;
 
@@ -147,6 +143,7 @@ private:
   edm::InputTag genParticleLabel_;
   /// Needed to add HepMC::GenVertex to SimVertex
   edm::InputTag hepMCproductLabel_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
 
   bool selectorFlag_;
   TrackingParticleSelector selector_;

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.cc
@@ -3,28 +3,30 @@
 
 #include "SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 // Geometry
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 using namespace edm;
 
 void PSPDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_) {  // Get Lorentz angle from DB record
-    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(siPhase2OTLorentzAngle_);
+    siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
   }
 
-  es.get<TrackerDigiGeometryRecord>().get(geom_);
+  geom_ = &es.getData(geomToken_);
 }
 
-PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf)
+PSPDigitizerAlgorithm::PSPDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
-                                      conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm")) {
+                                      conf.getParameter<ParameterSet>("PSPDigitizerAlgorithm"),
+                                      iC),
+      geomToken_(iC.esConsumes()) {
+  if (use_LorentzAngle_DB_)
+    siPhase2OTLorentzAngleToken_ = iC.esConsumes();
   pixelFlag_ = false;
   LogDebug("PSPDigitizerAlgorithm") << "Algorithm constructed "
                                     << "Configuration parameters:"

--- a/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSPDigitizerAlgorithm.h
@@ -1,11 +1,14 @@
 #ifndef _SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
 #define _SimTracker_SiPhase2Digitizer_PSPDigitizerAlgorithm_h
 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 class PSPDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
-  PSPDigitizerAlgorithm(const edm::ParameterSet& conf);
+  PSPDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~PSPDigitizerAlgorithm() override;
 
   // initialization that cannot be done in the constructor
@@ -13,5 +16,9 @@ public:
 
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
+
+private:
+  edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.cc
@@ -3,26 +3,28 @@
 
 #include "SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
 
 // Geometry
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 using namespace edm;
 
 void PSSDigitizerAlgorithm::init(const edm::EventSetup& es) {
   if (use_LorentzAngle_DB_)  // Get Lorentz angle from DB record
-    es.get<SiPhase2OuterTrackerLorentzAngleSimRcd>().get(siPhase2OTLorentzAngle_);
+    siPhase2OTLorentzAngle_ = &es.getData(siPhase2OTLorentzAngleToken_);
 
-  es.get<TrackerDigiGeometryRecord>().get(geom_);
+  geom_ = &es.getData(geomToken_);
 }
-PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf)
+PSSDigitizerAlgorithm::PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<ParameterSet>("AlgorithmCommon"),
-                                      conf.getParameter<ParameterSet>("PSSDigitizerAlgorithm")) {
+                                      conf.getParameter<ParameterSet>("PSSDigitizerAlgorithm"),
+                                      iC),
+      geomToken_(iC.esConsumes()) {
+  if (use_LorentzAngle_DB_)
+    siPhase2OTLorentzAngleToken_ = iC.esConsumes();
   pixelFlag_ = false;
   LogDebug("PSSDigitizerAlgorithm") << "Algorithm constructed "
                                     << "Configuration parameters: "

--- a/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PSSDigitizerAlgorithm.h
@@ -1,11 +1,14 @@
 #ifndef _SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
 #define _SimTracker_SiPhase2Digitizer_PSSDigitizerAlgorithm_h
 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 class PSSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
-  PSSDigitizerAlgorithm(const edm::ParameterSet& conf);
+  PSSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~PSSDigitizerAlgorithm() override;
 
   // initialization that cannot be done in the constructor
@@ -13,5 +16,9 @@ public:
 
   bool select_hit(const PSimHit& hit, double tCorr, double& sigScale) const override;
   bool isAboveThreshold(const DigitizerUtility::SimHitInfo* hitInfo, float charge, float thr) const override;
+
+private:
+  edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizer.h
@@ -16,12 +16,14 @@
 #include <vector>
 #include <unordered_map>
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerFwd.h"
 
@@ -60,7 +62,6 @@ namespace cms {
     void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
     void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
     virtual void beginJob() {}
-    void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& iSetup) override;
 
     template <class T>
     void accumulate_local(T const& iEvent, edm::EventSetup const& iSetup);
@@ -96,11 +97,13 @@ namespace cms {
     std::map<AlgorithmType, std::unique_ptr<Phase2TrackerDigitizerAlgorithm> > algomap_;
     const std::string hitsProducer_;
     const vstring trackerContainers_;
-    const std::string geometryType_;
-    edm::ESHandle<TrackerGeometry> pDD_;
-    edm::ESHandle<MagneticField> pSetup_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> pSetupToken_;
+    const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+    const TrackerGeometry* pDD_ = nullptr;
+    const MagneticField* pSetup_ = nullptr;
     std::map<uint32_t, const Phase2TrackerGeomDetUnit*> detectorUnits_;
-    edm::ESHandle<TrackerTopology> tTopoHand_;
+    const TrackerTopology* tTopo_ = nullptr;
     edm::ESWatcher<TrackerDigiGeometryRecord> theTkDigiGeomWatcher_;
     const bool isOuterTrackerReadoutAnalog_;
     const bool premixStage1_;

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.cc
@@ -57,7 +57,8 @@ namespace {
   }
 }  // namespace
 Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common,
-                                                                 const edm::ParameterSet& conf_specific)
+                                                                 const edm::ParameterSet& conf_specific,
+                                                                 edm::ConsumesCollector iC)
     : _signal(),
       makeDigiSimLinks_(conf_common.getUntrackedParameter<bool>("makeDigiSimLinks", true)),
       use_ineff_from_db_(conf_specific.getParameter<bool>("Inefficiency_DB")),
@@ -165,7 +166,7 @@ Phase2TrackerDigitizerAlgorithm::Phase2TrackerDigitizerAlgorithm(const edm::Para
       fluctuate_(fluctuateCharge_ ? std::make_unique<SiG4UniversalFluctuation>() : nullptr),
       theNoiser_(addNoise_ ? std::make_unique<GaussianTailNoiseGenerator>() : nullptr),
       theSiPixelGainCalibrationService_(
-          use_ineff_from_db_ ? std::make_unique<SiPixelGainCalibrationOfflineSimService>(conf_specific) : nullptr),
+          use_ineff_from_db_ ? std::make_unique<SiPixelGainCalibrationOfflineSimService>(conf_specific, iC) : nullptr),
       subdetEfficiencies_(conf_specific) {
   LogDebug("Phase2TrackerDigitizerAlgorithm")
       << "Phase2TrackerDigitizerAlgorithm constructed\n"
@@ -893,9 +894,9 @@ void Phase2TrackerDigitizerAlgorithm::module_killing_DB(const Phase2TrackerGeomD
     std::vector<GlobalPixel> badrocpositions;
     for (size_t j = 0; j < static_cast<size_t>(ncol); j++) {
       if (siPixelBadModule_->IsRocBad(detID, j)) {
-        std::vector<CablingPathToDetUnit> path = fedCablingMap_.product()->pathToDetUnit(detID);
+        std::vector<CablingPathToDetUnit> path = fedCablingMap_->pathToDetUnit(detID);
         for (auto const& p : path) {
-          const PixelROC* myroc = fedCablingMap_.product()->findItem(p);
+          const PixelROC* myroc = fedCablingMap_->findItem(p);
           if (myroc->idInDetUnit() == j) {
             LocalPixel::RocRowCol local = {39, 25};  //corresponding to center of ROC row, col
             GlobalPixel global = myroc->toGlobal(LocalPixel(local));

--- a/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h
@@ -6,7 +6,7 @@
 #include <vector>
 
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Math/interface/approx_exp.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
@@ -28,11 +28,6 @@ namespace CLHEP {
   class RandGaussQ;
   class RandFlat;
 }  // namespace CLHEP
-
-namespace edm {
-  class EventSetup;
-  class ParameterSet;
-}  // namespace edm
 
 class DetId;
 class GaussianTailNoiseGenerator;
@@ -58,7 +53,9 @@ constexpr double c_inv = 1.0 / c_cm_ns;
 
 class Phase2TrackerDigitizerAlgorithm {
 public:
-  Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common, const edm::ParameterSet& conf_specific);
+  Phase2TrackerDigitizerAlgorithm(const edm::ParameterSet& conf_common,
+                                  const edm::ParameterSet& conf_specific,
+                                  edm::ConsumesCollector iC);
   virtual ~Phase2TrackerDigitizerAlgorithm();
 
   // initialization that cannot be done in the constructor
@@ -85,17 +82,17 @@ public:
 
 protected:
   // Accessing Inner Tracker Lorentz angle from DB:
-  edm::ESHandle<SiPixelLorentzAngle> siPixelLorentzAngle_;
+  const SiPixelLorentzAngle* siPixelLorentzAngle_;
 
   // Accessing Outer Tracker Lorentz angle from DB:
-  edm::ESHandle<SiPhase2OuterTrackerLorentzAngle> siPhase2OTLorentzAngle_;
+  const SiPhase2OuterTrackerLorentzAngle* siPhase2OTLorentzAngle_;
 
   // Accessing Dead pixel modules from DB:
-  edm::ESHandle<SiPixelQuality> siPixelBadModule_;
+  const SiPixelQuality* siPixelBadModule_;
 
   // Accessing Map and Geom:
-  edm::ESHandle<SiPixelFedCablingMap> fedCablingMap_;
-  edm::ESHandle<TrackerGeometry> geom_;
+  const SiPixelFedCablingMap* fedCablingMap_;
+  const TrackerGeometry* geom_;
   struct SubdetEfficiencies {
     SubdetEfficiencies(const edm::ParameterSet& conf);
     std::vector<double> barrel_efficiencies;

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -12,6 +12,12 @@
 //          Clara Lasaosa Garcia (IFCA)
 //--------------------------------------------------------------
 
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 // Data formats
@@ -22,7 +28,7 @@
 
 class Pixel3DDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
-  Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf);
+  Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~Pixel3DDigitizerAlgorithm() override;
 
   // initialization that cannot be done in the constructor
@@ -60,6 +66,11 @@ private:
   const float ohm_column_radius_;
   // Gap of np column
   const float np_column_gap_;
+
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> siPixelBadModuleToken_;
+  edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleSimRcd> siPixelLorentzAngleToken_;
+  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> fedCablingMapToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 
   // Check if a carrier is inside the column: The point should
   // be described in the pixel cell frame

--- a/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/PixelDigitizerAlgorithm.h
@@ -1,6 +1,12 @@
 #ifndef _SimTracker_SiPhase2Digitizer_PixelDigitizerAlgorithm_h
 #define _SimTracker_SiPhase2Digitizer_PixelDigitizerAlgorithm_h
 
+#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
+#include "CondFormats/DataRecord/interface/SiPixelQualityRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
+#include "CondFormats/DataRecord/interface/SiPixelLorentzAngleSimRcd.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 class PixelDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
@@ -35,7 +41,7 @@ private:
   };
 
 public:
-  PixelDigitizerAlgorithm(const edm::ParameterSet& conf);
+  PixelDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~PixelDigitizerAlgorithm() override;
 
   // initialization that cannot be done in the constructor
@@ -54,5 +60,10 @@ public:
   // Timewalk parameters
   bool apply_timewalk_;
   const TimewalkModel timewalk_model_;
+
+  edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> siPixelBadModuleToken_;
+  edm::ESGetToken<SiPixelLorentzAngle, SiPixelLorentzAngleSimRcd> siPixelLorentzAngleToken_;
+  const edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> fedCablingMapToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/SSDigitizerAlgorithm.h
@@ -1,11 +1,14 @@
 #ifndef _SimTracker_SiPhase2Digitizer_SSDigitizerAlgorithm_h
 #define _SimTracker_SiPhase2Digitizer_SSDigitizerAlgorithm_h
 
+#include "CondFormats/DataRecord/interface/SiPhase2OuterTrackerLorentzAngleRcd.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "SimTracker/SiPhase2Digitizer/plugins/Phase2TrackerDigitizerAlgorithm.h"
 
 class SSDigitizerAlgorithm : public Phase2TrackerDigitizerAlgorithm {
 public:
-  SSDigitizerAlgorithm(const edm::ParameterSet& conf);
+  SSDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~SSDigitizerAlgorithm() override;
 
   // initialization that cannot be done in the constructor
@@ -27,6 +30,8 @@ private:
   std::vector<double> pulseShapeVec_;
   std::vector<double> pulseShapeParameters_;
   float deadTime_;
+  edm::ESGetToken<SiPhase2OuterTrackerLorentzAngle, SiPhase2OuterTrackerLorentzAngleSimRcd> siPhase2OTLorentzAngleToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   static constexpr float bx_time{25};
   static constexpr size_t interpolationPoints{1000};
   static constexpr int interpolationStep{10};

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelChargeReweightingAlgorithm.h
@@ -1,39 +1,22 @@
 #ifndef SimTracker_SiPixelDigitizer_SiPixelChargeReweightingAlgorithm_h
 #define SimTracker_SiPixelDigitizer_SiPixelChargeReweightingAlgorithm_h
 
+#include "CondFormats/DataRecord/interface/SiPixel2DTemplateDBObjectRcd.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixel2DTemplateDBObject.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.h"
 
 // forward declarations
-
-// For the random numbers
-namespace CLHEP {
-  class HepRandomEngine;
-}
-
-namespace edm {
-  class EventSetup;
-  class ParameterSet;
-}  // namespace edm
-
 class DetId;
 class GaussianTailNoiseGenerator;
 class PixelDigi;
 class PixelDigiSimLink;
 class PixelGeomDetUnit;
 class SiG4UniversalFluctuation;
-class SiPixelFedCablingMap;
-class SiPixelGainCalibrationOfflineSimService;
-class SiPixelLorentzAngle;
-class SiPixelQuality;
-class SiPixelDynamicInefficiency;
-class TrackerGeometry;
-class TrackerTopology;
-class SiPixelFEDChannelContainer;
-class SiPixelQualityProbabilities;
 
 class SiPixelChargeReweightingAlgorithm {
 public:
-  SiPixelChargeReweightingAlgorithm(const edm::ParameterSet& conf);
+  SiPixelChargeReweightingAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
   ~SiPixelChargeReweightingAlgorithm();
 
   // initialization that cannot be done in the constructor
@@ -73,6 +56,8 @@ private:
 
   std::vector<SiPixelTemplateStore2D> templateStores_;
 
+  edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectRcd> SiPixel2DTemp_den_token_;
+  edm::ESGetToken<SiPixel2DTemplateDBObject, SiPixel2DTemplateDBObjectRcd> SiPixel2DTemp_num_token_;
   const SiPixel2DTemplateDBObject* dbobject_den;
   const SiPixel2DTemplateDBObject* dbobject_num;
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -28,7 +28,6 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
@@ -41,14 +40,12 @@
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -57,7 +54,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
@@ -90,9 +86,11 @@ namespace cms {
         _pixeldigialgo(),
         hitsProducer(iConfig.getParameter<std::string>("hitsProducer")),
         trackerContainers(iConfig.getParameter<std::vector<std::string> >("RoutList")),
-        geometryType(iConfig.getParameter<std::string>("PixGeometryType")),
         pilotBlades(iConfig.exists("enablePilotBlades") ? iConfig.getParameter<bool>("enablePilotBlades") : false),
-        NumberOfEndcapDisks(iConfig.exists("NumPixelEndcap") ? iConfig.getParameter<int>("NumPixelEndcap") : 2) {
+        NumberOfEndcapDisks(iConfig.exists("NumPixelEndcap") ? iConfig.getParameter<int>("NumPixelEndcap") : 2),
+        tTopoToken_(iC.esConsumes()),
+        pDDToken_(iC.esConsumes(edm::ESInputTag("", iConfig.getParameter<std::string>("PixGeometryType")))),
+        pSetupToken_(iC.esConsumes()) {
     edm::LogInfo("PixelDigitizer ") << "Enter the Pixel Digitizer";
 
     const std::string alias("simSiPixelDigis");
@@ -112,7 +110,7 @@ namespace cms {
              "in the configuration file or remove the modules that require it.";
     }
 
-    _pixeldigialgo = std::make_unique<SiPixelDigitizerAlgorithm>(iConfig);
+    _pixeldigialgo = std::make_unique<SiPixelDigitizerAlgorithm>(iConfig, iC);
     if (NumberOfEndcapDisks != 2)
       producesCollector.produces<PixelFEDChannelCollection>();
   }
@@ -130,9 +128,7 @@ namespace cms {
     if (hSimHits.isValid()) {
       std::set<unsigned int> detIds;
       std::vector<PSimHit> const& simHits = *hSimHits.product();
-      edm::ESHandle<TrackerTopology> tTopoHand;
-      iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-      const TrackerTopology* tTopo = tTopoHand.product();
+      const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
       for (std::vector<PSimHit>::const_iterator it = simHits.begin(), itEnd = simHits.end(); it != itEnd;
            ++it, ++globalSimHitIndex) {
         unsigned int detId = (*it).detUnitId();
@@ -177,11 +173,9 @@ namespace cms {
     randomEngine_ = &rng->getEngine(e.streamID());
 
     _pixeldigialgo->initializeEvent();
-    iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
-    iSetup.get<IdealMagneticFieldRecord>().get(pSetup);
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology* tTopo = tTopoHand.product();
+    pDD = &iSetup.getData(pDDToken_);
+    pSetup = &iSetup.getData(pSetupToken_);
+    const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
     // FIX THIS! We only need to clear and (re)fill this map when the geometry type IOV changes.  Use ESWatcher to determine this.
     if (true) {  // Replace with ESWatcher
@@ -250,9 +244,7 @@ namespace cms {
 
   // ------------ method called to produce the data  ------------
   void SiPixelDigitizer::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    edm::ESHandle<TrackerTopology> tTopoHand;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-    const TrackerTopology* tTopo = tTopoHand.product();
+    const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
     std::vector<edm::DetSet<PixelDigi> > theDigiVector;
     std::vector<edm::DetSet<PixelDigiSimLink> > theDigiLinkVector;

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -18,20 +18,16 @@
 #include <string>
 #include <vector>
 
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ProducesCollector.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Provenance/interface/EventID.h"
-
-namespace edm {
-  class ConsumesCollector;
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-  template <typename T>
-  class Handle;
-  class StreamID;
-}  // namespace edm
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/ProducesCollector.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 class MagneticField;
 class PileUpEventPrincipal;
@@ -91,9 +87,8 @@ namespace cms {
     typedef std::vector<std::string> vstring;
     const std::string hitsProducer;
     const vstring trackerContainers;
-    const std::string geometryType;
-    edm::ESHandle<TrackerGeometry> pDD;
-    edm::ESHandle<MagneticField> pSetup;
+    const TrackerGeometry* pDD = nullptr;
+    const MagneticField* pSetup = nullptr;
     std::map<unsigned int, PixelGeomDetUnit const*> detectorUnits;
     CLHEP::HepRandomEngine* randomEngine_ = nullptr;
 
@@ -101,6 +96,10 @@ namespace cms {
 
     const bool pilotBlades;         // Default = false
     const int NumberOfEndcapDisks;  // Default = 2
+
+    const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> pSetupToken_;
 
     // infrastructure to reject dead pixels as defined in db (added by F.Blekman)
   };

--- a/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiDigitalConverter.h
@@ -2,7 +2,6 @@
 #define Tracker_SiDigitalConverter_H
 
 #include "SiPileUpSignals.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
@@ -15,8 +14,8 @@ public:
   typedef std::vector<SiStripRawDigi> DigitalRawVecType;
 
   virtual ~SiDigitalConverter() {}
-  virtual DigitalVecType convert(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) = 0;
-  virtual DigitalRawVecType convertRaw(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) = 0;
+  virtual DigitalVecType convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
+  virtual DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) = 0;
 };
 
 #endif

--- a/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
+++ b/SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h
@@ -9,8 +9,8 @@ class SiTrivialDigitalConverter : public SiDigitalConverter {
 public:
   SiTrivialDigitalConverter(float in, bool PreMix);
 
-  DigitalVecType convert(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) override;
-  DigitalRawVecType convertRaw(const std::vector<float>&, edm::ESHandle<SiStripGain>&, unsigned int detid) override;
+  DigitalVecType convert(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
+  DigitalRawVecType convertRaw(const std::vector<float>&, const SiStripGain*, unsigned int detid) override;
 
 private:
   int convert(float in) { return truncate(in / electronperADC); }

--- a/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/DigiSimLinkAlgorithm.cc
@@ -198,8 +198,11 @@ void DigiSimLinkAlgorithm::run(edm::DetSet<SiStripDigi>& outdigi,
       }
     }
     digis.clear();
-    theSiZeroSuppress->suppress(
-        theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
+    theSiZeroSuppress->suppress(theSiDigitalConverter->convert(detAmpl, gainHandle.product(), detID),
+                                digis,
+                                detID,
+                                *noiseHandle,
+                                *thresholdHandle);
     push_link(digis, theLink, theCounterLink, detAmpl, detID);
     outdigi.data = digis;
   }
@@ -302,7 +305,7 @@ void DigiSimLinkAlgorithm::run(edm::DetSet<SiStripDigi>& outdigi,
     //}else{
 
     rawdigis.clear();
-    rawdigis = theSiDigitalConverter->convertRaw(detAmpl, gainHandle, detID);
+    rawdigis = theSiDigitalConverter->convertRaw(detAmpl, gainHandle.product(), detID);
     push_link_raw(rawdigis, theLink, theCounterLink, detAmpl, detID);
     outrawdigi.data = rawdigis;
 

--- a/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
+++ b/SimTracker/SiStripDigitizer/plugins/PreMixingSiStripWorker.cc
@@ -65,6 +65,15 @@ private:
   edm::InputTag SiStripAPVPileInputTag_;
   std::string SistripAPVListDM_;  // output tag
 
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> const pDDToken_;
+  edm::ESGetToken<SiStripBadStrip, SiStripBadChannelRcd> const deadChannelToken_;
+  edm::ESGetToken<SiStripGain, SiStripGainSimRcd> const gainToken_;
+  edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> const noiseToken_;
+  edm::ESGetToken<SiStripThreshold, SiStripThresholdRcd> const thresholdToken_;
+  //edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> const pedestalToken_;
+  edm::ESGetToken<SiStripApvSimulationParameters, SiStripApvSimulationParametersRcd> apvSimulationParametersToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+
   //
 
   typedef float Amplitude;
@@ -100,20 +109,18 @@ private:
 
   // for noise adding:
 
-  std::string gainLabel;
   bool SingleStripNoise;
   bool peakMode;
   double theThreshold;
   double theElectronPerADC;
   bool APVSaturationFromHIP_;
   int theFedAlgo;
-  std::string geometryType;
 
   std::unique_ptr<SiGaussianTailNoiseAdder> theSiNoiseAdder;
   std::unique_ptr<SiStripFedZeroSuppression> theSiZeroSuppress;
   std::unique_ptr<SiTrivialDigitalConverter> theSiDigitalConverter;
 
-  edm::ESHandle<TrackerGeometry> pDD;
+  const TrackerGeometry* pDD;
 
   // bad channels for each detector ID
   std::map<unsigned int, std::vector<bool>> allBadChannels;
@@ -146,14 +153,17 @@ private:
 PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
                                                edm::ProducesCollector producesCollector,
                                                edm::ConsumesCollector&& iC)
-    : gainLabel(ps.getParameter<std::string>("Gain")),
+    : pDDToken_(iC.esConsumes(edm::ESInputTag("", ps.getParameter<std::string>("GeometryType")))),
+      deadChannelToken_(iC.esConsumes()),
+      gainToken_(iC.esConsumes(edm::ESInputTag("", ps.getParameter<std::string>("Gain")))),
+      noiseToken_(iC.esConsumes()),
+      thresholdToken_(iC.esConsumes()),
       SingleStripNoise(ps.getParameter<bool>("SingleStripNoise")),
       peakMode(ps.getParameter<bool>("APVpeakmode")),
       theThreshold(ps.getParameter<double>("NoiseSigmaThreshold")),
       theElectronPerADC(ps.getParameter<double>(peakMode ? "electronPerAdcPeak" : "electronPerAdcDec")),
       APVSaturationFromHIP_(ps.getParameter<bool>("APVSaturationFromHIP")),
       theFedAlgo(ps.getParameter<int>("FedAlgorithm_PM")),
-      geometryType(ps.getParameter<std::string>("GeometryType")),
       theSiZeroSuppress(new SiStripFedZeroSuppression(theFedAlgo)),
       theSiDigitalConverter(new SiTrivialDigitalConverter(theElectronPerADC, false)),  // no premixing
       includeAPVSimulation_(ps.getParameter<bool>("includeAPVSimulation")),
@@ -181,6 +191,11 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
     iC.consumes<std::vector<std::pair<int, std::bitset<6>>>>(SistripAPVLabelSig_);
   }
   iC.consumes<edm::DetSetVector<SiStripDigi>>(SistripLabelSig_);
+
+  if (includeAPVSimulation_) {
+    tTopoToken_ = iC.esConsumes();
+    apvSimulationParametersToken_ = iC.esConsumes();
+  }
   // clear local storage for this event
   SiHitStorage_.clear();
 
@@ -197,7 +212,7 @@ PreMixingSiStripWorker::PreMixingSiStripWorker(const edm::ParameterSet& ps,
 void PreMixingSiStripWorker::initializeEvent(const edm::Event& e, edm::EventSetup const& iSetup) {
   // initialize individual detectors so we can copy real digitization code:
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
+  pDD = &iSetup.getData(pDDToken_);
 
   for (auto iu = pDD->detUnits().begin(); iu != pDD->detUnits().end(); ++iu) {
     unsigned int detId = (*iu)->geographicalId().rawId();
@@ -213,13 +228,12 @@ void PreMixingSiStripWorker::initializeEvent(const edm::Event& e, edm::EventSetu
 }
 
 void PreMixingSiStripWorker::DMinitializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup) {
-  edm::ESHandle<SiStripBadStrip> deadChannelHandle;
-  iSetup.get<SiStripBadChannelRcd>().get(deadChannelHandle);
+  SiStripBadStrip const& deadChannel = iSetup.getData(deadChannelToken_);
 
   unsigned int detId = det->geographicalId().rawId();
   int numStrips = (det->specificTopology()).nstrips();
 
-  SiStripBadStrip::Range detBadStripRange = deadChannelHandle->getRange(detId);
+  SiStripBadStrip::Range detBadStripRange = deadChannel.getRange(detId);
   //storing the bad strip of the the module. the module is not removed but just signal put to 0
   std::vector<bool>& badChannels = allBadChannels[detId];
   std::vector<bool>& hipChannels = allHIPChannels[detId];
@@ -229,7 +243,7 @@ void PreMixingSiStripWorker::DMinitializeDetUnit(StripGeomDetUnit const* det, co
   hipChannels.insert(hipChannels.begin(), numStrips, false);
 
   for (SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
-    SiStripBadStrip::data fs = deadChannelHandle->decode(*it);
+    SiStripBadStrip::data fs = deadChannel.decode(*it);
     for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip)
       badChannels[strip] = true;
   }
@@ -342,17 +356,12 @@ void PreMixingSiStripWorker::put(edm::Event& e,
                                  std::vector<PileupSummaryInfo> const& ps,
                                  int bs) {
   // set up machinery to do proper noise adding:
-  edm::ESHandle<SiStripGain> gainHandle;
-  edm::ESHandle<SiStripNoises> noiseHandle;
-  edm::ESHandle<SiStripThreshold> thresholdHandle;
-  edm::ESHandle<SiStripPedestals> pedestalHandle;
-  edm::ESHandle<SiStripBadStrip> deadChannelHandle;
-  edm::ESHandle<SiStripApvSimulationParameters> apvSimulationParametersHandle;
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<SiStripGainSimRcd>().get(gainLabel, gainHandle);
-  iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
-  iSetup.get<SiStripThresholdRcd>().get(thresholdHandle);
-  iSetup.get<SiStripPedestalsRcd>().get(pedestalHandle);
+  SiStripGain const& gain = iSetup.getData(gainToken_);
+  SiStripNoises const& noise = iSetup.getData(noiseToken_);
+  SiStripThreshold const& threshold = iSetup.getData(thresholdToken_);
+  //SiStripPedestals const& pedestal = iSetup.getData(pedestalToken_);
+  SiStripApvSimulationParameters const* apvSimulationParameters = nullptr;
+  TrackerTopology const* tTopo = nullptr;
 
   edm::Service<edm::RandomNumberGenerator> rng;
   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
@@ -360,8 +369,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
   const bool simulateAPVInThisEvent = includeAPVSimulation_ && (CLHEP::RandFlat::shoot(engine) < fracOfEventsToSimAPV_);
   float nTruePU = 0.;  // = ps.getTrueNumInteractions();
   if (simulateAPVInThisEvent) {
-    iSetup.get<TrackerTopologyRcd>().get(tTopo);
-    iSetup.get<SiStripApvSimulationParametersRcd>().get(apvSimulationParametersHandle);
+    tTopo = &iSetup.getData(tTopoToken_);
+    apvSimulationParameters = &iSetup.getData(apvSimulationParametersToken_);
     const auto it = std::find_if(
         std::begin(ps), std::end(ps), [](const PileupSummaryInfo& bxps) { return bxps.getBunchCrossing() == 0; });
     if (it != std::begin(ps)) {
@@ -573,13 +582,13 @@ void PreMixingSiStripWorker::put(edm::Event& e,
             // Get APV baseline
             double baselineV = 0;
             if (SubDet == SiStripSubdetector::TIB) {
-              baselineV = apvSimulationParametersHandle->sampleTIB(tTopo->tibLayer(detID), detSet_z, nTruePU, engine);
+              baselineV = apvSimulationParameters->sampleTIB(tTopo->tibLayer(detID), detSet_z, nTruePU, engine);
             } else if (SubDet == SiStripSubdetector::TOB) {
-              baselineV = apvSimulationParametersHandle->sampleTOB(tTopo->tobLayer(detID), detSet_z, nTruePU, engine);
+              baselineV = apvSimulationParameters->sampleTOB(tTopo->tobLayer(detID), detSet_z, nTruePU, engine);
             } else if (SubDet == SiStripSubdetector::TID) {
-              baselineV = apvSimulationParametersHandle->sampleTID(tTopo->tidWheel(detID), detSet_r, nTruePU, engine);
+              baselineV = apvSimulationParameters->sampleTID(tTopo->tidWheel(detID), detSet_r, nTruePU, engine);
             } else if (SubDet == SiStripSubdetector::TEC) {
-              baselineV = apvSimulationParametersHandle->sampleTEC(tTopo->tecWheel(detID), detSet_r, nTruePU, engine);
+              baselineV = apvSimulationParameters->sampleTEC(tTopo->tecWheel(detID), detSet_r, nTruePU, engine);
             }
             // Fitted parameters from G Hall/M Raymond
             double maxResponse = apv_maxResponse_;
@@ -627,8 +636,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         }
       }
 
-      SiStripNoises::Range detNoiseRange = noiseHandle->getRange(detID);
-      SiStripApvGain::Range detGainRange = gainHandle->getRange(detID);
+      SiStripNoises::Range detNoiseRange = noise.getRange(detID);
+      SiStripApvGain::Range detGainRange = gain.getRange(detID);
 
       // Gain conversion is already done during signal adding
       //convert our signals back to raw counts so that we can add noise properly:
@@ -638,7 +647,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         for(unsigned int iv = 0; iv!=detAmpl.size(); iv++) {
         float signal = detAmpl[iv];
         if(signal > 0) {
-        float gainValue = gainHandle->getStripGain(iv, detGainRange);
+        float gainValue = gain.getStripGain(iv, detGainRange);
         signal *= theElectronPerADC/gainValue;
         detAmpl[iv] = signal;
         }
@@ -646,7 +655,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         }
       */
 
-      //SiStripPedestals::Range detPedestalRange = pedestalHandle->getRange(detID);
+      //SiStripPedestals::Range detPedestalRange = pedestal.getRange(detID);
 
       // -----------------------------------------------------------
 
@@ -659,8 +668,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
         noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
         for (int strip = 0; strip < numStrips; ++strip) {
           if (!badChannels[strip]) {
-            float gainValue = gainHandle->getStripGain(strip, detGainRange);
-            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
+            float gainValue = gain.getStripGain(strip, detGainRange);
+            noiseRMSv[strip] = (noise.getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
           }
         }
         theSiNoiseAdder->addNoiseVR(detAmpl, noiseRMSv, engine);
@@ -671,8 +680,8 @@ void PreMixingSiStripWorker::put(edm::Event& e,
           RefStrip++;
         }
         if (RefStrip < numStrips) {
-          float RefgainValue = gainHandle->getStripGain(RefStrip, detGainRange);
-          float RefnoiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
+          float RefgainValue = gain.getStripGain(RefStrip, detGainRange);
+          float RefnoiseRMS = noise.getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
 
           theSiNoiseAdder->addNoise(
               detAmpl, firstChannelWithSignal, lastChannelWithSignal, numStrips, RefnoiseRMS, engine);
@@ -681,7 +690,7 @@ void PreMixingSiStripWorker::put(edm::Event& e,
 
       DigitalVecType digis;
       theSiZeroSuppress->suppress(
-          theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
+          theSiDigitalConverter->convert(detAmpl, &gain, detID), digis, detID, noise, threshold);
 
       SSD.data = digis;
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -32,23 +32,17 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 //needed for the geometry:
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonTopologies/interface/StripTopology.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 //needed for the magnetic field:
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 //Data Base infromations
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
-#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
-#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
-#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
 
 //Random Number
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -59,19 +53,31 @@
 SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf,
                                    edm::ProducesCollector producesCollector,
                                    edm::ConsumesCollector& iC)
-    : gainLabel(conf.getParameter<std::string>("Gain")),
-      hitsProducer(conf.getParameter<std::string>("hitsProducer")),
+    : hitsProducer(conf.getParameter<std::string>("hitsProducer")),
       trackerContainers(conf.getParameter<std::vector<std::string>>("ROUList")),
       ZSDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("ZSDigi")),
       SCDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("SCDigi")),
       VRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("VRDigi")),
       PRDigi(conf.getParameter<edm::ParameterSet>("DigiModeList").getParameter<std::string>("PRDigi")),
-      geometryType(conf.getParameter<std::string>("GeometryType")),
       useConfFromDB(conf.getParameter<bool>("TrackerConfigurationFromDB")),
       zeroSuppression(conf.getParameter<bool>("ZeroSuppression")),
       makeDigiSimLinks_(conf.getUntrackedParameter<bool>("makeDigiSimLinks", false)),
       includeAPVSimulation_(conf.getParameter<bool>("includeAPVSimulation")),
-      fracOfEventsToSimAPV_(conf.getParameter<double>("fracOfEventsToSimAPV")) {
+      fracOfEventsToSimAPV_(conf.getParameter<double>("fracOfEventsToSimAPV")),
+      tTopoToken_(iC.esConsumes()),
+      pDDToken_(iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("GeometryType")))),
+      pSetupToken_(iC.esConsumes()),
+      gainToken_(iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("Gain")))),
+      noiseToken_(iC.esConsumes()),
+      thresholdToken_(iC.esConsumes()),
+      pedestalToken_(iC.esConsumes()) {
+  if (useConfFromDB) {
+    detCablingToken_ = iC.esConsumes();
+  }
+  if (includeAPVSimulation_) {
+    apvSimulationParametersToken_ = iC.esConsumes();
+  }
+
   const std::string alias("simSiStripDigis");
 
   producesCollector.produces<edm::DetSetVector<SiStripDigi>>(ZSDigi).setBranchAlias(ZSDigi);
@@ -99,7 +105,7 @@ SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf,
            "which is not present in the configuration file.  You must add the service\n"
            "in the configuration file or remove the modules that require it.";
   }
-  theDigiAlgo = std::make_unique<SiStripDigitizerAlgorithm>(conf);
+  theDigiAlgo = std::make_unique<SiStripDigitizerAlgorithm>(conf, iC);
 }
 
 // Virtual destructor needed.
@@ -138,9 +144,7 @@ void SiStripDigitizer::accumulateStripHits(edm::Handle<std::vector<PSimHit>> hSi
 // Functions that gets called by framework every event
 void SiStripDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology* tTopo = tTopoHand.product();
+  const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
   // Step A: Get Inputs
   for (auto const& trackerContainer : trackerContainers) {
@@ -164,9 +168,7 @@ void SiStripDigitizer::accumulate(edm::Event const& iEvent, edm::EventSetup cons
 void SiStripDigitizer::accumulate(PileUpEventPrincipal const& iEvent,
                                   edm::EventSetup const& iSetup,
                                   edm::StreamID const& streamID) {
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology* tTopo = tTopoHand.product();
+  const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
   //Re-compute luminosity for accumulation for HIP effects
   theDigiAlgo->calculateInstlumiScale(PileupInfo_.get());
@@ -200,9 +202,7 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
   // Step A: Get Inputs
 
   if (useConfFromDB) {
-    edm::ESHandle<SiStripDetCabling> detCabling;
-    iSetup.get<SiStripDetCablingRcd>().get(detCabling);
-    detCabling->addConnected(theDetIdList);
+    iSetup.getData(detCablingToken_).addConnected(theDetIdList);
   }
 
   // Cache random number engine
@@ -211,8 +211,8 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
 
   theDigiAlgo->initializeEvent(iSetup);
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometryType, pDD);
-  iSetup.get<IdealMagneticFieldRecord>().get(pSetup);
+  pDD = &iSetup.getData(pDDToken_);
+  pSetup = &iSetup.getData(pSetupToken_);
 
   // FIX THIS! We only need to clear and (re)fill detectorUnits when the geometry type IOV changes.  Use ESWatcher to determine this.
   bool changes = true;
@@ -233,21 +233,17 @@ void SiStripDigitizer::initializeEvent(edm::Event const& iEvent, edm::EventSetup
 }
 
 void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& iSetup) {
-  edm::ESHandle<SiStripGain> gainHandle;
-  edm::ESHandle<SiStripNoises> noiseHandle;
-  edm::ESHandle<SiStripThreshold> thresholdHandle;
-  edm::ESHandle<SiStripPedestals> pedestalHandle;
-  edm::ESHandle<SiStripApvSimulationParameters> apvSimulationParametersHandle;
-  iSetup.get<SiStripGainSimRcd>().get(gainLabel, gainHandle);
-  iSetup.get<SiStripNoisesRcd>().get(noiseHandle);
-  iSetup.get<SiStripThresholdRcd>().get(thresholdHandle);
-  iSetup.get<SiStripPedestalsRcd>().get(pedestalHandle);
+  auto const& gain = iSetup.getData(gainToken_);
+  auto const& noise = iSetup.getData(noiseToken_);
+  auto const& threshold = iSetup.getData(thresholdToken_);
+  auto const& pedestal = iSetup.getData(pedestalToken_);
+  SiStripApvSimulationParameters const* apvSimulationParameters = nullptr;
 
   std::unique_ptr<bool> simulateAPVInThisEvent = std::make_unique<bool>(false);
   if (includeAPVSimulation_) {
     if (CLHEP::RandFlat::shoot(randomEngine_) < fracOfEventsToSimAPV_) {
       *simulateAPVInThisEvent = true;
-      iSetup.get<SiStripApvSimulationParametersRcd>().get(apvSimulationParametersHandle);
+      apvSimulationParameters = &iSetup.getData(apvSimulationParametersToken_);
     }
   }
   std::vector<edm::DetSet<SiStripDigi>> theDigiVector;
@@ -258,9 +254,7 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
   std::unique_ptr<edm::DetSetVector<SiStripRawDigi>> theStripAPVBaselines(new edm::DetSetVector<SiStripRawDigi>());
   std::unique_ptr<edm::DetSetVector<StripDigiSimLink>> pOutputDigiSimLink(new edm::DetSetVector<StripDigiSimLink>);
 
-  edm::ESHandle<TrackerTopology> tTopoHand;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology* tTopo = tTopoHand.product();
+  const TrackerTopology* tTopo = &iSetup.getData(tTopoToken_);
 
   // Step B: LOOP on StripGeomDetUnit
   theDigiVector.reserve(10000);
@@ -291,12 +285,12 @@ void SiStripDigitizer::finalizeEvent(edm::Event& iEvent, edm::EventSetup const& 
                             collectorStripAPVBaselines,
                             collectorLink,
                             sgd,
-                            gainHandle,
-                            thresholdHandle,
-                            noiseHandle,
-                            pedestalHandle,
+                            gain,
+                            threshold,
+                            noise,
+                            pedestal,
                             *simulateAPVInThisEvent,
-                            apvSimulationParametersHandle,
+                            apvSimulationParameters,
                             theAffectedAPVvector,
                             randomEngine_,
                             tTopo);

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -6,10 +6,21 @@
 #include <string>
 #include <vector>
 #include <bitset>
-#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
-#include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
+#include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
+#include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
+#include "CondFormats/SiStripObjects/interface/SiStripThreshold.h"
 #include "FWCore/Framework/interface/ProducesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 class TrackerTopology;
 
@@ -74,19 +85,26 @@ private:
   typedef std::map<unsigned int, std::vector<std::pair<const PSimHit*, int>>, std::less<unsigned int>> simhit_map;
   typedef simhit_map::iterator simhit_map_iterator;
 
-  const std::string gainLabel;
   const std::string hitsProducer;
   const vstring trackerContainers;
   const std::string ZSDigi;
   const std::string SCDigi;
   const std::string VRDigi;
   const std::string PRDigi;
-  const std::string geometryType;
   const bool useConfFromDB;
   const bool zeroSuppression;
   const bool makeDigiSimLinks_;
   const bool includeAPVSimulation_;
   const double fracOfEventsToSimAPV_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> tTopoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> pDDToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> pSetupToken_;
+  const edm::ESGetToken<SiStripGain, SiStripGainSimRcd> gainToken_;
+  const edm::ESGetToken<SiStripNoises, SiStripNoisesRcd> noiseToken_;
+  const edm::ESGetToken<SiStripThreshold, SiStripThresholdRcd> thresholdToken_;
+  const edm::ESGetToken<SiStripPedestals, SiStripPedestalsRcd> pedestalToken_;
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
+  edm::ESGetToken<SiStripApvSimulationParameters, SiStripApvSimulationParametersRcd> apvSimulationParametersToken_;
 
   ///< Whether or not to create the association to sim truth collection. Set in configuration.
   /** @brief Offset to add to the index of each sim hit to account for which crossing it's in.
@@ -101,8 +119,8 @@ private:
 
   std::unique_ptr<SiStripDigitizerAlgorithm> theDigiAlgo;
   std::map<uint32_t, std::vector<int>> theDetIdList;
-  edm::ESHandle<TrackerGeometry> pDD;
-  edm::ESHandle<MagneticField> pSetup;
+  const TrackerGeometry* pDD = nullptr;
+  const MagneticField* pSetup = nullptr;
   std::map<unsigned int, StripGeomDetUnit const*> detectorUnits;
   CLHEP::HepRandomEngine* randomEngine_ = nullptr;
   std::vector<std::pair<int, std::bitset<6>>> theAffectedAPVvector;

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.cc
@@ -12,6 +12,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -23,7 +24,6 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "CalibTracker/Records/interface/SiStripDependentRecords.h"
 #include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
-#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "CondFormats/SiStripObjects/interface/SiStripNoises.h"
 #include "CondFormats/SiStripObjects/interface/SiStripThreshold.h"
 #include "CondFormats/SiStripObjects/interface/SiStripPedestals.h"
@@ -35,9 +35,8 @@
 
 #include <boost/algorithm/string.hpp>
 
-SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& conf)
-    : lorentzAngleName(conf.getParameter<std::string>("LorentzAngle")),
-      theThreshold(conf.getParameter<double>("NoiseSigmaThreshold")),
+SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC)
+    : theThreshold(conf.getParameter<double>("NoiseSigmaThreshold")),
       cmnRMStib(conf.getParameter<double>("cmnRMStib")),
       cmnRMStob(conf.getParameter<double>("cmnRMStob")),
       cmnRMStid(conf.getParameter<double>("cmnRMStid")),
@@ -61,6 +60,9 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
       inefficiency(conf.getParameter<double>("Inefficiency")),
       pedOffset((unsigned int)conf.getParameter<double>("PedestalsOffset")),
       PreMixing_(conf.getParameter<bool>("PreMixingMode")),
+      deadChannelToken_(iC.esConsumes()),
+      pdtToken_(iC.esConsumes()),
+      lorentzAngleToken_(iC.esConsumes(edm::ESInputTag("", conf.getParameter<std::string>("LorentzAngle")))),
       theSiHitDigitizer(new SiHitDigitizer(conf)),
       theSiPileUpSignals(new SiPileUpSignals()),
       theSiNoiseAdder(new SiGaussianTailNoiseAdder(theThreshold)),
@@ -107,19 +109,18 @@ SiStripDigitizerAlgorithm::SiStripDigitizerAlgorithm(const edm::ParameterSet& co
 SiStripDigitizerAlgorithm::~SiStripDigitizerAlgorithm() {}
 
 void SiStripDigitizerAlgorithm::initializeDetUnit(StripGeomDetUnit const* det, const edm::EventSetup& iSetup) {
-  edm::ESHandle<SiStripBadStrip> deadChannelHandle;
-  iSetup.get<SiStripBadChannelRcd>().get(deadChannelHandle);
+  auto const& deadChannel = iSetup.getData(deadChannelToken_);
 
   unsigned int detId = det->geographicalId().rawId();
   int numStrips = (det->specificTopology()).nstrips();
 
-  SiStripBadStrip::Range detBadStripRange = deadChannelHandle->getRange(detId);
+  SiStripBadStrip::Range detBadStripRange = deadChannel.getRange(detId);
   //storing the bad strip of the the module. the module is not removed but just signal put to 0
   std::vector<bool>& badChannels = allBadChannels[detId];
   badChannels.clear();
   badChannels.insert(badChannels.begin(), numStrips, false);
   for (SiStripBadStrip::ContainerIterator it = detBadStripRange.first; it != detBadStripRange.second; ++it) {
-    SiStripBadStrip::data fs = deadChannelHandle->decode(*it);
+    SiStripBadStrip::data fs = deadChannel.decode(*it);
     for (int strip = fs.firstStrip; strip < fs.firstStrip + fs.range; ++strip) {
       badChannels[strip] = true;
     }
@@ -146,10 +147,8 @@ void SiStripDigitizerAlgorithm::initializeEvent(const edm::EventSetup& iSetup) {
   nTruePU_ = 0;
 
   //get gain noise pedestal lorentzAngle from ES handle
-  edm::ESHandle<ParticleDataTable> pdt;
-  iSetup.getData(pdt);
-  setParticleDataTable(&*pdt);
-  iSetup.get<SiStripLorentzAngleSimRcd>().get(lorentzAngleName, lorentzAngleHandle);
+  setParticleDataTable(&iSetup.getData(pdtToken_));
+  lorentzAngleHandle = iSetup.getHandle(lorentzAngleToken_);
 }
 
 //  Run the algorithm for a given module
@@ -289,12 +288,12 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
                                          edm::DetSet<SiStripRawDigi>& outStripAPVBaselines,
                                          edm::DetSet<StripDigiSimLink>& outLink,
                                          const StripGeomDetUnit* det,
-                                         edm::ESHandle<SiStripGain>& gainHandle,
-                                         edm::ESHandle<SiStripThreshold>& thresholdHandle,
-                                         edm::ESHandle<SiStripNoises>& noiseHandle,
-                                         edm::ESHandle<SiStripPedestals>& pedestalHandle,
+                                         const SiStripGain& gain,
+                                         const SiStripThreshold& threshold,
+                                         const SiStripNoises& noiseObj,
+                                         const SiStripPedestals& pedestal,
                                          bool simulateAPVInThisEvent,
-                                         edm::ESHandle<SiStripApvSimulationParameters>& apvSimulationParametersHandle,
+                                         const SiStripApvSimulationParameters* apvSimulationParameters,
                                          std::vector<std::pair<int, std::bitset<6>>>& theAffectedAPVvector,
                                          CLHEP::HepRandomEngine* engine,
                                          const TrackerTopology* tTopo) {
@@ -344,13 +343,13 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
         // Get APV baseline
         double baselineV = 0;
         if (SubDet == SiStripSubdetector::TIB) {
-          baselineV = apvSimulationParametersHandle->sampleTIB(tTopo->tibLayer(detId), detSet_z, nTruePU_, engine);
+          baselineV = apvSimulationParameters->sampleTIB(tTopo->tibLayer(detId), detSet_z, nTruePU_, engine);
         } else if (SubDet == SiStripSubdetector::TOB) {
-          baselineV = apvSimulationParametersHandle->sampleTOB(tTopo->tobLayer(detId), detSet_z, nTruePU_, engine);
+          baselineV = apvSimulationParameters->sampleTOB(tTopo->tobLayer(detId), detSet_z, nTruePU_, engine);
         } else if (SubDet == SiStripSubdetector::TID) {
-          baselineV = apvSimulationParametersHandle->sampleTID(tTopo->tidWheel(detId), detSet_r, nTruePU_, engine);
+          baselineV = apvSimulationParameters->sampleTID(tTopo->tidWheel(detId), detSet_r, nTruePU_, engine);
         } else if (SubDet == SiStripSubdetector::TEC) {
-          baselineV = apvSimulationParametersHandle->sampleTEC(tTopo->tecWheel(detId), detSet_r, nTruePU_, engine);
+          baselineV = apvSimulationParameters->sampleTEC(tTopo->tecWheel(detId), detSet_r, nTruePU_, engine);
         }
         // Store APV baseline for this strip
         outStripAPVBaselines.emplace_back(SiStripRawDigi(baselineV));
@@ -445,9 +444,9 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
     }
   }
 
-  SiStripNoises::Range detNoiseRange = noiseHandle->getRange(detID);
-  SiStripApvGain::Range detGainRange = gainHandle->getRange(detID);
-  SiStripPedestals::Range detPedestalRange = pedestalHandle->getRange(detID);
+  SiStripNoises::Range detNoiseRange = noiseObj.getRange(detID);
+  SiStripApvGain::Range detGainRange = gain.getRange(detID);
+  SiStripPedestals::Range detPedestalRange = pedestal.getRange(detID);
 
   // -----------------------------------------------------------
 
@@ -467,8 +466,8 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
         noiseRMSv.insert(noiseRMSv.begin(), numStrips, 0.);
         for (int strip = 0; strip < numStrips; ++strip) {
           if (!badChannels[strip]) {
-            float gainValue = gainHandle->getStripGain(strip, detGainRange);
-            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
+            float gainValue = gain.getStripGain(strip, detGainRange);
+            noiseRMSv[strip] = (noiseObj.getNoise(strip, detNoiseRange)) * theElectronPerADC / gainValue;
             //std::cout<<"<SiStripDigitizerAlgorithm::digitize>: gainValue: "<<gainValue<<"\tnoiseRMSv["<<strip<<"]: "<<noiseRMSv[strip]<<std::endl;
           }
         }
@@ -480,8 +479,8 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
           RefStrip++;
         }
         if (RefStrip < numStrips) {
-          float RefgainValue = gainHandle->getStripGain(RefStrip, detGainRange);
-          float RefnoiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
+          float RefgainValue = gain.getStripGain(RefStrip, detGainRange);
+          float RefnoiseRMS = noiseObj.getNoise(RefStrip, detNoiseRange) * theElectronPerADC / RefgainValue;
 
           theSiNoiseAdder->addNoise(
               detAmpl, firstChannelWithSignal, lastChannelWithSignal, numStrips, RefnoiseRMS, engine);
@@ -492,7 +491,7 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
 
     DigitalVecType digis;
     theSiZeroSuppress->suppress(
-        theSiDigitalConverter->convert(detAmpl, gainHandle, detID), digis, detID, noiseHandle, thresholdHandle);
+        theSiDigitalConverter->convert(detAmpl, &gain, detID), digis, detID, noiseObj, threshold);
     // Now do the association to truth. Note that if truth association was turned off in the configuration this map
     // will be empty and the iterator will always equal associationInfoForDetId_.end().
     if (iAssociationInfoByChannel !=
@@ -554,7 +553,7 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
       if (SingleStripNoise) {
         for (int strip = 0; strip < numStrips; ++strip) {
           if (!badChannels[strip])
-            noiseRMSv[strip] = (noiseHandle->getNoise(strip, detNoiseRange)) * theElectronPerADC;
+            noiseRMSv[strip] = (noiseObj.getNoise(strip, detNoiseRange)) * theElectronPerADC;
         }
 
       } else {
@@ -564,7 +563,7 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
           RefStrip++;
         }
         if (RefStrip < numStrips) {
-          float noiseRMS = noiseHandle->getNoise(RefStrip, detNoiseRange) * theElectronPerADC;
+          float noiseRMS = noiseObj.getNoise(RefStrip, detNoiseRange) * theElectronPerADC;
           for (int strip = 0; strip < numStrips; ++strip) {
             if (!badChannels[strip])
               noiseRMSv[strip] = noiseRMS;
@@ -608,7 +607,7 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
     if (RealPedestals) {
       for (int strip = 0; strip < numStrips; ++strip) {
         if (!badChannels[strip])
-          vPeds[strip] = (pedestalHandle->getPed(strip, detPedestalRange) + pedOffset) * theElectronPerADC;
+          vPeds[strip] = (pedestal.getPed(strip, detPedestalRange) + pedOffset) * theElectronPerADC;
       }
     } else {
       for (int strip = 0; strip < numStrips; ++strip) {
@@ -624,7 +623,7 @@ void SiStripDigitizerAlgorithm::digitize(edm::DetSet<SiStripDigi>& outdigi,
     //  edm::LogWarning("SiStripDigitizer")<<"You are running the digitizer without Noise generation and without applying Zero Suppression. ARE YOU SURE???";
     //}else{
 
-    DigitalRawVecType rawdigis = theSiDigitalConverter->convertRaw(detAmpl, gainHandle, detID);
+    DigitalRawVecType rawdigis = theSiDigitalConverter->convertRaw(detAmpl, &gain, detID);
 
     // Now do the association to truth. Note that if truth association was turned off in the configuration this map
     // will be empty and the iterator will always equal associationInfoForDetId_.end().

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizerAlgorithm.h
@@ -24,6 +24,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripBadStrip.h"
 #include "CondFormats/SiStripObjects/interface/SiStripApvSimulationParameters.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripGain.h"
+#include "CondFormats/DataRecord/interface/SiStripCondDataRecords.h"
 #include "SimTracker/SiStripDigitizer/interface/SiTrivialDigitalConverter.h"
 #include "SimTracker/SiStripDigitizer/interface/SiGaussianTailNoiseAdder.h"
 #include "SiHitDigitizer.h"
@@ -35,6 +36,8 @@
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 #include "RecoLocalTracker/SiStripZeroSuppression/interface/SiStripFedZeroSuppression.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "TH1F.h"
 
@@ -42,10 +45,6 @@
 #include <fstream>
 
 class TrackerTopology;
-
-namespace edm {
-  class EventSetup;
-}
 
 class SiStripLorentzAngle;
 class StripDigiSimLink;
@@ -63,7 +62,7 @@ public:
   typedef float Amplitude;
 
   // Constructor
-  SiStripDigitizerAlgorithm(const edm::ParameterSet& conf);
+  SiStripDigitizerAlgorithm(const edm::ParameterSet& conf, edm::ConsumesCollector iC);
 
   // Destructor
   ~SiStripDigitizerAlgorithm();
@@ -89,12 +88,12 @@ public:
                 edm::DetSet<SiStripRawDigi>& outStripAPVBaselines,
                 edm::DetSet<StripDigiSimLink>& outLink,
                 const StripGeomDetUnit* stripdet,
-                edm::ESHandle<SiStripGain>&,
-                edm::ESHandle<SiStripThreshold>&,
-                edm::ESHandle<SiStripNoises>&,
-                edm::ESHandle<SiStripPedestals>&,
+                const SiStripGain&,
+                const SiStripThreshold&,
+                const SiStripNoises&,
+                const SiStripPedestals&,
                 bool simulateAPVInThisEvent,
-                edm::ESHandle<SiStripApvSimulationParameters>&,
+                const SiStripApvSimulationParameters*,
                 std::vector<std::pair<int, std::bitset<6>>>& theAffectedAPVvector,
                 CLHEP::HepRandomEngine*,
                 const TrackerTopology* tTopo);
@@ -108,7 +107,6 @@ public:
   }
 
 private:
-  const std::string lorentzAngleName;
   const double theThreshold;
   const double cmnRMStib;
   const double cmnRMStob;
@@ -136,6 +134,9 @@ private:
   const double inefficiency;
   const double pedOffset;
   const bool PreMixing_;
+  const edm::ESGetToken<SiStripBadStrip, SiStripBadChannelRcd> deadChannelToken_;
+  const edm::ESGetToken<HepPDT::ParticleDataTable, PDTRecord> pdtToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleSimRcd> lorentzAngleToken_;
 
   const ParticleDataTable* pdt;
   const ParticleData* particle;

--- a/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
+++ b/SimTracker/SiStripDigitizer/src/SiTrivialDigitalConverter.cc
@@ -8,7 +8,7 @@ SiTrivialDigitalConverter::SiTrivialDigitalConverter(float in, bool PreMix) : el
 }
 
 SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std::vector<float>& analogSignal,
-                                                                      edm::ESHandle<SiStripGain>& gainHandle,
+                                                                      const SiStripGain* gain,
                                                                       unsigned int detid) {
   _temp.clear();
 
@@ -22,13 +22,13 @@ SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std:
       if (adc > 0)
         _temp.push_back(SiStripDigi(i, adc));
     }
-  } else if (gainHandle.isValid()) {
-    SiStripApvGain::Range detGainRange = gainHandle->getRange(detid);
+  } else if (gain) {
+    SiStripApvGain::Range detGainRange = gain->getRange(detid);
     for (size_t i = 0; i < analogSignal.size(); i++) {
       if (analogSignal[i] <= 0)
         continue;
       // convert analog amplitude to digital
-      int adc = convert((gainHandle->getStripGain(i, detGainRange)) * (analogSignal[i]));
+      int adc = convert((gain->getStripGain(i, detGainRange)) * (analogSignal[i]));
       if (adc > 0)
         _temp.push_back(SiStripDigi(i, adc));
     }
@@ -46,19 +46,19 @@ SiDigitalConverter::DigitalVecType SiTrivialDigitalConverter::convert(const std:
 }
 
 SiDigitalConverter::DigitalRawVecType SiTrivialDigitalConverter::convertRaw(const std::vector<float>& analogSignal,
-                                                                            edm::ESHandle<SiStripGain>& gainHandle,
+                                                                            const SiStripGain* gain,
                                                                             unsigned int detid) {
   _tempRaw.clear();
 
-  if (gainHandle.isValid()) {
-    SiStripApvGain::Range detGainRange = gainHandle->getRange(detid);
+  if (gain) {
+    SiStripApvGain::Range detGainRange = gain->getRange(detid);
     for (size_t i = 0; i < analogSignal.size(); i++) {
       if (analogSignal[i] <= 0) {
         _tempRaw.push_back(SiStripRawDigi(0));
         continue;
       }
       // convert analog amplitude to digital
-      int adc = convertRaw((gainHandle->getStripGain(i, detGainRange)) * (analogSignal[i]));
+      int adc = convertRaw((gain->getStripGain(i, detGainRange)) * (analogSignal[i]));
       _tempRaw.push_back(SiStripRawDigi(adc));
     }
   } else {


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. In addition of plain migration to EventSetup consumes I did some refactoring related to getting the EventSetup products (like moving the `get()` calls from beginRun/beginLumi to Event, and passing around const references to ES products instead of `edm::ESHandle`). It has two caveats (which make the "most of") that need to be discussed/agreed:

I noticed the `MixingModule` (and `BMixingModule` base class, so affects all mixing modules) have the capability of updating the mixing parameters from the EventSetup, see e.g.
https://github.com/cms-sw/cmssw/blob/c51856dddbcd16b2f68d98df921df9d083abcbb6/SimGeneral/MixingModule/plugins/MixingModule.cc#L290-L301
https://github.com/cms-sw/cmssw/blob/c51856dddbcd16b2f68d98df921df9d083abcbb6/Mixing/Base/src/PileUp.cc#L235-L240
For the EventSetup consumes that alone is fine, but the pixel digitizer uses the bunchspacing to decide which of the two ES products it gets
https://github.com/cms-sw/cmssw/blob/c51856dddbcd16b2f68d98df921df9d083abcbb6/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc#L587-L595
In principle it could be possible for the product-to-be-got to change in the IOV boundaries of `MixingRcd` (if this mode of operation would be enabled), on the other hand updates after the first event are, in fact, already made impossible by
https://github.com/cms-sw/cmssw/blob/c51856dddbcd16b2f68d98df921df9d083abcbb6/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc#L260-L264
Nevertheless, it could be that the mixing parameters would be read from an EventSetup object instead of configuration. If this mode of operation needs to be supported, we need to figure out some way to get only (right) one of the `SiPixelDynamicInefficiency` products instead of both as in this PR. Possibilities include an ESProducer mayConsume-type feature, or abstracting the choice between the products into a new ESProducer. Anyway, the big question is **if MixingModule infrastructure has to continue to support changing mixing parameters based on `MixingModuleConfig` EventSetup product?**

[Answer below](https://github.com/cms-sw/cmssw/pull/31697#issuecomment-708095420): this mode should continue to be supported. To be done in a subsequent PR.

I did not migrate `DataMixingModule` (because it is not being used). Likely it becomes even more broken with this PR. **I hope this is acceptable.**

[Answer below](https://github.com/cms-sw/cmssw/pull/31697#issuecomment-708095420): Breaking `DataMixingModule` even more is acceptable.

#### PR validation:

Limited matrix runs.