### PR TITLE
Strip Gain Calibration PCL: split monitoring of TEC (in thick and thin sensors)

### DIFF
--- a/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainHelpers.h
@@ -19,6 +19,8 @@ namespace APVGain {
   int subdetectorId(uint32_t);
   int subdetectorId(const std::string&);
   int subdetectorSide(uint32_t, const TrackerTopology*);
+  int thickness(uint32_t);
+  int thickness(const std::string& tag);
   int subdetectorSide(const std::string&);
   int subdetectorPlane(uint32_t, const TrackerTopology*);
   int subdetectorPlane(const std::string&);
@@ -27,8 +29,8 @@ namespace APVGain {
 
   struct APVmon {
   public:
-    APVmon(int v1, int v2, int v3, MonitorElement* v4)
-        : m_subdetectorId(v1), m_subdetectorSide(v2), m_subdetectorPlane(v3), m_monitor(v4) {}
+    APVmon(int v0, int v1, int v2, int v3, MonitorElement* v4)
+        : m_thickness(v0), m_subdetectorId(v1), m_subdetectorSide(v2), m_subdetectorPlane(v3), m_monitor(v4) {}
 
     int getSubdetectorId() { return m_subdetectorId; }
 
@@ -36,17 +38,21 @@ namespace APVGain {
 
     int getSubdetectorPlane() { return m_subdetectorPlane; }
 
+    int getThickness() { return m_thickness; }
+
     MonitorElement* getMonitor() { return m_monitor; }
 
     void printAll() {
       LogDebug("APVGainHelpers") << "subDetectorID:" << m_subdetectorId << std::endl;
       LogDebug("APVGainHelpers") << "subDetectorSide:" << m_subdetectorSide << std::endl;
       LogDebug("APVGainHelpers") << "subDetectorPlane:" << m_subdetectorPlane << std::endl;
+      LogDebug("APVGainHelpers") << "thickness:" << m_thickness << std::endl;
       LogDebug("APVGainHelpers") << "histoName:" << m_monitor->getName() << std::endl;
       return;
     }
 
   private:
+    int m_thickness;
     int m_subdetectorId;
     int m_subdetectorSide;
     int m_subdetectorPlane;

--- a/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
+++ b/CalibTracker/SiStripChannelGain/interface/APVGainStruct.h
@@ -35,9 +35,10 @@ struct stAPVGain {
 
 struct APVloc {
 public:
-  APVloc(int v1, int v2, int v3, const std::string& s)
-      : m_subdetectorId(v1), m_subdetectorSide(v2), m_subdetectorPlane(v3), m_string(s) {}
+  APVloc(int v0, int v1, int v2, int v3, const std::string& s)
+      : m_thickness(v0), m_subdetectorId(v1), m_subdetectorSide(v2), m_subdetectorPlane(v3), m_string(s) {}
 
+  int m_thickness;
   int m_subdetectorId;
   int m_subdetectorSide;
   int m_subdetectorPlane;
@@ -45,7 +46,7 @@ public:
 
   bool operator==(const APVloc& a) const {
     return (m_subdetectorId == a.m_subdetectorId && m_subdetectorSide == a.m_subdetectorSide &&
-            m_subdetectorPlane == a.m_subdetectorPlane);
+            m_subdetectorPlane == a.m_subdetectorPlane && m_thickness == a.m_thickness);
   }
 };
 

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainFromCalibTree.cc
@@ -539,40 +539,44 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
   for (unsigned int i = 0; i < hnames.size(); i++) {
     std::string htag = (hnames[i]).first + stag;
     MonitorElement* monitor = dbe->book1DD(htag.c_str(), (hnames[i]).second.c_str(), 100, 0., 1000.);
+    int thick = APVGain::thickness((hnames[i]).first);
     int id = APVGain::subdetectorId((hnames[i]).first);
     int side = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_1[elepos].push_back(APVGain::APVmon(id, side, plane, monitor));
+    Charge_1[elepos].push_back(APVGain::APVmon(thick, id, side, plane, monitor));
   }
 
   hnames = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG2");
   for (unsigned int i = 0; i < hnames.size(); i++) {
     std::string htag = (hnames[i]).first + stag;
     MonitorElement* monitor = dbe->book1DD(htag.c_str(), (hnames[i]).second.c_str(), 100, 0., 1000.);
+    int thick = APVGain::thickness((hnames[i]).first);
     int id = APVGain::subdetectorId((hnames[i]).first);
     int side = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_2[elepos].push_back(APVGain::APVmon(id, side, plane, monitor));
+    Charge_2[elepos].push_back(APVGain::APVmon(thick, id, side, plane, monitor));
   }
 
   hnames = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG1");
   for (unsigned int i = 0; i < hnames.size(); i++) {
     std::string htag = (hnames[i]).first + stag;
     MonitorElement* monitor = dbe->book1DD(htag.c_str(), (hnames[i]).second.c_str(), 100, 0., 1000.);
+    int thick = APVGain::thickness((hnames[i]).first);
     int id = APVGain::subdetectorId((hnames[i]).first);
     int side = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_3[elepos].push_back(APVGain::APVmon(id, side, plane, monitor));
+    Charge_3[elepos].push_back(APVGain::APVmon(thick, id, side, plane, monitor));
   }
 
   hnames = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG1G2");
   for (unsigned int i = 0; i < hnames.size(); i++) {
     std::string htag = (hnames[i]).first + stag;
     MonitorElement* monitor = dbe->book1DD(htag.c_str(), (hnames[i]).second.c_str(), 100, 0., 1000.);
+    int thick = APVGain::thickness((hnames[i]).first);
     int id = APVGain::subdetectorId((hnames[i]).first);
     int side = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
-    Charge_4[elepos].push_back(APVGain::APVmon(id, side, plane, monitor));
+    Charge_4[elepos].push_back(APVGain::APVmon(thick, id, side, plane, monitor));
   }
 
   //Book validation histograms
@@ -637,10 +641,11 @@ void SiStripGainFromCalibTree::bookDQMHistos(const char* dqm_dir, const char* ta
         APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "newG2");
     for (unsigned int i = 0; i < hnames.size(); i++) {
       MonitorElement* monitor = dbe->book1DD((hnames[i]).first.c_str(), (hnames[i]).second.c_str(), 100, 0., 1000.);
+      int thick = APVGain::thickness((hnames[i]).first);
       int id = APVGain::subdetectorId((hnames[i]).first);
       int side = APVGain::subdetectorSide((hnames[i]).first);
       int plane = APVGain::subdetectorPlane((hnames[i]).first);
-      newCharge.push_back(APVGain::APVmon(id, side, plane, monitor));
+      newCharge.push_back(APVGain::APVmon(thick, id, side, plane, monitor));
     }
   }
 }
@@ -977,7 +982,7 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
           APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "");
       for (unsigned int i = 0; i < tags.size(); i++) {
         std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
-        Charge_1[elepos].push_back(APVGain::APVmon(0, 0, 0, dbe->get(tag)));
+        Charge_1[elepos].push_back(APVGain::APVmon(0, 0, 0, 0, dbe->get(tag)));
         if ((Charge_1[elepos][i]).getMonitor() == nullptr) {
           edm::LogError("SiStripGainFromCalibTree")
               << "Harvesting: could not retrieve " << tag.c_str() << ", statistics will not be summed!" << std::endl;
@@ -988,7 +993,7 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
       tags = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG2");
       for (unsigned int i = 0; i < tags.size(); i++) {
         std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
-        Charge_2[elepos].push_back(APVGain::APVmon(0, 0, 0, dbe->get(tag)));
+        Charge_2[elepos].push_back(APVGain::APVmon(0, 0, 0, 0, dbe->get(tag)));
         if ((Charge_2[elepos][i]).getMonitor() == nullptr) {
           edm::LogError("SiStripGainFromCalibTree")
               << "Harvesting: could not retrieve " << tag.c_str() << ", statistics will not be summed!" << std::endl;
@@ -999,7 +1004,7 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
       tags = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG1");
       for (unsigned int i = 0; i < tags.size(); i++) {
         std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
-        Charge_3[elepos].push_back(APVGain::APVmon(0, 0, 0, dbe->get(tag)));
+        Charge_3[elepos].push_back(APVGain::APVmon(0, 0, 0, 0, dbe->get(tag)));
         if ((Charge_3[elepos][i]).getMonitor() == nullptr) {
           edm::LogError("SiStripGainFromCalibTree")
               << "Harvesting: could not retrieve " << tag.c_str() << ", statistics will not be summed!" << std::endl;
@@ -1010,7 +1015,7 @@ void SiStripGainFromCalibTree::algoEndRun(const edm::Run& run, const edm::EventS
       tags = APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "woG1G2");
       for (unsigned int i = 0; i < tags.size(); i++) {
         std::string tag = DQM_dir + "/" + (tags[i]).first + stag;
-        Charge_4[elepos].push_back(APVGain::APVmon(0, 0, 0, dbe->get(tag)));
+        Charge_4[elepos].push_back(APVGain::APVmon(0, 0, 0, 0, dbe->get(tag)));
         if ((Charge_4[elepos][i]).getMonitor() == nullptr) {
           edm::LogError("SiStripGainFromCalibTree")
               << "Harvesting: could not retrieve " << tag.c_str() << ", statistics will not be summed!" << std::endl;

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLHarvester_cfi.py
@@ -10,5 +10,5 @@ SiStripGainsPCLHarvester = DQMEDHarvester(
     minNrEntries        = cms.untracked.double(25),
     GoodFracForTagProd  = cms.untracked.double(0.98),
     NClustersForTagProd = cms.untracked.double(8E8),
-    ChargeHisto         = cms.untracked.vstring('TIB','TIB_layer_1','TOB','TOB_layer_1','TIDminus','TIDplus','TECminus','TECplus')
+    ChargeHisto         = cms.untracked.vstring('TIB','TIB_layer_1','TOB','TOB_layer_1','TIDminus','TIDplus','TECminus','TECplus','TEC_thin','TEC_thick')
     )

--- a/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
+++ b/CalibTracker/SiStripChannelGain/python/SiStripGainsPCLWorker_cfi.py
@@ -11,7 +11,7 @@ SiStripGainsPCLWorker = DQMEDAnalyzer(
     UseCalibration      = cms.untracked.bool(False),
     DQMdir              = cms.untracked.string('AlCaReco/SiStripGains'),
     calibrationMode     = cms.untracked.string('StdBunch'),
-    ChargeHisto         = cms.untracked.vstring('TIB','TIB_layer_1','TOB','TOB_layer_1','TIDminus','TIDplus','TECminus','TECplus'),
+    ChargeHisto         = cms.untracked.vstring('TIB','TIB_layer_1','TOB','TOB_layer_1','TIDminus','TIDplus','TECminus','TECplus','TEC_thin','TEC_thick'),
     gain                = cms.untracked.PSet(label = cms.untracked.string('shallowGainCalibration'), 
                                              prefix = cms.untracked.string("GainCalibration"), 
                                              suffix = cms.untracked.string('')

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLHarvester.cc
@@ -167,10 +167,11 @@ void SiStripGainsPCLHarvester::gainQualityMonitor(DQMStore::IBooker& ibooker_,
       APVGain::monHnames(VChargeHisto, doChargeMonitorPerPlane, "newG2");
   for (unsigned int i = 0; i < cnames.size(); i++) {
     MonitorElement* monitor = ibooker_.book1DD((cnames[i]).first, (cnames[i]).second.c_str(), 100, 0., 1000.);
+    int thick = APVGain::thickness((cnames[i]).first);
     int id = APVGain::subdetectorId((cnames[i]).first);
     int side = APVGain::subdetectorSide((cnames[i]).first);
     int plane = APVGain::subdetectorPlane((cnames[i]).first);
-    new_charge_histos.push_back(APVGain::APVmon(id, side, plane, monitor));
+    new_charge_histos.push_back(APVGain::APVmon(thick, id, side, plane, monitor));
   }
 
   int MPVbin = 300;

--- a/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
+++ b/CalibTracker/SiStripChannelGain/src/SiStripGainsPCLWorker.cc
@@ -32,9 +32,10 @@ SiStripGainsPCLWorker::SiStripGainsPCLWorker(const edm::ParameterSet& iConfig) {
     int id = APVGain::subdetectorId((hnames[i]).first);
     int side = APVGain::subdetectorSide((hnames[i]).first);
     int plane = APVGain::subdetectorPlane((hnames[i]).first);
+    int thick = APVGain::thickness((hnames[i]).first);
     std::string s = hnames[i].first;
 
-    auto loc = APVloc(id, side, plane, s);
+    auto loc = APVloc(thick, id, side, plane, s);
     theTopologyMap.insert(std::make_pair(i, loc));
   }
 


### PR DESCRIPTION
#### PR description:

It has been noticed that the Strip normalized Cluster Charge monitoring plots for the Strip G2 Gain Calibration procedure do not differentiate by thickness of the sensor. 
This is relevant, especially in the Tracker End caps as two different thicknesses are employed based on the ring (thin sensors in TEC R1, R2, R3 and R4 while thick ones are used in TEC R5,R6 and R7).
This PR adds the necessary machinery to split thin and thick sensors and uses it to create plots for the Strip normalized Cluster Charge separately for `TEC thin` and `TEC thick`.

#### PR validation:

I've tested the full workflow with the following commands:
```
cmsDriver.py stepALCA --datatier ALCARECO --conditions auto:run2_data -s ALCA:PromptCalibProdSiStripGains --eventcontent ALCARECO -n 1000 --dasquery='file dataset=/ZeroBias/Run2016C-SiStripCalMinBias-18Apr2017-v1/ALCARECO run=276243' --nThreads=4 
```
followed by:
```
cmsDriver.py stepHarvest --data --conditions auto:run2_data --scenario pp -s ALCAHARVEST:SiStripGains --filein file:PromptCalibProdSiStripGains.root -n -1 --fileout file:calib.root
```

The output DQM file has been streamed to a local GUI and the new plots are visible:

![image](https://user-images.githubusercontent.com/5082376/95970535-5ac41e80-0e10-11eb-93bc-8b52b770943a.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, and no backport is needed.
