### PR TITLE
Migrate TrackDetectorAssociator to EventSetup consumes

### DIFF
--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
@@ -66,7 +66,6 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Common/interface/TriggerNames.h"
@@ -162,6 +161,12 @@ private:
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_caloEE_;
   const edm::EDGetTokenT<edm::PCaloHitContainer> tok_caloHH_;
   const edm::EDGetTokenT<edm::TriggerResults> tok_trigger_;
+
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> tok_geom_;
+  const edm::ESGetToken<CaloTopology, CaloTopologyRecord> tok_caloTopology_;
+  const edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> tok_topo_;
+  const edm::ESGetToken<EcalChannelStatus, EcalChannelStatusRcd> tok_ecalChStatus_;
+  const edm::ESGetToken<EcalSeverityLevelAlgo, EcalSeverityLevelAlgoRcd> tok_sevlv_;
 
   const double minTrackP_, maxTrackEta_, maxNearTrackP_;
   const int debugEcalSimInfo_;
@@ -348,6 +353,11 @@ IsolatedTracksCone::IsolatedTracksCone(const edm::ParameterSet& iConfig)
       tok_caloEE_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"))),
       tok_caloHH_(consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "HcalHits"))),
       tok_trigger_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"))),
+      tok_geom_(esConsumes()),
+      tok_caloTopology_(esConsumes()),
+      tok_topo_(esConsumes()),
+      tok_ecalChStatus_(esConsumes()),
+      tok_sevlv_(esConsumes()),
       minTrackP_(iConfig.getUntrackedParameter<double>("minTrackP", 10.0)),
       maxTrackEta_(iConfig.getUntrackedParameter<double>("maxTrackEta", 5.0)),
       maxNearTrackP_(iConfig.getUntrackedParameter<double>("maxNearTrackP", 1.0)),
@@ -485,21 +495,14 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent, const edm::EventSetup
   // Get the collection handles
   ///////////////////////////////////////////////
 
-  edm::ESHandle<CaloGeometry> pG;
-  iSetup.get<CaloGeometryRecord>().get(pG);
-  const CaloGeometry* geo = pG.product();
+  const CaloGeometry* geo = &iSetup.getData(tok_geom_);
   const CaloSubdetectorGeometry* gEB = (geo->getSubdetectorGeometry(DetId::Ecal, EcalBarrel));
   const CaloSubdetectorGeometry* gEE = (geo->getSubdetectorGeometry(DetId::Ecal, EcalEndcap));
   const CaloSubdetectorGeometry* gHB = (geo->getSubdetectorGeometry(DetId::Hcal, HcalBarrel));
   const CaloSubdetectorGeometry* gHE = (geo->getSubdetectorGeometry(DetId::Hcal, HcalEndcap));
 
-  edm::ESHandle<CaloTopology> theCaloTopology;
-  iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-  const CaloTopology* caloTopology = theCaloTopology.product();
-
-  edm::ESHandle<HcalTopology> htopo;
-  iSetup.get<HcalRecNumberingRecord>().get(htopo);
-  const HcalTopology* theHBHETopology = htopo.product();
+  const CaloTopology* caloTopology = &iSetup.getData(tok_caloTopology_);
+  const HcalTopology* theHBHETopology = &iSetup.getData(tok_topo_);
 
   edm::Handle<EcalRecHitCollection> barrelRecHitsHandle;
   edm::Handle<EcalRecHitCollection> endcapRecHitsHandle;
@@ -507,9 +510,7 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent, const edm::EventSetup
   iEvent.getByToken(tok_EE_, endcapRecHitsHandle);
 
   // Retrieve the good/bad ECAL channels from the DB
-  edm::ESHandle<EcalChannelStatus> ecalChStatus;
-  iSetup.get<EcalChannelStatusRcd>().get(ecalChStatus);
-  const EcalChannelStatus* theEcalChStatus = ecalChStatus.product();
+  const EcalChannelStatus* theEcalChStatus = &iSetup.getData(tok_ecalChStatus_);
 
   edm::Handle<HBHERecHitCollection> hbhe;
   iEvent.getByToken(tok_hbhe_, hbhe);
@@ -628,6 +629,7 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent, const edm::EventSetup
   nMissEcal = 0;
   nMissHcal = 0;
 
+  const EcalSeverityLevelAlgo* sevlv = &iSetup.getData(tok_sevlv_);
   for (trkItr = trkCollection->begin(); trkItr != trkCollection->end(); ++trkItr) {
     nRawTRK++;
 
@@ -668,7 +670,8 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent, const edm::EventSetup
     // Find track trajectory
     ////////////////////////////////////////////
 
-    const FreeTrajectoryState fts1 = trackAssociator_->getFreeTrajectoryState(iSetup, *pTrack);
+    const FreeTrajectoryState fts1 =
+        trackAssociator_->getFreeTrajectoryState(&iSetup.getData(parameters_.bFieldToken), *pTrack);
 
     TrackDetMatchInfo info1 = trackAssociator_->associate(iEvent, iSetup, fts1, parameters_);
 
@@ -757,33 +760,17 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent, const edm::EventSetup
     // NxN cluster
     double e3x3 = -999.0;
     double trkEcalEne = -999.0;
-    edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
-    iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
 
     if (std::abs(point1.eta()) < 1.479) {
       const DetId isoCell = gEB->getClosestCell(point1);
-      e3x3 = spr::eECALmatrix(isoCell,
-                              barrelRecHitsHandle,
-                              endcapRecHitsHandle,
-                              *theEcalChStatus,
-                              geo,
-                              caloTopology,
-                              sevlv.product(),
-                              1,
-                              1)
+      e3x3 = spr::eECALmatrix(
+                 isoCell, barrelRecHitsHandle, endcapRecHitsHandle, *theEcalChStatus, geo, caloTopology, sevlv, 1, 1)
                  .first;
       trkEcalEne = spr::eCaloSimInfo(iEvent, geo, pcaloeb, pcaloee, SimTk, SimVtx, pTrack, *associate);
     } else {
       const DetId isoCell = gEE->getClosestCell(point1);
-      e3x3 = spr::eECALmatrix(isoCell,
-                              barrelRecHitsHandle,
-                              endcapRecHitsHandle,
-                              *theEcalChStatus,
-                              geo,
-                              caloTopology,
-                              sevlv.product(),
-                              1,
-                              1)
+      e3x3 = spr::eECALmatrix(
+                 isoCell, barrelRecHitsHandle, endcapRecHitsHandle, *theEcalChStatus, geo, caloTopology, sevlv, 1, 1)
                  .first;
       trkEcalEne = spr::eCaloSimInfo(iEvent, geo, pcaloeb, pcaloee, SimTk, SimVtx, pTrack, *associate);
     }

--- a/Calibration/IsolatedParticles/src/ChargeIsolation.cc
+++ b/Calibration/IsolatedParticles/src/ChargeIsolation.cc
@@ -259,7 +259,8 @@ namespace spr {
       // candidate
       if (trkItr2 != trkItr) {
         // Get propagator
-        const FreeTrajectoryState fts2 = associator.getFreeTrajectoryState(iSetup, *pTrack2);
+        const FreeTrajectoryState fts2 =
+            associator.getFreeTrajectoryState(&iSetup.getData(parameters_.bFieldToken), *pTrack2);
         TrackDetMatchInfo info2 = associator.associate(iEvent, iSetup, fts2, parameters_);
 
         // Make sure it reaches Hcal

--- a/Calibration/IsolatedParticles/src/ChargeIsolationExtra.cc
+++ b/Calibration/IsolatedParticles/src/ChargeIsolationExtra.cc
@@ -41,7 +41,8 @@ namespace spr {
 
       bool trkQuality = pTrack2->quality(trackQuality_);
       if ((trkItr2 != trkItr) && trkQuality) {
-        const FreeTrajectoryState fts2 = associator.getFreeTrajectoryState(iSetup, *pTrack2);
+        const FreeTrajectoryState fts2 =
+            associator.getFreeTrajectoryState(&iSetup.getData(parameters_.bFieldToken), *pTrack2);
         TrackDetMatchInfo info2 = associator.associate(iEvent, iSetup, fts2, parameters_);
         const GlobalPoint point2(info2.trkGlobPosAtEcal.x(), info2.trkGlobPosAtEcal.y(), info2.trkGlobPosAtEcal.z());
 
@@ -131,7 +132,8 @@ namespace spr {
 
       bool trkQuality = pTrack2->quality(trackQuality_);
       if ((trkItr2 != trkItr) && trkQuality) {
-        const FreeTrajectoryState fts2 = associator.getFreeTrajectoryState(iSetup, *pTrack2);
+        const FreeTrajectoryState fts2 =
+            associator.getFreeTrajectoryState(&iSetup.getData(parameters_.bFieldToken), *pTrack2);
         TrackDetMatchInfo info2 = associator.associate(iEvent, iSetup, fts2, parameters_);
         const GlobalPoint point2(info2.trkGlobPosAtEcal.x(), info2.trkGlobPosAtEcal.y(), info2.trkGlobPosAtEcal.z());
 
@@ -204,7 +206,8 @@ namespace spr {
 
       bool trkQuality = pTrack2->quality(trackQuality_);
       if ((trkItr2 != trkItr) && trkQuality) {
-        const FreeTrajectoryState fts2 = associator.getFreeTrajectoryState(iSetup, *pTrack2);
+        const FreeTrajectoryState fts2 =
+            associator.getFreeTrajectoryState(&iSetup.getData(parameters_.bFieldToken), *pTrack2);
         TrackDetMatchInfo info2 = associator.associate(iEvent, iSetup, fts2, parameters_);
         const GlobalPoint point2(info2.trkGlobPosAtHcal.x(), info2.trkGlobPosAtHcal.y(), info2.trkGlobPosAtHcal.z());
 

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoSimTracks.cc
@@ -26,7 +26,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -191,8 +190,12 @@ void TestIsoSimTracks::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     //	  << " GeV" << std::endl;
 
     //      std::cout << "Details:\n" <<std::endl;
-    TrackDetMatchInfo info = trackAssociator_.associate(
-        iEvent, iSetup, trackAssociator_.getFreeTrajectoryState(iSetup, *tracksCI, vertex), trackAssociatorParameters_);
+    TrackDetMatchInfo info =
+        trackAssociator_.associate(iEvent,
+                                   iSetup,
+                                   trackAssociator_.getFreeTrajectoryState(
+                                       &iSetup.getData(trackAssociatorParameters_.bFieldToken), *tracksCI, vertex),
+                                   trackAssociatorParameters_);
     //      std::cout << "ECAL, if track reach ECAL:     " << info.isGoodEcal << std::endl;
     //      std::cout << "ECAL, number of crossed cells: " << info.crossedEcalRecHits.size() << std::endl;
     //      std::cout << "ECAL, energy of crossed cells: " << info.ecalEnergy() << " GeV" << std::endl;

--- a/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
+++ b/JetMETCorrections/IsolatedParticles/test/TestIsoTracks.cc
@@ -26,7 +26,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -215,7 +214,10 @@ void TestIsoTracks::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
     //      std::cout << "Details:\n" <<std::endl;
     TrackDetMatchInfo info = trackAssociator_.associate(
-        iEvent, iSetup, trackAssociator_.getFreeTrajectoryState(iSetup, *tracksCI), trackAssociatorParameters_);
+        iEvent,
+        iSetup,
+        trackAssociator_.getFreeTrajectoryState(&iSetup.getData(trackAssociatorParameters_.bFieldToken), *tracksCI),
+        trackAssociatorParameters_);
     //      std::cout << "ECAL, if track reach ECAL:     " << info.isGoodEcal << std::endl;
     //      std::cout << "ECAL, number of crossed cells: " << info.crossedEcalRecHits.size() << std::endl;
     //      std::cout << "ECAL, energy of crossed cells: " << info.ecalEnergy() << " GeV" << std::endl;

--- a/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
@@ -49,6 +49,7 @@ namespace cms {
                                  double& deltay,
                                  const reco::Muon& muon,
                                  double bfield,
+                                 const MagneticField& magneticField,
                                  edm::Event& iEvent,
                                  const edm::EventSetup& iSetup);
     reco::MuonMETCorrectionData::Type decide_correction_type(const reco::Muon& muon,

--- a/SUSYBSMAnalysis/HSCP/interface/BetaCalculatorECAL.h
+++ b/SUSYBSMAnalysis/HSCP/interface/BetaCalculatorECAL.h
@@ -5,18 +5,16 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
+#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
@@ -63,7 +61,9 @@ private:
   edm::EDGetTokenT<EBRecHitCollection> EBRecHitCollectionToken_;
   edm::EDGetTokenT<EERecHitCollection> EERecHitCollectionToken_;
 
-  edm::ESHandle<DetIdAssociator> ecalDetIdAssociator_;
-  edm::ESHandle<MagneticField> bField_;
-  edm::ESHandle<CaloGeometry> theCaloGeometry_;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> ecalDetIdAssociatorToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken_;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theCaloGeometryToken_;
+  edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopologyToken_;
+  const MagneticField* bField_;
 };

--- a/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
+++ b/TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h
@@ -31,6 +31,15 @@
 #include "DataFormats/GEMRecHit/interface/GEMSegmentCollection.h"
 #include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 
+class DetIdAssociator;
+class DetIdAssociatorRecord;
+class CaloGeometry;
+class CaloGeometryRecord;
+class GlobalTrackingGeometry;
+class GlobalTrackingGeometryRecord;
+class MagneticField;
+class IdealMagneticFieldRecord;
+
 class TrackAssociatorParameters {
 public:
   TrackAssociatorParameters() {}
@@ -109,5 +118,15 @@ public:
   edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEBToken;
   edm::EDGetTokenT<edm::PCaloHitContainer> simEcalHitsEEToken;
   edm::EDGetTokenT<edm::PCaloHitContainer> simHcalHitsToken;
+
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> ecalDetIdAssociatorToken;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> hcalDetIdAssociatorToken;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> hoDetIdAssociatorToken;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> caloDetIdAssociatorToken;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> muonDetIdAssociatorToken;
+  edm::ESGetToken<DetIdAssociator, DetIdAssociatorRecord> preshowerDetIdAssociatorToken;
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> theCaloGeometryToken;
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> bFieldToken;
 };
 #endif

--- a/TrackingTools/TrackAssociator/interface/TrackDetMatchInfo.h
+++ b/TrackingTools/TrackAssociator/interface/TrackDetMatchInfo.h
@@ -8,7 +8,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "TrackingTools/TrackAssociator/interface/TAMuonChamberMatch.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 class TrackDetMatchInfo {
@@ -109,7 +108,7 @@ public:
   int numberOfSegmentsInStation(int station, int detector) const;
   int numberOfSegmentsInDetector(int detector) const;
 
-  void setCaloGeometry(edm::ESHandle<CaloGeometry> geometry) { caloGeometry = geometry.product(); }
+  void setCaloGeometry(const CaloGeometry* geometry) { caloGeometry = geometry; }
   GlobalPoint getPosition(const DetId&);
   std::string dumpGeometry(const DetId&);
 

--- a/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
@@ -46,6 +46,7 @@
 class TrackDetectorAssociator {
 public:
   explicit TrackDetectorAssociator();
+  ~TrackDetectorAssociator();
 
   typedef TrackAssociatorParameters AssociatorParameters;
   enum Direction { Any, InsideOut, OutsideIn };

--- a/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h
@@ -19,10 +19,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "DataFormats/Common/interface/OrphanHandle.h"
 
 #include "DataFormats/TrackReco/interface/TrackBase.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -48,8 +45,7 @@
 
 class TrackDetectorAssociator {
 public:
-  TrackDetectorAssociator();
-  ~TrackDetectorAssociator();
+  explicit TrackDetectorAssociator();
 
   typedef TrackAssociatorParameters AssociatorParameters;
   enum Direction { Any, InsideOut, OutsideIn };
@@ -104,9 +100,9 @@ public:
   void useDefaultPropagator();
 
   /// get FreeTrajectoryState from different track representations
-  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&, const reco::Track&);
-  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&, const SimTrack&, const SimVertex&);
-  static FreeTrajectoryState getFreeTrajectoryState(const edm::EventSetup&,
+  static FreeTrajectoryState getFreeTrajectoryState(const MagneticField*, const reco::Track&);
+  static FreeTrajectoryState getFreeTrajectoryState(const MagneticField*, const SimTrack&, const SimVertex&);
+  static FreeTrajectoryState getFreeTrajectoryState(const MagneticField*,
                                                     const GlobalVector&,
                                                     const GlobalPoint&,
                                                     const int);
@@ -135,7 +131,7 @@ private:
   void getTAMuonChamberMatches(std::vector<TAMuonChamberMatch>& matches,
                                const AssociatorParameters& parameters) dso_internal;
 
-  void init(const edm::EventSetup&) dso_internal;
+  void init(const edm::EventSetup&, const AssociatorParameters&) dso_internal;
 
   math::XYZPoint getPoint(const GlobalPoint& point) dso_internal {
     return math::XYZPoint(point.x(), point.y(), point.z());
@@ -150,19 +146,19 @@ private:
   math::XYZVector getVector(const LocalVector& vec) dso_internal { return math::XYZVector(vec.x(), vec.y(), vec.z()); }
 
   const Propagator* ivProp_;
-  Propagator* defProp_;
+  std::unique_ptr<Propagator> defProp_;
   CachedTrajectory cachedTrajectory_;
   bool useDefaultPropagator_;
 
-  edm::ESHandle<DetIdAssociator> ecalDetIdAssociator_;
-  edm::ESHandle<DetIdAssociator> hcalDetIdAssociator_;
-  edm::ESHandle<DetIdAssociator> hoDetIdAssociator_;
-  edm::ESHandle<DetIdAssociator> caloDetIdAssociator_;
-  edm::ESHandle<DetIdAssociator> muonDetIdAssociator_;
-  edm::ESHandle<DetIdAssociator> preshowerDetIdAssociator_;
+  const DetIdAssociator* ecalDetIdAssociator_;
+  const DetIdAssociator* hcalDetIdAssociator_;
+  const DetIdAssociator* hoDetIdAssociator_;
+  const DetIdAssociator* caloDetIdAssociator_;
+  const DetIdAssociator* muonDetIdAssociator_;
+  const DetIdAssociator* preshowerDetIdAssociator_;
 
-  edm::ESHandle<CaloGeometry> theCaloGeometry_;
-  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry_;
+  const CaloGeometry* theCaloGeometry_;
+  const GlobalTrackingGeometry* theTrackingGeometry_;
 
   edm::ESWatcher<IdealMagneticFieldRecord> theMagneticFeildWatcher_;
 };

--- a/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
+++ b/TrackingTools/TrackAssociator/src/TrackAssociatorParameters.cc
@@ -80,6 +80,16 @@ void TrackAssociatorParameters::loadParameters(const edm::ParameterSet& iConfig,
     simEcalHitsEEToken = iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "EcalHitsEE"));
     simHcalHitsToken = iC.consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits", "HcalHits"));
   }
+
+  ecalDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "EcalDetIdAssociator"));
+  hcalDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "HcalDetIdAssociator"));
+  hoDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "HODetIdAssociator"));
+  caloDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "CaloDetIdAssociator"));
+  muonDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "MuonDetIdAssociator"));
+  preshowerDetIdAssociatorToken = iC.esConsumes(edm::ESInputTag("", "PreshowerDetIdAssociator"));
+  theCaloGeometryToken = iC.esConsumes();
+  theTrackingGeometryToken = iC.esConsumes();
+  bFieldToken = iC.esConsumes();
 }
 
 TrackAssociatorParameters::TrackAssociatorParameters(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {

--- a/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
@@ -25,11 +25,8 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/isFinite.h"
-#include "DataFormats/Common/interface/OrphanHandle.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -103,13 +100,7 @@ using namespace reco;
 
 TrackDetectorAssociator::TrackDetectorAssociator() {
   ivProp_ = nullptr;
-  defProp_ = nullptr;
   useDefaultPropagator_ = false;
-}
-
-TrackDetectorAssociator::~TrackDetectorAssociator() {
-  if (defProp_)
-    delete defProp_;
 }
 
 void TrackDetectorAssociator::setPropagator(const Propagator* ptr) {
@@ -119,36 +110,31 @@ void TrackDetectorAssociator::setPropagator(const Propagator* ptr) {
 
 void TrackDetectorAssociator::useDefaultPropagator() { useDefaultPropagator_ = true; }
 
-void TrackDetectorAssociator::init(const edm::EventSetup& iSetup) {
+void TrackDetectorAssociator::init(const edm::EventSetup& iSetup, const AssociatorParameters& parameters) {
   // access the calorimeter geometry
-  iSetup.get<CaloGeometryRecord>().get(theCaloGeometry_);
-  if (!theCaloGeometry_.isValid())
-    throw cms::Exception("FatalError") << "Unable to find CaloGeometryRecord in event!\n";
+  theCaloGeometry_ = &iSetup.getData(parameters.theCaloGeometryToken);
 
   // get the tracking Geometry
-  iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry_);
-  if (!theTrackingGeometry_.isValid())
-    throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
+  theTrackingGeometry_ = &iSetup.getData(parameters.theTrackingGeometryToken);
 
   if (useDefaultPropagator_ && (!defProp_ || theMagneticFeildWatcher_.check(iSetup))) {
     // setup propagator
-    edm::ESHandle<MagneticField> bField;
-    iSetup.get<IdealMagneticFieldRecord>().get(bField);
+    const MagneticField* bField = &iSetup.getData(parameters.bFieldToken);
 
-    SteppingHelixPropagator* prop = new SteppingHelixPropagator(&*bField, anyDirection);
+    auto prop = std::make_unique<SteppingHelixPropagator>(bField, anyDirection);
     prop->setMaterialMode(false);
     prop->applyRadX0Correction(true);
     // prop->setDebug(true); // tmp
-    defProp_ = prop;
-    setPropagator(defProp_);
+    defProp_ = std::move(prop);
+    setPropagator(defProp_.get());
   }
 
-  iSetup.get<DetIdAssociatorRecord>().get("EcalDetIdAssociator", ecalDetIdAssociator_);
-  iSetup.get<DetIdAssociatorRecord>().get("HcalDetIdAssociator", hcalDetIdAssociator_);
-  iSetup.get<DetIdAssociatorRecord>().get("HODetIdAssociator", hoDetIdAssociator_);
-  iSetup.get<DetIdAssociatorRecord>().get("CaloDetIdAssociator", caloDetIdAssociator_);
-  iSetup.get<DetIdAssociatorRecord>().get("MuonDetIdAssociator", muonDetIdAssociator_);
-  iSetup.get<DetIdAssociatorRecord>().get("PreshowerDetIdAssociator", preshowerDetIdAssociator_);
+  ecalDetIdAssociator_ = &iSetup.getData(parameters.ecalDetIdAssociatorToken);
+  hcalDetIdAssociator_ = &iSetup.getData(parameters.hcalDetIdAssociatorToken);
+  hoDetIdAssociator_ = &iSetup.getData(parameters.hoDetIdAssociatorToken);
+  caloDetIdAssociator_ = &iSetup.getData(parameters.caloDetIdAssociatorToken);
+  muonDetIdAssociator_ = &iSetup.getData(parameters.muonDetIdAssociatorToken);
+  preshowerDetIdAssociator_ = &iSetup.getData(parameters.preshowerDetIdAssociatorToken);
 }
 
 TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
@@ -173,7 +159,7 @@ TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
   info.stateAtIP = *innerState;
   cachedTrajectory_.setStateAtIP(trackOrigin);
 
-  init(iSetup);
+  init(iSetup, parameters);
   // get track trajectory
   // ECAL points (EB+EE)
   // If the phi angle between a track entrance and exit points is more
@@ -566,7 +552,7 @@ void TrackDetectorAssociator::fillHO(const edm::Event& iEvent,
   }
 }
 
-FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const edm::EventSetup& iSetup,
+FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const MagneticField* bField,
                                                                     const SimTrack& track,
                                                                     const SimVertex& vertex) {
   GlobalVector vector(track.momentum().x(), track.momentum().y(), track.momentum().z());
@@ -577,17 +563,14 @@ FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const edm::E
       abs(track.type()) == 321 ||          // kaon
       abs(track.type()) == 2212)
     charge = track.type() < 0 ? -1 : 1;
-  return getFreeTrajectoryState(iSetup, vector, point, charge);
+  return getFreeTrajectoryState(bField, vector, point, charge);
 }
 
-FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const edm::EventSetup& iSetup,
+FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const MagneticField* bField,
                                                                     const GlobalVector& momentum,
                                                                     const GlobalPoint& vertex,
                                                                     const int charge) {
-  edm::ESHandle<MagneticField> bField;
-  iSetup.get<IdealMagneticFieldRecord>().get(bField);
-
-  GlobalTrajectoryParameters tPars(vertex, momentum, charge, &*bField);
+  GlobalTrajectoryParameters tPars(vertex, momentum, charge, bField);
 
   ROOT::Math::SMatrixIdentity id;
   AlgebraicSymMatrix66 covT(id);
@@ -597,16 +580,13 @@ FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const edm::E
   return FreeTrajectoryState(tPars, tCov);
 }
 
-FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const edm::EventSetup& iSetup,
+FreeTrajectoryState TrackDetectorAssociator::getFreeTrajectoryState(const MagneticField* bField,
                                                                     const reco::Track& track) {
-  edm::ESHandle<MagneticField> bField;
-  iSetup.get<IdealMagneticFieldRecord>().get(bField);
-
   GlobalVector vector(track.momentum().x(), track.momentum().y(), track.momentum().z());
 
   GlobalPoint point(track.vertex().x(), track.vertex().y(), track.vertex().z());
 
-  GlobalTrajectoryParameters tPars(point, vector, track.charge(), &*bField);
+  GlobalTrajectoryParameters tPars(point, vector, track.charge(), bField);
 
   // FIX THIS !!!
   // need to convert from perigee to global or helix (curvilinear) frame
@@ -1011,8 +991,7 @@ TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
                                                      Direction direction /*= Any*/) {
   double currentStepSize = cachedTrajectory_.getPropagationStep();
 
-  edm::ESHandle<MagneticField> bField;
-  iSetup.get<IdealMagneticFieldRecord>().get(bField);
+  const MagneticField* bField = &iSetup.getData(parameters.bFieldToken);
 
   if (track.extra().isNull()) {
     if (direction != InsideOut)
@@ -1020,14 +999,14 @@ TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
                                             "something else than InsideOut track.\n"
                                          << "Either change the parameter or provide needed data!\n";
     LogTrace("TrackAssociator") << "Track Extras not found\n";
-    FreeTrajectoryState initialState = trajectoryStateTransform::initialFreeState(track, &*bField);
+    FreeTrajectoryState initialState = trajectoryStateTransform::initialFreeState(track, bField);
     return associate(iEvent, iSetup, parameters, &initialState);  // 5th argument is null pointer
   }
 
   LogTrace("TrackAssociator") << "Track Extras found\n";
-  FreeTrajectoryState innerState = trajectoryStateTransform::innerFreeState(track, &*bField);
-  FreeTrajectoryState outerState = trajectoryStateTransform::outerFreeState(track, &*bField);
-  FreeTrajectoryState referenceState = trajectoryStateTransform::initialFreeState(track, &*bField);
+  FreeTrajectoryState innerState = trajectoryStateTransform::innerFreeState(track, bField);
+  FreeTrajectoryState outerState = trajectoryStateTransform::outerFreeState(track, bField);
+  FreeTrajectoryState referenceState = trajectoryStateTransform::initialFreeState(track, bField);
 
   LogTrace("TrackAssociator") << "inner track state (rho, z, phi):" << track.innerPosition().Rho() << ", "
                               << track.innerPosition().z() << ", " << track.innerPosition().phi() << "\n";
@@ -1092,7 +1071,8 @@ TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
                                                      const SimTrack& track,
                                                      const SimVertex& vertex,
                                                      const AssociatorParameters& parameters) {
-  return associate(iEvent, iSetup, getFreeTrajectoryState(iSetup, track, vertex), parameters);
+  auto const* bField = &iSetup.getData(parameters.bFieldToken);
+  return associate(iEvent, iSetup, getFreeTrajectoryState(bField, track, vertex), parameters);
 }
 
 TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
@@ -1101,7 +1081,8 @@ TrackDetMatchInfo TrackDetectorAssociator::associate(const edm::Event& iEvent,
                                                      const GlobalPoint& vertex,
                                                      const int charge,
                                                      const AssociatorParameters& parameters) {
-  return associate(iEvent, iSetup, getFreeTrajectoryState(iSetup, momentum, vertex, charge), parameters);
+  auto const* bField = &iSetup.getData(parameters.bFieldToken);
+  return associate(iEvent, iSetup, getFreeTrajectoryState(bField, momentum, vertex, charge), parameters);
 }
 
 bool TrackDetectorAssociator::crossedIP(const reco::Track& track) {

--- a/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
+++ b/TrackingTools/TrackAssociator/src/TrackDetectorAssociator.cc
@@ -103,6 +103,8 @@ TrackDetectorAssociator::TrackDetectorAssociator() {
   useDefaultPropagator_ = false;
 }
 
+TrackDetectorAssociator::~TrackDetectorAssociator() = default;
+
 void TrackDetectorAssociator::setPropagator(const Propagator* ptr) {
   ivProp_ = ptr;
   cachedTrajectory_.setPropagator(ivProp_);


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/31061. It migrates `TrackDetectorAssociator` helper class to EventSetup consumes as part of my attempt to fix failures of https://github.com/cms-sw/cmssw/pull/31746 (i.e. some user of it has been migrated to it). On the same go I migrated calling EDModules to ES consumes, and did some related minimal refactoring.

#### PR validation:

Code compiles.