### PR TITLE
Update PPS tags in Run 2 offline GTs for re-miniAOD [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v28',
+    'run1_data'         :   '106X_dataRun2_v29',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v28',
+    'run2_data'         :   '106X_dataRun2_v29',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v26',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v27',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #31635. See the description of that PR for details. The GT diff is as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v28/106X_dataRun2_v29

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v26/106X_dataRun2_relval_v27

The obsolete record `L1TMuonEndcapParamsRcd` removed in PR #31635 is not removed here in order to minimize the changes made here.

#### PR validation:

See the description of PR #31635 for details. In addition, a technical test was performed: `runTheMatrix.py -l limited,136.8642,136.72411 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #31635. The GTs in this PR are needed for the re-miniAOD of the Run 2 legacy dataset.
