### PR TITLE
[SLHCUpgradeSimulations/Geometry] update writeFile_phase2_cfg.py and use it for unit tests

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
+++ b/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
@@ -38,4 +38,9 @@
     <use name="FWCore/Utilities"/>
   </bin>
 
+  <bin name="testPhase2SkimmedGeometry" file="testPhase2SkimmedGeometry.cpp">
+    <flags TEST_RUNNER_ARGS="/bin/bash SLHCUpgradeSimulations/Geometry/test phase2_skimmed_geometry.sh "/>
+    <use name="FWCore/Utilities"/>
+  </bin>
+
 </environment>

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_skimmed_geometry.sh
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_skimmed_geometry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+(cmsRun ${LOCAL_TEST_DIR}/writeFile_phase2_cfg.py 0) || die 'Failure running cmsRun writeFile_phase2_cfg.py 0' $?

--- a/SLHCUpgradeSimulations/Geometry/test/testPhase2SkimmedGeometry.cpp
+++ b/SLHCUpgradeSimulations/Geometry/test/testPhase2SkimmedGeometry.cpp
@@ -1,0 +1,2 @@
+#include "FWCore/Utilities/interface/TestHelper.h"
+RUNTEST()

--- a/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/writeFile_phase2_cfg.py
@@ -2,14 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
 process.load("Configuration.StandardSequences.Services_cff")
-process.load('Configuration.Geometry.GeometryExtended2023D17Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
 
 process.trackerGeometry.applyAlignment = cms.bool(False)
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
-
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
 
 process.source = cms.Source("EmptyIOVSource",
     firstValue = cms.uint64(1),
@@ -29,7 +28,7 @@ process.prodstrip = cms.EDAnalyzer("SiStripDetInfoFileWriter",
 )
 
 process.prodpixel = cms.EDAnalyzer("SiPixelDetInfoFileWriter",
-    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2023Tilted.txt'),
+    FilePath = cms.untracked.string('PixelSkimmedGeometry_GeometryExtended2026Tilted_D49.txt'),
     WriteROCInfo = cms.untracked.bool(True)
 )
 


### PR DESCRIPTION
#### PR description:

This PR addresses problem n. 3) described in issue: https://github.com/cms-sw/cmssw/issues/31739.
The test configuration `writeFile_phase2_cfg.py` is still potentially needed to generate pixel skimmed geometry files to be given as input of pixel fake conditions `ESproducer`s. The functionality of the configuration is restored (by updating to the detector geometry D49 / T15, long-term supported for the HLT TDR) and a new unit test is added, exercising it.

#### PR validation:

The new unit test runs.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
cc:
@vargasa 
