### PR TITLE
Clean up a few dead assignments from CalibCalorimetry/HcalAlgos and RecoMuon/TrackingTools

### DIFF
--- a/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
@@ -2021,7 +2021,7 @@ void HcalLogicalMapGenerator::buildHOXMap(const HcalTopology* topo,
               ihtr_fi = HO_htr_fi_eta1234_sipm[phmod6][4][(irm - 1) / 2][sidear];
               itb = 0;
               fpga = "top";
-              mytype = 3;
+              //              mytype = 3;
               ih = 2;
               ihtr = ihslotho[php2mod18ov6][ih];
               ispigot = ihtr < 9 ? (ihtr - 2) * 2 + itb : (ihtr - 13) * 2 + itb;

--- a/CalibCalorimetry/HcalAlgos/src/HcalPedestalAnalysis.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPedestalAnalysis.cc
@@ -803,7 +803,6 @@ void HcalPedestalAnalysis::Trendings(map<HcalDetId, map<int, PEDBUNCH> >& toolT,
       _meot->second[i].second.second[4]->GetYaxis()->SetTitle("Distant correlation");
       _meot->second[i].second.second[4]->Write(); */
       // chi2
-      j = 0;
       for (sample_it = _meot->second[i].second.first[4].begin(); sample_it != _meot->second[i].second.first[4].end();
            ++sample_it) {
         Chi2->Fill(*sample_it);

--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -428,19 +428,15 @@ double MuonErrorMatrix::Term(const AlgebraicSymMatrix55 &curv, int i, int j) {
   } else {
     double si = curv(i, i);
     double sj = curv(j, j);
-
     if (si <= 0 || sj <= 0) {
+      //check validity
       edm::LogError("MuonErrorMatrix") << "invalid term in the error matrix.\n si: " << si << " sj: " << sj
                                        << ". result will be corrupted\n"
                                        << curv;
       return 0;
     }
-
-    si = sqrt(si);
-    sj = sqrt(sj);
-    //check validity
-
-    return result = curv(i, j) / (si * sj);
+    result = curv(i, j) / sqrt(si * sj);
+    return result;
   }
   //by default
   return 0;


### PR DESCRIPTION
#### PR description:

Following some finding of the static analyzer, a few dead assignments are removed from the mentioned packages
I also took the opportunitiy to get rid of one extra sqrt computation in `MuonErrorMatrix::Term(const AlgebraicSymMatrix55 &curv, int i, int j)`


#### PR validation:

It builds correctly