### PR TITLE
Read SLHA from TTree

### DIFF
--- a/GeneratorInterface/Pythia8Interface/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="evtgen"/>
 <use name="hepmc"/>
 <use name="clhep"/>
+<use name="root"/>
 <export>
   <lib name="1"/>
 </export>

--- a/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
@@ -30,9 +30,9 @@ namespace gen {
     ~Py8InterfaceBase() override {}
 
     virtual bool generatePartonsAndHadronize() = 0;
-    bool decay() { return true; }  // NOT used - let's call it "design imperfection"
-    bool readSettings(int);        // common func
-    void makeTmpSLHA(const std::string&); //helper for above
+    bool decay() { return true; }          // NOT used - let's call it "design imperfection"
+    bool readSettings(int);                // common func
+    void makeTmpSLHA(const std::string&);  //helper for above
     virtual bool initializeForInternalPartons() = 0;
     bool declareStableParticles(const std::vector<int>&);          // common func
     bool declareSpecialSettings(const std::vector<std::string>&);  // common func

--- a/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/Py8InterfaceBase.h
@@ -32,6 +32,7 @@ namespace gen {
     virtual bool generatePartonsAndHadronize() = 0;
     bool decay() { return true; }  // NOT used - let's call it "design imperfection"
     bool readSettings(int);        // common func
+    void makeTmpSLHA(const std::string&); //helper for above
     virtual bool initializeForInternalPartons() = 0;
     bool declareStableParticles(const std::vector<int>&);          // common func
     bool declareSpecialSettings(const std::vector<std::string>&);  // common func

--- a/GeneratorInterface/Pythia8Interface/interface/SLHAReaderBase.h
+++ b/GeneratorInterface/Pythia8Interface/interface/SLHAReaderBase.h
@@ -1,0 +1,32 @@
+#ifndef GeneratorInterface_Pythia8Interface_SLHAReaderBase
+#define GeneratorInterface_Pythia8Interface_SLHAReaderBase
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <string>
+#include <vector>
+
+class TFile;
+class TTree;
+
+class SLHAReaderBase {
+public:
+  SLHAReaderBase(const edm::ParameterSet& conf);
+  virtual ~SLHAReaderBase();
+
+  //this function should parse the config description (e.g. with splitline() below)
+  //then use the information to get the SLHA info out of the tree and return it
+  virtual std::string getSLHA(const std::string& configDesc) = 0;
+
+  static std::vector<std::string> splitline(const std::string& line, char delim);
+
+protected:
+  //members
+  TFile* file_;
+  TTree* tree_;
+};
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory<SLHAReaderBase*(const edm::ParameterSet&)> SLHAReaderFactory;
+
+#endif

--- a/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Pythia8Interface/plugins/BuildFile.xml
@@ -19,3 +19,8 @@
   <use name="GeneratorInterface/ExternalDecays"/>
   <flags EDM_PLUGIN="1"/>
 </library>
+
+<library file="SLHA*.cc" name="GeneratorInterfacePythia8SLHAReader">
+  <use name="GeneratorInterface/Pythia8Interface"/>
+  <use name="root"/>
+</library>

--- a/GeneratorInterface/Pythia8Interface/plugins/SLHAReaderpMSSM.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/SLHAReaderpMSSM.cc
@@ -8,7 +8,7 @@
 class SLHAReaderpMSSM : public SLHAReaderBase {
 public:
   SLHAReaderpMSSM(const edm::ParameterSet& conf) : SLHAReaderBase(conf) {}
-  virtual ~SLHAReaderpMSSM() {}
+  ~SLHAReaderpMSSM() override {}
 
   std::string getSLHA(const std::string& configDesc) override;
 };
@@ -27,4 +27,3 @@ std::string SLHAReaderpMSSM::getSLHA(const std::string& configDesc) {
 
   return std::string(*slhabranch);
 }
-

--- a/GeneratorInterface/Pythia8Interface/plugins/SLHAReaderpMSSM.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/SLHAReaderpMSSM.cc
@@ -1,0 +1,30 @@
+#include "GeneratorInterface/Pythia8Interface/interface/SLHAReaderBase.h"
+
+#include "TTree.h"
+#include "TString.h"
+
+#include <memory>
+
+class SLHAReaderpMSSM : public SLHAReaderBase {
+public:
+  SLHAReaderpMSSM(const edm::ParameterSet& conf) : SLHAReaderBase(conf) {}
+  virtual ~SLHAReaderpMSSM() {}
+
+  std::string getSLHA(const std::string& configDesc) override;
+};
+
+DEFINE_EDM_PLUGIN(SLHAReaderFactory, SLHAReaderpMSSM, "SLHAReaderpMSSM");
+
+std::string SLHAReaderpMSSM::getSLHA(const std::string& configDesc) {
+  const auto& config_fields = splitline(configDesc, '_');
+  int chain = std::stoi(config_fields.at(2));
+  int iteration = std::stoi(config_fields.at(3));
+
+  auto slhabranch = std::make_unique<TString>();
+  auto slhabranch_ptr = slhabranch.get();
+  tree_->SetBranchAddress("slhacontent", &slhabranch_ptr);
+  tree_->GetEntryWithIndex(chain, iteration);
+
+  return std::string(*slhabranch);
+}
+

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -171,7 +171,8 @@ namespace gen {
       makeTmpSLHA(slhatable);
     } else if (currentParameters.exists("SLHATreeForPythia8")) {
       auto slhaReaderParams = currentParameters.getParameter<edm::ParameterSet>("SLHATreeForPythia8");
-      std::unique_ptr<SLHAReaderBase> reader = SLHAReaderFactory::get()->create(slhaReaderParams.getParameter<std::string>("name"), slhaReaderParams);
+      std::unique_ptr<SLHAReaderBase> reader =
+          SLHAReaderFactory::get()->create(slhaReaderParams.getParameter<std::string>("name"), slhaReaderParams);
 
       makeTmpSLHA(reader->getSLHA(currentParameters.getParameter<std::string>("ConfigDescription")));
     }

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -187,11 +187,11 @@ namespace gen {
 
       makeTmpSLHA(slhatable);
     } else if (currentParameters.exists("SLHATreeForPythia8")) {
-        auto f1 = currentParameters.getParameter<edm::FileInPath>("SLHATreeForPythia8");
-        TFile* file = TFile::Open(f1.fullPath().c_str());
-		if(!file) throw cms::Exception("MissingFile") << "Could not open file: " << f1.fullPath();
+        auto f1 = currentParameters.getParameter<std::string>("SLHATreeForPythia8");
+        TFile* file = TFile::Open(f1.c_str());
+		if(!file) throw cms::Exception("MissingFile") << "Could not open file: " << f1;
         TTree* tree = (TTree*)file->Get("mcmc");
-		if(!tree) throw cms::Exception("MissingTree") << "Could not get tree from file: " << f1.fullPath();
+		if(!tree) throw cms::Exception("MissingTree") << "Could not get tree from file: " << f1;
 
         //parse config description pMSSM_MCMC_#_# to get index: chain, iteration
         const auto& config_fields = splitline(currentParameters.getParameter<std::string>("ConfigDescription"),'_');

--- a/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/Py8InterfaceBase.cc
@@ -22,16 +22,16 @@
 using namespace Pythia8;
 
 namespace {
-	std::vector<std::string> splitline(const std::string& line, char delim){
-		std::stringstream ss(line);
-		std::string field;
-		std::vector<std::string> fields;
-		while(getline(ss,field,delim)){
-			fields.push_back(field);
-		}
-		return fields;
-	}
-}
+  std::vector<std::string> splitline(const std::string& line, char delim) {
+    std::stringstream ss(line);
+    std::string field;
+    std::vector<std::string> fields;
+    while (getline(ss, field, delim)) {
+      fields.push_back(field);
+    }
+    return fields;
+  }
+}  // namespace
 
 namespace gen {
 
@@ -187,43 +187,45 @@ namespace gen {
 
       makeTmpSLHA(slhatable);
     } else if (currentParameters.exists("SLHATreeForPythia8")) {
-        auto f1 = currentParameters.getParameter<std::string>("SLHATreeForPythia8");
-        TFile* file = TFile::Open(f1.c_str());
-		if(!file) throw cms::Exception("MissingFile") << "Could not open file: " << f1;
-        TTree* tree = (TTree*)file->Get("mcmc");
-		if(!tree) throw cms::Exception("MissingTree") << "Could not get tree from file: " << f1;
+      auto f1 = currentParameters.getParameter<std::string>("SLHATreeForPythia8");
+      TFile* file = TFile::Open(f1.c_str());
+      if (!file)
+        throw cms::Exception("MissingFile") << "Could not open file: " << f1;
+      TTree* tree = (TTree*)file->Get("mcmc");
+      if (!tree)
+        throw cms::Exception("MissingTree") << "Could not get tree from file: " << f1;
 
-        //parse config description pMSSM_MCMC_#_# to get index: chain, iteration
-        const auto& config_fields = splitline(currentParameters.getParameter<std::string>("ConfigDescription"),'_');
-		int chain = std::stoi(config_fields.at(2));
-		int iteration = std::stoi(config_fields.at(3));
+      //parse config description pMSSM_MCMC_#_# to get index: chain, iteration
+      const auto& config_fields = splitline(currentParameters.getParameter<std::string>("ConfigDescription"), '_');
+      int chain = std::stoi(config_fields.at(2));
+      int iteration = std::stoi(config_fields.at(3));
 
-        //get slha string branch
-        auto slhabranch = std::make_unique<TString>();
-		auto slhabranch_ptr = slhabranch.get();
-        tree->SetBranchAddress("slhacontent",&slhabranch_ptr);
-		tree->GetEntryWithIndex(chain,iteration);
+      //get slha string branch
+      auto slhabranch = std::make_unique<TString>();
+      auto slhabranch_ptr = slhabranch.get();
+      tree->SetBranchAddress("slhacontent", &slhabranch_ptr);
+      tree->GetEntryWithIndex(chain, iteration);
 
-		//make tmp file
-		makeTmpSLHA(std::string(*slhabranch));
+      //make tmp file
+      makeTmpSLHA(std::string(*slhabranch));
 
-        //finish
-        file->Close();
+      //finish
+      file->Close();
     }
 
     return true;
   }
 
   void Py8InterfaceBase::makeTmpSLHA(const std::string& slhatable) {
-      char tempslhaname[] = "pythia8SLHAtableXXXXXX";
-      int fd = mkstemp(tempslhaname);
-      write(fd, slhatable.c_str(), slhatable.size());
-      close(fd);
+    char tempslhaname[] = "pythia8SLHAtableXXXXXX";
+    int fd = mkstemp(tempslhaname);
+    write(fd, slhatable.c_str(), slhatable.size());
+    close(fd);
 
-      slhafile_ = tempslhaname;
+    slhafile_ = tempslhaname;
 
-      fMasterGen->settings.mode("SLHA:readFrom", 2);
-      fMasterGen->settings.word("SLHA:file", slhafile_);
+    fMasterGen->settings.mode("SLHA:readFrom", 2);
+    fMasterGen->settings.word("SLHA:file", slhafile_);
   }
 
   bool Py8InterfaceBase::declareStableParticles(const std::vector<int>& pdgIds) {

--- a/GeneratorInterface/Pythia8Interface/src/SLHAReaderBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/SLHAReaderBase.cc
@@ -18,9 +18,7 @@ SLHAReaderBase::SLHAReaderBase(const edm::ParameterSet& conf) {
     throw cms::Exception("MissingTree") << "Could not get tree " << treename << " from file " << filename;
 }
 
-SLHAReaderBase::~SLHAReaderBase() {
-  file_->Close();
-}
+SLHAReaderBase::~SLHAReaderBase() { file_->Close(); }
 
 std::vector<std::string> SLHAReaderBase::splitline(const std::string& line, char delim) {
   std::stringstream ss(line);

--- a/GeneratorInterface/Pythia8Interface/src/SLHAReaderBase.cc
+++ b/GeneratorInterface/Pythia8Interface/src/SLHAReaderBase.cc
@@ -1,0 +1,35 @@
+#include "GeneratorInterface/Pythia8Interface/interface/SLHAReaderBase.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <sstream>
+
+#include "TFile.h"
+#include "TTree.h"
+
+SLHAReaderBase::SLHAReaderBase(const edm::ParameterSet& conf) {
+  auto filename = conf.getParameter<std::string>("file");
+  file_ = TFile::Open(filename.c_str());
+  if (!file_)
+    throw cms::Exception("MissingFile") << "Could not open file " << filename;
+
+  auto treename = conf.getParameter<std::string>("tree");
+  tree_ = (TTree*)file_->Get(treename.c_str());
+  if (!tree_)
+    throw cms::Exception("MissingTree") << "Could not get tree " << treename << " from file " << filename;
+}
+
+SLHAReaderBase::~SLHAReaderBase() {
+  file_->Close();
+}
+
+std::vector<std::string> SLHAReaderBase::splitline(const std::string& line, char delim) {
+  std::stringstream ss(line);
+  std::string field;
+  std::vector<std::string> fields;
+  while (getline(ss, field, delim)) {
+    fields.push_back(field);
+  }
+  return fields;
+}
+
+EDM_REGISTER_PLUGINFACTORY(SLHAReaderFactory, "SLHAReaderFactory");


### PR DESCRIPTION
#### PR description:

The upcoming pMSSM scan covers O(500K) different signal models, each with their own SLHA parameters. It is prohibitive to have a separate text file for each model, or to put all the SLHA tables directly into the generator fragment.

Instead, we have deployed a new method, using a ROOT `TTree` to compress the information and then efficiently read just the SLHA table for a specific model. This uses a `TTreeIndex` to search the tree, with the index information derived from the `configDescription` used for the randomized parameter signal scan.

In case others want to use this method in the future, it is implemented using a factory pattern, where the base class handles getting the ROOT file and tree, and the derived class handles parsing the `configDescription` and extracting the information from the tree. The expected PSet looks like this:
```python
SLHATreeForPythia8 = cms.PSet(
    name = cms.string("SLHAReaderpMSSM"),
    file = cms.string(os.path.expandvars('$CMSSW_BASE/src/GeneratorInterface/Pythia8Interface/data/pMSSM_selected.root')),
    tree = cms.string('mcmc'),
),
```

#### PR validation:

The full pMSSM generator fragment is still being finalized, and the associated ROOT file (1.7GB) is expected to be uploaded somewhere in cvmfs. For now, the PR can be tested following these instructions: https://gist.github.com/kpedro88/ab8a1350dd6c4f7f52275bbb993cf741.

Backports are planned to 10_6_X, 10_2_X, and 9_4_X. I will wait to submit the backports until this PR is reviewed and approved.