### PR TITLE
Removed Framework depencency from L1MuBMTrack

### DIFF
--- a/DataFormats/L1TMuon/interface/L1MuBMTrack.h
+++ b/DataFormats/L1TMuon/interface/L1MuBMTrack.h
@@ -32,8 +32,6 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/L1TMuon/interface/BMTF/L1MuBMTrackAssParam.h"
 #include "DataFormats/L1TMuon/interface/BMTF/L1MuBMAddressArray.h"
 #include "DataFormats/L1TMuon/interface/BMTF/L1MuBMSecProcId.h"
@@ -172,9 +170,6 @@ public:
 
   /// set eta track segments used to form the muon candidate
   void setTSeta(const std::vector<const L1MuBMTrackSegEta*>& tsList);
-
-  /// convert  pt value in GeV to pt code
-  unsigned int triggerScale(float value, const edm::EventSetup& c) const;
 
   /// assignment operator
   L1MuBMTrack& operator=(const L1MuBMTrack&);

--- a/DataFormats/L1TMuon/src/L1MuBMTrack.cc
+++ b/DataFormats/L1TMuon/src/L1MuBMTrack.cc
@@ -168,20 +168,6 @@ void L1MuBMTrack::setTSeta(const vector<const L1MuBMTrackSegEta*>& tsList) {
 }
 
 //
-// convert pt value in GeV to pt code
-//
-unsigned int L1MuBMTrack::triggerScale(float value, const edm::EventSetup& c) const {
-  /*const float eps = 1.e-5; // add an epsilon so that setting works with low edge value
-
-  edm::ESHandle< L1MuTriggerPtScale > theTriggerScales;
-  c.get< L1MuTriggerPtScaleRcd >().get( theTriggerScales );
-  unsigned int t_Scale = theTriggerScales->getPtScale()->getPacked( value + eps );
-
-  return t_Scale;*/
-  return (unsigned int)0.5;
-}
-
-//
 // Assignment operator
 //
 L1MuBMTrack& L1MuBMTrack::operator=(const L1MuBMTrack& track) {


### PR DESCRIPTION
#### PR description:

The function triggerScale did not actually use the EventSetup nor does any code actually call the function.

This fixes the code-violation of a DataFormats class depending upon FWCore/Framework.

#### PR validation:

The code compiles.