### PR TITLE
Avoid a dead assignment in DDFilteredView.cc

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -6,7 +6,6 @@
 #include "DD4hep/Shapes.h"
 #include <TGeoBBox.h>
 #include <TGeoBoolNode.h>
-#include <vector>
 #include <charconv>
 
 using namespace cms;
@@ -758,7 +757,6 @@ bool DDFilteredView::matchPath(const std::string_view path) const {
         break;
       } else {
         refname.remove_suffix(refname.size() - pos);
-        result = true;
       }
     }
     if (!compareEqualName(refname, name)) {


### PR DESCRIPTION
#### PR description:

A dead assignment for an internal bool variable was notified by the static analyzer in DDFilteredView.cc: removed here
At the same time I also took the opportunity to remove a duplicate header include in the same file

#### PR validation:

Quite trivial update, just checked that it builds correctly
No changes in output expected