### PR TITLE
drop type specs in RecoTauTag

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -419,7 +419,7 @@ hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw = hpsPFTauDiscrimina
     mvaName = "RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT",
     mvaOpt = "DBoldDMwLTwGJ",
     srcBasicTauDiscriminators = "hpsPFTauBasicDiscriminatorsdR03",
-    inputIDNameSuffix = cms.string("dR03"),
+    inputIDNameSuffix = "dR03",
     verbosity = 0
 )
 hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLT = hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT.clone(

--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -30,7 +30,7 @@ ak4dBetaCorrection = 0.20
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator, decayMode_1Prong0Pi0, decayMode_1Prong1Pi0, decayMode_1Prong2Pi0, decayMode_2Prong0Pi0, decayMode_2Prong1Pi0, decayMode_3Prong0Pi0, decayMode_3Prong1Pi0
 
 hpsPFTauDiscriminationByDecayModeFindingNewDMs = hpsSelectionDiscriminator.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     #----------------------------------------------------------------------------
     # CV: disable 3Prong1Pi0 decay mode
     decayModes = cms.VPSet(
@@ -45,14 +45,14 @@ hpsPFTauDiscriminationByDecayModeFindingNewDMs = hpsSelectionDiscriminator.clone
     #----------------------------------------------------------------------------
 )
 hpsPFTauDiscriminationByDecayModeFindingOldDMs = hpsSelectionDiscriminator.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     decayModes = cms.VPSet(
         decayMode_1Prong0Pi0,
         decayMode_1Prong1Pi0,
         decayMode_1Prong2Pi0,
         decayMode_3Prong0Pi0
     ),
-    requireTauChargedHadronsToBeChargedPFCands = cms.bool(True)
+    requireTauChargedHadronsToBeChargedPFCands = True
 )
 hpsPFTauDiscriminationByDecayModeFinding = hpsPFTauDiscriminationByDecayModeFindingOldDMs.clone() ## CV: kept for backwards compatibility
 
@@ -67,7 +67,7 @@ requireDecayMode = cms.PSet(
 
 ## Cut based isolations dR=0.5
 hpsPFTauBasicDiscriminators = pfRecoTauDiscriminationByIsolation.clone(
-    PFTauProducer = cms.InputTag("hpsPFTauProducer"),
+    PFTauProducer = "hpsPFTauProducer",
     Prediscriminants = requireDecayMode.clone(),
     deltaBetaPUTrackPtCutOverride     = True, # Set the boolean = True to override.
     deltaBetaPUTrackPtCutOverride_val = 0.5,  # Set the value for new value.
@@ -170,7 +170,7 @@ hpsPFTauBasicDiscriminatorsdR03Task = cms.Task(
 # define helper function to read indices of basic IDs or antimuon
 ## MuonRejection3
 hpsPFTauDiscriminationByMuonRejection3 = pfRecoTauDiscriminationAgainstMuon2Container.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = noPrediscriminants,
     IDWPdefinitions = cms.VPSet(
         cms.PSet(
@@ -195,50 +195,50 @@ hpsPFTauDiscriminationByMuonRejection3 = pfRecoTauDiscriminationAgainstMuon2Cont
 
 ## ByLooseElectronRejection
 hpsPFTauDiscriminationByLooseElectronRejection = pfRecoTauDiscriminationAgainstElectron.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = noPrediscriminants,
-    PFElectronMVA_maxValue = cms.double(0.6)
+    PFElectronMVA_maxValue = 0.6
 )
 ## ByMediumElectronRejection
 hpsPFTauDiscriminationByMediumElectronRejection = pfRecoTauDiscriminationAgainstElectron.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = noPrediscriminants,
-    ApplyCut_EcalCrackCut = cms.bool(True)
+    ApplyCut_EcalCrackCut = True
 )
 ## ByTightElectronRejection
 hpsPFTauDiscriminationByTightElectronRejection = pfRecoTauDiscriminationAgainstElectron.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = noPrediscriminants,
-    ApplyCut_EcalCrackCut = cms.bool(True),
-    ApplyCut_BremCombined = cms.bool(True)
+    ApplyCut_EcalCrackCut = True,
+    ApplyCut_BremCombined = True
 )
 ## ByDeadECALElectronRejection 
 hpsPFTauDiscriminationByDeadECALElectronRejection = pfRecoTauDiscriminationAgainstElectronDeadECAL.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone()
 )
 ## ByMVA6rawElectronRejection
 hpsPFTauDiscriminationByMVA6rawElectronRejection = pfRecoTauDiscriminationAgainstElectronMVA6.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
-    srcElectrons = cms.InputTag('gedGsfElectrons'),
+    PFTauProducer = 'hpsPFTauProducer',
+    srcElectrons = 'gedGsfElectrons',
     Prediscriminants = requireDecayMode.clone(),
-    loadMVAfromDB = cms.bool(True),
-    vetoEcalCracks = cms.bool(False),
-    mvaName_NoEleMatch_woGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVA_NoEleMatch_woGwoGSF_BL"),
-    mvaName_NoEleMatch_wGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVA_NoEleMatch_wGwoGSF_BL"),
-    mvaName_woGwGSF_BL = cms.string("RecoTauTag_antiElectronMVA_woGwGSF_BL"),
-    mvaName_wGwGSF_BL = cms.string("RecoTauTag_antiElectronMVA_wGwGSF_BL"),
-    mvaName_NoEleMatch_woGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVA_NoEleMatch_woGwoGSF_EC"),
-    mvaName_NoEleMatch_wGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVA_NoEleMatch_wGwoGSF_EC"),
-    mvaName_woGwGSF_EC = cms.string("RecoTauTag_antiElectronMVA_woGwGSF_EC"),
-    mvaName_wGwGSF_EC = cms.string("RecoTauTag_antiElectronMVA_wGwGSF_EC")
+    loadMVAfromDB  = True,
+    vetoEcalCracks = False,
+    mvaName_NoEleMatch_woGwoGSF_BL = "RecoTauTag_antiElectronMVA_NoEleMatch_woGwoGSF_BL",
+    mvaName_NoEleMatch_wGwoGSF_BL  = "RecoTauTag_antiElectronMVA_NoEleMatch_wGwoGSF_BL",
+    mvaName_woGwGSF_BL             = "RecoTauTag_antiElectronMVA_woGwGSF_BL",
+    mvaName_wGwGSF_BL              = "RecoTauTag_antiElectronMVA_wGwGSF_BL",
+    mvaName_NoEleMatch_woGwoGSF_EC = "RecoTauTag_antiElectronMVA_NoEleMatch_woGwoGSF_EC",
+    mvaName_NoEleMatch_wGwoGSF_EC  = "RecoTauTag_antiElectronMVA_NoEleMatch_wGwoGSF_EC",
+    mvaName_woGwGSF_EC             = "RecoTauTag_antiElectronMVA_woGwGSF_EC",
+    mvaName_wGwGSF_EC              = "RecoTauTag_antiElectronMVA_wGwGSF_EC"
 )
 ## ByMVA6ElectronRejection
 hpsPFTauDiscriminationByMVA6ElectronRejection = recoTauDiscriminantCutMultiplexerDefault.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone(),
-    toMultiplex = cms.InputTag('hpsPFTauDiscriminationByMVA6rawElectronRejection'),
-    loadMVAfromDB = cms.bool(True),
+    toMultiplex = 'hpsPFTauDiscriminationByMVA6rawElectronRejection',
+    loadMVAfromDB = True,
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0), # minMVANoEleMatchWOgWOgsfBL
@@ -311,46 +311,46 @@ hpsSelectionDiscriminator.decayModes = cms.VPSet(
 
 from RecoTauTag.RecoTau.RecoTauCleaner_cfi import RecoTauCleaner
 hpsPFTauProducerSansRefs = RecoTauCleaner.clone(
-    src = cms.InputTag("combinatoricRecoTaus")
+    src = "combinatoricRecoTaus",
+    cleaners = {1: dict(src = "hpsSelectionDiscriminator")}
 )
-hpsPFTauProducerSansRefs.cleaners[1].src = cms.InputTag("hpsSelectionDiscriminator")
 
 from RecoTauTag.RecoTau.RecoTauPiZeroUnembedder_cfi import RecoTauPiZeroUnembedder
 hpsPFTauProducer = RecoTauPiZeroUnembedder.clone(
-    src = cms.InputTag("hpsPFTauProducerSansRefs")
+    src = "hpsPFTauProducerSansRefs"
 )
 
 from RecoTauTag.RecoTau.PFTauPrimaryVertexProducer_cfi      import *
 from RecoTauTag.RecoTau.PFTauSecondaryVertexProducer_cfi    import *
 from RecoTauTag.RecoTau.PFTauTransverseImpactParameters_cfi import *
 hpsPFTauPrimaryVertexProducer = PFTauPrimaryVertexProducer.clone(
-    PFTauTag = cms.InputTag("hpsPFTauProducer"),
-    ElectronTag = cms.InputTag(""),
-    MuonTag = cms.InputTag(""),
-    PVTag = cms.InputTag("offlinePrimaryVertices"),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    Algorithm = cms.int32(0),
-    useBeamSpot = cms.bool(True),
-    RemoveMuonTracks = cms.bool(False),
-    RemoveElectronTracks = cms.bool(False),
-    useSelectedTaus = cms.bool(False),
+    PFTauTag = "hpsPFTauProducer",
+    ElectronTag = "",
+    MuonTag = "",
+    PVTag = "offlinePrimaryVertices",
+    beamSpot = "offlineBeamSpot",
+    Algorithm = 0,
+    useBeamSpot = True,
+    RemoveMuonTracks = False,
+    RemoveElectronTracks = False,
+    useSelectedTaus = False,
     discriminators = cms.VPSet(
         cms.PSet(
             discriminator = cms.InputTag('hpsPFTauDiscriminationByDecayModeFindingNewDMs'),
             selectionCut = cms.double(0.5)
         )
     ),
-    cut = cms.string("pt > 18.0 & abs(eta) < 2.4")
+    cut = "pt > 18.0 & abs(eta) < 2.4"
 )
 
 hpsPFTauSecondaryVertexProducer = PFTauSecondaryVertexProducer.clone(
-    PFTauTag = cms.InputTag("hpsPFTauProducer")
+    PFTauTag = "hpsPFTauProducer"
 )
 hpsPFTauTransverseImpactParameters = PFTauTransverseImpactParameters.clone(
-    PFTauTag = cms.InputTag("hpsPFTauProducer"),
-    PFTauPVATag = cms.InputTag("hpsPFTauPrimaryVertexProducer"),
-    PFTauSVATag = cms.InputTag("hpsPFTauSecondaryVertexProducer"),
-    useFullCalculation = cms.bool(True)
+    PFTauTag = "hpsPFTauProducer",
+    PFTauPVATag = "hpsPFTauPrimaryVertexProducer",
+    PFTauSVATag = "hpsPFTauSecondaryVertexProducer",
+    useFullCalculation = True
 )
 hpsPFTauVertexAndImpactParametersTask = cms.Task(
     hpsPFTauPrimaryVertexProducer,
@@ -373,11 +373,11 @@ hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw = discriminationByIsolat
 )
 
 hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT = discriminationByIsolationMVArun2v1.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone(),
-    toMultiplex = cms.InputTag('hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw'),
-    loadMVAfromDB = cms.bool(True),
-    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMwLT_mvaOutput_normalization"),
+    toMultiplex = 'hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw',
+    loadMVAfromDB = True,
+    mvaOutput_normalization = "RecoTauTag_tauIdMVAIsoDBoldDMwLT_mvaOutput_normalization",
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),
@@ -385,7 +385,7 @@ hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT = discriminationByIsolation
             variable = cms.string("pt")
         )
     ),
-    workingPoints = cms.vstring(
+    workingPoints = [
         "_VVLoose",
         "_VLoose",
         "_Loose",
@@ -393,19 +393,19 @@ hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT = discriminationByIsolation
         "_Tight",
         "_VTight",
         "_VVTight"
-    )
+    ]
 )
     
 hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw = hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLTraw.clone(
-    mvaName = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT"),
-    mvaOpt = cms.string("DBnewDMwLTwGJ"),
-    verbosity = cms.int32(0)
+    mvaName = "RecoTauTag_tauIdMVAIsoDBnewDMwLT",
+    mvaOpt  = "DBnewDMwLTwGJ",
+    verbosity = 0
 )
 
 hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLT = hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT.clone(
-    toMultiplex = cms.InputTag('hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw'),
-    loadMVAfromDB = cms.bool(True),
-    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBnewDMwLT_mvaOutput_normalization"),
+    toMultiplex = 'hpsPFTauDiscriminationByIsolationMVArun2v1DBnewDMwLTraw',
+    loadMVAfromDB = True,
+    mvaOutput_normalization = "RecoTauTag_tauIdMVAIsoDBnewDMwLT_mvaOutput_normalization",
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),
@@ -423,11 +423,11 @@ hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw = hpsPFTauDiscrimina
     verbosity = 0
 )
 hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLT = hpsPFTauDiscriminationByIsolationMVArun2v1DBoldDMwLT.clone(
-    PFTauProducer = cms.InputTag('hpsPFTauProducer'),
+    PFTauProducer = 'hpsPFTauProducer',
     Prediscriminants = requireDecayMode.clone(),
-    toMultiplex = cms.InputTag('hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw'),
-    loadMVAfromDB = cms.bool(True),
-    mvaOutput_normalization = cms.string("RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT_mvaOutput_normalization"),
+    toMultiplex = 'hpsPFTauDiscriminationByIsolationMVArun2v1DBdR03oldDMwLTraw',
+    loadMVAfromDB = True,
+    mvaOutput_normalization = "RecoTauTag_tauIdMVAIsoDBoldDMdR0p3wLT_mvaOutput_normalization",
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-import copy
 
 '''
 
@@ -9,12 +8,12 @@ Sequences for reconstructing boosted taus using the HPS algorithm
 
 import CommonTools.ParticleFlow.pfNoPileUp_cff as boostedTaus
 pfPileUpForBoostedTaus = boostedTaus.pfPileUp.clone(
-    PFCandidates = cms.InputTag('particleFlow'),
-    checkClosestZVertex = cms.bool(False)
+    PFCandidates = 'particleFlow',
+    checkClosestZVertex = False
 )
 pfNoPileUpForBoostedTaus = boostedTaus.pfNoPileUp.clone(
-    topCollection = cms.InputTag('pfPileUpForBoostedTaus'),
-    bottomCollection = cms.InputTag('particleFlow')
+    topCollection = 'pfPileUpForBoostedTaus',
+    bottomCollection = 'particleFlow'
 )
 
 
@@ -23,11 +22,11 @@ import RecoJets.JetProducers.CMSBoostedTauSeedingParameters_cfi as boostedTaus3
 ca8PFJetsCHSprunedForBoostedTaus = boostedTaus2.ak4PFJets.clone(
     boostedTaus3.CMSBoostedTauSeedingParameters,
     #src = cms.InputTag('pfNoPileUpForBoostedTaus'),
-    jetPtMin = cms.double(100.0),
-    doAreaFastjet = cms.bool(True),
+    jetPtMin = 100.0,
+    doAreaFastjet = True,
     nFilt = cms.int32(100),
-    rParam = cms.double(0.8),
-    jetAlgorithm = cms.string("CambridgeAachen"),
+    rParam = 0.8,
+    jetAlgorithm = "CambridgeAachen",
     writeCompound = cms.bool(True),
     jetCollInstanceName = cms.string('subJetsForSeedingBoostedTaus')
 )

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -21,7 +21,7 @@ import RecoJets.JetProducers.ak4PFJets_cfi as boostedTaus2
 import RecoJets.JetProducers.CMSBoostedTauSeedingParameters_cfi as boostedTaus3
 ca8PFJetsCHSprunedForBoostedTaus = boostedTaus2.ak4PFJets.clone(
     boostedTaus3.CMSBoostedTauSeedingParameters,
-    #src = cms.InputTag('pfNoPileUpForBoostedTaus'),
+    #src = 'pfNoPileUpForBoostedTaus',
     jetPtMin = 100.0,
     doAreaFastjet = True,
     nFilt = cms.int32(100),

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -2,7 +2,7 @@ import socket
 from CondCore.CondDB.CondDB_cfi import *
 '''Helper procedure that loads mva inputs from database'''
 
-CondDBTauConnection = CondDB.clone( connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ) )
+CondDBTauConnection = CondDB.clone( connect = 'frontier://FrontierProd/CMS_CONDITIONS' )
 
 loadRecoTauTagMVAsFromPrepDB = cms.ESSource( "PoolDBESSource",
                                              CondDBTauConnection,

--- a/RecoTauTag/HLTProducers/python/CandidateSeededTrackingRegionsProducer_cff.py
+++ b/RecoTauTag/HLTProducers/python/CandidateSeededTrackingRegionsProducer_cff.py
@@ -28,11 +28,12 @@ SeededTrackingRegionsFromBeamSpotFixedZLength = cms.PSet(
     )
 )
 
-SeededTrackingRegionsFromBeamSpotSigmaZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone()
-SeededTrackingRegionsFromBeamSpotSigmaZLength.mode = "BeamSpotSigma"
-
-SeededTrackingRegionsFromVerticesFixedZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone()
-SeededTrackingRegionsFromVerticesFixedZLength.mode = "VerticesFixed"
-
-SeededTrackingRegionsFromVerticesSigmaZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone()
-SeededTrackingRegionsFromVerticesSigmaZLength.mode = "VerticesSigma"
+SeededTrackingRegionsFromBeamSpotSigmaZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone(
+    mode = "BeamSpotSigma"
+)
+SeededTrackingRegionsFromVerticesFixedZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone(
+    mode = "VerticesFixed"
+)
+SeededTrackingRegionsFromVerticesSigmaZLength = SeededTrackingRegionsFromBeamSpotFixedZLength.clone(
+    mode = "VerticesSigma"
+)

--- a/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
+++ b/RecoTauTag/HLTProducers/python/PixelTracksL2Tau_cfi.py
@@ -7,6 +7,6 @@ from RecoTauTag.HLTProducers.trackingRegionsFromBeamSpotAndL2Tau_cfi import trac
 # Previously the TrackingRegion was set as a parameter of PixelTrackProducer
 # Now the TrackingRegion EDProducer must be inserted in a sequence, and set as an input to HitPairEDProducer
 
-pixelTracksL2Tau = _pixelTracks.clone()
-pixelTracksL2Tau.passLabel  = cms.string('pixelTracksL2Tau')
-
+pixelTracksL2Tau = _pixelTracks.clone(
+    passLabel = 'pixelTracksL2Tau'
+)

--- a/RecoTauTag/RecoTau/python/HLTPFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/HLTPFRecoTauDiscriminationByIsolation_cfi.py
@@ -5,7 +5,7 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import requireLeadTrack, noPredisc
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByIsolation_cfi import pfRecoTauDiscriminationByIsolation
 
 hltPFRecoTauDiscriminationByIsolation = pfRecoTauDiscriminationByIsolation.clone(
-    PFTauProducer = cms.InputTag('hltPFRecoTauProducer'), #tau collection to discriminate
+    PFTauProducer = 'hltPFRecoTauProducer', #tau collection to discriminate
 
     # Require leading pion ensures that:
     # 1) these is at least one track above threshold (0.5 GeV) in the signal cone
@@ -15,29 +15,29 @@ hltPFRecoTauDiscriminationByIsolation = pfRecoTauDiscriminationByIsolation.clone
     qualityCuts = hltPFTauQualityCuts,# set the standard quality cuts
 
     # Delta-Beta corrections to remove Pileup
-    particleFlowSrc = cms.InputTag("hltParticleFlow"),
+    particleFlowSrc = "hltParticleFlow",
     vertexSrc = hltPFTauQualityCuts.primaryVertexSrc,
-    customOuterCone = cms.double( -1.0 ),
+    customOuterCone = -1.0,
 
     # This must correspond to the cone size of the algorithm which built the
     # tau. (or if customOuterCone option is used, the custom cone size)
-    isoConeSizeForDeltaBeta = cms.double(0.3),
+    isoConeSizeForDeltaBeta = 0.3,
     # The delta beta factor maps the expected neutral contribution in the
     # isolation cone from the observed PU charged contribution.  This factor can
     # optionally be a function (use 'x') of the number of vertices in the event
     # (taken from the multiplicity of vertexSrc collection)
-    deltaBetaFactor = cms.string("0.38"),
+    deltaBetaFactor = "0.38",
     # By default, the pt threshold for tracks used to compute the DeltaBeta
     # correction is taken as the gamma Et threshold from the isolation quality
     # cuts.
-    deltaBetaPUTrackPtCutOverride     = cms.bool(True),  # Set the boolean = True to override.
-    deltaBetaPUTrackPtCutOverride_val = cms.double(0.5), # Set the value for new value.
+    deltaBetaPUTrackPtCutOverride     = True,  # Set the boolean = True to override.
+    deltaBetaPUTrackPtCutOverride_val = 0.5, # Set the value for new value.
 
     # Rho corrections
-    applyRhoCorrection = cms.bool(False),
-    rhoProducer = cms.InputTag("kt6PFJets", "rho"),
-    rhoConeSize = cms.double(0.5),
-    rhoUEOffsetCorrection = cms.double(1.0),
+    applyRhoCorrection = False,
+    rhoProducer = "kt6PFJets:rho",
+    rhoConeSize = 0.5,
+    rhoUEOffsetCorrection = 1.0,
 
     IDdefinitions = cms.VPSet(),
     IDWPdefinitions = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/PATTauDiscriminationByMVAIsolationRun2_cff.py
+++ b/RecoTauTag/RecoTau/python/PATTauDiscriminationByMVAIsolationRun2_cff.py
@@ -28,11 +28,11 @@ patDiscriminationByIsolationMVArun2v1raw = cms.EDProducer("PATTauDiscriminationB
 )
 
 patDiscriminationByIsolationMVArun2v1 = patTauDiscriminantCutMultiplexer.clone(
-    PATTauProducer = cms.InputTag('replaceMeByTauCollectionToBeUsed'), # in MiniAOD: slimmedTaus
+    PATTauProducer = 'replaceMeByTauCollectionToBeUsed', # in MiniAOD: slimmedTaus
     Prediscriminants = noPrediscriminants,
-    toMultiplex = cms.InputTag('patDiscriminationByIsolationMVArun2v1raw'),
-    loadMVAfromDB = cms.bool(True),
-    mvaOutput_normalization = cms.string("replaceMeByNormalizationToBeUsedIfAny"), # e.g. RecoTauTag_tauIdMVADBoldDMwLTv1_mvaOutput_normalization
+    toMultiplex = 'patDiscriminationByIsolationMVArun2v1raw',
+    loadMVAfromDB = True,
+    mvaOutput_normalization = "replaceMeByNormalizationToBeUsedIfAny", # e.g. RecoTauTag_tauIdMVADBoldDMwLTv1_mvaOutput_normalization
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),
@@ -40,13 +40,13 @@ patDiscriminationByIsolationMVArun2v1 = patTauDiscriminantCutMultiplexer.clone(
             variable = cms.string("pt"),
         )
     ),
-    workingPoints = cms.vstring(
+    workingPoints = [
         "Eff80",
         "Eff70",
         "Eff60",
         "Eff50",
         "Eff40"
-    )
+    ]
 )
 
 mvaIsolation2TaskRun2 = cms.Task(

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronBuilderPlugins_cfi.py
@@ -56,11 +56,11 @@ tracks = cms.PSet(
 
 # Produce a ChargedHadron candidate for high Pt PFNeutralHadrons
 PFNeutralHadrons = chargedPFCandidates.clone(
-    name = cms.string("PFNeutralHadrons"),
-    plugin = cms.string("PFRecoTauChargedHadronFromPFCandidatePlugin"),
+    name = "PFNeutralHadrons",
+    plugin = "PFRecoTauChargedHadronFromPFCandidatePlugin",
     # process PFNeutralHadrons
     # (numbering scheme defined in DataFormats/ParticleFlowCandidate/interface/PFCandidate.h)
-    chargedHadronCandidatesParticleIds = cms.vint32(5),
-    minMergeChargedHadronPt = cms.double(0.),
-    verbosity = cms.int32(0)
+    chargedHadronCandidatesParticleIds = [5],
+    minMergeChargedHadronPt = 0.,
+    verbosity = 0
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cff.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cff.py
@@ -11,7 +11,7 @@ ak4PFJetsRecoTauChargedHadrons = pfRecoTauChargedHadronProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    outputSelection = cms.string('pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value()), # CV: apply minimum Pt cut as sanity check
+    outputSelection = 'pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value(), # CV: apply minimum Pt cut as sanity check
     builders = cms.VPSet(
         builders.chargedPFCandidates,
         builders.tracks,

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronQualityPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronQualityPlugins_cfi.py
@@ -18,9 +18,9 @@ isChargedPFCandidate = cms.PSet(
 )
 
 isTrack = isChargedPFCandidate.clone(
-    selection = cms.string("algoIs('kTrack')")
+    selection = "algoIs('kTrack')"
 )
 
 isPFNeutralHadron = isChargedPFCandidate.clone(
-    selection = cms.string("algoIs('kPFNeutralHadron')")
+    selection = "algoIs('kPFNeutralHadron')"
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -11,32 +11,32 @@ pfRecoTauDiscriminationByIsolation = pfRecoTauDiscriminationByIsolationContainer
     Prediscriminants = requireLeadTrack,
 
     # Select which collections to use for isolation. You can select one or both
-    WeightECALIsolation = cms.double(1.), # apply a flat, overall weight to ECAL isolation. Useful to combine charged and neutral isolations with different relative weights. Default 1. 
+    WeightECALIsolation = 1., # apply a flat, overall weight to ECAL isolation. Useful to combine charged and neutral isolations with different relative weights. Default 1. 
 
-    minTauPtForNoIso = cms.double(-99.), # minimum tau pt at which the isolation is completely relaxed. If negative, this is disabled
+    minTauPtForNoIso = -99., # minimum tau pt at which the isolation is completely relaxed. If negative, this is disabled
 
     qualityCuts = PFTauQualityCuts, # set the standard quality cuts
 
     # Delta-Beta corrections to remove Pileup
-    particleFlowSrc = cms.InputTag("particleFlow"),
+    particleFlowSrc = "particleFlow",
     vertexSrc = PFTauQualityCuts.primaryVertexSrc,
     # This must correspond to the cone size of the algorithm which built the
     # tau. (or if customOuterCone option is used, the custom cone size)
-    customOuterCone = cms.double(-1.), # propagated this default from .cc, it probably corresponds to not using customOuterCone
-    isoConeSizeForDeltaBeta = cms.double(0.5),
+    customOuterCone = -1., # propagated this default from .cc, it probably corresponds to not using customOuterCone
+    isoConeSizeForDeltaBeta = 0.5,
     # The delta beta factor maps the expected neutral contribution in the
     # isolation cone from the observed PU charged contribution.  This factor can
     # optionally be a function (use 'x') of the number of vertices in the event
     # (taken from the multiplicity of vertexSrc collection)
-    deltaBetaFactor = cms.string("0.38"),
+    deltaBetaFactor = "0.38",
     # By default, the pt threshold for tracks used to compute the DeltaBeta
     # correction is taken as the gamma Et threshold from the isolation quality
     # cuts.
-    deltaBetaPUTrackPtCutOverride     = cms.bool(False),  # Set the boolean = True to override.
-    deltaBetaPUTrackPtCutOverride_val = cms.double(-1.5), # Set the value for new value.
+    deltaBetaPUTrackPtCutOverride     = False,  # Set the boolean = True to override.
+    deltaBetaPUTrackPtCutOverride_val = -1.5, # Set the value for new value.
 
     # Tau footprint correction
-    applyFootprintCorrection = cms.bool(False),
+    applyFootprintCorrection = False,
     footprintCorrections = cms.VPSet(
         cms.PSet(
             selection = cms.string("decayMode() = 0"),
@@ -61,10 +61,10 @@ pfRecoTauDiscriminationByIsolation = pfRecoTauDiscriminationByIsolationContainer
     ),                                                        
 
     # Rho corrections
-    applyRhoCorrection = cms.bool(False),
-    rhoProducer = cms.InputTag("fixedGridRhoFastjetAll"),
-    rhoConeSize = cms.double(0.5),
-    rhoUEOffsetCorrection = cms.double(1.0),
+    applyRhoCorrection = False,
+    rhoProducer = "fixedGridRhoFastjetAll",
+    rhoConeSize = 0.5,
+    rhoUEOffsetCorrection = 1.0,
 
-    verbosity = cms.int32(0),
+    verbosity = 0,
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByLeadingTrackFinding_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByLeadingTrackFinding_cfi.py
@@ -4,16 +4,16 @@ from RecoTauTag.RecoTau.PFRecoTauDiscriminationByLeadingObjectPtCut_cfi import p
 
 pfRecoTauDiscriminationByLeadingTrackFinding = pfRecoTauDiscriminationByLeadingObjectPtCut.clone(
     # Tau collection to discriminate
-    PFTauProducer = cms.InputTag('pfRecoTauProducer'),
+    PFTauProducer = 'pfRecoTauProducer',
 
     # Only look for charged PFCandidates
-    UseOnlyChargedHadrons = cms.bool(True),            
+    UseOnlyChargedHadrons = True,            
 
     # no pre-reqs for this cut
     Prediscriminants = noPrediscriminants,
 
     # Any *existing* charged PFCandidate will meet this requirement - so it is 
     # a test for existence, not pt
-    MinPtLeadingObject = cms.double(0.0)
+    MinPtLeadingObject = 0.0
 )
 

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolation2_cff.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolation2_cff.py
@@ -29,10 +29,10 @@ discriminationByIsolationMVA2raw = cms.EDProducer("PFRecoTauDiscriminationByIsol
 )
 
 discriminationByIsolationMVA2 = recoTauDiscriminantCutMultiplexerDefault.clone(
-    PFTauProducer = cms.InputTag('pfTauProducer'),    
+    PFTauProducer = 'pfTauProducer',    
     Prediscriminants = requireLeadTrack,
-    toMultiplex = cms.InputTag('discriminationByIsolationMVA2raw'),
-    loadMVAfromDB = cms.bool(True),
+    toMultiplex = 'discriminationByIsolationMVA2raw',
+    loadMVAfromDB = True,
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),
@@ -40,13 +40,13 @@ discriminationByIsolationMVA2 = recoTauDiscriminantCutMultiplexerDefault.clone(
             variable = cms.string("pt"),
         )
     ),
-    workingPoints = cms.vstring(
+    workingPoints = [
         "Eff80",
         "Eff70",
         "Eff60",
         "Eff50",
         "Eff40"
-    )
+    ]
 )
 
 mvaIsolation2Task = cms.Task(

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolationRun2_cff.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByMVAIsolationRun2_cff.py
@@ -8,22 +8,22 @@ from RecoTauTag.Configuration.HPSPFTaus_cff import hpsPFTauBasicDiscriminators
 discriminationByIsolationMVArun2v1raw = pfRecoTauDiscriminationByMVAIsolationRun2.clone(
 
     # tau collection to discriminate
-    PFTauProducer = cms.InputTag('pfTauProducer'),
+    PFTauProducer = 'pfTauProducer',
 
     # Require leading pion ensures that:
     #  1) these is at least one track above threshold (0.5 GeV) in the signal cone
     #  2) a track OR a pi-zero in the signal cone has pT > 5 GeV
     Prediscriminants = requireLeadTrack,
-    loadMVAfromDB = cms.bool(True),
+    loadMVAfromDB = True,
         
-    srcBasicTauDiscriminators = cms.InputTag('hpsPFTauBasicDiscriminators')
+    srcBasicTauDiscriminators = 'hpsPFTauBasicDiscriminators'
 )
 
 discriminationByIsolationMVArun2v1 = recoTauDiscriminantCutMultiplexerDefault.clone(
-    PFTauProducer = cms.InputTag('pfTauProducer'),    
+    PFTauProducer = 'pfTauProducer',    
     Prediscriminants = requireLeadTrack,
-    toMultiplex = cms.InputTag('discriminationByIsolationMVArun2v1raw'),
-    loadMVAfromDB = cms.bool(True),
+    toMultiplex = 'discriminationByIsolationMVArun2v1raw',
+    loadMVAfromDB = True,
     mapping = cms.VPSet(
         cms.PSet(
             category = cms.uint32(0),

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
@@ -44,9 +44,9 @@ strips = cms.PSet(
 )
 
 comboStrips = strips.clone(
-    name = cms.string("cs"),
-    plugin = cms.string("RecoTauPiZeroStripPlugin"),
-    makeCombinatoricStrips = cms.bool(True),
+    name = "cs",
+    plugin = "RecoTauPiZeroStripPlugin",
+    makeCombinatoricStrips = True,
     maxInputStrips = cms.int32(5),
     stripMassWhenCombining = cms.double(0.0), # assume photon like
 )
@@ -68,7 +68,7 @@ modStrips = strips.clone(
 # and eta x phi size of strip increasing for low pT photons
 
 modStrips2 = strips.clone(
-    plugin = cms.string('RecoTauPiZeroStripPlugin3'),
+    plugin = 'RecoTauPiZeroStripPlugin3',
     qualityCuts = PFTauQualityCuts,
     applyElecTrackQcuts = cms.bool(False),
     stripEtaAssociationDistanceFunc = cms.PSet(

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroBuilderPlugins_cfi.py
@@ -54,7 +54,7 @@ comboStrips = strips.clone(
 # Produce a "strips" of photons
 # with no track quality cuts applied to PFElectrons
 modStrips = strips.clone(
-    plugin = cms.string('RecoTauPiZeroStripPlugin2'),
+    plugin = 'RecoTauPiZeroStripPlugin2',
     applyElecTrackQcuts = cms.bool(False),
     minGammaEtStripSeed = cms.double(1.0),
     minGammaEtStripAdd = cms.double(1.0),
@@ -81,7 +81,7 @@ modStrips2 = strips.clone(
         par0 = cms.double(3.52476e-01),
         par1 = cms.double(7.07716e-01)
     ),
-    makeCombinatoricStrips = cms.bool(False),
+    makeCombinatoricStrips = False,
     minGammaEtStripSeed = cms.double(1.0),
     minGammaEtStripAdd = cms.double(1.0),
     minStripEt = cms.double(1.0),

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cff.py
@@ -27,7 +27,7 @@ ak4PFJetsRecoTauGreedyPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    outputSelection = cms.string('pt > 1.5'),
+    outputSelection = 'pt > 1.5',
     builders = cms.VPSet(
         builders.comboStrips
     ),
@@ -41,7 +41,7 @@ ak4PFJetsRecoTauPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    outputSelection = cms.string('pt > 1.5'),
+    outputSelection = 'pt > 1.5',
     builders = cms.VPSet(
         builders.combinatoricPhotonPairs,
         builders.modStrips2
@@ -58,7 +58,7 @@ ak4PFJetsLegacyTaNCPiZeros = recoTauPiZeroProducer.clone(
     jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     minJetPt = PFRecoTauPFJetInputs.minJetPt,
     maxJetAbsEta = PFRecoTauPFJetInputs.maxJetAbsEta,
-    outputSelection = cms.string('pt > 1.5'),
+    outputSelection = 'pt > 1.5',
     builders = cms.VPSet(
         builders.allSinglePhotons,
         builders.combinatoricPhotonPairs


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389), [PR#31523](https://github.com/cms-sw/cmssw/pull/31523), [PR#31538](https://github.com/cms-sw/cmssw/pull/31538))

In this PR, total 17 files changed. 
- RecoTauTag/Configuration  : 4 files 
- RecoTauTag/HLTProducers : 2 files
- RecoTauTag/RecoTau :  11 files 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).