### PR TITLE
Make EventSetup get to throw if called without a token when EDModule consumed any ES product

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -135,6 +135,8 @@ namespace edm {
       return esRecordsToGetFromTransition_[static_cast<unsigned int>(iTrans)];
     }
 
+    bool esAnyConsumed() const { return m_esTokenInfo.size() != 0; }
+
   protected:
     friend class ConsumesCollector;
     template <Transition Tr>

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -33,7 +33,8 @@ namespace edm {
     e.setConsumer(this);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
     this->analyze(e, c);
     return true;
   }
@@ -50,8 +51,10 @@ namespace edm {
   bool EDAnalyzer::doBeginRun(RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
     Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
-    const EventSetup c{
-        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+    const EventSetup c{info,
+                       static_cast<unsigned int>(Transition::BeginRun),
+                       esGetTokenIndices(Transition::BeginRun),
+                       esAnyConsumed()};
     this->beginRun(r, c);
     return true;
   }
@@ -60,7 +63,7 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, true);
     r.setConsumer(this);
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
     this->endRun(r, c);
     return true;
   }
@@ -71,7 +74,7 @@ namespace edm {
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
-                       false};
+                       esAnyConsumed()};
     this->beginLuminosityBlock(lb, c);
     return true;
   }
@@ -82,7 +85,7 @@ namespace edm {
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
-                       false};
+                       esAnyConsumed()};
     this->endLuminosityBlock(lb, c);
     return true;
   }

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -29,7 +29,8 @@ namespace edm {
     e.setProducer(this, &previousParentage_);
     e.setSharedResourcesAcquirer(&resourceAcquirer_);
     EventSignalsSentry sentry(act, mcc);
-    const EventSetup c{info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+    const EventSetup c{
+        info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
     this->produce(e, c);
     commit_(e, &previousParentageId_);
     return true;
@@ -47,8 +48,10 @@ namespace edm {
     Run r(info, moduleDescription_, mcc, false);
     r.setConsumer(this);
     Run const& cnstR = r;
-    const EventSetup c{
-        info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+    const EventSetup c{info,
+                       static_cast<unsigned int>(Transition::BeginRun),
+                       esGetTokenIndices(Transition::BeginRun),
+                       esAnyConsumed()};
     this->beginRun(cnstR, c);
     commit_(r);
   }
@@ -58,7 +61,7 @@ namespace edm {
     r.setConsumer(this);
     Run const& cnstR = r;
     const EventSetup c{
-        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+        info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
     this->endRun(cnstR, c);
     commit_(r);
   }
@@ -70,7 +73,7 @@ namespace edm {
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                        esGetTokenIndices(Transition::BeginLuminosityBlock),
-                       false};
+                       esAnyConsumed()};
     this->beginLuminosityBlock(cnstLb, c);
     commit_(lb);
   }
@@ -81,7 +84,7 @@ namespace edm {
     const EventSetup c{info,
                        static_cast<unsigned int>(Transition::EndLuminosityBlock),
                        esGetTokenIndices(Transition::EndLuminosityBlock),
-                       false};
+                       esAnyConsumed()};
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);
     commit_(lb);

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -55,7 +55,7 @@ namespace edm {
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -96,8 +96,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -107,7 +109,7 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -119,7 +121,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
@@ -131,7 +133,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -141,15 +143,17 @@ namespace edm {
     void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -161,7 +165,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -173,7 +177,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -60,7 +60,7 @@ namespace edm {
           this, &previousParentages_[streamIndex], hasAcquire() ? &gotBranchIDsFromAcquire_[streamIndex] : nullptr);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return returnValue;
@@ -76,7 +76,7 @@ namespace edm {
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -128,8 +128,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -143,7 +145,7 @@ namespace edm {
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -157,7 +159,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -173,7 +175,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -185,15 +187,17 @@ namespace edm {
     void EDFilterBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -205,7 +209,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -217,7 +221,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -81,7 +81,7 @@ namespace edm {
       e.setProducerForAcquire(this, nullptr, gotBranchIDsFromAcquire_[streamIndex]);
       EventAcquireSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->doAcquire_(e.streamID(), e, c, holder);
     }
 
@@ -133,8 +133,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -148,7 +150,7 @@ namespace edm {
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -162,7 +164,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -178,7 +180,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -190,17 +192,18 @@ namespace edm {
     void EDProducerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      this->doStreamBeginRun_(
-          id,
-          r,
-          EventSetup{
-              info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false});
+      this->doStreamBeginRun_(id,
+                              r,
+                              EventSetup{info,
+                                         static_cast<unsigned int>(Transition::BeginRun),
+                                         esGetTokenIndices(Transition::BeginRun),
+                                         esAnyConsumed()});
     }
     void EDProducerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -214,7 +217,7 @@ namespace edm {
                                           EventSetup{info,
                                                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                                                      esGetTokenIndices(Transition::BeginLuminosityBlock),
-                                                     false});
+                                                     esAnyConsumed()});
     }
 
     void EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
@@ -225,7 +228,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/limited/EDAnalyzerBase.cc
@@ -56,7 +56,7 @@ namespace edm {
       e.setConsumer(this);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->analyze(e.streamID(), e, c);
       return true;
     }
@@ -97,8 +97,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
     }
@@ -108,7 +110,7 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRun_(cnstR, c);
     }
@@ -120,7 +122,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
     }
@@ -132,7 +134,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
     }
@@ -142,15 +144,17 @@ namespace edm {
     void EDAnalyzerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDAnalyzerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -162,7 +166,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -174,7 +178,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDFilterBase.cc
+++ b/FWCore/Framework/src/limited/EDFilterBase.cc
@@ -58,7 +58,7 @@ namespace edm {
       const auto streamIndex = e.streamID().value();
       e.setProducer(this, &previousParentages_[streamIndex]);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       EventSignalsSentry sentry(act, mcc);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
@@ -110,8 +110,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -125,7 +127,7 @@ namespace edm {
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -139,7 +141,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -155,7 +157,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -167,15 +169,17 @@ namespace edm {
     void EDFilterBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDFilterBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -186,7 +190,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
@@ -199,7 +203,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/limited/EDProducerBase.cc
+++ b/FWCore/Framework/src/limited/EDProducerBase.cc
@@ -59,7 +59,7 @@ namespace edm {
       e.setProducer(this, &previousParentages_[streamIndex]);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->produce(e.streamID(), e, c);
       commit_(e, &previousParentageIds_[streamIndex]);
       return true;
@@ -110,8 +110,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       this->doBeginRunSummary_(cnstR, c);
       r.setProducer(this);
@@ -125,7 +127,7 @@ namespace edm {
       r.setProducer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunSummary_(r, c);
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
@@ -139,7 +141,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       this->doBeginLuminosityBlockSummary_(cnstLb, c);
       lb.setProducer(this);
@@ -155,7 +157,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockSummary_(cnstLb, c);
       this->doEndLuminosityBlockProduce_(lb, c);
       this->doEndLuminosityBlock_(cnstLb, c);
@@ -167,15 +169,17 @@ namespace edm {
     void EDProducerBase::doStreamBeginRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doStreamBeginRun_(id, r, c);
     }
     void EDProducerBase::doStreamEndRun(StreamID id, RunTransitionInfo const& info, ModuleCallingContext const* mcc) {
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
     }
@@ -187,7 +191,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamBeginLuminosityBlock_(id, lb, c);
     }
 
@@ -199,7 +203,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doStreamEndLuminosityBlock_(id, lb, c);
       this->doStreamEndLuminosityBlockSummary_(id, lb, c);
     }

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -58,7 +58,7 @@ namespace edm {
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->analyze(e, c);
       return true;
     }
@@ -109,8 +109,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
     }
 
@@ -119,7 +121,7 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRun_(cnstR, c);
     }
 
@@ -130,7 +132,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
     }
 
@@ -141,7 +143,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlock_(cnstLb, c);
     }
 

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -55,7 +55,7 @@ namespace edm {
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       returnValue = this->filter(e, c);
       commit_(e, &previousParentageId_);
       return returnValue;
@@ -115,8 +115,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -128,7 +130,7 @@ namespace edm {
       r.setConsumer(this);
       Run const& cnstR = r;
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRun_(cnstR, c);
       r.setProducer(this);
       this->doEndRunProduce_(r, c);
@@ -142,7 +144,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -156,7 +158,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doEndLuminosityBlockProduce_(lb, c);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -54,7 +54,7 @@ namespace edm {
       e.setSharedResourcesAcquirer(&resourcesAcquirer_);
       EventSignalsSentry sentry(act, mcc);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), false};
+          info, static_cast<unsigned int>(Transition::Event), esGetTokenIndices(Transition::Event), esAnyConsumed()};
       this->produce(e, c);
       commit_(e, &previousParentageId_);
       return true;
@@ -115,8 +115,10 @@ namespace edm {
       Run r(info, moduleDescription_, mcc, false);
       r.setConsumer(this);
       Run const& cnstR = r;
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         esGetTokenIndices(Transition::BeginRun),
+                         esAnyConsumed()};
       this->doBeginRun_(cnstR, c);
       r.setProducer(this);
       this->doBeginRunProduce_(r, c);
@@ -129,7 +131,7 @@ namespace edm {
       Run const& cnstR = r;
       r.setProducer(this);
       const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), false};
+          info, static_cast<unsigned int>(Transition::EndRun), esGetTokenIndices(Transition::EndRun), esAnyConsumed()};
       this->doEndRunProduce_(r, c);
       this->doEndRun_(cnstR, c);
       commit_(r);
@@ -142,7 +144,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doBeginLuminosityBlock_(cnstLb, c);
       lb.setProducer(this);
       this->doBeginLuminosityBlockProduce_(lb, c);
@@ -156,7 +158,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         esAnyConsumed()};
       this->doEndLuminosityBlockProduce_(lb, c);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -149,8 +149,10 @@ bool EDAnalyzerAdaptorBase::doEvent(EventTransitionInfo const& info,
   auto mod = m_streamModules[ep.streamID()];
   Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+  const EventSetup c{info,
+                     static_cast<unsigned int>(Transition::Event),
+                     mod->esGetTokenIndices(Transition::Event),
+                     mod->esAnyConsumed()};
   EventSignalsSentry sentry(act, mcc);
   mod->analyze(e, c);
   return true;
@@ -167,8 +169,10 @@ void EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
   setupRun(mod, rp.index());
 
   Run r(rp, moduleDescription_, mcc, false);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+  const EventSetup c{info,
+                     static_cast<unsigned int>(Transition::BeginRun),
+                     mod->esGetTokenIndices(Transition::BeginRun),
+                     mod->esAnyConsumed()};
   r.setConsumer(mod);
   mod->beginRun(r, c);
 }
@@ -179,8 +183,10 @@ void EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
   auto mod = m_streamModules[id];
   Run r(info, moduleDescription_, mcc, true);
   r.setConsumer(mod);
-  const EventSetup c{
-      info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+  const EventSetup c{info,
+                     static_cast<unsigned int>(Transition::EndRun),
+                     mod->esGetTokenIndices(Transition::EndRun),
+                     mod->esAnyConsumed()};
   mod->endRun(r, c);
   streamEndRunSummary(mod, r, c);
 }
@@ -197,7 +203,7 @@ void EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
   const EventSetup c{info,
                      static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                      mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
-                     false};
+                     mod->esAnyConsumed()};
   mod->beginLuminosityBlock(lb, c);
 }
 void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
@@ -209,7 +215,7 @@ void EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
   const EventSetup c{info,
                      static_cast<unsigned int>(Transition::EndLuminosityBlock),
                      mod->esGetTokenIndices(Transition::EndLuminosityBlock),
-                     false};
+                     mod->esAnyConsumed()};
   mod->endLuminosityBlock(lb, c);
   streamEndLuminosityBlockSummary(mod, lb, c);
 }

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -54,8 +54,10 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::Event),
+                         mod->esGetTokenIndices(Transition::Event),
+                         mod->esAnyConsumed()};
       bool result = mod->filter(e, c);
       commit(e, &mod->previousParentageId_);
       return result;
@@ -72,8 +74,10 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::Event),
+                         mod->esGetTokenIndices(Transition::Event),
+                         mod->esAnyConsumed()};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -54,8 +54,10 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducer(mod, &mod->previousParentage_, &mod->gotBranchIDsFromAcquire_);
       EventSignalsSentry sentry(act, mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::Event),
+                         mod->esGetTokenIndices(Transition::Event),
+                         mod->esAnyConsumed()};
       mod->produce(e, c);
       commit(e, &mod->previousParentageId_);
       return true;
@@ -72,8 +74,10 @@ namespace edm {
       e.setConsumer(mod);
       e.setProducerForAcquire(mod, nullptr, mod->gotBranchIDsFromAcquire_);
       EventAcquireSignalsSentry sentry(act, mcc);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::Event), mod->esGetTokenIndices(Transition::Event), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::Event),
+                         mod->esGetTokenIndices(Transition::Event),
+                         mod->esAnyConsumed()};
       mod->doAcquire_(e, c, holder);
     }
 

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -188,8 +188,10 @@ namespace edm {
 
       Run r(rp, moduleDescription_, mcc, false);
       r.setConsumer(mod);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::BeginRun), mod->esGetTokenIndices(Transition::BeginRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::BeginRun),
+                         mod->esGetTokenIndices(Transition::BeginRun),
+                         mod->esAnyConsumed()};
       mod->beginRun(r, c);
     }
 
@@ -200,8 +202,10 @@ namespace edm {
       auto mod = m_streamModules[id];
       Run r(info, moduleDescription_, mcc, true);
       r.setConsumer(mod);
-      const EventSetup c{
-          info, static_cast<unsigned int>(Transition::EndRun), mod->esGetTokenIndices(Transition::EndRun), false};
+      const EventSetup c{info,
+                         static_cast<unsigned int>(Transition::EndRun),
+                         mod->esGetTokenIndices(Transition::EndRun),
+                         mod->esAnyConsumed()};
       mod->endRun(r, c);
       streamEndRunSummary(mod, r, c);
     }
@@ -219,7 +223,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::BeginLuminosityBlock),
                          mod->esGetTokenIndices(Transition::BeginLuminosityBlock),
-                         false};
+                         mod->esAnyConsumed()};
       mod->beginLuminosityBlock(lb, c);
     }
 
@@ -233,7 +237,7 @@ namespace edm {
       const EventSetup c{info,
                          static_cast<unsigned int>(Transition::EndLuminosityBlock),
                          mod->esGetTokenIndices(Transition::EndLuminosityBlock),
-                         false};
+                         mod->esAnyConsumed()};
       mod->endLuminosityBlock(lb, c);
       streamEndLuminosityBlockSummary(mod, lb, c);
     }

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -385,3 +385,4 @@
 
 <test name="testFWCoreFrameworkNonEventOrdering" command="test_non_event_ordering.sh"/>
 <test name="testFWCoreFramework1ThreadESPrefetch" command="run_test_1_thread_es_prefetching.sh"/>
+<test name="testFWCoreFrameworkESNoTokenGet" command="run_es_notokenget.sh"/>

--- a/FWCore/Framework/test/run_es_notokenget.sh
+++ b/FWCore/Framework/test/run_es_notokenget.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo Failure $1: status $2 ; exit $2 ; }
+
+
+TEST_DIR=src/FWCore/Framework/test
+
+cmsRun ${TEST_DIR}/test_es_notokenget_cfg.py && die "EventSetup get without token did not fail" 1
+echo "EventSetup get without token failed as expected"

--- a/FWCore/Framework/test/test_es_notokenget_cfg.py
+++ b/FWCore/Framework/test/test_es_notokenget_cfg.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Test")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents.input = 1
+
+process.b = cms.EDProducer("edmtest::one::WatchRunsProducer",
+                           transitions = cms.int32(3))
+process.c = cms.EDAnalyzer("TestESDummyDataFailingAnalyzer",
+                           expected = cms.int32(5))
+
+process.add_(cms.ESProducer("LoadableDummyProvider",
+                            value = cms.untracked.int32(5)))
+
+process.essource = cms.ESSource("EmptyESSource",
+    recordName = cms.string('DummyRecord'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+process.p2 = cms.Path(process.b)
+process.p3 = cms.Path(process.c)


### PR DESCRIPTION
#### PR description:

I thought this was already the behavior, but it turned out not to be the case. Similar behavior was used for ESProducers during the migration-to-ES-consumes period. (note that I did not change `EDLooperBase` because of https://github.com/cms-sw/cmssw/issues/31745)

#### PR validation:

Framework unit tests pass.