### PR TITLE
MTD geometry/reconstruction: define new ETL reco layer geometry, update LGAD pixel structure, activate workflows for scenarios D72 and D73

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C11_etlV4_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11_etlV4_cff.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+
+Phase2C11_etlV4 = cms.ModifierChain(Phase2C11, phase2_etlV4)

--- a/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
@@ -1,0 +1,3 @@
+import FWCore.ParameterSet.Config as cms
+ 
+phase2_etlV4 =  cms.Modifier()

--- a/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
+++ b/Configuration/Eras/python/Modifier_phase2_etlV4_cff.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
- 
+
 phase2_etlV4 =  cms.Modifier()

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -1186,7 +1186,7 @@ timingDict = {
             'from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *',
             'mtdGeometry.applyAlignment = cms.bool(False)'
         ],
-        "era" : "phase2_timing, phase2_timing_layer",
+        "era" : "phase2_timing, phase2_timing_layer, phase2_etlV4",
     },
     "I13" : {
         1 : [
@@ -1214,7 +1214,7 @@ timingDict = {
            'from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *',
            'mtdGeometry.applyAlignment = cms.bool(False)'
            ],
-       "era" : "phase2_timing, phase2_timing_layer",
+       "era" : "phase2_timing, phase2_timing_layer, phase2_etlV4",
     },
 }
 

--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -29,6 +29,8 @@ numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([31834.0]) #2026D69
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([32634.0]) #2026D71
+numWFIB.extend([33034.0]) #2026D72
+numWFIB.extend([33434.0]) #2026D73
 numWFIB.extend([33834.0]) #2026D74
 
 for numWF in numWFIB:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1020,14 +1020,14 @@ upgradeProperties[2026] = {
         'Geom' : 'Extended2026D72',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C11',
+        'Era' : 'Phase2C11_etlV4',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D73' : {
         'Geom' : 'Extended2026D73',
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T21',
-        'Era' : 'Phase2C11',
+        'Era' : 'Phase2C11_etlV4',
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D74' : {

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -42,6 +42,7 @@ class Eras (object):
                  'Phase2C9_dd4hep',
                  'Phase2C10_dd4hep',
                  'Phase2C11_dd4hep',
+                 'Phase2C11_etlV4',
                  'Phase2C12_dd4hep',
                  'Phase2C11M9',
         ]

--- a/DataFormats/GeometrySurface/interface/BoundDiskSector.h
+++ b/DataFormats/GeometrySurface/interface/BoundDiskSector.h
@@ -1,10 +1,9 @@
-#ifndef RecoTracker_TkDetLayers_BoundDiskSector_h
-#define RecoTracker_TkDetLayers_BoundDiskSector_h
+#ifndef DataFormats_GeometrySurface_BoundDiskSector_h
+#define DataFormats_GeometrySurface_BoundDiskSector_h
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DiskSectorBounds.h"
 
-#pragma GCC visibility push(hidden)
 class BoundDiskSector final : public Plane {
 public:
   ~BoundDiskSector() override {}
@@ -19,5 +18,4 @@ public:
   DiskSectorBounds const& bounds() const { return static_cast<DiskSectorBounds const&>(Plane::bounds()); }
 };
 
-#pragma GCC visibility pop
 #endif

--- a/DataFormats/GeometrySurface/interface/DiskSectorBounds.h
+++ b/DataFormats/GeometrySurface/interface/DiskSectorBounds.h
@@ -1,5 +1,5 @@
-#ifndef RecoTracker_TkDetLayers_DiskSectorBounds_h
-#define RecoTracker_TkDetLayers_DiskSectorBounds_h
+#ifndef DataFormats_GeometrySurface_DiskSectorBounds_h
+#define DataFormats_GeometrySurface_DiskSectorBounds_h
 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
@@ -8,7 +8,6 @@
 #include <cmath>
 #include <cassert>
 
-#pragma GCC visibility push(hidden)
 class DiskSectorBounds final : public Bounds {
 public:
   DiskSectorBounds(float rmin, float rmax, float zmin, float zmax, float phiExt)
@@ -44,5 +43,4 @@ private:
   float theOffset;
 };
 
-#pragma GCC visibility pop
 #endif

--- a/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
+++ b/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
@@ -1,4 +1,4 @@
-#include "DiskSectorBounds.h"
+#include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 
 using namespace std;
 

--- a/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
+++ b/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
@@ -1,5 +1,3 @@
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 
 using namespace std;
@@ -8,8 +6,6 @@ bool DiskSectorBounds::inside(const Local3DPoint& p) const {
   // transform to system with local frame situated at disk center
   // and rotated  x/y axis
   Local3DPoint tmp(p.y() + theOffset, -p.x(), p.z());
-
-  edm::LogWarning("DiskSectorBounds") << tmp;
 
   return ((tmp.z() >= theZmin) & (tmp.z() <= theZmax) & (tmp.perp2() >= theRmin * theRmin) &
           (tmp.perp2() <= theRmax * theRmax)) &&

--- a/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
+++ b/DataFormats/GeometrySurface/src/DiskSectorBounds.cc
@@ -1,3 +1,5 @@
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
 #include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 
 using namespace std;
@@ -6,6 +8,8 @@ bool DiskSectorBounds::inside(const Local3DPoint& p) const {
   // transform to system with local frame situated at disk center
   // and rotated  x/y axis
   Local3DPoint tmp(p.y() + theOffset, -p.x(), p.z());
+
+  edm::LogWarning("DiskSectorBounds") << tmp;
 
   return ((tmp.z() >= theZmin) & (tmp.z() <= theZmax) & (tmp.perp2() >= theRmin * theRmin) &
           (tmp.perp2() <= theRmax * theRmax)) &&

--- a/Geometry/MTDCommonData/data/mtdParameters/v2/mtdParameters.xml
+++ b/Geometry/MTDCommonData/data/mtdParameters/v2/mtdParameters.xml
@@ -9,7 +9,7 @@
     22, 24, 16, 10, 0x1, 0x3, 0x3F, 0x3F, 1, 16, 3, 1
   </Vector>
   <Vector name="ETL" type="numeric" nEntries="12">
-    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 24, 4, 2, 8
+    22, 24, 16, 7, 0x1, 0x3, 0x3F, 0xFF, 16, 16, 1, 2
   </Vector>
 
   </ConstantsSection>

--- a/Geometry/MTDGeometryBuilder/src/MTDTopologyBuilder.cc
+++ b/Geometry/MTDGeometryBuilder/src/MTDTopologyBuilder.cc
@@ -1,7 +1,11 @@
+//#define EDM_ML_DEBUG
+
 // Make the change for "big" pixels. 3/06 d.k.
 #include "Geometry/MTDGeometryBuilder/interface/MTDTopologyBuilder.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
 #include "DataFormats/GeometrySurface/interface/Bounds.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 MTDTopologyBuilder::MTDTopologyBuilder(void) {}
 
@@ -25,6 +29,19 @@ PixelTopology* MTDTopologyBuilder::build(const Bounds* bs,
   float pitchX = width / (nrows + pixelROCsInX * BIG_PIX_PER_ROC_X);
   // 2 big pixels per ROC
   float pitchY = length / (ncols + pixelROCsInY * BIG_PIX_PER_ROC_Y);
+
+#ifdef EDM_ML_DEBUG
+  edm::LogInfo("MTDTopologyBuilder") << std::fixed << "Building topology for module of width(X) = " << std::setw(10)
+                                     << width << " length(Y) = " << std::setw(10) << length
+                                     << "\n Rows per ROC   = " << std::setw(10) << pixelROCRows
+                                     << " Cols per ROC   = " << std::setw(10) << pixelROCCols
+                                     << "\n ROCs in X      = " << std::setw(10) << pixelROCsInX
+                                     << " ROCs in Y      = " << std::setw(10) << pixelROCsInY
+                                     << "\n # pixel rows X = " << std::setw(10) << nrows
+                                     << " # pixel cols Y = " << std::setw(10) << ncols
+                                     << "\n pitch in X     = " << std::setw(10) << pitchX
+                                     << " # pitch in Y   = " << std::setw(10) << pitchY;
+#endif
 
   return (new RectangularMTDTopology(nrows,
                                      ncols,

--- a/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
+++ b/Geometry/MTDGeometryBuilder/test/MTDDigiGeometryAnalyzer.cc
@@ -59,6 +59,8 @@ void MTDDigiGeometryAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
       << "Geometry node for MTDGeom is  " << &(*pDD) << "\n"
       << " # detectors = " << pDD->detUnits().size() << "\n"
       << " # types     = " << pDD->detTypes().size() << "\n"
+      << " # BTL dets  = " << pDD->detsBTL().size() << "\n"
+      << " # ETL dets  = " << pDD->detsETL().size() << "\n"
       << " # layers " << pDD->geomDetSubDetector(1) << "  = " << pDD->numberOfLayers(1) << "\n"
       << " # layers " << pDD->geomDetSubDetector(2) << "  = " << pDD->numberOfLayers(2) << "\n";
   sunitt << std::fixed << std::setw(7) << pDD->detUnits().size() << std::setw(7) << pDD->detTypes().size() << "\n";

--- a/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
+++ b/RecoLocalFastTime/FTLClusterizer/src/MTDThresholdClusterizer.cc
@@ -211,7 +211,7 @@ void MTDThresholdClusterizer::copy_to_buffer(RecHitIterator itr, const MTDGeomet
   if (mtdId.mtdSubDetector() == MTDDetId::BTL) {
     subDet = GeomDetEnumerators::barrel;
     BTLDetId id = itr->id();
-    DetId geoId = id.geographicalId((BTLDetId::CrysLayout)topo->getMTDTopologyMode());
+    DetId geoId = id.geographicalId(MTDTopologyMode::crysLayoutFromTopoMode(topo->getMTDTopologyMode()));
     const auto& det = geom->idToDet(geoId);
     const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(det->topology());
     const RectangularMTDTopology& topol = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -14,8 +14,7 @@ _endcapAlgo = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
-phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005 )
-phase2_etlV4.toModify(_endcapAlgo, calibrationConstant = 0.001 )
+phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005, calibrationConstant = 0.001 )
 
 mtdRecHits = cms.EDProducer(
     "MTDRecHitProducer",
@@ -26,5 +25,3 @@ mtdRecHits = cms.EDProducer(
     BarrelHitsName = cms.string('FTLBarrel'),
     EndcapHitsName = cms.string('FTLEndcap'),
 )
-
-

--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -13,6 +13,9 @@ _endcapAlgo = cms.PSet(
     calibrationConstant = cms.double(0.085), # MeV/MIP
 )
 
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005 )
+phase2_etlV4.toModify(_endcapAlgo, calibrationConstant = 0.001 )
 
 mtdRecHits = cms.EDProducer(
     "MTDRecHitProducer",
@@ -23,3 +26,5 @@ mtdRecHits = cms.EDProducer(
     BarrelHitsName = cms.string('FTLBarrel'),
     EndcapHitsName = cms.string('FTLEndcap'),
 )
+
+

--- a/RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h
+++ b/RecoMTD/DetLayers/interface/MTDDetLayerGeometry.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDDetLayerGeometry_h
-#define DetLayers_MTDDetLayerGeometry_h
+#ifndef RecoMTD_DetLayers_MTDDetLayerGeometry_h
+#define RecoMTD_DetLayers_MTDDetLayerGeometry_h
 
 /** \class MTDDetLayerGeometry
  *

--- a/RecoMTD/DetLayers/interface/MTDDetRing.h
+++ b/RecoMTD/DetLayers/interface/MTDDetRing.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDDetRing_H
-#define DetLayers_MTDDetRing_H
+#ifndef RecoMTD_DetLayers_MTDDetRing_H
+#define RecoMTD_DetLayers_MTDDetRing_H
 
 /** \class MTDDetRing
  *  A ring of periodic, possibly overlapping vertical detectors.

--- a/RecoMTD/DetLayers/interface/MTDDetSector.h
+++ b/RecoMTD/DetLayers/interface/MTDDetSector.h
@@ -52,7 +52,7 @@ public:
 protected:
   void setDisk(BoundDiskSector* diskS) { theDiskS = diskS; }
 
-  bool add(int idet,
+  bool add(size_t idet,
            std::vector<DetWithState>& result,
            const TrajectoryStateOnSurface& tsos,
            const Propagator& prop,

--- a/RecoMTD/DetLayers/interface/MTDDetSector.h
+++ b/RecoMTD/DetLayers/interface/MTDDetSector.h
@@ -20,6 +20,8 @@ public:
 
   // GeometricSearchDet structure
 
+  const std::vector<const GeomDet*>& basicComponents() const override { return theDets; }
+
   const BoundSurface& surface() const final { return *theDiskS; }
 
   const std::vector<const GeometricSearchDet*>& components() const override;
@@ -47,6 +49,12 @@ public:
 
 protected:
   void setDisk(BoundDiskSector* diskS) { theDiskS = diskS; }
+
+  bool add(int idet,
+           std::vector<DetWithState>& result,
+           const TrajectoryStateOnSurface& tsos,
+           const Propagator& prop,
+           const MeasurementEstimator& est) const;
 
 private:
   ReferenceCountingPointer<BoundDiskSector> theDiskS;

--- a/RecoMTD/DetLayers/interface/MTDDetSector.h
+++ b/RecoMTD/DetLayers/interface/MTDDetSector.h
@@ -18,7 +18,7 @@ public:
   /// Construct from a vector of GeomDet*
   MTDDetSector(const std::vector<const GeomDet*>& dets);
 
-  ~MTDDetSector() override;
+  ~MTDDetSector() override{};
 
   // GeometricSearchDet structure
 
@@ -61,6 +61,13 @@ protected:
 private:
   ReferenceCountingPointer<BoundDiskSector> theDiskS;
   std::vector<const GeomDet*> theDets;
+
+  // Window of detid ordered modules around that closest to the track extrapolation on the sector surface
+  // needed to limit the size of the vector of distances to sort
+  // value 50 based on the possible mismatch of module number between adjacent
+  // modules, due to left-right type imparity
+
+  static constexpr size_t detsRange = 50;
 
   void init();
 };

--- a/RecoMTD/DetLayers/interface/MTDDetSector.h
+++ b/RecoMTD/DetLayers/interface/MTDDetSector.h
@@ -4,6 +4,8 @@
 #include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
 #include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
 
+#include <ostream>
+
 class GeomDet;
 
 class MTDDetSector : public GeometricSearchDet {
@@ -62,4 +64,7 @@ private:
 
   void init();
 };
+
+std::ostream& operator<<(std::ostream&, const MTDDetSector&);
+
 #endif

--- a/RecoMTD/DetLayers/interface/MTDDetSector.h
+++ b/RecoMTD/DetLayers/interface/MTDDetSector.h
@@ -1,0 +1,57 @@
+#ifndef RecoMTD_DetLayers_MTDDetSector_H
+#define RecoMTD_DetLayers_MTDDetSector_H
+
+#include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
+
+class GeomDet;
+
+class MTDDetSector : public GeometricSearchDet {
+public:
+  using GeometricSearchDet::GeometricSearchDet;
+
+  /// Construct from iterators on GeomDet*
+  MTDDetSector(std::vector<const GeomDet*>::const_iterator first, std::vector<const GeomDet*>::const_iterator last);
+
+  /// Construct from a vector of GeomDet*
+  MTDDetSector(const std::vector<const GeomDet*>& dets);
+
+  ~MTDDetSector() override;
+
+  // GeometricSearchDet structure
+
+  const BoundSurface& surface() const final { return *theDiskS; }
+
+  const std::vector<const GeometricSearchDet*>& components() const override;
+
+  std::pair<bool, TrajectoryStateOnSurface> compatible(const TrajectoryStateOnSurface& ts,
+                                                       const Propagator& prop,
+                                                       const MeasurementEstimator& est) const override;
+
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
+
+  void compatibleDetsV(const TrajectoryStateOnSurface& startingState,
+                       const Propagator& prop,
+                       const MeasurementEstimator& est,
+                       std::vector<DetWithState>& result) const override;
+
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
+
+  // GeometricSearchDet extension
+
+  const BoundDiskSector& specificSurface() const { return *theDiskS; }
+
+protected:
+  void setDisk(BoundDiskSector* diskS) { theDiskS = diskS; }
+
+private:
+  ReferenceCountingPointer<BoundDiskSector> theDiskS;
+  std::vector<const GeomDet*> theDets;
+
+  void init();
+};
+#endif

--- a/RecoMTD/DetLayers/interface/MTDDetTray.h
+++ b/RecoMTD/DetLayers/interface/MTDDetTray.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDDetTray_H
-#define DetLayers_MTDDetTray_H
+#ifndef RecoMTD_DetLayers_MTDDetTray_H
+#define RecoMTD_DetLayers_MTDDetTray_H
 
 /** \class MTDDetTray
  *  A tray of aligned equal-sized non-overlapping detectors.  

--- a/RecoMTD/DetLayers/interface/MTDRingForwardDoubleLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDRingForwardDoubleLayer.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDRingForwardDoubleLayer_H
-#define DetLayers_MTDRingForwardDoubleLayer_H
+#ifndef RecoMTD_DetLayers_MTDRingForwardDoubleLayer_H
+#define RecoMTD_DetLayers_MTDRingForwardDoubleLayer_H
 
 /** \class MTDRingForwardDoubleLayer
  *  A plane composed two layers of disks. The Endcap Timing Layer.

--- a/RecoMTD/DetLayers/interface/MTDRingForwardLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDRingForwardLayer.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDRingForwardLayer_H
-#define DetLayers_MTDRingForwardLayer_H
+#ifndef RecoMTD_DetLayers_MTDRingForwardLayer_H
+#define RecoMTD_DetLayers_MTDRingForwardLayer_H
 
 /** \class MTDRingForwardLayer
  *  A plane composed of disks (MTDRingForwardDisk). Represents ETL.

--- a/RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h
@@ -12,7 +12,7 @@ class MTDSectorForwardDoubleLayer : public ForwardDetLayer {
 public:
   /// Constructor, takes ownership of pointers
   MTDSectorForwardDoubleLayer(const std::vector<const MTDDetSector*>& frontSectors,
-                            const std::vector<const MTDDetSector*>& backSectors);
+                              const std::vector<const MTDDetSector*>& backSectors);
 
   ~MTDSectorForwardDoubleLayer() override {}
 

--- a/RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h
@@ -1,0 +1,65 @@
+#ifndef RecoMTD_DetLayers_MTDSectorForwardDoubleLayer_H
+#define RecoMTD_DetLayers_MTDSectorForwardDoubleLayer_H
+
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
+#include "Utilities/BinningTools/interface/BaseBinFinder.h"
+#include "RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h"
+
+class MTDDetSector;
+class GeomDet;
+
+class MTDSectorForwardDoubleLayer : public ForwardDetLayer {
+public:
+  /// Constructor, takes ownership of pointers
+  MTDSectorForwardDoubleLayer(const std::vector<const MTDDetSector*>& frontSectors,
+                            const std::vector<const MTDDetSector*>& backSectors);
+
+  ~MTDSectorForwardDoubleLayer() override {}
+
+  // GeometricSearchDet interface
+
+  const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComponents; }
+
+  const std::vector<const GeometricSearchDet*>& components() const override { return theComponents; }
+
+  bool isInsideOut(const TrajectoryStateOnSurface& tsos) const;
+
+  // tries closest layer first
+  std::pair<bool, TrajectoryStateOnSurface> compatible(const TrajectoryStateOnSurface&,
+                                                       const Propagator&,
+                                                       const MeasurementEstimator&) const override;
+
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
+
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
+
+  // DetLayer interface
+  SubDetector subDetector() const override { return theBackLayer.subDetector(); }
+
+  // Extension of the interface
+
+  /// Return the vector of sectors.
+  virtual const std::vector<const MTDDetSector*>& sectors() const { return theSectors; }
+
+  bool isCrack(const GlobalPoint& gp) const;
+
+  const MTDSectorForwardLayer* frontLayer() const { return &theFrontLayer; }
+  const MTDSectorForwardLayer* backLayer() const { return &theBackLayer; }
+
+  void selfTest() const;
+
+protected:
+  BoundDisk* computeSurface() override;
+
+private:
+  MTDSectorForwardLayer theFrontLayer;
+  MTDSectorForwardLayer theBackLayer;
+  std::vector<const MTDDetSector*> theSectors;
+  std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
+  std::vector<const GeomDet*> theBasicComponents;        // All chambers
+};
+#endif

--- a/RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h
@@ -2,7 +2,6 @@
 #define RecoMTD_DetLayers_MTDSectorForwardLayer_H
 
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
-#include "Utilities/BinningTools/interface/BaseBinFinder.h"
 
 class MTDDetSector;
 class GeomDet;
@@ -40,7 +39,5 @@ private:
   std::vector<const MTDDetSector*> theSectors;
   std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
   std::vector<const GeomDet*> theBasicComps;             // All chambers
-  BaseBinFinder<double>* theBinFinder;
-  bool isOverlapping;
 };
 #endif

--- a/RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h
@@ -1,0 +1,46 @@
+#ifndef RecoMTD_DetLayers_MTDSectorForwardLayer_H
+#define RecoMTD_DetLayers_MTDSectorForwardLayer_H
+
+#include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
+#include "Utilities/BinningTools/interface/BaseBinFinder.h"
+
+class MTDDetSector;
+class GeomDet;
+
+class MTDSectorForwardLayer : public ForwardDetLayer {
+public:
+  /// Constructor, takes ownership of pointers
+  MTDSectorForwardLayer(const std::vector<const MTDDetSector*>& sectors);
+
+  ~MTDSectorForwardLayer() override;
+
+  // GeometricSearchDet interface
+
+  const std::vector<const GeomDet*>& basicComponents() const override { return theBasicComps; }
+
+  const std::vector<const GeometricSearchDet*>& components() const override;
+
+  std::vector<DetWithState> compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                           const Propagator& prop,
+                                           const MeasurementEstimator& est) const override;
+
+  std::vector<DetGroup> groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                              const Propagator& prop,
+                                              const MeasurementEstimator& est) const override;
+
+  // DetLayer interface
+  SubDetector subDetector() const override;
+
+  // Extension of the interface
+
+  /// Return the vector of sectors
+  virtual const std::vector<const MTDDetSector*>& sectors() const { return theSectors; }
+
+private:
+  std::vector<const MTDDetSector*> theSectors;
+  std::vector<const GeometricSearchDet*> theComponents;  // duplication of the above
+  std::vector<const GeomDet*> theBasicComps;             // All chambers
+  BaseBinFinder<double>* theBinFinder;
+  bool isOverlapping;
+};
+#endif

--- a/RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h
+++ b/RecoMTD/DetLayers/interface/MTDTrayBarrelLayer.h
@@ -1,5 +1,5 @@
-#ifndef DetLayers_MTDTrayBarrelLayer_H
-#define DetLayers_MTDTrayBarrelLayer_H
+#ifndef RecoMTD_DetLayers_MTDTrayBarrelLayer_H
+#define RecoMTD_DetLayers_MTDTrayBarrelLayer_H
 
 /** \class MTDTrayBarrelLayer
  *  A cylinder composed of half-trays. Represents Barrel Timing Layer.

--- a/RecoMTD/DetLayers/plugins/BTLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/BTLDetLayerGeometryBuilder.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 #include "BTLDetLayerGeometryBuilder.h"
 

--- a/RecoMTD/DetLayers/plugins/BTLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/BTLDetLayerGeometryBuilder.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include "BTLDetLayerGeometryBuilder.h"
 

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -6,6 +6,7 @@
 #include <RecoMTD/DetLayers/interface/MTDDetRing.h>
 #include <DataFormats/ForwardDetId/interface/ETLDetId.h>
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include <Geometry/MTDCommonData/interface/MTDTopologyMode.h>
 
 #include <Utilities/General/interface/precomputed_value_sort.h>
 #include <Geometry/CommonDetUnit/interface/DetSorting.h>
@@ -15,19 +16,22 @@
 
 using namespace std;
 
-pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLayers(const MTDGeometry& geo) {
+pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLayers(const MTDGeometry& geo,
+                                                                                    const int mtdTopologyMode) {
   vector<DetLayer*> result[2];  // one for each endcap
 
-  for (unsigned endcap = 0; endcap < 2; ++endcap) {
-    // there is only one layer for ETL right now, maybe more later
-    for (unsigned layer = 0; layer <= 0; ++layer) {
-      vector<unsigned> rings;
-      for (unsigned ring = 1; ring <= 12; ++ring) {
-        rings.push_back(ring);
+  if (mtdTopologyMode <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
+    for (unsigned endcap = 0; endcap < 2; ++endcap) {
+      // there is only one layer for ETL right now, maybe more later
+      for (unsigned layer = 0; layer <= 0; ++layer) {
+        vector<unsigned> rings;
+        for (unsigned ring = 1; ring <= 12; ++ring) {
+          rings.push_back(ring);
+        }
+        MTDRingForwardDoubleLayer* thelayer = buildLayer(endcap, layer, rings, geo);
+        if (thelayer)
+          result[endcap].push_back(thelayer);
       }
-      MTDRingForwardDoubleLayer* thelayer = buildLayer(endcap, layer, rings, geo);
-      if (thelayer)
-        result[endcap].push_back(thelayer);
     }
   }
   pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -210,5 +210,5 @@ MTDDetSector* ETLDetLayerGeometryBuilder::makeDetSector(vector<const GeomDet*>& 
 }
 
 bool ETLDetLayerGeometryBuilder::orderGeomDets(const GeomDet*& gd1, const GeomDet*& gd2) {
-  return {gd1->geographicalId().rawId() < gd2->geographicalId().rawId()};
+  return gd1->geographicalId().rawId() < gd2->geographicalId().rawId();
 }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -27,6 +27,7 @@ pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLay
       // there is only one layer for ETL right now, maybe more later
       for (unsigned layer = 0; layer < ETLDetId::kETLv1nDisc; ++layer) {
         vector<unsigned> rings;
+        rings.reserve(ETLDetId::kETLv1maxRing + 1);
         for (unsigned ring = 1; ring <= ETLDetId::kETLv1maxRing; ++ring) {
           rings.push_back(ring);
         }
@@ -55,6 +56,7 @@ pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLay
       // number of layers is two, identical for post TDR scenarios, pick v4
       for (unsigned layer = 1; layer <= ETLDetId::kETLv4nDisc; ++layer) {
         vector<unsigned> sectors;
+        sectors.reserve(nSector + 1);
         for (unsigned sector = 1; sector <= nSector; ++sector) {
           sectors.push_back(sector);
         }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -150,7 +150,10 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
     for (auto det : geo.detsETL()) {
       ETLDetId theMod(det->geographicalId().rawId());
       if (theMod.mtdSide() == endcap && theMod.nDisc() == layer && theMod.sector() == static_cast<int>(sector)) {
-        LogDebug("MTDDetLayers") << theMod;
+        LogDebug("MTDDetLayers") << "ETLDetId " << theMod.rawId() << " side = " << theMod.mtdSide()
+                                 << " Disc/Side/Sector = " << theMod.nDisc() << " " << theMod.discSide() << " "
+                                 << theMod.sector() << " mod/type = " << theMod.module() << " " << theMod.modType()
+                                 << " pos = " << det->position();
         // front layer face
         if (theMod.discSide() == 0) {
 #ifdef EDM_ML_DEBUG
@@ -194,13 +197,14 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
 }
 
 MTDDetSector* ETLDetLayerGeometryBuilder::makeDetSector(vector<const GeomDet*>& geomDets) {
-  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: new MTDDetSector with " << geomDets.size();
+  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: new MTDDetSector with " << geomDets.size() << " modules";
 
   MTDDetSector* result = new MTDDetSector(geomDets);
-  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: new MTDDetSector with " << geomDets.size()
-                           << " chambers at z=" << result->position().z()
-                           << " R1: " << result->specificSurface().innerRadius()
-                           << " R2: " << result->specificSurface().outerRadius();
+  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: pos = " << result->position()
+                           << " rmin = " << result->specificSurface().innerRadius()
+                           << " rmax = " << result->specificSurface().outerRadius()
+                           << " phi ref = " << result->specificSurface().position().phi()
+                           << " phi/2 = " << result->specificSurface().phiHalfExtension();
 
   return result;
 }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -43,9 +43,9 @@ pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLay
       case static_cast<int>(MTDTopologyMode::Mode::btlv1etlv4):
         nSector *= ETLDetId::kETLv4maxSector;
         break;
-      //case static_cast<int>(MTDTopologyMode::Mode::btlv1etlv5):
-      //nSector *= ETLDetId::kETLv5maxSector;
-      //break;
+      case static_cast<int>(MTDTopologyMode::Mode::btlv1etlv5):
+        nSector *= ETLDetId::kETLv5maxSector;
+        break;
       default:
         throw cms::Exception("MTDDetLayers") << "Not implemented scenario " << mtdTopologyMode;
         break;

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -150,10 +150,11 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
     for (auto det : geo.detsETL()) {
       ETLDetId theMod(det->geographicalId().rawId());
       if (theMod.mtdSide() == endcap && theMod.nDisc() == layer && theMod.sector() == static_cast<int>(sector)) {
-        LogDebug("MTDDetLayers") << "ETLDetId " << theMod.rawId() << " side = " << theMod.mtdSide()
-                                 << " Disc/Side/Sector = " << theMod.nDisc() << " " << theMod.discSide() << " "
-                                 << theMod.sector() << " mod/type = " << theMod.module() << " " << theMod.modType()
-                                 << " pos = " << det->position();
+        LogTrace("MTDLayerDump") << std::fixed << "ETLDetId " << theMod.rawId() << " side = " << std::setw(4)
+                                 << theMod.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << theMod.nDisc() << " "
+                                 << std::setw(4) << theMod.discSide() << " " << std::setw(4) << theMod.sector()
+                                 << " mod/type = " << std::setw(4) << theMod.module() << " " << std::setw(4)
+                                 << theMod.modType() << " pos = " << std::setw(14) << det->position();
         // front layer face
         if (theMod.discSide() == 0) {
 #ifdef EDM_ML_DEBUG
@@ -188,23 +189,20 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
   }
 
   result = new MTDSectorForwardDoubleLayer(frontSectors, backSectors);
-  LogTrace("MTDDetLayers") << "New MTDSectorForwardDoubleLayer with " << frontSectors.size() << " and "
-                           << backSectors.size() << " rings, at Z " << result->position().z()
-                           << " R1: " << result->specificSurface().innerRadius()
-                           << " R2: " << result->specificSurface().outerRadius();
+  LogTrace("MTDDetLayers") << "New MTDSectorForwardDoubleLayer with " << std::fixed << std::setw(14)
+                           << frontSectors.size() << " and " << std::setw(14) << backSectors.size() << " rings, at Z "
+                           << std::setw(14) << result->specificSurface().position().z() << " R1: " << std::setw(14)
+                           << result->specificSurface().innerRadius() << " R2: " << std::setw(14)
+                           << result->specificSurface().outerRadius();
 
   return result;
 }
 
 MTDDetSector* ETLDetLayerGeometryBuilder::makeDetSector(vector<const GeomDet*>& geomDets) {
-  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: new MTDDetSector with " << geomDets.size() << " modules";
-
   MTDDetSector* result = new MTDDetSector(geomDets);
-  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder: pos = " << result->position()
-                           << " rmin = " << result->specificSurface().innerRadius()
-                           << " rmax = " << result->specificSurface().outerRadius()
-                           << " phi ref = " << result->specificSurface().position().phi()
-                           << " phi/2 = " << result->specificSurface().phiHalfExtension();
+  LogTrace("MTDDetLayers") << "ETLDetLayerGeometryBuilder::makeDetSector new MTDDetSector with " << std::fixed
+                           << std::setw(14) << geomDets.size() << " modules \n"
+                           << (*result);
 
   return result;
 }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include "ETLDetLayerGeometryBuilder.h"
 

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -105,7 +105,7 @@ MTDRingForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayer(int endcap,
       assert(!backGeomDets.empty());
       float frontz = frontRings[0]->position().z();
       float backz = backRings[0]->position().z();
-      assert(fabs(frontz) < fabs(backz));
+      assert(std::abs(frontz) < std::abs(backz));
     }
   }
 
@@ -186,7 +186,7 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
       assert(!backGeomDets.empty());
       float frontz = frontSectors.back()->position().z();
       float backz = backSectors.back()->position().z();
-      assert(fabs(frontz) < fabs(backz));
+      assert(std::abs(frontz) < std::abs(backz));
     }
   }
 

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -154,7 +154,7 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
                                  << theMod.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << theMod.nDisc() << " "
                                  << std::setw(4) << theMod.discSide() << " " << std::setw(4) << theMod.sector()
                                  << " mod/type = " << std::setw(4) << theMod.module() << " " << std::setw(4)
-                                 << theMod.modType() << " pos = " << std::setw(14) << det->position();
+                                 << theMod.modType() << " pos = " << det->position();
         // front layer face
         if (theMod.discSide() == 0) {
 #ifdef EDM_ML_DEBUG

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -174,11 +174,13 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
     }
 
     if (!backGeomDets.empty()) {
+      std::sort(backGeomDets.begin(), backGeomDets.end(), orderGeomDets);
       LogDebug("MTDDetLayers") << "backGeomDets size = " << backGeomDets.size();
       backSectors.emplace_back(makeDetSector(backGeomDets));
     }
 
     if (!frontGeomDets.empty()) {
+      std::sort(frontGeomDets.begin(), frontGeomDets.end(), orderGeomDets);
       LogDebug("MTDDetLayers") << "frontGeomDets size = " << frontGeomDets.size();
       frontSectors.emplace_back(makeDetSector(frontGeomDets));
       assert(!backGeomDets.empty());
@@ -205,4 +207,8 @@ MTDDetSector* ETLDetLayerGeometryBuilder::makeDetSector(vector<const GeomDet*>& 
                            << (*result);
 
   return result;
+}
+
+bool ETLDetLayerGeometryBuilder::orderGeomDets(const GeomDet*& gd1, const GeomDet*& gd2) {
+  return {gd1->geographicalId().rawId() < gd2->geographicalId().rawId()};
 }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 #include "ETLDetLayerGeometryBuilder.h"
 
@@ -18,14 +18,16 @@ using namespace std;
 
 pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLayers(const MTDGeometry& geo,
                                                                                     const int mtdTopologyMode) {
-  vector<DetLayer*> result[2];  // one for each endcap
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair;
 
   if (mtdTopologyMode <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
+    vector<DetLayer*> result[2];  // one for each endcap
+
     for (unsigned endcap = 0; endcap < 2; ++endcap) {
       // there is only one layer for ETL right now, maybe more later
-      for (unsigned layer = 0; layer <= 0; ++layer) {
+      for (unsigned layer = 0; layer < ETLDetId::kETLv1nDisc; ++layer) {
         vector<unsigned> rings;
-        for (unsigned ring = 1; ring <= 12; ++ring) {
+        for (unsigned ring = 1; ring <= ETLDetId::kETLv1maxRing; ++ring) {
           rings.push_back(ring);
         }
         MTDRingForwardDoubleLayer* thelayer = buildLayer(endcap, layer, rings, geo);
@@ -33,8 +35,8 @@ pair<vector<DetLayer*>, vector<DetLayer*> > ETLDetLayerGeometryBuilder::buildLay
           result[endcap].push_back(thelayer);
       }
     }
+    res_pair = std::make_pair(result[0], result[1]);
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
   return res_pair;
 }
 

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.cc
@@ -143,7 +143,7 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
 
   for (unsigned sector : sectors) {
     std::vector<const GeomDet*> frontGeomDets, backGeomDets;
-    LogTrace("MTDDetLayers") << "endcap = " << endcap << " layer = " << layer << " sector = " << sector;
+    LogDebug("MTDDetLayers") << "endcap = " << endcap << " layer = " << layer << " sector = " << sector;
 #ifdef EDM_ML_DEBUG
     unsigned int nfront(0), nback(0);
 #endif
@@ -183,6 +183,12 @@ MTDSectorForwardDoubleLayer* ETLDetLayerGeometryBuilder::buildLayerNew(int endca
       assert(fabs(frontz) < fabs(backz));
     }
   }
+
+  result = new MTDSectorForwardDoubleLayer(frontSectors, backSectors);
+  LogTrace("MTDDetLayers") << "New MTDSectorForwardDoubleLayer with " << frontSectors.size() << " and "
+                           << backSectors.size() << " rings, at Z " << result->position().z()
+                           << " R1: " << result->specificSurface().innerRadius()
+                           << " R2: " << result->specificSurface().outerRadius();
 
   return result;
 }

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
@@ -41,5 +41,6 @@ private:
   static MTDDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
   static bool isFront(int layer, int ring, int module);
   static MTDDetSector* makeDetSector(std::vector<const GeomDet*>& geomDets);
+  static bool orderGeomDets(const GeomDet*&, const GeomDet*&);
 };
 #endif

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
@@ -14,6 +14,8 @@
 class DetLayer;
 class MTDRingForwardDoubleLayer;
 class MTDDetRing;
+class MTDSectorForwardDoubleLayer;
+class MTDDetSector;
 
 class ETLDetLayerGeometryBuilder {
 public:
@@ -31,7 +33,13 @@ private:
                                                std::vector<unsigned>& rings,
                                                const MTDGeometry& geo);
 
+  static MTDSectorForwardDoubleLayer* buildLayerNew(int endcap,
+                                                    int layer,
+                                                    std::vector<unsigned>& sectors,
+                                                    const MTDGeometry& geo);
+
   static MTDDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
   static bool isFront(int layer, int ring, int module);
+  static MTDDetSector* makeDetSector(std::vector<const GeomDet*>& geomDets);
 };
 #endif

--- a/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
+++ b/RecoMTD/DetLayers/plugins/ETLDetLayerGeometryBuilder.h
@@ -19,7 +19,8 @@ class ETLDetLayerGeometryBuilder {
 public:
   /// return.first=forward (+Z), return.second=backward (-Z)
   /// both vectors are sorted inside-out
-  static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildLayers(const MTDGeometry& geo);
+  static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildLayers(const MTDGeometry& geo,
+                                                                                const int mtdTopologyMode);
 
 private:
   // Disable constructor - only static access is allowed.

--- a/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
+++ b/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
@@ -38,14 +38,17 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
-  const edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
-  const edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  edm::ESGetToken<MTDGeometry, MTDDigiGeometryRecord> geomToken_;
+  edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
 };
 
 using namespace edm;
 
-MTDDetLayerGeometryESProducer::MTDDetLayerGeometryESProducer(const edm::ParameterSet& p)
-    : geomToken_(setWhatProduced(this).consumes()),mtdtopoToken_(setWhatProduced(this).consumes()) {}
+MTDDetLayerGeometryESProducer::MTDDetLayerGeometryESProducer(const edm::ParameterSet& p) {
+  auto cc = setWhatProduced(this);
+  geomToken_ = cc.consumes();
+  mtdtopoToken_ = cc.consumes();
+}
 
 std::unique_ptr<MTDDetLayerGeometry> MTDDetLayerGeometryESProducer::produce(const MTDRecoGeometryRecord& record) {
   auto mtdDetLayerGeometry = std::make_unique<MTDDetLayerGeometry>();

--- a/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
+++ b/RecoMTD/DetLayers/plugins/MTDDetLayerGeometryESProducer.cc
@@ -53,11 +53,11 @@ std::unique_ptr<MTDDetLayerGeometry> MTDDetLayerGeometryESProducer::produce(cons
   if (auto mtd = record.getHandle(geomToken_)) {
     // Build BTL layers
     mtdDetLayerGeometry->addBTLLayers(BTLDetLayerGeometryBuilder::buildLayers(*mtd));
-    // Build ETL layers
-    // depends on the scenario
+    // Build ETL layers, depends on the scenario
     if (auto mtdtopo = record.getHandle(mtdtopoToken_)) {
       mtdDetLayerGeometry->addETLLayers(ETLDetLayerGeometryBuilder::buildLayers(*mtd, mtdtopo->getMTDTopologyMode()));
-      //mtdDetLayerGeometry->addETLLayers(ETLDetLayerGeometryBuilder::buildLayers(*mtd));
+    } else {
+      LogWarning("MTDDetLayers") << "No MTD topology  is available.";
     }
   } else {
     LogWarning("MTDDetLayers") << "No MTD geometry is available.";

--- a/RecoMTD/DetLayers/src/MTDDetRing.cc
+++ b/RecoMTD/DetLayers/src/MTDDetRing.cc
@@ -53,10 +53,7 @@ pair<bool, TrajectoryStateOnSurface> MTDDetRing::compatible(const TrajectoryStat
   }
 #endif
 
-  if (ms.isValid())
-    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
-  else
-    return make_pair(false, ms);
+  return make_pair(ms.isValid() and est.estimate(ms, specificSurface()) != 0, ms);
 }
 
 vector<GeometricSearchDet::DetWithState> MTDDetRing::compatibleDets(const TrajectoryStateOnSurface& startingState,

--- a/RecoMTD/DetLayers/src/MTDDetRing.cc
+++ b/RecoMTD/DetLayers/src/MTDDetRing.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDDetRing.cc
+++ b/RecoMTD/DetLayers/src/MTDDetRing.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -55,10 +55,7 @@ pair<bool, TrajectoryStateOnSurface> MTDDetSector::compatible(const TrajectorySt
   }
 #endif
 
-  if (ms.isValid())
-    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
-  else
-    return make_pair(false, ms);
+  return make_pair(ms.isValid() and est.estimate(ms, specificSurface()) != 0, ms);
 }
 
 vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const TrajectoryStateOnSurface& startingState,
@@ -88,7 +85,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   // determine distance of det center from extrapolation on the surface, sort dets accordingly
 
   size_t idetMin = basicComponents().size();
-  double dist2Min = 1.e6;  // arbitrary big number
+  double dist2Min = std::numeric_limits<double>::max();
   std::vector<std::pair<double, size_t> > tmpDets;
 
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
@@ -107,7 +104,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   // loop on an interval od ordered detIds around the minimum
   // set a range of GeomDets around the minimum compatible with the geometry of ETL
 
-  size_t detsRange = 50;
+  constexpr size_t detsRange(50);
   size_t iniPos(idetMin > detsRange ? idetMin - detsRange : static_cast<size_t>(0));
   size_t endPos(std::min(idetMin + detsRange, basicComponents().size() - 1));
   std::vector<std::pair<double, size_t> > tmpDets2;

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -1,0 +1,93 @@
+//#define EDM_ML_DEBUG
+
+#include "RecoMTD/DetLayers/interface/MTDDetSector.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+MTDDetSector::MTDDetSector(vector<const GeomDet*>::const_iterator first, vector<const GeomDet*>::const_iterator last)
+    : GeometricSearchDet(false), theDets(first, last) {
+  init();
+}
+
+MTDDetSector::MTDDetSector(const vector<const GeomDet*>& vdets) : GeometricSearchDet(false), theDets(vdets) { init(); }
+
+void MTDDetSector::init() {
+  //theBinFinder = BinFinderType(basicComponents().front()->position().phi(), basicComponents().size());
+}
+
+MTDDetSector::~MTDDetSector() {}
+
+const vector<const GeometricSearchDet*>& MTDDetSector::components() const {
+  // FIXME dummy impl.
+  edm::LogError("MTDDetLayers") << "temporary dummy implementation of MTDDetSector::components()!!";
+  static const vector<const GeometricSearchDet*> result;
+  return result;
+}
+
+pair<bool, TrajectoryStateOnSurface> MTDDetSector::compatible(const TrajectoryStateOnSurface& ts,
+                                                            const Propagator& prop,
+                                                            const MeasurementEstimator& est) const {
+  TrajectoryStateOnSurface ms = prop.propagate(ts, specificSurface());
+
+#ifdef EDM_ML_DEBUG
+  LogTrace("MTDDetLayers") << "MTDDetSector::compatible, Surface at Z: " << specificSurface().position().z()
+                            << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                            << " TS   at Z,R: " << ts.globalPosition().z() << "," << ts.globalPosition().perp();
+  if (ms.isValid()) {
+    LogTrace("MTDDetLayers") << " DEST at Z,R: " << ms.globalPosition().z() << "," << ms.globalPosition().perp()
+                              << " local Z: " << ms.localPosition().z();
+  } else {
+    LogTrace("MTDDetLayers") << " DEST: not valid";
+  }
+#endif
+
+  if (ms.isValid())
+    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
+  else
+    return make_pair(false, ms);
+}
+
+vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                    const Propagator& prop,
+                                                                    const MeasurementEstimator& est) const {
+  LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets, Surface at Z: " << surface().position().z()
+                            << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                            << " TS at Z,R: " << startingState.globalPosition().z() << ","
+                            << startingState.globalPosition().perp() << "     DetRing pos." << position();
+
+  vector<DetWithState> result;
+
+  // Propagate and check that the result is within bounds
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
+  if (!compat.first) {
+    LogTrace("MTDDetLayers") << "    MTDDetSector::compatibleDets: not compatible"
+                              << "    (should not have been selected!)";
+    return result;
+  }
+
+  return result;
+}
+
+void MTDDetSector::compatibleDetsV(const TrajectoryStateOnSurface&,
+                                   const Propagator&,
+                                   const MeasurementEstimator&,
+                                   std::vector<DetWithState>&) const {
+   edm::LogError("MTDDetLayers") << "At the moment not a real implementation";
+}
+
+vector<DetGroup> MTDDetSector::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                   const Propagator& prop,
+                                                   const MeasurementEstimator& est) const {
+  // FIXME should be implemented to allow returning  overlapping chambers
+  // as separate groups!
+  edm::LogInfo("MTDDetLayers") << "dummy implementation of MTDDetSector::groupedCompatibleDets()";
+  vector<DetGroup> result;
+  return result;
+}

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -32,17 +32,17 @@ const vector<const GeometricSearchDet*>& MTDDetSector::components() const {
 }
 
 pair<bool, TrajectoryStateOnSurface> MTDDetSector::compatible(const TrajectoryStateOnSurface& ts,
-                                                            const Propagator& prop,
-                                                            const MeasurementEstimator& est) const {
+                                                              const Propagator& prop,
+                                                              const MeasurementEstimator& est) const {
   TrajectoryStateOnSurface ms = prop.propagate(ts, specificSurface());
 
 #ifdef EDM_ML_DEBUG
   LogTrace("MTDDetLayers") << "MTDDetSector::compatible, Surface at Z: " << specificSurface().position().z()
-                            << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
-                            << " TS   at Z,R: " << ts.globalPosition().z() << "," << ts.globalPosition().perp();
+                           << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                           << " TS   at Z,R: " << ts.globalPosition().z() << "," << ts.globalPosition().perp();
   if (ms.isValid()) {
     LogTrace("MTDDetLayers") << " DEST at Z,R: " << ms.globalPosition().z() << "," << ms.globalPosition().perp()
-                              << " local Z: " << ms.localPosition().z();
+                             << " local Z: " << ms.localPosition().z();
   } else {
     LogTrace("MTDDetLayers") << " DEST: not valid";
   }
@@ -55,12 +55,12 @@ pair<bool, TrajectoryStateOnSurface> MTDDetSector::compatible(const TrajectorySt
 }
 
 vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const TrajectoryStateOnSurface& startingState,
-                                                                    const Propagator& prop,
-                                                                    const MeasurementEstimator& est) const {
+                                                                      const Propagator& prop,
+                                                                      const MeasurementEstimator& est) const {
   LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets, Surface at Z: " << surface().position().z()
-                            << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
-                            << " TS at Z,R: " << startingState.globalPosition().z() << ","
-                            << startingState.globalPosition().perp() << "     DetRing pos." << position();
+                           << " R1: " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                           << " TS at Z,R: " << startingState.globalPosition().z() << ","
+                           << startingState.globalPosition().perp() << "     DetRing pos." << position();
 
   vector<DetWithState> result;
 
@@ -68,7 +68,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
   if (!compat.first) {
     LogTrace("MTDDetLayers") << "    MTDDetSector::compatibleDets: not compatible"
-                              << "    (should not have been selected!)";
+                             << "    (should not have been selected!)";
     return result;
   }
 
@@ -79,12 +79,12 @@ void MTDDetSector::compatibleDetsV(const TrajectoryStateOnSurface&,
                                    const Propagator&,
                                    const MeasurementEstimator&,
                                    std::vector<DetWithState>&) const {
-   edm::LogError("MTDDetLayers") << "At the moment not a real implementation";
+  edm::LogError("MTDDetLayers") << "At the moment not a real implementation";
 }
 
 vector<DetGroup> MTDDetSector::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
-                                                   const Propagator& prop,
-                                                   const MeasurementEstimator& est) const {
+                                                     const Propagator& prop,
+                                                     const MeasurementEstimator& est) const {
   // FIXME should be implemented to allow returning  overlapping chambers
   // as separate groups!
   edm::LogInfo("MTDDetLayers") << "dummy implementation of MTDDetSector::groupedCompatibleDets()";

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 #include "RecoMTD/DetLayers/interface/MTDDetSector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -9,6 +9,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
+#include <iomanip>
 #include <vector>
 
 using namespace std;
@@ -26,8 +27,6 @@ void MTDDetSector::init() {
   // simple initial version, no sorting for the time being
   setDisk(MTDDiskSectorBuilderFromDet()(theDets));
 }
-
-MTDDetSector::~MTDDetSector() {}
 
 const vector<const GeometricSearchDet*>& MTDDetSector::components() const {
   // FIXME dummy impl.
@@ -87,6 +86,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   size_t idetMin = basicComponents().size();
   double dist2Min = std::numeric_limits<double>::max();
   std::vector<std::pair<double, size_t> > tmpDets;
+  tmpDets.reserve(basicComponents().size());
 
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
     double dist2 = (startPos - theDets[idet]->position()).mag2();
@@ -104,7 +104,6 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   // loop on an interval od ordered detIds around the minimum
   // set a range of GeomDets around the minimum compatible with the geometry of ETL
 
-  constexpr size_t detsRange(50);
   size_t iniPos(idetMin > detsRange ? idetMin - detsRange : static_cast<size_t>(0));
   size_t endPos(std::min(idetMin + detsRange, basicComponents().size() - 1));
   tmpDets.erase(tmpDets.begin() + endPos, tmpDets.end());
@@ -161,8 +160,6 @@ bool MTDDetSector::add(size_t idet,
 
   return compat.first;
 }
-
-#include <iomanip>
 
 std::ostream& operator<<(std::ostream& os, const MTDDetSector& id) {
   os << " MTDDetSector at " << std::fixed << id.specificSurface().position() << std::endl

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -83,37 +83,46 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   TrajectoryStateOnSurface& tsos = compat.second;
   GlobalPoint startPos = tsos.globalPosition();
 
+  LogTrace("MTDDetLayers") << "Starting position: " << startPos;
+
   // determine distance of det center from extrapolation on the surface, sort dets accordingly
 
   size_t idetMin = basicComponents().size();
   double dist2Min = 1.e6;  // arbitrary big number
+  std::vector<std::pair<double, size_t> > tmpDets;
+
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
     double dist2 = (startPos - theDets[idet]->position()).mag2();
+    tmpDets.emplace_back(make_pair(dist2, idet));
     if (dist2 < dist2Min) {
       dist2Min = dist2;
       idetMin = idet;
     }
     LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets " << std::fixed << std::setw(8) << idet << " "
-                             << theDets[idet]->geographicalId().rawId() << " " << startPos << " "
-                             << theDets[idet]->position() << " " << std::setw(10) << dist2
-                             << " Min idet/dist2 = " << std::setw(8) << idetMin << " " << std::setw(10) << dist2Min;
+                             << theDets[idet]->geographicalId().rawId() << " dist = " << std::setw(10)
+                             << std::sqrt(dist2) << " Min idet/dist = " << std::setw(8) << idetMin << " "
+                             << std::setw(10) << std::sqrt(dist2Min) << " " << theDets[idet]->position();
   }
 
   // loop on an interval od ordered detIds around the minimum
   // set a range of GeomDets around the minimum compatible with the geometry of ETL
 
-  size_t detsRange = 10;
+  size_t detsRange = 50;
+  size_t iniPos(idetMin > detsRange ? idetMin - detsRange : static_cast<size_t>(0));
+  size_t endPos(std::min(idetMin + detsRange, basicComponents().size() - 1));
+  std::vector<std::pair<double, size_t> > tmpDets2;
+  LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets iniPos, endPos = " << iniPos << " " << endPos;
+  std::copy(tmpDets.begin() + iniPos, tmpDets.begin() + endPos, std::back_inserter(tmpDets2));
+  std::sort(tmpDets2.begin(), tmpDets2.end());
 
-  for (size_t idet = std::max(idetMin - detsRange, static_cast<size_t>(0));
-       idet < std::min(idetMin + detsRange, basicComponents().size());
-       idet++) {
-    if (add(static_cast<int>(idet), result, tsos, prop, est)) {
-#ifdef EDM_ML_DEBUG
-      LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets found compatible det " << idet
-                               << " detId = " << theDets[idet]->geographicalId().rawId() << " at "
-                               << theDets[idet]->position()
-                               << " dist = " << (startPos - theDets[idet]->position()).mag();
-#endif
+  for (const auto& thisDet : tmpDets2) {
+    LogTrace("MTDDetLayers") << "after sorting " << thisDet.second << " " << std::sqrt(thisDet.first);
+    if (add(static_cast<int>(thisDet.second), result, tsos, prop, est)) {
+      LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets found compatible det " << thisDet.second
+                               << " detId = " << theDets[thisDet.second]->geographicalId().rawId() << " at "
+                               << theDets[thisDet.second]->position() << " dist = " << std::sqrt(thisDet.first);
+    } else {
+      break;
     }
   }
 #ifdef EDM_ML_DEBUG

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -69,7 +69,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
                            << " PhiMin: " << specificSurface().position().phi() - specificSurface().phiHalfExtension()
                            << " PhiMax: " << specificSurface().position().phi() + specificSurface().phiHalfExtension()
                            << " TS at Z,R: " << startingState.globalPosition().z() << ","
-                           << startingState.globalPosition().perp() << "     DetRing pos." << position();
+                           << startingState.globalPosition().perp() << "     DetSector pos." << position();
 
   vector<DetWithState> result;
 

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -90,7 +90,7 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
 
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
     double dist2 = (startPos - theDets[idet]->position()).mag2();
-    tmpDets.emplace_back(make_pair(dist2, idet));
+    tmpDets.emplace_back(dist2, idet);
     if (dist2 < dist2Min) {
       dist2Min = dist2;
       idetMin = idet;
@@ -107,11 +107,11 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   constexpr size_t detsRange(50);
   size_t iniPos(idetMin > detsRange ? idetMin - detsRange : static_cast<size_t>(0));
   size_t endPos(std::min(idetMin + detsRange, basicComponents().size() - 1));
-  std::vector<std::pair<double, size_t> > tmpDets2;
-  std::copy(tmpDets.begin() + iniPos, tmpDets.begin() + endPos, std::back_inserter(tmpDets2));
-  std::sort(tmpDets2.begin(), tmpDets2.end());
+  tmpDets.erase(tmpDets.begin() + endPos, tmpDets.end());
+  tmpDets.erase(tmpDets.begin(), tmpDets.begin() + iniPos);
+  std::sort(tmpDets.begin(), tmpDets.end());
 
-  for (const auto& thisDet : tmpDets2) {
+  for (const auto& thisDet : tmpDets) {
     if (add(thisDet.second, result, tsos, prop, est)) {
       LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets found compatible det " << thisDet.second
                                << " detId = " << theDets[thisDet.second]->geographicalId().rawId() << " at "

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include "RecoMTD/DetLayers/interface/MTDDetSector.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
@@ -111,13 +111,11 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   size_t iniPos(idetMin > detsRange ? idetMin - detsRange : static_cast<size_t>(0));
   size_t endPos(std::min(idetMin + detsRange, basicComponents().size() - 1));
   std::vector<std::pair<double, size_t> > tmpDets2;
-  LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets iniPos, endPos = " << iniPos << " " << endPos;
   std::copy(tmpDets.begin() + iniPos, tmpDets.begin() + endPos, std::back_inserter(tmpDets2));
   std::sort(tmpDets2.begin(), tmpDets2.end());
 
   for (const auto& thisDet : tmpDets2) {
-    LogTrace("MTDDetLayers") << "after sorting " << thisDet.second << " " << std::sqrt(thisDet.first);
-    if (add(static_cast<int>(thisDet.second), result, tsos, prop, est)) {
+    if (add(thisDet.second, result, tsos, prop, est)) {
       LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets found compatible det " << thisDet.second
                                << " detId = " << theDets[thisDet.second]->geographicalId().rawId() << " at "
                                << theDets[thisDet.second]->position() << " dist = " << std::sqrt(thisDet.first);
@@ -153,7 +151,7 @@ vector<DetGroup> MTDDetSector::groupedCompatibleDets(const TrajectoryStateOnSurf
   return result;
 }
 
-bool MTDDetSector::add(int idet,
+bool MTDDetSector::add(size_t idet,
                        vector<DetWithState>& result,
                        const TrajectoryStateOnSurface& tsos,
                        const Propagator& prop,

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -88,9 +88,9 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   std::vector<std::pair<double, size_t> > tmpDets;
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
     double dist2 = (startPos - theDets[idet]->position()).mag2();
-    LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets " << std::fixed << std::setw(14) << idet << " "
-                             << std::setw(14) << startPos << " " << std::setw(14) << theDets[idet]->position() << " "
-                             << std::setw(14) << dist2;
+    //LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets " << std::fixed << std::setw(14) << idet << " "
+    //<< std::setw(14) << startPos << " " << std::setw(14) << theDets[idet]->position() << " "
+    //<< std::setw(14) << dist2;
     tmpDets.emplace_back(make_pair(dist2, idet));
   }
   sort(tmpDets.begin(), tmpDets.end());
@@ -98,11 +98,18 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   // start from the closest det, loop until no compatibility is seen
 
   for (const auto& thisDet : tmpDets) {
-    LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets trial: " << std::setw(14) << thisDet.first << " "
-                             << std::setw(14) << thisDet.second;
+    //LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets trial: " << std::setw(14) << thisDet.second << " "
+    //<< std::setw(14) << thisDet.first:q;
     if (!add(static_cast<int>(thisDet.second), result, tsos, prop, est)) {
       break;
     }
+#ifdef EDM_ML_DEBUG
+    else {
+      LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets found compatible det "
+                               << theDets[thisDet.second]->geographicalId().rawId() << " at "
+                               << theDets[thisDet.second]->position() << " dist = " << std::sqrt(thisDet.first);
+    }
+#endif
   }
 #ifdef EDM_ML_DEBUG
   if (result.empty()) {

--- a/RecoMTD/DetLayers/src/MTDDetSector.cc
+++ b/RecoMTD/DetLayers/src/MTDDetSector.cc
@@ -88,11 +88,9 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   std::vector<std::pair<double, size_t> > tmpDets;
   for (size_t idet = 0; idet < basicComponents().size(); idet++) {
     double dist2 = (startPos - theDets[idet]->position()).mag2();
-#ifdef EDM_ML_DEBUG
     LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets " << std::fixed << std::setw(14) << idet << " "
                              << std::setw(14) << startPos << " " << std::setw(14) << theDets[idet]->position() << " "
                              << std::setw(14) << dist2;
-#endif
     tmpDets.emplace_back(make_pair(dist2, idet));
   }
   sort(tmpDets.begin(), tmpDets.end());
@@ -100,10 +98,8 @@ vector<GeometricSearchDet::DetWithState> MTDDetSector::compatibleDets(const Traj
   // start from the closest det, loop until no compatibility is seen
 
   for (const auto& thisDet : tmpDets) {
-#ifdef EDM_ML_DEBUG
     LogTrace("MTDDetLayers") << "MTDDetSector::compatibleDets trial: " << std::setw(14) << thisDet.first << " "
                              << std::setw(14) << thisDet.second;
-#endif
     if (!add(static_cast<int>(thisDet.second), result, tsos, prop, est)) {
       break;
     }
@@ -153,13 +149,13 @@ bool MTDDetSector::add(int idet,
 #include <iomanip>
 
 std::ostream& operator<<(std::ostream& os, const MTDDetSector& id) {
-  os << " MTDDetSector at " << std::fixed << std::setw(14) << id.specificSurface().position() << std::endl
+  os << " MTDDetSector at " << std::fixed << id.specificSurface().position() << std::endl
      << " L/W/T   : " << std::setw(14) << id.specificSurface().bounds().length() << " / " << std::setw(14)
      << id.specificSurface().bounds().width() << " / " << std::setw(14) << id.specificSurface().bounds().thickness()
      << std::endl
      << " rmin    : " << std::setw(14) << id.specificSurface().innerRadius() << std::endl
      << " rmax    : " << std::setw(14) << id.specificSurface().outerRadius() << std::endl
      << " phi ref : " << std::setw(14) << id.specificSurface().position().phi() << std::endl
-     << " phi win : " << std::setw(14) << id.specificSurface().phiHalfExtension() << std::endl;
+     << " phi w/2 : " << std::setw(14) << id.specificSurface().phiHalfExtension() << std::endl;
   return os;
 }

--- a/RecoMTD/DetLayers/src/MTDDetTray.cc
+++ b/RecoMTD/DetLayers/src/MTDDetTray.cc
@@ -37,10 +37,7 @@ pair<bool, TrajectoryStateOnSurface> MTDDetTray::compatible(const TrajectoryStat
                                                             const Propagator& prop,
                                                             const MeasurementEstimator& est) const {
   TrajectoryStateOnSurface ms = prop.propagate(ts, specificSurface());
-  if (ms.isValid())
-    return make_pair(est.estimate(ms, specificSurface()) != 0, ms);
-  else
-    return make_pair(false, ms);
+  return make_pair(ms.isValid() and est.estimate(ms, specificSurface()) != 0, ms);
 }
 
 vector<GeometricSearchDet::DetWithState> MTDDetTray::compatibleDets(const TrajectoryStateOnSurface& startingState,

--- a/RecoMTD/DetLayers/src/MTDDetTray.cc
+++ b/RecoMTD/DetLayers/src/MTDDetTray.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDDetTray.cc
+++ b/RecoMTD/DetLayers/src/MTDDetTray.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
+++ b/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
@@ -1,0 +1,128 @@
+#define EDM_ML_DEBUG
+
+#include "MTDDiskSectorBuilderFromDet.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/GeometryVector/interface/VectorUtil.h"
+#include "DataFormats/GeometrySurface/interface/BoundingBox.h"
+
+#include <iomanip>
+
+using namespace std;
+
+namespace {
+
+  pair<DiskSectorBounds*, GlobalVector> computeBounds(const vector<const GeomDet*>& dets, const Plane& plane) {
+    Surface::PositionType tmpPos = dets.front()->surface().position();
+
+    float rmin(plane.toLocal(tmpPos).perp());
+    float rmax(plane.toLocal(tmpPos).perp());
+    float zmin(plane.toLocal(tmpPos).z());
+    float zmax(plane.toLocal(tmpPos).z());
+    float phimin(plane.toLocal(tmpPos).phi());
+    float phimax(plane.toLocal(tmpPos).phi());
+
+    for (vector<const GeomDet*>::const_iterator it = dets.begin(); it != dets.end(); it++) {
+      vector<GlobalPoint> corners = BoundingBox().corners((*it)->specificSurface());
+
+      for (vector<GlobalPoint>::const_iterator i = corners.begin(); i != corners.end(); i++) {
+        float r = plane.toLocal(*i).perp();
+        float z = plane.toLocal(*i).z();
+        float phi = plane.toLocal(*i).phi();
+        rmin = min(rmin, r);
+        rmax = max(rmax, r);
+        zmin = min(zmin, z);
+        zmax = max(zmax, z);
+        if (Geom::phiLess(phi, phimin))
+          phimin = phi;
+        if (Geom::phiLess(phimax, phi))
+          phimax = phi;
+      }
+      // in addition to the corners we have to check the middle of the
+      // det +/- length/2, since the min (max) radius for typical fw
+      // dets is reached there
+
+      float rdet = (*it)->position().perp();
+      float height = (*it)->surface().bounds().width();
+      rmin = min(rmin, rdet - height / 2.F);
+      rmax = max(rmax, rdet + height / 2.F);
+    }
+
+    if (!Geom::phiLess(phimin, phimax))
+      edm::LogError("MTDDetLayers") << " MTDDiskSectorBuilderFromDet : "
+                                    << "Something went wrong with Phi Sorting !";
+    float zPos = (zmax + zmin) / 2.;
+    float phiWin = phimax - phimin;
+    float phiPos = (phimax + phimin) / 2.;
+    float rmed = (rmin + rmax) / 2.;
+    if (phiWin < 0.) {
+      if ((phimin < Geom::pi() / 2.) || (phimax > -Geom::pi() / 2.)) {
+        edm::LogError("MTDDetLayers") << " something strange going on, please check " << phimin << " " << phimax << " "
+                                      << phiWin;
+      }
+      //edm::LogInfo(MTDDetLayers) << " Wedge at pi: phi " << phimin << " " << phimax << " " << phiWin
+      //	 << " " << 2.*Geom::pi()+phiWin << " " ;
+      phiWin += 2. * Geom::pi();
+      phiPos += Geom::pi();
+    }
+
+    LocalVector localPos(rmed * cos(phiPos), rmed * sin(phiPos), zPos);
+
+    LogDebug("MTDDetLayers") << "localPos in computeBounds: " << localPos << "\n"
+                             << "rmin:   " << rmin << "\n"
+                             << "rmax:   " << rmax << "\n"
+                             << "zmin:   " << zmin << "\n"
+                             << "zmax:   " << zmax << "\n"
+                             << "phiWin: " << phiWin;
+
+    return make_pair(new DiskSectorBounds(rmin, rmax, zmin, zmax, phiWin), plane.toGlobal(localPos));
+  }
+
+  Surface::RotationType computeRotation(const vector<const GeomDet*>& dets, const Surface::PositionType& meanPos) {
+    const Plane& plane = dets.front()->surface();
+
+    GlobalVector xAxis;
+    GlobalVector yAxis;
+    GlobalVector zAxis;
+
+    GlobalVector planeXAxis = plane.toGlobal(LocalVector(1, 0, 0));
+    const GlobalPoint& planePosition = plane.position();
+
+    if (planePosition.x() * planeXAxis.x() + planePosition.y() * planeXAxis.y() > 0.) {
+      yAxis = planeXAxis;
+    } else {
+      yAxis = -planeXAxis;
+    }
+
+    GlobalVector planeZAxis = plane.toGlobal(LocalVector(0, 0, 1));
+    if (planeZAxis.z() * planePosition.z() > 0.) {
+      zAxis = planeZAxis;
+    } else {
+      zAxis = -planeZAxis;
+    }
+
+    xAxis = yAxis.cross(zAxis);
+
+    return Surface::RotationType(xAxis, yAxis);
+  }
+
+}  // namespace
+
+BoundDiskSector* MTDDiskSectorBuilderFromDet::operator()(const vector<const GeomDet*>& dets) const {
+  // find mean position
+  typedef Surface::PositionType::BasicVectorType Vector;
+  Vector posSum(0, 0, 0);
+  for (vector<const GeomDet*>::const_iterator i = dets.begin(); i != dets.end(); i++) {
+    posSum += (**i).surface().position().basicVector();
+  }
+  Surface::PositionType meanPos(0., 0., posSum.z() / float(dets.size()));
+
+  // temporary plane - for the computation of bounds
+  Surface::RotationType rotation = computeRotation(dets, meanPos);
+  Plane tmpPlane(meanPos, rotation);
+
+  auto bo = computeBounds(dets, tmpPlane);
+  GlobalPoint pos = meanPos + bo.second;
+  LogDebug("MTDDetLayers") << "global pos in operator: " << pos;
+  return new BoundDiskSector(pos, rotation, bo.first);
+}

--- a/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
+++ b/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
@@ -68,12 +68,22 @@ namespace {
 
     LocalVector localPos(rmed * cos(phiPos), rmed * sin(phiPos), zPos);
 
-    LogDebug("MTDDetLayers") << "localPos in computeBounds: " << localPos << "\n"
-                             << "rmin:   " << rmin << "\n"
-                             << "rmax:   " << rmax << "\n"
-                             << "zmin:   " << zmin << "\n"
-                             << "zmax:   " << zmax << "\n"
-                             << "phiWin: " << phiWin;
+#ifdef EDM_ML_DEBUG
+    LogDebug("MTDDetLayers") << "localPos in computeBounds: " << std::fixed << std::setw(14) << localPos << "\n"
+                             << "rmin:   " << std::setw(14) << rmin << "\n"
+                             << "rmax:   " << std::setw(14) << rmax << "\n"
+                             << "zmin:   " << std::setw(14) << zmin << "\n"
+                             << "zmax:   " << std::setw(14) << zmax << "\n"
+                             << "phiWin: " << std::setw(14) << phiWin;
+
+    LocalVector lX(1, 0, 0);
+    LocalVector lY(0, 1, 0);
+    LocalVector lZ(0, 0, 1);
+    LogDebug("MTDDetLayers") << "Local versors transformations: \n"
+                             << std::fixed << "x = " << std::setw(14) << plane.toGlobal(lX) << "\n"
+                             << "y = " << std::setw(14) << plane.toGlobal(lY) << "\n"
+                             << "z = " << std::setw(14) << plane.toGlobal(lZ);
+#endif
 
     return make_pair(new DiskSectorBounds(rmin, rmax, zmin, zmax, phiWin), plane.toGlobal(localPos));
   }
@@ -123,6 +133,6 @@ BoundDiskSector* MTDDiskSectorBuilderFromDet::operator()(const vector<const Geom
 
   auto bo = computeBounds(dets, tmpPlane);
   GlobalPoint pos = meanPos + bo.second;
-  LogDebug("MTDDetLayers") << "global pos in operator: " << pos;
+  LogDebug("MTDDetLayers") << "global pos in operator: " << std::fixed << std::setw(14) << pos;
   return new BoundDiskSector(pos, rotation, bo.first);
 }

--- a/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
+++ b/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
@@ -81,12 +81,14 @@ namespace {
 BoundDiskSector* MTDDiskSectorBuilderFromDet::operator()(const vector<const GeomDet*>& dets) const {
   // check that the dets are all at about the same z
   float zcheck = dets.front()->surface().position().z();
-  for (vector<const GeomDet*>::const_iterator i = dets.begin(); i != dets.end(); i++) {
-    float zdiff = zcheck - (**i).surface().position().z();
-    if (std::abs(zdiff) > 0.5)  // distance between modules on opposite faces of disk is about 1 cm
+  constexpr double tol(0.5);  // minimal safety check on z position of modules within a sector, width ~ 10 mm
+  for (auto const& idet : dets) {
+    float zdiff = zcheck - (*idet).surface().position().z();
+    if (std::abs(zdiff) > tol) {
       edm::LogError("MTDDetLayers")
           << " MTDDiskSectorBuilderFromDet: Trying to build sector from Dets at different z positions !! Delta_z = "
           << zdiff;
+    }
   }
 
   auto bo = computeBounds(dets);

--- a/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
+++ b/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include "MTDDiskSectorBuilderFromDet.h"
 
@@ -56,7 +56,7 @@ namespace {
 
     GlobalVector pos(rmed * cos(phiPos), rmed * sin(phiPos), zPos);
 
-    LogDebug("MTDDetLayers") << "MTDDiskSectorBuilderFromDet::computeBounds sector at: " << std::fixed << pos << "\n"
+    LogTrace("MTDDetLayers") << "MTDDiskSectorBuilderFromDet::computeBounds sector at: " << std::fixed << pos << "\n"
                              << "zmin    : " << std::setw(14) << zmin << "\n"
                              << "zmax    : " << std::setw(14) << zmax << "\n"
                              << "rmin    : " << std::setw(14) << rmin << "\n"

--- a/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.h
+++ b/RecoMTD/DetLayers/src/MTDDiskSectorBuilderFromDet.h
@@ -1,0 +1,20 @@
+#ifndef RecoMTD_DetLayers_MTDDiskSectorBuilderFromDet_H
+#define RecoMTD_DetLayers_MTDDiskSectorBuilderFromDet_H
+
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include <utility>
+#include <vector>
+#include <iostream>
+
+/** The trapezoid has the minimal size fully containing all Dets.
+ */
+
+class MTDDiskSectorBuilderFromDet {
+public:
+  BoundDiskSector* operator()(const std::vector<const GeomDet*>& dets) const;
+};
+
+#endif

--- a/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
@@ -13,6 +13,8 @@
 #include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h>
 
+#include <DataFormats/ForwardDetId/interface/ETLDetId.h>
+
 #include <algorithm>
 #include <iostream>
 #include <vector>
@@ -170,12 +172,25 @@ void MTDRingForwardDoubleLayer::selfTest() const {
   const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
-  // test that each front z is less than each back z
-  for (const auto& thisFront : frontDets) {
-    float frontz = std::abs(thisFront->surface().position().z());
-    for (const auto& thisBack : backDets) {
-      float backz = std::abs(thisBack->surface().position().z());
-      assert(frontz < backz);
+  for (int iring = 0; iring <= ETLDetId::kETLv1maxRing; iring++) {
+    float frontz(0.);
+    float backz(1e3f);
+    for (const auto& thisFront : frontDets) {
+      if (static_cast<ETLDetId>(thisFront->geographicalId().rawId()).mtdRR() == iring) {
+        float tmpz(std::abs(thisFront->surface().position().z()));
+        if (tmpz > frontz) {
+          frontz = tmpz;
+        }
+      }
     }
+    for (const auto& thisBack : backDets) {
+      if (static_cast<ETLDetId>(thisBack->geographicalId().rawId()).mtdRR() == iring) {
+        float tmpz(std::abs(thisBack->surface().position().z()));
+        if (tmpz < backz) {
+          backz = tmpz;
+        }
+      }
+    }
+    assert(frontz < backz);
   }
 }

--- a/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
@@ -118,9 +118,9 @@ vector<GeometricSearchDet::DetWithState> MTDRingForwardDoubleLayer::compatibleDe
   // This code should be moved in a common place intead of being
   // copied many times.
   vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos, prop, est);
-  for (vector<DetGroup>::const_iterator itDG = vectorGroups.begin(); itDG != vectorGroups.end(); itDG++) {
-    for (vector<DetGroupElement>::const_iterator itDGE = itDG->begin(); itDGE != itDG->end(); itDGE++) {
-      result.push_back(DetWithState(itDGE->det(), itDGE->trajectoryState()));
+  for (const auto& thisDG : vectorGroups) {
+    for (const auto& thisDGE : thisDG) {
+      result.emplace_back(DetWithState(thisDGE.det(), thisDGE.trajectoryState()));
     }
   }
   return result;
@@ -170,14 +170,11 @@ void MTDRingForwardDoubleLayer::selfTest() const {
   const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
-  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(), lastFront = frontDets.end(),
-                                              backItr = backDets.begin(), lastBack = backDets.end();
-
   // test that each front z is less than each back z
-  for (; frontItr != lastFront; ++frontItr) {
-    float frontz = fabs((**frontItr).surface().position().z());
-    for (; backItr != lastBack; ++backItr) {
-      float backz = fabs((**backItr).surface().position().z());
+  for (const auto& thisFront : frontDets) {
+    float frontz = std::abs(thisFront->surface().position().z());
+    for (const auto& thisBack : backDets) {
+      float backz = std::abs(thisBack->surface().position().z());
       assert(frontz < backz);
     }
   }

--- a/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardDoubleLayer.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
@@ -36,14 +36,14 @@ MTDRingForwardLayer::MTDRingForwardLayer(const vector<const ForwardDetRing*>& ri
 
   // Cache chamber pointers (the basic components_)
   // and find extension in R and Z
-  for (vector<const ForwardDetRing*>::const_iterator it = rings.begin(); it != rings.end(); it++) {
-    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+  for (const auto& it : rings) {
+    vector<const GeomDet*> tmp2 = it->basicComponents();
     theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
 
-    theRmin = min(theRmin, (*it)->specificSurface().innerRadius());
-    theRmax = max(theRmax, (*it)->specificSurface().outerRadius());
-    float halfThick = (*it)->surface().bounds().thickness() / 2.;
-    float zCenter = (*it)->surface().position().z();
+    theRmin = min(theRmin, it->specificSurface().innerRadius());
+    theRmax = max(theRmax, it->specificSurface().outerRadius());
+    float halfThick = it->surface().bounds().thickness() / 2.;
+    float zCenter = it->surface().position().z();
     theZmin = min(theZmin, zCenter - halfThick);
     theZmax = max(theZmax, zCenter + halfThick);
   }
@@ -69,8 +69,8 @@ MTDRingForwardLayer::MTDRingForwardLayer(const vector<const ForwardDetRing*>& ri
 
 MTDRingForwardLayer::~MTDRingForwardLayer() {
   delete theBinFinder;
-  for (vector<const ForwardDetRing*>::iterator i = theRings.begin(); i < theRings.end(); i++) {
-    delete *i;
+  for (auto& i : theRings) {
+    delete i;
   }
 }
 

--- a/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDRingForwardLayer.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include <RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h>
 #include <RecoMTD/DetLayers/interface/MTDDetSector.h>

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -15,7 +15,7 @@
 using namespace std;
 
 MTDSectorForwardDoubleLayer::MTDSectorForwardDoubleLayer(const vector<const MTDDetSector*>& frontSectors,
-                                                     const vector<const MTDDetSector*>& backSectors)
+                                                         const vector<const MTDDetSector*>& backSectors)
     : ForwardDetLayer(true),
       theFrontLayer(frontSectors),
       theBackLayer(backSectors),
@@ -122,8 +122,8 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardDoubleLayer::compatible
 }
 
 vector<DetGroup> MTDSectorForwardDoubleLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
-                                                                  const Propagator& prop,
-                                                                  const MeasurementEstimator& est) const {
+                                                                    const Propagator& prop,
+                                                                    const MeasurementEstimator& est) const {
   vector<GeometricSearchDet::DetWithState> detWithStates1, detWithStates2;
 
   LogTrace("MTDDetLayers") << "groupedCompatibleDets are currently given always in inside-out order";

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -143,21 +143,9 @@ vector<DetGroup> MTDSectorForwardDoubleLayer::groupedCompatibleDets(const Trajec
 }
 
 bool MTDSectorForwardDoubleLayer::isCrack(const GlobalPoint& gp) const {
-  // approximate
   bool result = false;
-  double r = gp.perp();
-  const std::vector<const MTDDetSector*>& backSectors = theBackLayer.sectors();
-  if (backSectors.size() > 1) {
-    const MTDDetSector* innerSector = dynamic_cast<const MTDDetSector*>(backSectors[0]);
-    const MTDDetSector* outerSector = dynamic_cast<const MTDDetSector*>(backSectors[1]);
-    assert(innerSector && outerSector);
-    float crackInner = innerSector->specificSurface().outerRadius();
-    float crackOuter = outerSector->specificSurface().innerRadius();
-    LogTrace("MTDDetLayers") << "In a crack:" << crackInner << " " << r << " " << crackOuter;
-    if (r > crackInner && r < crackOuter)
-      return true;
-  }
-  // non-overlapping sectors
+  LogTrace("MTDDetLayers")
+      << "MTDSectorForwardDoubleLayer::isCrack kept only for backward compatibility, no real implementation";
   return result;
 }
 

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -156,11 +156,19 @@ void MTDSectorForwardDoubleLayer::selfTest() const {
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
   // test that each front z is less than each back z
+  float frontz(0.);
+  float backz(1e3f);
   for (const auto& thisFront : frontDets) {
-    float frontz = std::abs(thisFront->surface().position().z());
-    for (const auto& thisBack : backDets) {
-      float backz = std::abs(thisBack->surface().position().z());
-      assert(frontz < backz);
+    float tmpz(std::abs(thisFront->surface().position().z()));
+    if (tmpz > frontz) {
+      frontz = tmpz;
     }
   }
+  for (const auto& thisBack : backDets) {
+    float tmpz(std::abs(thisBack->surface().position().z()));
+    if (tmpz < backz) {
+      backz = tmpz;
+    }
+  }
+  assert(frontz < backz);
 }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -34,10 +34,11 @@ MTDSectorForwardDoubleLayer::MTDSectorForwardDoubleLayer(const vector<const MTDD
 
   setSurface(computeSurface());
 
-  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardDoubleLayer: " << basicComponents().size() << " Dets "
-                           << theSectors.size() << " Sectors "
-                           << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
-                           << " R2: " << specificSurface().outerRadius();
+  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardDoubleLayer: " << std::fixed << std::setw(14)
+                           << basicComponents().size() << " Dets " << std::setw(14) << theSectors.size() << " Sectors "
+                           << " Z: " << std::setw(14) << specificSurface().position().z() << " R1: " << std::setw(14)
+                           << specificSurface().innerRadius() << " R2: " << std::setw(14)
+                           << specificSurface().outerRadius();
 
   selfTest();
 }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -83,7 +83,7 @@ std::pair<bool, TrajectoryStateOnSurface> MTDSectorForwardDoubleLayer::compatibl
   float deltaR = surface().bounds().thickness() / 2. * std::abs(tan(myState.localDirection().theta()));
 
   // take into account the error on the predicted state
-  const float nSigma = 3.;
+  constexpr float nSigma = 3.;
   if (myState.hasError()) {
     LocalError err = myState.localError().positionError();
     // ignore correlation for the moment...
@@ -113,7 +113,7 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardDoubleLayer::compatible
   // groupedCompatibleDets implemented.
   // This code should be moved in a common place intead of being
   // copied many times.
-  vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos, prop, est);
+  vector<DetGroup> vectorGroups(groupedCompatibleDets(tsos, prop, est));
   for (const auto& thisDG : vectorGroups) {
     for (const auto& thisDGE : thisDG) {
       result.emplace_back(DetWithState(thisDGE.det(), thisDGE.trajectoryState()));

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -114,11 +114,12 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardDoubleLayer::compatible
   // This code should be moved in a common place intead of being
   // copied many times.
   vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos, prop, est);
-  for (vector<DetGroup>::const_iterator itDG = vectorGroups.begin(); itDG != vectorGroups.end(); itDG++) {
-    for (vector<DetGroupElement>::const_iterator itDGE = itDG->begin(); itDGE != itDG->end(); itDGE++) {
-      result.push_back(DetWithState(itDGE->det(), itDGE->trajectoryState()));
+  for (const auto& thisDG : vectorGroups) {
+    for (const auto& thisDGE : thisDG) {
+      result.emplace_back(DetWithState(thisDGE.det(), thisDGE.trajectoryState()));
     }
   }
+
   return result;
 }
 
@@ -154,14 +155,11 @@ void MTDSectorForwardDoubleLayer::selfTest() const {
   const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
   const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
 
-  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(), lastFront = frontDets.end(),
-                                              backItr = backDets.begin(), lastBack = backDets.end();
-
   // test that each front z is less than each back z
-  for (; frontItr != lastFront; ++frontItr) {
-    float frontz = std::abs((**frontItr).surface().position().z());
-    for (; backItr != lastBack; ++backItr) {
-      float backz = std::abs((**backItr).surface().position().z());
+  for (const auto& thisFront : frontDets) {
+    float frontz = std::abs(thisFront->surface().position().z());
+    for (const auto& thisBack : backDets) {
+      float backz = std::abs(thisBack->surface().position().z());
       assert(frontz < backz);
     }
   }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 #include <RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h>
 #include <RecoMTD/DetLayers/interface/MTDDetSector.h>

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -27,8 +27,8 @@ MTDSectorForwardDoubleLayer::MTDSectorForwardDoubleLayer(const vector<const MTDD
 
   // Cache chamber pointers (the basic components_)
   // and find extension in R and Z
-  for (vector<const MTDDetSector*>::const_iterator it = theSectors.begin(); it != theSectors.end(); it++) {
-    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+  for (const auto& isect : theSectors) {
+    vector<const GeomDet*> tmp2 = isect->basicComponents();
     theBasicComponents.insert(theBasicComponents.end(), tmp2.begin(), tmp2.end());
   }
 
@@ -80,7 +80,7 @@ std::pair<bool, TrajectoryStateOnSurface> MTDSectorForwardDoubleLayer::compatibl
     return make_pair(false, myState);
 
   // take into account the thickness of the layer
-  float deltaR = surface().bounds().thickness() / 2. * fabs(tan(myState.localDirection().theta()));
+  float deltaR = surface().bounds().thickness() / 2. * std::abs(tan(myState.localDirection().theta()));
 
   // take into account the error on the predicted state
   const float nSigma = 3.;
@@ -159,9 +159,9 @@ void MTDSectorForwardDoubleLayer::selfTest() const {
 
   // test that each front z is less than each back z
   for (; frontItr != lastFront; ++frontItr) {
-    float frontz = fabs((**frontItr).surface().position().z());
+    float frontz = std::abs((**frontItr).surface().position().z());
     for (; backItr != lastBack; ++backItr) {
-      float backz = fabs((**backItr).surface().position().z());
+      float backz = std::abs((**backItr).surface().position().z());
       assert(frontz < backz);
     }
   }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardDoubleLayer.cc
@@ -1,0 +1,179 @@
+//#define EDM_ML_DEBUG
+
+#include <RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h>
+#include <RecoMTD/DetLayers/interface/MTDDetSector.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include <DataFormats/GeometrySurface/interface/SimpleDiskBounds.h>
+#include <TrackingTools/GeomPropagators/interface/Propagator.h>
+#include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+MTDSectorForwardDoubleLayer::MTDSectorForwardDoubleLayer(const vector<const MTDDetSector*>& frontSectors,
+                                                     const vector<const MTDDetSector*>& backSectors)
+    : ForwardDetLayer(true),
+      theFrontLayer(frontSectors),
+      theBackLayer(backSectors),
+      theSectors(frontSectors),  // add back later
+      theComponents(),
+      theBasicComponents() {
+  theSectors.insert(theSectors.end(), backSectors.begin(), backSectors.end());
+  theComponents = std::vector<const GeometricSearchDet*>(theSectors.begin(), theSectors.end());
+
+  // Cache chamber pointers (the basic components_)
+  // and find extension in R and Z
+  for (vector<const MTDDetSector*>::const_iterator it = theSectors.begin(); it != theSectors.end(); it++) {
+    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+    theBasicComponents.insert(theBasicComponents.end(), tmp2.begin(), tmp2.end());
+  }
+
+  setSurface(computeSurface());
+
+  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardDoubleLayer: " << basicComponents().size() << " Dets "
+                           << theSectors.size() << " Sectors "
+                           << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
+                           << " R2: " << specificSurface().outerRadius();
+
+  selfTest();
+}
+
+BoundDisk* MTDSectorForwardDoubleLayer::computeSurface() {
+  const BoundDisk& frontDisk = theFrontLayer.specificSurface();
+  const BoundDisk& backDisk = theBackLayer.specificSurface();
+
+  float rmin = min(frontDisk.innerRadius(), backDisk.innerRadius());
+  float rmax = max(frontDisk.outerRadius(), backDisk.outerRadius());
+  float zmin = frontDisk.position().z();
+  float halfThickness = frontDisk.bounds().thickness() / 2.;
+  zmin = (zmin > 0) ? zmin - halfThickness : zmin + halfThickness;
+  float zmax = backDisk.position().z();
+  halfThickness = backDisk.bounds().thickness() / 2.;
+  zmax = (zmax > 0) ? zmax + halfThickness : zmax - halfThickness;
+  float zPos = (zmax + zmin) / 2.;
+  PositionType pos(0., 0., zPos);
+  RotationType rot;
+
+  return new BoundDisk(pos, rot, new SimpleDiskBounds(rmin, rmax, zmin - zPos, zmax - zPos));
+}
+
+bool MTDSectorForwardDoubleLayer::isInsideOut(const TrajectoryStateOnSurface& tsos) const {
+  return tsos.globalPosition().basicVector().dot(tsos.globalMomentum().basicVector()) > 0;
+}
+
+std::pair<bool, TrajectoryStateOnSurface> MTDSectorForwardDoubleLayer::compatible(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
+  // mostly copied from ForwardDetLayer, except propagates to closest surface,
+  // not to center
+
+  bool insideOut = isInsideOut(startingState);
+  const MTDSectorForwardLayer& closerLayer = (insideOut) ? theFrontLayer : theBackLayer;
+  LogTrace("MTDDetLayers") << "MTDSectorForwardDoubleLayer::compatible is assuming inside-out direction: " << insideOut;
+
+  TrajectoryStateOnSurface myState = prop.propagate(startingState, closerLayer.specificSurface());
+  if (!myState.isValid())
+    return make_pair(false, myState);
+
+  // take into account the thickness of the layer
+  float deltaR = surface().bounds().thickness() / 2. * fabs(tan(myState.localDirection().theta()));
+
+  // take into account the error on the predicted state
+  const float nSigma = 3.;
+  if (myState.hasError()) {
+    LocalError err = myState.localError().positionError();
+    // ignore correlation for the moment...
+    deltaR += nSigma * sqrt(err.xx() + err.yy());
+  }
+
+  float zPos = (zmax() + zmin()) / 2.;
+  SimpleDiskBounds tmp(rmin() - deltaR, rmax() + deltaR, zmin() - zPos, zmax() - zPos);
+
+  return make_pair(tmp.inside(myState.localPosition()), myState);
+}
+
+vector<GeometricSearchDet::DetWithState> MTDSectorForwardDoubleLayer::compatibleDets(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
+  vector<DetWithState> result;
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
+
+  if (!compat.first) {
+    LogTrace("MTDDetLayers") << "     MTDSectorForwardDoubleLayer::compatibleDets: not compatible"
+                             << " (should not have been selected!)";
+    return result;
+  }
+
+  TrajectoryStateOnSurface& tsos = compat.second;
+
+  // standard implementation of compatibleDets() for class which have
+  // groupedCompatibleDets implemented.
+  // This code should be moved in a common place intead of being
+  // copied many times.
+  vector<DetGroup> vectorGroups = groupedCompatibleDets(tsos, prop, est);
+  for (vector<DetGroup>::const_iterator itDG = vectorGroups.begin(); itDG != vectorGroups.end(); itDG++) {
+    for (vector<DetGroupElement>::const_iterator itDGE = itDG->begin(); itDGE != itDG->end(); itDGE++) {
+      result.push_back(DetWithState(itDGE->det(), itDGE->trajectoryState()));
+    }
+  }
+  return result;
+}
+
+vector<DetGroup> MTDSectorForwardDoubleLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                                  const Propagator& prop,
+                                                                  const MeasurementEstimator& est) const {
+  vector<GeometricSearchDet::DetWithState> detWithStates1, detWithStates2;
+
+  LogTrace("MTDDetLayers") << "groupedCompatibleDets are currently given always in inside-out order";
+  // this should be fixed either in RecoMTD/MeasurementDet/MTDDetLayerMeasurements or
+  // RecoMTD/DetLayers/MTDSectorForwardDoubleLayer
+
+  detWithStates1 = theFrontLayer.compatibleDets(startingState, prop, est);
+  detWithStates2 = theBackLayer.compatibleDets(startingState, prop, est);
+
+  vector<DetGroup> result;
+  if (!detWithStates1.empty())
+    result.push_back(DetGroup(detWithStates1));
+  if (!detWithStates2.empty())
+    result.push_back(DetGroup(detWithStates2));
+  LogTrace("MTDDetLayers") << "DoubleLayer Compatible dets: " << result.size();
+  return result;
+}
+
+bool MTDSectorForwardDoubleLayer::isCrack(const GlobalPoint& gp) const {
+  // approximate
+  bool result = false;
+  double r = gp.perp();
+  const std::vector<const MTDDetSector*>& backSectors = theBackLayer.sectors();
+  if (backSectors.size() > 1) {
+    const MTDDetSector* innerSector = dynamic_cast<const MTDDetSector*>(backSectors[0]);
+    const MTDDetSector* outerSector = dynamic_cast<const MTDDetSector*>(backSectors[1]);
+    assert(innerSector && outerSector);
+    float crackInner = innerSector->specificSurface().outerRadius();
+    float crackOuter = outerSector->specificSurface().innerRadius();
+    LogTrace("MTDDetLayers") << "In a crack:" << crackInner << " " << r << " " << crackOuter;
+    if (r > crackInner && r < crackOuter)
+      return true;
+  }
+  // non-overlapping sectors
+  return result;
+}
+
+void MTDSectorForwardDoubleLayer::selfTest() const {
+  const std::vector<const GeomDet*>& frontDets = theFrontLayer.basicComponents();
+  const std::vector<const GeomDet*>& backDets = theBackLayer.basicComponents();
+
+  std::vector<const GeomDet*>::const_iterator frontItr = frontDets.begin(), lastFront = frontDets.end(),
+                                              backItr = backDets.begin(), lastBack = backDets.end();
+
+  // test that each front z is less than each back z
+  for (; frontItr != lastFront; ++frontItr) {
+    float frontz = fabs((**frontItr).surface().position().z());
+    for (; backItr != lastBack; ++backItr) {
+      float backz = fabs((**backItr).surface().position().z());
+      assert(frontz < backz);
+    }
+  }
+}

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 #include <RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h>
 #include <RecoMTD/DetLayers/interface/MTDDetSector.h>

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -111,7 +111,7 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
                                  << " sX: " << sqrt(tsos.localError().positionError().xx());
       }
 #endif
-      vector<DetWithState> nextRodDets = theSectors[isect]->compatibleDets(tsos, prop, est);
+      vector<DetWithState> nextRodDets(theSectors[isect]->compatibleDets(tsos, prop, est));
       if (!nextRodDets.empty()) {
         result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
       } else {

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -54,8 +54,8 @@ MTDSectorForwardLayer::MTDSectorForwardLayer(const vector<const MTDDetSector*>& 
 }
 
 MTDSectorForwardLayer::~MTDSectorForwardLayer() {
-  for (vector<const MTDDetSector*>::iterator i = theSectors.begin(); i < theSectors.end(); i++) {
-    delete *i;
+  for (auto& i : theSectors) {
+    delete i;
   }
 }
 

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -1,0 +1,195 @@
+//#define EDM_ML_DEBUG
+
+#include <RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h>
+#include <RecoMTD/DetLayers/interface/MTDDetSector.h>
+#include <Geometry/CommonDetUnit/interface/GeomDet.h>
+#include <DataFormats/GeometrySurface/interface/DiskSectorBounds.h>
+#include <TrackingTools/GeomPropagators/interface/Propagator.h>
+#include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
+
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
+
+//#include "RBorderFinder.h"
+//#include "GeneralBinFinderInR.h"
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+MTDSectorForwardLayer::MTDSectorForwardLayer(const vector<const MTDDetSector*>& sectors)
+    : ForwardDetLayer(false),
+      theSectors(sectors),
+      theComponents(theSectors.begin(), theSectors.end()),
+      theBinFinder(nullptr),
+      isOverlapping(false) {
+  // Initial values for R and Z bounds
+  float theRmin = sectors.front()->basicComponents().front()->position().perp();
+  float theRmax = theRmin;
+  float theZmin = sectors.front()->position().z();
+  float theZmax = theZmin;
+
+  // Cache chamber pointers (the basic components_)
+  // and find extension in R and Z
+  for (vector<const MTDDetSector*>::const_iterator it = sectors.begin(); it != sectors.end(); it++) {
+    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+    theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
+
+    theRmin = min(theRmin, (*it)->specificSurface().innerRadius());
+    theRmax = max(theRmax, (*it)->specificSurface().outerRadius());
+    float halfThick = (*it)->surface().bounds().thickness() / 2.;
+    float zCenter = (*it)->surface().position().z();
+    theZmin = min(theZmin, zCenter - halfThick);
+    theZmax = max(theZmax, zCenter + halfThick);
+  }
+
+  //RBorderFinder bf(theSectors);
+  //isOverlapping = bf.isROverlapping();
+  //theBinFinder = new GeneralBinFinderInR<double>(bf);
+
+  // Build surface
+
+  float zPos = (theZmax + theZmin) / 2.;
+  PositionType pos(0., 0., zPos);
+  RotationType rot;
+
+  setSurface(new BoundDisk(pos, rot, new SimpleDiskBounds(theRmin, theRmax, theZmin - zPos, theZmax - zPos)));
+
+  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardLayer: " << basicComponents().size() << " Dets "
+                            << theSectors.size() << " Sectors "
+                            << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
+                            << " R2: " << specificSurface().outerRadius();
+                            //<< " Per.: " << bf.isRPeriodic()
+                            //<< " Overl.: " << bf.isROverlapping();
+}
+
+MTDSectorForwardLayer::~MTDSectorForwardLayer() {
+  delete theBinFinder;
+  for (vector<const MTDDetSector*>::iterator i = theSectors.begin(); i < theSectors.end(); i++) {
+    delete *i;
+  }
+}
+
+vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
+    const TrajectoryStateOnSurface& startingState, const Propagator& prop, const MeasurementEstimator& est) const {
+  vector<DetWithState> result;
+
+  LogTrace("MTDDetLayers") << "MTDSectorForwardLayer::compatibleDets,"
+                            << " R1 " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                            << " FTS at R: " << startingState.globalPosition().perp();
+
+  pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
+
+  if (!compat.first) {
+    LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::compatibleDets: not compatible"
+                              << " (should not have been selected!)";
+    return result;
+  }
+
+  TrajectoryStateOnSurface& tsos = compat.second;
+
+  int closest = theBinFinder->binIndex(tsos.globalPosition().perp());
+  const MTDDetSector* closestSector = theSectors[closest];
+
+  // Check the closest ring
+
+#ifdef EDM_ML_DEBUG
+  LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets, closestSector: " << closest << " R1 "
+                            << closestSector->specificSurface().innerRadius()
+                            << " R2: " << closestSector->specificSurface().outerRadius()
+                            << " FTS R: " << tsos.globalPosition().perp();
+  if (tsos.hasError()) {
+    LogTrace("MTDDetLayers") << " sR: " << sqrt(tsos.localError().positionError().yy())
+                              << " sX: " << sqrt(tsos.localError().positionError().xx());
+  }
+#endif
+
+  result = closestSector->compatibleDets(tsos, prop, est);
+
+#ifdef EDM_ML_DEBUG
+  int nclosest = result.size();
+  int nnextdet = 0;  // MDEBUG counters
+#endif
+
+  //FIXME: if closest is not compatible next cannot be either?
+
+  // Use state on layer surface. Note that local coordinates and errors
+  // are the same on the layer and on all sectors surfaces, since
+  // all BoundDisks are centered in 0,0 and have the same rotation.
+  // CAVEAT: if the sectors are not at the same Z, the local position and error
+  // will be "Z-projected" to the sectors. This is a fairly good approximation.
+  // However in this case additional propagation will be done when calling
+  // compatibleDets.
+  GlobalPoint startPos = tsos.globalPosition();
+  LocalPoint nextPos(surface().toLocal(startPos));
+
+  for (unsigned int idet = closest + 1; idet < theSectors.size(); idet++) {
+    bool inside = false;
+    if (tsos.hasError()) {
+      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
+    } else {
+      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos);
+    }
+    if (inside) {
+#ifdef EDM_ML_DEBUG
+      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector" << idet << " R1 "
+                                << theSectors[idet]->specificSurface().innerRadius()
+                                << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
+                                << nextPos.perp();
+      nnextdet++;
+#endif
+      vector<DetWithState> nextRodDets = theSectors[idet]->compatibleDets(tsos, prop, est);
+      if (!nextRodDets.empty()) {
+        result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
+      } else {
+        break;
+      }
+    }
+  }
+
+  for (int idet = closest - 1; idet >= 0; idet--) {
+    bool inside = false;
+    if (tsos.hasError()) {
+      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
+    } else {
+      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos);
+    }
+    if (inside) {
+#ifdef EDM_ML_DEBUG
+      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:PreviousSector:" << idet << " R1 "
+                                << theSectors[idet]->specificSurface().innerRadius()
+                                << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
+                                << nextPos.perp();
+      nnextdet++;
+#endif
+      vector<DetWithState> nextRodDets = theSectors[idet]->compatibleDets(tsos, prop, est);
+      if (!nextRodDets.empty()) {
+        result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
+      } else {
+        break;
+      }
+    }
+  }
+
+#ifdef EDM_ML_DEBUG
+  LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets: found: " << result.size()
+                            << " on closest: " << nclosest << " # checked sectors: " << 1 + nnextdet;
+#endif
+
+  return result;
+}
+
+vector<DetGroup> MTDSectorForwardLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
+                                                            const Propagator& prop,
+                                                            const MeasurementEstimator& est) const {
+  // FIXME should return only 1 group
+  edm::LogInfo("MTDDetLayers") << "dummy implementation of MTDSectorForwardLayer::groupedCompatibleDets()";
+  return vector<DetGroup>();
+}
+
+GeomDetEnumerators::SubDetector MTDSectorForwardLayer::subDetector() const {
+  return theBasicComps.front()->subDetector();
+}
+
+const vector<const GeometricSearchDet*>& MTDSectorForwardLayer::components() const { return theComponents; }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -25,14 +25,14 @@ MTDSectorForwardLayer::MTDSectorForwardLayer(const vector<const MTDDetSector*>& 
 
   // Cache chamber pointers (the basic components_)
   // and find extension in R and Z
-  for (vector<const MTDDetSector*>::const_iterator it = sectors.begin(); it != sectors.end(); it++) {
-    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+  for (const auto& isect : sectors) {
+    vector<const GeomDet*> tmp2 = isect->basicComponents();
     theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
 
-    theRmin = min(theRmin, (*it)->specificSurface().innerRadius());
-    theRmax = max(theRmax, (*it)->specificSurface().outerRadius());
-    float halfThick = (*it)->surface().bounds().thickness() / 2.;
-    float zCenter = (*it)->surface().position().z();
+    theRmin = min(theRmin, isect->specificSurface().innerRadius());
+    theRmax = max(theRmax, isect->specificSurface().outerRadius());
+    float halfThick = isect->surface().bounds().thickness() / 2.;
+    float zCenter = isect->surface().position().z();
     theZmin = min(theZmin, zCenter - halfThick);
     theZmax = max(theZmax, zCenter + halfThick);
   }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 #include <RecoMTD/DetLayers/interface/MTDSectorForwardLayer.h>
 #include <RecoMTD/DetLayers/interface/MTDDetSector.h>
@@ -92,7 +92,7 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
   for (unsigned int isect = 0; isect < theSectors.size(); isect++) {
     LocalPoint nextPos(theSectors[isect]->specificSurface().toLocal(startPos));
     LogDebug("MTDDetLayers") << "Global point = " << std::fixed << startPos << " local point = " << nextPos
-                             << " global pos = " << theSectors[isect]->specificSurface().position();
+                             << " global sector ref pos = " << theSectors[isect]->specificSurface().position();
     bool inside = false;
     if (tsos.hasError()) {
       inside = theSectors[isect]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -91,8 +91,8 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
 
   for (unsigned int isect = 0; isect < theSectors.size(); isect++) {
     LocalPoint nextPos(theSectors[isect]->specificSurface().toLocal(startPos));
-    LogDebug("MTDDetLayers") << "Global point = " << std::fixed << std::setw(14) << startPos
-                             << " local point = " << std::setw(14) << nextPos;
+    LogDebug("MTDDetLayers") << "Global point = " << std::fixed << startPos << " local point = " << nextPos
+                             << " global pos = " << theSectors[isect]->specificSurface().position();
     bool inside = false;
     if (tsos.hasError()) {
       inside = theSectors[isect]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
@@ -120,9 +120,7 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
     }
   }
 
-#ifdef EDM_ML_DEBUG
   LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets: found: " << result.size();
-#endif
 
   return result;
 }

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -96,7 +96,7 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
     }
     if (inside) {
 #ifdef EDM_ML_DEBUG
-      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector" << idet << " R1 "
+      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector " << idet << " R1 "
                                << theSectors[idet]->specificSurface().innerRadius()
                                << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " PhiMin: "
                                << theSectors[idet]->specificSurface().position().phi() -

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -45,10 +45,12 @@ MTDSectorForwardLayer::MTDSectorForwardLayer(const vector<const MTDDetSector*>& 
 
   setSurface(new BoundDisk(pos, rot, new SimpleDiskBounds(theRmin, theRmax, theZmin - zPos, theZmax - zPos)));
 
-  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardLayer: " << basicComponents().size() << " Dets "
-                           << theSectors.size() << " Sectors "
-                           << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
-                           << " R2: " << specificSurface().outerRadius();
+  LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardLayer: " << std::fixed << std::setw(14)
+                           << basicComponents().size() << " Dets, " << std::setw(14) << theSectors.size()
+                           << " Sectors, "
+                           << " Z: " << std::setw(14) << specificSurface().position().z() << " R1: " << std::setw(14)
+                           << specificSurface().innerRadius() << " R2: " << std::setw(14)
+                           << specificSurface().outerRadius();
 }
 
 MTDSectorForwardLayer::~MTDSectorForwardLayer() {
@@ -62,8 +64,9 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
   vector<DetWithState> result;
 
   LogTrace("MTDDetLayers") << "MTDSectorForwardLayer::compatibleDets,"
-                           << " R1 " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
-                           << " FTS at R: " << startingState.globalPosition().perp();
+                           << " R1 " << std::fixed << std::setw(14) << specificSurface().innerRadius()
+                           << " R2: " << std::setw(14) << specificSurface().outerRadius()
+                           << " FTS at R: " << std::setw(14) << startingState.globalPosition().perp();
 
   pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
 
@@ -88,7 +91,8 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
 
   for (unsigned int isect = 0; isect < theSectors.size(); isect++) {
     LocalPoint nextPos(theSectors[isect]->specificSurface().toLocal(startPos));
-    LogDebug("MTDDetLayers") << "Global point = " << startPos << " local point = " << nextPos;
+    LogDebug("MTDDetLayers") << "Global point = " << std::fixed << std::setw(14) << startPos
+                             << " local point = " << std::setw(14) << nextPos;
     bool inside = false;
     if (tsos.hasError()) {
       inside = theSectors[isect]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
@@ -97,15 +101,11 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
     }
     if (inside) {
 #ifdef EDM_ML_DEBUG
-      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector " << isect << " R1 "
-                               << theSectors[isect]->specificSurface().innerRadius()
-                               << " R2: " << theSectors[isect]->specificSurface().outerRadius() << " PhiMin: "
-                               << theSectors[isect]->specificSurface().position().phi() -
-                                      theSectors[isect]->specificSurface().phiHalfExtension()
-                               << " PhiMax: "
-                               << theSectors[isect]->specificSurface().position().phi() +
-                                      theSectors[isect]->specificSurface().phiHalfExtension()
-                               << " FTS R,phi: " << tsos.globalPosition().perp() << "," << tsos.globalPosition().phi();
+      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector " << std::fixed
+                               << std::setw(14) << isect << "\n"
+                               << (*theSectors[isect]) << "\n FTS at Z,R,phi: " << std::setw(14)
+                               << tsos.globalPosition().z() << " , " << std::setw(14) << tsos.globalPosition().perp()
+                               << "," << std::setw(14) << tsos.globalPosition().phi();
       if (tsos.hasError()) {
         LogTrace("MTDDetLayers") << " sR: " << sqrt(tsos.localError().positionError().yy())
                                  << " sX: " << sqrt(tsos.localError().positionError().xx());

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -85,32 +85,33 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
   // However in this case additional propagation will be done when calling
   // compatibleDets.
   GlobalPoint startPos = tsos.globalPosition();
-  LocalPoint nextPos(surface().toLocal(startPos));
 
-  for (unsigned int idet = 0; idet < theSectors.size(); idet++) {
+  for (unsigned int isect = 0; isect < theSectors.size(); isect++) {
+    LocalPoint nextPos(theSectors[isect]->specificSurface().toLocal(startPos));
+    LogDebug("MTDDetLayers") << "Global point = " << startPos << " local point = " << nextPos;
     bool inside = false;
     if (tsos.hasError()) {
-      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
+      inside = theSectors[isect]->specificSurface().bounds().inside(nextPos, tsos.localError().positionError(), 1.);
     } else {
-      inside = theSectors[idet]->specificSurface().bounds().inside(nextPos);
+      inside = theSectors[isect]->specificSurface().bounds().inside(nextPos);
     }
     if (inside) {
 #ifdef EDM_ML_DEBUG
-      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector " << idet << " R1 "
-                               << theSectors[idet]->specificSurface().innerRadius()
-                               << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " PhiMin: "
-                               << theSectors[idet]->specificSurface().position().phi() -
-                                      theSectors[idet]->specificSurface().phiHalfExtension()
+      LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector " << isect << " R1 "
+                               << theSectors[isect]->specificSurface().innerRadius()
+                               << " R2: " << theSectors[isect]->specificSurface().outerRadius() << " PhiMin: "
+                               << theSectors[isect]->specificSurface().position().phi() -
+                                      theSectors[isect]->specificSurface().phiHalfExtension()
                                << " PhiMax: "
-                               << theSectors[idet]->specificSurface().position().phi() +
-                                      theSectors[idet]->specificSurface().phiHalfExtension()
-                               << " FTS R: " << tsos.globalPosition().perp();
+                               << theSectors[isect]->specificSurface().position().phi() +
+                                      theSectors[isect]->specificSurface().phiHalfExtension()
+                               << " FTS R,phi: " << tsos.globalPosition().perp() << "," << tsos.globalPosition().phi();
       if (tsos.hasError()) {
         LogTrace("MTDDetLayers") << " sR: " << sqrt(tsos.localError().positionError().yy())
                                  << " sX: " << sqrt(tsos.localError().positionError().xx());
       }
 #endif
-      vector<DetWithState> nextRodDets = theSectors[idet]->compatibleDets(tsos, prop, est);
+      vector<DetWithState> nextRodDets = theSectors[isect]->compatibleDets(tsos, prop, est);
       if (!nextRodDets.empty()) {
         result.insert(result.end(), nextRodDets.begin(), nextRodDets.end());
       } else {

--- a/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDSectorForwardLayer.cc
@@ -57,11 +57,11 @@ MTDSectorForwardLayer::MTDSectorForwardLayer(const vector<const MTDDetSector*>& 
   setSurface(new BoundDisk(pos, rot, new SimpleDiskBounds(theRmin, theRmax, theZmin - zPos, theZmax - zPos)));
 
   LogTrace("MTDDetLayers") << "Constructing MTDSectorForwardLayer: " << basicComponents().size() << " Dets "
-                            << theSectors.size() << " Sectors "
-                            << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
-                            << " R2: " << specificSurface().outerRadius();
-                            //<< " Per.: " << bf.isRPeriodic()
-                            //<< " Overl.: " << bf.isROverlapping();
+                           << theSectors.size() << " Sectors "
+                           << " Z: " << specificSurface().position().z() << " R1: " << specificSurface().innerRadius()
+                           << " R2: " << specificSurface().outerRadius();
+  //<< " Per.: " << bf.isRPeriodic()
+  //<< " Overl.: " << bf.isROverlapping();
 }
 
 MTDSectorForwardLayer::~MTDSectorForwardLayer() {
@@ -76,14 +76,14 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
   vector<DetWithState> result;
 
   LogTrace("MTDDetLayers") << "MTDSectorForwardLayer::compatibleDets,"
-                            << " R1 " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
-                            << " FTS at R: " << startingState.globalPosition().perp();
+                           << " R1 " << specificSurface().innerRadius() << " R2: " << specificSurface().outerRadius()
+                           << " FTS at R: " << startingState.globalPosition().perp();
 
   pair<bool, TrajectoryStateOnSurface> compat = compatible(startingState, prop, est);
 
   if (!compat.first) {
     LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::compatibleDets: not compatible"
-                              << " (should not have been selected!)";
+                             << " (should not have been selected!)";
     return result;
   }
 
@@ -96,12 +96,12 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
 
 #ifdef EDM_ML_DEBUG
   LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets, closestSector: " << closest << " R1 "
-                            << closestSector->specificSurface().innerRadius()
-                            << " R2: " << closestSector->specificSurface().outerRadius()
-                            << " FTS R: " << tsos.globalPosition().perp();
+                           << closestSector->specificSurface().innerRadius()
+                           << " R2: " << closestSector->specificSurface().outerRadius()
+                           << " FTS R: " << tsos.globalPosition().perp();
   if (tsos.hasError()) {
     LogTrace("MTDDetLayers") << " sR: " << sqrt(tsos.localError().positionError().yy())
-                              << " sX: " << sqrt(tsos.localError().positionError().xx());
+                             << " sX: " << sqrt(tsos.localError().positionError().xx());
   }
 #endif
 
@@ -134,9 +134,9 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
     if (inside) {
 #ifdef EDM_ML_DEBUG
       LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:NextSector" << idet << " R1 "
-                                << theSectors[idet]->specificSurface().innerRadius()
-                                << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
-                                << nextPos.perp();
+                               << theSectors[idet]->specificSurface().innerRadius()
+                               << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
+                               << nextPos.perp();
       nnextdet++;
 #endif
       vector<DetWithState> nextRodDets = theSectors[idet]->compatibleDets(tsos, prop, est);
@@ -158,9 +158,9 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
     if (inside) {
 #ifdef EDM_ML_DEBUG
       LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets:PreviousSector:" << idet << " R1 "
-                                << theSectors[idet]->specificSurface().innerRadius()
-                                << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
-                                << nextPos.perp();
+                               << theSectors[idet]->specificSurface().innerRadius()
+                               << " R2: " << theSectors[idet]->specificSurface().outerRadius() << " FTS R "
+                               << nextPos.perp();
       nnextdet++;
 #endif
       vector<DetWithState> nextRodDets = theSectors[idet]->compatibleDets(tsos, prop, est);
@@ -174,15 +174,15 @@ vector<GeometricSearchDet::DetWithState> MTDSectorForwardLayer::compatibleDets(
 
 #ifdef EDM_ML_DEBUG
   LogTrace("MTDDetLayers") << "     MTDSectorForwardLayer::fastCompatibleDets: found: " << result.size()
-                            << " on closest: " << nclosest << " # checked sectors: " << 1 + nnextdet;
+                           << " on closest: " << nclosest << " # checked sectors: " << 1 + nnextdet;
 #endif
 
   return result;
 }
 
 vector<DetGroup> MTDSectorForwardLayer::groupedCompatibleDets(const TrajectoryStateOnSurface& startingState,
-                                                            const Propagator& prop,
-                                                            const MeasurementEstimator& est) const {
+                                                              const Propagator& prop,
+                                                              const MeasurementEstimator& est) const {
   // FIXME should return only 1 group
   edm::LogInfo("MTDDetLayers") << "dummy implementation of MTDSectorForwardLayer::groupedCompatibleDets()";
   return vector<DetGroup>();

--- a/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
@@ -33,8 +33,8 @@ MTDTrayBarrelLayer::MTDTrayBarrelLayer(vector<const DetRod*>& rods)
   std::copy(theRods.begin(), theRods.end(), back_inserter(theComponents));
 
   // Cache chamber pointers (the basic components_)
-  for (vector<const DetRod*>::const_iterator it = rods.begin(); it != rods.end(); it++) {
-    vector<const GeomDet*> tmp2 = (*it)->basicComponents();
+  for (const auto& it : rods) {
+    vector<const GeomDet*> tmp2 = it->basicComponents();
     theBasicComps.insert(theBasicComps.end(), tmp2.begin(), tmp2.end());
   }
 
@@ -59,8 +59,8 @@ MTDTrayBarrelLayer::MTDTrayBarrelLayer(vector<const DetRod*>& rods)
 
 MTDTrayBarrelLayer::~MTDTrayBarrelLayer() {
   delete theBinFinder;
-  for (vector<const DetRod*>::iterator i = theRods.begin(); i < theRods.end(); i++) {
-    delete *i;
+  for (auto& i : theRods) {
+    delete i;
   }
 }
 

--- a/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
@@ -1,4 +1,4 @@
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
+++ b/RecoMTD/DetLayers/src/MTDTrayBarrelLayer.cc
@@ -1,4 +1,4 @@
-#define EDM_ML_DEBUG
+//#define EDM_ML_DEBUG
 
 /** \file
  *

--- a/RecoMTD/DetLayers/test/BuildFile.xml
+++ b/RecoMTD/DetLayers/test/BuildFile.xml
@@ -8,4 +8,6 @@
   <use name="TrackPropagation/SteppingHelixPropagator"/>
   <use name="MagneticField/Records"/>
   <use name="MagneticField/Engine"/>
+  <use name="Geometry/MTDNumberingBuilder"/>
+  <use name="Geometry/Records"/>
 </library>

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -237,14 +237,14 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
     unsigned int isectInd(0);
     for (const auto& isector : layer->sectors()) {
       isectInd++;
-      LogVerbatim("MTDLayerDump") << std::fixed << "\nSector " << std::setw(4) << isectInd << " pos = " << isector;
+      LogVerbatim("MTDLayerDump") << std::fixed << "\nSector " << std::setw(4) << isectInd << "\n" << (*isector);
       for (const auto& imod : isector->basicComponents()) {
         ETLDetId modId(imod->geographicalId().rawId());
         LogVerbatim("MTDLayerDump") << std::fixed << "ETLDetId " << modId.rawId() << " side = " << std::setw(4)
                                     << modId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " "
                                     << std::setw(4) << modId.discSide() << " " << std::setw(4) << modId.sector()
                                     << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
-                                    << modId.modType() << " pos = " << std::setw(14) << imod->position();
+                                    << modId.modType() << " pos = " << imod->position();
       }
     }
   }
@@ -269,34 +269,31 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    LogInfo("MTDLayerDump") << "\ntestETLLayers: at " << std::fixed << std::setw(14) << tsos.globalPosition()
-                            << " R=" << std::setw(14) << tsos.globalPosition().perp() << " phi=" << std::setw(14)
-                            << tsos.globalPosition().phi() << " Z=" << std::setw(14) << tsos.globalPosition().z()
-                            << " p = " << std::setw(14) << tsos.globalMomentum();
+    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << std::fixed << tsos.globalPosition() << " R=" << std::setw(14)
+                            << tsos.globalPosition().perp() << " phi=" << std::setw(14) << tsos.globalPosition().phi()
+                            << " Z=" << std::setw(14) << tsos.globalPosition().z() << " p = " << tsos.globalMomentum();
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
-    LogInfo("MTDLayerDump") << std::fixed << "is compatible: " << comp.first << " at: R=" << std::setw(14)
+    LogVerbatim("MTDLayerDump") << std::fixed << "is compatible: " << comp.first << " at: R=" << std::setw(14)
                             << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
                             << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
                             << comp.second.globalPosition().z();
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
-      LogInfo("MTDLayerDump") << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
-                              << "  final state pos: " << std::setw(14) << compDets.front().second.globalPosition()
-                              << "\n"
-                              << "  det         pos: " << std::setw(14) << compDets.front().first->position()
-                              << " id: " << std::hex
+      LogVerbatim("MTDLayerDump") << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+                              << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
+                              << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
                               << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
                               << "  distance " << std::setw(14)
                               << (tsos.globalPosition() - compDets.front().first->position()).mag();
     } else {
       if (layer->isCrack(gp)) {
-        LogInfo("MTDLayerDump") << " MTD crack found ";
+        LogVerbatim("MTDLayerDump") << " MTD crack found ";
       } else {
-        LogInfo("MTDLayerDump") << " ERROR : no compatible det found in MTD"
+        LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found in MTD"
                                 << " at: R=" << std::setw(14) << gp.perp() << " phi= " << std::setw(14)
                                 << gp.phi().degrees() << " Z= " << std::setw(14) << gp.z();
       }

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -284,13 +284,13 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
-      LogVerbatim("MTDLayerDump") << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
-                                  << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
-                                  << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
-                                  << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
-                                  << "\n"
-                                  << "  distance " << std::setw(14)
-                                  << (compDets.front().second.globalPosition() - compDets.front().first->position()).mag();
+      LogVerbatim("MTDLayerDump")
+          << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+          << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
+          << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+          << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
+          << "  distance " << std::setw(14)
+          << (compDets.front().second.globalPosition() - compDets.front().first->position()).mag();
     } else {
       if (layer->isCrack(gp)) {
         LogVerbatim("MTDLayerDump") << " MTD crack found ";

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -269,33 +269,35 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << std::fixed << tsos.globalPosition() << " R=" << std::setw(14)
-                            << tsos.globalPosition().perp() << " phi=" << std::setw(14) << tsos.globalPosition().phi()
-                            << " Z=" << std::setw(14) << tsos.globalPosition().z() << " p = " << tsos.globalMomentum();
+    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << std::fixed << tsos.globalPosition()
+                                << " R=" << std::setw(14) << tsos.globalPosition().perp() << " phi=" << std::setw(14)
+                                << tsos.globalPosition().phi() << " Z=" << std::setw(14) << tsos.globalPosition().z()
+                                << " p = " << tsos.globalMomentum();
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
     LogVerbatim("MTDLayerDump") << std::fixed << "is compatible: " << comp.first << " at: R=" << std::setw(14)
-                            << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
-                            << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
-                            << comp.second.globalPosition().z();
+                                << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
+                                << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
+                                << comp.second.globalPosition().z();
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
       LogVerbatim("MTDLayerDump") << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
-                              << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
-                              << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
-                              << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
-                              << "  distance " << std::setw(14)
-                              << (tsos.globalPosition() - compDets.front().first->position()).mag();
+                                  << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
+                                  << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+                                  << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
+                                  << "\n"
+                                  << "  distance " << std::setw(14)
+                                  << (compDets.front().second.globalPosition() - compDets.front().first->position()).mag();
     } else {
       if (layer->isCrack(gp)) {
         LogVerbatim("MTDLayerDump") << " MTD crack found ";
       } else {
         LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found in MTD"
-                                << " at: R=" << std::setw(14) << gp.perp() << " phi= " << std::setw(14)
-                                << gp.phi().degrees() << " Z= " << std::setw(14) << gp.z();
+                                    << " at: R=" << std::setw(14) << gp.perp() << " phi= " << std::setw(14)
+                                    << gp.phi().degrees() << " Z= " << std::setw(14) << gp.z();
       }
     }
   }

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -229,12 +229,14 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
       LogVerbatim("MTDLayerDump") << "\nSector " << isectInd << " pos = " << isector->specificSurface().position()
                                   << " rmin = " << isector->specificSurface().innerRadius()
                                   << " rmax = " << isector->specificSurface().outerRadius()
+                                  << " phi ref = " << isector->specificSurface().position().phi()
                                   << " phi/2 = " << isector->specificSurface().phiHalfExtension();
       for (const auto& imod : isector->basicComponents()) {
         ETLDetId modId(imod->geographicalId().rawId());
         LogVerbatim("MTDLayerDump") << "ETLDetId " << modId.rawId() << " side = " << modId.mtdSide()
                                     << " Disc/Side/Sector = " << modId.nDisc() << " " << modId.discSide() << " "
-                                    << modId.sector() << " mod/type = " << modId.module() << " " << modId.modType();
+                                    << modId.sector() << " mod/type = " << modId.module() << " " << modId.modType()
+                                    << " pos = " << imod->position();
       }
     }
   }

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -2,7 +2,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -12,6 +12,10 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
+
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
@@ -19,6 +23,8 @@
 #include "RecoMTD/DetLayers/interface/MTDDetTray.h"
 #include "RecoMTD/DetLayers/interface/MTDRingForwardDoubleLayer.h"
 #include "RecoMTD/DetLayers/interface/MTDDetRing.h"
+#include "RecoMTD/DetLayers/interface/MTDSectorForwardDoubleLayer.h"
+#include "RecoMTD/DetLayers/interface/MTDDetSector.h"
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
@@ -40,25 +46,34 @@ public:
 
   void testBTLLayers(const MTDDetLayerGeometry*, const MagneticField* field);
   void testETLLayers(const MTDDetLayerGeometry*, const MagneticField* field);
+  void testETLLayersNew(const MTDDetLayerGeometry*, const MagneticField* field);
 
   string dumpLayer(const DetLayer* layer) const;
 
 private:
   MeasurementEstimator* theEstimator;
+
+  const edm::ESInputTag tag_;
+  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> geomToken_;
+  edm::ESGetToken<MTDTopology, MTDTopologyRcd> mtdtopoToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magfieldToken_;
 };
 
-MTDRecoGeometryAnalyzer::MTDRecoGeometryAnalyzer(const ParameterSet& iConfig) {
+MTDRecoGeometryAnalyzer::MTDRecoGeometryAnalyzer(const ParameterSet& iConfig) : tag_(edm::ESInputTag{"", ""}) {
+  geomToken_ = esConsumes<MTDDetLayerGeometry, MTDRecoGeometryRecord>(tag_);
+  mtdtopoToken_ = esConsumes<MTDTopology, MTDTopologyRcd>(tag_);
+  magfieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>(tag_);
+
   float theMaxChi2 = 25.;
   float theNSigma = 3.;
   theEstimator = new Chi2MeasurementEstimator(theMaxChi2, theNSigma);
 }
 
 void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
-  ESHandle<MTDDetLayerGeometry> geo;
-  es.get<MTDRecoGeometryRecord>().get(geo);
+  auto geo = es.getTransientHandle(geomToken_);
+  auto mtdtopo = es.getTransientHandle(mtdtopoToken_);
+  auto magfield = es.getTransientHandle(magfieldToken_);
 
-  ESHandle<MagneticField> magfield;
-  es.get<IdealMagneticFieldRecord>().get(magfield);
   // Some printouts
 
   LogVerbatim("MTDLayerDump") << "\n*** allBTLLayers(): " << geo->allBTLLayers().size();
@@ -77,7 +92,11 @@ void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
   }
 
   testBTLLayers(geo.product(), magfield.product());
-  testETLLayers(geo.product(), magfield.product());
+  if (mtdtopo->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
+    testETLLayers(geo.product(), magfield.product());
+  } else {
+    testETLLayersNew(geo.product(), magfield.product());
+  }
 }
 
 void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, const MagneticField* field) {
@@ -85,6 +104,9 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
 
   for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
     const MTDTrayBarrelLayer* layer = (const MTDTrayBarrelLayer*)(*ilay);
+
+    LogVerbatim("MTDLayerDump") << "\nBTL layer " << layer->subDetector() << " rods = " << layer->rods().size()
+                                << " dets = " << layer->basicComponents().size();
 
     const BoundCylinder& cyl = layer->specificSurface();
 
@@ -134,6 +156,83 @@ void MTDRecoGeometryAnalyzer::testETLLayers(const MTDDetLayerGeometry* geo, cons
 
   for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
     const MTDRingForwardDoubleLayer* layer = (const MTDRingForwardDoubleLayer*)(*ilay);
+
+    LogVerbatim("MTDLayerDump") << "\nETL layer " << layer->subDetector() << " rings = " << layer->rings().size()
+                                << " dets = " << layer->basicComponents().size()
+                                << " front dets = " << layer->frontLayer()->basicComponents().size()
+                                << " back dets = " << layer->backLayer()->basicComponents().size();
+
+    const BoundDisk& disk = layer->specificSurface();
+
+    // Generate a random point on the disk
+    double aPhi = CLHEP::RandFlat::shoot(-Geom::pi(), Geom::pi());
+    double aR = CLHEP::RandFlat::shoot(disk.innerRadius(), disk.outerRadius());
+    GlobalPoint gp(GlobalPoint::Cylindrical(aR, aPhi, disk.position().z()));
+
+    // Momentum: 10 GeV, straight from the origin
+    GlobalVector gv(GlobalVector::Spherical(gp.theta(), aPhi, 10.));
+
+    //FIXME: only negative charge
+    int charge = -1;
+
+    GlobalTrajectoryParameters gtp(gp, gv, charge, field);
+    TrajectoryStateOnSurface tsos(gtp, disk);
+    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << tsos.globalPosition()
+                                << " R=" << tsos.globalPosition().perp() << " phi=" << tsos.globalPosition().phi()
+                                << " Z=" << tsos.globalPosition().z() << " p = " << tsos.globalMomentum();
+
+    SteppingHelixPropagator prop(field, anyDirection);
+
+    pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
+    LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
+                                << " phi=" << comp.second.globalPosition().phi()
+                                << " Z=" << comp.second.globalPosition().z();
+
+    vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
+    if (compDets.size()) {
+      LogVerbatim("MTDLayerDump") << "compatibleDets: " << compDets.size() << "\n"
+                                  << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
+                                  << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+                                  << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
+                                  << "\n"
+                                  << "  distance "
+                                  << (tsos.globalPosition() - compDets.front().first->position()).mag();
+    } else {
+      if (layer->isCrack(gp)) {
+        LogVerbatim("MTDLayerDump") << " MTD crack found ";
+      } else {
+        LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found in MTD"
+                                    << " at: R=" << gp.perp() << " phi= " << gp.phi().degrees() << " Z= " << gp.z();
+      }
+    }
+  }
+}
+
+void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, const MagneticField* field) {
+  const vector<const DetLayer*>& layers = geo->allETLLayers();
+
+  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
+    const MTDSectorForwardDoubleLayer* layer = (const MTDSectorForwardDoubleLayer*)(*ilay);
+
+    LogVerbatim("MTDLayerDump") << "\nETL layer " << layer->subDetector() << " sectors = " << layer->sectors().size()
+                                << " dets = " << layer->basicComponents().size()
+                                << " front dets = " << layer->frontLayer()->basicComponents().size()
+                                << " back dets = " << layer->backLayer()->basicComponents().size();
+
+    unsigned int isectInd(0);
+    for (const auto& isector : layer->sectors()) {
+      isectInd++;
+      LogVerbatim("MTDLayerDump") << "Sector " << isectInd << " pos = " << isector->specificSurface().position()
+                                  << " rmin = " << isector->specificSurface().innerRadius()
+                                  << " rmax = " << isector->specificSurface().outerRadius()
+                                  << " phi/2 = " << isector->specificSurface().phiHalfExtension();
+      for (const auto& imod : isector->basicComponents()) {
+        ETLDetId modId(imod->geographicalId().rawId());
+        LogVerbatim("MTDLayerDump") << modId << " side = " << modId.mtdSide() << " Disc/Side/Sector = " << modId.nDisc()
+                                    << " " << modId.discSide() << " " << modId.sector()
+                                    << " mod/type = " << modId.module() << " " << modId.modType();
+      }
+    }
 
     const BoundDisk& disk = layer->specificSurface();
 
@@ -190,9 +289,11 @@ string MTDRecoGeometryAnalyzer::dumpLayer(const DetLayer* layer) const {
 
   sur = &(layer->surface());
   if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
-    output << "  Cylinder of radius: " << bc->radius();
+    output << " subdet = " << layer->subDetector() << " Barrel = " << layer->isBarrel()
+           << " Forward = " << layer->isForward() << "  Cylinder of radius: " << bc->radius();
   } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
-    output << "  Disk at: " << bd->position().z();
+    output << " subdet = " << layer->subDetector() << " Barrel = " << layer->isBarrel()
+           << " Forward = " << layer->isForward() << "  Disk at: " << bd->position().z();
   }
   return output.str();
 }

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -76,17 +76,17 @@ void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
 
   // Some printouts
 
-  LogVerbatim("MTDLayerDump") << "\n*** allBTLLayers(): " << geo->allBTLLayers().size();
+  LogVerbatim("MTDLayerDump") << "\n*** allBTLLayers(): " << std::fixed << std::setw(14) << geo->allBTLLayers().size();
   for (auto dl = geo->allBTLLayers().begin(); dl != geo->allBTLLayers().end(); ++dl) {
     LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allBTLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
-  LogVerbatim("MTDLayerDump") << "\n*** allETLLayers(): " << geo->allETLLayers().size();
+  LogVerbatim("MTDLayerDump") << "\n*** allETLLayers(): " << std::fixed << std::setw(14) << geo->allETLLayers().size();
   for (auto dl = geo->allETLLayers().begin(); dl != geo->allETLLayers().end(); ++dl) {
     LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allETLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
-  LogVerbatim("MTDLayerDump") << "\n*** allLayers(): " << geo->allLayers().size();
+  LogVerbatim("MTDLayerDump") << "\n*** allLayers(): " << std::fixed << std::setw(14) << geo->allLayers().size();
   for (auto dl = geo->allLayers().begin(); dl != geo->allLayers().end(); ++dl) {
     LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
   }
@@ -105,8 +105,9 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
   for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
     const MTDTrayBarrelLayer* layer = (const MTDTrayBarrelLayer*)(*ilay);
 
-    LogVerbatim("MTDLayerDump") << "\nBTL layer " << layer->subDetector() << " rods = " << layer->rods().size()
-                                << " dets = " << layer->basicComponents().size();
+    LogVerbatim("MTDLayerDump") << std::fixed << "\nBTL layer " << std::setw(4) << layer->subDetector()
+                                << " rods = " << std::setw(14) << layer->rods().size() << " dets = " << std::setw(14)
+                                << layer->basicComponents().size();
 
     const BoundCylinder& cyl = layer->specificSurface();
 
@@ -125,25 +126,29 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, cyl);
-    LogVerbatim("MTDLayerDump") << "\ntestBTLLayers: at " << tsos.globalPosition()
-                                << " R=" << tsos.globalPosition().perp() << " phi=" << tsos.globalPosition().phi()
-                                << " Z=" << tsos.globalPosition().z() << " p = " << tsos.globalMomentum();
+    LogVerbatim("MTDLayerDump") << "\ntestBTLLayers: at " << std::fixed << std::setw(14) << tsos.globalPosition()
+                                << " R=" << std::setw(14) << tsos.globalPosition().perp() << " phi=" << std::setw(14)
+                                << tsos.globalPosition().phi() << " Z=" << std::setw(14) << tsos.globalPosition().z()
+                                << " p = " << std::setw(14) << tsos.globalMomentum();
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
-    LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
-                                << " phi=" << comp.second.globalPosition().phi()
-                                << " Z=" << comp.second.globalPosition().z();
+    LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << std::setw(14)
+                                << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
+                                << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
+                                << comp.second.globalPosition().z();
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
-      LogVerbatim("MTDLayerDump") << "compatibleDets: " << compDets.size() << "\n"
-                                  << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
-                                  << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+      LogVerbatim("MTDLayerDump") << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+                                  << "  final state pos: " << std::setw(14) << compDets.front().second.globalPosition()
+                                  << "\n"
+                                  << "  det         pos: " << std::setw(14) << compDets.front().first->position()
+                                  << " id: " << std::hex
                                   << BTLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
                                   << "\n"
-                                  << "  distance "
+                                  << "  distance " << std::setw(14)
                                   << (tsos.globalPosition() - compDets.front().first->position()).mag();
     } else {
       LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found";
@@ -157,10 +162,11 @@ void MTDRecoGeometryAnalyzer::testETLLayers(const MTDDetLayerGeometry* geo, cons
   for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
     const MTDRingForwardDoubleLayer* layer = (const MTDRingForwardDoubleLayer*)(*ilay);
 
-    LogVerbatim("MTDLayerDump") << "\nETL layer " << layer->subDetector() << " rings = " << layer->rings().size()
-                                << " dets = " << layer->basicComponents().size()
-                                << " front dets = " << layer->frontLayer()->basicComponents().size()
-                                << " back dets = " << layer->backLayer()->basicComponents().size();
+    LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
+                                << " rings = " << std::setw(14) << layer->rings().size() << " dets = " << std::setw(14)
+                                << layer->basicComponents().size() << " front dets = " << std::setw(14)
+                                << layer->frontLayer()->basicComponents().size() << " back dets = " << std::setw(14)
+                                << layer->backLayer()->basicComponents().size();
 
     const BoundDisk& disk = layer->specificSurface();
 
@@ -177,32 +183,37 @@ void MTDRecoGeometryAnalyzer::testETLLayers(const MTDDetLayerGeometry* geo, cons
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << tsos.globalPosition()
-                                << " R=" << tsos.globalPosition().perp() << " phi=" << tsos.globalPosition().phi()
-                                << " Z=" << tsos.globalPosition().z() << " p = " << tsos.globalMomentum();
+    LogVerbatim("MTDLayerDump") << "\ntestETLLayers: at " << std::setw(14) << tsos.globalPosition()
+                                << " R=" << std::setw(14) << tsos.globalPosition().perp() << " phi=" << std::setw(14)
+                                << tsos.globalPosition().phi() << " Z=" << std::setw(14) << tsos.globalPosition().z()
+                                << " p = " << std::setw(14) << tsos.globalMomentum();
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
-    LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
-                                << " phi=" << comp.second.globalPosition().phi()
-                                << " Z=" << comp.second.globalPosition().z();
+    LogVerbatim("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << std::setw(14)
+                                << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
+                                << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
+                                << comp.second.globalPosition().z();
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
-      LogVerbatim("MTDLayerDump") << "compatibleDets: " << compDets.size() << "\n"
-                                  << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
-                                  << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+      LogVerbatim("MTDLayerDump") << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+                                  << "  final state pos: " << std::setw(14) << compDets.front().second.globalPosition()
+                                  << "\n"
+                                  << "  det         pos: " << std::setw(14) << compDets.front().first->position()
+                                  << " id: " << std::hex
                                   << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec
                                   << "\n"
-                                  << "  distance "
+                                  << "  distance " << std::setw(14)
                                   << (tsos.globalPosition() - compDets.front().first->position()).mag();
     } else {
       if (layer->isCrack(gp)) {
         LogVerbatim("MTDLayerDump") << " MTD crack found ";
       } else {
         LogVerbatim("MTDLayerDump") << " ERROR : no compatible det found in MTD"
-                                    << " at: R=" << gp.perp() << " phi= " << gp.phi().degrees() << " Z= " << gp.z();
+                                    << " at: R=" << std::setw(14) << gp.perp() << " phi= " << std::setw(14)
+                                    << gp.phi().degrees() << " Z= " << std::setw(14) << gp.z();
       }
     }
   }
@@ -216,27 +227,24 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
   for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
     const MTDSectorForwardDoubleLayer* layer = (const MTDSectorForwardDoubleLayer*)(*ilay);
 
-    LogVerbatim("MTDLayerDump") << "\nETL layer " << layer->subDetector()
-                                << " at z = " << layer->surface().position().z()
-                                << " sectors = " << layer->sectors().size()
-                                << " dets = " << layer->basicComponents().size()
-                                << " front dets = " << layer->frontLayer()->basicComponents().size()
-                                << " back dets = " << layer->backLayer()->basicComponents().size();
+    LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
+                                << " at z = " << std::setw(14) << layer->surface().position().z()
+                                << " sectors = " << std::setw(14) << layer->sectors().size()
+                                << " dets = " << std::setw(14) << layer->basicComponents().size()
+                                << " front dets = " << std::setw(14) << layer->frontLayer()->basicComponents().size()
+                                << " back dets = " << std::setw(14) << layer->backLayer()->basicComponents().size();
 
     unsigned int isectInd(0);
     for (const auto& isector : layer->sectors()) {
       isectInd++;
-      LogVerbatim("MTDLayerDump") << "\nSector " << isectInd << " pos = " << isector->specificSurface().position()
-                                  << " rmin = " << isector->specificSurface().innerRadius()
-                                  << " rmax = " << isector->specificSurface().outerRadius()
-                                  << " phi ref = " << isector->specificSurface().position().phi()
-                                  << " phi/2 = " << isector->specificSurface().phiHalfExtension();
+      LogVerbatim("MTDLayerDump") << std::fixed << "\nSector " << std::setw(4) << isectInd << " pos = " << isector;
       for (const auto& imod : isector->basicComponents()) {
         ETLDetId modId(imod->geographicalId().rawId());
-        LogVerbatim("MTDLayerDump") << "ETLDetId " << modId.rawId() << " side = " << modId.mtdSide()
-                                    << " Disc/Side/Sector = " << modId.nDisc() << " " << modId.discSide() << " "
-                                    << modId.sector() << " mod/type = " << modId.module() << " " << modId.modType()
-                                    << " pos = " << imod->position();
+        LogVerbatim("MTDLayerDump") << std::fixed << "ETLDetId " << modId.rawId() << " side = " << std::setw(4)
+                                    << modId.mtdSide() << " Disc/Side/Sector = " << std::setw(4) << modId.nDisc() << " "
+                                    << std::setw(4) << modId.discSide() << " " << std::setw(4) << modId.sector()
+                                    << " mod/type = " << std::setw(4) << modId.module() << " " << std::setw(4)
+                                    << modId.modType() << " pos = " << std::setw(14) << imod->position();
       }
     }
   }
@@ -261,30 +269,36 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
     GlobalTrajectoryParameters gtp(gp, gv, charge, field);
     TrajectoryStateOnSurface tsos(gtp, disk);
-    LogInfo("MTDLayerDump") << "\ntestETLLayers: at " << tsos.globalPosition() << " R=" << tsos.globalPosition().perp()
-                            << " phi=" << tsos.globalPosition().phi() << " Z=" << tsos.globalPosition().z()
-                            << " p = " << tsos.globalMomentum();
+    LogInfo("MTDLayerDump") << "\ntestETLLayers: at " << std::fixed << std::setw(14) << tsos.globalPosition()
+                            << " R=" << std::setw(14) << tsos.globalPosition().perp() << " phi=" << std::setw(14)
+                            << tsos.globalPosition().phi() << " Z=" << std::setw(14) << tsos.globalPosition().z()
+                            << " p = " << std::setw(14) << tsos.globalMomentum();
 
     SteppingHelixPropagator prop(field, anyDirection);
 
     pair<bool, TrajectoryStateOnSurface> comp = layer->compatible(tsos, prop, *theEstimator);
-    LogInfo("MTDLayerDump") << "is compatible: " << comp.first << " at: R=" << comp.second.globalPosition().perp()
-                            << " phi=" << comp.second.globalPosition().phi()
-                            << " Z=" << comp.second.globalPosition().z();
+    LogInfo("MTDLayerDump") << std::fixed << "is compatible: " << comp.first << " at: R=" << std::setw(14)
+                            << comp.second.globalPosition().perp() << " phi=" << std::setw(14)
+                            << comp.second.globalPosition().phi() << " Z=" << std::setw(14)
+                            << comp.second.globalPosition().z();
 
     vector<DetLayer::DetWithState> compDets = layer->compatibleDets(tsos, prop, *theEstimator);
     if (compDets.size()) {
-      LogInfo("MTDLayerDump") << "compatibleDets: " << compDets.size() << "\n"
-                              << "  final state pos: " << compDets.front().second.globalPosition() << "\n"
-                              << "  det         pos: " << compDets.front().first->position() << " id: " << std::hex
+      LogInfo("MTDLayerDump") << std::fixed << "compatibleDets: " << std::setw(14) << compDets.size() << "\n"
+                              << "  final state pos: " << std::setw(14) << compDets.front().second.globalPosition()
+                              << "\n"
+                              << "  det         pos: " << std::setw(14) << compDets.front().first->position()
+                              << " id: " << std::hex
                               << ETLDetId(compDets.front().first->geographicalId().rawId()).rawId() << std::dec << "\n"
-                              << "  distance " << (tsos.globalPosition() - compDets.front().first->position()).mag();
+                              << "  distance " << std::setw(14)
+                              << (tsos.globalPosition() - compDets.front().first->position()).mag();
     } else {
       if (layer->isCrack(gp)) {
         LogInfo("MTDLayerDump") << " MTD crack found ";
       } else {
         LogInfo("MTDLayerDump") << " ERROR : no compatible det found in MTD"
-                                << " at: R=" << gp.perp() << " phi= " << gp.phi().degrees() << " Z= " << gp.z();
+                                << " at: R=" << std::setw(14) << gp.perp() << " phi= " << std::setw(14)
+                                << gp.phi().degrees() << " Z= " << std::setw(14) << gp.z();
       }
     }
   }
@@ -299,11 +313,11 @@ string MTDRecoGeometryAnalyzer::dumpLayer(const DetLayer* layer) const {
 
   sur = &(layer->surface());
   if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
-    output << " subdet = " << layer->subDetector() << " Barrel = " << layer->isBarrel()
-           << " Forward = " << layer->isForward() << "  Cylinder of radius: " << bc->radius();
+    output << std::fixed << " subdet = " << std::setw(4) << layer->subDetector() << " Barrel = " << layer->isBarrel()
+           << " Forward = " << layer->isForward() << "  Cylinder of radius: " << std::setw(14) << bc->radius();
   } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
-    output << " subdet = " << layer->subDetector() << " Barrel = " << layer->isBarrel()
-           << " Forward = " << layer->isForward() << "  Disk at: " << bd->position().z();
+    output << std::fixed << " subdet = " << std::setw(4) << layer->subDetector() << " Barrel = " << layer->isBarrel()
+           << " Forward = " << layer->isForward() << "  Disk at: " << std::setw(14) << bd->position().z();
   }
   return output.str();
 }

--- a/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
+++ b/RecoMTD/DetLayers/test/MTDRecoGeometryAnalyzer.cc
@@ -78,17 +78,17 @@ void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
 
   LogVerbatim("MTDLayerDump") << "\n*** allBTLLayers(): " << std::fixed << std::setw(14) << geo->allBTLLayers().size();
   for (auto dl = geo->allBTLLayers().begin(); dl != geo->allBTLLayers().end(); ++dl) {
-    LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allBTLLayers().begin()) << " " << dumpLayer(*dl);
+    LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allBTLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
   LogVerbatim("MTDLayerDump") << "\n*** allETLLayers(): " << std::fixed << std::setw(14) << geo->allETLLayers().size();
   for (auto dl = geo->allETLLayers().begin(); dl != geo->allETLLayers().end(); ++dl) {
-    LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allETLLayers().begin()) << " " << dumpLayer(*dl);
+    LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allETLLayers().begin()) << " " << dumpLayer(*dl);
   }
 
   LogVerbatim("MTDLayerDump") << "\n*** allLayers(): " << std::fixed << std::setw(14) << geo->allLayers().size();
   for (auto dl = geo->allLayers().begin(); dl != geo->allLayers().end(); ++dl) {
-    LogVerbatim("MTDLayerDump") << "  " << (int)(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
+    LogVerbatim("MTDLayerDump") << "  " << static_cast<int>(dl - geo->allLayers().begin()) << " " << dumpLayer(*dl);
   }
 
   testBTLLayers(geo.product(), magfield.product());
@@ -102,8 +102,8 @@ void MTDRecoGeometryAnalyzer::analyze(const Event& ev, const EventSetup& es) {
 void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, const MagneticField* field) {
   const vector<const DetLayer*>& layers = geo->allBTLLayers();
 
-  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
-    const MTDTrayBarrelLayer* layer = (const MTDTrayBarrelLayer*)(*ilay);
+  for (const auto& ilay : layers) {
+    const MTDTrayBarrelLayer* layer = static_cast<const MTDTrayBarrelLayer*>(ilay);
 
     LogVerbatim("MTDLayerDump") << std::fixed << "\nBTL layer " << std::setw(4) << layer->subDetector()
                                 << " rods = " << std::setw(14) << layer->rods().size() << " dets = " << std::setw(14)
@@ -159,8 +159,8 @@ void MTDRecoGeometryAnalyzer::testBTLLayers(const MTDDetLayerGeometry* geo, cons
 void MTDRecoGeometryAnalyzer::testETLLayers(const MTDDetLayerGeometry* geo, const MagneticField* field) {
   const vector<const DetLayer*>& layers = geo->allETLLayers();
 
-  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
-    const MTDRingForwardDoubleLayer* layer = (const MTDRingForwardDoubleLayer*)(*ilay);
+  for (const auto& ilay : layers) {
+    const MTDRingForwardDoubleLayer* layer = static_cast<const MTDRingForwardDoubleLayer*>(ilay);
 
     LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
                                 << " rings = " << std::setw(14) << layer->rings().size() << " dets = " << std::setw(14)
@@ -224,8 +224,8 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
   // dump of ETL layers structure
 
-  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
-    const MTDSectorForwardDoubleLayer* layer = (const MTDSectorForwardDoubleLayer*)(*ilay);
+  for (const auto& ilay : layers) {
+    const MTDSectorForwardDoubleLayer* layer = static_cast<const MTDSectorForwardDoubleLayer*>(ilay);
 
     LogVerbatim("MTDLayerDump") << std::fixed << "\nETL layer " << std::setw(4) << layer->subDetector()
                                 << " at z = " << std::setw(14) << layer->surface().position().z()
@@ -251,8 +251,8 @@ void MTDRecoGeometryAnalyzer::testETLLayersNew(const MTDDetLayerGeometry* geo, c
 
   // test propagation through layers
 
-  for (auto ilay = layers.begin(); ilay != layers.end(); ++ilay) {
-    const MTDSectorForwardDoubleLayer* layer = (const MTDSectorForwardDoubleLayer*)(*ilay);
+  for (const auto& ilay : layers) {
+    const MTDSectorForwardDoubleLayer* layer = static_cast<const MTDSectorForwardDoubleLayer*>(ilay);
 
     const BoundDisk& disk = layer->specificSurface();
 

--- a/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
+++ b/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
@@ -11,11 +11,12 @@
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
+#include "Geometry/Records/interface/MTDTopologyRcd.h"
 
 #include "FWCore/Utilities/interface/mplVector.h"
 
 class MTDRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MTDRecoGeometryRecord,
-                                                            edm::mpl::Vector<MTDDigiGeometryRecord> > {};
+                                                            edm::mpl::Vector<MTDTopologyRcd, MTDDigiGeometryRecord> > {};
 
 #endif

--- a/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
+++ b/RecoMTD/Records/interface/MTDRecoGeometryRecord.h
@@ -17,6 +17,7 @@
 
 class MTDRecoGeometryRecord
     : public edm::eventsetup::DependentRecordImplementation<MTDRecoGeometryRecord,
-                                                            edm::mpl::Vector<MTDTopologyRcd, MTDDigiGeometryRecord> > {};
+                                                            edm::mpl::Vector<MTDTopologyRcd, MTDDigiGeometryRecord> > {
+};
 
 #endif

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_TkDetLayers_BladeShapeBuilderFromDet_h
 #define RecoTracker_TkDetLayers_BladeShapeBuilderFromDet_h
 
-#include "BoundDiskSector.h"
-#include "DiskSectorBounds.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>

--- a/RecoTracker/TkDetLayers/src/BoundDiskSector.cc
+++ b/RecoTracker/TkDetLayers/src/BoundDiskSector.cc
@@ -1,1 +1,0 @@
-#include "BoundDiskSector.h"

--- a/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
+++ b/RecoTracker/TkDetLayers/src/CompositeTECPetal.h
@@ -5,7 +5,7 @@
 
 #include "TECWedge.h"
 
-#include "BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
 
 #include "SubLayerCrossings.h"
 

--- a/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
+++ b/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromDet.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_TkDetLayers_ForwardDiskSectorBuilderFromDet_h
 #define RecoTracker_TkDetLayers_ForwardDiskSectorBuilderFromDet_h
 
-#include "BoundDiskSector.h"
-#include "DiskSectorBounds.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include <utility>

--- a/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromWedges.h
+++ b/RecoTracker/TkDetLayers/src/ForwardDiskSectorBuilderFromWedges.h
@@ -1,8 +1,8 @@
 #ifndef RecoTracker_TkDetLayers_ForwardDiskSectorBuilderFromWedges_h
 #define RecoTracker_TkDetLayers_ForwardDiskSectorBuilderFromWedges_h
 
-#include "BoundDiskSector.h"
-#include "DiskSectorBounds.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/DiskSectorBounds.h"
 #include "TECWedge.h"
 #include <utility>
 #include <vector>

--- a/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/Phase1PixelBlade.h
@@ -1,7 +1,7 @@
 #ifndef TkDetLayers_Phase1PixelBlade_h
 #define TkDetLayers_Phase1PixelBlade_h
 
-#include "BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
 #include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
 
 #include "TrackingTools/DetLayers/interface/PeriodicBinFinderInZ.h"

--- a/RecoTracker/TkDetLayers/src/PixelBlade.h
+++ b/RecoTracker/TkDetLayers/src/PixelBlade.h
@@ -1,7 +1,7 @@
 #ifndef TkDetLayers_PixelBlade_h
 #define TkDetLayers_PixelBlade_h
 
-#include "BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
 #include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
 
 #include "TrackingTools/DetLayers/interface/PeriodicBinFinderInZ.h"

--- a/RecoTracker/TkDetLayers/src/TECWedge.h
+++ b/RecoTracker/TkDetLayers/src/TECWedge.h
@@ -2,7 +2,7 @@
 #define TkDetLayers_TECWedge_h
 
 #include "TrackingTools/DetLayers/interface/GeometricSearchDet.h"
-#include "BoundDiskSector.h"
+#include "DataFormats/GeometrySurface/interface/BoundDiskSector.h"
 
 /** A concrete implementation for TEC layer 
  *  built out of TECPetals

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -34,8 +34,8 @@ _barrel_MTDDigitizer = cms.PSet(
         SigmaClock                 = cms.double(0.015), # [ns]
         CorrelationCoefficient     = cms.double(1.),
         SmearTimeForOOTtails       = cms.bool(True),
-        Npe_to_pC                  = cms.double(0.016), # [pC] 
-        Npe_to_V                   = cms.double(0.0064),# [V] 
+        Npe_to_pC                  = cms.double(0.016), # [pC]
+        Npe_to_V                   = cms.double(0.0064),# [V]
 
         # n bits for the ADC 
         adcNbits          = cms.uint32(10),
@@ -100,4 +100,3 @@ mtdDigitizer = cms.PSet(
     barrelDigitizer = _barrel_MTDDigitizer,
     endcapDigitizer = _endcap_MTDDigitizer
 )
-

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -84,6 +84,9 @@ _endcap_MTDDigitizer = cms.PSet(
         )
 )
 
+from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
+phase2_etlV4.toModify(_endcap_MTDDigitizer.DeviceSimulation, meVPerMIP = 0.001 )
+
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 for _m in [_barrel_MTDDigitizer, _endcap_MTDDigitizer]:
     premix_stage1.toModify(_m, premixStage1 = True)


### PR DESCRIPTION
#### PR description:

This PR is built on top of #31710 (here fully embedded), where the new ETL geometries implemented by @icosivi are integrated, and needs #31654 to provide physically meaningful results. Its full scrutiny will benefit from the updated MTD validation for 2-discs ETL prepared by @gsorrentino18 which will be presented in a separate PR.

To complete the basic geometry definition in view of the reconstruction, the logical partitioning of LGADs encoded in the MTD topology (from ```mtdParameters.xml```) is updated to the TDR scenario of 2 ROCs per LGAD, 16x32 pixels of 1.3x1.3 mm**2. 

The heart of the PR is the full update of ```RecoMTD/DetLayers``` package to add, in parallel to the existing ring-based layer, a sector-based layer suitable to describe both scenario D72 (4 sectors per disc face) and D73 (2 sectors per disc face). A parallel set of classes is built, and the choice of which layer geometry to build is made based on the ```MTDTopologyMode``` parameter provided by the topology ES. In order to describe the sector, which is a bounded disc sector, the existing classes developed for the tracker are used, and moved outside the ```RecoTracker/TkDetLayers``` area into the more standard ```DataFormats/GeometrySurface``` package (where other similar objects are stored).

Since at present this code must simultaneously describe two different detector designs, the strategy chosen to search for ```compatibleDets``` within a sector is kept simple, without and optimized navigation of the module matrix for the time being. As it cannot exploit existing geometrical ordering strategies (as for rings, concentring rings ordered in radius with modules ordered in phi), the numerical sorting of modules within a sectors by ```ETLDetId``` provides an approximate ordering of modules (same module number, different types corresponding to left/right side of a modules' strip). This ordering would be pair-wide lexicographic in a x,y matrix of modules, but for the fact that the left and right number of modules does not fully match, as can be seen from a geometry display for one of the D73 discs.

![image](https://user-images.githubusercontent.com/4058194/95835662-cccc3300-0d3e-11eb-9268-03f2c15929da.png)

When the module of closest approach to the track extrapolation onto the sector surface is identified in a loop probing the distance of all modules, a range of modules around the closest one is explored to search for possible other compatibilities. In order to limit the CPU time taken by the search, a fixed-range window of modules is defined around the closest one, and modules are sorted according to distances are sorted just in that range (and not on the whole sector), so the sorting involves at most 100 elements (in the present implementation), based on the geometry of the setups and observed behaviour.

#### PR validation:

The standard benchmark workflows for scenarios D72 and D73 , defined already in #31710, are activated in this PR to allow tests to systematically probe also this new code. They have been verified to smoothly run on 100 events. A refreshed dedicated test code is provided in the test area of ```RecoMTD/DetLayers```, it has been used to check the structure of layers and behaviour of the search code, and can be easily turned into a unit test like those running already for the ```Geometry/MTD*``` packages. A preliminary check with the updated MTD DQM performed by @gsorrentino18 on a late development stage of this PR showed reasonable results (to be reverified).