### PR TITLE
Patatrack integration - common data formats (5/N)

### DIFF
--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -27,13 +27,13 @@ public:
 
   auto const &operator*() const { return *get(); }
 
-  auto const *operator-> () const { return get(); }
+  auto const *operator->() const { return get(); }
 
   auto *get() { return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get()); }
 
   auto &operator*() { return *get(); }
 
-  auto *operator-> () { return get(); }
+  auto *operator->() { return get(); }
 
   // in reality valid only for GPU version...
   cms::cuda::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const {

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -74,7 +74,6 @@ private:
 };
 
 
-/*
 namespace cudaCompat {
 
   struct GPUTraits {
@@ -242,6 +241,6 @@ template<typename T>
 using HeterogeneousSoACPU =  HeterogeneousSoAImpl<T,cudaCompat::CPUTraits>;
 template<typename T>
 using HeterogeneousSoAHost = HeterogeneousSoAImpl<T,cudaCompat::HostTraits>;
-*/
+
 
 #endif

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -35,10 +35,10 @@ public:
   auto *operator-> () { return get(); }
 
   // in reality valid only for GPU version...
-  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const {
+  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const {
     assert(dm_ptr);
     auto ret = cudautils::make_host_unique<T>(stream);
-    cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+    cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream));
     return ret;
   }
 
@@ -56,27 +56,27 @@ namespace cudaCompat {
     using unique_ptr = cudautils::device::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &stream) {
+    static auto make_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream) {
+    static auto make_host_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream) {
+    static auto make_device_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_device_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
   };
@@ -86,22 +86,22 @@ namespace cudaCompat {
     using unique_ptr = cudautils::host::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &stream) {
+    static auto make_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream) {
+    static auto make_host_unique(cudaStream_t stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream) {
+    static auto make_device_unique(cudaStream_t stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
+    static auto make_device_unique(size_t size, cudaStream_t stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
   };
@@ -111,27 +111,27 @@ namespace cudaCompat {
     using unique_ptr = std::unique_ptr<T>;
 
     template <typename T>
-    static auto make_unique(cuda::stream_t<> &) {
+    static auto make_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &) {
+    static auto make_unique(size_t size, cudaStream_t) {
       return std::make_unique<T>(size);
     }
 
     template <typename T>
-    static auto make_host_unique(cuda::stream_t<> &) {
+    static auto make_host_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_device_unique(cuda::stream_t<> &) {
+    static auto make_device_unique(cudaStream_t) {
       return std::make_unique<T>();
     }
 
     template <typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &) {
+    static auto make_device_unique(size_t size, cudaStream_t) {
       return std::make_unique<T>(size);
     }
   };
@@ -151,28 +151,28 @@ public:
   HeterogeneousSoAImpl &operator=(HeterogeneousSoAImpl &&) = default;
 
   explicit HeterogeneousSoAImpl(unique_ptr<T> &&p) : m_ptr(std::move(p)) {}
-  explicit HeterogeneousSoAImpl(cuda::stream_t<> &stream);
+  explicit HeterogeneousSoAImpl(cudaStream_t stream);
 
   T const *get() const { return m_ptr.get(); }
 
   T *get() { return m_ptr.get(); }
 
-  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const;
+  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const;
 
 private:
   unique_ptr<T> m_ptr;  //!
 };
 
 template <typename T, typename Traits>
-HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
+HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cudaStream_t stream) {
   m_ptr = Traits::template make_unique<T>(stream);
 }
 
 // in reality valid only for GPU version...
 template <typename T, typename Traits>
-cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cuda::stream_t<> &stream) const {
+cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cudaStream_t stream) const {
   auto ret = cudautils::make_host_unique<T>(stream);
-  cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+  cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream));
   return ret;
 }
 

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -1,0 +1,247 @@
+#ifndef CUDADataFormatsCommonHeterogeneousSoA_H
+#define CUDADataFormatsCommonHeterogeneousSoA_H
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+
+// a heterogeneous unique pointer...
+template<typename T>
+class HeterogeneousSoA {
+public:
+
+  using Product = T;
+
+  HeterogeneousSoA() = default; // make root happy
+  ~HeterogeneousSoA() = default;
+  HeterogeneousSoA(HeterogeneousSoA&&) = default;
+  HeterogeneousSoA& operator=(HeterogeneousSoA&&) = default;
+
+  explicit HeterogeneousSoA(cudautils::device::unique_ptr<T> && p) : dm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(cudautils::host::unique_ptr<T> && p) : hm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(std::unique_ptr<T> && p) : std_ptr(std::move(p)) {}
+
+
+  auto const * get() const {
+    return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get());
+  }
+
+  auto const & operator*() const {
+    return *get();
+  }
+
+  auto const * operator->() const {
+    return get();
+  }
+
+
+  auto * get() {
+    return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get());
+  }
+
+  auto &  operator*() {
+    return *get();
+  }
+
+  auto * operator->() {
+    return get();
+  }
+
+
+
+  // in reality valid only for GPU version...
+  cudautils::host::unique_ptr<T>
+  toHostAsync(cuda::stream_t<>& stream) const {
+    assert(dm_ptr);
+    edm::Service<CUDAService> cs;
+    auto ret = cs->make_host_unique<T>(stream);
+    cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+    return ret;
+  }
+
+
+
+private:
+  // a union wan't do it, a variant will not be more efficienct
+  cudautils::device::unique_ptr<T> dm_ptr; //!
+  cudautils::host::unique_ptr<T> hm_ptr; //!
+  std::unique_ptr<T> std_ptr; //!
+
+};
+
+
+/*
+namespace cudaCompat {
+
+  struct GPUTraits {
+
+    template<typename T>
+    using unique_ptr =  cudautils::device::unique_ptr<T>;
+
+    template<typename T>
+    static auto make_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(stream);
+    }
+
+    template<typename T>
+    static auto make_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(size, stream);
+    }
+
+    template<typename T>
+    static auto make_host_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_host_unique<T>(stream);
+    }
+
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(stream);
+    }
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(size, stream);
+    }
+
+
+  };
+
+
+  struct HostTraits {
+
+    template<typename T>
+    using unique_ptr =  cudautils::host::unique_ptr<T>;
+
+    template<typename T>
+    static auto make_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_host_unique<T>(stream);
+    }
+
+
+    template<typename T>
+    static auto make_host_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_host_unique<T>(stream);
+    }
+
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(stream);
+    }
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
+      return cs->make_device_unique<T>(size, stream);
+    }
+
+
+  };
+
+
+  struct CPUTraits {
+
+    template<typename T>
+    using unique_ptr =  std::unique_ptr<T>;
+
+    template<typename T>
+    static auto make_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+      return std::make_unique<T>();
+    }
+
+
+    template<typename T>
+    static auto make_unique(edm::Service<CUDAService>&, size_t size, cuda::stream_t<> &)    {
+      return std::make_unique<T>(size);
+    }
+
+
+    template<typename T>
+    static auto make_host_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+      return std::make_unique<T>();
+    }
+
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+      return std::make_unique<T>();
+    }
+
+    template<typename T>
+    static auto make_device_unique(edm::Service<CUDAService>&, size_t size, cuda::stream_t<> &)    {
+      return std::make_unique<T>(size);
+    }
+
+
+  };
+
+}
+
+
+
+// a heterogeneous unique pointer (of a different sort) ...
+template<typename T, typename Traits>
+class HeterogeneousSoAImpl {
+public:
+
+  template<typename V>
+  using unique_ptr = typename Traits:: template unique_ptr<V>;
+
+
+  HeterogeneousSoAImpl() = default; // make root happy
+  ~HeterogeneousSoAImpl() = default;
+  HeterogeneousSoAImpl(HeterogeneousSoAImpl&&) = default;
+  HeterogeneousSoAImpl& operator=(HeterogeneousSoAImpl&&) = default;
+
+  explicit HeterogeneousSoAImpl(unique_ptr<T> && p) : m_ptr(std::move(p)) {}
+  explicit HeterogeneousSoAImpl(cuda::stream_t<> &stream);
+
+  T const * get() const {
+    return m_ptr.get();
+  }
+  
+  T * get() {
+    return m_ptr.get();
+  }
+
+
+  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<>& stream) const;
+
+private:
+  unique_ptr<T> m_ptr; //!
+
+};
+
+
+
+template<typename T, typename Traits>
+HeterogeneousSoAImpl<T,Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
+  edm::Service<CUDAService> cs;
+  m_ptr = Traits:: template make_unique<T>(cs,stream);
+}
+
+
+// in reality valid only for GPU version...
+template<typename T, typename Traits>
+cudautils::host::unique_ptr<T>
+HeterogeneousSoAImpl<T,Traits>::toHostAsync(cuda::stream_t<>& stream) const {
+  edm::Service<CUDAService> cs;
+  auto ret = cs->make_host_unique<T>(stream);
+  cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream.id()));
+  return ret;
+}
+
+
+template<typename T>
+using HeterogeneousSoAGPU = HeterogeneousSoAImpl<T,cudaCompat::GPUTraits>;
+template<typename T>
+using HeterogeneousSoACPU =  HeterogeneousSoAImpl<T,cudaCompat::CPUTraits>;
+template<typename T>
+using HeterogeneousSoAHost = HeterogeneousSoAImpl<T,cudaCompat::HostTraits>;
+*/
+
+#endif

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -4,8 +4,6 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
@@ -57,8 +55,7 @@ public:
   cudautils::host::unique_ptr<T>
   toHostAsync(cuda::stream_t<>& stream) const {
     assert(dm_ptr);
-    edm::Service<CUDAService> cs;
-    auto ret = cs->make_host_unique<T>(stream);
+    auto ret = cudautils::make_host_unique<T>(stream);
     cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream.id()));
     return ret;
   }
@@ -82,29 +79,29 @@ namespace cudaCompat {
     using unique_ptr =  cudautils::device::unique_ptr<T>;
 
     template<typename T>
-    static auto make_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(stream);
+    static auto make_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(stream);
     }
 
     template<typename T>
-    static auto make_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(size, stream);
+    static auto make_unique(size_t size, cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(size, stream);
     }
 
     template<typename T>
-    static auto make_host_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_host_unique<T>(stream);
+    static auto make_host_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_host_unique<T>(stream);
     }
 
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(stream);
+    static auto make_device_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(stream);
     }
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(size, stream);
+    static auto make_device_unique(size_t size, cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(size, stream);
     }
 
 
@@ -117,25 +114,25 @@ namespace cudaCompat {
     using unique_ptr =  cudautils::host::unique_ptr<T>;
 
     template<typename T>
-    static auto make_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_host_unique<T>(stream);
+    static auto make_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_host_unique<T>(stream);
     }
 
 
     template<typename T>
-    static auto make_host_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_host_unique<T>(stream);
+    static auto make_host_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_host_unique<T>(stream);
     }
 
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService> & cs, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(stream);
+    static auto make_device_unique(cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(stream);
     }
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService> & cs, size_t size, cuda::stream_t<> &stream)    {
-      return cs->make_device_unique<T>(size, stream);
+    static auto make_device_unique(size_t size, cuda::stream_t<> &stream)    {
+      return cudautils::make_device_unique<T>(size, stream);
     }
 
 
@@ -148,30 +145,30 @@ namespace cudaCompat {
     using unique_ptr =  std::unique_ptr<T>;
 
     template<typename T>
-    static auto make_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+    static auto make_unique(cuda::stream_t<> &)    {
       return std::make_unique<T>();
     }
 
 
     template<typename T>
-    static auto make_unique(edm::Service<CUDAService>&, size_t size, cuda::stream_t<> &)    {
+    static auto make_unique(size_t size, cuda::stream_t<> &)    {
       return std::make_unique<T>(size);
     }
 
 
     template<typename T>
-    static auto make_host_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+    static auto make_host_unique(cuda::stream_t<> &)    {
       return std::make_unique<T>();
     }
 
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService>&, cuda::stream_t<> &)    {
+    static auto make_device_unique(cuda::stream_t<> &)    {
       return std::make_unique<T>();
     }
 
     template<typename T>
-    static auto make_device_unique(edm::Service<CUDAService>&, size_t size, cuda::stream_t<> &)    {
+    static auto make_device_unique(size_t size, cuda::stream_t<> &)    {
       return std::make_unique<T>(size);
     }
 
@@ -219,8 +216,7 @@ private:
 
 template<typename T, typename Traits>
 HeterogeneousSoAImpl<T,Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
-  edm::Service<CUDAService> cs;
-  m_ptr = Traits:: template make_unique<T>(cs,stream);
+  m_ptr = Traits:: template make_unique<T>(stream);
 }
 
 
@@ -228,8 +224,7 @@ HeterogeneousSoAImpl<T,Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
 template<typename T, typename Traits>
 cudautils::host::unique_ptr<T>
 HeterogeneousSoAImpl<T,Traits>::toHostAsync(cuda::stream_t<>& stream) const {
-  edm::Service<CUDAService> cs;
-  auto ret = cs->make_host_unique<T>(stream);
+  auto ret = cudautils::make_host_unique<T>(stream);
   cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream.id()));
   return ret;
 }

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -8,234 +8,179 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
 
 // a heterogeneous unique pointer...
-template<typename T>
+template <typename T>
 class HeterogeneousSoA {
 public:
-
   using Product = T;
 
-  HeterogeneousSoA() = default; // make root happy
+  HeterogeneousSoA() = default;  // make root happy
   ~HeterogeneousSoA() = default;
-  HeterogeneousSoA(HeterogeneousSoA&&) = default;
-  HeterogeneousSoA& operator=(HeterogeneousSoA&&) = default;
+  HeterogeneousSoA(HeterogeneousSoA &&) = default;
+  HeterogeneousSoA &operator=(HeterogeneousSoA &&) = default;
 
-  explicit HeterogeneousSoA(cudautils::device::unique_ptr<T> && p) : dm_ptr(std::move(p)) {}
-  explicit HeterogeneousSoA(cudautils::host::unique_ptr<T> && p) : hm_ptr(std::move(p)) {}
-  explicit HeterogeneousSoA(std::unique_ptr<T> && p) : std_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(cudautils::device::unique_ptr<T> &&p) : dm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(cudautils::host::unique_ptr<T> &&p) : hm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(std::unique_ptr<T> &&p) : std_ptr(std::move(p)) {}
 
+  auto const *get() const { return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get()); }
 
-  auto const * get() const {
-    return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get());
-  }
+  auto const &operator*() const { return *get(); }
 
-  auto const & operator*() const {
-    return *get();
-  }
+  auto const *operator-> () const { return get(); }
 
-  auto const * operator->() const {
-    return get();
-  }
+  auto *get() { return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get()); }
 
+  auto &operator*() { return *get(); }
 
-  auto * get() {
-    return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get());
-  }
-
-  auto &  operator*() {
-    return *get();
-  }
-
-  auto * operator->() {
-    return get();
-  }
-
-
+  auto *operator-> () { return get(); }
 
   // in reality valid only for GPU version...
-  cudautils::host::unique_ptr<T>
-  toHostAsync(cuda::stream_t<>& stream) const {
+  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const {
     assert(dm_ptr);
     auto ret = cudautils::make_host_unique<T>(stream);
     cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream.id()));
     return ret;
   }
 
-
-
 private:
   // a union wan't do it, a variant will not be more efficienct
-  cudautils::device::unique_ptr<T> dm_ptr; //!
-  cudautils::host::unique_ptr<T> hm_ptr; //!
-  std::unique_ptr<T> std_ptr; //!
-
+  cudautils::device::unique_ptr<T> dm_ptr;  //!
+  cudautils::host::unique_ptr<T> hm_ptr;    //!
+  std::unique_ptr<T> std_ptr;               //!
 };
-
 
 namespace cudaCompat {
 
   struct GPUTraits {
+    template <typename T>
+    using unique_ptr = cudautils::device::unique_ptr<T>;
 
-    template<typename T>
-    using unique_ptr =  cudautils::device::unique_ptr<T>;
-
-    template<typename T>
-    static auto make_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_unique(cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
-    template<typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_unique(size_t size, cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
 
-    template<typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_host_unique(cuda::stream_t<> &stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
-
-    template<typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_device_unique(cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
-    template<typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
-
-
   };
-
 
   struct HostTraits {
+    template <typename T>
+    using unique_ptr = cudautils::host::unique_ptr<T>;
 
-    template<typename T>
-    using unique_ptr =  cudautils::host::unique_ptr<T>;
-
-    template<typename T>
-    static auto make_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_unique(cuda::stream_t<> &stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
-
-    template<typename T>
-    static auto make_host_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_host_unique(cuda::stream_t<> &stream) {
       return cudautils::make_host_unique<T>(stream);
     }
 
-
-    template<typename T>
-    static auto make_device_unique(cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_device_unique(cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(stream);
     }
 
-    template<typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &stream)    {
+    template <typename T>
+    static auto make_device_unique(size_t size, cuda::stream_t<> &stream) {
       return cudautils::make_device_unique<T>(size, stream);
     }
-
-
   };
-
 
   struct CPUTraits {
+    template <typename T>
+    using unique_ptr = std::unique_ptr<T>;
 
-    template<typename T>
-    using unique_ptr =  std::unique_ptr<T>;
-
-    template<typename T>
-    static auto make_unique(cuda::stream_t<> &)    {
+    template <typename T>
+    static auto make_unique(cuda::stream_t<> &) {
       return std::make_unique<T>();
     }
 
-
-    template<typename T>
-    static auto make_unique(size_t size, cuda::stream_t<> &)    {
+    template <typename T>
+    static auto make_unique(size_t size, cuda::stream_t<> &) {
       return std::make_unique<T>(size);
     }
 
-
-    template<typename T>
-    static auto make_host_unique(cuda::stream_t<> &)    {
+    template <typename T>
+    static auto make_host_unique(cuda::stream_t<> &) {
       return std::make_unique<T>();
     }
 
-
-    template<typename T>
-    static auto make_device_unique(cuda::stream_t<> &)    {
+    template <typename T>
+    static auto make_device_unique(cuda::stream_t<> &) {
       return std::make_unique<T>();
     }
 
-    template<typename T>
-    static auto make_device_unique(size_t size, cuda::stream_t<> &)    {
+    template <typename T>
+    static auto make_device_unique(size_t size, cuda::stream_t<> &) {
       return std::make_unique<T>(size);
     }
-
-
   };
 
-}
-
-
+}  // namespace cudaCompat
 
 // a heterogeneous unique pointer (of a different sort) ...
-template<typename T, typename Traits>
+template <typename T, typename Traits>
 class HeterogeneousSoAImpl {
 public:
+  template <typename V>
+  using unique_ptr = typename Traits::template unique_ptr<V>;
 
-  template<typename V>
-  using unique_ptr = typename Traits:: template unique_ptr<V>;
-
-
-  HeterogeneousSoAImpl() = default; // make root happy
+  HeterogeneousSoAImpl() = default;  // make root happy
   ~HeterogeneousSoAImpl() = default;
-  HeterogeneousSoAImpl(HeterogeneousSoAImpl&&) = default;
-  HeterogeneousSoAImpl& operator=(HeterogeneousSoAImpl&&) = default;
+  HeterogeneousSoAImpl(HeterogeneousSoAImpl &&) = default;
+  HeterogeneousSoAImpl &operator=(HeterogeneousSoAImpl &&) = default;
 
-  explicit HeterogeneousSoAImpl(unique_ptr<T> && p) : m_ptr(std::move(p)) {}
+  explicit HeterogeneousSoAImpl(unique_ptr<T> &&p) : m_ptr(std::move(p)) {}
   explicit HeterogeneousSoAImpl(cuda::stream_t<> &stream);
 
-  T const * get() const {
-    return m_ptr.get();
-  }
-  
-  T * get() {
-    return m_ptr.get();
-  }
+  T const *get() const { return m_ptr.get(); }
 
+  T *get() { return m_ptr.get(); }
 
-  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<>& stream) const;
+  cudautils::host::unique_ptr<T> toHostAsync(cuda::stream_t<> &stream) const;
 
 private:
-  unique_ptr<T> m_ptr; //!
-
+  unique_ptr<T> m_ptr;  //!
 };
 
-
-
-template<typename T, typename Traits>
-HeterogeneousSoAImpl<T,Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
-  m_ptr = Traits:: template make_unique<T>(stream);
+template <typename T, typename Traits>
+HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cuda::stream_t<> &stream) {
+  m_ptr = Traits::template make_unique<T>(stream);
 }
 
-
 // in reality valid only for GPU version...
-template<typename T, typename Traits>
-cudautils::host::unique_ptr<T>
-HeterogeneousSoAImpl<T,Traits>::toHostAsync(cuda::stream_t<>& stream) const {
+template <typename T, typename Traits>
+cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cuda::stream_t<> &stream) const {
   auto ret = cudautils::make_host_unique<T>(stream);
   cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream.id()));
   return ret;
 }
 
-
-template<typename T>
-using HeterogeneousSoAGPU = HeterogeneousSoAImpl<T,cudaCompat::GPUTraits>;
-template<typename T>
-using HeterogeneousSoACPU =  HeterogeneousSoAImpl<T,cudaCompat::CPUTraits>;
-template<typename T>
-using HeterogeneousSoAHost = HeterogeneousSoAImpl<T,cudaCompat::HostTraits>;
-
+template <typename T>
+using HeterogeneousSoAGPU = HeterogeneousSoAImpl<T, cudaCompat::GPUTraits>;
+template <typename T>
+using HeterogeneousSoACPU = HeterogeneousSoAImpl<T, cudaCompat::CPUTraits>;
+template <typename T>
+using HeterogeneousSoAHost = HeterogeneousSoAImpl<T, cudaCompat::HostTraits>;
 
 #endif

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -50,94 +50,96 @@ private:
   std::unique_ptr<T> std_ptr;               //!
 };
 
-namespace cudaCompat {
+namespace cms {
+  namespace cudacompat {
 
-  struct GPUTraits {
-    template <typename T>
-    using unique_ptr = cms::cuda::device::unique_ptr<T>;
+    struct GPUTraits {
+      template <typename T>
+      using unique_ptr = cms::cuda::device::unique_ptr<T>;
 
-    template <typename T>
-    static auto make_unique(cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_unique(cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_unique(size_t size, cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(size, stream);
-    }
+      template <typename T>
+      static auto make_unique(size_t size, cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(size, stream);
+      }
 
-    template <typename T>
-    static auto make_host_unique(cudaStream_t stream) {
-      return cms::cuda::make_host_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_host_unique(cudaStream_t stream) {
+        return cms::cuda::make_host_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_device_unique(cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_device_unique(cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_device_unique(size_t size, cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(size, stream);
-    }
-  };
+      template <typename T>
+      static auto make_device_unique(size_t size, cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(size, stream);
+      }
+    };
 
-  struct HostTraits {
-    template <typename T>
-    using unique_ptr = cms::cuda::host::unique_ptr<T>;
+    struct HostTraits {
+      template <typename T>
+      using unique_ptr = cms::cuda::host::unique_ptr<T>;
 
-    template <typename T>
-    static auto make_unique(cudaStream_t stream) {
-      return cms::cuda::make_host_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_unique(cudaStream_t stream) {
+        return cms::cuda::make_host_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_host_unique(cudaStream_t stream) {
-      return cms::cuda::make_host_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_host_unique(cudaStream_t stream) {
+        return cms::cuda::make_host_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_device_unique(cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(stream);
-    }
+      template <typename T>
+      static auto make_device_unique(cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(stream);
+      }
 
-    template <typename T>
-    static auto make_device_unique(size_t size, cudaStream_t stream) {
-      return cms::cuda::make_device_unique<T>(size, stream);
-    }
-  };
+      template <typename T>
+      static auto make_device_unique(size_t size, cudaStream_t stream) {
+        return cms::cuda::make_device_unique<T>(size, stream);
+      }
+    };
 
-  struct CPUTraits {
-    template <typename T>
-    using unique_ptr = std::unique_ptr<T>;
+    struct CPUTraits {
+      template <typename T>
+      using unique_ptr = std::unique_ptr<T>;
 
-    template <typename T>
-    static auto make_unique(cudaStream_t) {
-      return std::make_unique<T>();
-    }
+      template <typename T>
+      static auto make_unique(cudaStream_t) {
+        return std::make_unique<T>();
+      }
 
-    template <typename T>
-    static auto make_unique(size_t size, cudaStream_t) {
-      return std::make_unique<T>(size);
-    }
+      template <typename T>
+      static auto make_unique(size_t size, cudaStream_t) {
+        return std::make_unique<T>(size);
+      }
 
-    template <typename T>
-    static auto make_host_unique(cudaStream_t) {
-      return std::make_unique<T>();
-    }
+      template <typename T>
+      static auto make_host_unique(cudaStream_t) {
+        return std::make_unique<T>();
+      }
 
-    template <typename T>
-    static auto make_device_unique(cudaStream_t) {
-      return std::make_unique<T>();
-    }
+      template <typename T>
+      static auto make_device_unique(cudaStream_t) {
+        return std::make_unique<T>();
+      }
 
-    template <typename T>
-    static auto make_device_unique(size_t size, cudaStream_t) {
-      return std::make_unique<T>(size);
-    }
-  };
+      template <typename T>
+      static auto make_device_unique(size_t size, cudaStream_t) {
+        return std::make_unique<T>(size);
+      }
+    };
 
-}  // namespace cudaCompat
+  }  // namespace cudacompat
+}  // namespace cms
 
 // a heterogeneous unique pointer (of a different sort) ...
 template <typename T, typename Traits>
@@ -178,10 +180,10 @@ cms::cuda::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cuda
 }
 
 template <typename T>
-using HeterogeneousSoAGPU = HeterogeneousSoAImpl<T, cudaCompat::GPUTraits>;
+using HeterogeneousSoAGPU = HeterogeneousSoAImpl<T, cms::cudacompat::GPUTraits>;
 template <typename T>
-using HeterogeneousSoACPU = HeterogeneousSoAImpl<T, cudaCompat::CPUTraits>;
+using HeterogeneousSoACPU = HeterogeneousSoAImpl<T, cms::cudacompat::CPUTraits>;
 template <typename T>
-using HeterogeneousSoAHost = HeterogeneousSoAImpl<T, cudaCompat::HostTraits>;
+using HeterogeneousSoAHost = HeterogeneousSoAImpl<T, cms::cudacompat::HostTraits>;
 
 #endif

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -19,8 +19,8 @@ public:
   HeterogeneousSoA(HeterogeneousSoA &&) = default;
   HeterogeneousSoA &operator=(HeterogeneousSoA &&) = default;
 
-  explicit HeterogeneousSoA(cudautils::device::unique_ptr<T> &&p) : dm_ptr(std::move(p)) {}
-  explicit HeterogeneousSoA(cudautils::host::unique_ptr<T> &&p) : hm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(cms::cuda::device::unique_ptr<T> &&p) : dm_ptr(std::move(p)) {}
+  explicit HeterogeneousSoA(cms::cuda::host::unique_ptr<T> &&p) : hm_ptr(std::move(p)) {}
   explicit HeterogeneousSoA(std::unique_ptr<T> &&p) : std_ptr(std::move(p)) {}
 
   auto const *get() const { return dm_ptr ? dm_ptr.get() : (hm_ptr ? hm_ptr.get() : std_ptr.get()); }
@@ -36,17 +36,17 @@ public:
   auto *operator-> () { return get(); }
 
   // in reality valid only for GPU version...
-  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const {
+  cms::cuda::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const {
     assert(dm_ptr);
-    auto ret = cudautils::make_host_unique<T>(stream);
+    auto ret = cms::cuda::make_host_unique<T>(stream);
     cudaCheck(cudaMemcpyAsync(ret.get(), dm_ptr.get(), sizeof(T), cudaMemcpyDefault, stream));
     return ret;
   }
 
 private:
   // a union wan't do it, a variant will not be more efficienct
-  cudautils::device::unique_ptr<T> dm_ptr;  //!
-  cudautils::host::unique_ptr<T> hm_ptr;    //!
+  cms::cuda::device::unique_ptr<T> dm_ptr;  //!
+  cms::cuda::host::unique_ptr<T> hm_ptr;    //!
   std::unique_ptr<T> std_ptr;               //!
 };
 
@@ -54,56 +54,56 @@ namespace cudaCompat {
 
   struct GPUTraits {
     template <typename T>
-    using unique_ptr = cudautils::device::unique_ptr<T>;
+    using unique_ptr = cms::cuda::device::unique_ptr<T>;
 
     template <typename T>
     static auto make_unique(cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(stream);
+      return cms::cuda::make_device_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_unique(size_t size, cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(size, stream);
+      return cms::cuda::make_device_unique<T>(size, stream);
     }
 
     template <typename T>
     static auto make_host_unique(cudaStream_t stream) {
-      return cudautils::make_host_unique<T>(stream);
+      return cms::cuda::make_host_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_device_unique(cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(stream);
+      return cms::cuda::make_device_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_device_unique(size_t size, cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(size, stream);
+      return cms::cuda::make_device_unique<T>(size, stream);
     }
   };
 
   struct HostTraits {
     template <typename T>
-    using unique_ptr = cudautils::host::unique_ptr<T>;
+    using unique_ptr = cms::cuda::host::unique_ptr<T>;
 
     template <typename T>
     static auto make_unique(cudaStream_t stream) {
-      return cudautils::make_host_unique<T>(stream);
+      return cms::cuda::make_host_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_host_unique(cudaStream_t stream) {
-      return cudautils::make_host_unique<T>(stream);
+      return cms::cuda::make_host_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_device_unique(cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(stream);
+      return cms::cuda::make_device_unique<T>(stream);
     }
 
     template <typename T>
     static auto make_device_unique(size_t size, cudaStream_t stream) {
-      return cudautils::make_device_unique<T>(size, stream);
+      return cms::cuda::make_device_unique<T>(size, stream);
     }
   };
 
@@ -158,7 +158,7 @@ public:
 
   T *get() { return m_ptr.get(); }
 
-  cudautils::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const;
+  cms::cuda::host::unique_ptr<T> toHostAsync(cudaStream_t stream) const;
 
 private:
   unique_ptr<T> m_ptr;  //!
@@ -171,8 +171,8 @@ HeterogeneousSoAImpl<T, Traits>::HeterogeneousSoAImpl(cudaStream_t stream) {
 
 // in reality valid only for GPU version...
 template <typename T, typename Traits>
-cudautils::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cudaStream_t stream) const {
-  auto ret = cudautils::make_host_unique<T>(stream);
+cms::cuda::host::unique_ptr<T> HeterogeneousSoAImpl<T, Traits>::toHostAsync(cudaStream_t stream) const {
+  auto ret = cms::cuda::make_host_unique<T>(stream);
   cudaCheck(cudaMemcpyAsync(ret.get(), get(), sizeof(T), cudaMemcpyDefault, stream));
   return ret;
 }

--- a/CUDADataFormats/Common/interface/HeterogeneousSoA.h
+++ b/CUDADataFormats/Common/interface/HeterogeneousSoA.h
@@ -1,11 +1,12 @@
 #ifndef CUDADataFormatsCommonHeterogeneousSoA_H
 #define CUDADataFormatsCommonHeterogeneousSoA_H
 
-#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
-#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include <cassert>
 
 #include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
 #include "HeterogeneousCore/CUDAUtilities/interface/cudaCheck.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 
 // a heterogeneous unique pointer...
 template <typename T>

--- a/CUDADataFormats/Common/interface/HostProduct.h
+++ b/CUDADataFormats/Common/interface/HostProduct.h
@@ -19,7 +19,7 @@ public:
 
   auto const& operator*() const { return *get(); }
 
-  auto const* operator-> () const { return get(); }
+  auto const* operator->() const { return get(); }
 
 private:
   cms::cuda::host::unique_ptr<T> hm_ptr;  //!

--- a/CUDADataFormats/Common/interface/HostProduct.h
+++ b/CUDADataFormats/Common/interface/HostProduct.h
@@ -32,8 +32,8 @@ public:
   
 
 private:
-  cudautils::host::unique_ptr<T> hm_ptr;
-  std::unique_ptr<T> std_ptr;
+  cudautils::host::unique_ptr<T> hm_ptr; //!
+  std::unique_ptr<T> std_ptr;  //!
 
 };
 

--- a/CUDADataFormats/Common/interface/HostProduct.h
+++ b/CUDADataFormats/Common/interface/HostProduct.h
@@ -4,37 +4,26 @@
 #include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
 
 // a heterogeneous unique pointer...
-template<typename T>
+template <typename T>
 class HostProduct {
 public:
-
-
-  HostProduct() = default; // make root happy
+  HostProduct() = default;  // make root happy
   ~HostProduct() = default;
   HostProduct(HostProduct&&) = default;
   HostProduct& operator=(HostProduct&&) = default;
 
-  explicit HostProduct(cudautils::host::unique_ptr<T> && p) : hm_ptr(std::move(p)) {}
-  explicit HostProduct(std::unique_ptr<T> && p) : std_ptr(std::move(p)) {}
+  explicit HostProduct(cudautils::host::unique_ptr<T>&& p) : hm_ptr(std::move(p)) {}
+  explicit HostProduct(std::unique_ptr<T>&& p) : std_ptr(std::move(p)) {}
 
+  auto const* get() const { return hm_ptr ? hm_ptr.get() : std_ptr.get(); }
 
-  auto const * get() const {
-    return hm_ptr ? hm_ptr.get() : std_ptr.get();
-  }
-  
-  auto const & operator*() const {
-    return *get();
-  }
+  auto const& operator*() const { return *get(); }
 
-  auto const * operator->() const {
-    return get();
-  }
-  
+  auto const* operator-> () const { return get(); }
 
 private:
-  cudautils::host::unique_ptr<T> hm_ptr; //!
-  std::unique_ptr<T> std_ptr;  //!
-
+  cudautils::host::unique_ptr<T> hm_ptr;  //!
+  std::unique_ptr<T> std_ptr;             //!
 };
 
 #endif

--- a/CUDADataFormats/Common/interface/HostProduct.h
+++ b/CUDADataFormats/Common/interface/HostProduct.h
@@ -1,0 +1,40 @@
+#ifndef CUDADataFormatsCommonHostProduct_H
+#define CUDADataFormatsCommonHostProduct_H
+
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+
+// a heterogeneous unique pointer...
+template<typename T>
+class HostProduct {
+public:
+
+
+  HostProduct() = default; // make root happy
+  ~HostProduct() = default;
+  HostProduct(HostProduct&&) = default;
+  HostProduct& operator=(HostProduct&&) = default;
+
+  explicit HostProduct(cudautils::host::unique_ptr<T> && p) : hm_ptr(std::move(p)) {}
+  explicit HostProduct(std::unique_ptr<T> && p) : std_ptr(std::move(p)) {}
+
+
+  auto const * get() const {
+    return hm_ptr ? hm_ptr.get() : std_ptr.get();
+  }
+  
+  auto const & operator*() const {
+    return *get();
+  }
+
+  auto const * operator->() const {
+    return get();
+  }
+  
+
+private:
+  cudautils::host::unique_ptr<T> hm_ptr;
+  std::unique_ptr<T> std_ptr;
+
+};
+
+#endif

--- a/CUDADataFormats/Common/interface/HostProduct.h
+++ b/CUDADataFormats/Common/interface/HostProduct.h
@@ -12,7 +12,7 @@ public:
   HostProduct(HostProduct&&) = default;
   HostProduct& operator=(HostProduct&&) = default;
 
-  explicit HostProduct(cudautils::host::unique_ptr<T>&& p) : hm_ptr(std::move(p)) {}
+  explicit HostProduct(cms::cuda::host::unique_ptr<T>&& p) : hm_ptr(std::move(p)) {}
   explicit HostProduct(std::unique_ptr<T>&& p) : std_ptr(std::move(p)) {}
 
   auto const* get() const { return hm_ptr ? hm_ptr.get() : std_ptr.get(); }
@@ -22,7 +22,7 @@ public:
   auto const* operator-> () const { return get(); }
 
 private:
-  cudautils::host::unique_ptr<T> hm_ptr;  //!
+  cms::cuda::host::unique_ptr<T> hm_ptr;  //!
   std::unique_ptr<T> std_ptr;             //!
 };
 

--- a/CUDADataFormats/StdDictionaries/BuildFile.xml
+++ b/CUDADataFormats/StdDictionaries/BuildFile.xml
@@ -1,0 +1,5 @@
+<use name="rootcore"/>
+<use name="HeterogeneousCore/CUDAUtilities"/>
+<export>
+  <lib name="1"/>
+</export>

--- a/CUDADataFormats/StdDictionaries/src/classes.h
+++ b/CUDADataFormats/StdDictionaries/src/classes.h
@@ -1,0 +1,4 @@
+#include <cstddef>
+#include <vector>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/HostAllocator.h"

--- a/CUDADataFormats/StdDictionaries/src/classes_def.xml
+++ b/CUDADataFormats/StdDictionaries/src/classes_def.xml
@@ -1,0 +1,14 @@
+<lcgdict>
+    <class name="std::vector<std::byte, cms::cuda::HostAllocator<std::byte, 0>>" />
+
+    <class name="std::vector<uint8_t, cms::cuda::HostAllocator<uint8_t, 0>>" />
+    <class name="std::vector<uint16_t, cms::cuda::HostAllocator<uint16_t, 0>>" />
+    <class name="std::vector<uint32_t, cms::cuda::HostAllocator<uint32_t, 0>>" />
+
+    <class name="std::vector<int8_t, cms::cuda::HostAllocator<int8_t, 0>>" />
+    <class name="std::vector<int16_t, cms::cuda::HostAllocator<int16_t, 0>>" />
+    <class name="std::vector<int32_t, cms::cuda::HostAllocator<int32_t, 0>>" />
+
+    <class name="std::vector<float, cms::cuda::HostAllocator<float, 0>>" />
+    <class name="std::vector<double, cms::cuda::HostAllocator<double, 0>>" />
+</lcgdict>


### PR DESCRIPTION
#### PR description:

Common data formats and dictionaries for CUDA modules.

#### PR validation:

Changes in use in the Patatrack releases.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Includes changes from:
  - cms-patatrack#384: Port the whole pixel workflow to new heterogeneous framework
  - cms-patatrack#385: Implement full Pixel SoA workflow on CPU
  - cms-patatrack#364: Move event and stream caches, and caching allocators out from CUDAService
  - cms-patatrack#389: Replace use of API wrapper stream and event with plain CUDA, part 1
  - cms-patatrack#416: Drop obsolete heterogenous framework
  - cms-patatrack#429: Implement changes from the CUDA framework review
  - cms-patatrack#442: Integrate the comments from the upstream PRs
  - cms-patatrack#470: Update HCAL local reconstruction on GPUs
  - cms-patatrack#526: Apply code formatting