### PR TITLE
GEM - fed data size bugfix [EventFilter/GEMRawToDigi]

### DIFF
--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -122,8 +122,8 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     }
   }
 
-  uint32_t amc13EvtLength = 0;
   for (unsigned int fedId = FEDNumbering::MINGEMFEDID; fedId <= FEDNumbering::MAXGEMFEDID; ++fedId) {
+    uint32_t amc13EvtLength = 0;
     std::unique_ptr<AMC13Event> amc13Event = std::make_unique<AMC13Event>();
 
     for (auto const& gemBx : gemBxMap) {
@@ -222,6 +222,8 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       amc13Event->setAMC13Trailer(BX_id, LV1_id, BX_id);
       //CDF trailer
       uint32_t EvtLength = amc13EvtLength + 4;  // 2 header and 2 trailer
+      LogDebug("GEMDigiToRawModule") << " EvtLength: " << int(EvtLength);
+      
       amc13Event->setCDFTrailer(EvtLength);
       amc13Events.emplace_back(std::move(amc13Event));
     }  // finished making amc13Event data
@@ -266,10 +268,13 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     fedRawData.resize(dataSize);
 
     uint64_t* w = reinterpret_cast<uint64_t*>(fedRawData.data());
-    for (const auto& word : words)
+    for (const auto& word : words) {
+#ifdef EDM_ML_DEBUG
+      std::cout << std::bitset<64>(word) << std::endl;
+#endif
       *(w++) = word;
-
-    LogDebug("GEMDigiToRawModule") << " words " << words.size();
+    }    
+    LogDebug("GEMDigiToRawModule") << " words " << words.size();    
   }
 
   iEvent.put(std::move(fedRawDataCol));

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -223,7 +223,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       //CDF trailer
       uint32_t EvtLength = amc13EvtLength + 4;  // 2 header and 2 trailer
       LogDebug("GEMDigiToRawModule") << " EvtLength: " << int(EvtLength);
-      
+
       amc13Event->setCDFTrailer(EvtLength);
       amc13Events.emplace_back(std::move(amc13Event));
     }  // finished making amc13Event data
@@ -273,8 +273,8 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       std::cout << std::bitset<64>(word) << std::endl;
 #endif
       *(w++) = word;
-    }    
-    LogDebug("GEMDigiToRawModule") << " words " << words.size();    
+    }
+    LogDebug("GEMDigiToRawModule") << " words " << words.size();
   }
 
   iEvent.put(std::move(fedRawDataCol));

--- a/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMDigiToRawModule.cc
@@ -24,6 +24,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class GEMDigiToRawModule : public edm::global::EDProducer<edm::RunCache<GEMROMapping>> {
 public:
@@ -269,9 +270,7 @@ void GEMDigiToRawModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
     uint64_t* w = reinterpret_cast<uint64_t*>(fedRawData.data());
     for (const auto& word : words) {
-#ifdef EDM_ML_DEBUG
-      std::cout << std::bitset<64>(word) << std::endl;
-#endif
+      LogDebug("GEMDigiToRawModule") << std::bitset<64>(word);
       *(w++) = word;
     }
     LogDebug("GEMDigiToRawModule") << " words " << words.size();

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -113,13 +113,21 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     const FEDRawData& fedData = fed_buffers->FEDData(fedId);
 
     int nWords = fedData.size() / sizeof(uint64_t);
-    LogDebug("GEMRawToDigiModule") << " words " << nWords;
-
+    LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
+    
     if (nWords < 5)
       continue;
     const unsigned char* data = fedData.data();
 
     const uint64_t* word = reinterpret_cast<const uint64_t*>(data);
+
+#ifdef EDM_ML_DEBUG
+    const uint64_t* w = word;
+    for (int i =0; i< nWords;i++) {
+      std::cout << std::bitset<64>(*(w++)) << std::endl;
+    }
+#endif
+    
     auto amc13Event = gemRawToDigi_->convertWordToAMC13Event(word);
 
     if (amc13Event == nullptr)
@@ -133,7 +141,6 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       for (auto gebData : *amcData.gebs()) {
         uint8_t gebId = gebData.inputID();
         GEMROMapping::chamEC geb_ec = {fedId, amcNum, gebId};
-        LogDebug("GEMRawToDigiModule") << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId);
         GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
         GEMDetId gemChId = geb_dc.detId;
 
@@ -142,7 +149,6 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           vfatData.setVersion(geb_dc.vfatVer);
           uint16_t vfatId = vfatData.vfatId();
           GEMROMapping::vfatEC vfat_ec = {vfatId, gemChId};
-          LogDebug("GEMRawToDigiModule") << " vfatId: " << vfatId << " gemChId:" << gemChId;
 
           // check if ChipID exists.
           if (!gemROMap->isValidChipID(vfat_ec)) {
@@ -167,7 +173,6 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           vfatData.setPhi(vfat_dc.localPhi);
           GEMDetId gemId = vfat_dc.detId;
           int bx(vfatData.bc());
-          LogDebug("GEMRawToDigiModule") << " gemId: " << gemId << " bx:" << bx;
 
           for (int chan = 0; chan < VFATdata::nChannels; ++chan) {
             uint8_t chan0xf = 0;
@@ -187,7 +192,10 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
             GEMDigi digi(stripId, bx);
 
-            LogDebug("GEMRawToDigiModule") << stripId << " ";
+            LogDebug("GEMRawToDigiModule")
+              << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId)
+              << " vfat:" << vfat_dc.localPhi << ",type: " << vfat_dc.vfatType << " id:" << gemId
+              << " ch:" << chMap.chNum << " st:" << digi.strip() << " bx:" << digi.bx();
 
             outGEMDigis.get()->insertDigi(gemId, digi);
 

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/Transition.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class GEMRawToDigiModule : public edm::global::EDProducer<edm::RunCache<GEMROMapping> > {
 public:
@@ -120,13 +121,6 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     const unsigned char* data = fedData.data();
 
     const uint64_t* word = reinterpret_cast<const uint64_t*>(data);
-
-#ifdef EDM_ML_DEBUG
-    const uint64_t* w = word;
-    for (int i = 0; i < nWords; i++) {
-      std::cout << std::bitset<64>(*(w++)) << std::endl;
-    }
-#endif
 
     auto amc13Event = gemRawToDigi_->convertWordToAMC13Event(word);
 

--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -114,7 +114,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
     int nWords = fedData.size() / sizeof(uint64_t);
     LogDebug("GEMRawToDigiModule") << "fedId:" << fedId << " words: " << nWords;
-    
+
     if (nWords < 5)
       continue;
     const unsigned char* data = fedData.data();
@@ -123,11 +123,11 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
 
 #ifdef EDM_ML_DEBUG
     const uint64_t* w = word;
-    for (int i =0; i< nWords;i++) {
+    for (int i = 0; i < nWords; i++) {
       std::cout << std::bitset<64>(*(w++)) << std::endl;
     }
 #endif
-    
+
     auto amc13Event = gemRawToDigi_->convertWordToAMC13Event(word);
 
     if (amc13Event == nullptr)
@@ -193,9 +193,9 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
             GEMDigi digi(stripId, bx);
 
             LogDebug("GEMRawToDigiModule")
-              << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId)
-              << " vfat:" << vfat_dc.localPhi << ",type: " << vfat_dc.vfatType << " id:" << gemId
-              << " ch:" << chMap.chNum << " st:" << digi.strip() << " bx:" << digi.bx();
+                << " fed: " << fedId << " amc:" << int(amcNum) << " geb:" << int(gebId) << " vfat:" << vfat_dc.localPhi
+                << ",type: " << vfat_dc.vfatType << " id:" << gemId << " ch:" << chMap.chNum << " st:" << digi.strip()
+                << " bx:" << digi.bx();
 
             outGEMDigis.get()->insertDigi(gemId, digi);
 


### PR DESCRIPTION
#### PR description:

- error in how FED trailer fragmentLength was stored

#### PR validation:

- only changes 1 number in FED data that isn't used

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

- no backport needed