### PR TITLE
Update DT vdrift calibration code to allow using "new" DB format

### DIFF
--- a/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftMeanTimer.cc
@@ -13,7 +13,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
-#include "CondFormats/DTObjects/interface/DTMtime.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
 
 #include "CalibMuon/DTCalibration/interface/DTMeanTimerFitter.h"
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
@@ -34,9 +34,9 @@ using namespace edm;
 namespace dtCalibration {
 
   DTVDriftSegment::DTVDriftSegment(const ParameterSet& pset)
-    : nSigmas_(pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1)),
-      mTimeMap_(nullptr),
-      vDriftMap_(nullptr) {
+      : nSigmas_(pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1)),
+        mTimeMap_(nullptr),
+        vDriftMap_(nullptr) {
     string rootFileName = pset.getParameter<string>("rootFileName");
     rootFile_ = new TFile(rootFileName.c_str(), "READ");
 
@@ -65,7 +65,7 @@ namespace dtCalibration {
       // Consistency check: no parametrization is implemented for the time being
       int version = vDriftMap_->version();
       if (version != 1) {
-	throw cms::Exception("Configuration") << "only version 1 is presently supported for VDriftDB";
+        throw cms::Exception("Configuration") << "only version 1 is presently supported for VDriftDB";
       }
     }
   }
@@ -73,13 +73,13 @@ namespace dtCalibration {
   DTVDriftData DTVDriftSegment::compute(DTSuperLayerId const& slId) {
     // Get original value from DB; vdrift is cm/ns , resolution is cm
     // Note that resolution is irrelevant as it is no longer used anywhere in reconstruction.
- 
-    float vDrift = 0., resolution = 0.; 
-    if (readLegacyVDriftDB) { // Legacy format
+
+    float vDrift = 0., resolution = 0.;
+    if (readLegacyVDriftDB) {  // Legacy format
       int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
       if (status != 0)
-	throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for" << slId << endl;
-    } else { // New DB format
+        throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for" << slId << endl;
+    } else {  // New DB format
       vDrift = vDriftMap_->get(DTWireId(slId.rawId()));
     }
 

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.cc
@@ -16,6 +16,8 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "CondFormats/DTObjects/interface/DTMtime.h"
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
 
 #include "CalibMuon/DTCalibration/interface/DTResidualFitter.h"
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
@@ -32,14 +34,17 @@ using namespace edm;
 namespace dtCalibration {
 
   DTVDriftSegment::DTVDriftSegment(const ParameterSet& pset)
-      : nSigmas_(pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1)) {
+    : nSigmas_(pset.getUntrackedParameter<unsigned int>("nSigmasFitRange", 1)),
+      mTimeMap_(nullptr),
+      vDriftMap_(nullptr) {
     string rootFileName = pset.getParameter<string>("rootFileName");
     rootFile_ = new TFile(rootFileName.c_str(), "READ");
 
     bool debug = pset.getUntrackedParameter<bool>("debug", false);
     fitter_ = new DTResidualFitter(debug);
-    //bool debug = pset.getUntrackedParameter<bool>("debug", false);
     //if(debug) fitter_->setVerbosity(1);
+
+    readLegacyVDriftDB = pset.getParameter<bool>("readLegacyVDriftDB");
   }
 
   DTVDriftSegment::~DTVDriftSegment() {
@@ -49,18 +54,34 @@ namespace dtCalibration {
 
   void DTVDriftSegment::setES(const edm::EventSetup& setup) {
     // Get the map of vdrift from the setup
-    ESHandle<DTMtime> mTime;
-    setup.get<DTMtimeRcd>().get(mTime);
-    mTimeMap_ = &*mTime;
+    if (readLegacyVDriftDB) {
+      ESHandle<DTMtime> mTime;
+      setup.get<DTMtimeRcd>().get(mTime);
+      mTimeMap_ = &*mTime;
+    } else {
+      ESHandle<DTRecoConditions> hVdrift;
+      setup.get<DTRecoConditionsVdriftRcd>().get(hVdrift);
+      vDriftMap_ = &*hVdrift;
+      // Consistency check: no parametrization is implemented for the time being
+      int version = vDriftMap_->version();
+      if (version != 1) {
+	throw cms::Exception("Configuration") << "only version 1 is presently supported for VDriftDB";
+      }
+    }
   }
 
   DTVDriftData DTVDriftSegment::compute(DTSuperLayerId const& slId) {
     // Get original value from DB; vdrift is cm/ns , resolution is cm
-    float vDrift = 0., resolution = 0.;
-    int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
-
-    if (status != 0)
-      throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for" << slId << endl;
+    // Note that resolution is irrelevant as it is no longer used anywhere in reconstruction.
+ 
+    float vDrift = 0., resolution = 0.; 
+    if (readLegacyVDriftDB) { // Legacy format
+      int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
+      if (status != 0)
+	throw cms::Exception("DTCalibration") << "Could not find vDrift entry in DB for" << slId << endl;
+    } else { // New DB format
+      vDrift = vDriftMap_->get(DTWireId(slId.rawId()));
+    }
 
     // For RZ superlayers use original value
     if (slId.superLayer() == 2) {

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
@@ -14,6 +14,7 @@
 #include <string>
 
 class DTMtime;
+class DTRecoConditions;
 class DTResidualFitter;
 class TH1F;
 class TFile;
@@ -34,7 +35,9 @@ namespace dtCalibration {
 
     unsigned int nSigmas_;
 
-    const DTMtime* mTimeMap_;
+    const DTMtime* mTimeMap_;           // legacy DB object
+    const DTRecoConditions* vDriftMap_; // DB object in new format 
+    bool readLegacyVDriftDB;            // which one to use
     TFile* rootFile_;
     DTResidualFitter* fitter_;
   };

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegment.h
@@ -35,9 +35,9 @@ namespace dtCalibration {
 
     unsigned int nSigmas_;
 
-    const DTMtime* mTimeMap_;           // legacy DB object
-    const DTRecoConditions* vDriftMap_; // DB object in new format 
-    bool readLegacyVDriftDB;            // which one to use
+    const DTMtime* mTimeMap_;            // legacy DB object
+    const DTRecoConditions* vDriftMap_;  // DB object in new format
+    bool readLegacyVDriftDB;             // which one to use
     TFile* rootFile_;
     DTResidualFitter* fitter_;
   };

--- a/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftSegmentCalibration.cc
@@ -17,7 +17,6 @@
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
-#include "CondFormats/DTObjects/interface/DTMtime.h"
 
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
 #include "CalibMuon/DTCalibration/interface/DTSegmentSelector.h"

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.cc
@@ -19,6 +19,8 @@
 
 #include "CondFormats/DTObjects/interface/DTMtime.h"
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
+#include "CondFormats/DataRecord/interface/DTRecoConditionsVdriftRcd.h"
 
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
 #include "CalibMuon/DTCalibration/interface/DTVDriftPluginFactory.h"
@@ -32,6 +34,8 @@ using namespace edm;
 
 DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
     : granularity_(pset.getUntrackedParameter<string>("calibGranularity", "bySL")),
+      mTimeMap_(nullptr),
+      vDriftMap_(nullptr),
       vDriftAlgo_{DTVDriftPluginFactory::get()->create(pset.getParameter<string>("vDriftAlgo"),
                                                        pset.getParameter<ParameterSet>("vDriftAlgoConfig"))} {
   LogVerbatim("Calibration") << "[DTVDriftWriter]Constructor called!";
@@ -39,15 +43,30 @@ DTVDriftWriter::DTVDriftWriter(const ParameterSet& pset)
   if (granularity_ != "bySL")
     throw cms::Exception("Configuration")
         << "[DTVDriftWriter] Check parameter calibGranularity: " << granularity_ << " option not available.";
+
+  readLegacyVDriftDB = pset.getParameter<bool>("readLegacyVDriftDB");
+  writeLegacyVDriftDB = pset.getParameter<bool>("writeLegacyVDriftDB");
+
 }
 
 DTVDriftWriter::~DTVDriftWriter() { LogVerbatim("Calibration") << "[DTVDriftWriter]Destructor called!"; }
 
 void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup) {
-  // Get the map of ttrig from the Setup
-  ESHandle<DTMtime> mTime;
-  setup.get<DTMtimeRcd>().get(mTime);
-  mTimeMap_ = &*mTime;
+  // Get the map of vdrift from the Setup
+  if (readLegacyVDriftDB) {
+    ESHandle<DTMtime> mTime;
+    setup.get<DTMtimeRcd>().get(mTime);
+    mTimeMap_ = &*mTime;
+  } else { 
+    ESHandle<DTRecoConditions> hVdrift;
+    setup.get<DTRecoConditionsVdriftRcd>().get(hVdrift);
+    vDriftMap_ = &*hVdrift;
+    // Consistency check: no parametrization is implemented for the time being
+    int version = vDriftMap_->version();
+    if (version != 1) {
+      throw cms::Exception("Configuration") << "only version 1 is presently supported for VDriftDB";
+    }
+  }
 
   // Get geometry from Event Setup
   setup.get<MuonGeometryRecord>().get(dtGeom_);
@@ -57,7 +76,16 @@ void DTVDriftWriter::beginRun(const edm::Run& run, const edm::EventSetup& setup)
 
 void DTVDriftWriter::endJob() {
   // Create the object to be written to DB
-  DTMtime* mTimeNewMap = new DTMtime();
+  DTMtime* mTimeNewMap = nullptr;
+  DTRecoConditions* vDriftNewMap = nullptr;
+  if (writeLegacyVDriftDB) {
+    mTimeNewMap = new DTMtime();
+  } else{
+    vDriftNewMap = new DTRecoConditions();
+    vDriftNewMap->setFormulaExpr("[0]");
+    //vDriftNewMap->setFormulaExpr("[0]*(1-[1]*x)"); // add parametrization for dependency along Y
+    vDriftNewMap->setVersion(1);
+  }
 
   if (granularity_ == "bySL") {
     // Get all the sls from the geometry
@@ -66,34 +94,52 @@ void DTVDriftWriter::endJob() {
     auto sl_end = superLayers.end();
     for (; sl != sl_end; ++sl) {
       DTSuperLayerId slId = (*sl)->id();
-      // Get original value from DB
-      float vDrift = 0., resolution = 0.;
-      // vdrift is cm/ns , resolution is cm
-      int status = mTimeMap_->get(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
 
       // Compute vDrift
+      float vDriftNew = -1.;
+      float resolutionNew = -1;
       try {
-        dtCalibration::DTVDriftData vDriftData = vDriftAlgo_->compute(slId);
-        float vDriftNew = vDriftData.vdrift;
-        float resolutionNew = vDriftData.resolution;
-        // vdrift is cm/ns , resolution is cm
-        mTimeNewMap->set(slId, vDriftNew, resolutionNew, DTVelocityUnits::cm_per_ns);
-        LogVerbatim("Calibration") << "vDrift for: " << slId << " Mean " << vDriftNew << " Resolution "
-                                   << resolutionNew;
-      } catch (cms::Exception& e) {
+	dtCalibration::DTVDriftData vDriftData = vDriftAlgo_->compute(slId);
+	 vDriftNew = vDriftData.vdrift;
+	 resolutionNew = vDriftData.resolution;
+	 LogVerbatim("Calibration") << "vDrift for: " << slId << " Mean " << vDriftNew << " Resolution "
+				    << resolutionNew;
+      } catch (cms::Exception& e) { // Failure to compute new value, fall back to old table
         LogError("Calibration") << e.explainSelf();
-        // Go back to original value in case of error
-        if (!status) {
-          mTimeNewMap->set(slId, vDrift, resolution, DTVelocityUnits::cm_per_ns);
-          LogVerbatim("Calibration") << "Keep original vDrift for: " << slId << " Mean " << vDrift << " Resolution "
-                                     << resolution;
-        }
+	if (readLegacyVDriftDB) { //...reading old db format...
+	  int status = mTimeMap_->get(slId, vDriftNew, resolutionNew, DTVelocityUnits::cm_per_ns);	
+	  if (status == 0) { // not found; silently skip this SL
+	    continue;
+	  }
+	} else { //...reading new db format
+	  try {
+	    vDriftNew = vDriftMap_->get(DTWireId(slId.rawId()));
+	  } catch (cms::Exception& e2) {
+	    // not found; silently skip this SL
+	    continue;
+	  }
+	}
+	LogVerbatim("Calibration") << "Keep original vDrift for: " << slId << " Mean " << vDriftNew << " Resolution "
+                                     << resolutionNew;
+
+      }
+      
+      // Add value to the vdrift table
+      if (writeLegacyVDriftDB) {
+	mTimeNewMap->set(slId, vDriftNew, resolutionNew, DTVelocityUnits::cm_per_ns);
+      } else {
+        vector<double> params = {vDriftNew};
+	vDriftNewMap->set(DTWireId(slId.rawId()), params);
       }
     }  // End of loop on superlayers
   }
 
   // Write the vDrift object to DB
   LogVerbatim("Calibration") << "[DTVDriftWriter]Writing vdrift object to DB!";
-  string record = "DTMtimeRcd";
-  DTCalibDBUtils::writeToDB<DTMtime>(record, mTimeNewMap);
+  if (writeLegacyVDriftDB) {
+    string record = "DTMtimeRcd";
+    DTCalibDBUtils::writeToDB<DTMtime>(record, mTimeNewMap);
+  } else{
+    DTCalibDBUtils::writeToDB<DTRecoConditions>("DTRecoConditionsVdriftRcd", vDriftNewMap);
+  }
 }

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -16,6 +16,7 @@
 #include <string>
 
 class DTMtime;
+class DTRecoConditions;
 class DTGeometry;
 namespace dtCalibration {
   class DTVDriftBaseAlgo;
@@ -34,7 +35,11 @@ public:
 private:
   std::string granularity_;  // enforced by SL
 
-  const DTMtime* mTimeMap_;
+  const DTMtime* mTimeMap_;           // legacy DB object
+  const DTRecoConditions* vDriftMap_; // DB object in new format 
+  bool readLegacyVDriftDB;            // which format to use to read old values
+  bool writeLegacyVDriftDB;           // which format to be created
+
   edm::ESHandle<DTGeometry> dtGeom_;
 
   std::unique_ptr<dtCalibration::DTVDriftBaseAlgo> vDriftAlgo_;

--- a/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
+++ b/CalibMuon/DTCalibration/plugins/DTVDriftWriter.h
@@ -35,10 +35,10 @@ public:
 private:
   std::string granularity_;  // enforced by SL
 
-  const DTMtime* mTimeMap_;           // legacy DB object
-  const DTRecoConditions* vDriftMap_; // DB object in new format 
-  bool readLegacyVDriftDB;            // which format to use to read old values
-  bool writeLegacyVDriftDB;           // which format to be created
+  const DTMtime* mTimeMap_;            // legacy DB object
+  const DTRecoConditions* vDriftMap_;  // DB object in new format
+  bool readLegacyVDriftDB;             // which format to use to read old values
+  bool writeLegacyVDriftDB;            // which format to be created
 
   edm::ESHandle<DTGeometry> dtGeom_;
 

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
@@ -2,6 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DTVDriftWriter")
 
+### Set to true to switch to writing constants in the new DB format.
+NEWDBFORMAT = False 
+###
+
 process.load("CalibMuon.DTCalibration.messageLoggerDebug_cff")
 process.MessageLogger.debugModules = cms.untracked.vstring('dtVDriftSegmentWriter')
 
@@ -21,11 +25,15 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+RECORD = 'DTMtimeRcd'
+if NEWDBFORMAT :
+    RECORD = 'DTRecoConditionsVdriftRcd'
+
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB,
     timetype = cms.untracked.string('runnumber'),
     toPut = cms.VPSet(cms.PSet(
-        record = cms.string('DTMtimeRcd'),
+        record = cms.string(RECORD),
         tag = cms.string('vDrift')
     ))
 )

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfg.py
@@ -16,6 +16,8 @@ process.GlobalTag.globaltag = ''
 
 process.load("CondCore.CondDB.CondDB_cfi")
 
+process.load("CalibMuon.DTCalibration.dtVDriftSegmentWriter_cfi")
+
 process.source = cms.Source("EmptySource",
     numberEventsInRun = cms.untracked.uint32(1),
     firstRun = cms.untracked.uint32(1)
@@ -28,6 +30,10 @@ process.maxEvents = cms.untracked.PSet(
 RECORD = 'DTMtimeRcd'
 if NEWDBFORMAT :
     RECORD = 'DTRecoConditionsVdriftRcd'
+    process.dtVDriftSegmentWriter.writeLegacyVDriftDB = False
+    # The following needs to be set as well if calibration should start use
+    # constants written in the new format as a starting point.
+    # process.dtVDriftSegmentWriter.vDriftAlgoConfig.readLegacyVDriftDB = False
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     process.CondDB,
@@ -38,7 +44,5 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
     ))
 )
 process.PoolDBOutputService.connect = cms.string('sqlite_file:vDrift.db')
-
-process.load("CalibMuon.DTCalibration.dtVDriftSegmentWriter_cfi")
 
 process.p = cms.Path(process.dtVDriftSegmentWriter)

--- a/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfi.py
+++ b/CalibMuon/DTCalibration/python/dtVDriftSegmentWriter_cfi.py
@@ -2,9 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 dtVDriftSegmentWriter = cms.EDAnalyzer("DTVDriftWriter",
     vDriftAlgo = cms.string('DTVDriftSegment'),
+    readLegacyVDriftDB =cms.bool(True),
+    writeLegacyVDriftDB =cms.bool(True),
     vDriftAlgoConfig = cms.PSet(
         rootFileName = cms.string(''),
         nSigmasFitRange = cms.untracked.uint32(1),
+        readLegacyVDriftDB =cms.bool(True),
         debug = cms.untracked.bool(False)
     )
 )

--- a/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
@@ -1,0 +1,211 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+options = VarParsing.VarParsing()
+
+options.register('dbformat',
+                 'Legacy', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "DB format to use: 'Legacy' or 'DTRecoConditions'")
+
+options.register('type',
+                 'TTrigDB', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Database to read: 'TZeroDB', 'TTrigDB',  'VDriftDB',  or 'UncertDB'")
+
+options.register('GT',
+                 'auto:run2_data', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Global tag to read, default is auto:run2_data")
+
+options.register('inputfile',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Read payload from db file instead than GT")
+
+options.register('inputtag',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Read payload from tag in frontier instead than GT")
+
+options.register('run',
+                 999999, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.int,
+                 "Run number (determines IOV to be read)")
+
+
+options.parseArguments()
+
+DBFORMAT  = options.dbformat
+TYPE      = options.type
+INPUTFILE = options.inputfile
+INPUTTAG  = options.inputtag
+GLOBALTAG = options.GT
+RUN       = options.run
+
+
+
+#Input sanification
+
+if DBFORMAT not in ['Legacy', 'DTRecoConditions'] :
+    print '\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n'
+    exit()
+    
+if TYPE not in ['TZeroDB', 'TTrigDB',  'VDriftDB', 'UncertDB'] :
+    print '\nERROR: invalid value for type: ',  TYPE,'\n'
+    exit()
+
+
+if INPUTTAG!="" and INPUTFILE!="" :
+    print '\nERROR: specify either inputtag or inputfile\n'
+    exit()
+
+
+
+
+ofExt = {'TZeroDB'  : '_t0.txt',
+         'TTrigDB'  : '_ttrig.txt',
+         'VDriftDB' : '_vdrift.txt',
+         'UncertDB' : '_uncert.txt'}
+
+
+if INPUTFILE!="":
+    OUTPUTFILE=INPUTFILE
+elif INPUTTAG!="" :
+    OUTPUTFILE=INPUTTAG
+else :
+    OUTPUTFILE=GLOBALTAG+"_"+str(RUN)
+    if OUTPUTFILE[0:5] == 'auto:' : OUTPUTFILE=OUTPUTFILE[5:]
+OUTPUTFILE+=ofExt[TYPE]
+
+
+###########
+
+RECORD=""
+if TYPE=="TZeroDB" : RECORD = "DTT0Rcd"
+elif DBFORMAT=="Legacy" :
+    if TYPE=="TTrigDB" : RECORD = "DTTtrigRcd"
+    if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
+    if TYPE=="UncertDB" :
+        RECORD = "DTRecoUncertaintiesRcd"
+        print '\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code'
+elif DBFORMAT=="DTRecoConditions" :
+    if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
+    if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"
+    if TYPE=="UncertDB" : RECORD = "DTRecoConditionsUncertRcd"
+
+
+process = cms.Process("DumpDBToFile")
+process.load("CondCore.CondDB.CondDB_cfi")
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(1),
+    firstRun = cms.untracked.uint32(RUN)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, GLOBALTAG, '')
+
+# Read from local db file
+if INPUTFILE!="" :
+    print "\nDumpDBToFile: Read from: ", INPUTFILE
+    print "              Record:    ", RECORD
+    print "              Type:      ", TYPE
+
+
+    process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string(RECORD),
+                 tag = cms.string(TYPE), # NOTE: commonly used tags for db files are 'ttrig', 't0','T0DB', etc.
+                 connect = cms.string("sqlite_file:"+INPUTFILE)
+                 )
+        )
+
+
+# Read payload with the specified tag from frontier
+if INPUTTAG!="" :
+    print "\nDumpDBToFile: Read from Frontier, tag:    ", INPUTTAG
+    print "                               Record: ", RECORD
+    print "                                 Type:   ", TYPE
+
+    process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string(RECORD),
+                 tag = cms.string(INPUTTAG),
+                 connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+#                 connect = cms.string('frontier://FrontierProd/CMS_COND_DT_000')
+                 )
+        )
+
+# Read payload specified in the GT
+else :
+    print "\nDumpDBToFile: Read from GT:", GLOBALTAG
+    print "                      Type:", TYPE
+
+print 'Writing to file: ', OUTPUTFILE, '\n'
+
+
+
+
+process.dumpT0ToFile = cms.EDAnalyzer("DumpDBToFile",
+    dbToDump = cms.untracked.string('TZeroDB'),
+    dbLabel = cms.untracked.string(''),
+    calibFileConfig = cms.untracked.PSet(
+        nFields = cms.untracked.int32(8),
+        calibConstGranularity = cms.untracked.string('byWire')
+    ),
+    outputFileName = cms.untracked.string(OUTPUTFILE)
+)
+
+process.dumpTTrigToFile = cms.EDAnalyzer("DumpDBToFile",
+    dbToDump = cms.untracked.string('TTrigDB'),
+    dbLabel = cms.untracked.string(''),
+    dbFormat = cms.untracked.string(DBFORMAT),
+    calibFileConfig = cms.untracked.PSet(
+        nFields = cms.untracked.int32(8),
+        calibConstGranularity = cms.untracked.string('bySL')
+    ),
+    outputFileName = cms.untracked.string(OUTPUTFILE)
+)
+
+
+process.dumpVdToFile = cms.EDAnalyzer("DumpDBToFile",
+    dbToDump = cms.untracked.string('VDriftDB'),
+    dbLabel = cms.untracked.string(''),
+    dbFormat = cms.untracked.string(DBFORMAT),
+    calibFileConfig = cms.untracked.PSet(
+        nFields = cms.untracked.int32(8),
+        calibConstGranularity = cms.untracked.string('bySL')
+    ),
+    outputFileName = cms.untracked.string(OUTPUTFILE)
+)
+
+
+process.dumpUncertToFile = cms.EDAnalyzer("DumpDBToFile",
+    dbToDump = cms.untracked.string('RecoUncertDB'),
+    dbLabel = cms.untracked.string(''),
+    dbFormat = cms.untracked.string(DBFORMAT),
+    calibFileConfig = cms.untracked.PSet(
+        nFields = cms.untracked.int32(8),
+        calibConstGranularity = cms.untracked.string('bySL')
+    ),
+    outputFileName = cms.untracked.string(OUTPUTFILE)
+)
+
+
+if TYPE=="TZeroDB" :     process.p2 = cms.Path(process.dumpT0ToFile)
+if TYPE=="TTrigDB" :     process.p2 = cms.Path(process.dumpTTrigToFile)
+if TYPE=="VDriftDB" :    process.p2 = cms.Path(process.dumpVdToFile)
+if TYPE=="UncertDB": process.p2 = cms.Path(process.dumpUncertToFile)
+
+

--- a/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpDBToFile_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 
@@ -54,16 +55,16 @@ RUN       = options.run
 #Input sanification
 
 if DBFORMAT not in ['Legacy', 'DTRecoConditions'] :
-    print '\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n'
+    print('\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n')
     exit()
     
 if TYPE not in ['TZeroDB', 'TTrigDB',  'VDriftDB', 'UncertDB'] :
-    print '\nERROR: invalid value for type: ',  TYPE,'\n'
+    print('\nERROR: invalid value for type: ',  TYPE,'\n')
     exit()
 
 
 if INPUTTAG!="" and INPUTFILE!="" :
-    print '\nERROR: specify either inputtag or inputfile\n'
+    print('\nERROR: specify either inputtag or inputfile\n')
     exit()
 
 
@@ -94,7 +95,7 @@ elif DBFORMAT=="Legacy" :
     if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
     if TYPE=="UncertDB" :
         RECORD = "DTRecoUncertaintiesRcd"
-        print '\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code'
+        print('\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code')
 elif DBFORMAT=="DTRecoConditions" :
     if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"
@@ -120,9 +121,9 @@ process.GlobalTag = GlobalTag(process.GlobalTag, GLOBALTAG, '')
 
 # Read from local db file
 if INPUTFILE!="" :
-    print "\nDumpDBToFile: Read from: ", INPUTFILE
-    print "              Record:    ", RECORD
-    print "              Type:      ", TYPE
+    print("\nDumpDBToFile: Read from: ", INPUTFILE)
+    print("              Record:    ", RECORD)
+    print("              Type:      ", TYPE)
 
 
     process.GlobalTag.toGet = cms.VPSet(
@@ -135,9 +136,9 @@ if INPUTFILE!="" :
 
 # Read payload with the specified tag from frontier
 if INPUTTAG!="" :
-    print "\nDumpDBToFile: Read from Frontier, tag:    ", INPUTTAG
-    print "                               Record: ", RECORD
-    print "                                 Type:   ", TYPE
+    print("\nDumpDBToFile: Read from Frontier, tag:    ", INPUTTAG)
+    print("                               Record: ", RECORD)
+    print("                                 Type:   ", TYPE)
 
     process.GlobalTag.toGet = cms.VPSet(
         cms.PSet(record = cms.string(RECORD),
@@ -149,10 +150,10 @@ if INPUTTAG!="" :
 
 # Read payload specified in the GT
 else :
-    print "\nDumpDBToFile: Read from GT:", GLOBALTAG
-    print "                      Type:", TYPE
+    print("\nDumpDBToFile: Read from GT:", GLOBALTAG)
+    print("                      Type:", TYPE)
 
-print 'Writing to file: ', OUTPUTFILE, '\n'
+print('Writing to file: ', OUTPUTFILE, '\n')
 
 
 

--- a/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
@@ -1,0 +1,119 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import os
+
+options = VarParsing.VarParsing()
+
+options.register('dbformat',
+                 'Legacy', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "DB format to use: 'Legacy' or 'DTRecoConditions'")
+
+options.register('type',
+                 'TTrigDB', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Database to read: 'TZeroDB', 'TTrigDB',  'VDriftDB',  or 'UncertDB'")
+
+options.register('inputfile',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "Input text file to be converted")
+
+
+options.parseArguments()
+
+DBFORMAT  = options.dbformat
+TYPE      = options.type
+INPUTFILE = options.inputfile
+
+#Input sanification
+
+if DBFORMAT not in ['Legacy', 'DTRecoConditions'] :
+    print '\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n'
+    exit()
+    
+if TYPE not in ['TZeroDB', 'TTrigDB',  'VDriftDB', 'UncertDB'] :
+    print '\nERROR: invalid value for type: ',  TYPE,'\n'
+    exit()
+
+if INPUTFILE == '' :
+    print '\nERROR: must specify inputfile\n'
+    exit()
+    
+
+
+process = cms.Process("DumpFileToDB")
+process.load("CondCore.DBCommon.CondDBSetup_cfi")
+
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(1),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+
+
+OUTPUTFILE = INPUTFILE.replace('.txt','')+"_"+DBFORMAT+".db"
+
+
+RECORD=""
+GRANULARITY = "bySL"
+
+if TYPE=="TZeroDB" :
+    RECORD = "DTT0Rcd"
+    GRANULARITY = "byWire"
+if DBFORMAT=="Legacy" :
+    if TYPE=="TTrigDB" : RECORD = "DTTtrigRcd"
+    if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
+    if TYPE=="UncertDB" :
+        RECORD = "DTRecoUncertaintiesRcd"
+        print '\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code'
+elif DBFORMAT=="DTRecoConditions" :
+    if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
+    if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"
+    if TYPE=="UncertDB" :
+        RECORD = "DTRecoConditionsUncertRcd"
+        TYPE='RecoUncertDB'
+try:
+    os.remove(OUTPUTFILE)
+except OSError:
+    pass
+
+
+print '\n Reading ', TYPE, ' from ', INPUTFILE
+print '      Record : ', RECORD
+print 'writing db file : ', OUTPUTFILE, '\n'
+
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                          process.CondDBSetup,
+                                          connect = cms.string("sqlite_file:"+OUTPUTFILE),
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string(RECORD),
+                                                                     tag = cms.string(TYPE)))
+                                          )
+
+
+
+#Module to convert calibration table into a DB file
+process.dumpToDB = cms.EDAnalyzer("DumpFileToDB",
+                                  calibFileConfig = cms.untracked.PSet(
+                                      calibConstFileName = cms.untracked.string(INPUTFILE),
+                                      calibConstGranularity = cms.untracked.string(GRANULARITY),
+                                      ),
+                                  dbFormat = cms.untracked.string(DBFORMAT),
+                                  dbToDump = cms.untracked.string(TYPE),
+                                )
+
+
+
+
+process.p = cms.Path(process.dumpToDB)
+    
+

--- a/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
+++ b/CalibMuon/DTCalibration/test/DumpFileToDB_cfg.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import FWCore.ParameterSet.Config as cms
 import FWCore.ParameterSet.VarParsing as VarParsing
 import os
@@ -32,15 +33,15 @@ INPUTFILE = options.inputfile
 #Input sanification
 
 if DBFORMAT not in ['Legacy', 'DTRecoConditions'] :
-    print '\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n'
+    print('\nERROR: invalid value for dbformat: ',  DBFORMAT,'\n')
     exit()
     
 if TYPE not in ['TZeroDB', 'TTrigDB',  'VDriftDB', 'UncertDB'] :
-    print '\nERROR: invalid value for type: ',  TYPE,'\n'
+    print('\nERROR: invalid value for type: ',  TYPE,'\n')
     exit()
 
 if INPUTFILE == '' :
-    print '\nERROR: must specify inputfile\n'
+    print('\nERROR: must specify inputfile\n')
     exit()
     
 
@@ -74,7 +75,7 @@ if DBFORMAT=="Legacy" :
     if TYPE=="VDriftDB" : RECORD = "DTMtimeRcd"
     if TYPE=="UncertDB" :
         RECORD = "DTRecoUncertaintiesRcd"
-        print '\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code'
+        print('\nWARNING, Legacy RecoUncertDB is deprecated, as it is no longer used in reconstruction code')
 elif DBFORMAT=="DTRecoConditions" :
     if TYPE=="TTrigDB" : RECORD = "DTRecoConditionsTtrigRcd"
     if TYPE=="VDriftDB" : RECORD = "DTRecoConditionsVdriftRcd"
@@ -87,9 +88,9 @@ except OSError:
     pass
 
 
-print '\n Reading ', TYPE, ' from ', INPUTFILE
-print '      Record : ', RECORD
-print 'writing db file : ', OUTPUTFILE, '\n'
+print('\n Reading ', TYPE, ' from ', INPUTFILE)
+print('      Record : ', RECORD)
+print('writing db file : ', OUTPUTFILE, '\n')
 
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",


### PR DESCRIPTION
#### PR description:

New DT payload formats were introduced with #5977, but so far have been adopted only for uncertainties (#9883).
This PR includes some updates to DT vdrift calibration code/scripts to enable to optionally read/write constants in the new format.
The default behaviour is unchanged (ie use the legacy format); it is one step towards enabling a complete migration.

#### PR validation:

Code changes tested by @saghosh : 
- running the calibration with the default configuration (ie legacy format) produces identical results as before;
- enabling the writing in the new fomat produces identical constants as in the previous step.