### PR TITLE
update HGCal unit test for new geometry

### DIFF
--- a/Validation/Geometry/test/genHGCalPlots.sh
+++ b/Validation/Geometry/test/genHGCalPlots.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-geom=Extended2026D62
+geom=Extended2026D71
 VGEO_DIR=$CMSSW_BASE/src/Validation/Geometry
 TEST_DIR=${VGEO_DIR}/test/materialBudgetHGCalPlots
 


### PR DESCRIPTION
#### PR description:

The D62 geometry was removed in #31673. The unit test is updated to use the corresponding new D71 geometry (both have C14).

#### PR validation:

Ran unit test.