### PR TITLE
Update SonicTriton client to Triton version 2.3

### DIFF
--- a/HeterogeneousCore/SonicTriton/README.md
+++ b/HeterogeneousCore/SonicTriton/README.md
@@ -23,23 +23,25 @@ The model information from the server can be printed by enabling `verbose` outpu
 * `modelName`: name of model with which to perform inference
 * `modelVersion`: version number of model (default: -1, use latest available version on server)
 * `batchSize`: number of objects sent per request
-  * can also be set on per-event basis
+  * can also be set on per-event basis using `setBatchSize()`
   * some models don't support batching
 * `address`: server IP address
 * `port`: server port
-* `timeout`: maximum time a request is allowed to take
-  * currently not used, will be supported in next Triton version
+* `timeout`: maximum allowed time for a request
 * `outputs`: optional, specify which output(s) the server should send
 
 Useful `TritonData` accessors include:
-* `dims()`: return dimensions (provided by server)
 * `variableDims()`: return true if any variable dimensions
 * `sizeDims()`: return product of dimensions (-1 if any variable dimensions)
-* `shape()`: return concrete shape (if any variable dimensions), otherwise `dims()`
-  * a non-`const` accessor is also provided to modify `shape()` directly (for specifying concrete values)
+* `shape()`: return actual shape (list of dimensions)
 * `sizeShape()`: return product of shape dimensions (returns `sizeDims()` if no variable dimensions)
-* `byteSize()`: return # bytes for data type
+* `byteSize()`: return number of bytes for data type
 * `dname()`: return name of data type
+* `batchSize()`: return current batch size
+
+To update the `TritonData` shape in the variable-dimension case:
+* `setShape(const std::vector<int64_t>& newShape)`: update all (variable) dimensions with values provided in `newShape`
+* `setShape(unsigned loc, int64_t val)`: update variable dimension at `loc` with `val`
 
 There are specific local input and output containers that should be used in producers.
 Here, `T` is a primitive type, and the two aliases listed below are passed to `TritonInputData::toServer()`

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -68,3 +68,4 @@ protected:
 
 #endif
 
+

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -12,18 +12,20 @@
 #include <exception>
 #include <unordered_map>
 
-#include "request_grpc.h"
+#include "grpc_client.h"
+#include "grpc_service.pb.h"
 
 class TritonClient : public SonicClient<TritonInputMap, TritonOutputMap> {
 public:
-  using ModelStatus = nvidia::inferenceserver::ModelStatus;
-  using InferContext = nvidia::inferenceserver::client::InferContext;
-
   struct ServerSideStats {
-    uint64_t request_count_;
-    uint64_t cumul_time_ns_;
+    uint64_t inference_count_;
+    uint64_t execution_count_;
+    uint64_t success_count_;
+    uint64_t cumm_time_ns_;
     uint64_t queue_time_ns_;
-    uint64_t compute_time_ns_;
+    uint64_t compute_input_time_ns_;
+    uint64_t compute_infer_time_ns_;
+    uint64_t compute_output_time_ns_;
   };
 
   //constructor
@@ -40,28 +42,29 @@ public:
 
 protected:
   //helper
-  bool getResults(std::map<std::string, std::unique_ptr<InferContext::Result>>& results);
+  bool getResults(std::shared_ptr<nvidia::inferenceserver::client::InferResult> results);
 
   void evaluate() override;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
-  ServerSideStats summarizeServerStats(const ModelStatus& start_status, const ModelStatus& end_status) const;
+  ServerSideStats summarizeServerStats(const inference::ModelStatistics& start_status, const inference::ModelStatistics& end_status) const;
 
-  ModelStatus getServerSideStatus() const;
+  inference::ModelStatistics getServerSideStatus() const;
 
   //members
-  std::string url_;
-  unsigned timeout_;
-  std::string modelName_;
-  int modelVersion_;
   unsigned maxBatchSize_;
   unsigned batchSize_;
   bool noBatch_;
   bool verbose_;
 
-  std::unique_ptr<InferContext> context_;
-  std::unique_ptr<nvidia::inferenceserver::client::ServerStatusContext> serverCtx_;
-  std::unique_ptr<InferContext::Options> options_;
+  //IO pointers for triton
+  std::vector<nvidia::inferenceserver::client::InferInput*> inputsTriton_;
+  std::vector<const nvidia::inferenceserver::client::InferRequestedOutput*> outputsTriton_;
+
+  std::unique_ptr<nvidia::inferenceserver::client::InferenceServerGrpcClient> client_;
+  //stores timeout, model name and version
+  nvidia::inferenceserver::client::InferOptions options_;
 };
 
 #endif
+

--- a/HeterogeneousCore/SonicTriton/interface/TritonClient.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonClient.h
@@ -47,7 +47,8 @@ protected:
   void evaluate() override;
 
   void reportServerSideStats(const ServerSideStats& stats) const;
-  ServerSideStats summarizeServerStats(const inference::ModelStatistics& start_status, const inference::ModelStatistics& end_status) const;
+  ServerSideStats summarizeServerStats(const inference::ModelStatistics& start_status,
+                                       const inference::ModelStatistics& end_status) const;
 
   inference::ModelStatistics getServerSideStatus() const;
 
@@ -67,5 +68,3 @@ protected:
 };
 
 #endif
-
-

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -120,5 +120,3 @@ extern template class TritonData<nvidia::inferenceserver::client::InferInput>;
 extern template class TritonData<nvidia::inferenceserver::client::InferRequestedOutput>;
 
 #endif
-
-

--- a/HeterogeneousCore/SonicTriton/interface/TritonData.h
+++ b/HeterogeneousCore/SonicTriton/interface/TritonData.h
@@ -30,13 +30,14 @@ class TritonData {
 public:
   using Result = nvidia::inferenceserver::client::InferResult;
   using TensorMetadata = inference::ModelMetadataResponse_TensorMetadata;
-  using ShapeView = edm::Span<const int64_t*>;
+  using ShapeType = std::vector<int64_t>;
+  using ShapeView = edm::Span<ShapeType::const_iterator>;
 
   //constructor
   TritonData(const std::string& name, const TensorMetadata& model_info, bool noBatch);
 
   //some members can be modified
-  bool setShape(const std::vector<int64_t>& newShape) { return setShape(newShape, true); }
+  bool setShape(const ShapeType& newShape) { return setShape(newShape, true); }
   bool setShape(unsigned loc, int64_t val) { return setShape(loc, val, true); }
 
   //io accessors
@@ -61,7 +62,7 @@ private:
   friend class TritonClient;
 
   //private accessors only used by client
-  bool setShape(const std::vector<int64_t>& newShape, bool canThrow);
+  bool setShape(const ShapeType& newShape, bool canThrow);
   bool setShape(unsigned loc, int64_t val, bool canThrow);
   void setBatchSize(unsigned bsize);
   void reset();
@@ -80,10 +81,10 @@ private:
   //members
   std::string name_;
   std::shared_ptr<IO> data_;
-  const std::vector<int64_t> dims_;
+  const ShapeType dims_;
   bool noBatch_;
   unsigned batchSize_;
-  std::vector<int64_t> fullShape_;
+  ShapeType fullShape_;
   ShapeView shape_;
   bool variableDims_;
   int64_t productDims_;

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <unordered_set>
 
-#include "request_grpc.h"
+#include "grpc_client.h"
 
 namespace triton_utils {
 

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -1,6 +1,8 @@
 #ifndef HeterogeneousCore_SonicTriton_triton_utils
 #define HeterogeneousCore_SonicTriton_triton_utils
 
+#include "FWCore/Utilities/interface/Span.h"
+
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,7 +25,7 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-extern template std::string triton_utils::printColl(const std::vector<int64_t>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const edm::Span<const int64_t*>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll,

--- a/HeterogeneousCore/SonicTriton/interface/triton_utils.h
+++ b/HeterogeneousCore/SonicTriton/interface/triton_utils.h
@@ -25,7 +25,8 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-extern template std::string triton_utils::printColl(const edm::Span<const int64_t*>& coll, const std::string& delim);
+extern template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,
+                                                    const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
 extern template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll,

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -37,7 +37,8 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
 
   //set options
   options_.model_version_ = params.getParameter<std::string>("modelVersion");
-  options_.client_timeout_ = params.getUntrackedParameter<unsigned>("timeout");
+  //convert seconds to microseconds
+  options_.client_timeout_ = params.getUntrackedParameter<unsigned>("timeout") * 1e6;
 
   //config needed for batch size
   inference::ModelConfigResponse modelConfigResponse;

--- a/HeterogeneousCore/SonicTriton/src/TritonClient.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonClient.cc
@@ -3,7 +3,8 @@
 #include "HeterogeneousCore/SonicTriton/interface/TritonClient.h"
 #include "HeterogeneousCore/SonicTriton/interface/triton_utils.h"
 
-#include "request_grpc.h"
+#include "grpc_client.h"
+#include "grpc_service.pb.h"
 
 #include <string>
 #include <cmath>
@@ -16,31 +17,35 @@
 namespace ni = nvidia::inferenceserver;
 namespace nic = ni::client;
 
-//based on https://github.com/NVIDIA/triton-inference-server/blob/v1.12.0/src/clients/c++/examples/simple_callback_client.cc
+//based on https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c++/examples/simple_grpc_async_infer_client.cc
+//and https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c++/perf_client/perf_client.cc
 
 TritonClient::TritonClient(const edm::ParameterSet& params)
     : SonicClient(params),
-      url_(params.getUntrackedParameter<std::string>("address") + ":" +
-           std::to_string(params.getUntrackedParameter<unsigned>("port"))),
-      timeout_(params.getUntrackedParameter<unsigned>("timeout")),
-      modelName_(params.getParameter<std::string>("modelName")),
-      modelVersion_(params.getParameter<int>("modelVersion")),
-      verbose_(params.getUntrackedParameter<bool>("verbose")) {
+      verbose_(params.getUntrackedParameter<bool>("verbose")),
+	  options_(params.getParameter<std::string>("modelName"))
+	  {
   clientName_ = "TritonClient";
   //will get overwritten later, just used in constructor
   fullDebugName_ = clientName_;
 
   //connect to the server
-  triton_utils::throwIfError(nic::InferGrpcContext::Create(&context_, url_, modelName_, modelVersion_, false),
+  //TODO: add SSL options
+  std::string url(params.getUntrackedParameter<std::string>("address") + ":" + std::to_string(params.getUntrackedParameter<unsigned>("port")));
+  triton_utils::throwIfError(nic::InferenceServerGrpcClient::Create(&client_, url, false),
                              "TritonClient(): unable to create inference context");
 
-  //get options
-  triton_utils::throwIfError(nic::InferContext::Options::Create(&options_),
-                             "TritonClient(): unable to create inference context options");
+  //set options
+  options_.model_version_ = params.getParameter<std::string>("modelVersion");
+  options_.client_timeout_ = params.getUntrackedParameter<unsigned>("timeout");
+
+  //get model info
+  inference::ModelMetadataResponse modelMetadata;
+  triton_utils::throwIfError(client_->ModelMetadata(&modelMetadata, options_.model_name_, options_.model_version_), "TritonClient(): unable to get model metadata");
 
   //get input and output (which know their sizes)
-  const auto& nicInputs = context_->Inputs();
-  const auto& nicOutputs = context_->Outputs();
+  const auto& nicInputs = modelMetadata.inputs();
+  const auto& nicOutputs = modelMetadata.outputs();
 
   //report all model errors at once
   std::stringstream msg;
@@ -63,12 +68,14 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
   if (verbose_)
     io_msg << "Model inputs: "
            << "\n";
+  inputsTriton_.reserve(nicInputs.size());
   for (const auto& nicInput : nicInputs) {
-    const auto& iname = nicInput->Name();
-    const auto& curr_itr =
+    const auto& iname = nicInput.name();
+    auto [curr_itr, success] =
         input_.emplace(std::piecewise_construct, std::forward_as_tuple(iname), std::forward_as_tuple(iname, nicInput));
+    auto& curr_input = curr_itr->second;
+	inputsTriton_.push_back(curr_input.data());
     if (verbose_) {
-      const auto& curr_input = curr_itr.first->second;
       io_msg << "  " << iname << " (" << curr_input.dname() << ", " << curr_input.byteSize()
              << " b) : " << triton_utils::printColl(curr_input.dims()) << "\n";
     }
@@ -82,15 +89,15 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
   if (verbose_)
     io_msg << "Model outputs: "
            << "\n";
+  outputsTriton_.reserve(nicOutputs.size());
   for (const auto& nicOutput : nicOutputs) {
-    const auto& oname = nicOutput->Name();
+    const auto& oname = nicOutput.name();
     if (!s_outputs.empty() and s_outputs.find(oname) == s_outputs.end())
       continue;
-    const auto& curr_itr = output_.emplace(
+    auto [curr_itr, success] = output_.emplace(
         std::piecewise_construct, std::forward_as_tuple(oname), std::forward_as_tuple(oname, nicOutput));
-    const auto& curr_output = curr_itr.first->second;
-    triton_utils::throwIfError(options_->AddRawResult(nicOutput),
-                               "TritonClient(): unable to add raw result " + curr_itr.first->first);
+    auto& curr_output = curr_itr->second;
+    outputsTriton_.push_back(curr_output.data());
     if (verbose_) {
       io_msg << "  " << oname << " (" << curr_output.dname() << ", " << curr_output.byteSize()
              << " b) : " << triton_utils::printColl(curr_output.dims()) << "\n";
@@ -104,38 +111,30 @@ TritonClient::TritonClient(const edm::ParameterSet& params)
     throw cms::Exception("MissingOutput")
         << "Some requested outputs were not available on the server: " << triton_utils::printColl(s_outputs);
 
+  //config needed for batch size
+  inference::ModelConfigResponse modelConfigResponse;
+  triton_utils::throwIfError(client_->ModelConfig(&modelConfigResponse, options_.model_name_, options_.model_version_), "TritonClient(): unable to get model config");
+  inference::ModelConfig modelConfig(modelConfigResponse.config());
+
   //check batch size limitations (after i/o setup)
   //triton uses max batch size = 0 to denote a model that does not support batching
   //but for models that do support batching, a given event may set batch size 0 to indicate no valid input is present
   //so set the local max to 1 and keep track of "no batch" case
-  maxBatchSize_ = context_->MaxBatchSize();
+
+  maxBatchSize_ = modelConfig.max_batch_size();
   noBatch_ = maxBatchSize_ == 0;
   maxBatchSize_ = std::max(1u, maxBatchSize_);
   //check requested batch size
   setBatchSize(params.getUntrackedParameter<unsigned>("batchSize"));
 
-  //initial server settings
-  triton_utils::throwIfError(context_->SetRunOptions(*options_), "TritonClient(): unable to set run options");
-
   //print model info
   std::stringstream model_msg;
   if (verbose_) {
-    model_msg << "Model name: " << modelName_ << "\n"
-              << "Model version: " << modelVersion_ << "\n"
+    model_msg << "Model name: " << options_.model_name_ << "\n"
+              << "Model version: " << options_.model_version_ << "\n"
               << "Model max batch size: " << (noBatch_ ? 0 : maxBatchSize_) << "\n";
-  }
-
-  //only used for monitoring
-  bool has_server = false;
-  if (verbose_) {
-    //print model info
     edm::LogInfo(fullDebugName_) << model_msg.str() << io_msg.str();
-
-    has_server = triton_utils::warnIfError(nic::ServerStatusGrpcContext::Create(&serverCtx_, url_, false),
-                                           "TritonClient(): unable to create server context");
   }
-  if (!has_server)
-    serverCtx_ = nullptr;
 }
 
 bool TritonClient::setBatchSize(unsigned bsize) {
@@ -152,11 +151,6 @@ bool TritonClient::setBatchSize(unsigned bsize) {
     for (auto& element : output_) {
       element.second.setBatchSize(bsize);
     }
-    //set for server (and Input objects)
-    if (!noBatch_) {
-      options_->SetBatchSize(batchSize_);
-      triton_utils::throwIfError(context_->SetRunOptions(*options_), "setBatchSize(): unable to set run options");
-    }
     return true;
   }
 }
@@ -170,28 +164,17 @@ void TritonClient::reset() {
   }
 }
 
-bool TritonClient::getResults(std::map<std::string, std::unique_ptr<nic::InferContext::Result>>& results) {
-  for (auto& element : results) {
-    const auto& oname = element.first;
-    auto& result = element.second;
-
-    //check for corresponding entry in output map
-    auto itr = output_.find(oname);
-    if (itr == output_.end()) {
-      edm::LogError("TritonServerError") << "getResults(): no entry in output map for result " << oname;
-      return false;
-    }
-    auto& output = itr->second;
-
+bool TritonClient::getResults(std::shared_ptr<nic::InferResult> results) {
+  for (auto& [oname,output] : output_) {
     //set shape here before output becomes const
     if (output.variableDims()) {
       bool status =
-          triton_utils::warnIfError(result->GetRawShape(&(output.shape())), "getResults(): unable to get output shape");
+          triton_utils::warnIfError(results->Shape(oname, &(output.shape())), "getResults(): unable to get output shape for "+oname);
       if (!status)
         return status;
     }
-    //transfer ownership
-    output.setResult(std::move(result));
+    //extend lifetime
+    output.setResult(results);
   }
 
   return true;
@@ -212,12 +195,11 @@ void TritonClient::evaluate() {
     //non-blocking call
     auto t1 = std::chrono::high_resolution_clock::now();
     bool status = triton_utils::warnIfError(
-        context_->AsyncRun([t1, start_status, this](nic::InferContext* ctx,
-                                                    const std::shared_ptr<nic::InferContext::Request>& request) {
+        client_->AsyncInfer([t1, start_status, this](nic::InferResult* results) {
           //get results
-          std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
+		  std::shared_ptr<nic::InferResult> results_ptr(results);
           bool status =
-              triton_utils::warnIfError(ctx->GetAsyncRunResults(request, &results), "evaluate(): unable to get result");
+              triton_utils::warnIfError(results_ptr->RequestStatus(), "evaluate(): unable to get result");
           if (!status) {
             finish(false);
             return;
@@ -236,11 +218,11 @@ void TritonClient::evaluate() {
           }
 
           //check result
-          status = getResults(results);
+          status = getResults(results_ptr);
 
           //finish
           finish(status);
-        }),
+        }, options_, inputsTriton_, outputsTriton_),
         "evaluate(): unable to launch async run");
 
     //if AsyncRun failed, finish() wasn't called
@@ -249,8 +231,8 @@ void TritonClient::evaluate() {
   } else {
     //blocking call
     auto t1 = std::chrono::high_resolution_clock::now();
-    std::map<std::string, std::unique_ptr<nic::InferContext::Result>> results;
-    bool status = triton_utils::warnIfError(context_->Run(&results), "evaluate(): unable to run and/or get result");
+    nic::InferResult* results;
+    bool status = triton_utils::warnIfError(client_->Infer(&results, options_, inputsTriton_, outputsTriton_), "evaluate(): unable to run and/or get result");
     if (!status) {
       finish(false);
       return;
@@ -268,7 +250,8 @@ void TritonClient::evaluate() {
       reportServerSideStats(stats);
     }
 
-    status = getResults(results);
+	std::shared_ptr<nic::InferResult> results_ptr(results);
+    status = getResults(results_ptr);
 
     finish(status);
   }
@@ -277,9 +260,11 @@ void TritonClient::evaluate() {
 void TritonClient::reportServerSideStats(const TritonClient::ServerSideStats& stats) const {
   std::stringstream msg;
 
-  // https://github.com/NVIDIA/tensorrt-inference-server/blob/v1.12.0/src/clients/c++/perf_client/inference_profiler.cc
-  const uint64_t count = stats.request_count_;
-  msg << "  Request count: " << count;
+  // https://github.com/triton-inference-server/server/blob/v2.3.0/src/clients/c%2B%2B/perf_client/inference_profiler.cc
+  const uint64_t count = stats.success_count_;
+  msg << "  Inference count: " << stats.inference_count_ << "\n";
+  msg << "  Execution count: " << stats.execution_count_ << "\n";
+  msg << "  Successful request count: " << count << "\n";
 
   if (count > 0) {
     auto get_avg_us = [count](uint64_t tval) {
@@ -287,75 +272,51 @@ void TritonClient::reportServerSideStats(const TritonClient::ServerSideStats& st
       return tval / us_to_ns / count;
     };
 
-    const uint64_t cumul_avg_us = get_avg_us(stats.cumul_time_ns_);
+    const uint64_t cumm_avg_us = get_avg_us(stats.cumm_time_ns_);
     const uint64_t queue_avg_us = get_avg_us(stats.queue_time_ns_);
-    const uint64_t compute_avg_us = get_avg_us(stats.compute_time_ns_);
+    const uint64_t compute_input_avg_us = get_avg_us(stats.compute_input_time_ns_);
+    const uint64_t compute_infer_avg_us = get_avg_us(stats.compute_infer_time_ns_);
+    const uint64_t compute_output_avg_us = get_avg_us(stats.compute_output_time_ns_);
+    const uint64_t compute_avg_us =
+        compute_input_avg_us + compute_infer_avg_us + compute_output_avg_us;
     const uint64_t overhead =
-        (cumul_avg_us > queue_avg_us + compute_avg_us) ? (cumul_avg_us - queue_avg_us - compute_avg_us) : 0;
+        (cumm_avg_us > queue_avg_us + compute_avg_us) ? (cumm_avg_us - queue_avg_us - compute_avg_us) : 0;
 
-    msg << "\n"
-        << "  Avg request latency: " << cumul_avg_us << " usec"
-        << "\n"
+    msg << "  Avg request latency: " << cumm_avg_us << " usec" << "\n"
         << "  (overhead " << overhead << " usec + "
         << "queue " << queue_avg_us << " usec + "
-        << "compute " << compute_avg_us << " usec)" << std::endl;
+        << "compute input " << compute_input_avg_us << " usec + "
+        << "compute infer " << compute_infer_avg_us << " usec + "
+        << "compute output " << compute_output_avg_us << " usec)" << std::endl;
   }
 
   if (!debugName_.empty())
     edm::LogInfo(fullDebugName_) << msg.str();
 }
 
-TritonClient::ServerSideStats TritonClient::summarizeServerStats(const ni::ModelStatus& start_status,
-                                                                 const ni::ModelStatus& end_status) const {
-  // If model_version is -1 then look in the end status to find the
-  // latest (highest valued version) and use that as the version.
-  int64_t status_model_version = 0;
-  if (modelVersion_ < 0) {
-    for (const auto& vp : end_status.version_status()) {
-      status_model_version = std::max(status_model_version, vp.first);
-    }
-  } else
-    status_model_version = modelVersion_;
-
+TritonClient::ServerSideStats TritonClient::summarizeServerStats(const inference::ModelStatistics& start_status,
+                                                                 const inference::ModelStatistics& end_status) const {
   TritonClient::ServerSideStats server_stats;
-  auto vend_itr = end_status.version_status().find(status_model_version);
-  if (vend_itr != end_status.version_status().end()) {
-    auto end_itr = vend_itr->second.infer_stats().find(batchSize_);
-    if (end_itr != vend_itr->second.infer_stats().end()) {
-      uint64_t start_count = 0;
-      uint64_t start_cumul_time_ns = 0;
-      uint64_t start_queue_time_ns = 0;
-      uint64_t start_compute_time_ns = 0;
 
-      auto vstart_itr = start_status.version_status().find(status_model_version);
-      if (vstart_itr != start_status.version_status().end()) {
-        auto start_itr = vstart_itr->second.infer_stats().find(batchSize_);
-        if (start_itr != vstart_itr->second.infer_stats().end()) {
-          start_count = start_itr->second.success().count();
-          start_cumul_time_ns = start_itr->second.success().total_time_ns();
-          start_queue_time_ns = start_itr->second.queue().total_time_ns();
-          start_compute_time_ns = start_itr->second.compute().total_time_ns();
-        }
-      }
+  server_stats.inference_count_ = end_status.inference_count() - start_status.inference_count();
+  server_stats.execution_count_ = end_status.execution_count() - start_status.execution_count();
+  server_stats.success_count_ = end_status.inference_stats().success().count() - start_status.inference_stats().success().count();
+  server_stats.cumm_time_ns_ = end_status.inference_stats().success().ns() - start_status.inference_stats().success().ns();
+  server_stats.queue_time_ns_ = end_status.inference_stats().queue().ns() - start_status.inference_stats().queue().ns();
+  server_stats.compute_input_time_ns_ = end_status.inference_stats().compute_input().ns() - start_status.inference_stats().compute_input().ns();
+  server_stats.compute_infer_time_ns_ = end_status.inference_stats().compute_infer().ns() - start_status.inference_stats().compute_infer().ns();
+  server_stats.compute_output_time_ns_ = end_status.inference_stats().compute_output().ns() - start_status.inference_stats().compute_output().ns();
 
-      server_stats.request_count_ = end_itr->second.success().count() - start_count;
-      server_stats.cumul_time_ns_ = end_itr->second.success().total_time_ns() - start_cumul_time_ns;
-      server_stats.queue_time_ns_ = end_itr->second.queue().total_time_ns() - start_queue_time_ns;
-      server_stats.compute_time_ns_ = end_itr->second.compute().total_time_ns() - start_compute_time_ns;
-    }
-  }
   return server_stats;
 }
 
-ni::ModelStatus TritonClient::getServerSideStatus() const {
-  if (serverCtx_) {
-    ni::ServerStatus server_status;
-    serverCtx_->GetServerStatus(&server_status);
-    auto itr = server_status.model_status().find(modelName_);
-    if (itr != server_status.model_status().end())
-      return itr->second;
+inference::ModelStatistics TritonClient::getServerSideStatus() const {
+  if (verbose_) {
+    inference::ModelStatisticsResponse resp;
+    triton_utils::warnIfError(client_->ModelInferenceStatistics(&resp, options_.model_name_, options_.model_version_), "getServerSideStatus(): unable to get model statistics");
+	return *(resp.model_stats().begin());
   }
-  return ni::ModelStatus{};
+  return inference::ModelStatistics{};
 }
 
 //for fillDescriptions
@@ -363,7 +324,7 @@ void TritonClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   edm::ParameterSetDescription descClient;
   fillBasePSetDescription(descClient);
   descClient.add<std::string>("modelName");
-  descClient.add<int>("modelVersion", -1);
+  descClient.add<std::string>("modelVersion", "");
   //server parameters should not affect the physics results
   descClient.addUntracked<unsigned>("batchSize");
   descClient.addUntracked<std::string>("address");
@@ -373,3 +334,4 @@ void TritonClient::fillPSetDescription(edm::ParameterSetDescription& iDesc) {
   descClient.addUntracked<std::vector<std::string>>("outputs", {});
   iDesc.add<edm::ParameterSetDescription>("Client", descClient);
 }
+

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -33,8 +33,7 @@ TritonData<IO>::TritonData(const std::string& name, const TritonData<IO>::Tensor
       productDims_(variableDims_ ? -1 : dimProduct(shape_)),
       dname_(model_info.datatype()),
       dtype_(ni::ProtocolStringToDataType(dname_)),
-      byteSize_(ni::GetDataTypeByteSize(dtype_))
-      {
+      byteSize_(ni::GetDataTypeByteSize(dtype_)) {
   //create input or output object
   IO* iotmp;
   createObject(&iotmp);
@@ -55,7 +54,7 @@ void TritonOutputData::createObject(nic::InferRequestedOutput** ioptr) const {
 template <typename IO>
 bool TritonData<IO>::setShape(const std::vector<int64_t>& newShape, bool canThrow) {
   bool result = true;
-  for (unsigned i = 0; i < newShape.size(); ++i){
+  for (unsigned i = 0; i < newShape.size(); ++i) {
     result &= setShape(i, newShape[i], canThrow);
   }
   return result;
@@ -81,8 +80,7 @@ bool TritonData<IO>::setShape(unsigned loc, int64_t val, bool canThrow) {
     if (dims_[full_loc] == -1) {
       fullShape_[full_loc] = val;
       return true;
-	}
-    else {
+    } else {
       msg << name_ << " setShape(): attempt to change value of non-variable shape dimension " << loc;
       if (canThrow)
         throw cms::Exception("TritonDataError") << msg.str();
@@ -150,8 +148,7 @@ TritonOutput<DT> TritonOutputData::fromServer() const {
   const uint8_t* r0;
   size_t contentByteSize;
   size_t expectedContentByteSize = nOutput * byteSize_ * batchSize_;
-  triton_utils::throwIfError(result_->RawData(name_, &r0, &contentByteSize),
-                             "output(): unable to get raw");
+  triton_utils::throwIfError(result_->RawData(name_, &r0, &contentByteSize), "output(): unable to get raw");
   if (contentByteSize != expectedContentByteSize) {
     throw cms::Exception("TritonDataError") << name_ << " output(): unexpected content byte size " << contentByteSize
                                             << " (expected " << expectedContentByteSize << ")";
@@ -186,5 +183,3 @@ template void TritonInputData::toServer(std::shared_ptr<TritonInput<float>> data
 template void TritonInputData::toServer(std::shared_ptr<TritonInput<int64_t>> data_in);
 
 template TritonOutput<float> TritonOutputData::fromServer() const;
-
-

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -115,10 +115,8 @@ void TritonInputData::toServer(std::shared_ptr<TritonInput<DT>> ptr) {
                                             << " but specified batch size is " << batchSize_;
   }
 
-  //shape must be specified for variable dims
-  if (variableDims_) {
-    triton_utils::throwIfError(data_->SetShape(fullShape_), name_ + " input(): unable to set input shape");
-  }
+  //shape must be specified for variable dims or if batch size changes
+  data_->SetShape(fullShape_);
 
   if (byteSize_ != sizeof(DT))
     throw cms::Exception("TritonDataError") << name_ << " input(): inconsistent byte size " << sizeof(DT)

--- a/HeterogeneousCore/SonicTriton/src/TritonData.cc
+++ b/HeterogeneousCore/SonicTriton/src/TritonData.cc
@@ -28,7 +28,7 @@ TritonData<IO>::TritonData(const std::string& name, const TritonData<IO>::Tensor
       noBatch_(noBatch),
       batchSize_(0),
       fullShape_(dims_),
-      shape_(&*(fullShape_.begin() + (noBatch_ ? 0 : 1)), &*(fullShape_.end())),
+      shape_(fullShape_.begin() + (noBatch_ ? 0 : 1), fullShape_.end()),
       variableDims_(anyNeg(shape_)),
       productDims_(variableDims_ ? -1 : dimProduct(shape_)),
       dname_(model_info.datatype()),
@@ -52,7 +52,7 @@ void TritonOutputData::createObject(nic::InferRequestedOutput** ioptr) const {
 
 //setters
 template <typename IO>
-bool TritonData<IO>::setShape(const std::vector<int64_t>& newShape, bool canThrow) {
+bool TritonData<IO>::setShape(const TritonData<IO>::ShapeType& newShape, bool canThrow) {
   bool result = true;
   for (unsigned i = 0; i < newShape.size(); ++i) {
     result &= setShape(i, newShape[i], canThrow);

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -30,7 +30,8 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-template std::string triton_utils::printColl(const edm::Span<const int64_t*>& coll, const std::string& delim);
+template std::string triton_utils::printColl(const edm::Span<std::vector<int64_t>::const_iterator>& coll,
+                                             const std::string& delim);
 template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
 template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
 template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll, const std::string& delim);

--- a/HeterogeneousCore/SonicTriton/src/triton_utils.cc
+++ b/HeterogeneousCore/SonicTriton/src/triton_utils.cc
@@ -30,7 +30,7 @@ namespace triton_utils {
 
 }  // namespace triton_utils
 
-template std::string triton_utils::printColl(const std::vector<int64_t>& coll, const std::string& delim);
+template std::string triton_utils::printColl(const edm::Span<const int64_t*>& coll, const std::string& delim);
 template std::string triton_utils::printColl(const std::vector<uint8_t>& coll, const std::string& delim);
 template std::string triton_utils::printColl(const std::vector<float>& coll, const std::string& delim);
 template std::string triton_utils::printColl(const std::unordered_set<std::string>& coll, const std::string& delim);

--- a/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
+++ b/HeterogeneousCore/SonicTriton/test/TritonGraphProducer.cc
@@ -33,13 +33,13 @@ public:
 
     //set shapes
     auto& input1 = iInput.at("x__0");
-    input1.shape() = {nnodes, input1.dims()[1]};
+    input1.setShape(0, nnodes);
     auto data1 = std::make_shared<TritonInput<float>>(1);
     auto& vdata1 = (*data1)[0];
     vdata1.reserve(input1.sizeShape());
 
     auto& input2 = iInput.at("edgeindex__1");
-    input2.shape() = {input2.dims()[0], nedges};
+    input2.setShape(1, nedges);
     auto data2 = std::make_shared<TritonInput<int64_t>>(1);
     auto& vdata2 = (*data2)[0];
     vdata2.reserve(input2.sizeShape());

--- a/HeterogeneousCore/SonicTriton/test/fetch_model.sh
+++ b/HeterogeneousCore/SonicTriton/test/fetch_model.sh
@@ -51,4 +51,4 @@ output [
 EOF
 
 mkdir -p 1
-cp /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.06-v1-py3-geometric/torch_geometric/examples/model.pt 1/model.pt
+cp /cvmfs/unpacked.cern.ch/registry.hub.docker.com/fastml/triton-torchgeo:20.09-py3-geometric/torch_geometric/examples/model.pt 1/model.pt

--- a/HeterogeneousCore/SonicTriton/test/triton
+++ b/HeterogeneousCore/SonicTriton/test/triton
@@ -56,11 +56,11 @@ if [ "$OP" != start ] && [ "$OP" != stop ]; then
 fi
 
 DOCKER="sudo docker"
-IMAGE=fastml/triton-torchgeo:20.06-v1-py3-geometric
+IMAGE=fastml/triton-torchgeo:20.09-py3-geometric
 MODELS=${CMSSW_BASE}/src/HeterogeneousCore/SonicTriton/data/models
 LOG=log_triton_server.log
 LIB=lib
-STARTED_INDICATOR="Started GRPCService"
+STARTED_INDICATOR="Started GRPCInferenceService"
 EXTRA=""
 
 start_docker(){

--- a/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
+++ b/HeterogeneousCore/SonicTriton/test/tritonTest_cfg.py
@@ -46,7 +46,7 @@ process.TritonProducer = cms.EDProducer(options.producer,
         port = cms.untracked.uint32(options.port),
         timeout = cms.untracked.uint32(options.timeout),
         modelName = cms.string(models[options.producer]),
-        modelVersion = cms.int32(-1),
+        modelVersion = cms.string(""),
         verbose = cms.untracked.bool(options.verbose),
         allowedTries = cms.untracked.uint32(0),
     )


### PR DESCRIPTION
#### PR description:

Triton version 2 redesigns the client API. Most of the redesign is just reorganization and renaming. Important Triton changes:
1. client-side timeouts now supported
2. https/ssl now supported (not introduced here, support will come in a followup)
3. batch size handling changed: models that support triton-style batching have the specified shape modified so that the first entry is the batch size. The handling of shapes in SonicTriton is modified so that the user does not have to worry about this, and can continue to consider batch size and input shape separately, which is conceptually easier.

SonicTriton interface changes:
1. `modelVersion = cms.string()` (was `cms.int32()`)
2. `setShape()` accessors to change one dimension or all dimensions (rather than non-const ref `shape()` accessor)
3. unneeded `dims()` accessor removed
4. some other accessors made private (only used by `TritonClient`)

The cvmfs server image for tests is updated accordingly (see https://github.com/lgray/triton-torchgeo-gat-example/pull/1).

The corresponding external update is https://github.com/cms-sw/cmsdist/pull/6293.

#### PR validation:

Ran examples in `HeterogeneousCore/SonicTriton/test`.