### PR TITLE
Migrate rest of {Cosmic,GlobalCosmic,Global,L2,L3,Standalone}MuonProduer to EventSetup consumes

### DIFF
--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
@@ -23,7 +23,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -59,7 +58,8 @@ CosmicMuonProducer::CosmicMuonProducer(const ParameterSet& iConfig) {
   theService = std::make_unique<MuonServiceProxy>(serviceParameters, consumesCollector());
   theTrackFinder =
       std::make_unique<MuonTrackFinder>(std::make_unique<CosmicMuonTrajectoryBuilder>(tbpar, theService.get(), iC),
-                                        std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()));
+                                        std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()),
+                                        iC);
 
   produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
@@ -21,7 +21,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
@@ -51,7 +50,8 @@ GlobalCosmicMuonProducer::GlobalCosmicMuonProducer(const edm::ParameterSet& iCon
   edm::ConsumesCollector iC = consumesCollector();
   theTrackFinder = std::make_unique<MuonTrackFinder>(
       std::make_unique<GlobalCosmicMuonTrajectoryBuilder>(tbpar, theService.get(), iC),
-      std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()));
+      std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()),
+      iC);
 
   produces<reco::TrackCollection>();
   produces<TrackingRecHitCollection>();

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -64,7 +64,7 @@ GlobalMuonProducer::GlobalMuonProducer(const ParameterSet& parameterSet) {
   auto mtl = std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService);
   auto gmtb = std::make_unique<GlobalMuonTrajectoryBuilder>(trajectoryBuilderParameters, theService, iC);
 
-  theTrackFinder = new MuonTrackFinder(std::move(gmtb), std::move(mtl));
+  theTrackFinder = std::make_unique<MuonTrackFinder>(std::move(gmtb), std::move(mtl), iC);
 
   setAlias(parameterSet.getParameter<std::string>("@module_label"));
   produces<reco::TrackCollection>().setBranchAlias(theAlias + "Tracks");
@@ -82,8 +82,6 @@ GlobalMuonProducer::~GlobalMuonProducer() {
   LogTrace("Muon|RecoMuon|GlobalMuonProducer") << "destructor called" << endl;
   if (theService)
     delete theService;
-  if (theTrackFinder)
-    delete theTrackFinder;
 }
 
 //

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.h
@@ -52,7 +52,7 @@ private:
   edm::EDGetTokenT<TrajTrackAssociationCollection> staAssoMapToken;
   edm::EDGetTokenT<reco::TrackToTrackMap> updatedStaAssoMapToken;
 
-  MuonTrackFinder* theTrackFinder;
+  std::unique_ptr<MuonTrackFinder> theTrackFinder;
 
   /// the event setup proxy, it takes care the services update
   MuonServiceProxy* theService;

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -88,7 +88,8 @@ L2MuonProducer::L2MuonProducer(const ParameterSet& parameterSet) {
   theTrackFinder =
       std::make_unique<MuonTrackFinder>(std::move(trajectoryBuilder),
                                         std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get()),
-                                        std::make_unique<MuonTrajectoryCleaner>(true));
+                                        std::make_unique<MuonTrajectoryCleaner>(true),
+                                        iC);
 
   produces<reco::TrackCollection>();
   produces<reco::TrackCollection>("UpdatedAtVtx");

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -58,7 +58,7 @@ L3MuonProducer::L3MuonProducer(const ParameterSet& parameterSet) {
   // instantiate the concrete trajectory builder in the Track Finder
   auto mtl = std::make_unique<MuonTrackLoader>(trackLoaderParameters, iC, theService.get());
   auto l3mtb = std::make_unique<L3MuonTrajectoryBuilder>(trajectoryBuilderParameters, theService.get(), iC);
-  theTrackFinder = std::make_unique<MuonTrackFinder>(std::move(l3mtb), std::move(mtl));
+  theTrackFinder = std::make_unique<MuonTrackFinder>(std::move(l3mtb), std::move(mtl), iC);
 
   theL2SeededTkLabel =
       trackLoaderParameters.getUntrackedParameter<std::string>("MuonSeededTracksInstance", std::string());

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
@@ -80,7 +80,7 @@ StandAloneMuonProducer::StandAloneMuonProducer(const ParameterSet& parameterSet)
     trajectoryBuilder =
         std::make_unique<StandAloneMuonTrajectoryBuilder>(trajectoryBuilderParameters, theService.get(), iC);
   }
-  theTrackFinder = std::make_unique<MuonTrackFinder>(std::move(trajectoryBuilder), std::move(trackLoader));
+  theTrackFinder = std::make_unique<MuonTrackFinder>(std::move(trajectoryBuilder), std::move(trackLoader), iC);
 
   setAlias(parameterSet.getParameter<std::string>("@module_label"));
 

--- a/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
@@ -12,17 +12,15 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 
 #include <vector>
 
-namespace edm {
-  class ParameterSet;
-  class Event;
-  class EventSetup;
-}  // namespace edm
 class TrackerTopology;
+class TrackerTopologyRcd;
 
 class MuonTrajectoryBuilder;
 class MuonTrajectoryCleaner;
@@ -37,12 +35,14 @@ public:
 public:
   /// Constructor, with default cleaner. For the STA reconstruction the trackLoader must have the propagator.
   MuonTrackFinder(std::unique_ptr<MuonTrajectoryBuilder> ConcreteMuonTrajectoryBuilder,
-                  std::unique_ptr<MuonTrackLoader> trackLoader);
+                  std::unique_ptr<MuonTrackLoader> trackLoader,
+                  edm::ConsumesCollector iC);
 
   /// Constructor, with user-defined cleaner. For the STA reconstruction the trackLoader must have the propagator.
   MuonTrackFinder(std::unique_ptr<MuonTrajectoryBuilder> ConcreteMuonTrajectoryBuilder,
                   std::unique_ptr<MuonTrackLoader> trackLoader,
-                  std::unique_ptr<MuonTrajectoryCleaner> cleaner);
+                  std::unique_ptr<MuonTrajectoryCleaner> cleaner,
+                  edm::ConsumesCollector iC);
 
   /// destructor
   virtual ~MuonTrackFinder();
@@ -68,6 +68,8 @@ private:
   void load(CandidateContainer&, edm::Event&, const TrackerTopology& ttopo);
 
 private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> theTtopoToken;
+
   std::unique_ptr<MuonTrajectoryBuilder> theTrajBuilder;
 
   std::unique_ptr<MuonTrajectoryCleaner> theTrajCleaner;

--- a/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
@@ -19,9 +19,6 @@
 
 #include <vector>
 
-class TrackerTopology;
-class TrackerTopologyRcd;
-
 class MuonTrajectoryBuilder;
 class MuonTrajectoryCleaner;
 class MuonTrackLoader;

--- a/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
@@ -30,16 +30,20 @@ using namespace edm;
 
 // Constructor, with default cleaner. For the STA reconstruction the trackLoader must have the propagator.
 MuonTrackFinder::MuonTrackFinder(std::unique_ptr<MuonTrajectoryBuilder> ConcreteMuonTrajectoryBuilder,
-                                 std::unique_ptr<MuonTrackLoader> trackLoader)
-    : theTrajBuilder(std::move(ConcreteMuonTrajectoryBuilder)),
-      theTrajCleaner(new MuonTrajectoryCleaner()),
-      theTrackLoader(std::move(trackLoader)) {}
+                                 std::unique_ptr<MuonTrackLoader> trackLoader,
+                                 edm::ConsumesCollector iC)
+    : MuonTrackFinder(std::move(ConcreteMuonTrajectoryBuilder),
+                      std::move(trackLoader),
+                      std::make_unique<MuonTrajectoryCleaner>(),
+                      iC) {}
 
 // Constructor, with user-defined cleaner. For the STA reconstruction the trackLoader must have the propagator.
 MuonTrackFinder::MuonTrackFinder(std::unique_ptr<MuonTrajectoryBuilder> ConcreteMuonTrajectoryBuilder,
                                  std::unique_ptr<MuonTrackLoader> trackLoader,
-                                 std::unique_ptr<MuonTrajectoryCleaner> cleaner)
-    : theTrajBuilder(std::move(ConcreteMuonTrajectoryBuilder)),
+                                 std::unique_ptr<MuonTrajectoryCleaner> cleaner,
+                                 edm::ConsumesCollector iC)
+    : theTtopoToken(iC.esConsumes()),
+      theTrajBuilder(std::move(ConcreteMuonTrajectoryBuilder)),
       theTrajCleaner(std::move(cleaner)),
       theTrackLoader(std::move(trackLoader)) {}
 
@@ -72,8 +76,7 @@ edm::OrphanHandle<reco::TrackCollection> MuonTrackFinder::reconstruct(
   // Percolate the event
   setEvent(event);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  es.get<TrackerTopologyRcd>().get(httopo);
+  const auto& ttopo = es.getData(theTtopoToken);
 
   // Trajectory container
   TrajectoryContainer muonTrajectories;
@@ -96,7 +99,7 @@ edm::OrphanHandle<reco::TrackCollection> MuonTrackFinder::reconstruct(
 
   // convert the trajectories into tracks and load them in to the event
   LogTrace(metname) << "Convert the trajectories into tracks and load them in to the event" << endl;
-  return load(muonTrajectories, event, *httopo);
+  return load(muonTrajectories, event, ttopo);
 }
 
 // reconstruct trajectories
@@ -106,8 +109,7 @@ void MuonTrackFinder::reconstruct(const std::vector<TrackCand>& staCandColl, Eve
   // percolate the event
   setEvent(event);
 
-  edm::ESHandle<TrackerTopology> httopo;
-  es.get<TrackerTopologyRcd>().get(httopo);
+  const auto& ttopo = es.getData(theTtopoToken);
 
   // Muon Candidate container
   CandidateContainer muonCandidates;
@@ -126,5 +128,5 @@ void MuonTrackFinder::reconstruct(const std::vector<TrackCand>& staCandColl, Eve
 
   // convert the trajectories into staTracks and load them into the event
   LogTrace(metname) << "Load Muon Candidates into the event" << endl;
-  load(muonCandidates, event, *httopo);
+  load(muonCandidates, event, ttopo);
 }

--- a/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
@@ -22,9 +22,6 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-
 using namespace std;
 using namespace edm;
 


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. It completes the EventSetup-consumes migration for bunch of Muon modules that were partly migrated earlier, but were causing failures in #31746.

#### PR validation:

Code compiles, these modules no longer triggers the exception of #31746 in a job using them.
