### PR TITLE
[HGCAL] CLUE and regional factors

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -47,9 +47,7 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
         thickness_index = maxNumberOfThickIndices_;
 
       double storedThreshold = thresholds_[layerOnSide][thickness_index];
-      if (detid.subdetId() == HGCEE) {
-        storedThreshold = thresholds_[layerOnSide][thickness_index];
-      } else if (detid.subdetId() == HGCHEF) {
+      if ( detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF ) {
         storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
       }
       sigmaNoise = v_sigmaNoise_[layerOnSide][thickness_index];

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -43,15 +43,14 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
     float sigmaNoise = 1.f;
     if (dependSensor_) {
       int thickness_index = rhtools_.getSiThickIndex(detid);
-      double storedThreshold = 9999.;
+      if (thickness_index == -1)
+        thickness_index = 6;      
+      double storedThreshold = thresholds_[layerOnSide][thickness_index];
       if ( detid.det() == DetId::HGCalEE  || detid.subdetId() == HGCEE ){
 	storedThreshold = thresholds_[layerOnSide][thickness_index];
       } else if ( detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF){
 	storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
-      } else if ( thickness_index == -1 ){
-        thickness_index = 6;	
-	storedThreshold = thresholds_[layerOnSide][thickness_index];
-      }
+      } 
       sigmaNoise = v_sigmaNoise_[layerOnSide][thickness_index];
 
       if (hgrh.energy() < storedThreshold)

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -47,9 +47,9 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
         thickness_index = maxNumberOfThickIndices_;
 
       double storedThreshold = thresholds_[layerOnSide][thickness_index];
-      if (detid.det() == DetId::HGCalEE || detid.subdetId() == HGCEE) {
+      if (detid.subdetId() == HGCEE) {
         storedThreshold = thresholds_[layerOnSide][thickness_index];
-      } else if (detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF) {
+      } else if (detid.subdetId() == HGCHEF) {
         storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
       }
       sigmaNoise = v_sigmaNoise_[layerOnSide][thickness_index];

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -44,7 +44,8 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
     if (dependSensor_) {
       int thickness_index = rhtools_.getSiThickIndex(detid);
       if (thickness_index == -1)
-        thickness_index = 6;
+        thickness_index = maxNumberOfThickIndices_;
+
       double storedThreshold = thresholds_[layerOnSide][thickness_index];
       if (detid.det() == DetId::HGCalEE || detid.subdetId() == HGCEE) {
         storedThreshold = thresholds_[layerOnSide][thickness_index];
@@ -523,13 +524,13 @@ void HGCalCLUEAlgoT<T>::computeThreshold() {
   initialized_ = true;
 
   std::vector<double> dummy;
-  const unsigned maxNumberOfThickIndices = 6;
-  dummy.resize(maxNumberOfThickIndices + !isNose_, 0);  // +1 to accomodate for the Scintillators
+
+  dummy.resize(maxNumberOfThickIndices_ + !isNose_, 0);  // +1 to accomodate for the Scintillators
   thresholds_.resize(maxlayer_, dummy);
   v_sigmaNoise_.resize(maxlayer_, dummy);
 
   for (unsigned ilayer = 1; ilayer <= maxlayer_; ++ilayer) {
-    for (unsigned ithick = 0; ithick < maxNumberOfThickIndices; ++ithick) {
+    for (unsigned ithick = 0; ithick < maxNumberOfThickIndices_; ++ithick) {
       float sigmaNoise = 0.001f * fcPerEle_ * nonAgedNoises_[ithick] * dEdXweights_[ilayer] /
                          (fcPerMip_[ithick] * thicknessCorrection_[ithick]);
       thresholds_[ilayer - 1][ithick] = sigmaNoise * ecut_;
@@ -542,8 +543,8 @@ void HGCalCLUEAlgoT<T>::computeThreshold() {
 
     if (!isNose_) {
       float scintillators_sigmaNoise = 0.001f * noiseMip_ * dEdXweights_[ilayer] / sciThicknessCorrection_;
-      thresholds_[ilayer - 1][maxNumberOfThickIndices] = ecut_ * scintillators_sigmaNoise;
-      v_sigmaNoise_[ilayer - 1][maxNumberOfThickIndices] = scintillators_sigmaNoise;
+      thresholds_[ilayer - 1][maxNumberOfThickIndices_] = ecut_ * scintillators_sigmaNoise;
+      v_sigmaNoise_[ilayer - 1][maxNumberOfThickIndices_] = scintillators_sigmaNoise;
       LogDebug("HGCalCLUEAlgo") << "ilayer: " << ilayer << " noiseMip: " << noiseMip_
                                 << " scintillators_sigmaNoise: " << scintillators_sigmaNoise << "\n";
     }

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -44,13 +44,13 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
     if (dependSensor_) {
       int thickness_index = rhtools_.getSiThickIndex(detid);
       if (thickness_index == -1)
-        thickness_index = 6;      
+        thickness_index = 6;
       double storedThreshold = thresholds_[layerOnSide][thickness_index];
-      if ( detid.det() == DetId::HGCalEE  || detid.subdetId() == HGCEE ){
-	storedThreshold = thresholds_[layerOnSide][thickness_index];
-      } else if ( detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF){
-	storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
-      } 
+      if (detid.det() == DetId::HGCalEE || detid.subdetId() == HGCEE) {
+        storedThreshold = thresholds_[layerOnSide][thickness_index];
+      } else if (detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF) {
+        storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
+      }
       sigmaNoise = v_sigmaNoise_[layerOnSide][thickness_index];
 
       if (hgrh.energy() < storedThreshold)

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -47,7 +47,7 @@ void HGCalCLUEAlgoT<T>::populate(const HGCRecHitCollection& hits) {
         thickness_index = maxNumberOfThickIndices_;
 
       double storedThreshold = thresholds_[layerOnSide][thickness_index];
-      if ( detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF ) {
+      if (detid.det() == DetId::HGCalHSi || detid.subdetId() == HGCHEF) {
         storedThreshold = thresholds_[layerOnSide][thickness_index + deltasi_index_regemfac_];
       }
       sigmaNoise = v_sigmaNoise_[layerOnSide][thickness_index];

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -96,7 +96,7 @@ public:
     iDesc.addUntracked<unsigned int>("verbosity", 3);
     iDesc.add<std::vector<double>>("dEdXweights", {});
     iDesc.add<std::vector<double>>("thicknessCorrection", {});
-    iDesc.add<double>("sciThicknessCorrection", 1.0);
+    iDesc.add<double>("sciThicknessCorrection", 0.9);
     iDesc.add<int>("deltasi_index_regemfac", 3);
     iDesc.add<std::vector<double>>("fcPerMip", {});
     iDesc.add<double>("fcPerEle", 0.0);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -47,7 +47,12 @@ public:
         nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
         noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
         use2x2_(ps.getParameter<bool>("use2x2")),
-        initialized_(false) {}
+        initialized_(false) {
+          // repeat same noises for CE-H as well
+          if (!isNose_) {  
+            nonAgedNoises_.insert(std::end(nonAgedNoises_), std::begin(nonAgedNoises_), std::end(nonAgedNoises_));
+          }
+        }
 
   ~HGCalCLUEAlgoT() override {}
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -41,18 +41,18 @@ public:
         dEdXweights_(ps.getParameter<std::vector<double>>("dEdXweights")),
         thicknessCorrection_(ps.getParameter<std::vector<double>>("thicknessCorrection")),
         sciThicknessCorrection_(ps.getParameter<double>("sciThicknessCorrection")),
-	deltasi_index_regemfac_(ps.getParameter<int>("deltasi_index_regemfac")),
+        deltasi_index_regemfac_(ps.getParameter<int>("deltasi_index_regemfac")),
         fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
         fcPerEle_(ps.getParameter<double>("fcPerEle")),
         nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
         noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
         use2x2_(ps.getParameter<bool>("use2x2")),
         initialized_(false) {
-          // repeat same noises for CE-H as well
-          if (!isNose_) {  
-            nonAgedNoises_.insert(std::end(nonAgedNoises_), std::begin(nonAgedNoises_), std::end(nonAgedNoises_));
-          }
-        }
+    // repeat same noises for CE-H as well
+    if (!isNose_) {
+      nonAgedNoises_.insert(std::end(nonAgedNoises_), std::begin(nonAgedNoises_), std::end(nonAgedNoises_));
+    }
+  }
 
   ~HGCalCLUEAlgoT() override {}
 

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -40,6 +40,8 @@ public:
         dependSensor_(ps.getParameter<bool>("dependSensor")),
         dEdXweights_(ps.getParameter<std::vector<double>>("dEdXweights")),
         thicknessCorrection_(ps.getParameter<std::vector<double>>("thicknessCorrection")),
+        sciThicknessCorrection_(ps.getParameter<double>("sciThicknessCorrection")),
+	deltasi_index_regemfac_(ps.getParameter<int>("deltasi_index_regemfac")),
         fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
         fcPerEle_(ps.getParameter<double>("fcPerEle")),
         nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
@@ -94,6 +96,8 @@ public:
     iDesc.addUntracked<unsigned int>("verbosity", 3);
     iDesc.add<std::vector<double>>("dEdXweights", {});
     iDesc.add<std::vector<double>>("thicknessCorrection", {});
+    iDesc.add<double>("sciThicknessCorrection", 1.0);
+    iDesc.add<int>("deltasi_index_regemfac", 3);
     iDesc.add<std::vector<double>>("fcPerMip", {});
     iDesc.add<double>("fcPerEle", 0.0);
     edm::ParameterSetDescription descNestedNoises;
@@ -131,6 +135,8 @@ private:
   bool dependSensor_;
   std::vector<double> dEdXweights_;
   std::vector<double> thicknessCorrection_;
+  double sciThicknessCorrection_;
+  int deltasi_index_regemfac_;
   std::vector<double> fcPerMip_;
   double fcPerEle_;
   std::vector<double> nonAgedNoises_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -42,6 +42,7 @@ public:
         thicknessCorrection_(ps.getParameter<std::vector<double>>("thicknessCorrection")),
         sciThicknessCorrection_(ps.getParameter<double>("sciThicknessCorrection")),
         deltasi_index_regemfac_(ps.getParameter<int>("deltasi_index_regemfac")),
+        maxNumberOfThickIndices_(ps.getParameter<unsigned>("maxNumberOfThickIndices")),
         fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
         fcPerEle_(ps.getParameter<double>("fcPerEle")),
         nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
@@ -103,6 +104,7 @@ public:
     iDesc.add<std::vector<double>>("thicknessCorrection", {});
     iDesc.add<double>("sciThicknessCorrection", 0.9);
     iDesc.add<int>("deltasi_index_regemfac", 3);
+    iDesc.add<unsigned>("maxNumberOfThickIndices", 6);
     iDesc.add<std::vector<double>>("fcPerMip", {});
     iDesc.add<double>("fcPerEle", 0.0);
     edm::ParameterSetDescription descNestedNoises;
@@ -142,6 +144,7 @@ private:
   std::vector<double> thicknessCorrection_;
   double sciThicknessCorrection_;
   int deltasi_index_regemfac_;
+  unsigned maxNumberOfThickIndices_;
   std::vector<double> fcPerMip_;
   double fcPerEle_;
   std::vector<double> nonAgedNoises_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -185,7 +185,7 @@ bool HGCalRecHitWorkerSimple::run(const edm::Event& evt,
       break;
     case hgcbh:
       rechitMaker_->setADCToGeVConstant(float(hgchebUncalib2GeV_));
-      sigmaNoiseGeV = 1e-3 * hgcHEB_noise_MIP_ * weights_[layer];
+      sigmaNoiseGeV = 1e-3 * hgcHEB_noise_MIP_ * weights_[layer] * rcorrscint_;
       break;
     case hgchfnose:
       rechitMaker_->setADCToGeVConstant(float(hgchfnoseUncalib2GeV_));

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -59,7 +59,9 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
     rcorr_.push_back(1.0 / corr);
   }
   // here for scintillator
-  rcorrscint_ = ps.getParameter<double>("sciThicknessCorrection");
+  const auto& rcorrscint = ps.getParameter<double>("sciThicknessCorrection");
+  rcorrscint_ = 1.0 / rcorrscint;
+
   //This is for the index position in CE_H silicon thickness cases
   deltasi_index_regemfac_ = ps.getParameter<int>("deltasi_index_regemfac");
   const auto& rcorrnose = ps.getParameter<std::vector<double> >("thicknessNoseCorrection");

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalRecHitWorkerSimple.cc
@@ -59,8 +59,7 @@ HGCalRecHitWorkerSimple::HGCalRecHitWorkerSimple(const edm::ParameterSet& ps) : 
     rcorr_.push_back(1.0 / corr);
   }
   // here for scintillator
-  const auto& rcorrscint = ps.getParameter<double>("sciThicknessCorrection");
-  rcorrscint_ = 1.0 / rcorrscint;
+  rcorrscint_ = 1.0 / ps.getParameter<double>("sciThicknessCorrection");
 
   //This is for the index position in CE_H silicon thickness cases
   deltasi_index_regemfac_ = ps.getParameter<int>("deltasi_index_regemfac");

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -14,6 +14,8 @@ hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
 hgcalLayerClusters.plugin.dEdXweights = cms.vdouble(dEdX.weights)
 hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP)
 hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
+hgcalLayerClusters.plugin.sciThicknessCorrection = cms.double(HGCalRecHit.sciThicknessCorrection)
+hgcalLayerClusters.plugin.deltasi_index_regemfac = cms.int32(HGCalRecHit.deltasi_index_regemfac)
 hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
 hgcalLayerClusters.plugin.noises = cms.PSet(refToPSet_ = cms.string('HGCAL_noises'))
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -14,8 +14,8 @@ hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
 hgcalLayerClusters.plugin.dEdXweights = cms.vdouble(dEdX.weights)
 hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP)
 hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
-hgcalLayerClusters.plugin.sciThicknessCorrection = cms.double(HGCalRecHit.sciThicknessCorrection)
-hgcalLayerClusters.plugin.deltasi_index_regemfac = cms.int32(HGCalRecHit.deltasi_index_regemfac)
+hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
+hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac
 hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
 hgcalLayerClusters.plugin.noises = cms.PSet(refToPSet_ = cms.string('HGCAL_noises'))
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -12,7 +12,7 @@ hgcalLayerClusters = hgcalLayerClusters_.clone()
 
 hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
 hgcalLayerClusters.plugin.dEdXweights = cms.vdouble(dEdX.weights)
-hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP)
+hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP)
 hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
 hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
 hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac


### PR DESCRIPTION
#### PR description:

This PR addresses two issues: 

1. Recently, the regional em factors were introduced (PR #29165), since the previous thickness correction factors applied only in the calibration of RecHits corresponding to Silicon sensor cells from the results we got with the CE_E region of the detector, while for Scintillator only dEdx weights were applied. However, thickness correction factors are also used in the CLUE algorithm to define the noise threshold.

2. The scintillator factor wasn’t correctly applied. 

#### PR validation:

You can find in [1] a thorough validation of the PR. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

I don't know the procedure for backporting a PR, but we would like to backport this is 11_1_X. 

[1] https://indico.cern.ch/event/965023/contributions/4063982/attachments/2123036/3573722/Regionalemfactors_noisecorrections_14Oct20.pdf

@rovere @cseez @felicepantaleo @lecriste @pfs @franzoni @mariadalfonso 
