### PR TITLE
Add maximum of pileup pT hats in JME custom NanoAOD

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -18,8 +18,7 @@ public:
       : npuTag_(consumes<std::vector<PileupSummaryInfo>>(params.getParameter<edm::InputTag>("src"))),
         pvTag_(consumes<std::vector<reco::Vertex>>(params.getParameter<edm::InputTag>("pvsrc"))),
         vz_(params.getParameter<std::vector<double>>("zbins")),
-        savePtHatMax_(params.getParameter<bool>("savePtHatMax"))
-        {
+        savePtHatMax_(params.getParameter<bool>("savePtHatMax")) {
     produces<nanoaod::FlatTable>();
   }
 
@@ -51,7 +50,7 @@ public:
     float gpudensity = 0;
 
     float pthatmax = 0;
-    
+
     for (unsigned int ibx = 0; ibx < npuProd.size(); ibx++) {
       if (npuProd[ibx].getBunchCrossing() == 0) {
         bx0 = ibx;
@@ -70,7 +69,7 @@ public:
         }
         gpudensity /= (20.0 * (*(zbin) - *(zbin - 1)));
 
-        if (savePtHatMax_){
+        if (savePtHatMax_) {
           pthatmax = *max_element(npuProd[ibx].getPU_pT_hats().begin(), npuProd[ibx].getPU_pT_hats().end());
         }
       }
@@ -95,7 +94,7 @@ public:
     out.addColumnValue<int>("sumLOOT", loot, "number of late out of time pileup");
     out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
     out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
-    if (savePtHatMax_){
+    if (savePtHatMax_) {
       out.addColumnValue<float>("pthatmax", pthatmax, "Maximum pt-hat");
     }
   }
@@ -107,7 +106,7 @@ public:
     desc.add<edm::InputTag>("pvsrc", edm::InputTag("offlineSlimmedPrimaryVertices"))->setComment("tag for the PVs");
     desc.add<std::vector<double>>("zbins", {})
         ->setComment("Z bins to compute the generator-level number of PU vertices per mm");
-    desc.add<bool>("savePtHatMax",false)->setComment("Store maximum pt-hat of PU");
+    desc.add<bool>("savePtHatMax", false)->setComment("Store maximum pt-hat of PU");
     descriptions.add("puTable", desc);
   }
 

--- a/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/NPUTablesProducer.cc
@@ -10,13 +10,16 @@
 
 #include <vector>
 #include <iostream>
+#include <algorithm>
 
 class NPUTablesProducer : public edm::global::EDProducer<> {
 public:
   NPUTablesProducer(edm::ParameterSet const& params)
       : npuTag_(consumes<std::vector<PileupSummaryInfo>>(params.getParameter<edm::InputTag>("src"))),
         pvTag_(consumes<std::vector<reco::Vertex>>(params.getParameter<edm::InputTag>("pvsrc"))),
-        vz_(params.getParameter<std::vector<double>>("zbins")) {
+        vz_(params.getParameter<std::vector<double>>("zbins")),
+        savePtHatMax_(params.getParameter<bool>("savePtHatMax"))
+        {
     produces<nanoaod::FlatTable>();
   }
 
@@ -47,6 +50,8 @@ public:
     float pudensity = 0;
     float gpudensity = 0;
 
+    float pthatmax = 0;
+    
     for (unsigned int ibx = 0; ibx < npuProd.size(); ibx++) {
       if (npuProd[ibx].getBunchCrossing() == 0) {
         bx0 = ibx;
@@ -64,6 +69,10 @@ public:
             gpudensity++;
         }
         gpudensity /= (20.0 * (*(zbin) - *(zbin - 1)));
+
+        if (savePtHatMax_){
+          pthatmax = *max_element(npuProd[ibx].getPU_pT_hats().begin(), npuProd[ibx].getPU_pT_hats().end());
+        }
       }
     }
     unsigned int eoot = 0;
@@ -86,6 +95,9 @@ public:
     out.addColumnValue<int>("sumLOOT", loot, "number of late out of time pileup");
     out.addColumnValue<float>("pudensity", pudensity, "PU vertices / mm");
     out.addColumnValue<float>("gpudensity", gpudensity, "Generator-level PU vertices / mm");
+    if (savePtHatMax_){
+      out.addColumnValue<float>("pthatmax", pthatmax, "Maximum pt-hat");
+    }
   }
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -95,6 +107,7 @@ public:
     desc.add<edm::InputTag>("pvsrc", edm::InputTag("offlineSlimmedPrimaryVertices"))->setComment("tag for the PVs");
     desc.add<std::vector<double>>("zbins", {})
         ->setComment("Z bins to compute the generator-level number of PU vertices per mm");
+    desc.add<bool>("savePtHatMax",false)->setComment("Store maximum pt-hat of PU");
     descriptions.add("puTable", desc);
   }
 
@@ -103,6 +116,8 @@ protected:
   const edm::EDGetTokenT<std::vector<reco::Vertex>> pvTag_;
 
   const std::vector<double> vz_;
+
+  bool savePtHatMax_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/NanoAOD/python/custom_jme_cff.py
+++ b/PhysicsTools/NanoAOD/python/custom_jme_cff.py
@@ -874,6 +874,12 @@ def PrepJMECustomNanoAOD(process,runOnMC):
     cfg = { k : v for k, v in jetConfig.items() if k != "enabled"}
     recoJetInfo = recoJA.addRecoJetCollection(process, **cfg)
     AddNewPatJets(process, recoJetInfo, runOnMC)
+
+  ###########################################################################
+  # Save Maximum of Pt Hat Max
+  ###########################################################################
+  if runOnMC:
+    process.puTable.savePtHatMax = True
   
   return process
 

--- a/PhysicsTools/NanoAOD/python/globals_cff.py
+++ b/PhysicsTools/NanoAOD/python/globals_cff.py
@@ -14,7 +14,8 @@ rhoTable = cms.EDProducer("GlobalVariablesTableProducer",
 puTable = cms.EDProducer("NPUTablesProducer",
         src = cms.InputTag("slimmedAddPileupInfo"),
         pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
-        zbins = cms.vdouble( [0.0,1.7,2.6,3.0,3.5,4.2,5.2,6.0,7.5,9.0,12.0] )
+        zbins = cms.vdouble( [0.0,1.7,2.6,3.0,3.5,4.2,5.2,6.0,7.5,9.0,12.0] ),
+        savePtHatMax = cms.bool(False), 
 )
 
 genTable  = cms.EDProducer("SimpleGenEventFlatTableProducer",


### PR DESCRIPTION
**PR description:**

This PR adds the maximum of the pileup pT hats into the JME custom NanoAOD. This is done by modifying `NPUTablesProducer.cc`  to find the maximum value in the `vector<float>` returned by `getPU_pT_hats()` and then store in the PileUp table. 

A flag is also added and set to **false** in `globals_cff.py` so that this variable will not be stored in the main NanoAODs. The flag is set to true in `custom_jme_cff.py` so that it will be stored in the JME custom NanoAOD format.  

The variable is needed by JERC analyses, which will use the JME Custom NanoAODs.

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

This PR needs to be backported to 10_6_X, once merged, for the ultra legacy campaigns.