### PR TITLE
[GCC9]Add explicit fallthrough attribute to fix gcc9 warnings

### DIFF
--- a/CondFormats/L1TObjects/src/L1TUtmTriggerMenu.cc
+++ b/CondFormats/L1TObjects/src/L1TUtmTriggerMenu.cc
@@ -49,8 +49,10 @@ unsigned long L1TUtmTriggerMenu::murmurHashNeutral2(const void* key, int len, un
   switch (len) {
     case 3:
       h ^= data[2] << 16;
+      [[fallthrough]];
     case 2:
       h ^= data[1] << 8;
+      [[fallthrough]];
     case 1:
       h ^= data[0];
       h *= m;


### PR DESCRIPTION
After the integration of https://github.com/cms-sw/cmssw/pull/31461 we have couple of warnings in gcc 9 build. Following the logic of code at https://github.com/cms-sw/cmssw/pull/31461/files#diff-a30c4a7e7b7c0ef805308e09ce88ca4ccf9488123572c17d35579d12399636e7R28-R45 , the fallthrough is on purpose. This PR explicitly adds the fallthrough attribute to silence GCC 9 warnings