### PR TITLE
Removed use of boost::any in edmNew::DetSetVector

### DIFF
--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -39,7 +39,6 @@
 </bin>
 
 <bin file="DetSetNewTS_t.cpp">
-  <flags CXXFLAGS="-fopenmp"/>
 </bin>
 
 <bin file="MapOfVectors_t.cpp">


### PR DESCRIPTION
#### PR description:

The type being used is known at compile time so a static_cast is sufficient.
This avoids the need for ROOT to have to parse boost::any.

#### PR validation:

The code compiles and the relevant unit tests pass.