### PR TITLE
Some clean up on reco muon classes

### DIFF
--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -419,12 +419,14 @@ namespace reco {
 
     float t0(int n = 0) {
       int i = 0;
-      for (auto& chamber : muMatches_)
-        for (auto& segment : chamber.segmentMatches) {
-          if (i == n)
-            return segment.t0;
-          ++i;
+      for (auto& chamber : muMatches_) {
+        int segmentMatchesSize = (int)chamber.segmentMatches.size();
+        if (i + segmentMatchesSize < n) {
+          i += segmentMatchesSize;
+          continue;
         }
+        return chamber.segmentMatches[n - i].t0;
+      }
       return 0;
     }
   };

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -419,13 +419,10 @@ namespace reco {
 
     float t0(int n = 0) {
       int i = 0;
-      for (std::vector<MuonChamberMatch>::const_iterator chamber = muMatches_.begin(); chamber != muMatches_.end();
-           ++chamber)
-        for (std::vector<reco::MuonSegmentMatch>::const_iterator segment = chamber->segmentMatches.begin();
-             segment != chamber->segmentMatches.end();
-             ++segment) {
+      for (auto& chamber : muMatches_)
+        for (auto& segment : chamber.segmentMatches) {
           if (i == n)
-            return segment->t0;
+            return segment.t0;
           ++i;
         }
       return 0;

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -151,7 +151,7 @@ unsigned int Muon::stationMask(ArbitrationType type) const {
 
       //    for (auto& rpcMatch : chamberMatch.rpcMatches) { // TO BE FIXED: there is clearly something odd here
       // Replaced by something which restores the previous functionality, but one should verify which were the
-      // Original intentions of the author and provide a more appropriate fix (and remove these comment lines)
+      // original intentions of the author and provide a more appropriate fix (and remove these comment lines)
       if (!chamberMatch.rpcMatches.empty()) {
         curMask = 1 << ((chamberMatch.station() - 1) + 4 * (rpcIndex - 1));
 
@@ -227,19 +227,20 @@ unsigned int Muon::RPClayerMask(ArbitrationType type) const {
 
     RPCDetId rollId = chamberMatch.id.rawId();
     const int region = rollId.region();
+    const int stationIndex = chamberMatch.station();
 
-    int rpcLayer = chamberMatch.station();
+    int rpcLayer = stationIndex;
     if (region == 0) {
       const int layer = rollId.layer();
-      rpcLayer = chamberMatch.station() - 1 + chamberMatch.station() * layer;
-      if ((chamberMatch.station() == 2 && layer == 2) || (chamberMatch.station() == 4 && layer == 1))
+      rpcLayer = stationIndex - 1 + stationIndex * layer;
+      if ((stationIndex == 2 && layer == 2) || (stationIndex == 4 && layer == 1))
         rpcLayer -= 1;
     } else
       rpcLayer += 6;
 
     //    for (auto& rpcMatch : chamberMatch.rpcMatches) { // TO BE FIXED: there is clearly something odd here
     // Replaced by something which restores the previous functionality, but one should verify which were the
-    // Original intentions of the author and provide a more appropriate fix (and remove these comment lines)
+    // original intentions of the author and provide a more appropriate fix (and remove these comment lines)
     if (!chamberMatch.rpcMatches.empty()) {
       curMask = 1 << (rpcLayer - 1);
 
@@ -257,11 +258,11 @@ unsigned int Muon::stationGapMaskDistance(float distanceCut) const {
   distanceCut = std::abs(distanceCut);
   for (auto& chamberMatch : muMatches_) {
     unsigned int curMask(0);
-    int stationIndex = chamberMatch.station();
-    if (stationIndex < 1 || stationIndex >= 5)
-      continue;
-    int detectorIndex = chamberMatch.detector();
+    const int detectorIndex = chamberMatch.detector();
     if (detectorIndex < 1 || detectorIndex >= 4)
+      continue;
+    const int stationIndex = chamberMatch.station();
+    if (stationIndex < 1 || stationIndex >= 5)
       continue;
 
     float edgeX = chamberMatch.edgeX;
@@ -284,11 +285,11 @@ unsigned int Muon::stationGapMaskPull(float sigmaCut) const {
   unsigned int totMask(0);
   for (auto& chamberMatch : muMatches_) {
     unsigned int curMask(0);
-    int stationIndex = chamberMatch.station();
-    if (stationIndex < 1 || stationIndex >= 5)
-      continue;
-    int detectorIndex = chamberMatch.detector();
+    const int detectorIndex = chamberMatch.detector();
     if (detectorIndex < 1 || detectorIndex >= 4)
+      continue;
+    const int stationIndex = chamberMatch.station();
+    if (stationIndex < 1 || stationIndex >= 5)
       continue;
 
     float edgeX = chamberMatch.edgeX;
@@ -376,7 +377,7 @@ int Muon::numberOfSegments(int station, int muonSubdetId, ArbitrationType type) 
   for (auto& chamberMatch : muMatches_) {
     if (chamberMatch.segmentMatches.empty())
       continue;
-    if (!(chamberMatch.station() == station && chamberMatch.detector() == muonSubdetId))
+    if (chamberMatch.detector() != muonSubdetId || chamberMatch.station() != station)
       continue;
 
     if (type == NoArbitration) {
@@ -414,7 +415,7 @@ const std::vector<const MuonChamberMatch*> Muon::chambers(int station, int muonS
   for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
        chamberMatch != muMatches_.end();
        chamberMatch++)
-    if (chamberMatch->station() == station && chamberMatch->detector() == muonSubdetId)
+    if (chamberMatch->detector() == muonSubdetId && chamberMatch->station() == station)
       chambers.push_back(&(*chamberMatch));
   return chambers;
 }

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -149,7 +149,10 @@ unsigned int Muon::stationMask(ArbitrationType type) const {
       RPCDetId rollId = chamberMatch.id.rawId();
       int rpcIndex = rollId.region() == 0 ? 1 : 2;
 
-      for (auto& rpcMatch : chamberMatch.rpcMatches) {
+      //    for (auto& rpcMatch : chamberMatch.rpcMatches) { // TO BE FIXED: there is clearly something odd here
+      // Replaced by something which restores the previous functionality, but one should verify which were the
+      // Original intentions of the author and provide a more appropriate fix (and remove these comment lines)
+      if (!chamberMatch.rpcMatches.empty()) {
         curMask = 1 << ((chamberMatch.station() - 1) + 4 * (rpcIndex - 1));
 
         // do not double count
@@ -234,7 +237,10 @@ unsigned int Muon::RPClayerMask(ArbitrationType type) const {
     } else
       rpcLayer += 6;
 
-    for (auto& rpcMatch : chamberMatch.rpcMatches) {  // There is clearly something odd here
+    //    for (auto& rpcMatch : chamberMatch.rpcMatches) { // TO BE FIXED: there is clearly something odd here
+    // Replaced by something which restores the previous functionality, but one should verify which were the
+    // Original intentions of the author and provide a more appropriate fix (and remove these comment lines)
+    if (!chamberMatch.rpcMatches.empty()) {
       curMask = 1 << (rpcLayer - 1);
 
       // do not double count
@@ -293,8 +299,8 @@ unsigned int Muon::stationGapMaskPull(float sigmaCut) const {
         std::abs(edgeY / yErr) > sigmaCut)  // inside the chamber so negates all gaps for this station
       continue;
 
-    if ((std::abs(edgeX / xErr) < sigmaCut && edgeY / yErr < sigmaCut) ||
-        (std::abs(edgeY / yErr) < sigmaCut && edgeX / xErr < sigmaCut))  // inside gap
+    if ((std::abs(edgeX / xErr) < sigmaCut && edgeY < sigmaCut * yErr) ||
+        (std::abs(edgeY / yErr) < sigmaCut && edgeX < sigmaCut * xErr))  // inside gap
       curMask = 1 << ((stationIndex - 1) + 4 * (detectorIndex - 1));
     totMask += curMask;  // add to total mask
   }
@@ -503,7 +509,7 @@ float Muon::pullX(int station, int muonSubdetId, ArbitrationType type, bool incl
     return 999999;
   if (includeSegmentError)
     return (chamberSegmentPair.first->x - chamberSegmentPair.second->x) /
-           sqrt(pow(chamberSegmentPair.first->xErr, 2) + pow(chamberSegmentPair.second->xErr, 2));
+           sqrt(std::pow(chamberSegmentPair.first->xErr, 2) + std::pow(chamberSegmentPair.second->xErr, 2));
   return (chamberSegmentPair.first->x - chamberSegmentPair.second->x) / chamberSegmentPair.first->xErr;
 }
 
@@ -518,7 +524,7 @@ float Muon::pullY(int station, int muonSubdetId, ArbitrationType type, bool incl
     return 999999;
   if (includeSegmentError)
     return (chamberSegmentPair.first->y - chamberSegmentPair.second->y) /
-           sqrt(pow(chamberSegmentPair.first->yErr, 2) + pow(chamberSegmentPair.second->yErr, 2));
+           sqrt(std::pow(chamberSegmentPair.first->yErr, 2) + std::pow(chamberSegmentPair.second->yErr, 2));
   return (chamberSegmentPair.first->y - chamberSegmentPair.second->y) / chamberSegmentPair.first->yErr;
 }
 
@@ -531,7 +537,7 @@ float Muon::pullDxDz(int station, int muonSubdetId, ArbitrationType type, bool i
     return 999999;
   if (includeSegmentError)
     return (chamberSegmentPair.first->dXdZ - chamberSegmentPair.second->dXdZ) /
-           sqrt(pow(chamberSegmentPair.first->dXdZErr, 2) + pow(chamberSegmentPair.second->dXdZErr, 2));
+           sqrt(std::pow(chamberSegmentPair.first->dXdZErr, 2) + std::pow(chamberSegmentPair.second->dXdZErr, 2));
   return (chamberSegmentPair.first->dXdZ - chamberSegmentPair.second->dXdZ) / chamberSegmentPair.first->dXdZErr;
 }
 
@@ -546,7 +552,7 @@ float Muon::pullDyDz(int station, int muonSubdetId, ArbitrationType type, bool i
     return 999999;
   if (includeSegmentError)
     return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) /
-           sqrt(pow(chamberSegmentPair.first->dYdZErr, 2) + pow(chamberSegmentPair.second->dYdZErr, 2));
+           sqrt(std::pow(chamberSegmentPair.first->dYdZErr, 2) + std::pow(chamberSegmentPair.second->dYdZErr, 2));
   return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) / chamberSegmentPair.first->dYdZErr;
 }
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -564,7 +564,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
 
         for (auto& muon : *outputMuons) {
           if (muon.innerTrack().get() == trackerMuon.innerTrack().get() &&
-              cos(phiOfMuonIneteractionRegion(muon) - phiOfMuonIneteractionRegion(trackerMuon)) > 0) {
+              cos(phiOfMuonInteractionRegion(muon) - phiOfMuonInteractionRegion(trackerMuon)) > 0) {
             newMuon = false;
             muon.setMatches(trackerMuon.matches());
             if (trackerMuon.isTimeValid())
@@ -665,7 +665,7 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
       // predict direction based on the muon interaction region location
       // if it's available
       if (muon.isStandAloneMuon()) {
-        if (cos(phiOfMuonIneteractionRegion(muon) - muon.phi()) > 0) {
+        if (cos(phiOfMuonInteractionRegion(muon) - muon.phi()) > 0) {
           fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::InsideOut);
         } else {
           fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::OutsideIn);
@@ -1322,7 +1322,7 @@ double MuonIdProducer::sectorPhi(const DetId& id) {
   return phi;
 }
 
-double MuonIdProducer::phiOfMuonIneteractionRegion(const reco::Muon& muon) const {
+double MuonIdProducer::phiOfMuonInteractionRegion(const reco::Muon& muon) const {
   if (muon.isStandAloneMuon())
     return muon.standAloneMuon()->innerPosition().phi();
   // the rest is tracker muon only

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -205,9 +205,9 @@ private:
 
   // matching
   double maxAbsDx_;
-  double maxAbsPullX_;
+  double maxAbsPullX2_;
   double maxAbsDy_;
-  double maxAbsPullY_;
+  double maxAbsPullY2_;
 
   // what information to fill
   bool fillCaloCompatibility_;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -122,7 +122,7 @@ private:
 
   unsigned int chamberId(const DetId&);
 
-  double phiOfMuonIneteractionRegion(const reco::Muon& muon) const;
+  double phiOfMuonInteractionRegion(const reco::Muon& muon) const;
 
   bool checkLinks(const reco::MuonTrackLinks*) const;
   inline bool approxEqual(const double a, const double b, const double tol = 1E-3) const {


### PR DESCRIPTION
#### PR description:

Some cleanup is applied in the MuonReco DataFormat, mostly replacing loop expressions with more readable range based ones.  This simplifications, among other things, allowed pinpointing the issue described in https://github.com/cms-sw/cmssw/issues/31783 (which is **not** addressed here, waiting for the input from the muon pog)

Moreover, also a few simplifications in the code are implemented, like avoiding repeated computations of the same quantities or reducing the loop iterations when possible. This is not expected to provide significant improvements in the timing, but it shouldn't hurt too.

The updates in the MuonIdProducer are meant to simplify and speed up the algo in a few points, and fix the name of a method which is only used internally to that producer (and therefore does not need to be propagated elsewhere).

#### PR validation:

I just checked that the code runs without errors in a typical Run2 workflow.
No change is expected in output: therefore, if any shows up from the automatic comparisons it may suggest some bug/typo in this implementation

@trocino @ArnabPurohit FYI
