### PR TITLE
ES DQM: Enable concurrent processing of lumisections

### DIFF
--- a/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
@@ -11,6 +11,7 @@
 
 struct ESLSCache {
   int ievtLS_;
+  int DIErrorsLS_[2][2][40][40];
 };
 
 class ESIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESLSCache>> {

--- a/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
@@ -9,7 +9,11 @@
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-class ESIntegrityTask : public DQMOneLumiEDAnalyzer<> {
+struct ESLSCache {
+  int ievtLS_;
+};
+
+class ESIntegrityTask : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<ESLSCache>> {
 public:
   ESIntegrityTask(const edm::ParameterSet& ps);
   ~ESIntegrityTask() override {}
@@ -27,13 +31,13 @@ protected:
   void dqmEndRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   /// Begin Lumi
-  void dqmBeginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
+  std::shared_ptr<ESLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) const override;
 
   /// End Lumi
-  void dqmEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;
 
   /// Calculate Data Integrity Fraction
-  void calculateDIFraction(void);
+  void calculateDIFraction(const edm::LuminosityBlock& lumi, const edm::EventSetup& c);
 
 private:
   int ievt_;

--- a/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
+++ b/DQM/EcalPreshowerMonitorModule/interface/ESIntegrityTask.h
@@ -31,7 +31,8 @@ protected:
   void dqmEndRun(const edm::Run& r, const edm::EventSetup& c) override;
 
   /// Begin Lumi
-  std::shared_ptr<ESLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) const override;
+  std::shared_ptr<ESLSCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                        const edm::EventSetup& c) const override;
 
   /// End Lumi
   void globalEndLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) override;

--- a/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
@@ -67,7 +67,8 @@ void ESIntegrityTask::dqmEndRun(const Run& r, const EventSetup& c) {
   // TODO: no longer possible, clone histo beforehand if full statisticcs at end of run are required.
 }
 
-std::shared_ptr<ESLSCache> ESIntegrityTask::globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& c) const {
+std::shared_ptr<ESLSCache> ESIntegrityTask::globalBeginLuminosityBlock(const edm::LuminosityBlock& lumi,
+                                                                       const edm::EventSetup& c) const {
   LogInfo("ESIntegrityTask") << "analyzed " << ievt_ << " events";
   // In case of Lumi based analysis SoftReset the Integrity histogram
   auto lumiCache = std::make_shared<ESLSCache>();
@@ -343,7 +344,8 @@ void ESIntegrityTask::calculateDIFraction(const edm::LuminosityBlock& lumi, cons
           nValidChannelsES++;
         }
       }
-      if (nValidChannelsES != 0) reportSummaryES = 1 - nGlobalErrorsES / nValidChannelsES;
+      if (nValidChannelsES != 0)
+        reportSummaryES = 1 - nGlobalErrorsES / nValidChannelsES;
       meDIFraction_->setBinContent(i + 1, j + 1, reportSummaryES);
     }
   }

--- a/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
+++ b/DQM/EcalPreshowerMonitorModule/src/ESIntegrityTask.cc
@@ -336,7 +336,7 @@ void ESIntegrityTask::calculateDIFraction(const edm::LuminosityBlock& lumi, cons
       float reportSummaryES = -1;
       for (int x = 0; x < 40; ++x) {
         for (int y = 0; y < 40; ++y) {
-          float val = 1.0*((lumiCache->DIErrorsLS_)[i][j][x][y]);
+          float val = 1.0 * ((lumiCache->DIErrorsLS_)[i][j][x][y]);
           if (fed_[i][j][x][y] == -1)
             continue;
           if ((lumiCache->ievtLS_) != 0)


### PR DESCRIPTION
This fix enables concurrent processing of lumisections with ESIntegrityTask included in the workflow.

#### PR description:

This PR changes ESIntegrityTask from a `DQMOneLumiEDAnalyzer` to a `DQMOneEDAnalyzer` to enable concurrent processing of lumisections.

#### PR validation:
The standard suite of tests was run: `runTheMatrix.py -l limited -i all --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport.

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
