### PR TITLE
Migrate rest of MuonIdProducer to EventSetup consumes

### DIFF
--- a/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
@@ -26,7 +26,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
@@ -36,6 +35,7 @@
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 #include "DataFormats/MuonReco/interface/MuonChamberMatch.h"
 #include "TrackingTools/TrackAssociator/interface/TAMuonChamberMatch.h"
@@ -59,6 +59,9 @@ private:
 
   edm::EDGetTokenT<DTDigiCollection> m_dtDigisToken;
   edm::EDGetTokenT<CSCStripDigiCollection> m_cscDigisToken;
+
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> m_dtGeometryToken;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_cscGeometryToken;
 
   edm::ESHandle<DTGeometry> m_dtGeometry;
   edm::ESHandle<CSCGeometry> m_cscGeometry;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -246,6 +246,9 @@ private:
   edm::Handle<RPCRecHitCollection> rpcHitHandle_;
   edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
 
+  const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> geomTokenRun_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+
   MuonCaloCompatibility muonCaloCompatibility_;
   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorCalo_;
   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorTrack_;

--- a/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
@@ -20,8 +20,6 @@
 // user include files
 #include "RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h"
 
-#include "Geometry/Records/interface/MuonGeometryRecord.h"
-
 //
 // constructors and destructor
 //
@@ -30,15 +28,17 @@ MuonShowerDigiFiller::MuonShowerDigiFiller(const edm::ParameterSet& iConfig, edm
     : m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX")),
       m_dtDigisToken(iC.consumes<DTDigiCollection>(iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel"))),
       m_cscDigisToken(
-          iC.consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel"))) {}
+          iC.consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel"))),
+      m_dtGeometryToken(iC.esConsumes<edm::Transition::BeginRun>()),
+      m_cscGeometryToken(iC.esConsumes<edm::Transition::BeginRun>()) {}
 
 //
 // member functions
 //
 
 void MuonShowerDigiFiller::getES(const edm::EventSetup& iSetup) {
-  iSetup.get<MuonGeometryRecord>().get(m_dtGeometry);
-  iSetup.get<MuonGeometryRecord>().get(m_cscGeometry);
+  m_dtGeometry = iSetup.getHandle(m_dtGeometryToken);
+  m_cscGeometry = iSetup.getHandle(m_cscGeometryToken);
 }
 
 void MuonShowerDigiFiller::getDigis(edm::Event& iEvent) {


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. It completes the EventSetup-consumes migration for `MuonIdProducer` was partly migrated earlier, but was causing failures in #31746.

#### PR validation:

Code compiles, this module no longer triggers the exception of #31746 in a job using it.

