### PR TITLE
Remove obsolete records

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,86 +2,86 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '110X_mcRun1_design_v2',
+    'run1_design'       :   '112X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '110X_mcRun1_realistic_v2',
+    'run1_mc'           :   '112X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '110X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '112X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '110X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '112X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '110X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '112X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '110X_mcRun2_asymptotic_l1stage1_v2',
+    'run2_mc_l1stage1'  :   '112X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '110X_mcRun2_design_v5',
+    'run2_design'       :   '112X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '111X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'   :   '112X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '111X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '112X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '111X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_startup_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '110X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '112X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '110X_mcRun2_pA_v3',
+    'run2_mc_pa'        :   '112X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v4',
+    'run1_data'         :   '112X_dataRun2_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v4',
+    'run2_data'         :   '112X_dataRun2_v5',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v4',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v5',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v4',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v5',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v8',
-    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v4',
+    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v9',
+    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v5',
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v10',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '111X_dataRun3_Express_v2',
+    'run3_data_express'        :   '111X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v2',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '111X_mc2017_design_v2',
+    'phase1_2017_design'       :  '112X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '112X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '112X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '112X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '112X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '112X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '112X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '112X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '112X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v3',
+    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v4',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v4',
+    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v3',
+    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '112X_upgrade2018cosmics_realistic_deco_v3',
+    'phase1_2018_cosmics'      :  '112X_upgrade2018cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v3',
+    'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v8', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '112X_mcRun3_2021_design_v9', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v9', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v8',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v9',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v9',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v8', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v9', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v8', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v9', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '112X_mcRun4_realistic_v2'
+    'phase2_realistic'         : '112X_mcRun4_realistic_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR removes several obsolete records:

- `L1TMuonEndcapParamsRcd` so that the obsolete class can be removed (see #30109 and #17061)
- `PGeometricDetExtraRcd` to address #31729
- `SiPixelCPEGenericErrorParmRcd`

Nearly all GTs need to have `PGeometricDetExtraRcd` removed, all Phase-1 and later GTs need to have `L1TMuonEndcapParamsRcd` removed, and `SiPixelCPEGenericErrorParmRcd` is removed from the Run 3 GTs.

The GTs used for HLT relvals are modified as well, despite being `101X` and `103X` GTs. The naming has not been updated in order to reflect the starting release of the GT.

The GT diffs are as follows:

**Run 1 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun1_design_v2/112X_mcRun1_design_v1 

**Run 1 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun1_realistic_v2/112X_mcRun1_realistic_v1 

**Run 1 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun1_HeavyIon_v2/112X_mcRun1_HeavyIon_v1 

**Run 1 proton-lead**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun1_pA_v2/112X_mcRun1_pA_v2 

**Run 2 startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_startup_v2/112X_mcRun2_startup_v1 

**Run 2 (L1 trigger stage 1)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_asymptotic_l1stage1_v2/112X_mcRun2_asymptotic_l1stage1_v1 

**2016 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_design_v5/112X_mcRun2_design_v1 

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun2_asymptotic_preVFP_v1/112X_mcRun2_asymptotic_preVFP_v1 

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun2_asymptotic_v1/112X_mcRun2_asymptotic_v1 

**2016 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun2cosmics_startup_deco_v1/112X_mcRun2cosmics_startup_deco_v1 

**Run 2 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_HeavyIon_v2/112X_mcRun2_HeavyIon_v1 

**Run 2 proton-lead**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/110X_mcRun2_pA_v3/112X_mcRun2_pA_v1 

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_v4/112X_dataRun2_v5 

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HEfail_v4/112X_dataRun2_HEfail_v5 

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_relval_v4/112X_dataRun2_relval_v5 

**Prompt-like data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_PromptLike_HI_v1/112X_dataRun2_PromptLike_HI_v2 

**Data (Frozen HLT GT)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_frozen_v9/101X_dataRun2_HLT_frozen_v10 

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_v8/103X_dataRun2_HLT_relval_v9 

**Run 2 HI HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_HI_v4/103X_dataRun2_HLT_relval_HI_v5 

**Run 2 HLT for HI (not 2018 HI)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLTHI_frozen_v9/101X_dataRun2_HLTHI_frozen_v10 

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Express_v2/111X_dataRun3_Express_v4 

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v2/111X_dataRun3_Prompt_v4 

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017_design_v2/112X_mc2017_design_v1 

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017_realistic_v2/112X_mc2017_realistic_v3 

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017cosmics_realistic_deco_v2/112X_mc2017cosmics_realistic_deco_v3 

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017cosmics_realistic_peak_v2/112X_mc2017cosmics_realistic_peak_v3 

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_design_v2/112X_upgrade2018_design_v3 

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_v3/112X_upgrade2018_realistic_v4 

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HI_v4/112X_upgrade2018_realistic_HI_v5 

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HEfail_v3/112X_upgrade2018_realistic_HEfail_v4 

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_deco_v3/112X_upgrade2018cosmics_realistic_deco_v4 

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_peak_v3/112X_upgrade2018cosmics_realistic_peak_v4 

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v8/112X_mcRun3_2021_design_v9 

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v8/112X_mcRun3_2021_realistic_v9 

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v8/112X_mcRun3_2021cosmics_realistic_deco_v9 

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v9/112X_mcRun3_2021_realistic_HI_v10 

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v8/112X_mcRun3_2023_realistic_v9 

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v8/112X_mcRun3_2024_realistic_v9 

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun4_realistic_v2/112X_mcRun4_realistic_v3 

#### PR validation:

`addOnTests.py` and `runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, though the Run 3 data GTs will be backported to 111X, as that is the release series that is used for online data-taking.