### PR TITLE
migrate Strip Hit Efficiency HitEff class to use esconsumes

### DIFF
--- a/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
+++ b/CalibTracker/SiStripHitEfficiency/interface/HitEff.h
@@ -12,6 +12,8 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoLocalTracker/Records/interface/TkStripCPERecord.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
@@ -81,6 +83,17 @@ private:
   const edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clusters_token_;
   const edm::EDGetTokenT<DetIdCollection> digis_token_;
   const edm::EDGetTokenT<MeasurementTrackerEvent> trackerEvent_token_;
+
+  // ES tokens
+
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<StripClusterParameterEstimator, TkStripCPERecord> cpeToken_;
+  const edm::ESGetToken<SiStripQuality, SiStripQualityRcd> siStripQualityToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTkToken_;
+  const edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> chi2MeasurementEstimatorToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
 
   edm::ParameterSet conf_;
 


### PR DESCRIPTION
#### PR description:

Title says it all. Part of https://github.com/cms-sw/cmssw/issues/31061

#### PR validation:

Run the unit tests in `CalibTracker/SiStripCommon`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
