### PR TITLE
New ETL Geometry Validation

### DIFF
--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -283,11 +283,11 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL DIGI hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL DIGI hits Y (+Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -310, -301);
-  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -310, -301);
+      "EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -304.2, -303.4);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -304.2, -303.4);
   meHitZ_[2] = ibook.book1D(
-      "EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 301, 310);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 301, 310);
+      "EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 303.4, 304.2);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 303.4, 304.2);
 
   meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1",
                               "ETL DIGI hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]",

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -367,7 +367,7 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       0.,
       1024.);
   meHitQvsPhi_[3] =
-      ibook.bookProfile("EtlHitQvsPhiZpos",
+      ibook.bookProfile("EtlHitQvsPhiZposD2",
                         "ETL DIGI charge vs #phi (+Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
                         50,
                         -3.15,

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -28,6 +28,8 @@
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
 class EtlDigiHitsValidation : public DQMEDAnalyzer {
 public:
@@ -49,24 +51,24 @@ private:
 
   // --- histograms declaration
 
-  MonitorElement* meNhits_[2];
+  MonitorElement* meNhits_[4];
 
-  MonitorElement* meHitCharge_[2];
-  MonitorElement* meHitTime_[2];
+  MonitorElement* meHitCharge_[4];
+  MonitorElement* meHitTime_[4];
 
-  MonitorElement* meOccupancy_[2];
+  MonitorElement* meOccupancy_[4];
 
-  MonitorElement* meHitX_[2];
-  MonitorElement* meHitY_[2];
-  MonitorElement* meHitZ_[2];
-  MonitorElement* meHitPhi_[2];
-  MonitorElement* meHitEta_[2];
+  MonitorElement* meHitX_[4];
+  MonitorElement* meHitY_[4];
+  MonitorElement* meHitZ_[4];
+  MonitorElement* meHitPhi_[4];
+  MonitorElement* meHitEta_[4];
 
-  MonitorElement* meHitTvsQ_[2];
-  MonitorElement* meHitQvsPhi_[2];
-  MonitorElement* meHitQvsEta_[2];
-  MonitorElement* meHitTvsPhi_[2];
-  MonitorElement* meHitTvsEta_[2];
+  MonitorElement* meHitTvsQ_[4];
+  MonitorElement* meHitQvsPhi_[4];
+  MonitorElement* meHitQvsEta_[4];
+  MonitorElement* meHitTvsPhi_[4];
+  MonitorElement* meHitTvsEta_[4];
 };
 
 // ------------ constructor and destructor --------------
@@ -81,24 +83,31 @@ EtlDigiHitsValidation::~EtlDigiHitsValidation() {}
 void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  const MTDTopology* topology = topologyHandle.product();
+
+  bool topo1Dis = false;
+  bool topo2Dis = false;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
   const MTDGeometry* geom = geometryHandle.product();
 
   auto etlDigiHitsHandle = makeValid(iEvent.getHandle(etlDigiHitsToken_));
 
-  // --- Loop over the ELT DIGI hits
+  // --- Loop over the ETL DIGI hits
 
-  unsigned int n_digi_etl[2] = {0, 0};
+  unsigned int n_digi_etl[4] = {0, 0, 0, 0};
 
   for (const auto& dataFrame : *etlDigiHitsHandle) {
     // --- Get the on-time sample
     int isample = 2;
 
     const auto& sample = dataFrame.sample(isample);
-
     ETLDetId detId = dataFrame.id();
-
     DetId geoId = detId.geographicalId();
 
     const MTDGeomDet* thedet = geom->idToDet(geoId);
@@ -112,7 +121,31 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
     // --- Fill the histograms
 
-    int idet = (detId.zside() + 1) / 2;
+    int idet = 999;
+    
+    if (topo1Dis) {
+      if (detId.zside() == -1) {
+        idet = 0;
+      } else if (detId.zside() == 1) {
+        idet = 2;
+      } else {
+        continue;
+      }
+    }
+
+    if (topo2Dis) {
+      if ((detId.zside() == -1) && (detId.nDisc() == 1)) {
+        idet = 0;
+      } else if ((detId.zside() == -1) && (detId.nDisc() == 2)) {
+        idet = 1;
+      } else if ((detId.zside() == 1) && (detId.nDisc() == 1)) {
+        idet = 2;
+      } else if ((detId.zside() == 1) && (detId.nDisc() == 2)) {
+        idet = 3;
+      } else {
+        continue;
+      }
+    }
 
     meHitCharge_[idet]->Fill(sample.data());
     meHitTime_[idet]->Fill(sample.toa());
@@ -134,8 +167,16 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   }  // dataFrame loop
 
-  meNhits_[0]->Fill(n_digi_etl[0]);
-  meNhits_[1]->Fill(n_digi_etl[1]);
+  if (topo1Dis) {
+    meNhits_[0]->Fill(n_digi_etl[0]);
+    meNhits_[2]->Fill(n_digi_etl[2]);
+  }
+
+  if (topo2Dis) {
+    for (int i=0; i<4; i++) {
+      meNhits_[i]->Fill(n_digi_etl[i]);
+    }
+  } 
 }
 
 // ------------ method for histogram booking ------------
@@ -146,24 +187,46 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL DIGI hits (-Z);N_{DIGI}", 100, 0., 5000.);
-  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL DIGI hits (+Z);N_{DIGI}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL DIGI hits (-Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL DIGI hits (-Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL DIGI hits (+Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
+  meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL DIGI hits (+Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
 
-  meHitCharge_[0] = ibook.book1D("EtlHitChargeZneg", "ETL DIGI hits charge (-Z);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitCharge_[1] = ibook.book1D("EtlHitChargeZpos", "ETL DIGI hits charge (+Z);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL DIGI hits ToA (-Z);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL DIGI hits ToA (+Z);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitCharge_[0] = ibook.book1D("EtlHitChargeZnegD1", "ETL DIGI hits charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitCharge_[1] = ibook.book1D("EtlHitChargeZnegD2", "ETL DIGI hits charge (-Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitCharge_[2] = ibook.book1D("EtlHitChargeZposD1", "ETL DIGI hits charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitCharge_[3] = ibook.book1D("EtlHitChargeZposD2", "ETL DIGI hits charge (+Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL DIGI hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL DIGI hits ToA (-Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL DIGI hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL DIGI hits ToA (+Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg",
-                                 "ETL DIGI hits occupancy (-Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZnegD1",
+                                 "ETL DIGI hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
                                  135,
                                  -135.,
                                  135.,
                                  135,
                                  -135.,
                                  135.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos",
-                                 "ETL DIGI hits occupancy (+Z);X_{DIGI} [cm];Y_{DIGI} [cm]",
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
+                                 "ETL DIGI hits occupancy (-Z, Second disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[2] = ibook.book2D("EtlOccupancyZposD1",
+                                 "ETL DIGI hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
+                                 "ETL DIGI hits occupancy (+Z, Second disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
                                  135,
                                  -135.,
                                  135.,
@@ -171,68 +234,128 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  -135.,
                                  135.);
 
-  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL DIGI hits X (-Z);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL DIGI hits X (+Z);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL DIGI hits Y (-Z);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL DIGI hits Y (+Z);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL DIGI hits Z (-Z);Z_{DIGI} [cm]", 100, -304.2, -303.4);
-  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL DIGI hits Z (+Z);Z_{DIGI} [cm]", 100, 303.4, 304.2);
+  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL DIGI hits X (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL DIGI hits X (-Z, Second disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL DIGI hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL DIGI hits X (+Z, Second disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL DIGI hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL DIGI hits Y (-Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL DIGI hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL DIGI hits Y (+Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -310, -301);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -310, -301);
+  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 301, 310);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 301, 310);
 
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL DIGI hits #phi (-Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL DIGI hits #phi (+Z);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL DIGI hits #eta (-Z);#eta_{DIGI}", 100, -3.2, -1.56);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL DIGI hits #eta (+Z);#eta_{DIGI}", 100, 1.56, 3.2);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL DIGI hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL DIGI hits #phi (-Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL DIGI hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL DIGI hits #phi (+Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL DIGI hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, -3.2, -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL DIGI hits #eta (-Z, Second disk);#eta_{DIGI}", 100, -3.2, -1.56);
+  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL DIGI hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, 1.56, 3.2);
+  meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL DIGI hits #eta (+Z, Second disk);#eta_{DIGI}", 100, 1.56, 3.2);
 
-  meHitTvsQ_[0] = ibook.bookProfile("EtlHitTvsQZneg",
-                                    "ETL DIGI ToA vs charge (-Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+  meHitTvsQ_[0] = ibook.bookProfile("EtlHitTvsQZnegD1",
+                                    "ETL DIGI ToA vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
                                     50,
                                     0.,
                                     256.,
                                     0.,
                                     1024.);
-  meHitTvsQ_[1] = ibook.bookProfile("EtlHitTvsQZpos",
-                                    "ETL DIGI ToA vs charge (+Z);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+  meHitTvsQ_[1] = ibook.bookProfile("EtlHitTvsQZnegD2",
+                                    "ETL DIGI ToA vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
                                     50,
                                     0.,
                                     256.,
                                     0.,
                                     1024.);
-  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZneg",
-                                      "ETL DIGI charge vs #phi (-Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+  meHitTvsQ_[2] = ibook.bookProfile("EtlHitTvsQZposD1",
+                                    "ETL DIGI ToA vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    256.,
+                                    0.,
+                                    1024.);
+  meHitTvsQ_[3] = ibook.bookProfile("EtlHitTvsQZposD2",
+                                    "ETL DIGI ToA vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                                    50,
+                                    0.,
+                                    256.,
+                                    0.,
+                                    1024.);
+  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZnegD1",
+                                      "ETL DIGI charge vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
                                       50,
                                       -3.15,
                                       3.15,
                                       0.,
                                       1024.);
-  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZpos",
-                                      "ETL DIGI charge vs #phi (+Z);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZnegD2",
+                                      "ETL DIGI charge vs #phi (-Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsPhi_[2] = ibook.bookProfile("EtlHitQvsPhiZposD1",
+                                      "ETL DIGI charge vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitQvsPhi_[3] = ibook.bookProfile("EtlHitQvsPhiZpos",
+                                      "ETL DIGI charge vs #phi (+Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
                                       50,
                                       -3.15,
                                       3.15,
                                       0.,
                                       1024.);
   meHitQvsEta_[0] = ibook.bookProfile(
-      "EtlHitQvsEtaZneg", "ETL DIGI charge vs #eta (-Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
+      "EtlHitQvsEtaZnegD1", "ETL DIGI charge vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
   meHitQvsEta_[1] = ibook.bookProfile(
-      "EtlHitQvsEtaZpos", "ETL DIGI charge vs #eta (+Z);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
-  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZneg",
-                                      "ETL DIGI ToA vs #phi (-Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+      "EtlHitQvsEtaZnegD2", "ETL DIGI charge vs #eta (-Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
+  meHitQvsEta_[2] = ibook.bookProfile(
+      "EtlHitQvsEtaZposD1", "ETL DIGI charge vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
+  meHitQvsEta_[3] = ibook.bookProfile(
+      "EtlHitQvsEtaZposD2", "ETL DIGI charge vs #eta (+Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
+  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZnegD1",
+                                      "ETL DIGI ToA vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
                                       50,
                                       -3.15,
                                       3.15,
                                       0.,
                                       1024.);
-  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZpos",
-                                      "ETL DIGI ToA vs #phi (+Z);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZnegD2",
+                                      "ETL DIGI ToA vs #phi (-Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitTvsPhi_[2] = ibook.bookProfile("EtlHitTvsPhiZposD1",
+                                      "ETL DIGI ToA vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      1024.);
+  meHitTvsPhi_[3] = ibook.bookProfile("EtlHitTvsPhiZposD2",
+                                      "ETL DIGI ToA vs #phi (+Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
                                       50,
                                       -3.15,
                                       3.15,
                                       0.,
                                       1024.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZneg", "ETL DIGI ToA vs #eta (-Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
+      "EtlHitTvsEtaZnegD1", "ETL DIGI ToA vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
   meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL DIGI ToA vs #eta (+Z);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
+      "EtlHitTvsEtaZnegD2", "ETL DIGI ToA vs #eta (-Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
+  meHitTvsEta_[2] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD1", "ETL DIGI ToA vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
+  meHitTvsEta_[3] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD2", "ETL DIGI ToA vs #eta (+Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -89,8 +89,10 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo2Dis = true;
 
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
@@ -122,7 +124,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     // --- Fill the histograms
 
     int idet = 999;
-    
+
     if (topo1Dis) {
       if (detId.zside() == -1) {
         idet = 0;
@@ -173,10 +175,10 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
   }
 
   if (topo2Dis) {
-    for (int i=0; i<4; i++) {
+    for (int i = 0; i < 4; i++) {
       meNhits_[i]->Fill(n_digi_etl[i]);
     }
-  } 
+  }
 }
 
 // ------------ method for histogram booking ------------
@@ -187,28 +189,59 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL DIGI hits (-Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
-  meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL DIGI hits (-Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
-  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL DIGI hits (+Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
-  meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL DIGI hits (+Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1",
+                             "Number of ETL DIGI hits (-Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})",
+                             100,
+                             0.,
+                             5000.);
+  meNhits_[1] =
+      ibook.book1D("EtlNhitsZnegD2", "Number of ETL DIGI hits (-Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D("EtlNhitsZposD1",
+                             "Number of ETL DIGI hits (+Z, Single(topo1D)/First(topo2D) disk);log_{10}(N_{DIGI})",
+                             100,
+                             0.,
+                             5000.);
+  meNhits_[3] =
+      ibook.book1D("EtlNhitsZposD2", "Number of ETL DIGI hits (+Z, Second disk);log_{10}(N_{DIGI})", 100, 0., 5000.);
 
-  meHitCharge_[0] = ibook.book1D("EtlHitChargeZnegD1", "ETL DIGI hits charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitCharge_[1] = ibook.book1D("EtlHitChargeZnegD2", "ETL DIGI hits charge (-Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitCharge_[2] = ibook.book1D("EtlHitChargeZposD1", "ETL DIGI hits charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitCharge_[3] = ibook.book1D("EtlHitChargeZposD2", "ETL DIGI hits charge (+Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL DIGI hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL DIGI hits ToA (-Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
-  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL DIGI hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
-  meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL DIGI hits ToA (+Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitCharge_[0] = ibook.book1D("EtlHitChargeZnegD1",
+                                 "ETL DIGI hits charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]",
+                                 100,
+                                 0.,
+                                 256.);
+  meHitCharge_[1] =
+      ibook.book1D("EtlHitChargeZnegD2", "ETL DIGI hits charge (-Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitCharge_[2] = ibook.book1D("EtlHitChargeZposD1",
+                                 "ETL DIGI hits charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts]",
+                                 100,
+                                 0.,
+                                 256.);
+  meHitCharge_[3] =
+      ibook.book1D("EtlHitChargeZposD2", "ETL DIGI hits charge (+Z, Second disk);Q_{DIGI} [ADC counts]", 100, 0., 256.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1",
+                               "ETL DIGI hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]",
+                               100,
+                               0.,
+                               2000.);
+  meHitTime_[1] =
+      ibook.book1D("EtlHitTimeZnegD2", "ETL DIGI hits ToA (-Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
+  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1",
+                               "ETL DIGI hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{DIGI} [TDC counts]",
+                               100,
+                               0.,
+                               2000.);
+  meHitTime_[3] =
+      ibook.book1D("EtlHitTimeZposD2", "ETL DIGI hits ToA (+Z, Second disk);ToA_{DIGI} [TDC counts]", 100, 0., 2000.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZnegD1",
-                                 "ETL DIGI hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
-                                 135,
-                                 -135.,
-                                 135.,
-                                 135,
-                                 -135.,
-                                 135.);
+  meOccupancy_[0] =
+      ibook.book2D("EtlOccupancyZnegD1",
+                   "ETL DIGI hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
   meOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
                                  "ETL DIGI hits occupancy (-Z, Second disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
                                  135,
@@ -217,14 +250,15 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-  meOccupancy_[2] = ibook.book2D("EtlOccupancyZposD1",
-                                 "ETL DIGI hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
-                                 135,
-                                 -135.,
-                                 135.,
-                                 135,
-                                 -135.,
-                                 135.);
+  meOccupancy_[2] =
+      ibook.book2D("EtlOccupancyZposD1",
+                   "ETL DIGI hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
   meOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
                                  "ETL DIGI hits occupancy (+Z, Second disk);X_{DIGI} [cm];Y_{DIGI} [cm]",
                                  135,
@@ -234,128 +268,202 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  -135.,
                                  135.);
 
-  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL DIGI hits X (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[0] = ibook.book1D(
+      "EtlHitXZnegD1", "ETL DIGI hits X (-Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
   meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL DIGI hits X (-Z, Second disk);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL DIGI hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D(
+      "EtlHitXZposD1", "ETL DIGI hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{DIGI} [cm]", 100, -130., 130.);
   meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL DIGI hits X (+Z, Second disk);X_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL DIGI hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D(
+      "EtlHitYZnegD1", "ETL DIGI hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL DIGI hits Y (-Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL DIGI hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D(
+      "EtlHitYZposD1", "ETL DIGI hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL DIGI hits Y (+Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
-  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -310, -301);
+  meHitZ_[0] = ibook.book1D(
+      "EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -310, -301);
   meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -310, -301);
-  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 301, 310);
+  meHitZ_[2] = ibook.book1D(
+      "EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 301, 310);
   meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 301, 310);
 
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL DIGI hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL DIGI hits #phi (-Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL DIGI hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL DIGI hits #phi (+Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL DIGI hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, -3.2, -1.56);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1",
+                              "ETL DIGI hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]",
+                              100,
+                              -3.15,
+                              3.15);
+  meHitPhi_[1] =
+      ibook.book1D("EtlHitPhiZnegD2", "ETL DIGI hits #phi (-Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1",
+                              "ETL DIGI hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]",
+                              100,
+                              -3.15,
+                              3.15);
+  meHitPhi_[3] =
+      ibook.book1D("EtlHitPhiZposD2", "ETL DIGI hits #phi (+Z, Second disk);#phi_{DIGI} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D(
+      "EtlHitEtaZnegD1", "ETL DIGI hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, -3.2, -1.56);
   meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL DIGI hits #eta (-Z, Second disk);#eta_{DIGI}", 100, -3.2, -1.56);
-  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL DIGI hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, 1.56, 3.2);
+  meHitEta_[2] = ibook.book1D(
+      "EtlHitEtaZposD1", "ETL DIGI hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL DIGI hits #eta (+Z, Second disk);#eta_{DIGI}", 100, 1.56, 3.2);
 
-  meHitTvsQ_[0] = ibook.bookProfile("EtlHitTvsQZnegD1",
-                                    "ETL DIGI ToA vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-                                    50,
-                                    0.,
-                                    256.,
-                                    0.,
-                                    1024.);
-  meHitTvsQ_[1] = ibook.bookProfile("EtlHitTvsQZnegD2",
-                                    "ETL DIGI ToA vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-                                    50,
-                                    0.,
-                                    256.,
-                                    0.,
-                                    1024.);
-  meHitTvsQ_[2] = ibook.bookProfile("EtlHitTvsQZposD1",
-                                    "ETL DIGI ToA vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-                                    50,
-                                    0.,
-                                    256.,
-                                    0.,
-                                    1024.);
-  meHitTvsQ_[3] = ibook.bookProfile("EtlHitTvsQZposD2",
-                                    "ETL DIGI ToA vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
-                                    50,
-                                    0.,
-                                    256.,
-                                    0.,
-                                    1024.);
-  meHitQvsPhi_[0] = ibook.bookProfile("EtlHitQvsPhiZnegD1",
-                                      "ETL DIGI charge vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
-  meHitQvsPhi_[1] = ibook.bookProfile("EtlHitQvsPhiZnegD2",
-                                      "ETL DIGI charge vs #phi (-Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
-  meHitQvsPhi_[2] = ibook.bookProfile("EtlHitQvsPhiZposD1",
-                                      "ETL DIGI charge vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
-  meHitQvsPhi_[3] = ibook.bookProfile("EtlHitQvsPhiZpos",
-                                      "ETL DIGI charge vs #phi (+Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
+  meHitTvsQ_[0] = ibook.bookProfile(
+      "EtlHitTvsQZnegD1",
+      "ETL DIGI ToA vs charge (-Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+      50,
+      0.,
+      256.,
+      0.,
+      1024.);
+  meHitTvsQ_[1] =
+      ibook.bookProfile("EtlHitTvsQZnegD2",
+                        "ETL DIGI ToA vs charge (-Z, Second Disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                        50,
+                        0.,
+                        256.,
+                        0.,
+                        1024.);
+  meHitTvsQ_[2] = ibook.bookProfile(
+      "EtlHitTvsQZposD1",
+      "ETL DIGI ToA vs charge (+Z, Single(topo1D)/First(topo2D) disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+      50,
+      0.,
+      256.,
+      0.,
+      1024.);
+  meHitTvsQ_[3] =
+      ibook.bookProfile("EtlHitTvsQZposD2",
+                        "ETL DIGI ToA vs charge (+Z, Second disk);Q_{DIGI} [ADC counts];ToA_{DIGI} [TDC counts]",
+                        50,
+                        0.,
+                        256.,
+                        0.,
+                        1024.);
+  meHitQvsPhi_[0] = ibook.bookProfile(
+      "EtlHitQvsPhiZnegD1",
+      "ETL DIGI charge vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+      50,
+      -3.15,
+      3.15,
+      0.,
+      1024.);
+  meHitQvsPhi_[1] =
+      ibook.bookProfile("EtlHitQvsPhiZnegD2",
+                        "ETL DIGI charge vs #phi (-Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        1024.);
+  meHitQvsPhi_[2] = ibook.bookProfile(
+      "EtlHitQvsPhiZposD1",
+      "ETL DIGI charge vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+      50,
+      -3.15,
+      3.15,
+      0.,
+      1024.);
+  meHitQvsPhi_[3] =
+      ibook.bookProfile("EtlHitQvsPhiZpos",
+                        "ETL DIGI charge vs #phi (+Z, Second disk);#phi_{DIGI} [rad];Q_{DIGI} [ADC counts]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        1024.);
   meHitQvsEta_[0] = ibook.bookProfile(
-      "EtlHitQvsEtaZnegD1", "ETL DIGI charge vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
-  meHitQvsEta_[1] = ibook.bookProfile(
-      "EtlHitQvsEtaZnegD2", "ETL DIGI charge vs #eta (-Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, -3.2, -1.56, 0., 1024.);
+      "EtlHitQvsEtaZnegD1",
+      "ETL DIGI charge vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]",
+      50,
+      -3.2,
+      -1.56,
+      0.,
+      1024.);
+  meHitQvsEta_[1] = ibook.bookProfile("EtlHitQvsEtaZnegD2",
+                                      "ETL DIGI charge vs #eta (-Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]",
+                                      50,
+                                      -3.2,
+                                      -1.56,
+                                      0.,
+                                      1024.);
   meHitQvsEta_[2] = ibook.bookProfile(
-      "EtlHitQvsEtaZposD1", "ETL DIGI charge vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
-  meHitQvsEta_[3] = ibook.bookProfile(
-      "EtlHitQvsEtaZposD2", "ETL DIGI charge vs #eta (+Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]", 50, 1.56, 3.2, 0., 1024.);
-  meHitTvsPhi_[0] = ibook.bookProfile("EtlHitTvsPhiZnegD1",
-                                      "ETL DIGI ToA vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+      "EtlHitQvsEtaZposD1",
+      "ETL DIGI charge vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};Q_{DIGI} [ADC counts]",
+      50,
+      1.56,
+      3.2,
+      0.,
+      1024.);
+  meHitQvsEta_[3] = ibook.bookProfile("EtlHitQvsEtaZposD2",
+                                      "ETL DIGI charge vs #eta (+Z, Second disk);#eta_{DIGI};Q_{DIGI} [ADC counts]",
                                       50,
-                                      -3.15,
-                                      3.15,
+                                      1.56,
+                                      3.2,
                                       0.,
                                       1024.);
-  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZnegD2",
-                                      "ETL DIGI ToA vs #phi (-Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
-  meHitTvsPhi_[2] = ibook.bookProfile("EtlHitTvsPhiZposD1",
-                                      "ETL DIGI ToA vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
-  meHitTvsPhi_[3] = ibook.bookProfile("EtlHitTvsPhiZposD2",
-                                      "ETL DIGI ToA vs #phi (+Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
-                                      50,
-                                      -3.15,
-                                      3.15,
-                                      0.,
-                                      1024.);
+  meHitTvsPhi_[0] = ibook.bookProfile(
+      "EtlHitTvsPhiZnegD1",
+      "ETL DIGI ToA vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+      50,
+      -3.15,
+      3.15,
+      0.,
+      1024.);
+  meHitTvsPhi_[1] =
+      ibook.bookProfile("EtlHitTvsPhiZnegD2",
+                        "ETL DIGI ToA vs #phi (-Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        1024.);
+  meHitTvsPhi_[2] = ibook.bookProfile(
+      "EtlHitTvsPhiZposD1",
+      "ETL DIGI ToA vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+      50,
+      -3.15,
+      3.15,
+      0.,
+      1024.);
+  meHitTvsPhi_[3] =
+      ibook.bookProfile("EtlHitTvsPhiZposD2",
+                        "ETL DIGI ToA vs #phi (+Z, Second disk);#phi_{DIGI} [rad];ToA_{DIGI} [TDC counts]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        1024.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZnegD1", "ETL DIGI ToA vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
-  meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZnegD2", "ETL DIGI ToA vs #eta (-Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, -3.2, -1.56, 0., 1024.);
+      "EtlHitTvsEtaZnegD1",
+      "ETL DIGI ToA vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+      50,
+      -3.2,
+      -1.56,
+      0.,
+      1024.);
+  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZnegD2",
+                                      "ETL DIGI ToA vs #eta (-Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      -3.2,
+                                      -1.56,
+                                      0.,
+                                      1024.);
   meHitTvsEta_[2] = ibook.bookProfile(
-      "EtlHitTvsEtaZposD1", "ETL DIGI ToA vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
-  meHitTvsEta_[3] = ibook.bookProfile(
-      "EtlHitTvsEtaZposD2", "ETL DIGI ToA vs #eta (+Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]", 50, 1.56, 3.2, 0., 1024.);
+      "EtlHitTvsEtaZposD1",
+      "ETL DIGI ToA vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+      50,
+      1.56,
+      3.2,
+      0.,
+      1024.);
+  meHitTvsEta_[3] = ibook.bookProfile("EtlHitTvsEtaZposD2",
+                                      "ETL DIGI ToA vs #eta (+Z, Second disk);#eta_{DIGI};ToA_{DIGI} [TDC counts]",
+                                      50,
+                                      1.56,
+                                      3.2,
+                                      0.,
+                                      1024.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -89,10 +89,12 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  }
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo2Dis = true;
+  }
 
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -118,7 +118,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   // --- Loop over the ELT RECO hits
 
-  unsigned int n_reco_etl[4];
+  unsigned int n_reco_etl[4] = {0, 0, 0, 0};
   for (const auto& recHit : *etlRecHitsHandle) {
     ETLDetId detId = recHit.id();
     DetId geoId = detId.geographicalId();

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -29,6 +29,8 @@
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
 class EtlLocalRecoValidation : public DQMEDAnalyzer {
 public:
@@ -45,44 +47,46 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
-  const float hitMinEnergy_;
+  const float hitMinEnergy1Dis_;
+  const float hitMinEnergy2Dis_;
 
   edm::EDGetTokenT<FTLRecHitCollection> etlRecHitsToken_;
   edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
 
   // --- histograms declaration
+  
+  MonitorElement* meNhits_[4];
+  MonitorElement* meHitEnergy_[4];
+  MonitorElement* meHitTime_[4];
 
-  MonitorElement* meNhits_[2];
+  MonitorElement* meOccupancy_[4];
 
-  MonitorElement* meHitEnergy_[2];
-  MonitorElement* meHitTime_[2];
+  MonitorElement* meHitX_[4];
+  MonitorElement* meHitY_[4];
+  MonitorElement* meHitZ_[4];
+  MonitorElement* meHitPhi_[4];
+  MonitorElement* meHitEta_[4];
 
-  MonitorElement* meOccupancy_[2];
+  MonitorElement* meHitTvsE_[4];
+  MonitorElement* meHitEvsPhi_[4];
+  MonitorElement* meHitEvsEta_[4];
+  MonitorElement* meHitTvsPhi_[4];
+  MonitorElement* meHitTvsEta_[4];
 
-  MonitorElement* meHitX_[2];
-  MonitorElement* meHitY_[2];
-  MonitorElement* meHitZ_[2];
-  MonitorElement* meHitPhi_[2];
-  MonitorElement* meHitEta_[2];
+  MonitorElement* meCluTime_[4];
+  MonitorElement* meCluEnergy_[4];
+  MonitorElement* meCluPhi_[4];
+  MonitorElement* meCluEta_[4];
+  MonitorElement* meCluHits_[4];
+  MonitorElement* meCluOccupancy_[4];
 
-  MonitorElement* meHitTvsE_[2];
-  MonitorElement* meHitEvsPhi_[2];
-  MonitorElement* meHitEvsEta_[2];
-  MonitorElement* meHitTvsPhi_[2];
-  MonitorElement* meHitTvsEta_[2];
-
-  MonitorElement* meCluTime_[2];
-  MonitorElement* meCluEnergy_[2];
-  MonitorElement* meCluPhi_[2];
-  MonitorElement* meCluEta_[2];
-  MonitorElement* meCluHits_[2];
-  MonitorElement* meCluOccupancy_[2];
 };
 
 // ------------ constructor and destructor --------------
 EtlLocalRecoValidation::EtlLocalRecoValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
-      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
+      hitMinEnergy1Dis_(iConfig.getParameter<double>("hitMinimumEnergy1Dis")),
+      hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")) {
   etlRecHitsToken_ = consumes<FTLRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsTag"));
   etlRecCluToken_ = consumes<FTLClusterCollection>(iConfig.getParameter<edm::InputTag>("recCluTag"));
 }
@@ -92,7 +96,16 @@ EtlLocalRecoValidation::~EtlLocalRecoValidation() {}
 // ------------ method called for each event  ------------
 void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
+  using namespace std;
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  const MTDTopology* topology = topologyHandle.product();
 
+  bool topo1Dis = false;
+  bool topo2Dis = false;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+ 
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
   const MTDGeometry* geom = geometryHandle.product();
@@ -102,12 +115,12 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   // --- Loop over the ELT RECO hits
 
-  unsigned int n_reco_etl[2] = {0, 0};
-
+  unsigned int n_reco_etl[4];
   for (const auto& recHit : *etlRecHitsHandle) {
-    ETLDetId detId = recHit.id();
 
+    ETLDetId detId = recHit.id();
     DetId geoId = detId.geographicalId();
+    std::cout << "ETl Det Id: " << detId << std::endl;
     const MTDGeomDet* thedet = geom->idToDet(geoId);
     if (thedet == nullptr)
       throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
@@ -117,21 +130,43 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     Local3DPoint local_point(topo.localX(recHit.row()), topo.localY(recHit.column()), 0.);
     const auto& global_point = thedet->toGlobal(local_point);
 
+    int idet = 999;
+
+    if (topo1Dis) {
+      if (detId.zside() == -1) {
+        idet = 0;
+      } else if (detId.zside() == 1) {
+        idet = 2;
+      } else {
+        continue;
+      }
+    }
+
+    if (topo2Dis) {
+      if ((detId.zside() == -1) && (detId.nDisc() == 1)) {
+        idet = 0;
+      } else if ((detId.zside() == -1) && (detId.nDisc() == 2)) {
+        idet = 1;
+      } else if ((detId.zside() == 1) && (detId.nDisc() == 1)) {
+        idet = 2;
+      } else if ((detId.zside() == 1) && (detId.nDisc() == 2)) {
+        idet = 3;
+      } else {
+        continue;
+      }
+    }
+
     // --- Fill the histograms
-
-    int idet = (detId.zside() + 1) / 2;
-
+    
     meHitEnergy_[idet]->Fill(recHit.energy());
     meHitTime_[idet]->Fill(recHit.time());
 
     meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
-
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
     meHitZ_[idet]->Fill(global_point.z());
     meHitPhi_[idet]->Fill(global_point.phi());
     meHitEta_[idet]->Fill(global_point.eta());
-
     meHitTvsE_[idet]->Fill(recHit.energy(), recHit.time());
     meHitEvsPhi_[idet]->Fill(global_point.phi(), recHit.energy());
     meHitEvsEta_[idet]->Fill(global_point.eta(), recHit.energy());
@@ -139,17 +174,32 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitTvsEta_[idet]->Fill(global_point.eta(), recHit.time());
 
     n_reco_etl[idet]++;
-
   }  // recHit loop
 
-  meNhits_[0]->Fill(n_reco_etl[0]);
-  meNhits_[1]->Fill(n_reco_etl[1]);
+  if (topo1Dis) {
+    meNhits_[0]->Fill(n_reco_etl[0]);
+    meNhits_[2]->Fill(n_reco_etl[2]);
+  }
+
+  if (topo2Dis) {
+    for (int i=0; i<4; i++) {
+      meNhits_[i]->Fill(n_reco_etl[i]);
+    }
+  }
 
   // --- Loop over the ETL RECO clusters ---
+  int i;
   for (const auto& DetSetClu : *etlRecCluHandle) {
+    i++;
     for (const auto& cluster : DetSetClu) {
-      if (cluster.energy() < hitMinEnergy_)
-        continue;
+      if (topo1Dis) {
+          if (cluster.energy() < hitMinEnergy1Dis_)
+          continue;
+      }
+      if (topo2Dis) {
+          if (cluster.energy() < hitMinEnergy2Dis_)
+          continue;
+      }
       ETLDetId cluId = cluster.id();
       DetId detIdObject(cluId);
       const auto& genericDet = geom->idToDetUnit(detIdObject);
@@ -158,15 +208,36 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
             << "GeographicalID: " << std::hex << cluId << " is invalid!" << std::dec << std::endl;
       }
 
-      //const ProxyMTDTopology& topoproxy = static_cast<const ProxyMTDTopology&>(genericDet->topology());
-      //const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
       const PixelTopology& topo = static_cast<const PixelTopology&>(genericDet->topology());
 
       Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
-      //Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
       const auto& global_point = genericDet->toGlobal(local_point);
+      
+      int idet=999;
 
-      int idet = (cluId.zside() + 1) / 2;
+      if (topo1Dis) {
+        if (cluId.zside() == -1) {
+          idet = 0;
+        } else if (cluId.zside() == 1) {
+          idet = 2;
+        } else {
+          continue;
+        }
+      }
+
+      if (topo2Dis) {
+        if ((cluId.zside() == -1) && (cluId.nDisc() == 1)) {
+          idet = 0;
+        } else if ((cluId.zside() == -1) && (cluId.nDisc() == 2)) {
+          idet = 1;
+        } else if ((cluId.zside() == 1) && (cluId.nDisc() == 1)) {
+          idet = 2;
+        } else if ((cluId.zside() == 1) && (cluId.nDisc() == 2)) {
+          idet = 3;
+        } else {
+          continue;
+        }
+      }
 
       meCluEnergy_[idet]->Fill(cluster.energy());
       meCluTime_[idet]->Fill(cluster.time());
@@ -186,25 +257,45 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL RECO hits (-Z);N_{RECO}", 100, 0., 5000.);
-  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL RECO hits (+Z);N_{RECO}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL RECO hits (-Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL RECO hits (-Z, Second disk);N_{RECO}", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL RECO hits (+Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
+  meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL RECO hits (+Z, Second disk);N_{RECO}", 100, 0., 5000.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[2] = ibook.book1D("EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[3] = ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL RECO hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL RECO hits ToA (-Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL RECO hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL RECO hits ToA (+Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
 
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL RECO hits energy (-Z);E_{RECO} [MeV]", 100, 0., 3.);
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL RECO hits energy (+Z);E_{RECO} [MeV]", 100, 0., 3.);
-
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL RECO hits ToA (-Z);ToA_{RECO} [ns]", 100, 0., 25.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL RECO hits ToA (+Z);ToA_{RECO} [ns]", 100, 0., 25.);
-
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZneg",
-                                 "ETL RECO hits occupancy (-Z);X_{RECO} [cm];Y_{RECO} [cm]",
+  meOccupancy_[0] = ibook.book2D("EtlOccupancyZnegD1",
+                                 "ETL RECO hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
                                  135,
                                  -135.,
                                  135.,
                                  135,
                                  -135.,
                                  135.);
-  meOccupancy_[1] = ibook.book2D("EtlOccupancyZpos",
-                                 "ETL DIGI hits occupancy (+Z);X_{RECO} [cm];Y_{RECO} [cm]",
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
+                                 "ETL RECO hits occupancy (-Z, Second disk);X_{RECO} [cm];Y_{RECO} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[2] = ibook.book2D("EtlOccupancyZposD1",
+                                 "ETL RECO hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
+                                 "ETL RECO hits occupancy (+Z, Second disk);X_{RECO} [cm];Y_{RECO} [cm]",
                                  135,
                                  -135.,
                                  135.,
@@ -212,52 +303,96 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  -135.,
                                  135.);
 
-  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL RECO hits X (+Z);X_{RECO} [cm]", 100, -130., 130.);
-  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL RECO hits X (-Z);X_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL RECO hits Y (+Z);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL RECO hits Y (-Z);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL RECO hits Z (+Z);Z_{RECO} [cm]", 100, 303.4, 304.2);
-  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL RECO hits Z (-Z);Z_{RECO} [cm]", 100, -304.2, -303.4);
+  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL RECO hits X (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL RECO hits X (-Z, Second Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL RECO hits X (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL RECO hits X (+Z, Second Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL RECO hits Y (-Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL RECO hits Y (-Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL RECO hits Y (+Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL RECO hits Y (+Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL RECO hits Z (-Z, Second Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
+  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL RECO hits Z (+Z, Second Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL RECO hits #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL RECO hits #phi (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL RECO hits #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL RECO hits #phi (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL RECO hits #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL RECO hits #eta (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.56);
+  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
+  meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
 
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL RECO hits #phi (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL RECO hits #phi (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL RECO hits #eta (+Z);#eta_{RECO}", 100, 1.56, 3.2);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL RECO hits #eta (-Z);#eta_{RECO}", 100, -3.2, -1.56);
-
-  meHitTvsE_[1] = ibook.bookProfile(
-      "EtlHitTvsEZpos", "ETL RECO time vs energy (+Z);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
   meHitTvsE_[0] = ibook.bookProfile(
-      "EtlHitTvsEZneg", "ETL RECO time vs energy (-Z);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
-  meHitEvsPhi_[1] = ibook.bookProfile(
-      "EtlHitEvsPhiZpos", "ETL RECO energy vs #phi (+Z);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
+      "EtlHitTvsEZnegD1", "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[1] = ibook.bookProfile(
+      "EtlHitTvsEZnegD2", "ETL RECO time vs energy (-Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[2] = ibook.bookProfile(
+      "EtlHitTvsEZposD1", "ETL RECO time vs energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[3] = ibook.bookProfile(
+      "EtlHitTvsEZposD2", "ETL RECO time vs energy (+Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
   meHitEvsPhi_[0] = ibook.bookProfile(
-      "EtlHitEvsPhiZneg", "ETL RECO energy vs #phi (-Z);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
-  meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZpos", "ETL RECO energy vs #eta (+Z);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
+      "EtlHitEvsPhiZnegD1", "ETL RECO energy vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
+  meHitEvsPhi_[1] = ibook.bookProfile(
+      "EtlHitEvsPhiZnegD2", "ETL RECO energy vs #phi (-Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
+  meHitEvsPhi_[2] = ibook.bookProfile(
+      "EtlHitEvsPhiZposD1", "ETL RECO energy vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
+  meHitEvsPhi_[3] = ibook.bookProfile(
+      "EtlHitEvsPhiZposD2", "ETL RECO energy vs #phi (+Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
   meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZneg", "ETL RECO energy vs #eta (-Z);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitTvsPhi_[1] = ibook.bookProfile(
-      "EtlHitTvsPhiZpos", "ETL RECO time vs #phi (+Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
+      "EtlHitEvsEtaZnegD1", "ETL RECO energy vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
+  meHitEvsEta_[1] = ibook.bookProfile(
+      "EtlHitEvsEtaZnegD2", "ETL RECO energy vs #eta (-Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
+  meHitEvsEta_[2] = ibook.bookProfile(
+      "EtlHitEvsEtaZposD1", "ETL RECO energy vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
+  meHitEvsEta_[3] = ibook.bookProfile(
+      "EtlHitEvsEtaZposD2", "ETL RECO energy vs #eta (+Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
   meHitTvsPhi_[0] = ibook.bookProfile(
-      "EtlHitTvsPhiZneg", "ETL RECO time vs #phi (-Z);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
-  meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL RECO time vs #eta (+Z);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
+      "EtlHitTvsPhiZnegD1", "ETL RECO time vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
+  meHitTvsPhi_[1] = ibook.bookProfile(
+      "EtlHitTvsPhiZnegD2", "ETL RECO time vs #phi (-Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
+  meHitTvsPhi_[2] = ibook.bookProfile(
+      "EtlHitTvsPhiZposD1", "ETL RECO time vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
+  meHitTvsPhi_[3] = ibook.bookProfile(
+      "EtlHitTvsPhiZposD2", "ETL RECO time vs #phi (+Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZneg", "ETL RECO time vs #eta (-Z);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
-  meCluTime_[0] = ibook.book1D("EtlCluTimeZneg", "ETL cluster ToA (-Z);ToA [ns]", 250, 0, 25);
-  meCluTime_[1] = ibook.book1D("EtlCluTimeZpos", "ETL cluster ToA (+Z);ToA [ns]", 250, 0, 25);
-  meCluEnergy_[0] = ibook.book1D("EtlCluEnergyZneg", "ETL cluster energy (-Z);E_{RECO} [MeV]", 100, 0, 10);
-  meCluEnergy_[1] = ibook.book1D("EtlCluEnergyZpos", "ETL cluster energy (+Z);E_{RECO} [MeV]", 100, 0, 10);
-  meCluPhi_[0] = ibook.book1D("EtlCluPhiZneg", "ETL cluster #phi (-Z);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluPhi_[1] = ibook.book1D("EtlCluPhiZpos", "ETL cluster #phi (+Z);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluEta_[0] = ibook.book1D("EtlCluEtaZneg", "ETL cluster #eta (-Z);#eta_{RECO}", 100, -3.2, -1.4);
-  meCluEta_[1] = ibook.book1D("EtlCluEtaZpos", "ETL cluster #eta (+Z);#eta_{RECO}", 100, 1.4, 3.2);
-  meCluHits_[0] = ibook.book1D("EtlCluHitNumberZneg", "ETL hits per cluster (-Z);Cluster size", 10, 0, 10);
-  meCluHits_[1] = ibook.book1D("EtlCluHitNumberZpos", "ETL hits per cluster (+Z);Cluster size", 10, 0, 10);
+      "EtlHitTvsEtaZnegD1", "ETL RECO time vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "EtlHitTvsEtaZnegD2", "ETL RECO time vs #eta (-Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
+  meHitTvsEta_[2] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD1", "ETL RECO time vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
+  meHitTvsEta_[3] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD2", "ETL RECO time vs #eta (+Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
+  meCluTime_[0] = ibook.book1D("EtlCluTimeZnegD1", "ETL cluster ToA (-Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
+  meCluTime_[1] = ibook.book1D("EtlCluTimeZnegD2", "ETL cluster ToA (-Z, Second Disk);ToA [ns]", 250, 0, 25);
+  meCluTime_[2] = ibook.book1D("EtlCluTimeZposD1", "ETL cluster ToA (+Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
+  meCluTime_[3] = ibook.book1D("EtlCluTimeZposD2", "ETL cluster ToA (+Z, Second Disk);ToA [ns]", 250, 0, 25);
+  meCluEnergy_[0] = ibook.book1D("EtlCluEnergyZnegD1", "ETL cluster energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[1] = ibook.book1D("EtlCluEnergyZnegD2", "ETL cluster energy (-Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[2] = ibook.book1D("EtlCluEnergyZposD1", "ETL cluster energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[3] = ibook.book1D("EtlCluEnergyZposD2", "ETL cluster energy (+Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluPhi_[0] = ibook.book1D("EtlCluPhiZnegD1", "ETL cluster #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[1] = ibook.book1D("EtlCluPhiZnegD2", "ETL cluster #phi (-Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[2] = ibook.book1D("EtlCluPhiZposD1", "ETL cluster #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[3] = ibook.book1D("EtlCluPhiZposD2", "ETL cluster #phi (+Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluEta_[0] = ibook.book1D("EtlCluEtaZnegD1", "ETL cluster #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.4);
+  meCluEta_[1] = ibook.book1D("EtlCluEtaZnegD2", "ETL cluster #eta (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
+  meCluEta_[2] = ibook.book1D("EtlCluEtaZposD1", "ETL cluster #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.4, 3.2);
+  meCluEta_[3] = ibook.book1D("EtlCluEtaZposD2", "ETL cluster #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
+  meCluHits_[0] = ibook.book1D("EtlCluHitNumberZnegD1", "ETL hits per cluster (-Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
+  meCluHits_[1] = ibook.book1D("EtlCluHitNumberZnegD2", "ETL hits per cluster (-Z, Second Disk);Cluster size", 10, 0, 10);
+  meCluHits_[2] = ibook.book1D("EtlCluHitNumberZposD1", "ETL hits per cluster (+Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
+  meCluHits_[3] = ibook.book1D("EtlCluHitNumberZposD2", "ETL hits per cluster (+Z, Second Disk);Cluster size", 10, 0, 10);
   meCluOccupancy_[0] = ibook.book2D(
-      "EtlOccupancyZneg", "ETL cluster X vs Y (-Z);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
+      "EtlOccupancyZnegD1", "ETL cluster X vs Y (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
   meCluOccupancy_[1] = ibook.book2D(
-      "EtlOccupancyZpos", "ETL cluster X vs Y (+Z);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
+      "EtlOccupancyZnegD2", "ETL cluster X vs Y (-Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
+  meCluOccupancy_[2] = ibook.book2D(
+      "EtlOccupancyZposD1", "ETL cluster X vs Y (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
+  meCluOccupancy_[3] = ibook.book2D(
+      "EtlOccupancyZposD2", "ETL cluster X vs Y (+Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
+
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -267,7 +402,8 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("folder", "MTD/ETL/LocalReco");
   desc.add<edm::InputTag>("recHitsTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
-  desc.add<double>("hitMinimumEnergy", 1.);  // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.01);  // [MeV]
+  desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlLocalReco", desc);
 }

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -574,7 +574,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("folder", "MTD/ETL/LocalReco");
   desc.add<edm::InputTag>("recHitsTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 0.01);   // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 1.);   // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlLocalReco", desc);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -187,9 +187,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   }
 
   // --- Loop over the ETL RECO clusters ---
-  int i;
   for (const auto& DetSetClu : *etlRecCluHandle) {
-    i++;
     for (const auto& cluster : DetSetClu) {
       if (topo1Dis) {
         if (cluster.energy() < hitMinEnergy1Dis_)

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -102,10 +102,12 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  }
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo2Dis = true;
+  }
 
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -54,7 +54,7 @@ private:
   edm::EDGetTokenT<FTLClusterCollection> etlRecCluToken_;
 
   // --- histograms declaration
-  
+
   MonitorElement* meNhits_[4];
   MonitorElement* meHitEnergy_[4];
   MonitorElement* meHitTime_[4];
@@ -79,7 +79,6 @@ private:
   MonitorElement* meCluEta_[4];
   MonitorElement* meCluHits_[4];
   MonitorElement* meCluOccupancy_[4];
-
 };
 
 // ------------ constructor and destructor --------------
@@ -103,9 +102,11 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
- 
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo2Dis = true;
+
   edm::ESHandle<MTDGeometry> geometryHandle;
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
   const MTDGeometry* geom = geometryHandle.product();
@@ -117,10 +118,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
   unsigned int n_reco_etl[4];
   for (const auto& recHit : *etlRecHitsHandle) {
-
     ETLDetId detId = recHit.id();
     DetId geoId = detId.geographicalId();
-    std::cout << "ETl Det Id: " << detId << std::endl;
     const MTDGeomDet* thedet = geom->idToDet(geoId);
     if (thedet == nullptr)
       throw cms::Exception("EtlLocalRecoValidation") << "GeographicalID: " << std::hex << geoId.rawId() << " ("
@@ -157,7 +156,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     }
 
     // --- Fill the histograms
-    
+
     meHitEnergy_[idet]->Fill(recHit.energy());
     meHitTime_[idet]->Fill(recHit.time());
 
@@ -182,7 +181,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   }
 
   if (topo2Dis) {
-    for (int i=0; i<4; i++) {
+    for (int i = 0; i < 4; i++) {
       meNhits_[i]->Fill(n_reco_etl[i]);
     }
   }
@@ -193,11 +192,11 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     i++;
     for (const auto& cluster : DetSetClu) {
       if (topo1Dis) {
-          if (cluster.energy() < hitMinEnergy1Dis_)
+        if (cluster.energy() < hitMinEnergy1Dis_)
           continue;
       }
       if (topo2Dis) {
-          if (cluster.energy() < hitMinEnergy2Dis_)
+        if (cluster.energy() < hitMinEnergy2Dis_)
           continue;
       }
       ETLDetId cluId = cluster.id();
@@ -212,8 +211,8 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
 
       Local3DPoint local_point(topo.localX(cluster.x()), topo.localY(cluster.y()), 0.);
       const auto& global_point = genericDet->toGlobal(local_point);
-      
-      int idet=999;
+
+      int idet = 999;
 
       if (topo1Dis) {
         if (cluId.zside() == -1) {
@@ -257,27 +256,36 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL RECO hits (-Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
+  meNhits_[0] = ibook.book1D(
+      "EtlNhitsZnegD1", "Number of ETL RECO hits (-Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
   meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL RECO hits (-Z, Second disk);N_{RECO}", 100, 0., 5000.);
-  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL RECO hits (+Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D(
+      "EtlNhitsZposD1", "Number of ETL RECO hits (+Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
   meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL RECO hits (+Z, Second disk);N_{RECO}", 100, 0., 5000.);
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
-  meHitEnergy_[2] = ibook.book1D("EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
-  meHitEnergy_[3] = ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL RECO hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitEnergy_[0] = ibook.book1D(
+      "EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[1] =
+      ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[2] = ibook.book1D(
+      "EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitEnergy_[3] =
+      ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+  meHitTime_[0] = ibook.book1D(
+      "EtlHitTimeZnegD1", "ETL RECO hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL RECO hits ToA (-Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
-  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL RECO hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
+  meHitTime_[2] = ibook.book1D(
+      "EtlHitTimeZposD1", "ETL RECO hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL RECO hits ToA (+Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
 
-  meOccupancy_[0] = ibook.book2D("EtlOccupancyZnegD1",
-                                 "ETL RECO hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
-                                 135,
-                                 -135.,
-                                 135.,
-                                 135,
-                                 -135.,
-                                 135.);
+  meOccupancy_[0] =
+      ibook.book2D("EtlOccupancyZnegD1",
+                   "ETL RECO hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
   meOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
                                  "ETL RECO hits occupancy (-Z, Second disk);X_{RECO} [cm];Y_{RECO} [cm]",
                                  135,
@@ -286,14 +294,15 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  135,
                                  -135.,
                                  135.);
-  meOccupancy_[2] = ibook.book2D("EtlOccupancyZposD1",
-                                 "ETL RECO hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
-                                 135,
-                                 -135.,
-                                 135.,
-                                 135,
-                                 -135.,
-                                 135.);
+  meOccupancy_[2] =
+      ibook.book2D("EtlOccupancyZposD1",
+                   "ETL RECO hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{RECO} [cm];Y_{RECO} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
   meOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
                                  "ETL RECO hits occupancy (+Z, Second disk);X_{RECO} [cm];Y_{RECO} [cm]",
                                  135,
@@ -303,96 +312,259 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                  -135.,
                                  135.);
 
-  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL RECO hits X (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[0] = ibook.book1D(
+      "EtlHitXZnegD1", "ETL RECO hits X (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
   meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL RECO hits X (-Z, Second Disk);X_{RECO} [cm]", 100, -130., 130.);
-  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL RECO hits X (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D(
+      "EtlHitXZposD1", "ETL RECO hits X (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]", 100, -130., 130.);
   meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL RECO hits X (+Z, Second Disk);X_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL RECO hits Y (-Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D(
+      "EtlHitYZnegD1", "ETL RECO hits Y (-Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL RECO hits Y (-Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL RECO hits Y (+Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D(
+      "EtlHitYZposD1", "ETL RECO hits Y (+Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL RECO hits Y (+Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
-  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
+  meHitZ_[0] = ibook.book1D(
+      "EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
   meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL RECO hits Z (-Z, Second Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
-  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
+  meHitZ_[2] = ibook.book1D(
+      "EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
   meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL RECO hits Z (+Z, Second Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL RECO hits #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL RECO hits #phi (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL RECO hits #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL RECO hits #phi (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL RECO hits #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.56);
+  meHitPhi_[0] = ibook.book1D(
+      "EtlHitPhiZnegD1", "ETL RECO hits #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[1] =
+      ibook.book1D("EtlHitPhiZnegD2", "ETL RECO hits #phi (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[2] = ibook.book1D(
+      "EtlHitPhiZposD1", "ETL RECO hits #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitPhi_[3] =
+      ibook.book1D("EtlHitPhiZposD2", "ETL RECO hits #phi (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meHitEta_[0] = ibook.book1D(
+      "EtlHitEtaZnegD1", "ETL RECO hits #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.56);
   meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL RECO hits #eta (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.56);
-  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
+  meHitEta_[2] = ibook.book1D(
+      "EtlHitEtaZposD1", "ETL RECO hits #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL RECO hits #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.56, 3.2);
 
   meHitTvsE_[0] = ibook.bookProfile(
-      "EtlHitTvsEZnegD1", "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
-  meHitTvsE_[1] = ibook.bookProfile(
-      "EtlHitTvsEZnegD2", "ETL RECO time vs energy (-Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+      "EtlHitTvsEZnegD1",
+      "ETL RECO time vs energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
+      50,
+      0.,
+      2.,
+      0.,
+      100.);
+  meHitTvsE_[1] = ibook.bookProfile("EtlHitTvsEZnegD2",
+                                    "ETL RECO time vs energy (-Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
+                                    50,
+                                    0.,
+                                    2.,
+                                    0.,
+                                    100.);
   meHitTvsE_[2] = ibook.bookProfile(
-      "EtlHitTvsEZposD1", "ETL RECO time vs energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
-  meHitTvsE_[3] = ibook.bookProfile(
-      "EtlHitTvsEZposD2", "ETL RECO time vs energy (+Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]", 50, 0., 2., 0., 100.);
+      "EtlHitTvsEZposD1",
+      "ETL RECO time vs energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
+      50,
+      0.,
+      2.,
+      0.,
+      100.);
+  meHitTvsE_[3] = ibook.bookProfile("EtlHitTvsEZposD2",
+                                    "ETL RECO time vs energy (+Z, Second Disk);E_{RECO} [MeV];ToA_{RECO} [ns]",
+                                    50,
+                                    0.,
+                                    2.,
+                                    0.,
+                                    100.);
   meHitEvsPhi_[0] = ibook.bookProfile(
-      "EtlHitEvsPhiZnegD1", "ETL RECO energy vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
-  meHitEvsPhi_[1] = ibook.bookProfile(
-      "EtlHitEvsPhiZnegD2", "ETL RECO energy vs #phi (-Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
+      "EtlHitEvsPhiZnegD1",
+      "ETL RECO energy vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]",
+      50,
+      -3.2,
+      3.2,
+      0.,
+      100.);
+  meHitEvsPhi_[1] = ibook.bookProfile("EtlHitEvsPhiZnegD2",
+                                      "ETL RECO energy vs #phi (-Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]",
+                                      50,
+                                      -3.2,
+                                      3.2,
+                                      0.,
+                                      100.);
   meHitEvsPhi_[2] = ibook.bookProfile(
-      "EtlHitEvsPhiZposD1", "ETL RECO energy vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
-  meHitEvsPhi_[3] = ibook.bookProfile(
-      "EtlHitEvsPhiZposD2", "ETL RECO energy vs #phi (+Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]", 50, -3.2, 3.2, 0., 100.);
-  meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZnegD1", "ETL RECO energy vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZnegD2", "ETL RECO energy vs #eta (-Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitEvsEta_[2] = ibook.bookProfile(
-      "EtlHitEvsEtaZposD1", "ETL RECO energy vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
-  meHitEvsEta_[3] = ibook.bookProfile(
-      "EtlHitEvsEtaZposD2", "ETL RECO energy vs #eta (+Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]", 50, 1.56, 3.2, 0., 100.);
+      "EtlHitEvsPhiZposD1",
+      "ETL RECO energy vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];E_{RECO} [MeV]",
+      50,
+      -3.2,
+      3.2,
+      0.,
+      100.);
+  meHitEvsPhi_[3] = ibook.bookProfile("EtlHitEvsPhiZposD2",
+                                      "ETL RECO energy vs #phi (+Z, Second Disk);#phi_{RECO} [rad];E_{RECO} [MeV]",
+                                      50,
+                                      -3.2,
+                                      3.2,
+                                      0.,
+                                      100.);
+  meHitEvsEta_[0] =
+      ibook.bookProfile("EtlHitEvsEtaZnegD1",
+                        "ETL RECO energy vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]",
+                        50,
+                        -3.2,
+                        -1.56,
+                        0.,
+                        100.);
+  meHitEvsEta_[1] = ibook.bookProfile("EtlHitEvsEtaZnegD2",
+                                      "ETL RECO energy vs #eta (-Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]",
+                                      50,
+                                      -3.2,
+                                      -1.56,
+                                      0.,
+                                      100.);
+  meHitEvsEta_[2] =
+      ibook.bookProfile("EtlHitEvsEtaZposD1",
+                        "ETL RECO energy vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};E_{RECO} [MeV]",
+                        50,
+                        1.56,
+                        3.2,
+                        0.,
+                        100.);
+  meHitEvsEta_[3] = ibook.bookProfile("EtlHitEvsEtaZposD2",
+                                      "ETL RECO energy vs #eta (+Z, Second Disk);#eta_{RECO};E_{RECO} [MeV]",
+                                      50,
+                                      1.56,
+                                      3.2,
+                                      0.,
+                                      100.);
   meHitTvsPhi_[0] = ibook.bookProfile(
-      "EtlHitTvsPhiZnegD1", "ETL RECO time vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
-  meHitTvsPhi_[1] = ibook.bookProfile(
-      "EtlHitTvsPhiZnegD2", "ETL RECO time vs #phi (-Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
+      "EtlHitTvsPhiZnegD1",
+      "ETL RECO time vs #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+      50,
+      -3.2,
+      3.2,
+      0.,
+      100.);
+  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZnegD2",
+                                      "ETL RECO time vs #phi (-Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+                                      50,
+                                      -3.2,
+                                      3.2,
+                                      0.,
+                                      100.);
   meHitTvsPhi_[2] = ibook.bookProfile(
-      "EtlHitTvsPhiZposD1", "ETL RECO time vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
-  meHitTvsPhi_[3] = ibook.bookProfile(
-      "EtlHitTvsPhiZposD2", "ETL RECO time vs #phi (+Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]", 50, -3.2, 3.2, 0., 100.);
-  meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZnegD1", "ETL RECO time vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
-  meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZnegD2", "ETL RECO time vs #eta (-Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, -3.2, -1.56, 0., 100.);
-  meHitTvsEta_[2] = ibook.bookProfile(
-      "EtlHitTvsEtaZposD1", "ETL RECO time vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
-  meHitTvsEta_[3] = ibook.bookProfile(
-      "EtlHitTvsEtaZposD2", "ETL RECO time vs #eta (+Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]", 50, 1.56, 3.2, 0., 100.);
-  meCluTime_[0] = ibook.book1D("EtlCluTimeZnegD1", "ETL cluster ToA (-Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
+      "EtlHitTvsPhiZposD1",
+      "ETL RECO time vs #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+      50,
+      -3.2,
+      3.2,
+      0.,
+      100.);
+  meHitTvsPhi_[3] = ibook.bookProfile("EtlHitTvsPhiZposD2",
+                                      "ETL RECO time vs #phi (+Z, Second Disk);#phi_{RECO} [rad];ToA_{RECO} [ns]",
+                                      50,
+                                      -3.2,
+                                      3.2,
+                                      0.,
+                                      100.);
+  meHitTvsEta_[0] =
+      ibook.bookProfile("EtlHitTvsEtaZnegD1",
+                        "ETL RECO time vs #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]",
+                        50,
+                        -3.2,
+                        -1.56,
+                        0.,
+                        100.);
+  meHitTvsEta_[1] = ibook.bookProfile("EtlHitTvsEtaZnegD2",
+                                      "ETL RECO time vs #eta (-Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]",
+                                      50,
+                                      -3.2,
+                                      -1.56,
+                                      0.,
+                                      100.);
+  meHitTvsEta_[2] =
+      ibook.bookProfile("EtlHitTvsEtaZposD1",
+                        "ETL RECO time vs #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO};ToA_{RECO} [ns]",
+                        50,
+                        1.56,
+                        3.2,
+                        0.,
+                        100.);
+  meHitTvsEta_[3] = ibook.bookProfile("EtlHitTvsEtaZposD2",
+                                      "ETL RECO time vs #eta (+Z, Second Disk);#eta_{RECO};ToA_{RECO} [ns]",
+                                      50,
+                                      1.56,
+                                      3.2,
+                                      0.,
+                                      100.);
+  meCluTime_[0] =
+      ibook.book1D("EtlCluTimeZnegD1", "ETL cluster ToA (-Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
   meCluTime_[1] = ibook.book1D("EtlCluTimeZnegD2", "ETL cluster ToA (-Z, Second Disk);ToA [ns]", 250, 0, 25);
-  meCluTime_[2] = ibook.book1D("EtlCluTimeZposD1", "ETL cluster ToA (+Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
+  meCluTime_[2] =
+      ibook.book1D("EtlCluTimeZposD1", "ETL cluster ToA (+Z, Single(topo1D)/First(topo2D) Disk);ToA [ns]", 250, 0, 25);
   meCluTime_[3] = ibook.book1D("EtlCluTimeZposD2", "ETL cluster ToA (+Z, Second Disk);ToA [ns]", 250, 0, 25);
-  meCluEnergy_[0] = ibook.book1D("EtlCluEnergyZnegD1", "ETL cluster energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
-  meCluEnergy_[1] = ibook.book1D("EtlCluEnergyZnegD2", "ETL cluster energy (-Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
-  meCluEnergy_[2] = ibook.book1D("EtlCluEnergyZposD1", "ETL cluster energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
-  meCluEnergy_[3] = ibook.book1D("EtlCluEnergyZposD2", "ETL cluster energy (+Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
-  meCluPhi_[0] = ibook.book1D("EtlCluPhiZnegD1", "ETL cluster #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluPhi_[1] = ibook.book1D("EtlCluPhiZnegD2", "ETL cluster #phi (-Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluPhi_[2] = ibook.book1D("EtlCluPhiZposD1", "ETL cluster #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluPhi_[3] = ibook.book1D("EtlCluPhiZposD2", "ETL cluster #phi (+Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
-  meCluEta_[0] = ibook.book1D("EtlCluEtaZnegD1", "ETL cluster #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.4);
+  meCluEnergy_[0] = ibook.book1D(
+      "EtlCluEnergyZnegD1", "ETL cluster energy (-Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[1] =
+      ibook.book1D("EtlCluEnergyZnegD2", "ETL cluster energy (-Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[2] = ibook.book1D(
+      "EtlCluEnergyZposD1", "ETL cluster energy (+Z, Single(topo1D)/First(topo2D) Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluEnergy_[3] =
+      ibook.book1D("EtlCluEnergyZposD2", "ETL cluster energy (+Z, Second Disk);E_{RECO} [MeV]", 100, 0, 10);
+  meCluPhi_[0] = ibook.book1D(
+      "EtlCluPhiZnegD1", "ETL cluster #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[1] =
+      ibook.book1D("EtlCluPhiZnegD2", "ETL cluster #phi (-Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[2] = ibook.book1D(
+      "EtlCluPhiZposD1", "ETL cluster #phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluPhi_[3] =
+      ibook.book1D("EtlCluPhiZposD2", "ETL cluster #phi (+Z, Second Disk);#phi_{RECO} [rad]", 126, -3.2, 3.2);
+  meCluEta_[0] = ibook.book1D(
+      "EtlCluEtaZnegD1", "ETL cluster #eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.4);
   meCluEta_[1] = ibook.book1D("EtlCluEtaZnegD2", "ETL cluster #eta (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
-  meCluEta_[2] = ibook.book1D("EtlCluEtaZposD1", "ETL cluster #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.4, 3.2);
+  meCluEta_[2] = ibook.book1D(
+      "EtlCluEtaZposD1", "ETL cluster #eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.4, 3.2);
   meCluEta_[3] = ibook.book1D("EtlCluEtaZposD2", "ETL cluster #eta (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
-  meCluHits_[0] = ibook.book1D("EtlCluHitNumberZnegD1", "ETL hits per cluster (-Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
-  meCluHits_[1] = ibook.book1D("EtlCluHitNumberZnegD2", "ETL hits per cluster (-Z, Second Disk);Cluster size", 10, 0, 10);
-  meCluHits_[2] = ibook.book1D("EtlCluHitNumberZposD1", "ETL hits per cluster (+Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
-  meCluHits_[3] = ibook.book1D("EtlCluHitNumberZposD2", "ETL hits per cluster (+Z, Second Disk);Cluster size", 10, 0, 10);
-  meCluOccupancy_[0] = ibook.book2D(
-      "EtlOccupancyZnegD1", "ETL cluster X vs Y (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
-  meCluOccupancy_[1] = ibook.book2D(
-      "EtlOccupancyZnegD2", "ETL cluster X vs Y (-Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
-  meCluOccupancy_[2] = ibook.book2D(
-      "EtlOccupancyZposD1", "ETL cluster X vs Y (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
-  meCluOccupancy_[3] = ibook.book2D(
-      "EtlOccupancyZposD2", "ETL cluster X vs Y (+Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]", 100, -150., 150., 100, -150, 150);
-
+  meCluHits_[0] = ibook.book1D(
+      "EtlCluHitNumberZnegD1", "ETL hits per cluster (-Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
+  meCluHits_[1] =
+      ibook.book1D("EtlCluHitNumberZnegD2", "ETL hits per cluster (-Z, Second Disk);Cluster size", 10, 0, 10);
+  meCluHits_[2] = ibook.book1D(
+      "EtlCluHitNumberZposD1", "ETL hits per cluster (+Z, Single(topo1D)/First(topo2D) Disk);Cluster size", 10, 0, 10);
+  meCluHits_[3] =
+      ibook.book1D("EtlCluHitNumberZposD2", "ETL hits per cluster (+Z, Second Disk);Cluster size", 10, 0, 10);
+  meCluOccupancy_[0] =
+      ibook.book2D("EtlOccupancyZnegD1",
+                   "ETL cluster X vs Y (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
+                   100,
+                   -150.,
+                   150.,
+                   100,
+                   -150,
+                   150);
+  meCluOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
+                                    "ETL cluster X vs Y (-Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
+                                    100,
+                                    -150.,
+                                    150.,
+                                    100,
+                                    -150,
+                                    150);
+  meCluOccupancy_[2] =
+      ibook.book2D("EtlOccupancyZposD1",
+                   "ETL cluster X vs Y (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
+                   100,
+                   -150.,
+                   150.,
+                   100,
+                   -150,
+                   150);
+  meCluOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
+                                    "ETL cluster X vs Y (+Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
+                                    100,
+                                    -150.,
+                                    150.,
+                                    100,
+                                    -150,
+                                    150);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -402,7 +574,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("folder", "MTD/ETL/LocalReco");
   desc.add<edm::InputTag>("recHitsTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 0.01);  // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.01);   // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlLocalReco", desc);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -574,7 +574,7 @@ void EtlLocalRecoValidation::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<std::string>("folder", "MTD/ETL/LocalReco");
   desc.add<edm::InputTag>("recHitsTag", edm::InputTag("mtdRecHits", "FTLEndcap"));
   desc.add<edm::InputTag>("recCluTag", edm::InputTag("mtdClusters", "FTLEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 1.);   // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 1.);     // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlLocalReco", desc);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -523,7 +523,7 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
   meHitTvsEta_[1] = ibook.bookProfile(
       "EtlHitTvsEtaZnegD2", "ETL SIM time vs #eta (-Z, Second disk);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
   meHitTvsEta_[2] =
-      ibook.bookProfile("EtlHitTvsEtaZposD2",
+      ibook.bookProfile("EtlHitTvsEtaZposD1",
                         "ETL SIM time vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]",
                         50,
                         1.56,

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -381,11 +381,11 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL SIM hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL SIM hits Y (+Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -305, -301);
-  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -305, -301);
+      "EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -304.2, -303.4);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -304.2, -303.4);
   meHitZ_[2] = ibook.book1D(
-      "EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 301, 305);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 301, 305);
+      "EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 303.4, 304.2);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 303.4, 304.2);
 
   meHitPhi_[0] = ibook.book1D(
       "EtlHitPhiZnegD1", "ETL SIM hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -540,7 +540,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 0.1);   // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.1);    // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlSimHits", desc);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -114,8 +114,10 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo2Dis = true;
 
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
@@ -180,8 +182,9 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   //  Histogram filling
   // ==============================================================================
 
-  for (int idet = 0; idet < 4; ++idet) { //two disks per side
-    if ( ((idet == 1) || (idet == 3)) && (topo1Dis == true) ) continue;
+  for (int idet = 0; idet < 4; ++idet) {  //two disks per side
+    if (((idet == 1) || (idet == 3)) && (topo1Dis == true))
+      continue;
     meNhits_[idet]->Fill(m_etlHits[idet].size());
 
     for (auto const& hit : m_etlTrkPerCell[idet]) {
@@ -191,11 +194,11 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     for (auto const& hit : m_etlHits[idet]) {
       if (topo1Dis) {
         if ((hit.second).energy < hitMinEnergy1Dis_)
-           continue;
+          continue;
       }
       if (topo2Dis) {
         if ((hit.second).energy < hitMinEnergy2Dis_)
-           continue;
+          continue;
       }
       // --- Get the SIM hit global position
       ETLDetId detId(hit.first);
@@ -240,107 +243,291 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL cells with SIM hits (-Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}", 100, 0., 5000.);
-  meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL cells with SIM hits (-Z, Second disk);N_{ETL cells}", 100, 0., 5000.);
-  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL cells with SIM hits (+Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}", 100, 0., 5000.);
-  meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL cells with SIM hits (+Z, Second Disk);N_{ETL cells}", 100, 0., 5000.);
-  meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZnegD1", "Number of tracks per ETL sensor (-Z, Single(topo1D)/First(topo2D) disk);N_{trk}", 10, 0., 10.);
-  meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z, Second disk);N_{trk}", 10, 0., 10.);
-  meNtrkPerCell_[2] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Single(topo1D)/First(topo2D) disk);N_{trk}", 10, 0., 10.);
-  meNtrkPerCell_[3] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1",
+                             "Number of ETL cells with SIM hits (-Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}",
+                             100,
+                             0.,
+                             5000.);
+  meNhits_[1] = ibook.book1D(
+      "EtlNhitsZnegD2", "Number of ETL cells with SIM hits (-Z, Second disk);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D("EtlNhitsZposD1",
+                             "Number of ETL cells with SIM hits (+Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}",
+                             100,
+                             0.,
+                             5000.);
+  meNhits_[3] = ibook.book1D(
+      "EtlNhitsZposD2", "Number of ETL cells with SIM hits (+Z, Second Disk);N_{ETL cells}", 100, 0., 5000.);
+  meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZnegD1",
+                                   "Number of tracks per ETL sensor (-Z, Single(topo1D)/First(topo2D) disk);N_{trk}",
+                                   10,
+                                   0.,
+                                   10.);
+  meNtrkPerCell_[1] =
+      ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z, Second disk);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[2] = ibook.book1D("EtlNtrkPerCellZpos",
+                                   "Number of tracks per ETL sensor (+Z, Single(topo1D)/First(topo2D) disk);N_{trk}",
+                                   10,
+                                   0.,
+                                   10.);
+  meNtrkPerCell_[3] =
+      ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
 
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZnegD2", "ETL SIM hits energy (-Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitEnergy_[2] = ibook.book1D("EtlHitEnergyZposD1", "ETL SIM hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitEnergy_[3] = ibook.book1D("EtlHitEnergyZposD2", "ETL SIM hits energy (+Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL SIM hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitEnergy_[0] = ibook.book1D(
+      "EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[1] =
+      ibook.book1D("EtlHitEnergyZnegD2", "ETL SIM hits energy (-Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[2] = ibook.book1D(
+      "EtlHitEnergyZposD1", "ETL SIM hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[3] =
+      ibook.book1D("EtlHitEnergyZposD2", "ETL SIM hits energy (+Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitTime_[0] = ibook.book1D(
+      "EtlHitTimeZnegD1", "ETL SIM hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL SIM hits ToA (-Z, Second disk);ToA_{SIM} [ns]", 100, 0., 25.);
-  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL SIM hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[2] = ibook.book1D(
+      "EtlHitTimeZposD1", "ETL SIM hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
   meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL SIM hits ToA (+Z, Second disk);ToA_{SIM} [ns]", 100, 0., 25.);
 
-  meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZnegD1", "ETL SIM local X (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZnegD2", "ETL SIM local X (-Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitXlocal_[2] = ibook.book1D("EtlHitXlocalZposD1", "ETL SIM local X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitXlocal_[3] = ibook.book1D("EtlHitXlocalZposD2", "ETL SIM local X (+Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZnegD1",
+                                 "ETL SIM local X (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]",
+                                 100,
+                                 -25.,
+                                 25.);
+  meHitXlocal_[1] =
+      ibook.book1D("EtlHitXlocalZnegD2", "ETL SIM local X (-Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[2] = ibook.book1D("EtlHitXlocalZposD1",
+                                 "ETL SIM local X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]",
+                                 100,
+                                 -25.,
+                                 25.);
+  meHitXlocal_[3] =
+      ibook.book1D("EtlHitXlocalZposD2", "ETL SIM local X (+Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
 
-  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZnegD1", "ETL SIM local Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZnegD2", "ETL SIM local Y (-Z, Second Disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitYlocal_[2] = ibook.book1D("EtlHitYlocalZposD1", "ETL SIM local Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitYlocal_[3] = ibook.book1D("EtlHitYlocalZposD2", "ETL SIM local Y (+Z, Second disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZnegD1", "ETL SIM local Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
-  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZnegD2", "ETL SIM local Z (-Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
-  meHitZlocal_[2] = ibook.book1D("EtlHitZlocalZposD1", "ETL SIM local Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
-  meHitZlocal_[3] = ibook.book1D("EtlHitZlocalZposD2", "ETL SIM local Z (+Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZnegD1",
+                                 "ETL SIM local Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]",
+                                 100,
+                                 -48.,
+                                 48.);
+  meHitYlocal_[1] =
+      ibook.book1D("EtlHitYlocalZnegD2", "ETL SIM local Y (-Z, Second Disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitYlocal_[2] = ibook.book1D("EtlHitYlocalZposD1",
+                                 "ETL SIM local Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]",
+                                 100,
+                                 -48.,
+                                 48.);
+  meHitYlocal_[3] =
+      ibook.book1D("EtlHitYlocalZposD2", "ETL SIM local Y (+Z, Second disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZnegD1",
+                                 "ETL SIM local Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]",
+                                 80,
+                                 -0.16,
+                                 0.16);
+  meHitZlocal_[1] =
+      ibook.book1D("EtlHitZlocalZnegD2", "ETL SIM local Z (-Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitZlocal_[2] = ibook.book1D("EtlHitZlocalZposD1",
+                                 "ETL SIM local Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]",
+                                 80,
+                                 -0.16,
+                                 0.16);
+  meHitZlocal_[3] =
+      ibook.book1D("EtlHitZlocalZposD2", "ETL SIM local Z (+Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
 
-  meOccupancy_[0] = ibook.book2D(
-      "EtlOccupancyZnegD1", "ETL SIM hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
-  meOccupancy_[1] = ibook.book2D(
-      "EtlOccupancyZnegD2", "ETL SIM hits occupancy (-Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
-  meOccupancy_[2] = ibook.book2D(
-      "EtlOccupancyZposD1", "ETL SIM hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
-  meOccupancy_[3] = ibook.book2D(
-      "EtlOccupancyZposD2", "ETL SIM hits occupancy (+Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[0] =
+      ibook.book2D("EtlOccupancyZnegD1",
+                   "ETL SIM hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
+  meOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
+                                 "ETL SIM hits occupancy (-Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
+  meOccupancy_[2] =
+      ibook.book2D("EtlOccupancyZposD1",
+                   "ETL SIM hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]",
+                   135,
+                   -135.,
+                   135.,
+                   135,
+                   -135.,
+                   135.);
+  meOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
+                                 "ETL SIM hits occupancy (+Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]",
+                                 135,
+                                 -135.,
+                                 135.,
+                                 135,
+                                 -135.,
+                                 135.);
 
-  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[0] = ibook.book1D(
+      "EtlHitXZnegD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
   meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL SIM hits X (-Z, Second disk);X_{SIM} [cm]", 100, -130., 130.);
-  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D(
+      "EtlHitXZposD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
   meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL SIM hits X (+Z, Second disk);X_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL SIM hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D(
+      "EtlHitYZnegD1", "ETL SIM hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL SIM hits Y (-Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL SIM hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D(
+      "EtlHitYZposD1", "ETL SIM hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL SIM hits Y (+Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -305, -301);
+  meHitZ_[0] = ibook.book1D(
+      "EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -305, -301);
   meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -305, -301);
-  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 301, 305);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 301, 305);  
+  meHitZ_[2] = ibook.book1D(
+      "EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 301, 305);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 301, 305);
 
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL SIM hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL SIM hits #phi (-Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL SIM hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL SIM hits #phi (+Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL SIM hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, -3.2, -1.56);
+  meHitPhi_[0] = ibook.book1D(
+      "EtlHitPhiZnegD1", "ETL SIM hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[1] =
+      ibook.book1D("EtlHitPhiZnegD2", "ETL SIM hits #phi (-Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[2] = ibook.book1D(
+      "EtlHitPhiZposD1", "ETL SIM hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[3] =
+      ibook.book1D("EtlHitPhiZposD2", "ETL SIM hits #phi (+Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D(
+      "EtlHitEtaZnegD1", "ETL SIM hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, -3.2, -1.56);
   meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL SIM hits #eta (-Z, Second disk);#eta_{SIM}", 100, -3.2, -1.56);
-  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL SIM hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, 1.56, 3.2);
+  meHitEta_[2] = ibook.book1D(
+      "EtlHitEtaZposD1", "ETL SIM hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, 1.56, 3.2);
   meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL SIM hits #eta (+Z, Second disk);#eta_{SIM}", 100, 1.56, 3.2);
 
-  meHitTvsE_[0] = ibook.bookProfile(
-      "EtlHitTvsEZnegD1", "ETL SIM time vs energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[0] =
+      ibook.bookProfile("EtlHitTvsEZnegD1",
+                        "ETL SIM time vs energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]",
+                        50,
+                        0.,
+                        2.,
+                        0.,
+                        100.);
   meHitTvsE_[1] = ibook.bookProfile(
       "EtlHitTvsEZnegD2", "ETL SIM time vs energy (-Z, Second disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
-  meHitTvsE_[2] = ibook.bookProfile(
-      "EtlHitTvsEZposD1", "ETL SIM time vs energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[2] =
+      ibook.bookProfile("EtlHitTvsEZposD1",
+                        "ETL SIM time vs energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]",
+                        50,
+                        0.,
+                        2.,
+                        0.,
+                        100.);
   meHitTvsE_[3] = ibook.bookProfile(
       "EtlHitTvsEZposD2", "ETL SIM time vs energy (+Z, Second disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
-  meHitEvsPhi_[0] = ibook.bookProfile(
-      "EtlHitEvsPhiZnegD1", "ETL SIM energy vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
-  meHitEvsPhi_[1] = ibook.bookProfile(
-      "EtlHitEvsPhiZnegD2", "ETL SIM energy vs #phi (-Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
-  meHitEvsPhi_[2] = ibook.bookProfile(
-      "EtlHitEvsPhiZposD1", "ETL SIM energy vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
-  meHitEvsPhi_[3] = ibook.bookProfile(
-      "EtlHitEvsPhiZposD2", "ETL SIM energy vs #phi (+Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZnegD1", "ETL SIM energy vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZnegD2", "ETL SIM energy vs #eta (-Z, Second disk);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitEvsEta_[2] = ibook.bookProfile(
-      "EtlHitEvsEtaZposD1", "ETL SIM energy vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
-  meHitEvsEta_[3] = ibook.bookProfile(
-      "EtlHitEvsEtaZposD2", "ETL SIM energy vs #eta (+Z, Second disk);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
-  meHitTvsPhi_[0] = ibook.bookProfile(
-      "EtlHitTvsPhiZnegD1", "ETL SIM time vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
-  meHitTvsPhi_[1] = ibook.bookProfile(
-      "EtlHitTvsPhiZnegD2", "ETL SIM time vs #phi (-Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
-  meHitTvsPhi_[2] = ibook.bookProfile(
-      "EtlHitTvsPhiZposD1", "ETL SIM time vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
-  meHitTvsPhi_[3] = ibook.bookProfile(
-      "EtlHitTvsPhiZposD2", "ETL SIM time vs #phi (+Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZnegD1", "ETL SIM time vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
+  meHitEvsPhi_[0] =
+      ibook.bookProfile("EtlHitEvsPhiZnegD1",
+                        "ETL SIM energy vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        100.);
+  meHitEvsPhi_[1] = ibook.bookProfile("EtlHitEvsPhiZnegD2",
+                                      "ETL SIM energy vs #phi (-Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      100.);
+  meHitEvsPhi_[2] =
+      ibook.bookProfile("EtlHitEvsPhiZposD1",
+                        "ETL SIM energy vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        100.);
+  meHitEvsPhi_[3] = ibook.bookProfile("EtlHitEvsPhiZposD2",
+                                      "ETL SIM energy vs #phi (+Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      100.);
+  meHitEvsEta_[0] =
+      ibook.bookProfile("EtlHitEvsEtaZnegD1",
+                        "ETL SIM energy vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]",
+                        50,
+                        -3.2,
+                        -1.56,
+                        0.,
+                        100.);
+  meHitEvsEta_[1] = ibook.bookProfile("EtlHitEvsEtaZnegD2",
+                                      "ETL SIM energy vs #eta (-Z, Second disk);#eta_{SIM};E_{SIM} [MeV]",
+                                      50,
+                                      -3.2,
+                                      -1.56,
+                                      0.,
+                                      100.);
+  meHitEvsEta_[2] =
+      ibook.bookProfile("EtlHitEvsEtaZposD1",
+                        "ETL SIM energy vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]",
+                        50,
+                        1.56,
+                        3.2,
+                        0.,
+                        100.);
+  meHitEvsEta_[3] = ibook.bookProfile("EtlHitEvsEtaZposD2",
+                                      "ETL SIM energy vs #eta (+Z, Second disk);#eta_{SIM};E_{SIM} [MeV]",
+                                      50,
+                                      1.56,
+                                      3.2,
+                                      0.,
+                                      100.);
+  meHitTvsPhi_[0] =
+      ibook.bookProfile("EtlHitTvsPhiZnegD1",
+                        "ETL SIM time vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        100.);
+  meHitTvsPhi_[1] = ibook.bookProfile("EtlHitTvsPhiZnegD2",
+                                      "ETL SIM time vs #phi (-Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      100.);
+  meHitTvsPhi_[2] =
+      ibook.bookProfile("EtlHitTvsPhiZposD1",
+                        "ETL SIM time vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]",
+                        50,
+                        -3.15,
+                        3.15,
+                        0.,
+                        100.);
+  meHitTvsPhi_[3] = ibook.bookProfile("EtlHitTvsPhiZposD2",
+                                      "ETL SIM time vs #phi (+Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]",
+                                      50,
+                                      -3.15,
+                                      3.15,
+                                      0.,
+                                      100.);
+  meHitTvsEta_[0] =
+      ibook.bookProfile("EtlHitTvsEtaZnegD1",
+                        "ETL SIM time vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]",
+                        50,
+                        -3.2,
+                        -1.56,
+                        0.,
+                        100.);
   meHitTvsEta_[1] = ibook.bookProfile(
       "EtlHitTvsEtaZnegD2", "ETL SIM time vs #eta (-Z, Second disk);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
-  meHitTvsEta_[2] = ibook.bookProfile(
-      "EtlHitTvsEtaZposD2", "ETL SIM time vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
+  meHitTvsEta_[2] =
+      ibook.bookProfile("EtlHitTvsEtaZposD2",
+                        "ETL SIM time vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]",
+                        50,
+                        1.56,
+                        3.2,
+                        0.,
+                        100.);
   meHitTvsEta_[3] = ibook.bookProfile(
       "EtlHitTvsEtaZposD2", "ETL SIM time vs #eta (+Z, Second disk);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
 }
@@ -351,7 +538,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 0.01);  // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.01);   // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlSimHits", desc);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -540,7 +540,7 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
-  desc.add<double>("hitMinimumEnergy1Dis", 0.01);   // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.1);   // [MeV]
   desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlSimHits", desc);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -265,14 +265,14 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                    0.,
                                    10.);
   meNtrkPerCell_[1] =
-      ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z, Second disk);N_{trk}", 10, 0., 10.);
-  meNtrkPerCell_[2] = ibook.book1D("EtlNtrkPerCellZpos",
+      ibook.book1D("EtlNtrkPerCellZnegD2", "Number of tracks per ETL sensor (-Z, Second disk);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[2] = ibook.book1D("EtlNtrkPerCellZposD1",
                                    "Number of tracks per ETL sensor (+Z, Single(topo1D)/First(topo2D) disk);N_{trk}",
                                    10,
                                    0.,
                                    10.);
   meNtrkPerCell_[3] =
-      ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
+      ibook.book1D("EtlNtrkPerCellZposD2", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
 
   meHitEnergy_[0] = ibook.book1D(
       "EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -31,6 +31,8 @@
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
+#include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 
 struct MTDHit {
   float energy;
@@ -55,41 +57,43 @@ private:
   // ------------ member data ------------
 
   const std::string folder_;
-  const float hitMinEnergy_;
+  const float hitMinEnergy1Dis_;
+  const float hitMinEnergy2Dis_;
 
   edm::EDGetTokenT<CrossingFrame<PSimHit> > etlSimHitsToken_;
 
   // --- histograms declaration
 
-  MonitorElement* meNhits_[2];
-  MonitorElement* meNtrkPerCell_[2];
+  MonitorElement* meNhits_[4];
+  MonitorElement* meNtrkPerCell_[4];
 
-  MonitorElement* meHitEnergy_[2];
-  MonitorElement* meHitTime_[2];
+  MonitorElement* meHitEnergy_[4];
+  MonitorElement* meHitTime_[4];
 
-  MonitorElement* meHitXlocal_[2];
-  MonitorElement* meHitYlocal_[2];
-  MonitorElement* meHitZlocal_[2];
+  MonitorElement* meHitXlocal_[4];
+  MonitorElement* meHitYlocal_[4];
+  MonitorElement* meHitZlocal_[4];
 
-  MonitorElement* meOccupancy_[2];
+  MonitorElement* meOccupancy_[4];
 
-  MonitorElement* meHitX_[2];
-  MonitorElement* meHitY_[2];
-  MonitorElement* meHitZ_[2];
-  MonitorElement* meHitPhi_[2];
-  MonitorElement* meHitEta_[2];
+  MonitorElement* meHitX_[4];
+  MonitorElement* meHitY_[4];
+  MonitorElement* meHitZ_[4];
+  MonitorElement* meHitPhi_[4];
+  MonitorElement* meHitEta_[4];
 
-  MonitorElement* meHitTvsE_[2];
-  MonitorElement* meHitEvsPhi_[2];
-  MonitorElement* meHitEvsEta_[2];
-  MonitorElement* meHitTvsPhi_[2];
-  MonitorElement* meHitTvsEta_[2];
+  MonitorElement* meHitTvsE_[4];
+  MonitorElement* meHitEvsPhi_[4];
+  MonitorElement* meHitEvsEta_[4];
+  MonitorElement* meHitTvsPhi_[4];
+  MonitorElement* meHitTvsEta_[4];
 };
 
 // ------------ constructor and destructor --------------
 EtlSimHitsValidation::EtlSimHitsValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")),
-      hitMinEnergy_(iConfig.getParameter<double>("hitMinimumEnergy")) {
+      hitMinEnergy1Dis_(iConfig.getParameter<double>("hitMinimumEnergy1Dis")),
+      hitMinEnergy2Dis_(iConfig.getParameter<double>("hitMinimumEnergy2Dis")) {
   etlSimHitsToken_ = consumes<CrossingFrame<PSimHit> >(iConfig.getParameter<edm::InputTag>("inputTag"));
 }
 
@@ -104,21 +108,54 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   iSetup.get<MTDDigiGeometryRecord>().get(geometryHandle);
   const MTDGeometry* geom = geometryHandle.product();
 
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  const MTDTopology* topology = topologyHandle.product();
+
+  bool topo1Dis = false;
+  bool topo2Dis = false;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());
 
-  std::unordered_map<uint32_t, MTDHit> m_etlHits[2];
-  std::unordered_map<uint32_t, std::set<int> > m_etlTrkPerCell[2];
+  std::unordered_map<uint32_t, MTDHit> m_etlHits[4];
+  std::unordered_map<uint32_t, std::set<int> > m_etlTrkPerCell[4];
 
-  // --- Loop over the BLT SIM hits
+  // --- Loop over the ETL SIM hits
+
+  int idet = 999;
+
   for (auto const& simHit : etlSimHits) {
     // --- Use only hits compatible with the in-time bunch-crossing
     if (simHit.tof() < 0 || simHit.tof() > 25.)
       continue;
 
     ETLDetId id = simHit.detUnitId();
+    if (topo1Dis) {
+      if (id.zside() == -1) {
+        idet = 0;
+      } else if (id.zside() == 1) {
+        idet = 2;
+      } else {
+        continue;
+      }
+    }
 
-    int idet = (id.zside() + 1) / 2;
+    if (topo2Dis) {
+      if ((id.zside() == -1) && (id.nDisc() == 1)) {
+        idet = 0;
+      } else if ((id.zside() == -1) && (id.nDisc() == 2)) {
+        idet = 1;
+      } else if ((id.zside() == 1) && (id.nDisc() == 1)) {
+        idet = 2;
+      } else if ((id.zside() == 1) && (id.nDisc() == 2)) {
+        idet = 3;
+      } else {
+        continue;
+      }
+    }
 
     m_etlTrkPerCell[idet][id.rawId()].insert(simHit.trackId());
 
@@ -143,19 +180,25 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
   //  Histogram filling
   // ==============================================================================
 
-  for (int idet = 0; idet < 2; ++idet) {
+  for (int idet = 0; idet < 4; ++idet) { //two disks per side
+    if ( ((idet == 1) || (idet == 3)) && (topo1Dis == true) ) continue;
     meNhits_[idet]->Fill(m_etlHits[idet].size());
 
-    for (auto const& hit : m_etlTrkPerCell[idet])
+    for (auto const& hit : m_etlTrkPerCell[idet]) {
       meNtrkPerCell_[idet]->Fill((hit.second).size());
+    }
 
     for (auto const& hit : m_etlHits[idet]) {
-      if ((hit.second).energy < hitMinEnergy_)
-        continue;
-
+      if (topo1Dis) {
+        if ((hit.second).energy < hitMinEnergy1Dis_)
+           continue;
+      }
+      if (topo2Dis) {
+        if ((hit.second).energy < hitMinEnergy2Dis_)
+           continue;
+      }
       // --- Get the SIM hit global position
       ETLDetId detId(hit.first);
-
       DetId geoId = detId.geographicalId();
       const MTDGeomDet* thedet = geom->idToDet(geoId);
       if (thedet == nullptr)
@@ -167,22 +210,17 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
       const auto& global_point = thedet->toGlobal(local_point);
 
       // --- Fill the histograms
-
       meHitEnergy_[idet]->Fill((hit.second).energy);
       meHitTime_[idet]->Fill((hit.second).time);
-
       meHitXlocal_[idet]->Fill((hit.second).x);
       meHitYlocal_[idet]->Fill((hit.second).y);
       meHitZlocal_[idet]->Fill((hit.second).z);
-
       meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
-
       meHitX_[idet]->Fill(global_point.x());
       meHitY_[idet]->Fill(global_point.y());
       meHitZ_[idet]->Fill(global_point.z());
       meHitPhi_[idet]->Fill(global_point.phi());
       meHitEta_[idet]->Fill(global_point.eta());
-
       meHitTvsE_[idet]->Fill((hit.second).energy, (hit.second).time);
       meHitEvsPhi_[idet]->Fill(global_point.phi(), (hit.second).energy);
       meHitEvsEta_[idet]->Fill(global_point.eta(), (hit.second).energy);
@@ -202,60 +240,109 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
 
   // --- histograms booking
 
-  meNhits_[1] = ibook.book1D("EtlNhitsZpos", "Number of ETL cells with SIM hits (+Z);N_{ETL cells}", 100, 0., 5000.);
-  meNhits_[0] = ibook.book1D("EtlNhitsZneg", "Number of ETL cells with SIM hits (-Z);N_{ETL cells}", 100, 0., 5000.);
-  meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z);N_{trk}", 10, 0., 10.);
-  meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z);N_{trk}", 10, 0., 10.);
+  meNhits_[0] = ibook.book1D("EtlNhitsZnegD1", "Number of ETL cells with SIM hits (-Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[1] = ibook.book1D("EtlNhitsZnegD2", "Number of ETL cells with SIM hits (-Z, Second disk);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[2] = ibook.book1D("EtlNhitsZposD1", "Number of ETL cells with SIM hits (+Z, Single(topo1D)/First(topo2D) disk);N_{ETL cells}", 100, 0., 5000.);
+  meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL cells with SIM hits (+Z, Second Disk);N_{ETL cells}", 100, 0., 5000.);
+  meNtrkPerCell_[0] = ibook.book1D("EtlNtrkPerCellZnegD1", "Number of tracks per ETL sensor (-Z, Single(topo1D)/First(topo2D) disk);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[1] = ibook.book1D("EtlNtrkPerCellZneg", "Number of tracks per ETL sensor (-Z, Second disk);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[2] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Single(topo1D)/First(topo2D) disk);N_{trk}", 10, 0., 10.);
+  meNtrkPerCell_[3] = ibook.book1D("EtlNtrkPerCellZpos", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
 
-  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZpos", "ETL SIM hits energy (+Z);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZneg", "ETL SIM hits energy (-Z);E_{SIM} [MeV]", 100, 0., 3.);
-  meHitTime_[1] = ibook.book1D("EtlHitTimeZpos", "ETL SIM hits ToA (+Z);ToA_{SIM} [ns]", 100, 0., 25.);
-  meHitTime_[0] = ibook.book1D("EtlHitTimeZneg", "ETL SIM hits ToA (-Z);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitEnergy_[0] = ibook.book1D("EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[1] = ibook.book1D("EtlHitEnergyZnegD2", "ETL SIM hits energy (-Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[2] = ibook.book1D("EtlHitEnergyZposD1", "ETL SIM hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitEnergy_[3] = ibook.book1D("EtlHitEnergyZposD2", "ETL SIM hits energy (+Z, Second disk);E_{SIM} [MeV]", 100, 0., 3.);
+  meHitTime_[0] = ibook.book1D("EtlHitTimeZnegD1", "ETL SIM hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL SIM hits ToA (-Z, Second disk);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[2] = ibook.book1D("EtlHitTimeZposD1", "ETL SIM hits ToA (+Z, Single(topo1D)/First(topo2D) disk);ToA_{SIM} [ns]", 100, 0., 25.);
+  meHitTime_[3] = ibook.book1D("EtlHitTimeZposD2", "ETL SIM hits ToA (+Z, Second disk);ToA_{SIM} [ns]", 100, 0., 25.);
 
-  meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZpos", "ETL SIM local X (+Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZneg", "ETL SIM local X (-Z);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
-  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZpos", "ETL SIM local Y (+Z);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZneg", "ETL SIM local Y (-Z);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
-  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZpos", "ETL SIM local Z (+Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
-  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZneg", "ETL SIM local Z (-Z);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitXlocal_[0] = ibook.book1D("EtlHitXlocalZnegD1", "ETL SIM local X (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[1] = ibook.book1D("EtlHitXlocalZnegD2", "ETL SIM local X (-Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[2] = ibook.book1D("EtlHitXlocalZposD1", "ETL SIM local X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
+  meHitXlocal_[3] = ibook.book1D("EtlHitXlocalZposD2", "ETL SIM local X (+Z, Second disk);X_{SIM}^{LOC} [mm]", 100, -25., 25.);
 
-  meOccupancy_[1] = ibook.book2D(
-      "EtlOccupancyZpos", "ETL SIM hits occupancy (+Z);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meHitYlocal_[0] = ibook.book1D("EtlHitYlocalZnegD1", "ETL SIM local Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitYlocal_[1] = ibook.book1D("EtlHitYlocalZnegD2", "ETL SIM local Y (-Z, Second Disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitYlocal_[2] = ibook.book1D("EtlHitYlocalZposD1", "ETL SIM local Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitYlocal_[3] = ibook.book1D("EtlHitYlocalZposD2", "ETL SIM local Y (+Z, Second disk);Y_{SIM}^{LOC} [mm]", 100, -48., 48.);
+  meHitZlocal_[0] = ibook.book1D("EtlHitZlocalZnegD1", "ETL SIM local Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitZlocal_[1] = ibook.book1D("EtlHitZlocalZnegD2", "ETL SIM local Z (-Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitZlocal_[2] = ibook.book1D("EtlHitZlocalZposD1", "ETL SIM local Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+  meHitZlocal_[3] = ibook.book1D("EtlHitZlocalZposD2", "ETL SIM local Z (+Z, Second disk);Z_{SIM}^{LOC} [mm]", 80, -0.16, 0.16);
+
   meOccupancy_[0] = ibook.book2D(
-      "EtlOccupancyZneg", "ETL SIM hits occupancy (-Z);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+      "EtlOccupancyZnegD1", "ETL SIM hits occupancy (-Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[1] = ibook.book2D(
+      "EtlOccupancyZnegD2", "ETL SIM hits occupancy (-Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[2] = ibook.book2D(
+      "EtlOccupancyZposD1", "ETL SIM hits occupancy (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
+  meOccupancy_[3] = ibook.book2D(
+      "EtlOccupancyZposD2", "ETL SIM hits occupancy (+Z, Second disk);X_{SIM} [cm];Y_{SIM} [cm]", 135, -135., 135., 135, -135., 135.);
 
-  meHitX_[1] = ibook.book1D("EtlHitXZpos", "ETL SIM hits X (+Z);X_{SIM} [cm]", 100, -130., 130.);
-  meHitX_[0] = ibook.book1D("EtlHitXZneg", "ETL SIM hits X (-Z);X_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[1] = ibook.book1D("EtlHitYZpos", "ETL SIM hits Y (+Z);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitY_[0] = ibook.book1D("EtlHitYZneg", "ETL SIM hits Y (-Z);Y_{SIM} [cm]", 100, -130., 130.);
-  meHitZ_[1] = ibook.book1D("EtlHitZZpos", "ETL SIM hits Z (+Z);Z_{SIM} [cm]", 100, 303.4, 304.2);
-  meHitZ_[0] = ibook.book1D("EtlHitZZneg", "ETL SIM hits Z (-Z);Z_{SIM} [cm]", 100, -304.2, -303.4);
+  meHitX_[0] = ibook.book1D("EtlHitXZnegD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[1] = ibook.book1D("EtlHitXZnegD2", "ETL SIM hits X (-Z, Second disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[2] = ibook.book1D("EtlHitXZposD1", "ETL SIM hits X (+Z, Single(topo1D)/First(topo2D) disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitX_[3] = ibook.book1D("EtlHitXZposD2", "ETL SIM hits X (+Z, Second disk);X_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[0] = ibook.book1D("EtlHitYZnegD1", "ETL SIM hits Y (-Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[1] = ibook.book1D("EtlHitYZnegD2", "ETL SIM hits Y (-Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[2] = ibook.book1D("EtlHitYZposD1", "ETL SIM hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL SIM hits Y (+Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
+  meHitZ_[0] = ibook.book1D("EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -305, -301);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -305, -301);
+  meHitZ_[2] = ibook.book1D("EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 301, 305);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 301, 305);  
 
-  meHitPhi_[1] = ibook.book1D("EtlHitPhiZpos", "ETL SIM hits #phi (+Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitPhi_[0] = ibook.book1D("EtlHitPhiZneg", "ETL SIM hits #phi (-Z);#phi_{SIM} [rad]", 100, -3.15, 3.15);
-  meHitEta_[1] = ibook.book1D("EtlHitEtaZpos", "ETL SIM hits #eta (+Z);#eta_{SIM}", 100, 1.56, 3.2);
-  meHitEta_[0] = ibook.book1D("EtlHitEtaZneg", "ETL SIM hits #eta (-Z);#eta_{SIM}", 100, -3.2, -1.56);
+  meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1", "ETL SIM hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[1] = ibook.book1D("EtlHitPhiZnegD2", "ETL SIM hits #phi (-Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[2] = ibook.book1D("EtlHitPhiZposD1", "ETL SIM hits #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitPhi_[3] = ibook.book1D("EtlHitPhiZposD2", "ETL SIM hits #phi (+Z, Second disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);
+  meHitEta_[0] = ibook.book1D("EtlHitEtaZnegD1", "ETL SIM hits #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, -3.2, -1.56);
+  meHitEta_[1] = ibook.book1D("EtlHitEtaZnegD2", "ETL SIM hits #eta (-Z, Second disk);#eta_{SIM}", 100, -3.2, -1.56);
+  meHitEta_[2] = ibook.book1D("EtlHitEtaZposD1", "ETL SIM hits #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM}", 100, 1.56, 3.2);
+  meHitEta_[3] = ibook.book1D("EtlHitEtaZposD2", "ETL SIM hits #eta (+Z, Second disk);#eta_{SIM}", 100, 1.56, 3.2);
 
-  meHitTvsE_[1] = ibook.bookProfile(
-      "EtlHitTvsEZpos", "ETL SIM time vs energy (+Z);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
   meHitTvsE_[0] = ibook.bookProfile(
-      "EtlHitTvsEZneg", "ETL SIM time vs energy (-Z);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
-  meHitEvsPhi_[1] = ibook.bookProfile(
-      "EtlHitEvsPhiZpos", "ETL SIM energy vs #phi (+Z);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+      "EtlHitTvsEZnegD1", "ETL SIM time vs energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[1] = ibook.bookProfile(
+      "EtlHitTvsEZnegD2", "ETL SIM time vs energy (-Z, Second disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[2] = ibook.bookProfile(
+      "EtlHitTvsEZposD1", "ETL SIM time vs energy (+Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
+  meHitTvsE_[3] = ibook.bookProfile(
+      "EtlHitTvsEZposD2", "ETL SIM time vs energy (+Z, Second disk);E_{SIM} [MeV];T_{SIM} [ns]", 50, 0., 2., 0., 100.);
   meHitEvsPhi_[0] = ibook.bookProfile(
-      "EtlHitEvsPhiZneg", "ETL SIM energy vs #phi (-Z);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
-  meHitEvsEta_[1] = ibook.bookProfile(
-      "EtlHitEvsEtaZpos", "ETL SIM energy vs #eta (+Z);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
+      "EtlHitEvsPhiZnegD1", "ETL SIM energy vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[1] = ibook.bookProfile(
+      "EtlHitEvsPhiZnegD2", "ETL SIM energy vs #phi (-Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[2] = ibook.bookProfile(
+      "EtlHitEvsPhiZposD1", "ETL SIM energy vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
+  meHitEvsPhi_[3] = ibook.bookProfile(
+      "EtlHitEvsPhiZposD2", "ETL SIM energy vs #phi (+Z, Second disk);#phi_{SIM} [rad];E_{SIM} [MeV]", 50, -3.15, 3.15, 0., 100.);
   meHitEvsEta_[0] = ibook.bookProfile(
-      "EtlHitEvsEtaZneg", "ETL SIM energy vs #eta (-Z);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
-  meHitTvsPhi_[1] = ibook.bookProfile(
-      "EtlHitTvsPhiZpos", "ETL SIM time vs #phi (+Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+      "EtlHitEvsEtaZnegD1", "ETL SIM energy vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
+  meHitEvsEta_[1] = ibook.bookProfile(
+      "EtlHitEvsEtaZnegD2", "ETL SIM energy vs #eta (-Z, Second disk);#eta_{SIM};E_{SIM} [MeV]", 50, -3.2, -1.56, 0., 100.);
+  meHitEvsEta_[2] = ibook.bookProfile(
+      "EtlHitEvsEtaZposD1", "ETL SIM energy vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
+  meHitEvsEta_[3] = ibook.bookProfile(
+      "EtlHitEvsEtaZposD2", "ETL SIM energy vs #eta (+Z, Second disk);#eta_{SIM};E_{SIM} [MeV]", 50, 1.56, 3.2, 0., 100.);
   meHitTvsPhi_[0] = ibook.bookProfile(
-      "EtlHitTvsPhiZneg", "ETL SIM time vs #phi (-Z);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
-  meHitTvsEta_[1] = ibook.bookProfile(
-      "EtlHitTvsEtaZpos", "ETL SIM time vs #eta (+Z);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
+      "EtlHitTvsPhiZnegD1", "ETL SIM time vs #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[1] = ibook.bookProfile(
+      "EtlHitTvsPhiZnegD2", "ETL SIM time vs #phi (-Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[2] = ibook.bookProfile(
+      "EtlHitTvsPhiZposD1", "ETL SIM time vs #phi (+Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
+  meHitTvsPhi_[3] = ibook.bookProfile(
+      "EtlHitTvsPhiZposD2", "ETL SIM time vs #phi (+Z, Second disk);#phi_{SIM} [rad];T_{SIM} [ns]", 50, -3.15, 3.15, 0., 100.);
   meHitTvsEta_[0] = ibook.bookProfile(
-      "EtlHitTvsEtaZneg", "ETL SIM time vs #eta (-Z);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
+      "EtlHitTvsEtaZnegD1", "ETL SIM time vs #eta (-Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
+  meHitTvsEta_[1] = ibook.bookProfile(
+      "EtlHitTvsEtaZnegD2", "ETL SIM time vs #eta (-Z, Second disk);#eta_{SIM};T_{SIM} [ns]", 50, -3.2, -1.56, 0., 100.);
+  meHitTvsEta_[2] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD2", "ETL SIM time vs #eta (+Z, Single(topo1D)/First(topo2D) disk);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
+  meHitTvsEta_[3] = ibook.bookProfile(
+      "EtlHitTvsEtaZposD2", "ETL SIM time vs #eta (+Z, Second disk);#eta_{SIM};T_{SIM} [ns]", 50, 1.56, 3.2, 0., 100.);
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -264,7 +351,8 @@ void EtlSimHitsValidation::fillDescriptions(edm::ConfigurationDescriptions& desc
 
   desc.add<std::string>("folder", "MTD/ETL/SimHits");
   desc.add<edm::InputTag>("inputTag", edm::InputTag("mix", "g4SimHitsFastTimerHitsEndcap"));
-  desc.add<double>("hitMinimumEnergy", 0.1);  // [MeV]
+  desc.add<double>("hitMinimumEnergy1Dis", 0.01);  // [MeV]
+  desc.add<double>("hitMinimumEnergy2Dis", 0.001);  // [MeV]
 
   descriptions.add("etlSimHits", desc);
 }

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -114,10 +114,12 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  }
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo2Dis = true;
+  }
 
   auto etlSimHitsHandle = makeValid(iEvent.getHandle(etlSimHitsToken_));
   MixCollection<PSimHit> etlSimHits(etlSimHitsHandle.product());

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
@@ -27,9 +27,9 @@ private:
   MonitorElement* meBtlEtaEff_;
   MonitorElement* meBtlPhiEff_;
   MonitorElement* meBtlPtEff_;
-  MonitorElement* meEtlEtaEff_[2];
-  MonitorElement* meEtlPhiEff_[2];
-  MonitorElement* meEtlPtEff_[2];
+  MonitorElement* meEtlEtaEff_[4];
+  MonitorElement* meEtlPhiEff_[4];
+  MonitorElement* meEtlPtEff_[4];
 };
 
 // ------------ constructor and destructor --------------
@@ -50,21 +50,28 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
   MonitorElement* meETLTrackEffEtaTotZneg = igetter.get(folder_ + "TrackETLEffEtaTotZneg");
   MonitorElement* meETLTrackEffPhiTotZneg = igetter.get(folder_ + "TrackETLEffPhiTotZneg");
   MonitorElement* meETLTrackEffPtTotZneg = igetter.get(folder_ + "TrackETLEffPtTotZneg");
-  MonitorElement* meETLTrackEffEtaMtdZneg = igetter.get(folder_ + "TrackETLEffEtaMtdZneg");
-  MonitorElement* meETLTrackEffPhiMtdZneg = igetter.get(folder_ + "TrackETLEffPhiMtdZneg");
-  MonitorElement* meETLTrackEffPtMtdZneg = igetter.get(folder_ + "TrackETLEffPtMtdZneg");
+  MonitorElement* meETLTrackEffEtaMtdZnegD1 = igetter.get(folder_ + "TrackETLEffEtaMtdZnegD1");
+  MonitorElement* meETLTrackEffEtaMtdZnegD2 = igetter.get(folder_ + "TrackETLEffEtaMtdZnegD2");
+  MonitorElement* meETLTrackEffPhiMtdZnegD1 = igetter.get(folder_ + "TrackETLEffPhiMtdZnegD1");
+  MonitorElement* meETLTrackEffPhiMtdZnegD2 = igetter.get(folder_ + "TrackETLEffPhiMtdZnegD2");
+  MonitorElement* meETLTrackEffPtMtdZnegD1 = igetter.get(folder_ + "TrackETLEffPtMtdZnegD1");
+  MonitorElement* meETLTrackEffPtMtdZnegD2 = igetter.get(folder_ + "TrackETLEffPtMtdZnegD2");
   MonitorElement* meETLTrackEffEtaTotZpos = igetter.get(folder_ + "TrackETLEffEtaTotZpos");
   MonitorElement* meETLTrackEffPhiTotZpos = igetter.get(folder_ + "TrackETLEffPhiTotZpos");
   MonitorElement* meETLTrackEffPtTotZpos = igetter.get(folder_ + "TrackETLEffPtTotZpos");
-  MonitorElement* meETLTrackEffEtaMtdZpos = igetter.get(folder_ + "TrackETLEffEtaMtdZpos");
-  MonitorElement* meETLTrackEffPhiMtdZpos = igetter.get(folder_ + "TrackETLEffPhiMtdZpos");
-  MonitorElement* meETLTrackEffPtMtdZpos = igetter.get(folder_ + "TrackETLEffPtMtdZpos");
+  MonitorElement* meETLTrackEffEtaMtdZposD1 = igetter.get(folder_ + "TrackETLEffEtaMtdZposD1");
+  MonitorElement* meETLTrackEffEtaMtdZposD2 = igetter.get(folder_ + "TrackETLEffEtaMtdZposD2");
+  MonitorElement* meETLTrackEffPhiMtdZposD1 = igetter.get(folder_ + "TrackETLEffPhiMtdZposD1");
+  MonitorElement* meETLTrackEffPhiMtdZposD2 = igetter.get(folder_ + "TrackETLEffPhiMtdZposD2");
+  MonitorElement* meETLTrackEffPtMtdZposD1 = igetter.get(folder_ + "TrackETLEffPtMtdZposD1");
+  MonitorElement* meETLTrackEffPtMtdZposD2 = igetter.get(folder_ + "TrackETLEffPtMtdZposD2");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
-      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZneg || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
-      !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos ||
-      !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos) {
+      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZnegD1 || !meETLTrackEffPhiMtdZnegD1 || !meETLTrackEffPtMtdZnegD1 ||
+      !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZposD1 ||
+      !meETLTrackEffPhiMtdZposD1 || !meETLTrackEffPtMtdZposD1 || !meETLTrackEffEtaMtdZnegD2 || !meETLTrackEffPhiMtdZnegD2 ||
+      !meETLTrackEffPtMtdZnegD2 || !meETLTrackEffEtaMtdZposD2 || !meETLTrackEffPhiMtdZposD2 || !meETLTrackEffPtMtdZposD2) {
     edm::LogError("MtdGlobalRecoHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -86,45 +93,74 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
                              meBTLTrackEffPtTot->getNbinsX(),
                              meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
                              meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[0] = ibook.book1D("EtlEtaEffZneg",
-                                 " Track Efficiency VS Eta (-Z);#eta;Efficiency",
+  meEtlEtaEff_[0] = ibook.book1D("EtlEtaEffZnegD1",
+                                 " Track Efficiency VS Eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta;Efficiency",
                                  meETLTrackEffEtaTotZneg->getNbinsX(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZneg",
-                                 "Track Efficiency VS Phi (-Z);#phi [rad];Efficiency",
+  meEtlEtaEff_[1] = ibook.book1D("EtlEtaEffZnegD2",
+                                 " Track Efficiency VS Eta (-Z, Second Disk);#eta;Efficiency",
+                                 meETLTrackEffEtaTotZneg->getNbinsX(),
+                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
+                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZnegD1",
+                                 "Track Efficiency VS Phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZneg->getNbinsX(),
                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[0] = ibook.book1D("EtlPtEffZneg",
-                                "Track Efficiency VS Pt (-Z);Pt [GeV];Efficiency",
+  meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZnegD2",
+                                 "Track Efficiency VS Phi (-Z, Second Disk);#phi [rad];Efficiency",
+                                 meETLTrackEffPhiTotZneg->getNbinsX(),
+                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
+                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
+  meEtlPtEff_[0] = ibook.book1D("EtlPtEffZnegD1",
+                                "Track Efficiency VS Pt (-Z, Single(topo1D)/First(topo2D) Disk);Pt [GeV];Efficiency",
                                 meETLTrackEffPtTotZneg->getNbinsX(),
                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[1] = ibook.book1D("EtlEtaEffZpos",
-                                 " Track Efficiency VS Eta (+Z);#eta;Efficiency",
+  meEtlPtEff_[1] = ibook.book1D("EtlPtEffZnegD2",
+                                "Track Efficiency VS Pt (-Z, Second Disk);Pt [GeV];Efficiency",
+                                meETLTrackEffPtTotZneg->getNbinsX(),
+                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
+                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
+  meEtlEtaEff_[2] = ibook.book1D("EtlEtaEffZposD1",
+                                 " Track Efficiency VS Eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta;Efficiency",
                                  meETLTrackEffEtaTotZpos->getNbinsX(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZpos",
-                                 "Track Efficiency VS Phi (+Z);#phi [rad];Efficiency",
+  meEtlEtaEff_[3] = ibook.book1D("EtlEtaEffZposD2",
+                                 " Track Efficiency VS Eta (+Z, Second Disk);#eta;Efficiency",
+                                 meETLTrackEffEtaTotZpos->getNbinsX(),
+                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
+                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff_[2] = ibook.book1D("EtlPhiEffZposD1",
+                                 "Track Efficiency VS Phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZpos->getNbinsX(),
                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[1] = ibook.book1D("EtlPtEffZpos",
-                                "Track Efficiency VS Pt (+Z);Pt [GeV];Efficiency",
+  meEtlPhiEff_[3] = ibook.book1D("EtlPhiEffZposD2",
+                                 "Track Efficiency VS Phi (+Z, Second Disk);#phi [rad];Efficiency",
+                                 meETLTrackEffPhiTotZpos->getNbinsX(),
+                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
+                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
+  meEtlPtEff_[2] = ibook.book1D("EtlPtEffZposD1",
+                                "Track Efficiency VS Pt (+Z, Single(topo1D)/First(topo2D) Disk);Pt [GeV];Efficiency",
+                                meETLTrackEffPtTotZpos->getNbinsX(),
+                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
+                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
+  meEtlPtEff_[3] = ibook.book1D("EtlPtEffZposD2",
+                                "Track Efficiency VS Pt (+Z, Second Disk);Pt [GeV];Efficiency",
                                 meETLTrackEffPtTotZpos->getNbinsX(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
   meBtlPtEff_->getTH1()->SetMinimum(0.);
-  meEtlEtaEff_[0]->getTH1()->SetMinimum(0.);
-  meEtlPhiEff_[0]->getTH1()->SetMinimum(0.);
-  meEtlPtEff_[0]->getTH1()->SetMinimum(0.);
-  meEtlEtaEff_[1]->getTH1()->SetMinimum(0.);
-  meEtlPhiEff_[1]->getTH1()->SetMinimum(0.);
-  meEtlPtEff_[1]->getTH1()->SetMinimum(0.);
+  for (int i=0; i<4; i++) {
+    meEtlEtaEff_[i]->getTH1()->SetMinimum(0.);
+    meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
+    meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
+  }
 
   // --- Calculate efficiency BTL
   for (int ibin = 1; ibin <= meBTLTrackEffEtaTot->getNbinsX(); ibin++) {
@@ -165,10 +201,10 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
   }
   // --- Calculate efficiency ETL
   for (int ibin = 1; ibin <= meETLTrackEffEtaTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZneg->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffEtaMtdZnegD1->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffEtaMtdZneg->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZneg->getBinContent(ibin))) /
+        sqrt((meETLTrackEffEtaMtdZnegD1->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZnegD1->getBinContent(ibin))) /
              pow(meETLTrackEffEtaTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffEtaTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -178,25 +214,53 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlEtaEff_[0]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZpos->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZneg->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffEtaMtdZnegD2->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffEtaMtdZpos->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZpos->getBinContent(ibin))) /
-             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffEtaMtdZnegD2->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZnegD2->getBinContent(ibin))) /
+             pow(meETLTrackEffEtaTotZneg->getBinContent(ibin), 3));
+    if (meETLTrackEffEtaTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
     meEtlEtaEff_[1]->setBinContent(ibin, eff);
     meEtlEtaEff_[1]->setBinError(ibin, bin_err);
+  } 
+
+  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffEtaMtdZposD1->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffEtaMtdZposD1->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZposD1->getBinContent(ibin))) /
+             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlEtaEff_[2]->setBinContent(ibin, eff);
+    meEtlEtaEff_[2]->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffEtaMtdZposD2->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffEtaMtdZposD2->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZposD2->getBinContent(ibin))) /
+             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlEtaEff_[3]->setBinContent(ibin, eff);
+    meEtlEtaEff_[3]->setBinError(ibin, bin_err);
   }
 
   for (int ibin = 1; ibin <= meETLTrackEffPhiTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZneg->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffPhiMtdZnegD1->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPhiMtdZneg->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZneg->getBinContent(ibin))) /
+        sqrt((meETLTrackEffPhiMtdZnegD1->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZnegD1->getBinContent(ibin))) /
              pow(meETLTrackEffPhiTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffPhiTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -205,26 +269,55 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPhiEff_[0]->setBinContent(ibin, eff);
     meEtlPhiEff_[0]->setBinError(ibin, bin_err);
   }
-
-  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZpos->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
+  
+  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZneg->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPhiMtdZnegD2->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPhiMtdZpos->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZpos->getBinContent(ibin))) /
-             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffPhiMtdZnegD2->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZnegD2->getBinContent(ibin))) /
+             pow(meETLTrackEffPhiTotZneg->getBinContent(ibin), 3));
+    if (meETLTrackEffPhiTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
     meEtlPhiEff_[1]->setBinContent(ibin, eff);
     meEtlPhiEff_[1]->setBinError(ibin, bin_err);
+
+  }  
+
+  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPhiMtdZposD1->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffPhiMtdZposD1->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZposD1->getBinContent(ibin))) /
+             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlPhiEff_[2]->setBinContent(ibin, eff);
+    meEtlPhiEff_[2]->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPhiMtdZposD2->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffPhiMtdZposD2->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZposD2->getBinContent(ibin))) /
+             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlPhiEff_[3]->setBinContent(ibin, eff);
+    meEtlPhiEff_[3]->setBinError(ibin, bin_err);
   }
 
   for (int ibin = 1; ibin <= meETLTrackEffPtTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZneg->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffPtMtdZnegD1->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPtMtdZneg->getBinContent(ibin) *
-              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZneg->getBinContent(ibin))) /
+        sqrt((meETLTrackEffPtMtdZnegD1->getBinContent(ibin) *
+              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZnegD1->getBinContent(ibin))) /
              pow(meETLTrackEffPtTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffPtTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -234,18 +327,46 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPtEff_[0]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZpos->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meETLTrackEffPtTotZneg->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPtMtdZnegD2->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPtMtdZpos->getBinContent(ibin) *
-              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZpos->getBinContent(ibin))) /
-             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffPtMtdZnegD2->getBinContent(ibin) *
+              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZnegD2->getBinContent(ibin))) /
+             pow(meETLTrackEffPtTotZneg->getBinContent(ibin), 3));
+    if (meETLTrackEffPtTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
     meEtlPtEff_[1]->setBinContent(ibin, eff);
     meEtlPtEff_[1]->setBinError(ibin, bin_err);
+  }
+
+  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPtMtdZposD1->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffPtMtdZposD1->getBinContent(ibin) *
+              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZposD1->getBinContent(ibin))) /
+             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlPtEff_[2]->setBinContent(ibin, eff);
+    meEtlPtEff_[2]->setBinError(ibin, bin_err);
+  }
+  
+  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPtMtdZposD2->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
+    double bin_err =
+        sqrt((meETLTrackEffPtMtdZposD2->getBinContent(ibin) *
+              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZposD2->getBinContent(ibin))) /
+             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
+      eff = 0;
+      bin_err = 0;
+    }
+    meEtlPtEff_[3]->setBinContent(ibin, eff);
+    meEtlPtEff_[3]->setBinError(ibin, bin_err);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
@@ -68,10 +68,11 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
-      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZnegD1 || !meETLTrackEffPhiMtdZnegD1 || !meETLTrackEffPtMtdZnegD1 ||
-      !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZposD1 ||
-      !meETLTrackEffPhiMtdZposD1 || !meETLTrackEffPtMtdZposD1 || !meETLTrackEffEtaMtdZnegD2 || !meETLTrackEffPhiMtdZnegD2 ||
-      !meETLTrackEffPtMtdZnegD2 || !meETLTrackEffEtaMtdZposD2 || !meETLTrackEffPhiMtdZposD2 || !meETLTrackEffPtMtdZposD2) {
+      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZnegD1 || !meETLTrackEffPhiMtdZnegD1 ||
+      !meETLTrackEffPtMtdZnegD1 || !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos ||
+      !meETLTrackEffEtaMtdZposD1 || !meETLTrackEffPhiMtdZposD1 || !meETLTrackEffPtMtdZposD1 ||
+      !meETLTrackEffEtaMtdZnegD2 || !meETLTrackEffPhiMtdZnegD2 || !meETLTrackEffPtMtdZnegD2 ||
+      !meETLTrackEffEtaMtdZposD2 || !meETLTrackEffPhiMtdZposD2 || !meETLTrackEffPtMtdZposD2) {
     edm::LogError("MtdGlobalRecoHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -103,11 +104,12 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
                                  meETLTrackEffEtaTotZneg->getNbinsX(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZnegD1",
-                                 "Track Efficiency VS Phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
-                                 meETLTrackEffPhiTotZneg->getNbinsX(),
-                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff_[0] =
+      ibook.book1D("EtlPhiEffZnegD1",
+                   "Track Efficiency VS Phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
+                   meETLTrackEffPhiTotZneg->getNbinsX(),
+                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
   meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZnegD2",
                                  "Track Efficiency VS Phi (-Z, Second Disk);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZneg->getNbinsX(),
@@ -133,11 +135,12 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
                                  meETLTrackEffEtaTotZpos->getNbinsX(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[2] = ibook.book1D("EtlPhiEffZposD1",
-                                 "Track Efficiency VS Phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
-                                 meETLTrackEffPhiTotZpos->getNbinsX(),
-                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
+  meEtlPhiEff_[2] =
+      ibook.book1D("EtlPhiEffZposD1",
+                   "Track Efficiency VS Phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
+                   meETLTrackEffPhiTotZpos->getNbinsX(),
+                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
+                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
   meEtlPhiEff_[3] = ibook.book1D("EtlPhiEffZposD2",
                                  "Track Efficiency VS Phi (+Z, Second Disk);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZpos->getNbinsX(),
@@ -156,7 +159,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
   meBtlPtEff_->getTH1()->SetMinimum(0.);
-  for (int i=0; i<4; i++) {
+  for (int i = 0; i < 4; i++) {
     meEtlEtaEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
@@ -226,7 +229,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     }
     meEtlEtaEff_[1]->setBinContent(ibin, eff);
     meEtlEtaEff_[1]->setBinError(ibin, bin_err);
-  } 
+  }
 
   for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
     double eff = meETLTrackEffEtaMtdZposD1->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
@@ -269,7 +272,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPhiEff_[0]->setBinContent(ibin, eff);
     meEtlPhiEff_[0]->setBinError(ibin, bin_err);
   }
-  
+
   for (int ibin = 1; ibin <= meETLTrackEffPhiTotZneg->getNbinsX(); ibin++) {
     double eff = meETLTrackEffPhiMtdZnegD2->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
     double bin_err =
@@ -282,8 +285,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     }
     meEtlPhiEff_[1]->setBinContent(ibin, eff);
     meEtlPhiEff_[1]->setBinError(ibin, bin_err);
-
-  }  
+  }
 
   for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
     double eff = meETLTrackEffPhiMtdZposD1->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
@@ -354,7 +356,7 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPtEff_[2]->setBinContent(ibin, eff);
     meEtlPtEff_[2]->setBinError(ibin, bin_err);
   }
-  
+
   for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
     double eff = meETLTrackEffPtMtdZposD2->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
     double bin_err =

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -62,9 +62,9 @@ private:
 
   MonitorElement* meETLTrackRPTime_[4];
   MonitorElement* meETLTrackNumHits_[4];
-  MonitorElement* meETLTrackEffEtaTot_[4];
-  MonitorElement* meETLTrackEffPhiTot_[4];
-  MonitorElement* meETLTrackEffPtTot_[4];
+  MonitorElement* meETLTrackEffEtaTot_[2];
+  MonitorElement* meETLTrackEffPhiTot_[2];
+  MonitorElement* meETLTrackEffPtTot_[2];
   MonitorElement* meETLTrackEffEtaMtd_[4];
   MonitorElement* meETLTrackEffPhiMtd_[4];
   MonitorElement* meETLTrackEffPtMtd_[4];
@@ -308,13 +308,13 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meETLTrackEffPhiMtd_[1] = ibook.book1D(
       "TrackETLEffPhiMtdZnegD2", "Track efficiency vs phi (Mtd) (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPhiMtd_[2] =
-      ibook.book1D("TrackETLEffPhiMtdZposD2",
+      ibook.book1D("TrackETLEffPhiMtdZposD1",
                    "Track efficiency vs phi (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]",
                    100,
                    -3.2,
                    3.2);
   meETLTrackEffPhiMtd_[3] = ibook.book1D(
-      "TrackETLEffPhiMtdZposD1", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      "TrackETLEffPhiMtdZposD2", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPtMtd_[0] =
       ibook.book1D("TrackETLEffPtMtdZnegD1",
                    "Track efficiency vs pt (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]",

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -20,12 +20,7 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
-//#include "DataFormats/TrackReco/interface/TrackFwd.h"
-//#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-//#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-//#include "DataFormats/VertexReco/interface/VertexFwd.h"
-//#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
@@ -105,8 +100,10 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+    topo2Dis = true;
 
   auto RecTrackHandle = makeValid(iEvent.getHandle(RecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));
@@ -171,30 +168,30 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
           ETLDetId ETLHit = hit->geographicalId();
 
           if (topo2Dis) {
-  	    if  ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1 ) ) {
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
               MTDEtlZnegD1 = true;
               numMTDEtlvalidhits++;
             }
-            if  ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2 ) ) {
+            if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
               MTDEtlZnegD2 = true;
               numMTDEtlvalidhits++;
             }
-            if  ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1 ) ) {
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
               MTDEtlZposD1 = true;
               numMTDEtlvalidhits++;
             }
-            if  ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2 ) ) {
+            if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
               MTDEtlZposD2 = true;
               numMTDEtlvalidhits++;
             }
           }
 
           if (topo1Dis) {
-            if  (ETLHit.zside() == -1) {
+            if (ETLHit.zside() == -1) {
               MTDEtlZnegD1 = true;
               numMTDEtlvalidhits++;
             }
-            if  (ETLHit.zside() == 1) {
+            if (ETLHit.zside() == 1) {
               MTDEtlZposD1 = true;
               numMTDEtlvalidhits++;
             }
@@ -264,10 +261,14 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meBTLTrackEffPhiMtd_ =
       ibook.book1D("TrackBTLEffPhiMtd", "Track efficiency vs phi (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Track efficiency vs pt (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackRPTime_[0] = ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, Firstl Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[1] = ibook.book1D("TrackETLRPTimeZnegD2", "Track t0 with respect to R.P. (-Z, Second Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[2] = ibook.book1D("TrackETLRPTimeZposD1", "Track t0 with respect to R.P. (+Z, First Disk);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[3] = ibook.book1D("TrackETLRPTimeZposD2", "Track t0 with respect to R.P. (+Z, Second Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[0] =
+      ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, Firstl Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[1] =
+      ibook.book1D("TrackETLRPTimeZnegD2", "Track t0 with respect to R.P. (-Z, Second Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[2] =
+      ibook.book1D("TrackETLRPTimeZposD1", "Track t0 with respect to R.P. (+Z, First Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[3] =
+      ibook.book1D("TrackETLRPTimeZposD2", "Track t0 with respect to R.P. (+Z, Second Disk);t0 [ns]", 100, -1, 3);
   meETLTrackEffEtaTot_[0] =
       ibook.book1D("TrackETLEffEtaTotZneg", "Track efficiency vs eta (Tot) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaTot_[1] =
@@ -281,29 +282,53 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meETLTrackEffPtTot_[1] =
       ibook.book1D("TrackETLEffPtTotZpos", "Track efficiency vs pt (Tot) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffEtaMtd_[0] =
-      ibook.book1D("TrackETLEffEtaMtdZnegD1", "Track efficiency vs eta (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.4);
-  meETLTrackEffEtaMtd_[1] =
-      ibook.book1D("TrackETLEffEtaMtdZnegD2", "Track efficiency vs eta (Mtd) (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
+      ibook.book1D("TrackETLEffEtaMtdZnegD1",
+                   "Track efficiency vs eta (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}",
+                   100,
+                   -3.2,
+                   -1.4);
+  meETLTrackEffEtaMtd_[1] = ibook.book1D(
+      "TrackETLEffEtaMtdZnegD2", "Track efficiency vs eta (Mtd) (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaMtd_[2] =
-      ibook.book1D("TrackETLEffEtaMtdZposD1", "Track efficiency vs eta (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.4, 3.2);
-  meETLTrackEffEtaMtd_[3] =
-      ibook.book1D("TrackETLEffEtaMtdZposD2", "Track efficiency vs eta (Mtd) (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
+      ibook.book1D("TrackETLEffEtaMtdZposD1",
+                   "Track efficiency vs eta (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}",
+                   100,
+                   1.4,
+                   3.2);
+  meETLTrackEffEtaMtd_[3] = ibook.book1D(
+      "TrackETLEffEtaMtdZposD2", "Track efficiency vs eta (Mtd) (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
   meETLTrackEffPhiMtd_[0] =
-      ibook.book1D("TrackETLEffPhiMtdZnegD1", "Track efficiency vs phi (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhiMtd_[1] =
-      ibook.book1D("TrackETLEffPhiMtdZnegD2", "Track efficiency vs phi (Mtd) (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      ibook.book1D("TrackETLEffPhiMtdZnegD1",
+                   "Track efficiency vs phi (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]",
+                   100,
+                   -3.2,
+                   3.2);
+  meETLTrackEffPhiMtd_[1] = ibook.book1D(
+      "TrackETLEffPhiMtdZnegD2", "Track efficiency vs phi (Mtd) (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPhiMtd_[2] =
-      ibook.book1D("TrackETLEffPhiMtdZposD2", "Track efficiency vs phi (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhiMtd_[3] =
-      ibook.book1D("TrackETLEffPhiMtdZposD1", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      ibook.book1D("TrackETLEffPhiMtdZposD2",
+                   "Track efficiency vs phi (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]",
+                   100,
+                   -3.2,
+                   3.2);
+  meETLTrackEffPhiMtd_[3] = ibook.book1D(
+      "TrackETLEffPhiMtdZposD1", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPtMtd_[0] =
-      ibook.book1D("TrackETLEffPtMtdZnegD1", "Track efficiency vs pt (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPtMtd_[1] =
-      ibook.book1D("TrackETLEffPtMtdZnegD2", "Track efficiency vs pt (Mtd) (-Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
+      ibook.book1D("TrackETLEffPtMtdZnegD1",
+                   "Track efficiency vs pt (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]",
+                   50,
+                   0,
+                   10);
+  meETLTrackEffPtMtd_[1] = ibook.book1D(
+      "TrackETLEffPtMtdZnegD2", "Track efficiency vs pt (Mtd) (-Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffPtMtd_[2] =
-      ibook.book1D("TrackETLEffPtMtdZposD1", "Track efficiency vs pt (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPtMtd_[3] =
-      ibook.book1D("TrackETLEffPtMtdZposD2", "Track efficiency vs pt (Mtd) (+Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
+      ibook.book1D("TrackETLEffPtMtdZposD1",
+                   "Track efficiency vs pt (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]",
+                   50,
+                   0,
+                   10);
+  meETLTrackEffPtMtd_[3] = ibook.book1D(
+      "TrackETLEffPtMtdZposD2", "Track efficiency vs pt (Mtd) (+Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -20,16 +20,17 @@
 #include "DataFormats/Common/interface/RefVector.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+//#include "DataFormats/TrackReco/interface/TrackFwd.h"
+//#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+//#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
+//#include "DataFormats/VertexReco/interface/VertexFwd.h"
+//#include "DataFormats/TrackerRecHit2D/interface/MTDTrackingRecHit.h"
 
 #include "Geometry/Records/interface/MTDDigiGeometryRecord.h"
 #include "Geometry/Records/interface/MTDTopologyRcd.h"
 #include "Geometry/MTDNumberingBuilder/interface/MTDTopology.h"
+#include "Geometry/MTDCommonData/interface/MTDTopologyMode.h"
 #include "Geometry/MTDGeometryBuilder/interface/MTDGeometry.h"
 #include "Geometry/MTDGeometryBuilder/interface/ProxyMTDTopology.h"
 #include "Geometry/MTDGeometryBuilder/interface/RectangularMTDTopology.h"
@@ -64,14 +65,14 @@ private:
   MonitorElement* meBTLTrackEffPhiMtd_;
   MonitorElement* meBTLTrackEffPtMtd_;
 
-  MonitorElement* meETLTrackRPTime_[2];
-  MonitorElement* meETLTrackNumHits_[2];
-  MonitorElement* meETLTrackEffEtaTot_[2];
-  MonitorElement* meETLTrackEffPhiTot_[2];
-  MonitorElement* meETLTrackEffPtTot_[2];
-  MonitorElement* meETLTrackEffEtaMtd_[2];
-  MonitorElement* meETLTrackEffPhiMtd_[2];
-  MonitorElement* meETLTrackEffPtMtd_[2];
+  MonitorElement* meETLTrackRPTime_[4];
+  MonitorElement* meETLTrackNumHits_[4];
+  MonitorElement* meETLTrackEffEtaTot_[4];
+  MonitorElement* meETLTrackEffPhiTot_[4];
+  MonitorElement* meETLTrackEffPtTot_[4];
+  MonitorElement* meETLTrackEffEtaMtd_[4];
+  MonitorElement* meETLTrackEffPhiMtd_[4];
+  MonitorElement* meETLTrackEffPtMtd_[4];
 
   MonitorElement* meTrackNumHits_;
 
@@ -97,6 +98,15 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
   using namespace edm;
   using namespace geant_units::operators;
   using namespace std;
+
+  edm::ESHandle<MTDTopology> topologyHandle;
+  iSetup.get<MTDTopologyRcd>().get(topologyHandle);
+  const MTDTopology* topology = topologyHandle.product();
+
+  bool topo1Dis = false;
+  bool topo2Dis = false;
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo1Dis = true;
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) topo2Dis = true;
 
   auto RecTrackHandle = makeValid(iEvent.getHandle(RecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));
@@ -148,39 +158,78 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
         meETLTrackEffPtTot_[1]->Fill(track.pt());
       }
 
-      bool MTDEtlZneg = false;
-      bool MTDEtlZpos = false;
+      bool MTDEtlZnegD1 = false;
+      bool MTDEtlZnegD2 = false;
+      bool MTDEtlZposD1 = false;
+      bool MTDEtlZposD2 = false;
       int numMTDEtlvalidhits = 0;
       for (const auto hit : track.recHits()) {
         if (hit->isValid() == false)
           continue;
         MTDDetId Hit = hit->geographicalId();
-        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2) && (Hit.zside() == -1)) {
-          MTDEtlZneg = true;
-          numMTDEtlvalidhits++;
-        }
-        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2) && (Hit.zside() == 1)) {
-          MTDEtlZpos = true;
-          numMTDEtlvalidhits++;
+        if ((Hit.det() == 6) && (Hit.subdetId() == 1) && (Hit.mtdSubDetector() == 2)) {
+          ETLDetId ETLHit = hit->geographicalId();
+
+          if (topo2Dis) {
+  	    if  ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1 ) ) {
+              MTDEtlZnegD1 = true;
+              numMTDEtlvalidhits++;
+            }
+            if  ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2 ) ) {
+              MTDEtlZnegD2 = true;
+              numMTDEtlvalidhits++;
+            }
+            if  ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1 ) ) {
+              MTDEtlZposD1 = true;
+              numMTDEtlvalidhits++;
+            }
+            if  ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2 ) ) {
+              MTDEtlZposD2 = true;
+              numMTDEtlvalidhits++;
+            }
+          }
+
+          if (topo1Dis) {
+            if  (ETLHit.zside() == -1) {
+              MTDEtlZnegD1 = true;
+              numMTDEtlvalidhits++;
+            }
+            if  (ETLHit.zside() == 1) {
+              MTDEtlZposD1 = true;
+              numMTDEtlvalidhits++;
+            }
+          }
         }
       }
       meTrackNumHits_->Fill(-numMTDEtlvalidhits);
 
       // --- keeping only tracks with last hit in MTD ---
       if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-        if (MTDEtlZneg == true) {
+        if (MTDEtlZnegD1 == true) {
           meETLTrackEffEtaMtd_[0]->Fill(track.eta());
           meETLTrackEffPhiMtd_[0]->Fill(track.phi());
           meETLTrackEffPtMtd_[0]->Fill(track.pt());
           meETLTrackRPTime_[0]->Fill(track.t0());
         }
-      }
-      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-        if (MTDEtlZpos == true) {
+        if (MTDEtlZnegD2 == true) {
           meETLTrackEffEtaMtd_[1]->Fill(track.eta());
           meETLTrackEffPhiMtd_[1]->Fill(track.phi());
           meETLTrackEffPtMtd_[1]->Fill(track.pt());
           meETLTrackRPTime_[1]->Fill(track.t0());
+        }
+      }
+      if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
+        if (MTDEtlZposD1 == true) {
+          meETLTrackEffEtaMtd_[2]->Fill(track.eta());
+          meETLTrackEffPhiMtd_[2]->Fill(track.phi());
+          meETLTrackEffPtMtd_[2]->Fill(track.pt());
+          meETLTrackRPTime_[2]->Fill(track.t0());
+        }
+        if (MTDEtlZposD2 == true) {
+          meETLTrackEffEtaMtd_[3]->Fill(track.eta());
+          meETLTrackEffPhiMtd_[3]->Fill(track.phi());
+          meETLTrackEffPtMtd_[3]->Fill(track.pt());
+          meETLTrackRPTime_[3]->Fill(track.t0());
         }
       }
     }
@@ -215,8 +264,10 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meBTLTrackEffPhiMtd_ =
       ibook.book1D("TrackBTLEffPhiMtd", "Track efficiency vs phi (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Track efficiency vs pt (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackRPTime_[0] = ibook.book1D("TrackETLRPTimeZneg", "Track t0 with respect to R.P. (-Z);t0 [ns]", 100, -1, 3);
-  meETLTrackRPTime_[1] = ibook.book1D("TrackETLRPTimeZpos", "Track t0 with respect to R.P. (+Z);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[0] = ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, Firstl Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[1] = ibook.book1D("TrackETLRPTimeZnegD2", "Track t0 with respect to R.P. (-Z, Second Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[2] = ibook.book1D("TrackETLRPTimeZposD1", "Track t0 with respect to R.P. (+Z, First Disk);t0 [ns]", 100, -1, 3);
+  meETLTrackRPTime_[3] = ibook.book1D("TrackETLRPTimeZposD2", "Track t0 with respect to R.P. (+Z, Second Disk);t0 [ns]", 100, -1, 3);
   meETLTrackEffEtaTot_[0] =
       ibook.book1D("TrackETLEffEtaTotZneg", "Track efficiency vs eta (Tot) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaTot_[1] =
@@ -230,17 +281,29 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meETLTrackEffPtTot_[1] =
       ibook.book1D("TrackETLEffPtTotZpos", "Track efficiency vs pt (Tot) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffEtaMtd_[0] =
-      ibook.book1D("TrackETLEffEtaMtdZneg", "Track efficiency vs eta (Mtd) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
+      ibook.book1D("TrackETLEffEtaMtdZnegD1", "Track efficiency vs eta (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, -3.2, -1.4);
   meETLTrackEffEtaMtd_[1] =
-      ibook.book1D("TrackETLEffEtaMtdZpos", "Track efficiency vs eta (Mtd) (+Z);#eta_{RECO}", 100, 1.4, 3.2);
+      ibook.book1D("TrackETLEffEtaMtdZnegD2", "Track efficiency vs eta (Mtd) (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
+  meETLTrackEffEtaMtd_[2] =
+      ibook.book1D("TrackETLEffEtaMtdZposD1", "Track efficiency vs eta (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}", 100, 1.4, 3.2);
+  meETLTrackEffEtaMtd_[3] =
+      ibook.book1D("TrackETLEffEtaMtdZposD2", "Track efficiency vs eta (Mtd) (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
   meETLTrackEffPhiMtd_[0] =
-      ibook.book1D("TrackETLEffPhiMtdZneg", "Track efficiency vs phi (Mtd) (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      ibook.book1D("TrackETLEffPhiMtdZnegD1", "Track efficiency vs phi (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPhiMtd_[1] =
-      ibook.book1D("TrackETLEffPhiMtdZpos", "Track efficiency vs phi (Mtd) (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      ibook.book1D("TrackETLEffPhiMtdZnegD2", "Track efficiency vs phi (Mtd) (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackEffPhiMtd_[2] =
+      ibook.book1D("TrackETLEffPhiMtdZposD2", "Track efficiency vs phi (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackEffPhiMtd_[3] =
+      ibook.book1D("TrackETLEffPhiMtdZposD1", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPtMtd_[0] =
-      ibook.book1D("TrackETLEffPtMtdZneg", "Track efficiency vs pt (Mtd) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
+      ibook.book1D("TrackETLEffPtMtdZnegD1", "Track efficiency vs pt (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffPtMtd_[1] =
-      ibook.book1D("TrackETLEffPtMtdZpos", "Track efficiency vs pt (Mtd) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
+      ibook.book1D("TrackETLEffPtMtdZnegD2", "Track efficiency vs pt (Mtd) (-Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackEffPtMtd_[2] =
+      ibook.book1D("TrackETLEffPtMtdZposD1", "Track efficiency vs pt (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackEffPtMtd_[3] =
+      ibook.book1D("TrackETLEffPtMtdZposD2", "Track efficiency vs pt (Mtd) (+Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -100,10 +100,12 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
 
   bool topo1Dis = false;
   bool topo2Dis = false;
-  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  if (topology->getMTDTopologyMode() <= static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo1Dis = true;
-  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat))
+  }
+  if (topology->getMTDTopologyMode() > static_cast<int>(MTDTopologyMode::Mode::barphiflat)) {
     topo2Dis = true;
+  }
 
   auto RecTrackHandle = makeValid(iEvent.getHandle(RecTrackToken_));
   auto RecVertexHandle = makeValid(iEvent.getHandle(RecVertexToken_));


### PR DESCRIPTION
#### PR description:
This PR modifies the ETL plugins in order to validate the new ETL-2 disks geometry, following PR #31765 prepared by @fabiocos. It still provides monitoring histograms for the old ETL-1 disk geometry, distinguishing between the two geometries via MTDTopologyMode.

#### PR validation:

The new code has been tested in CMSSW_11_2_0_pre7. It needs the full 2-Disks geometry implemented in #31765 to be tested on 2-Disks scenarios, and #31654 to produce meaningful results for the new geometry. 
The size of the new histograms is:
962.49 KiB       MTD/ETL
238.40 KiB       MTD/BTL
18.05 KiB        MTD/GlobalReco
with respect to previous size:
481.31 KiB       MTD/ETL
238.40 KiB       MTD/BTL
12.77 KiB        MTD/GlobalReco
