### PR TITLE
Change input jet collection for b2g validation in HI wfs

### DIFF
--- a/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
@@ -50,3 +50,9 @@ b2gDiJetHLTValidation = DQMEDAnalyzer('B2GHadronicHLTValidation',
                                               'HLT_AK8PFHT650_TrimR0p1PT0p03Mass50',
                                               'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV_p20']),
 )
+
+# puppi jets don't exist in HI wfs, use Cs jets instead
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(b2gSingleJetHLTValidation, sJets = "akCs4PFJets")
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(b2gDiJetHLTValidation, sJets = "akCs4PFJets")


### PR DESCRIPTION
#### PR description:

As reported by @Martin-Grunewald in:
 https://github.com/cms-sw/cmssw/issues/31670#issuecomment-705403290
the b2g validation crashes after #30898 was merged

This error does not occur the relVal matrix b/c the HLT validation is never run in HI wfs. 
It looks like HLT validation and miniAOD validation are generally not run at the same time for some reason. 
Anywho, the error can be reproduced by making the following change in wf 159:
VALIDATION:@standardValidationNoHLT+@miniAODValidation
to
VALIDATION

#### PR validation:

The PR was checked by the making the above-mentioned change to wf 159

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
