### PR TITLE
Add ConfigurationDescriptions and ParameterSetDescription to framework forward declarations

### DIFF
--- a/FWCore/Framework/interface/Frameworkfwd.h
+++ b/FWCore/Framework/interface/Frameworkfwd.h
@@ -12,6 +12,7 @@ Forward declarations of types in the EDM.
 
 namespace edm {
   class PrincipalGetAdapter;
+  class ConfigurationDescriptions;
   class ConsumesCollector;
   class DelayedReader;
   class EDAnalyzer;
@@ -34,6 +35,7 @@ namespace edm {
   class OutputModule;
   struct OutputModuleDescription;
   class ParameterSet;
+  class ParameterSetDescription;
   class Principal;
   class PrincipalCache;
   class PrincipalGetAdapter;

--- a/FWCore/Framework/interface/FrameworkfwdMostUsed.h
+++ b/FWCore/Framework/interface/FrameworkfwdMostUsed.h
@@ -8,10 +8,12 @@ Forward declarations of types in the EDM that are most frequently used.
 ----------------------------------------------------------------------*/
 namespace edm {
   class ConsumesCollector;
+  class ConfigurationDescriptions;
   class Event;
   class EventSetup;
   class LuminosityBlock;
   class ParameterSet;
+  class ParameterSetDescription;
   class ProcessBlock;
   class Run;
   class StreamID;


### PR DESCRIPTION
#### PR description:

I encountered user code forward declaring `ParameterSetDescription`, and I decided to add `ConfigurationDescriptions` for completeness.

#### PR validation:

Code compiles.