### PR TITLE
Migrate rest of {HBHEPhase1,HcalHit,HcalSimple}Reconstructor to EventSetup consumes

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h
@@ -5,11 +5,14 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/HcalTimeSlewRecord.h"
 
 class HcalPulseContainmentManager {
 public:
+  // for callers not calling beginRun(EventSetup)
   HcalPulseContainmentManager(float max_fracerror);
+  // for callers calling beginRun(EventSetup)
+  HcalPulseContainmentManager(float max_fracerror, edm::ConsumesCollector iC);
   double correction(const HcalDetId& detId, int toAdd, float fixedphase_ns, double fc_ampl);
   const HcalPulseContainmentCorrection* get(const HcalDetId& detId, int toAdd, float fixedphase_ns);
 
@@ -35,6 +38,7 @@ private:
   HcalPulseShapes shapes_;
   float fixedphase_ns_;
   float max_fracerror_;
+  const edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> delayToken_;
 
   const HcalTimeSlew* hcalTimeSlew_delay_;
 };

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -8,6 +8,7 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
 /** \class HcalPulseShapes
   *  
@@ -21,7 +22,9 @@ namespace CLHEP {
 class HcalPulseShapes {
 public:
   typedef HcalPulseShape Shape;
+  // Default constructor is for callers that do not call beginRun(EventSetup)
   HcalPulseShapes();
+  explicit HcalPulseShapes(edm::ConsumesCollector iC);
   ~HcalPulseShapes();
   // only needed if you'll be getting shapes by DetId
   void beginRun(edm::EventSetup const& es);
@@ -112,6 +115,7 @@ private:
   Shape hpdShape_v2, hpdShapeMC_v2;
   Shape hpdShape_v3, hpdShapeMC_v3;
   Shape hpdBV30Shape_v2, hpdBV30ShapeMC_v2;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> theDbServiceToken;
   const HcalDbService* theDbService;
   typedef std::map<int, const Shape*> ShapeMap;
   ShapeMap theShapes;

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentManager.cc
@@ -1,7 +1,6 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseContainmentManager.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "CondFormats/DataRecord/interface/HcalTimeSlewRecord.h"
 #include <iostream>
 
 HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror)
@@ -9,10 +8,14 @@ HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror)
   hcalTimeSlew_delay_ = nullptr;
 }
 
+HcalPulseContainmentManager::HcalPulseContainmentManager(float max_fracerror, edm::ConsumesCollector iC)
+    : entries_(),
+      shapes_(iC),
+      max_fracerror_(max_fracerror),
+      delayToken_(iC.esConsumes<edm::Transition::BeginRun>(edm::ESInputTag("", "HBHE"))) {}
+
 void HcalPulseContainmentManager::beginRun(edm::EventSetup const& es) {
-  edm::ESHandle<HcalTimeSlew> delay;
-  es.get<HcalTimeSlewRecord>().get("HBHE", delay);
-  hcalTimeSlew_delay_ = &*delay;
+  hcalTimeSlew_delay_ = &es.getData(delayToken_);
 
   shapes_.beginRun(es);
 }

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseShapes.cc
@@ -1,10 +1,9 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CLHEP/Random/RandFlat.h"
-#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 
 // #include "CalibCalorimetry/HcalAlgos/interface/HcalDbASCIIIO.h"
 #include <cmath>
@@ -138,13 +137,13 @@ Reco  MC
   //theShapes[401] = new CaloCachedShapeIntegrator(&theZDCShape);
 }
 
+HcalPulseShapes::HcalPulseShapes(edm::ConsumesCollector iC) : HcalPulseShapes() {
+  theDbServiceToken = iC.esConsumes<edm::Transition::BeginRun>();
+}
+
 HcalPulseShapes::~HcalPulseShapes() {}
 
-void HcalPulseShapes::beginRun(edm::EventSetup const& es) {
-  edm::ESHandle<HcalDbService> conditions;
-  es.get<HcalDbRecord>().get(conditions);
-  theDbService = conditions.product();
-}
+void HcalPulseShapes::beginRun(edm::EventSetup const& es) { theDbService = &es.getData(theDbServiceToken); }
 
 void HcalPulseShapes::beginRun(const HcalDbService* conditions) { theDbService = conditions; }
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -34,7 +34,7 @@
 class HcalSimpleRecAlgo {
 public:
   /** Full featured constructor for HB/HE and HO (HPD-based detectors) */
-  HcalSimpleRecAlgo(bool correctForTimeslew, bool correctForContainment, float fixedPhaseNs);
+  HcalSimpleRecAlgo(bool correctForTimeslew, bool correctForContainment, float fixedPhaseNs, edm::ConsumesCollector iC);
 
   void beginRun(edm::EventSetup const& es);
   void endRun();
@@ -73,6 +73,7 @@ private:
   bool correctForTimeslew_;
   bool correctForPulse_;
   float phaseNS_;
+  const edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> delayToken_;
   std::unique_ptr<HcalPulseContainmentManager> pulseCorr_;
   int runnum_;  // data run numer
   bool setLeakCorrection_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/SimpleHBHEPhase1Algo.h
@@ -47,7 +47,8 @@ public:
                        bool applyLegacyHBMCorrection,
                        std::unique_ptr<PulseShapeFitOOTPileupCorrection> m2,
                        std::unique_ptr<HcalDeterministicFit> detFit,
-                       std::unique_ptr<MahiFit> mahi);
+                       std::unique_ptr<MahiFit> mahi,
+                       edm::ConsumesCollector iC);
 
   inline ~SimpleHBHEPhase1Algo() override {}
 
@@ -69,6 +70,7 @@ public:
   inline bool isCorrectingForPhaseContainment() const { return corrFPC_; }
   inline int getRunNumber() const { return runnum_; }
 
+  edm::ESGetToken<HcalTimeSlew, HcalTimeSlewRecord> delayToken_;
   const HcalTimeSlew* hcalTimeSlew_delay_;
 
 protected:

--- a/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h
@@ -3,11 +3,8 @@
 
 #include <memory>
 #include "RecoLocalCalo/HcalRecAlgos/interface/AbsHBHEPhase1Algo.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
-namespace edm {
-  class ParameterSet;
-}
 
 //
 // Factory function for creating objects of types
@@ -16,7 +13,8 @@ namespace edm {
 // Update the implementation of this function if you need
 // to add a new algorithm to HBHEPhase1Reconstructor.
 //
-std::unique_ptr<AbsHBHEPhase1Algo> parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps);
+std::unique_ptr<AbsHBHEPhase1Algo> parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps,
+                                                                  edm::ConsumesCollector iC);
 
 //
 // Parameter descriptions for "parseHBHEPhase1AlgoDescription".

--- a/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/parseHBHEPhase1AlgoDescription.cc
@@ -1,6 +1,7 @@
 #include <cassert>
 
 #include "RecoLocalCalo/HcalRecAlgos/interface/parseHBHEPhase1AlgoDescription.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -104,7 +105,8 @@ static std::unique_ptr<HcalDeterministicFit> parseHBHEMethod3Description(const e
   return fit;
 }
 
-std::unique_ptr<AbsHBHEPhase1Algo> parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps) {
+std::unique_ptr<AbsHBHEPhase1Algo> parseHBHEPhase1AlgoDescription(const edm::ParameterSet& ps,
+                                                                  edm::ConsumesCollector iC) {
   std::unique_ptr<AbsHBHEPhase1Algo> algo;
 
   const std::string& className = ps.getParameter<std::string>("Class");
@@ -126,16 +128,16 @@ std::unique_ptr<AbsHBHEPhase1Algo> parseHBHEPhase1AlgoDescription(const edm::Par
     if (ps.getParameter<bool>("useM3"))
       detFit = parseHBHEMethod3Description(ps);
 
-    algo =
-        std::unique_ptr<AbsHBHEPhase1Algo>(new SimpleHBHEPhase1Algo(ps.getParameter<int>("firstSampleShift"),
-                                                                    ps.getParameter<int>("samplesToAdd"),
-                                                                    ps.getParameter<double>("correctionPhaseNS"),
-                                                                    ps.getParameter<double>("tdcTimeShift"),
-                                                                    ps.getParameter<bool>("correctForPhaseContainment"),
-                                                                    ps.getParameter<bool>("applyLegacyHBMCorrection"),
-                                                                    std::move(m2),
-                                                                    std::move(detFit),
-                                                                    std::move(mahi)));
+    algo = std::make_unique<SimpleHBHEPhase1Algo>(ps.getParameter<int>("firstSampleShift"),
+                                                  ps.getParameter<int>("samplesToAdd"),
+                                                  ps.getParameter<double>("correctionPhaseNS"),
+                                                  ps.getParameter<double>("tdcTimeShift"),
+                                                  ps.getParameter<bool>("correctForPhaseContainment"),
+                                                  ps.getParameter<bool>("applyLegacyHBMCorrection"),
+                                                  std::move(m2),
+                                                  std::move(detFit),
+                                                  std::move(mahi),
+                                                  iC);
   }
 
   return algo;

--- a/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HBHEPhase1Reconstructor.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 
 // user include files
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
@@ -389,7 +390,7 @@ HBHEPhase1Reconstructor::HBHEPhase1Reconstructor(const edm::ParameterSet& conf)
       setNoiseFlagsQIE11_(conf.getParameter<bool>("setNoiseFlagsQIE11")),
       setPulseShapeFlagsQIE8_(conf.getParameter<bool>("setPulseShapeFlagsQIE8")),
       setPulseShapeFlagsQIE11_(conf.getParameter<bool>("setPulseShapeFlagsQIE11")),
-      reco_(parseHBHEPhase1AlgoDescription(conf.getParameter<edm::ParameterSet>("algorithm"))),
+      reco_(parseHBHEPhase1AlgoDescription(conf.getParameter<edm::ParameterSet>("algorithm"), consumesCollector())),
       negEFilter_(nullptr) {
   // Check that the reco algorithm has been successfully configured
   if (!reco_.get())

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -2,6 +2,7 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/Common/interface/EDCollection.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
@@ -25,7 +26,8 @@
 HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf)
     : reco_(conf.getParameter<bool>("correctForTimeslew"),
             conf.getParameter<bool>("correctForPhaseContainment"),
-            conf.getParameter<double>("correctionPhaseNS")),
+            conf.getParameter<double>("correctionPhaseNS"),
+            consumesCollector()),
       det_(DetId::Hcal),
       inputLabel_(conf.getParameter<edm::InputTag>("digiLabel")),
       correctTiming_(conf.getParameter<bool>("correctTiming")),

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -1,6 +1,7 @@
 #include "HcalSimpleReconstructor.h"
 #include "DataFormats/Common/interface/EDCollection.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -15,7 +16,8 @@
 HcalSimpleReconstructor::HcalSimpleReconstructor(edm::ParameterSet const& conf)
     : reco_(conf.getParameter<bool>("correctForTimeslew"),
             conf.getParameter<bool>("correctForPhaseContainment"),
-            conf.getParameter<double>("correctionPhaseNS")),
+            conf.getParameter<double>("correctionPhaseNS"),
+            consumesCollector()),
       det_(DetId::Hcal),
       inputLabel_(conf.getParameter<edm::InputTag>("digiLabel")),
       dropZSmarkedPassed_(conf.getParameter<bool>("dropZSmarkedPassed")),


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. It completes the EventSetup-consumes migration for bunch of HCAL modules that were partly migrated earlier, but were causing failures in #31746.

#### PR validation:

Code compiles, these modules no longer triggers the exception of #31746 in a job using them.

