### PR TITLE
Don't hardcode the global tag in the unit test

### DIFF
--- a/CondCore/ESSources/test/TestConcurrentIOVsCondCore_cfg.py
+++ b/CondCore/ESSources/test/TestConcurrentIOVsCondCore_cfg.py
@@ -66,11 +66,14 @@ process.GlobalTag = cms.ESSource("PoolDBESSource",
     RefreshEachRun = cms.untracked.bool(False),
     RefreshOpenIOVs = cms.untracked.bool(False),
     connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
-    globaltag = cms.string('110X_dataRun2_v5'),
+    globaltag = cms.string(''),
     pfnPostfix = cms.untracked.string(''),
     pfnPrefix = cms.untracked.string(''),
-    snapshotTime = cms.string(''),
-    toGet = cms.VPSet()
+    snapshotTime = cms.string('2020-10-10 00:00:00.000'),
+    toGet = cms.VPSet(cms.VPSet(cms.PSet(record = cms.string("BeamSpotObjectsRcd"),
+                                         tag = cms.string("BeamSpotObjects_2017UL_LumiBased_v2")
+                                         ))
+    )
 )
 
 process.test = cms.EDAnalyzer("TestConcurrentIOVsCondCore")


### PR DESCRIPTION
#### PR description:

The unit test has a problem because it hardcodes the global tag and this can cause failures when records in the global tag are removed from CMSSW. Hardcoding the tag instead is less brittle and should work just as well in this test.

See https://github.com/cms-sw/cmssw/pull/28010#pullrequestreview-509242393

#### PR validation:

Problem unit test passes with this change. This change does not affect anything other than the unit test.
