### PR TITLE
Migrate rest of CSCTFTrackProducer to EventSetup consumes

### DIFF
--- a/L1Trigger/CSCTrackFinder/interface/CSCTFPtLUT.h
+++ b/L1Trigger/CSCTrackFinder/interface/CSCTFPtLUT.h
@@ -1,20 +1,33 @@
 #ifndef CSCTrackFinder_CSCTFPtLUT_h
 #define CSCTrackFinder_CSCTFPtLUT_h
 
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <L1Trigger/CSCTrackFinder/interface/CSCTrackFinderDataTypes.h>
-#include <CondFormats/L1TObjects/interface/L1MuTriggerScales.h>
-#include <CondFormats/L1TObjects/interface/L1MuTriggerPtScale.h>
-#include <L1Trigger/CSCTrackFinder/interface/CSCTFPtMethods.h>
-#include <FWCore/ParameterSet/interface/FileInPath.h>
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCTrackFinderDataTypes.h"
+#include "CondFormats/L1TObjects/interface/L1MuCSCPtLut.h"
+#include "CondFormats/L1TObjects/interface/L1MuTriggerScales.h"
+#include "CondFormats/L1TObjects/interface/L1MuTriggerPtScale.h"
+#include "CondFormats/DataRecord/interface/L1MuCSCPtLutRcd.h"
+#include "CondFormats/DataRecord/interface/L1MuTriggerScalesRcd.h"
+#include "CondFormats/DataRecord/interface/L1MuTriggerPtScaleRcd.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCTFPtMethods.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 ///KK
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 ///
 
 class CSCTFPtLUT {
 public:
+  struct Tokens {
+    edm::ESGetToken<L1MuCSCPtLut, L1MuCSCPtLutRcd> ptLUT;
+    edm::ESGetToken<L1MuTriggerScales, L1MuTriggerScalesRcd> scales;
+    edm::ESGetToken<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd> ptScale;
+  };
+
+  static Tokens consumes(edm::ConsumesCollector iC);
+
   ///KK
-  CSCTFPtLUT(const edm::EventSetup& c);
+  CSCTFPtLUT(const edm::EventSetup& c, const Tokens& tokens);
   ///
 
   CSCTFPtLUT(const edm::ParameterSet&, const L1MuTriggerScales* scales, const L1MuTriggerPtScale* ptScale);

--- a/L1Trigger/CSCTrackFinder/interface/CSCTFSectorProcessor.h
+++ b/L1Trigger/CSCTrackFinder/interface/CSCTFSectorProcessor.h
@@ -11,20 +11,29 @@
 #include <vector>
 #include <map>
 #include <string>
-#include <DataFormats/L1CSCTrackFinder/interface/L1CSCTrackCollection.h>
-#include <DataFormats/L1CSCTrackFinder/interface/TrackStub.h>
-#include <DataFormats/L1CSCTrackFinder/interface/CSCTriggerContainer.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "CondFormats/L1TObjects/interface/L1MuCSCTFConfiguration.h"
+#include "CondFormats/DataRecord/interface/L1MuCSCTFConfigurationRcd.h"
+#include "DataFormats/L1CSCTrackFinder/interface/L1CSCTrackCollection.h"
+#include "DataFormats/L1CSCTrackFinder/interface/TrackStub.h"
+#include "DataFormats/L1CSCTrackFinder/interface/CSCTriggerContainer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h>
-#include <L1Trigger/CSCTrackFinder/interface/CSCTFSPCoreLogic.h>
-#include <L1Trigger/CSCTrackFinder/interface/CSCTFPtLUT.h>
+#include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCTFSPCoreLogic.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCTFPtLUT.h"
 ///KK
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/EventSetup.h"
 ///
 
 class CSCTFSectorProcessor {
 public:
+  struct Tokens {
+    CSCTFPtLUT::Tokens ptLUT;
+    edm::ESGetToken<L1MuCSCTFConfiguration, L1MuCSCTFConfigurationRcd> config;
+  };
+
+  static Tokens consumes(const edm::ParameterSet& pset, edm::ConsumesCollector iC);
+
   CSCTFSectorProcessor(const unsigned& endcap,
                        const unsigned& sector,
                        const edm::ParameterSet& pset,
@@ -33,7 +42,7 @@ public:
                        const L1MuTriggerPtScale* ptScale);
 
   ///KK
-  void initialize(const edm::EventSetup& c);
+  void initialize(const edm::EventSetup& c, const Tokens& tokens);
   ///
 
   ~CSCTFSectorProcessor();

--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
@@ -26,7 +26,8 @@ CSCTFTrackProducer::CSCTFTrackProducer(const edm::ParameterSet& pset)
       m_scalesToken(esConsumes<L1MuTriggerScales, L1MuTriggerScalesRcd>()),
       m_ptScaleToken(esConsumes<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd>()),
       m_pDDToken(esConsumes<CSCGeometry, MuonGeometryRecord>()),
-      sp_pset{pset.getParameter<edm::ParameterSet>("SectorProcessor")} {
+      sp_pset{pset.getParameter<edm::ParameterSet>("SectorProcessor")},
+      m_builderTokens(CSCTFTrackBuilder::consumes(sp_pset, consumesCollector())) {
   m_scalesCacheID = 0ULL;
   m_ptScaleCacheID = 0ULL;
   produces<L1CSCTrackCollection>();
@@ -48,10 +49,9 @@ void CSCTFTrackProducer::produce(edm::Event& e, const edm::EventSetup& c) {
     edm::ESHandle<L1MuTriggerScales> scales = c.getHandle(m_scalesToken);
 
     edm::ESHandle<L1MuTriggerPtScale> ptScale = c.getHandle(m_ptScaleToken);
-    c.get<L1MuTriggerPtScaleRcd>().get(ptScale);
 
     my_builder = std::make_unique<CSCTFTrackBuilder>(sp_pset, TMB07, scales.product(), ptScale.product());
-    my_builder->initialize(c);
+    my_builder->initialize(c, m_builderTokens);
 
     m_scalesCacheID = c.get<L1MuTriggerScalesRcd>().cacheIdentifier();
     m_ptScaleCacheID = c.get<L1MuTriggerPtScaleRcd>().cacheIdentifier();

--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.h
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.h
@@ -42,6 +42,7 @@ private:
   const edm::ESGetToken<L1MuTriggerPtScale, L1MuTriggerPtScaleRcd> m_ptScaleToken;
   const edm::ESGetToken<CSCGeometry, MuonGeometryRecord> m_pDDToken;
   const edm::ParameterSet sp_pset;
+  const CSCTFTrackBuilder::Tokens m_builderTokens;
   unsigned long long m_scalesCacheID;
   unsigned long long m_ptScaleCacheID;
   std::unique_ptr<CSCTFTrackBuilder> my_builder;

--- a/L1Trigger/CSCTrackFinder/src/CSCTFTrackBuilder.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFTrackBuilder.cc
@@ -11,7 +11,6 @@
 
 #include "CondFormats/L1TObjects/interface/L1MuCSCTFConfiguration.h"
 #include "CondFormats/DataRecord/interface/L1MuCSCTFConfigurationRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include <sstream>
 #include <cstdlib>
 
@@ -30,11 +29,11 @@ CSCTFTrackBuilder::CSCTFTrackBuilder(const edm::ParameterSet& pset,
   }
 }
 
-void CSCTFTrackBuilder::initialize(const edm::EventSetup& c) {
+void CSCTFTrackBuilder::initialize(const edm::EventSetup& c, const Tokens& tokens) {
   //my_dtrc->initialize(c);
   for (int e = CSCDetId::minEndcapId(); e <= CSCDetId::maxEndcapId(); ++e) {
     for (int s = CSCTriggerNumbering::minTriggerSectorId(); s <= CSCTriggerNumbering::maxTriggerSectorId(); ++s) {
-      my_SPs[e - 1][s - 1]->initialize(c);
+      my_SPs[e - 1][s - 1]->initialize(c, tokens);
     }
   }
 }

--- a/L1Trigger/CSCTrackFinder/src/CSCTFTrackBuilder.h
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFTrackBuilder.h
@@ -10,15 +10,20 @@
 #include <cstring>
 #include <FWCore/Framework/interface/EventSetup.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "L1Trigger/CSCTrackFinder/interface/CSCTFSectorProcessor.h"
 
 class CSCMuonPortCard;
-class CSCTFSectorProcessor;
 class L1MuTriggerScales;
 class L1MuTriggerPtScale;
 
 class CSCTFTrackBuilder {
 public:
-  void initialize(const edm::EventSetup& c);
+  using Tokens = CSCTFSectorProcessor::Tokens;
+  static Tokens consumes(const edm::ParameterSet& pset, edm::ConsumesCollector iC) {
+    return CSCTFSectorProcessor::consumes(pset, iC);
+  }
+
+  void initialize(const edm::EventSetup& c, const Tokens& tokens);
 
   enum { nEndcaps = 2, nSectors = 6 };
 


### PR DESCRIPTION
#### PR description:

This PR is part of #31061. It should complete the EventSetup consumes migration for CSCTFTrackProducer (the partial migration caused failures in #31746).

#### PR validation:

Code compiles.