### PR TITLE
fix DDFilteredView::parameters() crashing with a pseudotrapezoid

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -471,7 +471,7 @@ const std::vector<double> DDFilteredView::parameters() const {
   assert(node_);
   Volume currVol = node_->GetVolume();
   // Boolean shapes are a special case
-  if (currVol->GetShape()->IsA() == TGeoCompositeShape::Class()) {
+  if (currVol->GetShape()->IsA() == TGeoCompositeShape::Class() and not dd4hep::isA<dd4hep::PseudoTrap>(currVol.solid())) {
     const TGeoCompositeShape* shape = static_cast<const TGeoCompositeShape*>(currVol->GetShape());
     const TGeoBoolNode* boolean = shape->GetBoolNode();
     while (boolean->GetLeftShape()->IsA() != TGeoBBox::Class()) {

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -471,7 +471,8 @@ const std::vector<double> DDFilteredView::parameters() const {
   assert(node_);
   Volume currVol = node_->GetVolume();
   // Boolean shapes are a special case
-  if (currVol->GetShape()->IsA() == TGeoCompositeShape::Class() and not dd4hep::isA<dd4hep::PseudoTrap>(currVol.solid())) {
+  if (currVol->GetShape()->IsA() == TGeoCompositeShape::Class() and
+      not dd4hep::isA<dd4hep::PseudoTrap>(currVol.solid())) {
     const TGeoCompositeShape* shape = static_cast<const TGeoCompositeShape*>(currVol->GetShape());
     const TGeoBoolNode* boolean = shape->GetBoolNode();
     while (boolean->GetLeftShape()->IsA() != TGeoBBox::Class()) {

--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
@@ -90,7 +90,7 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
       buildTubs(zhalf, rIn, rOut, startPhi, deltaPhi);
     } break;
     case DDSolidShape::ddpseudotrap: {
-      vector<double> d = solid.volume().volume().solid().dimensions();
+      vector<double> d = solid.parameters();
       buildPseudoTrap(d[0], d[1], d[2], d[3], d[4], d[5], d[6]);
     } break;
     case DDSolidShape::ddtrunctubs: {


### PR DESCRIPTION
#### PR description:
Adrressing the issue discussed in [#29781 (comment)](https://github.com/cms-sw/cmssw/pull/29781#discussion_r422365054), so that [this hack](https://github.com/cms-sw/cmssw/pull/29781#discussion_r422365054) can be removed, as also discussed [here](https://github.com/cms-sw/cmssw/pull/31691#issuecomment-704896866).

@ianna, the problem was not solved in #31691 so I had to fix DDFilteredView. The fix is just an explicit protection for pseudotrapezoids. I guess it could have been implemented using `isASubtraction()` , as [introduced in 31691](https://github.com/cms-sw/cmssw/pull/31691/files#diff-7823e114fef4afa095ad8272d17c4238L168), but this way looks safer to me.

