### PR TITLE
TrackingMaterialProducer fix in volume accounting

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/TrackingMaterialProducer.cc
@@ -285,7 +285,7 @@ void TrackingMaterialProducer::update(const G4Step* step) {
   // update track accounting
   if (enter_sensitive) {
     if (m_track_volume != nullptr) {
-      edm::LogWarning("TrackingMaterialProducer") << "Entering volume " << sensitive << "while inside volume "
+      edm::LogWarning("TrackingMaterialProducer") << "Entering volume " << sensitive << " while inside volume "
                                                   << m_track_volume << ". Something is inconsistent";
       m_track.reset();
     }
@@ -295,11 +295,12 @@ void TrackingMaterialProducer::update(const G4Step* step) {
   m_track.step(MaterialAccountingStep(length, radiationLengths, energyLoss, globalPositionIn, globalPositionOut));
   if (leave_sensitive) {
     if (m_track_volume != sensitive) {
-      edm::LogWarning("TrackingMaterialProducer") << "Leaving volume " << sensitive << "while inside volume "
+      edm::LogWarning("TrackingMaterialProducer") << "Leaving volume " << sensitive << " while inside volume "
                                                   << m_track_volume << ". Something is inconsistent";
       m_track.reset();
     } else
       m_track.leaveDetector(cosThetaPost);
+    m_track_volume = nullptr;
   }
   if (sensitive)
     LogInfo("TrackingMaterialProducer") << "Track was near sensitive     volume " << sensitive->GetName() << std::endl;


### PR DESCRIPTION
bugfix: missed reseting the track_volume to null_ptr when leaving volume in SimTracker/TrackerMaterialAnalysis TrackingMaterialProducer. Discussion is in #31273 
