### PR TITLE
Fix initialisation of maxChi2 data member in PVClusterComparer

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -79,7 +79,7 @@ void PVClusterComparer::setChisquareQuantile() {
   maxChi2_.clear();
   maxChi2_.resize(20, 0.0);
   if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
-    for (size_t ndof = 0; ndof < 20; ++ndof)
+    for (size_t ndof = 0; ndof < maxChi2_.size(); ++ndof)
       // http://root.cern.ch/root/html/TMath.html#TMath:ChisquareQuantile
       maxChi2_[ndof] = TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
 }

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -77,11 +77,11 @@ double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) {
 
 void PVClusterComparer::setChisquareQuantile() {
   maxChi2_.clear();
-  maxChi2_.resize(20,0.0);
+  maxChi2_.resize(20, 0.0);
   if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
     for (size_t ndof = 0; ndof < 20; ++ndof)
       // http://root.cern.ch/root/html/TMath.html#TMath:ChisquareQuantile
-      maxChi2_[ndof]=TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
+      maxChi2_[ndof] = TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
 }
 
 void PVClusterComparer::updateChisquareQuantile(size_t ndof) {

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -76,13 +76,12 @@ double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) {
 }
 
 void PVClusterComparer::setChisquareQuantile() {
-  std::vector<double> maxChi2(20, 0.);
+  maxChi2_.clear();
+  maxChi2_.resize(20,0.0);
   if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
-    for (size_t ndof = 0; ndof < maxChi2.size(); ++ndof)
+    for (size_t ndof = 0; ndof < 20; ++ndof)
       // http://root.cern.ch/root/html/TMath.html#TMath:ChisquareQuantile
-      maxChi2[ndof] = TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
-
-  maxChi2_ = maxChi2;
+      maxChi2_[ndof]=TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
 }
 
 void PVClusterComparer::updateChisquareQuantile(size_t ndof) {

--- a/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PVClusterComparer.cc
@@ -78,7 +78,7 @@ double PVClusterComparer::pTSquaredSum(const reco::Vertex &v) {
 void PVClusterComparer::setChisquareQuantile() {
   std::vector<double> maxChi2(20, 0.);
   if (track_prob_min_ >= 0. && track_prob_min_ <= 1.)
-    for (size_t ndof = 0; ndof < maxChi2_.size(); ++ndof)
+    for (size_t ndof = 0; ndof < maxChi2.size(); ++ndof)
       // http://root.cern.ch/root/html/TMath.html#TMath:ChisquareQuantile
       maxChi2[ndof] = TMath::ChisquareQuantile(1 - track_prob_min_, ndof);
 


### PR DESCRIPTION
	modified:   PVClusterComparer.cc

#### PR description:

Minor bug fix. The code to initialize the maxChi2 values does not do the  job, due to an unfortunate typo in the loop break condition.
 



