### PR TITLE
[10_6_X] Add ntracks associated to each SV

### DIFF
--- a/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
+++ b/PhysicsTools/NanoAOD/python/nanoDQM_cfi.py
@@ -589,6 +589,7 @@ nanoDQM = DQMEDAnalyzer("NanoAODDQM",
                 Plot1D('x', 'x', 20, -0.5, 0.5, 'secondary vertex X position, in cm'),
                 Plot1D('y', 'y', 20, -0.5, 0.5, 'secondary vertex Y position, in cm'),
                 Plot1D('z', 'z', 20, -10, 10, 'secondary vertex Z position, in cm'),
+                Plot1D('ntracks', 'ntracks', 11, -0.5, 10.5, 'number of tracks'),
             )
         ),
         SoftActivityJet = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/vertices_cff.py
+++ b/PhysicsTools/NanoAOD/python/vertices_cff.py
@@ -31,6 +31,7 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
         z   = Var("position().z()", float, doc = "secondary vertex Z position, in cm",precision=14),
         ndof   = Var("vertexNdof()", float, doc = "number of degrees of freedom",precision=8),
         chi2   = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
+        ntracks = Var("numberOfDaughters()", "uint8", doc = "number of tracks"),
     ),
 )
 svCandidateTable.variables.pt.precision=10


### PR DESCRIPTION
Backport of PR #31696

**Validation:**
produced a test sample in mc and data
increase in size/evt and time/evt: negligible [<0.01%]

