### PR TITLE
static const -> const for thread safety in DeepMETProducer::produce variable

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
+++ b/RecoMET/METPUSubtraction/plugins/DeepMETProducer.cc
@@ -69,7 +69,7 @@ DeepMETProducer::DeepMETProducer(const edm::ParameterSet& cfg, const DeepMETCach
 void DeepMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   auto const& pfs = event.get(pf_token_);
 
-  static const tensorflow::NamedTensorList input_list = {
+  const tensorflow::NamedTensorList input_list = {
       {"input", input_}, {"input_cat0", input_cat0_}, {"input_cat1", input_cat1_}, {"input_cat2", input_cat2_}};
 
   // Set all inputs to zero


### PR DESCRIPTION
based on https://github.com/cms-sw/cmssw/issues/31731#issuecomment-706369821

multiple instances of DeepMETProducer (stream module) can end up using the same `static const ... input_list` initialized by another instance, which is a wrong behavior
