### PR TITLE
EventSetupRecord::doGet uses prefetching

### DIFF
--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -51,11 +51,6 @@ namespace edm {
       void prefetchAsync(
           WaitingTask*, EventSetupRecordImpl const&, DataKey const&, EventSetupImpl const*, ServiceToken const&) const;
 
-      void doGet(EventSetupRecordImpl const&,
-                 DataKey const&,
-                 bool iTransiently,
-                 ActivityRegistry const*,
-                 EventSetupImpl const*) const;
       void const* get(EventSetupRecordImpl const&,
                       DataKey const&,
                       bool iTransiently,

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -39,6 +39,7 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESGetTokenGeneric.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/SoATuple.h"
 #include "FWCore/Utilities/interface/Transition.h"
@@ -222,7 +223,16 @@ namespace edm {
       return EDConsumerBaseWithTagESAdaptor<Tr>(this, std::move(tag));
     }
 
+    ///Used with EventSetupRecord::doGet
+    template <Transition Tr = Transition::Event>
+    ESGetTokenGeneric esConsumes(eventsetup::EventSetupRecordKey const& iRecord, eventsetup::DataKey const& iKey) {
+      return ESGetTokenGeneric(static_cast<unsigned int>(Tr),
+                               recordESConsumes(Tr, iRecord, iKey.type(), ESInputTag("", iKey.name().value())),
+                               iRecord.type());
+    }
+
   private:
+    virtual void registerLateConsumes(eventsetup::ESRecordsToProxyIndices const&) {}
     unsigned int recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets);
     ESTokenIndex recordESConsumes(Transition,
                                   eventsetup::EventSetupRecordKey const&,

--- a/FWCore/Framework/interface/ESRecordsToProxyIndices.h
+++ b/FWCore/Framework/interface/ESRecordsToProxyIndices.h
@@ -51,6 +51,12 @@ namespace edm::eventsetup {
     }
 
     ESRecordIndex recordIndexFor(EventSetupRecordKey const& iRK) const noexcept;
+
+    std::pair<std::vector<DataKey>::const_iterator, std::vector<DataKey>::const_iterator> keysForRecord(
+        EventSetupRecordKey const& iRK) const noexcept;
+    ///The sorted list of keys
+    std::vector<EventSetupRecordKey> recordKeys() const noexcept { return recordKeys_; }
+
     // ---------- member functions ---------------------------
     ///This should be called for all records in the list passed to the constructor and
     /// in the same order as the list.

--- a/FWCore/Framework/interface/EventSetupRecord.h
+++ b/FWCore/Framework/interface/EventSetupRecord.h
@@ -45,6 +45,7 @@
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/EventSetupRecordImpl.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESGetTokenGeneric.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
 #include "FWCore/Utilities/interface/ESIndices.h"
 #include "FWCore/Utilities/interface/Likely.h"
@@ -155,7 +156,7 @@ namespace edm {
       }
 
       ///returns false if no data available for key
-      bool doGet(DataKey const& aKey, bool aGetTransiently = false) const;
+      bool doGet(ESGetTokenGeneric const&, bool aGetTransiently = false) const;
 
       /**returns true only if someone has already requested data for this key
           and the data was retrieved

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -85,10 +85,6 @@ namespace edm {
 
       ValidityInterval validityInterval() const;
 
-      ///returns false if no data available for key
-      bool doGet(DataKey const& aKey, EventSetupImpl const*, bool aGetTransiently = false) const;
-      bool doGet(ESProxyIndex iProxyIndex, EventSetupImpl const*, bool aGetTransiently = false) const;
-
       ///prefetch the data to setup for subsequent calls to getImplementation
       void prefetchAsync(WaitingTask* iTask, ESProxyIndex iProxyIndex, EventSetupImpl const*, ServiceToken const&) const;
 

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -115,13 +115,5 @@ namespace edm {
       return getAfterPrefetch(iRecord, iKey, iTransiently);
     }
 
-    void DataProxy::doGet(const EventSetupRecordImpl& iRecord,
-                          const DataKey& iKey,
-                          bool iTransiently,
-                          ActivityRegistry const* activityRegistry,
-                          EventSetupImpl const* iEventSetupImpl) const {
-      get(iRecord, iKey, iTransiently, activityRegistry, iEventSetupImpl);
-    }
-
   }  // namespace eventsetup
 }  // namespace edm

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -193,6 +193,8 @@ void EDConsumerBase::updateLookup(BranchType iBranchType,
 }
 
 void EDConsumerBase::updateLookup(eventsetup::ESRecordsToProxyIndices const& iPI) {
+  registerLateConsumes(iPI);
+
   unsigned int index = 0;
   for (auto it = m_esTokenInfo.begin<kESLookupInfo>(); it != m_esTokenInfo.end<kESLookupInfo>(); ++it, ++index) {
     auto indexInRecord = iPI.indexInRecord(it->m_record, it->m_key);

--- a/FWCore/Framework/src/ESRecordsToProxyIndices.cc
+++ b/FWCore/Framework/src/ESRecordsToProxyIndices.cc
@@ -47,8 +47,8 @@ namespace edm::eventsetup {
   //
   // const member functions
   //
-  ESProxyIndex ESRecordsToProxyIndices::indexInRecord(EventSetupRecordKey const& iRK, DataKey const& iDK) const
-      noexcept {
+  ESProxyIndex ESRecordsToProxyIndices::indexInRecord(EventSetupRecordKey const& iRK,
+                                                      DataKey const& iDK) const noexcept {
     auto it = std::lower_bound(recordKeys_.begin(), recordKeys_.end(), iRK);
     if (it == recordKeys_.end() or *it != iRK) {
       return missingProxyIndex();
@@ -121,6 +121,17 @@ namespace edm::eventsetup {
       ++keyIndex;
     }
     return returnValue;
+  }
+
+  std::pair<std::vector<DataKey>::const_iterator, std::vector<DataKey>::const_iterator>
+  ESRecordsToProxyIndices::keysForRecord(EventSetupRecordKey const& iRK) const noexcept {
+    auto recIndex = recordIndexFor(iRK);
+    if (recIndex == missingRecordIndex()) {
+      return std::make_pair(dataKeys_.end(), dataKeys_.end());
+    }
+    auto const beginIndex = recordOffsets_[recIndex.value()];
+    auto const endIndex = recordOffsets_[recIndex.value() + 1];
+    return std::make_pair(dataKeys_.begin() + beginIndex, dataKeys_.begin() + endIndex);
   }
 
 }  // namespace edm::eventsetup

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -257,49 +257,6 @@ namespace edm {
       return proxies_[std::distance(keysForProxies_.begin(), lb)].get();
     }
 
-    bool EventSetupRecordImpl::doGet(const DataKey& aKey,
-                                     EventSetupImpl const* iEventSetupImpl,
-                                     bool aGetTransiently) const {
-      const DataProxy* proxy = find(aKey);
-      if (nullptr != proxy) {
-        try {
-          convertException::wrap(
-              [&]() { proxy->doGet(*this, aKey, aGetTransiently, activityRegistry_, iEventSetupImpl); });
-        } catch (cms::Exception& e) {
-          addTraceInfoToCmsException(e, aKey.name().value(), proxy->providerDescription(), aKey);
-          //NOTE: the above function can't do the 'throw' since it causes the C++ class type
-          // of the throw to be changed, a 'rethrow' does not have that problem
-          throw;
-        }
-      }
-      return nullptr != proxy;
-    }
-
-    bool EventSetupRecordImpl::doGet(ESProxyIndex iProxyIndex,
-                                     EventSetupImpl const* iEventSetupImpl,
-                                     bool aGetTransiently) const {
-      if UNLIKELY (iProxyIndex.value() == std::numeric_limits<int>::max()) {
-        return false;
-      }
-
-      const DataProxy* proxy = proxies_[iProxyIndex.value()];
-      if (nullptr != proxy) {
-        try {
-          convertException::wrap([&]() {
-            auto const& key = keysForProxies_[iProxyIndex.value()];
-            proxy->doGet(*this, key, aGetTransiently, activityRegistry_, iEventSetupImpl);
-          });
-        } catch (cms::Exception& e) {
-          auto const& key = keysForProxies_[iProxyIndex.value()];
-          addTraceInfoToCmsException(e, key.name().value(), proxy->providerDescription(), key);
-          //NOTE: the above function can't do the 'throw' since it causes the C++ class type
-          // of the throw to be changed, a 'rethrow' does not have that problem
-          throw;
-        }
-      }
-      return nullptr != proxy;
-    }
-
     void EventSetupRecordImpl::prefetchAsync(WaitingTask* iTask,
                                              ESProxyIndex iProxyIndex,
                                              EventSetupImpl const* iEventSetupImpl,

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -257,6 +257,8 @@
 ++++ starting: global begin run 1 : time = 1
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
@@ -272,6 +274,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
@@ -283,6 +287,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
@@ -299,18 +305,12 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -321,6 +321,8 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -336,6 +338,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -347,6 +351,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -363,18 +369,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
@@ -1035,18 +1035,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
@@ -1055,6 +1049,8 @@
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -1070,6 +1066,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -1081,6 +1079,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -1111,6 +1111,8 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -1126,6 +1128,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -1137,6 +1141,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -1153,18 +1159,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1825,18 +1825,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
@@ -1845,6 +1839,8 @@
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -1860,6 +1856,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -1871,6 +1869,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -1901,6 +1901,8 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -1916,6 +1918,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -1927,6 +1931,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -1943,18 +1949,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2291,18 +2291,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
@@ -2311,6 +2305,8 @@
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -2326,6 +2322,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -2337,6 +2335,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -2369,18 +2369,12 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'get' id = 6
-++++++ finished: end run for module: stream = 0 label = 'get' id = 6
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 34
-++++++ finished: end run for module: stream = 0 label = 'get' id = 34
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
@@ -2389,6 +2383,8 @@
 ++++ starting: global end run 1 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
@@ -2404,6 +2400,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
 ++++++ starting: global end run for module: label = 'test' id = 32
 ++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
@@ -2415,6 +2413,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
 ++++++ starting: global end run for module: label = 'test' id = 19
 ++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
@@ -2445,6 +2445,8 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
@@ -2460,6 +2462,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
@@ -2471,6 +2475,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
@@ -2487,18 +2493,12 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2509,6 +2509,8 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -2524,6 +2526,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -2535,6 +2539,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -2551,18 +2557,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3223,18 +3223,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
@@ -3243,6 +3237,8 @@
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -3258,6 +3254,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -3269,6 +3267,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -3299,6 +3299,8 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -3314,6 +3316,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -3325,6 +3329,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -3341,18 +3347,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
@@ -4013,18 +4013,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
@@ -4033,6 +4027,8 @@
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -4048,6 +4044,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -4059,6 +4057,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -4089,6 +4089,8 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -4104,6 +4106,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -4115,6 +4119,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -4131,18 +4137,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
@@ -4479,18 +4479,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
@@ -4499,6 +4493,8 @@
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -4514,6 +4510,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -4525,6 +4523,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -4557,18 +4557,12 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'get' id = 6
-++++++ finished: end run for module: stream = 0 label = 'get' id = 6
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 34
-++++++ finished: end run for module: stream = 0 label = 'get' id = 34
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
@@ -4577,6 +4571,8 @@
 ++++ starting: global end run 2 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
@@ -4592,6 +4588,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
 ++++++ starting: global end run for module: label = 'test' id = 32
 ++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
@@ -4603,6 +4601,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
 ++++++ starting: global end run for module: label = 'test' id = 19
 ++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23
@@ -4633,6 +4633,8 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin run for module: label = 'get' id = 6
+++++++ finished: global begin run for module: label = 'get' id = 6
 ++++++ starting: global begin run for module: label = 'getInt' id = 10
 ++++++ finished: global begin run for module: label = 'getInt' id = 10
 ++++++ starting: global begin run for module: label = 'noPut' id = 11
@@ -4648,6 +4650,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 32
 ++++++ starting: global begin run for module: label = 'testmerge' id = 33
 ++++++ finished: global begin run for module: label = 'testmerge' id = 33
+++++++ starting: global begin run for module: label = 'get' id = 34
+++++++ finished: global begin run for module: label = 'get' id = 34
 ++++++ starting: global begin run for module: label = 'getInt' id = 35
 ++++++ finished: global begin run for module: label = 'getInt' id = 35
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 36
@@ -4659,6 +4663,8 @@
 ++++++ finished: global begin run for module: label = 'test' id = 19
 ++++++ starting: global begin run for module: label = 'testmerge' id = 20
 ++++++ finished: global begin run for module: label = 'testmerge' id = 20
+++++++ starting: global begin run for module: label = 'get' id = 21
+++++++ finished: global begin run for module: label = 'get' id = 21
 ++++++ starting: global begin run for module: label = 'getInt' id = 22
 ++++++ finished: global begin run for module: label = 'getInt' id = 22
 ++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 23
@@ -4675,18 +4681,12 @@
 ++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin run for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -4697,6 +4697,8 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -4712,6 +4714,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -4723,6 +4727,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -4739,18 +4745,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
@@ -5411,18 +5411,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
@@ -5431,6 +5425,8 @@
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -5446,6 +5442,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -5457,6 +5455,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -5487,6 +5487,8 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -5502,6 +5504,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -5513,6 +5517,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -5529,18 +5535,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
@@ -6201,18 +6201,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
@@ -6221,6 +6215,8 @@
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -6236,6 +6232,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -6247,6 +6245,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -6277,6 +6277,8 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'get' id = 6
+++++++ finished: global begin lumi for module: label = 'get' id = 6
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 10
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 10
 ++++++ starting: global begin lumi for module: label = 'noPut' id = 11
@@ -6292,6 +6294,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 32
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 33
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 33
+++++++ starting: global begin lumi for module: label = 'get' id = 34
+++++++ finished: global begin lumi for module: label = 'get' id = 34
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 35
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 35
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 36
@@ -6303,6 +6307,8 @@
 ++++++ finished: global begin lumi for module: label = 'test' id = 19
 ++++++ starting: global begin lumi for module: label = 'testmerge' id = 20
 ++++++ finished: global begin lumi for module: label = 'testmerge' id = 20
+++++++ starting: global begin lumi for module: label = 'get' id = 21
+++++++ finished: global begin lumi for module: label = 'get' id = 21
 ++++++ starting: global begin lumi for module: label = 'getInt' id = 22
 ++++++ finished: global begin lumi for module: label = 'getInt' id = 22
 ++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 23
@@ -6319,18 +6325,12 @@
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
@@ -6667,18 +6667,12 @@
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 6
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 6
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 34
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 34
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'get' id = 21
-++++++ finished: end lumi for module: stream = 0 label = 'get' id = 21
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
@@ -6687,6 +6681,8 @@
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end lumi for module: label = 'get' id = 6
+++++++ finished: global end lumi for module: label = 'get' id = 6
 ++++++ starting: global end lumi for module: label = 'getInt' id = 10
 ++++++ finished: global end lumi for module: label = 'getInt' id = 10
 ++++++ starting: global end lumi for module: label = 'noPut' id = 11
@@ -6702,6 +6698,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 33
 ++++++ starting: global end lumi for module: label = 'test' id = 32
 ++++++ finished: global end lumi for module: label = 'test' id = 32
+++++++ starting: global end lumi for module: label = 'get' id = 34
+++++++ finished: global end lumi for module: label = 'get' id = 34
 ++++++ starting: global end lumi for module: label = 'getInt' id = 35
 ++++++ finished: global end lumi for module: label = 'getInt' id = 35
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 36
@@ -6713,6 +6711,8 @@
 ++++++ finished: global end lumi for module: label = 'testmerge' id = 20
 ++++++ starting: global end lumi for module: label = 'test' id = 19
 ++++++ finished: global end lumi for module: label = 'test' id = 19
+++++++ starting: global end lumi for module: label = 'get' id = 21
+++++++ finished: global end lumi for module: label = 'get' id = 21
 ++++++ starting: global end lumi for module: label = 'getInt' id = 22
 ++++++ finished: global end lumi for module: label = 'getInt' id = 22
 ++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 23
@@ -6745,18 +6745,12 @@
 ++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 8
 ++++++ starting: end run for module: stream = 0 label = 'putInt' id = 7
 ++++++ finished: end run for module: stream = 0 label = 'putInt' id = 7
-++++++ starting: end run for module: stream = 0 label = 'get' id = 6
-++++++ finished: end run for module: stream = 0 label = 'get' id = 6
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 34
-++++++ finished: end run for module: stream = 0 label = 'get' id = 34
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'get' id = 21
-++++++ finished: end run for module: stream = 0 label = 'get' id = 21
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001
@@ -6765,6 +6759,8 @@
 ++++ starting: global end run 3 : time = 0
 ++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 5
 ++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 5
+++++++ starting: global end run for module: label = 'get' id = 6
+++++++ finished: global end run for module: label = 'get' id = 6
 ++++++ starting: global end run for module: label = 'getInt' id = 10
 ++++++ finished: global end run for module: label = 'getInt' id = 10
 ++++++ starting: global end run for module: label = 'noPut' id = 11
@@ -6780,6 +6776,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 33
 ++++++ starting: global end run for module: label = 'test' id = 32
 ++++++ finished: global end run for module: label = 'test' id = 32
+++++++ starting: global end run for module: label = 'get' id = 34
+++++++ finished: global end run for module: label = 'get' id = 34
 ++++++ starting: global end run for module: label = 'getInt' id = 35
 ++++++ finished: global end run for module: label = 'getInt' id = 35
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 36
@@ -6791,6 +6789,8 @@
 ++++++ finished: global end run for module: label = 'testmerge' id = 20
 ++++++ starting: global end run for module: label = 'test' id = 19
 ++++++ finished: global end run for module: label = 'test' id = 19
+++++++ starting: global end run for module: label = 'get' id = 21
+++++++ finished: global end run for module: label = 'get' id = 21
 ++++++ starting: global end run for module: label = 'getInt' id = 22
 ++++++ finished: global end run for module: label = 'getInt' id = 22
 ++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 23

--- a/FWCore/Modules/src/EventSetupRecordDataGetter.cc
+++ b/FWCore/Modules/src/EventSetupRecordDataGetter.cc
@@ -24,38 +24,50 @@
 #include <iostream>
 
 // user include files
-#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/ESRecordsToProxyIndices.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/ESGetTokenGeneric.h"
 
 //
 // class decleration
 //
 namespace edm {
-  class EventSetupRecordDataGetter : public edm::stream::EDAnalyzer<> {
+  class EventSetupRecordDataGetter
+      : public edm::global::EDAnalyzer<edm::RunCache<std::nullptr_t>, edm::LuminosityBlockCache<std::nullptr_t>> {
   public:
     explicit EventSetupRecordDataGetter(ParameterSet const&);
     ~EventSetupRecordDataGetter() override;
 
-    void analyze(Event const&, EventSetup const&) override;
-    void beginRun(Run const&, EventSetup const&) override;
-    void beginLuminosityBlock(LuminosityBlock const&, EventSetup const&) override;
+    void analyze(edm::StreamID, Event const&, EventSetup const&) const final;
+    std::shared_ptr<std::nullptr_t> globalBeginRun(edm::Run const&, edm::EventSetup const&) const final;
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const final {}
+
+    std::shared_ptr<std::nullptr_t> globalBeginLuminosityBlock(edm::LuminosityBlock const&,
+                                                               edm::EventSetup const&) const final;
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const final {}
 
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    void doGet(EventSetup const&);
+    void registerLateConsumes(eventsetup::ESRecordsToProxyIndices const&) final;
+
+    using RecordToTokens = std::map<eventsetup::EventSetupRecordKey, std::vector<ESGetTokenGeneric>>;
+    void doGet(EventSetup const&, RecordToTokens const&) const;
     // ----------member data ---------------------------
     const ParameterSet pSet_;
 
-    typedef std::map<eventsetup::EventSetupRecordKey, std::vector<eventsetup::DataKey> > RecordToDataKeys;
+    typedef std::map<eventsetup::EventSetupRecordKey, std::vector<eventsetup::DataKey>> RecordToDataKeys;
     RecordToDataKeys recordToDataKeys_;
-    std::map<eventsetup::EventSetupRecordKey, unsigned long long> recordToCacheIdentifier_;
+    RecordToTokens recordToTokensRuns_;
+    RecordToTokens recordToTokensLumis_;
+    mutable std::map<eventsetup::EventSetupRecordKey, std::atomic<unsigned long long>> recordToCacheIdentifier_;
     const bool verbose_;
   };
 
@@ -88,7 +100,7 @@ namespace edm {
     ParameterSetDescription toGet;
     toGet.add<std::string>("record")->setComment(
         "The name of an EventSetup record holding the data you want obtained.");
-    toGet.add<std::vector<std::string> >("data")->setComment(
+    toGet.add<std::vector<std::string>>("data")->setComment(
         "The identifier for the data you wish to retrieve. "
         "The identifier is in two parts separated by a backslash '/'. "
         "The first part is the C++ class name of the data and the "
@@ -110,103 +122,110 @@ namespace edm {
     descriptions.add("getEventSetupData", desc);
   }
 
-  void EventSetupRecordDataGetter::beginRun(Run const&, EventSetup const& iSetup) { doGet(iSetup); }
-
-  void EventSetupRecordDataGetter::beginLuminosityBlock(LuminosityBlock const&, EventSetup const& iSetup) {
-    doGet(iSetup);
+  std::shared_ptr<std::nullptr_t> EventSetupRecordDataGetter::globalBeginRun(Run const&,
+                                                                             EventSetup const& iSetup) const {
+    doGet(iSetup, recordToTokensRuns_);
+    return {};
   }
 
-  void EventSetupRecordDataGetter::analyze(edm::Event const& /*iEvent*/, edm::EventSetup const& iSetup) {
-    doGet(iSetup);
+  std::shared_ptr<std::nullptr_t> EventSetupRecordDataGetter::globalBeginLuminosityBlock(
+      LuminosityBlock const&, EventSetup const& iSetup) const {
+    doGet(iSetup, recordToTokensLumis_);
+    return {};
   }
 
-  void EventSetupRecordDataGetter::doGet(EventSetup const& iSetup) {
-    if (recordToDataKeys_.empty()) {
-      typedef std::vector<ParameterSet> Parameters;
-      Parameters const& toGet = pSet_.getParameterSetVector("toGet");
+  void EventSetupRecordDataGetter::analyze(edm::StreamID,
+                                           edm::Event const& /*iEvent*/,
+                                           edm::EventSetup const& iSetup) const {}
 
-      for (Parameters::const_iterator itToGet = toGet.begin(), itToGetEnd = toGet.end(); itToGet != itToGetEnd;
-           ++itToGet) {
-        std::string recordName = itToGet->getParameter<std::string>("record");
+  void EventSetupRecordDataGetter::registerLateConsumes(eventsetup::ESRecordsToProxyIndices const& iInfo) {
+    auto const& toGet = pSet_.getParameterSetVector("toGet");
 
-        eventsetup::EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
-        if (recordKey.type() == eventsetup::EventSetupRecordKey::TypeTag()) {
-          //record not found
-          edm::LogWarning("DataGetter") << "Record \"" << recordName << "\" does not exist " << std::endl;
+    for (auto const& iGet : toGet) {
+      std::string recordName = iGet.getParameter<std::string>("record");
+
+      eventsetup::EventSetupRecordKey recordKey(eventsetup::EventSetupRecordKey::TypeTag::findType(recordName));
+      if (recordKey.type() == eventsetup::EventSetupRecordKey::TypeTag()) {
+        //record not found
+        edm::LogWarning("DataGetter") << "Record \"" << recordName << "\" does not exist " << std::endl;
+
+        continue;
+      }
+      auto dataNames = iGet.getParameter<std::vector<std::string>>("data");
+      std::vector<eventsetup::DataKey> dataKeys;
+      for (auto const& datum : dataNames) {
+        std::string datumName(datum, 0, datum.find_first_of('/'));
+        std::string labelName;
+        if (datum.size() != datumName.size()) {
+          labelName = std::string(datum, datumName.size() + 1);
+        }
+        eventsetup::TypeTag datumType = eventsetup::TypeTag::findType(datumName);
+        if (datumType == eventsetup::TypeTag()) {
+          //not found
+          edm::LogWarning("DataGetter") << "data item of type \"" << datumName << "\" does not exist" << std::endl;
 
           continue;
         }
-        typedef std::vector<std::string> Strings;
-        Strings dataNames = itToGet->getParameter<Strings>("data");
-        std::vector<eventsetup::DataKey> dataKeys;
-        for (Strings::iterator itDatum = dataNames.begin(), itDatumEnd = dataNames.end(); itDatum != itDatumEnd;
-             ++itDatum) {
-          std::string datumName(*itDatum, 0, itDatum->find_first_of("/"));
-          std::string labelName;
-          if (itDatum->size() != datumName.size()) {
-            labelName = std::string(*itDatum, datumName.size() + 1);
-          }
-          eventsetup::TypeTag datumType = eventsetup::TypeTag::findType(datumName);
-          if (datumType == eventsetup::TypeTag()) {
-            //not found
-            edm::LogWarning("DataGetter") << "data item of type \"" << datumName << "\" does not exist" << std::endl;
-
-            continue;
-          }
-          eventsetup::DataKey datumKey(datumType, labelName.c_str());
-          dataKeys.push_back(datumKey);
-        }
-        recordToDataKeys_.insert(std::make_pair(recordKey, dataKeys));
-        recordToCacheIdentifier_.insert(std::make_pair(recordKey, 0));
+        eventsetup::DataKey datumKey(datumType, labelName.c_str());
+        dataKeys.push_back(datumKey);
       }
-      if (toGet.empty()) {
-        //This means we should get everything in the EventSetup
-        std::vector<eventsetup::EventSetupRecordKey> recordKeys;
-        iSetup.fillAvailableRecordKeys(recordKeys);
-        std::vector<eventsetup::DataKey> dataKeys;
+      recordToDataKeys_.insert(std::make_pair(recordKey, dataKeys));
+      recordToCacheIdentifier_.insert(std::make_pair(recordKey, 0));
+    }
+    if (toGet.empty()) {
+      //This means we should get everything in the EventSetup
+      std::vector<eventsetup::EventSetupRecordKey> recordKeys = iInfo.recordKeys();
 
-        for (std::vector<eventsetup::EventSetupRecordKey>::iterator itRKey = recordKeys.begin(),
-                                                                    itRKeyEnd = recordKeys.end();
-             itRKey != itRKeyEnd;
-             ++itRKey) {
-          auto record = iSetup.find(*itRKey);
-          assert(record);
-          dataKeys.clear();
-          record->fillRegisteredDataKeys(dataKeys);
-          recordToDataKeys_.insert(std::make_pair(*itRKey, dataKeys));
-          recordToCacheIdentifier_.insert(std::make_pair(*itRKey, 0));
-        }
+      for (auto const& rKey : recordKeys) {
+        auto range = iInfo.keysForRecord(rKey);
+        recordToDataKeys_.insert(std::make_pair(rKey, std::vector<eventsetup::DataKey>(range.first, range.second)));
+        recordToCacheIdentifier_.insert(std::make_pair(rKey, 0));
       }
     }
+    for (auto const& r : recordToDataKeys_) {
+      auto& runs = recordToTokensRuns_[r.first];
+      auto& lumis = recordToTokensLumis_[r.first];
+      runs.reserve(r.second.size());
+      lumis.reserve(r.second.size());
+      for (auto const& dk : r.second) {
+        runs.push_back(esConsumes<edm::Transition::BeginRun>(r.first, dk));
+        lumis.push_back(esConsumes<edm::Transition::BeginLuminosityBlock>(r.first, dk));
+      }
+    }
+  }
 
+  void EventSetupRecordDataGetter::doGet(EventSetup const& iSetup, RecordToTokens const& iRecordToTokens) const {
     using namespace edm::eventsetup;
 
     //For each requested Record get the requested data only if the Record is in a new IOV
 
-    for (RecordToDataKeys::iterator itRecord = recordToDataKeys_.begin(), itRecordEnd = recordToDataKeys_.end();
-         itRecord != itRecordEnd;
-         ++itRecord) {
-      auto pRecord = iSetup.find(itRecord->first);
+    for (auto const& record : recordToDataKeys_) {
+      auto pRecord = iSetup.find(record.first);
       if (not pRecord) {
         edm::LogWarning("RecordNotInIOV")
-            << "The EventSetup Record '" << itRecord->first.name() << "' is not available for this IOV.";
+            << "The EventSetup Record '" << record.first.name() << "' is not available for this IOV.";
       }
-      if (pRecord.has_value() && pRecord->cacheIdentifier() != recordToCacheIdentifier_[itRecord->first]) {
-        recordToCacheIdentifier_[itRecord->first] = pRecord->cacheIdentifier();
-        typedef std::vector<DataKey> Keys;
-        Keys const& keys = itRecord->second;
-        for (Keys::const_iterator itKey = keys.begin(), itKeyEnd = keys.end(); itKey != itKeyEnd; ++itKey) {
-          if (!pRecord->doGet(*itKey)) {
+      auto const& tokens = iRecordToTokens.find(record.first)->second;
+      auto ci = recordToCacheIdentifier_[record.first].load();
+      if (pRecord.has_value() && pRecord->cacheIdentifier() != ci) {
+        recordToCacheIdentifier_[record.first].compare_exchange_strong(ci, pRecord->cacheIdentifier());
+        auto const& keys = record.second;
+        size_t i = 0;
+        for (auto const& token : tokens) {
+          if (!pRecord->doGet(token)) {
+            auto const& key = keys[i];
             edm::LogWarning("DataGetter")
-                << "No data of type \"" << itKey->type().name() << "\" with name \"" << itKey->name().value()
-                << "\" in record " << itRecord->first.type().name() << " found " << std::endl;
+                << "No data of type \"" << key.type().name() << "\" with name \"" << key.name().value()
+                << "\" in record " << record.first.type().name() << " found " << std::endl;
           } else {
             if (verbose_) {
+              auto const& key = keys[i];
               edm::LogSystem("DataGetter")
-                  << "got data of type \"" << itKey->type().name() << "\" with name \"" << itKey->name().value()
-                  << "\" in record " << itRecord->first.type().name() << std::endl;
+                  << "got data of type \"" << key.type().name() << "\" with name \"" << key.name().value()
+                  << "\" in record " << record.first.type().name() << std::endl;
             }
           }
+          ++i;
         }
       }
     }

--- a/FWCore/Utilities/interface/ESGetTokenGeneric.h
+++ b/FWCore/Utilities/interface/ESGetTokenGeneric.h
@@ -1,0 +1,65 @@
+#ifndef FWCore_Utilities_ESGetTokenGeneric_h
+#define FWCore_Utilities_ESGetTokenGeneric_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     ESGetTokenGeneric
+//
+/**\class ESGetTokenGeneric ESGetTokenGeneric.h "FWCore/Utilities/interface/ESGetTokenGeneric.h"
+
+ Description: A token used call EventSetupRecord::doGet
+
+ Usage:
+    An ESGetTokenGeneric is created by calls to 'esConsumes' from an ED module.
+*/
+
+#include "FWCore/Utilities/interface/ESIndices.h"
+#include "FWCore/Utilities/interface/TypeIDBase.h"
+#include <limits>
+
+namespace edm {
+  class EDConsumerBase;
+  class EventSetup;
+  class EventSetupImpl;
+  namespace eventsetup {
+    class EventSetupRecord;
+  }
+
+  // A ESGetTokenGeneric is created by calls to 'esConsumes' from an EDM
+  // module.
+  class ESGetTokenGeneric {
+    friend class EDConsumerBase;
+    friend class EventSetup;
+    friend class EventSetupImpl;
+    friend class eventsetup::EventSetupRecord;
+
+  public:
+    constexpr ESGetTokenGeneric() noexcept = default;
+
+    constexpr ESGetTokenGeneric(ESGetTokenGeneric const&) noexcept = default;
+    constexpr ESGetTokenGeneric(ESGetTokenGeneric&&) noexcept = default;
+
+    constexpr ESGetTokenGeneric& operator=(ESGetTokenGeneric&&) noexcept = default;
+    constexpr ESGetTokenGeneric& operator=(ESGetTokenGeneric const&) noexcept = default;
+
+    constexpr unsigned int transitionID() const noexcept { return m_transitionID; }
+    constexpr TypeIDBase const& recordType() const noexcept { return m_recordType; }
+    constexpr bool isInitialized() const noexcept { return transitionID() != std::numeric_limits<unsigned int>::max(); }
+    constexpr ESTokenIndex index() const noexcept { return m_index; }
+    constexpr bool hasValidIndex() const noexcept { return index() != invalidIndex(); }
+    static constexpr ESTokenIndex invalidIndex() noexcept { return ESTokenIndex{std::numeric_limits<int>::max()}; }
+
+  private:
+    explicit constexpr ESGetTokenGeneric(unsigned int transitionID,
+                                         ESTokenIndex index,
+                                         TypeIDBase const& recordType) noexcept
+        : m_recordType{recordType}, m_transitionID{transitionID}, m_index{index} {}
+
+    TypeIDBase m_recordType{};
+    unsigned int m_transitionID{std::numeric_limits<unsigned int>::max()};
+    ESTokenIndex m_index{std::numeric_limits<int>::max()};
+  };
+
+}  // namespace edm
+
+#endif

--- a/FWCore/Utilities/interface/TypeIDBase.h
+++ b/FWCore/Utilities/interface/TypeIDBase.h
@@ -30,11 +30,11 @@ namespace edm {
   public:
     struct Def {};
 
-    TypeIDBase() : t_(&(typeid(Def))) {}
+    constexpr TypeIDBase() noexcept : t_(&(typeid(Def))) {}
 
-    explicit TypeIDBase(const std::type_info& t) : t_(&t) {}
+    constexpr explicit TypeIDBase(const std::type_info& t) noexcept : t_(&t) {}
 
-    explicit TypeIDBase(const std::type_info* t) : t_(t == nullptr ? &(typeid(Def)) : t) {}
+    constexpr explicit TypeIDBase(const std::type_info* t) noexcept : t_(t == nullptr ? &(typeid(Def)) : t) {}
 
     // ---------- const member functions ---------------------
 
@@ -47,7 +47,7 @@ namespace edm {
     bool operator==(const TypeIDBase& b) const { return (*t_) == *(b.t_); }
 
   protected:
-    const std::type_info& typeInfo() const { return *t_; }
+    constexpr const std::type_info& typeInfo() const { return *t_; }
 
   private:
     //const TypeIDBase& operator=(const TypeIDBase&); // stop default


### PR DESCRIPTION

#### PR description:

Changed EventSetupRecord::doGet to work with prefetching. This required the introduction of ESGetTokenGeneric and a new esConsumes method.
Added the EDConsumerBase::registerLateConsumes to be able to safely call esConsumes based on the contents of the EventSetup.

#### PR validation:

Code compiles and relevant framework unit tests pass.