### PR TITLE
Cleanup the inclusion of CUDAService and other central services

### DIFF
--- a/Configuration/StandardSequences/python/Services_cff.py
+++ b/Configuration/StandardSequences/python/Services_cff.py
@@ -1,21 +1,16 @@
-# The following comments couldn't be translated into the new config version:
-
-#
-
 import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.HepPDTESSource.pythiapdt_cfi import *
-# Random numbers initialization service
-# pick it up directly
+
+# random numbers initialization service
 from IOMC.RandomEngine.IOMC_cff import *
-#an "intermediate layer" remains, just in case somebody is using it...
-# from Configuration.StandardSequences.SimulationRandomNumberGeneratorSeeds_cff import *
-from DQMServices.Core.DQMStore_cfg import *
 
-# Add CUDAServices when using gpu Modifier is enabled
+# DQM store service
+from DQMServices.Core.DQMStore_cfi import *
+
+# load CUDA services when the "gpu" modifier is enabled
+def _addCUDAServices(process):
+     process.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
+
 from Configuration.ProcessModifiers.gpu_cff import gpu
-def _addCUDAServices(theProcess):
-     theProcess.load("HeterogeneousCore.CUDAServices.CUDAService_cfi")
-
-modifyConfigurationStandardSequencesServicesAddCUDAServices_ = gpu.makeProcessModifier( _addCUDAServices )
-
+modifyConfigurationStandardSequencesServicesAddCUDAServices_ = gpu.makeProcessModifier(_addCUDAServices)


### PR DESCRIPTION
#### PR description:

Cleanup the conditional inclusion of `CUDAService` and the configuration and comments regarding other central services.

#### PR validation:

None.