### PR TITLE
Require  highPurity for isolated tracks in heavy-ion workflows

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -102,6 +102,7 @@ namespace pat {
     const float pcRefNearest_DR_;     // radius for nearest charged packed candidate
     const float pcRefNearest_pTmin_;  // min pT for nearest charged packed candidate
     const float pfneutralsum_DR_;     // pf lepton overlap radius
+    const bool useHighPurity_;
     const bool saveDeDxHitInfo_;
     StringCutObjectSelector<pat::IsolatedTrack> saveDeDxHitInfoCut_;
 
@@ -146,6 +147,7 @@ pat::PATIsolatedTrackProducer::PATIsolatedTrackProducer(const edm::ParameterSet&
       pcRefNearest_DR_(iConfig.getParameter<double>("pcRefNearest_DR")),
       pcRefNearest_pTmin_(iConfig.getParameter<double>("pcRefNearest_pTmin")),
       pfneutralsum_DR_(iConfig.getParameter<double>("pfneutralsum_DR")),
+      useHighPurity_(iConfig.getParameter<bool>("useHighPurity")),
       saveDeDxHitInfo_(iConfig.getParameter<bool>("saveDeDxHitInfo")),
       saveDeDxHitInfoCut_(iConfig.getParameter<std::string>("saveDeDxHitInfoCut")) {
   // TrackAssociator parameters
@@ -237,6 +239,7 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
   //add general tracks
   for (unsigned int igt = 0; igt < generalTracks->size(); igt++) {
     const reco::Track& gentk = (*gt_h)[igt];
+    if(useHighPurity_) if (!(gentk.quality(reco::TrackBase::qualityByName("highPurity")))) continue;
     reco::TrackRef tkref = reco::TrackRef(gt_h, igt);
     pat::PackedCandidateRef pcref = (*gt2pc)[tkref];
     pat::PackedCandidateRef ltref = (*gt2lt)[tkref];

--- a/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATIsolatedTrackProducer.cc
@@ -239,7 +239,9 @@ void pat::PATIsolatedTrackProducer::produce(edm::Event& iEvent, const edm::Event
   //add general tracks
   for (unsigned int igt = 0; igt < generalTracks->size(); igt++) {
     const reco::Track& gentk = (*gt_h)[igt];
-    if(useHighPurity_) if (!(gentk.quality(reco::TrackBase::qualityByName("highPurity")))) continue;
+    if (useHighPurity_)
+      if (!(gentk.quality(reco::TrackBase::qualityByName("highPurity"))))
+        continue;
     reco::TrackRef tkref = reco::TrackRef(gt_h, igt);
     pat::PackedCandidateRef pcref = (*gt2pc)[tkref];
     pat::PackedCandidateRef ltref = (*gt2lt)[tkref];

--- a/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/isolatedTracks_cfi.py
@@ -58,9 +58,15 @@ isolatedTracks = cms.EDProducer("PATIsolatedTrackProducer",
 
     pfneutralsum_DR = cms.double(0.05),
 
+    useHighPurity = cms.bool(False),
+
     saveDeDxHitInfo = cms.bool(True),
     saveDeDxHitInfoCut = cms.string("(%s) || (%s)" % (_susySoftDisappearingTrackCut,_exoHighPtTrackCut)), 
 )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(isolatedTracks, useHighPurity = True)
 
 def miniAOD_customizeIsolatedTracksFastSim(process):
     """Switch off dE/dx hit info on fast sim, as it's not available"""

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -138,7 +138,7 @@ def miniAOD_customizeCommon(process):
         
         from PhysicsTools.PatAlgos.slimming.applySubstructure_cff import applySubstructure
         applySubstructure( process )
-    (~_hiGeneral).toModify(process, _applySubstructure)
+    #(~_hiGeneral).toModify(process, _applySubstructure)
 
     _hiGeneral.toModify(process, func = lambda p: addToProcessAndTask('slimmedJets', p.selectedPatJets.clone(), p, task))
     _hiGeneral.toModify(process, func = lambda p: addToProcessAndTask('slimmedJetsAK8', _dummyPatJets.clone(), p, task))

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -138,7 +138,7 @@ def miniAOD_customizeCommon(process):
         
         from PhysicsTools.PatAlgos.slimming.applySubstructure_cff import applySubstructure
         applySubstructure( process )
-    #(~_hiGeneral).toModify(process, _applySubstructure)
+    (~_hiGeneral).toModify(process, _applySubstructure)
 
     _hiGeneral.toModify(process, func = lambda p: addToProcessAndTask('slimmedJets', p.selectedPatJets.clone(), p, task))
     _hiGeneral.toModify(process, func = lambda p: addToProcessAndTask('slimmedJetsAK8', _dummyPatJets.clone(), p, task))


### PR DESCRIPTION
#### PR description:

In #31647 it was pointed out that isolatedTracks has a high CPU consumption in central heavy-ion events.  
This PR requires that only highPurity tracks are considered, which cuts the timing by a factor of 4 in wf 140.5611 
Non-highPurity tracks have a rather large fake rate and are not used for many purposes. 

#### PR validation:



#### if this PR is a backport please specify the original PR and why you need to backport that PR:



Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
