### PR TITLE
Complete EventSetup migration for bunch of L1 modules

### DIFF
--- a/DQM/L1TMonitor/interface/L1TMenuHelper.h
+++ b/DQM/L1TMonitor/interface/L1TMenuHelper.h
@@ -18,7 +18,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -78,8 +77,21 @@ struct SingleObjectTrigger {
 
 class L1TMenuHelper {
 public:
-  L1TMenuHelper(const edm::EventSetup& iSetup);  // Constructor
-  ~L1TMenuHelper();                              // Destructor
+  struct Tokens {
+    edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> menu;
+    edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> l1GtPfAlgo;
+  };
+
+  template <edm::Transition Tr = edm::Transition::Event>
+  static Tokens consumes(edm::ConsumesCollector iC) {
+    Tokens tok;
+    tok.menu = iC.esConsumes<Tr>();
+    tok.l1GtPfAlgo = iC.esConsumes<Tr>();
+    return tok;
+  }
+
+  L1TMenuHelper(const edm::EventSetup& iSetup, const Tokens& tokens);  // Constructor
+  ~L1TMenuHelper();                                                    // Destructor
 
   // Get Lowest Unprescaled Single Object Triggers
   std::map<std::string, std::string> getLUSOTrigger(const std::map<std::string, bool>& iCategories,
@@ -98,9 +110,6 @@ public:
   unsigned int getQualityAlias(const TString& iCategory, const TString& iAlias);
 
 private:
-  edm::ESHandle<L1GtTriggerMenu> menuRcd;
-  edm::ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-
   const L1GtTriggerMenu* m_l1GtMenu;
   const std::vector<std::vector<int> >* m_prescaleFactorsAlgoTrig;
 

--- a/DQM/L1TMonitor/interface/L1TRate.h
+++ b/DQM/L1TMonitor/interface/L1TRate.h
@@ -14,8 +14,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,7 +21,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Scalers/interface/LumiScalers.h"
@@ -34,6 +31,8 @@
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
+
+#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
 
 #include <TString.h>
 
@@ -97,6 +96,9 @@ private:
   edm::EDGetTokenT<LumiScalersCollection> m_scalersSource_colLScal;                 // Where to get L1 Scalers
   edm::EDGetTokenT<Level1TriggerScalersCollection> m_scalersSource_triggerScalers;  // Where to get L1 Scalers
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtDataDaqInputTag;             // Where to get L1 GT Data DAQ
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_menuToken;
+  const edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> m_l1GtPfAlgoToken;
+  L1TMenuHelper::Tokens m_helperTokens;
 
   // ParameterSet
   edm::ParameterSet m_parameters;

--- a/DQM/L1TMonitor/interface/L1TSync.h
+++ b/DQM/L1TMonitor/interface/L1TSync.h
@@ -14,8 +14,6 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,9 +21,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
 #include "DQM/L1TMonitor/interface/L1TOMDSHelper.h"
 
 //DataFormats
@@ -135,6 +133,8 @@ private:
   // Input tags
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtEvmSource;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtDataDaqInputTag;
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_menuToken;
+  L1TMenuHelper::Tokens m_helperTokens;
 
   L1GtUtils m_l1GtUtils;
 };

--- a/DQM/L1TMonitor/src/L1TMenuHelper.cc
+++ b/DQM/L1TMonitor/src/L1TMenuHelper.cc
@@ -35,14 +35,10 @@ using namespace std;
 //-------------------------------------------------------------------------------------
 //
 //-------------------------------------------------------------------------------------
-L1TMenuHelper::L1TMenuHelper(const edm::EventSetup& iSetup) {
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  iSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-
-  const L1GtPrescaleFactors* m_l1GtPfAlgo = l1GtPfAlgo.product();
-
-  m_l1GtMenu = menuRcd.product();                                    // Getting the menu
-  m_prescaleFactorsAlgoTrig = &(m_l1GtPfAlgo->gtPrescaleFactors());  // Retriving the list of prescale sets
+L1TMenuHelper::L1TMenuHelper(const edm::EventSetup& iSetup, const Tokens& tokens) {
+  m_l1GtMenu = &iSetup.getData(tokens.menu);  // Getting the menu
+  m_prescaleFactorsAlgoTrig =
+      &(iSetup.getData(tokens.l1GtPfAlgo).gtPrescaleFactors());  // Retriving the list of prescale sets
 }
 
 //-------------------------------------------------------------------------------------

--- a/DQM/L1TMonitor/src/L1TSync.cc
+++ b/DQM/L1TMonitor/src/L1TSync.cc
@@ -27,9 +27,6 @@
 //#include "DataFormats/Luminosity/interface/LumiDetails.h"
 //#include "DataFormats/Luminosity/interface/LumiSummary.h"
 
-// L1TMonitor includes
-#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
-
 #include "TList.h"
 
 using namespace edm;
@@ -37,7 +34,10 @@ using namespace std;
 
 //-------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------
-L1TSync::L1TSync(const ParameterSet& pset) : m_l1GtUtils(pset, consumesCollector(), false, *this) {
+L1TSync::L1TSync(const ParameterSet& pset)
+    : m_menuToken(esConsumes<edm::Transition::BeginRun>()),
+      m_helperTokens(L1TMenuHelper::consumes<edm::Transition::BeginRun>(consumesCollector())),
+      m_l1GtUtils(pset, consumesCollector(), false, *this) {
   m_parameters = pset;
 
   // Mapping parameter input variables
@@ -319,13 +319,11 @@ void L1TSync::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const 
   m_certLastLS.clear();
 
   // Getting Trigger menu from GT
-  ESHandle<L1GtTriggerMenu> menuRcd;
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  const L1GtTriggerMenu* menu = menuRcd.product();
+  const L1GtTriggerMenu& menu = iSetup.getData(m_menuToken);
 
   // Filling Alias-Bit Map
-  for (CItAlgo algo = menu->gtAlgorithmAliasMap().begin(); algo != menu->gtAlgorithmAliasMap().end(); ++algo) {
-    m_algoBit[(algo->second).algoAlias()] = (algo->second).algoBitNumber();
+  for (const auto& algo : menu.gtAlgorithmAliasMap()) {
+    m_algoBit[algo.second.algoAlias()] = algo.second.algoBitNumber();
   }
 
   // Getting fill number for this run
@@ -337,7 +335,7 @@ void L1TSync::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, const 
   //iSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
   //const L1GtPrescaleFactors* m_l1GtPfAlgo = l1GtPfAlgo.product();
 
-  L1TMenuHelper myMenuHelper = L1TMenuHelper(iSetup);
+  L1TMenuHelper myMenuHelper = L1TMenuHelper(iSetup, m_helperTokens);
 
   m_selectedTriggers = myMenuHelper.testAlgos(m_selectedTriggers);
 

--- a/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TRate_Offline.h
@@ -8,8 +8,6 @@
 // user include files
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,7 +15,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //DataFormats
@@ -30,6 +27,8 @@
 #include "DataFormats/Luminosity/interface/LumiSummary.h"  // Luminosity Information
 
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
+
+#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
 
 #include <TString.h>
 
@@ -117,6 +116,9 @@ private:
   // MonitorElement
   MonitorElement* m_ErrorMonitor;
 
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_menuToken;
+  const edm::ESGetToken<L1GtPrescaleFactors, L1GtPrescaleFactorsAlgoTrigRcd> m_l1GtPfAlgoToken;
+  L1TMenuHelper::Tokens m_helperTokens;
   L1GtUtils m_l1GtUtils;
 };
 

--- a/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
+++ b/DQMOffline/L1Trigger/interface/L1TSync_Offline.h
@@ -29,8 +29,6 @@
 // User include files
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,10 +36,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //L1 includes and dataformats
+#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
 #include "DQMOffline/L1Trigger/interface/L1TBeamConfiguration.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerEvmReadoutRecord.h"
@@ -155,6 +153,8 @@ private:
   // Input tags
   edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> m_l1GtEvmSource;
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtDataDaqInputTag;
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_menuToken;
+  L1TMenuHelper::Tokens m_helperTokens;
 
   L1GtUtils m_l1GtUtils;
 };

--- a/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
+++ b/DQMOffline/L1Trigger/src/L1TRate_Offline.cc
@@ -1,6 +1,5 @@
 // L1TMonitor includes
 #include "DQMOffline/L1Trigger/interface/L1TRate_Offline.h"
-#include "DQM/L1TMonitor/interface/L1TMenuHelper.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
@@ -16,7 +15,11 @@ using namespace edm;
 using namespace std;
 
 //_____________________________________________________________________
-L1TRate_Offline::L1TRate_Offline(const ParameterSet& ps) : m_l1GtUtils(ps, consumesCollector(), false, *this) {
+L1TRate_Offline::L1TRate_Offline(const ParameterSet& ps)
+    : m_menuToken(esConsumes<edm::Transition::BeginRun>()),
+      m_l1GtPfAlgoToken(esConsumes<edm::Transition::BeginRun>()),
+      m_helperTokens(L1TMenuHelper::consumes<edm::Transition::BeginRun>(consumesCollector())),
+      m_l1GtUtils(ps, consumesCollector(), false, *this) {
   m_maxNbins = 2500;  // Maximum LS for each run (for binning purposes)
   m_parameters = ps;
 
@@ -63,14 +66,8 @@ void L1TRate_Offline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
     cout << "[L1TRate_Offline:] Called beginRun." << endl;
   }
 
-  ESHandle<L1GtTriggerMenu> menuRcd;
-  ESHandle<L1GtPrescaleFactors> l1GtPfAlgo;
-
-  iSetup.get<L1GtTriggerMenuRcd>().get(menuRcd);
-  iSetup.get<L1GtPrescaleFactorsAlgoTrigRcd>().get(l1GtPfAlgo);
-
-  const L1GtTriggerMenu* menu = menuRcd.product();
-  const L1GtPrescaleFactors* m_l1GtPfAlgo = l1GtPfAlgo.product();
+  const L1GtTriggerMenu& menu = iSetup.getData(m_menuToken);
+  const L1GtPrescaleFactors& l1GtPfAlgo = iSetup.getData(m_l1GtPfAlgoToken);
 
   // Initializing DQM Monitor Elements
   ibooker.setCurrentFolder("L1T/L1TRate");
@@ -83,18 +80,18 @@ void L1TRate_Offline::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&
   }
 
   // Retriving the list of prescale sets
-  m_listsPrescaleFactors = &(m_l1GtPfAlgo->gtPrescaleFactors());
+  m_listsPrescaleFactors = &(l1GtPfAlgo.gtPrescaleFactors());
 
   // Getting Lowest Prescale Single Object Triggers from the menu
-  L1TMenuHelper myMenuHelper = L1TMenuHelper(iSetup);
+  L1TMenuHelper myMenuHelper = L1TMenuHelper(iSetup, m_helperTokens);
   m_l1GtUtils.retrieveL1EventSetup(iSetup);
   m_selectedTriggers = myMenuHelper.getLUSOTrigger(m_inputCategories, m_refPrescaleSet, m_l1GtUtils);
 
   //-> Getting template fits for the algLo cross sections
   getXSexFitsPython(m_parameters);
 
-  for (CItAlgo algo = menu->gtAlgorithmMap().begin(); algo != menu->gtAlgorithmMap().end(); ++algo) {
-    m_algoBit[(algo->second).algoAlias()] = (algo->second).algoBitNumber();
+  for (const auto& algo : menu.gtAlgorithmMap()) {
+    m_algoBit[(algo.second).algoAlias()] = (algo.second).algoBitNumber();
   }
 
   double minInstantLuminosity = m_parameters.getParameter<double>("minInstantLuminosity");

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
@@ -21,6 +21,9 @@
 #include <vector>
 
 // user include files
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
+#include "CondFormats/DataRecord/interface/L1CaloGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
@@ -102,13 +105,14 @@ private:
   // cached stuff
 
   // trigger menu
-  const L1GtTriggerMenu *m_l1GtMenu;
-  unsigned long long m_l1GtMenuCacheID;
+  const edm::ESGetToken<L1GtTriggerMenu, L1GtTriggerMenuRcd> m_l1GtMenuToken;
 
   // L1 scales (phi, eta) for Mu, Calo and EnergySum objects
+  const edm::ESGetToken<L1CaloGeometry, L1CaloGeometryRecord> m_l1CaloGeometryToken;
   const L1CaloGeometry *m_l1CaloGeometry;
   unsigned long long m_l1CaloGeometryCacheID;
 
+  const edm::ESGetToken<L1MuTriggerScales, L1MuTriggerScalesRcd> m_l1MuTriggerScalesToken;
   const L1MuTriggerScales *m_l1MuTriggerScales;
   unsigned long long m_l1MuTriggerScalesCacheID;
 

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtils.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtils.cc
@@ -230,9 +230,6 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup, bool isRun)
   unsigned long long l1GtTmVetoAlgoCacheID = l1GtTriggerMaskVetoAlgoTrigRcd.cacheIdentifier();
 
   if (m_l1GtTmVetoAlgoCacheID != l1GtTmVetoAlgoCacheID) {
-    edm::ESHandle<L1GtTriggerMask> l1GtTmVetoAlgo;
-    evSetup.get<L1GtTriggerMaskVetoAlgoTrigRcd>().get(l1GtTmVetoAlgo);
-    m_l1GtTmVetoAlgo = l1GtTmVetoAlgo.product();
     if (isRun) {
       m_l1GtTmVetoAlgo = &l1GtTriggerMaskVetoAlgoTrigRcd.get(m_L1GtTriggerMaskVetoAlgoTrigRunToken);
     } else {
@@ -266,9 +263,6 @@ void L1GtUtils::retrieveL1EventSetup(const edm::EventSetup& evSetup, bool isRun)
   unsigned long long l1GtMenuCacheID = l1GtTriggerMenuRcd.cacheIdentifier();
 
   if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
-    edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-    evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
-    m_l1GtMenu = l1GtMenu.product();
     if (isRun) {
       m_l1GtMenu = &l1GtTriggerMenuRcd.get(m_L1GtTriggerMenuRunToken);
     } else {


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. It completes the EventSetup-consumes migration for bunch of L1 modules that were partly migrated earlier, but were causing failures in #31746.

#### PR validation:

Code compiles, these modules no longer triggers the exception of #31746 in a job using them.