### PR TITLE
drop type specs in RecoVertex RecoPixelVertexing

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeExtractor_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeExtractor_cfi.py
@@ -20,5 +20,5 @@ clusterShapeExtractor = cms.EDAnalyzer("PixelClusterShapeExtractor",
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(clusterShapeExtractor,
-    pixelSimLinkSrc = cms.InputTag('simSiPixelDigis', 'Pixel'),
+    pixelSimLinkSrc = 'simSiPixelDigis:Pixel'),
 )

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeExtractor_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/ClusterShapeExtractor_cfi.py
@@ -20,5 +20,5 @@ clusterShapeExtractor = cms.EDAnalyzer("PixelClusterShapeExtractor",
 
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(clusterShapeExtractor,
-    pixelSimLinkSrc = 'simSiPixelDigis:Pixel'),
+    pixelSimLinkSrc = 'simSiPixelDigis:Pixel'
 )

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/MinBiasCkfTrajectoryFilter_cfi.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/MinBiasCkfTrajectoryFilter_cfi.py
@@ -2,11 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 # Trajectory filter for min bias
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
-ckfBaseTrajectoryFilterForMinBias = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone()
-
-ckfBaseTrajectoryFilterForMinBias.minimumNumberOfHits = 3
-ckfBaseTrajectoryFilterForMinBias.minPt               = 0.075
-
+ckfBaseTrajectoryFilterForMinBias = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 3,
+    minPt               = 0.075
+)
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi import *
 
@@ -14,5 +13,5 @@ from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilter_cfi imp
 MinBiasCkfTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CompositeTrajectoryFilter_block.clone(
     filters   = [cms.PSet(refToPSet_ = cms.string('ckfBaseTrajectoryFilterForMinBias')),
                  cms.PSet(refToPSet_ = cms.string('ClusterShapeTrajectoryFilter'))]
-    )
+)
 

--- a/RecoPixelVertexing/PixelTriplets/python/PixelTripletHLTGenerator_cfi.py
+++ b/RecoPixelVertexing/PixelTriplets/python/PixelTripletHLTGenerator_cfi.py
@@ -19,12 +19,12 @@ PixelTripletHLTGenerator = cms.PSet(
 
 # do thy make any difference anywhere?
 trackingPhase2PU140.toModify(PixelTripletHLTGenerator,
-    extraHitRPhitolerance = cms.double(0.016),
-    extraHitRZtolerance = cms.double(0.020)
+    extraHitRPhitolerance = 0.016,
+    extraHitRZtolerance   = 0.020
 )
 
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi
-PixelTripletHLTGeneratorWithFilter = PixelTripletHLTGenerator.clone()
-PixelTripletHLTGeneratorWithFilter.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
-
+PixelTripletHLTGeneratorWithFilter = PixelTripletHLTGenerator.clone(
+    SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor.clone()
+)
 

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -14,11 +14,19 @@ from CommonTools.RecoAlgos.sortedPrimaryVertices_cfi import *
 from RecoJets.JetProducers.caloJetsForTrk_cff import *
 
 unsortedOfflinePrimaryVertices=offlinePrimaryVertices.clone()
-offlinePrimaryVertices=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrimaryVertices", particles="trackRefsForJetsBeforeSorting")
-offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(vertices=cms.InputTag("unsortedOfflinePrimaryVertices","WithBS"), particles="trackRefsForJetsBeforeSorting")
-trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices")
-trackWithVertexRefSelectorBeforeSorting.ptMax=9e99
-trackWithVertexRefSelectorBeforeSorting.ptErrorCut=9e99
+offlinePrimaryVertices=sortedPrimaryVertices.clone(
+    vertices="unsortedOfflinePrimaryVertices", 
+    particles="trackRefsForJetsBeforeSorting"
+)
+offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(
+    vertices="unsortedOfflinePrimaryVertices:WithBS", 
+    particles="trackRefsForJetsBeforeSorting"
+)
+trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(
+    vertexTag="unsortedOfflinePrimaryVertices",
+    ptMax=9e99,
+    ptErrorCut=9e99
+)
 trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
 
 

--- a/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_phase2_timing_cff.py
@@ -3,46 +3,73 @@ from RecoVertex.Configuration.RecoVertex_cff import unsortedOfflinePrimaryVertic
 
 from RecoVertex.PrimaryVertexProducer.TkClusParameters_cff import DA2D_vectParameters
 
-unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone(TkClusParameters = DA2D_vectParameters,
-                                                                        TrackTimesLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),
-                                                                        TrackTimeResosLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),
-                                                                        )
-trackWithVertexRefSelectorBeforeSorting4D = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices4D",
-                                                                                    ptMax=9e99,
-                                                                                    ptErrorCut=9e99)
-trackRefsForJetsBeforeSorting4D = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting4D")
-offlinePrimaryVertices4D=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrimaryVertices4D",
-                                                            particles="trackRefsForJetsBeforeSorting4D",
-                                                            trackTimeTag=cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),
-                                                            trackTimeResoTag=cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),
-                                                            assignment=dict(useTiming=True))
-offlinePrimaryVertices4DWithBS=offlinePrimaryVertices4D.clone(vertices="unsortedOfflinePrimaryVertices4D:WithBS")
+unsortedOfflinePrimaryVertices4D = unsortedOfflinePrimaryVertices.clone(
+    TkClusParameters = DA2D_vectParameters,
+    TrackTimesLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModel"),
+    TrackTimeResosLabel = cms.InputTag("trackTimeValueMapProducer","generalTracksConfigurableFlatResolutionModelResolution"),
+)
+trackWithVertexRefSelectorBeforeSorting4D = trackWithVertexRefSelector.clone(
+    vertexTag = "unsortedOfflinePrimaryVertices4D",
+    ptMax = 9e99,
+    ptErrorCut = 9e99
+)
+trackRefsForJetsBeforeSorting4D = trackRefsForJets.clone(
+    src = "trackWithVertexRefSelectorBeforeSorting4D"
+)
+offlinePrimaryVertices4D = sortedPrimaryVertices.clone(
+    vertices = "unsortedOfflinePrimaryVertices4D",
+    particles = "trackRefsForJetsBeforeSorting4D",
+    trackTimeTag = "trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModel",
+    trackTimeResoTag = "trackTimeValueMapProducer:generalTracksConfigurableFlatResolutionModelResolution",
+    assignment = dict(useTiming = True)
+)
+offlinePrimaryVertices4DWithBS = offlinePrimaryVertices4D.clone(
+    vertices = "unsortedOfflinePrimaryVertices4D:WithBS"
+)
 
-unsortedOfflinePrimaryVertices4DnoPID = unsortedOfflinePrimaryVertices4D.clone(TrackTimesLabel = "trackExtenderWithMTD:generalTrackt0",
-                                                                         TrackTimeResosLabel = "trackExtenderWithMTD:generalTracksigmat0",
-                                                                         )
-trackWithVertexRefSelectorBeforeSorting4DnoPID = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices4DnoPID",
-                                                                                  ptMax=9e99,
-                                                                                  ptErrorCut=9e99)
-trackRefsForJetsBeforeSorting4DnoPID = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting4DnoPID")
-offlinePrimaryVertices4DnoPID=offlinePrimaryVertices4D.clone(vertices="unsortedOfflinePrimaryVertices4DnoPID",
-                                                          particles="trackRefsForJetsBeforeSorting4DnoPID",
-                                                          trackTimeTag="trackExtenderWithMTD:generalTrackt0",
-                                                          trackTimeResoTag="trackExtenderWithMTD:generalTracksigmat0")
-offlinePrimaryVertices4DnoPIDWithBS=offlinePrimaryVertices4DnoPID.clone(vertices="unsortedOfflinePrimaryVertices4DnoPID:WithBS")
+unsortedOfflinePrimaryVertices4DnoPID = unsortedOfflinePrimaryVertices4D.clone(
+    TrackTimesLabel = "trackExtenderWithMTD:generalTrackt0",
+    TrackTimeResosLabel = "trackExtenderWithMTD:generalTracksigmat0"
+)
+trackWithVertexRefSelectorBeforeSorting4DnoPID = trackWithVertexRefSelector.clone(
+    vertexTag = "unsortedOfflinePrimaryVertices4DnoPID",
+    ptMax = 9e99,
+    ptErrorCut = 9e99
+)
+trackRefsForJetsBeforeSorting4DnoPID = trackRefsForJets.clone(
+    src = "trackWithVertexRefSelectorBeforeSorting4DnoPID"
+)
+offlinePrimaryVertices4DnoPID = offlinePrimaryVertices4D.clone(
+    vertices = "unsortedOfflinePrimaryVertices4DnoPID",
+    particles = "trackRefsForJetsBeforeSorting4DnoPID",
+    trackTimeTag = "trackExtenderWithMTD:generalTrackt0",
+    trackTimeResoTag = "trackExtenderWithMTD:generalTracksigmat0"
+)
+offlinePrimaryVertices4DnoPIDWithBS=offlinePrimaryVertices4DnoPID.clone(
+    vertices = "unsortedOfflinePrimaryVertices4DnoPID:WithBS"
+)
 
-unsortedOfflinePrimaryVertices4DwithPID = unsortedOfflinePrimaryVertices4D.clone(TrackTimesLabel = "tofPID4DnoPID:t0safe",
-                                                                                 TrackTimeResosLabel = "tofPID4DnoPID:sigmat0safe",
-                                                                                 )
-trackWithVertexRefSelectorBeforeSorting4DwithPID = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices4DwithPID",
-                                                                             ptMax=9e99,
-                                                                             ptErrorCut=9e99)
-trackRefsForJetsBeforeSorting4DwithPID = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting4DwithPID")
-offlinePrimaryVertices4DwithPID=offlinePrimaryVertices4D.clone(vertices="unsortedOfflinePrimaryVertices4DwithPID",
-                                                     particles="trackRefsForJetsBeforeSorting4DwithPID",
-                                                     trackTimeTag="tofPID4DnoPID:t0safe",
-                                                     trackTimeResoTag="tofPID4DnoPID:sigmat0safe")
-offlinePrimaryVertices4DwithPIDWithBS=offlinePrimaryVertices4DwithPID.clone(vertices="unsortedOfflinePrimaryVertices4DwithPID:WithBS")
+unsortedOfflinePrimaryVertices4DwithPID = unsortedOfflinePrimaryVertices4D.clone(
+    TrackTimesLabel = "tofPID4DnoPID:t0safe",
+    TrackTimeResosLabel = "tofPID4DnoPID:sigmat0safe"
+)
+trackWithVertexRefSelectorBeforeSorting4DwithPID = trackWithVertexRefSelector.clone(
+    vertexTag = "unsortedOfflinePrimaryVertices4DwithPID",
+    ptMax = 9e99,
+    ptErrorCut = 9e99
+)
+trackRefsForJetsBeforeSorting4DwithPID = trackRefsForJets.clone(
+    src = "trackWithVertexRefSelectorBeforeSorting4DwithPID"
+)
+offlinePrimaryVertices4DwithPID=offlinePrimaryVertices4D.clone(
+    vertices = "unsortedOfflinePrimaryVertices4DwithPID",
+    particles = "trackRefsForJetsBeforeSorting4DwithPID",
+    trackTimeTag = "tofPID4DnoPID:t0safe",
+    trackTimeResoTag = "tofPID4DnoPID:sigmat0safe"
+)
+offlinePrimaryVertices4DwithPIDWithBS = offlinePrimaryVertices4DwithPID.clone(
+    vertices = "unsortedOfflinePrimaryVertices4DwithPID:WithBS"
+)
 
 from SimTracker.TrackerHitAssociation.tpClusterProducer_cfi import tpClusterProducer
 from SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi import quickTrackAssociatorByHits


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389), [PR#31523](https://github.com/cms-sw/cmssw/pull/31523), [PR#31538](https://github.com/cms-sw/cmssw/pull/31538), [PR#31748](https://github.com/cms-sw/cmssw/pull/31748))

In this PR, total 5 files changed. 

- RecoVertex/Configuration  : 2 files 

- RecoPixelVertexing/PixelLowPtUtilities : 2 files
- RecoPixelVertexing/PixelTriplets :  1 file 

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).