### PR TITLE
Tracking Validation: fix some more warnings (Tracking/TrackBHadron)

### DIFF
--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -17,6 +17,7 @@ def _addNoFlow(module):
             module.noFlowDists.append(tmp[ind-1])
 
 _defaultSubdirs = ["Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*","Tracking/TrackConversion/*", "Tracking/TrackGsf/*"]
+_defaultSubdirsSummary = [e.replace("/*","") for e in _defaultSubdirs]
 
 postProcessorTrack = DQMEDHarvester("DQMGenericClient",
     subDirs = cms.untracked.vstring(_defaultSubdirs),
@@ -297,7 +298,7 @@ _addNoFlow(postProcessorTrackNrecVsNsim2D)
 
 
 postProcessorTrackSummary = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring(_defaultSubdirs),
+    subDirs = cms.untracked.vstring(_defaultSubdirsSummary),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",
@@ -317,7 +318,7 @@ postProcessorTrackSequence = cms.Sequence(
 )
 
 fastSim.toModify(postProcessorTrack, subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*"]])
-fastSim.toModify(postProcessorTrackSummary, subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*"]])
+fastSim.toModify(postProcessorTrackSummary, subDirs = [e for e in _defaultSubdirsSummary if e not in ["Tracking/TrackGsf","Tracking/TrackConversion"]])
 
 #######
 # Define a standalone seuquence to support the Standalone harvesting mode
@@ -328,7 +329,7 @@ postProcessorTrackStandalone = postProcessorTrack.clone(
     subDirs = _defaultSubdirs+["Tracking/TrackBHadron/*"]
 )
 postProcessorTrackSummaryStandalone = postProcessorTrackSummary.clone(
-    subDirs = _defaultSubdirs+["Tracking/TrackBHadron/*"]
+    subDirs = _defaultSubdirs+["Tracking/TrackBHadron"]
 )
 
 postProcessorTrackSequenceStandalone = cms.Sequence(
@@ -349,7 +350,7 @@ phase2_tracker.toReplaceWith(postProcessorTrackSummary,postProcessorTrackSummary
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
 postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
 postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
-postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
+postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackBHadron","Tracking/TrackSeeding", "Tracking/PixelTrack"])
 
 postProcessorTrackSequenceTrackingOnly = cms.Sequence(
     postProcessorTrackTrackingOnly+
@@ -358,4 +359,4 @@ postProcessorTrackSequenceTrackingOnly = cms.Sequence(
 )
 
 fastSim.toModify(postProcessorTrackTrackingOnly,subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*","Tracking/TrackBHadron/*"]])
-fastSim.toModify(postProcessorTrackSummaryTrackingOnly,subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*","Tracking/TrackBHadron/*"]])
+fastSim.toModify(postProcessorTrackSummaryTrackingOnly,subDirs = [e for e in _defaultSubdirsSummary if e not in ["Tracking/TrackGsf","Tracking/TrackConversion","Tracking/TrackBHadron"]])

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -325,10 +325,10 @@ fastSim.toModify(postProcessorTrackSummary, subDirs = [e for e in _defaultSubdir
 ########
 
 postProcessorTrackStandalone = postProcessorTrack.clone(
-    subDirs = _defaultSubdirs.append("Tracking/TrackBHadron/*"),
+    subDirs = _defaultSubdirs+["Tracking/TrackBHadron/*"]
 )
 postProcessorTrackSummaryStandalone = postProcessorTrackSummary.clone(
-    subDirs = _defaultSubdirs.append("Tracking/TrackBHadron/*"),
+    subDirs = _defaultSubdirs+["Tracking/TrackBHadron/*"]
 )
 
 postProcessorTrackSequenceStandalone = cms.Sequence(

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from DQMServices.Core.DQMEDHarvester import DQMEDHarvester
+from Configuration.Eras.Modifier_fastSim_cff import fastSim
 
 def _addNoFlow(module):
     _noflowSeen = set()
@@ -315,6 +316,9 @@ postProcessorTrackSequence = cms.Sequence(
     postProcessorTrackSummary
 )
 
+fastSim.toModify(postProcessorTrack, subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*"]])
+fastSim.toModify(postProcessorTrackSummary, subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*"]])
+
 #######
 # Define a standalone seuquence to support the Standalone harvesting mode
 # see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMultiTrackValidator#cmsDriver_MTV_alone_i_e_standalone for more information
@@ -345,10 +349,13 @@ phase2_tracker.toReplaceWith(postProcessorTrackSummary,postProcessorTrackSummary
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
 postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
 postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
-postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding", "Tracking/PixelTrack"])
+postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
 
 postProcessorTrackSequenceTrackingOnly = cms.Sequence(
     postProcessorTrackTrackingOnly+
     postProcessorTrackNrecVsNsim+
     postProcessorTrackSummaryTrackingOnly
 )
+
+fastSim.toModify(postProcessorTrackTrackingOnly,subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*","Tracking/TrackBHadron/*"]])
+fastSim.toModify(postProcessorTrackSummaryTrackingOnly,subDirs = [e for e in _defaultSubdirs if e not in ["Tracking/TrackGsf/*","Tracking/TrackConversion/*","Tracking/TrackBHadron/*"]])

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -15,8 +15,10 @@ def _addNoFlow(module):
         if not tmp[ind-1] in _noflowSeen:
             module.noFlowDists.append(tmp[ind-1])
 
+_defaultSubdirs = ["Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*","Tracking/TrackConversion/*", "Tracking/TrackGsf/*"]
+
 postProcessorTrack = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
+    subDirs = cms.untracked.vstring(_defaultSubdirs),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -252,7 +254,7 @@ _addNoFlow(postProcessorTrack)
 
 postProcessorTrack2D = DQMEDHarvester("DQMGenericClient",
     makeGlobalEffienciesPlot = cms.untracked.bool(False),
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackTPPtLess09/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*", "Tracking/TrackBuilding/*", "Tracking/TrackConversion/*", "Tracking/TrackGsf/*", "Tracking/TrackBHadron/*"),
+    subDirs = cms.untracked.vstring(_defaultSubdirs),
     efficiency = cms.vstring(
     "efficPtvseta 'Efficiency in p_{T}-#eta plane' num_assoc(simToReco)_pTvseta num_simul_pTvseta",
     "duplicatesRate_Ptvseta 'Duplicates Rate in (p_{T}-#eta) plane' num_duplicate_pTvseta num_reco_pTvseta",
@@ -294,7 +296,7 @@ _addNoFlow(postProcessorTrackNrecVsNsim2D)
 
 
 postProcessorTrackSummary = DQMEDHarvester("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackTPPtLess09", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic", "Tracking/TrackBuilding", "Tracking/TrackConversion", "Tracking/TrackGsf", "Tracking/TrackBHadron"),
+    subDirs = cms.untracked.vstring(_defaultSubdirs),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",
@@ -313,6 +315,24 @@ postProcessorTrackSequence = cms.Sequence(
     postProcessorTrackSummary
 )
 
+#######
+# Define a standalone seuquence to support the Standalone harvesting mode
+# see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMultiTrackValidator#cmsDriver_MTV_alone_i_e_standalone for more information
+########
+
+postProcessorTrackStandalone = postProcessorTrack.clone(
+    subDirs = _defaultSubdirs.append("Tracking/TrackBHadron/*"),
+)
+postProcessorTrackSummaryStandalone = postProcessorTrackSummary.clone(
+    subDirs = _defaultSubdirs.append("Tracking/TrackBHadron/*"),
+)
+
+postProcessorTrackSequenceStandalone = cms.Sequence(
+    postProcessorTrackStandalone+
+    postProcessorTrackNrecVsNsim+
+    postProcessorTrackSummaryStandalone
+)
+
 postProcessorTrackPhase2 = postProcessorTrack.clone()
 postProcessorTrackPhase2.subDirs.extend(["Tracking/TrackTPEtaGreater2p7/*"])
 postProcessorTrackSummaryPhase2 = postProcessorTrackSummary.clone()
@@ -323,9 +343,9 @@ phase2_tracker.toReplaceWith(postProcessorTrack,postProcessorTrackPhase2)
 phase2_tracker.toReplaceWith(postProcessorTrackSummary,postProcessorTrackSummaryPhase2)
 
 postProcessorTrackTrackingOnly = postProcessorTrack.clone()
-postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
+postProcessorTrackTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding/*", "Tracking/PixelTrack/*"])
 postProcessorTrackSummaryTrackingOnly = postProcessorTrackSummary.clone()
-postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackSeeding", "Tracking/PixelTrack"])
+postProcessorTrackSummaryTrackingOnly.subDirs.extend(["Tracking/TrackBHadron/*","Tracking/TrackSeeding", "Tracking/PixelTrack"])
 
 postProcessorTrackSequenceTrackingOnly = cms.Sequence(
     postProcessorTrackTrackingOnly+


### PR DESCRIPTION
#### PR description:

I have been asked by central DQM to fix some more warnings, occurring in the harvesting step , related to the Tracking Validation, of the type:
```
%MSG-e DQMGenericClient:  DQMGenericClient:postProcessorTrack@endRun  14-Oct-2020 04:38:34 CEST End Run: 1
 DQMGenericClient::findAllSubdirectories ==> Missing folder Tracking/TrackBHadron !!!
%MSG
```
The ` Tracking/TrackBHadron` validation has been added in this PR: https://github.com/cms-sw/cmssw/pull/17591, but only to the standalone and `trackingOnly` modes. This means that in the generic validation the harvesting for this folder cannot occur, as the folder is not created.
I solve this issue by creating two clones: `postProcessorTrackStandalone` and `postProcessorTrackSummaryStandalone`  adding the `Tracking/TrackBHadron/*` to the folders to harvest and using them in the new sequence: `postProcessorTrackSequenceStandalone`.
This sequence will be used for the standalone usage by:
```
cmsDriver.py step4 ... -s HARVESTING:postProcessorTrackSequenceStandalone --filetype DQM --filein file:step3_inDQM.root
```
The twiki page at this [link](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMultiTrackValidator#cmsDriver_MTV_alone_i_e_standalo) will be adjusted once this PR is merged.

I profit of this PR to clean some other warnings related to missing folder in the case of `fastSim`  (commit 0f96a9f) 

#### PR validation:

Passes:
```
runTheMatrix.py -l limited -t 4 -j  8
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, and no backport is needed.
