### PR TITLE
DD4hep workflow: Fix issue at step 2

### DIFF
--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -45,8 +45,8 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
                                                            const TrackerTopology* tTopo) {
   if (ptp.vpars.size() != 6) {
     edm::LogError("TrackerGeomBuilderFromGeometricDet")
-      << "Tracker parameters block from XMLs called vPars is expected to have 6 entries, but has "
-      << ptp.vpars.size() << " entries.";
+        << "Tracker parameters block from XMLs called vPars is expected to have 6 entries, but has " << ptp.vpars.size()
+        << " entrie(s).";
   }
 
   const int BIG_PIX_PER_ROC_X = ptp.vpars.at(2);

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -44,13 +44,13 @@ TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* g
                                                            const PTrackerParameters& ptp,
                                                            const TrackerTopology* tTopo) {
   if (ptp.vpars.size() != 6) {
-    edm::LogError("TrackerGeomBuilderFromGeometricDet")
+    throw cms::Exception("TrackerGeomBuilderFromGeometricDet")
         << "Tracker parameters block from XMLs called vPars is expected to have 6 entries, but has " << ptp.vpars.size()
         << " entrie(s).";
   }
 
-  const int BIG_PIX_PER_ROC_X = ptp.vpars.at(2);
-  const int BIG_PIX_PER_ROC_Y = ptp.vpars.at(3);
+  const int BIG_PIX_PER_ROC_X = ptp.vpars[2];
+  const int BIG_PIX_PER_ROC_Y = ptp.vpars[3];
 
   thePixelDetTypeMap.clear();
   theStripDetTypeMap.clear();

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -43,8 +43,14 @@ namespace {
 TrackerGeometry* TrackerGeomBuilderFromGeometricDet::build(const GeometricDet* gd,
                                                            const PTrackerParameters& ptp,
                                                            const TrackerTopology* tTopo) {
-  int BIG_PIX_PER_ROC_X = ptp.vpars[2];
-  int BIG_PIX_PER_ROC_Y = ptp.vpars[3];
+  if (ptp.vpars.size() != 6) {
+    edm::LogError("TrackerGeomBuilderFromGeometricDet")
+      << "Tracker parameters block from XMLs called vPars is expected to have 6 entries, but has "
+      << ptp.vpars.size() << " entries.";
+  }
+
+  const int BIG_PIX_PER_ROC_X = ptp.vpars.at(2);
+  const int BIG_PIX_PER_ROC_Y = ptp.vpars.at(3);
 
   thePixelDetTypeMap.clear();
   theStripDetTypeMap.clear();

--- a/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
@@ -39,12 +39,19 @@ bool TrackerParametersFromDD::build(const cms::DDCompactView* cvp, PTrackerParam
     }
   }
 
-  auto it = vmap.find("vPars");
-  if (it != end(vmap)) {
-    std::vector<int> tmpVec;
-    for (const auto& i : it->second)
-      tmpVec.emplace_back(std::round(i));
-    ptp.vpars = tmpVec;
+  // get "vPars" parameter block from XMLs.
+  const std::string& vPars = "trackerParameters:vPars";
+  for (auto const& parameterXMLBlock : vmap) {
+    const std::string& parameterName = parameterXMLBlock.first;
+    // Look for vPars parameter XML block.
+    // Same logic as old DD: it should be found only once.
+    if (dd4hep::dd::compareEqual(vPars, parameterName)) {
+      const std::vector<double>& parameterValues = parameterXMLBlock.second;
+      for (const auto& value : parameterValues) {
+	ptp.vpars.emplace_back(std::round(value));
+      }
+      break;
+    }
   }
 
   return true;

--- a/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
@@ -44,13 +44,12 @@ bool TrackerParametersFromDD::build(const cms::DDCompactView* cvp, PTrackerParam
   for (auto const& parameterXMLBlock : vmap) {
     const std::string& parameterName = parameterXMLBlock.first;
     // Look for vPars parameter XML block.
-    // Same logic as old DD: it should be found only once.
     if (dd4hep::dd::compareEqual(vPars, parameterName)) {
       const std::vector<double>& parameterValues = parameterXMLBlock.second;
       for (const auto& value : parameterValues) {
-	ptp.vpars.emplace_back(std::round(value));
+        ptp.vpars.emplace_back(std::round(value));
       }
-      break;
+      break;  // Same logic as old DD: it should be found only once.
     }
   }
 


### PR DESCRIPTION
This is a small fix on an issue encountered at step 2, with the DD4hep workflow.

This lies in the context of the 'bug to bug' jumping for a DD4hep workflow.
This should be in addition to a parallel effort of checking all values of interest from XMLs, for all volumes and all scenarios, obtained at step 1, for all subdetectors.

**NB:**
The next issue to solve at step2, on a DD4hep workflow, is now:
```
----- Begin Fatal Exception 14-Oct-2020 15:07:08 CEST-----------------------
An exception of category 'NoProxyException' occurred while
   [0] Running EventSetup component GEMGeometryESModule/'gemGeometry
Exception Message:
No data of type "DDCompactView" with label "" in record "IdealGeometryRecord"
 Please add an ESSource or ESProducer to your job which can deliver this data.
----- End Fatal Exception -------------------------------------------------
```
