### PR TITLE
Add EventSetup-consumes-migrated code path to TrackTransformer, use it in some Muon code

### DIFF
--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -1,26 +1,31 @@
 #ifndef CSCSEGTORPC_H
 #define CSCSEGTORPC_H
 
-#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 
 #include <memory>
 
+class RPCGeometry;
+class CSCGeometry;
+class CSCObjectMap;
+class MuonGeometryRecord;
+
 class CSCSegtoRPC {
 public:
-  CSCSegtoRPC(CSCSegmentCollection const* allCSCSegments, edm::EventSetup const& iSetup, bool debug, double eyr);
-  ~CSCSegtoRPC();
-  std::unique_ptr<RPCRecHitCollection>&& thePoints() { return std::move(_ThePoints); }
+  explicit CSCSegtoRPC(edm::ConsumesCollector iC);
+  std::unique_ptr<RPCRecHitCollection> thePoints(CSCSegmentCollection const* allCSCSegments,
+                                                 edm::EventSetup const& iSetup,
+                                                 bool debug,
+                                                 double eyr);
 
 private:
-  std::unique_ptr<RPCRecHitCollection> _ThePoints;
-  edm::OwnVector<RPCRecHit> RPCPointVector;
-  bool inclcsc;
-  double MaxD;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeoToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeoToken_;
+  edm::ESGetToken<CSCObjectMap, MuonGeometryRecord> cscMapToken_;
 };
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -1,31 +1,38 @@
 #ifndef DTSEGTORPC_H
 #define DTSEGTORPC_H
 
-#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
 #include <memory>
 
+class RPCGeometry;
+class DTGeometry;
+class DTObjectMap;
+class MuonGeometryRecord;
+
 class DTSegtoRPC {
 public:
-  DTSegtoRPC(DTRecSegment4DCollection const* all4DSegments, edm::EventSetup const& iSetup, bool debug, double eyr);
-  ~DTSegtoRPC();
-  std::unique_ptr<RPCRecHitCollection>&& thePoints() { return std::move(_ThePoints); }
+  explicit DTSegtoRPC(edm::ConsumesCollector iC);
+  std::unique_ptr<RPCRecHitCollection> thePoints(DTRecSegment4DCollection const* all4DSegments,
+                                                 edm::EventSetup const& iSetup,
+                                                 bool debug,
+                                                 double eyr);
 
 private:
-  std::unique_ptr<RPCRecHitCollection> _ThePoints;
-  edm::OwnVector<RPCRecHit> RPCPointVector;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeoToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeoToken_;
+  edm::ESGetToken<DTObjectMap, MuonGeometryRecord> dtMapToken_;
+
   bool incldt;
   bool incldtMB4;
   double MinCosAng;
   double MaxD;
   double MaxDrb4;
   double MaxDistanceBetweenSegments;
-  std::vector<uint32_t> extrapolatedRolls;
 };
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -19,17 +19,20 @@
 // class decleration
 //
 
-class RPCPointProducer : public edm::global::EDProducer<> {
+class RPCPointProducer : public edm::stream::EDProducer<> {
 public:
   explicit RPCPointProducer(const edm::ParameterSet&);
 
 private:
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-  const edm::EDGetTokenT<CSCSegmentCollection> cscSegments;
-  const edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegments;
-  const edm::EDGetTokenT<reco::TrackCollection> tracks;
-  const edm::InputTag tracks_;
+  edm::EDGetTokenT<CSCSegmentCollection> cscSegments;
+  edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegments;
+  edm::EDGetTokenT<reco::TrackCollection> tracks;
+
+  std::unique_ptr<DTSegtoRPC> dtSegtoRPC;
+  std::unique_ptr<CSCSegtoRPC> cscSegtoRPC;
+  std::unique_ptr<TracktoRPC> tracktoRPC;
 
   const bool incldt;
   const bool inclcsc;
@@ -39,5 +42,4 @@ private:
   const double MaxD;
   const double MaxDrb4;
   const double ExtrapolatedRegion;
-  const edm::ParameterSet trackTransformerParam;
 };

--- a/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
@@ -3,11 +3,9 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -51,29 +49,36 @@
 
 #include <memory>
 
+class RPCGeometry;
+class DTGeometry;
+class DTObjectMap;
+class CSCGeometry;
+class CSCObjectMap;
+class MuonGeometryRecord;
+class Propagator;
+class TrackingComponentsRecord;
+
 using reco::MuonCollection;
 using reco::TrackCollection;
 typedef std::vector<Trajectory> Trajectories;
 
 class TracktoRPC {
 public:
-  TracktoRPC(reco::TrackCollection const* alltracks,
-             edm::EventSetup const& iSetup,
-             bool debug,
-             const edm::ParameterSet& iConfig,
-             const edm::InputTag& tracklabel);
-  ~TracktoRPC();
-  std::unique_ptr<RPCRecHitCollection>&& thePoints() { return std::move(_ThePoints); }
+  TracktoRPC(const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel, edm::ConsumesCollector iC);
+  std::unique_ptr<RPCRecHitCollection> thePoints(reco::TrackCollection const* alltracks,
+                                                 edm::EventSetup const& iSetup,
+                                                 bool debug);
 
 private:
-  bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup);
+  bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const RPCGeometry* rpcGeo);
 
-  std::unique_ptr<RPCRecHitCollection> _ThePoints;
-  edm::OwnVector<RPCRecHit> RPCPointVector;
-  double MaxD;
-
-  TrackTransformerBase* theTrackTransformer;
-  edm::ESHandle<Propagator> thePropagator;
+  edm::ESGetToken<RPCGeometry, MuonGeometryRecord> rpcGeoToken_;
+  edm::ESGetToken<DTGeometry, MuonGeometryRecord> dtGeoToken_;
+  edm::ESGetToken<DTObjectMap, MuonGeometryRecord> dtMapToken_;
+  edm::ESGetToken<CSCGeometry, MuonGeometryRecord> cscGeoToken_;
+  edm::ESGetToken<CSCObjectMap, MuonGeometryRecord> cscMapToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+  std::unique_ptr<TrackTransformerBase> theTrackTransformer;
 };
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -12,24 +12,24 @@
 #include "RecoLocalMuon/RPCRecHit/src/CSCStationIndex.h"
 #include "RecoLocalMuon/RPCRecHit/src/CSCObjectMap.h"
 
-CSCSegtoRPC::CSCSegtoRPC(const CSCSegmentCollection* allCSCSegments,
-                         const edm::EventSetup& iSetup,
-                         bool debug,
-                         double eyr) {
-  edm::ESHandle<RPCGeometry> rpcGeo;
-  edm::ESHandle<CSCGeometry> cscGeo;
-  edm::ESHandle<CSCObjectMap> cscMap;
+CSCSegtoRPC::CSCSegtoRPC(edm::ConsumesCollector iC)
+    : rpcGeoToken_(iC.esConsumes()), cscGeoToken_(iC.esConsumes()), cscMapToken_(iC.esConsumes()) {}
 
-  iSetup.get<MuonGeometryRecord>().get(rpcGeo);
-  iSetup.get<MuonGeometryRecord>().get(cscGeo);
-  iSetup.get<MuonGeometryRecord>().get(cscMap);
+std::unique_ptr<RPCRecHitCollection> CSCSegtoRPC::thePoints(const CSCSegmentCollection* allCSCSegments,
+                                                            const edm::EventSetup& iSetup,
+                                                            bool debug,
+                                                            double eyr) {
+  edm::ESHandle<RPCGeometry> rpcGeo = iSetup.getHandle(rpcGeoToken_);
+  edm::ESHandle<CSCGeometry> cscGeo = iSetup.getHandle(cscGeoToken_);
+  edm::ESHandle<CSCObjectMap> cscMap = iSetup.getHandle(cscMapToken_);
 
-  MaxD = 80.;
+  double MaxD = 80.;
 
   if (debug)
     std::cout << "CSC \t Number of CSC Segments in this event = " << allCSCSegments->size() << std::endl;
 
-  _ThePoints = std::make_unique<RPCRecHitCollection>();
+  auto _ThePoints = std::make_unique<RPCRecHitCollection>();
+  edm::OwnVector<RPCRecHit> RPCPointVector;
 
   if (allCSCSegments->size() == 0) {
     if (debug)
@@ -280,6 +280,5 @@ CSCSegtoRPC::CSCSegtoRPC(const CSCSegmentCollection* allCSCSegments,
       }
     }
   }
+  return _ThePoints;
 }
-
-CSCSegtoRPC::~CSCSegtoRPC() {}

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -26,31 +26,41 @@
 // user include files
 
 RPCPointProducer::RPCPointProducer(const edm::ParameterSet& iConfig)
-    : cscSegments(consumes<CSCSegmentCollection>(iConfig.getParameter<edm::InputTag>("cscSegments"))),
-      dt4DSegments(consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("dt4DSegments"))),
-      tracks(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
-      tracks_(iConfig.getParameter<edm::InputTag>("tracks")),
-      incldt(iConfig.getUntrackedParameter<bool>("incldt", true)),
+    : incldt(iConfig.getUntrackedParameter<bool>("incldt", true)),
       inclcsc(iConfig.getUntrackedParameter<bool>("inclcsc", true)),
       incltrack(iConfig.getUntrackedParameter<bool>("incltrack", true)),
       debug(iConfig.getUntrackedParameter<bool>("debug", false)),
       MinCosAng(iConfig.getUntrackedParameter<double>("MinCosAng", 0.95)),
       MaxD(iConfig.getUntrackedParameter<double>("MaxD", 80.)),
       MaxDrb4(iConfig.getUntrackedParameter<double>("MaxDrb4", 150.)),
-      ExtrapolatedRegion(iConfig.getUntrackedParameter<double>("ExtrapolatedRegion", 0.5)),
-      trackTransformerParam(iConfig.getParameter<edm::ParameterSet>("TrackTransformer")) {
+      ExtrapolatedRegion(iConfig.getUntrackedParameter<double>("ExtrapolatedRegion", 0.5)) {
+  if (incldt) {
+    dt4DSegments = consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("dt4DSegments"));
+    dtSegtoRPC = std::make_unique<DTSegtoRPC>(consumesCollector());
+  }
+  if (inclcsc) {
+    cscSegments = consumes<CSCSegmentCollection>(iConfig.getParameter<edm::InputTag>("cscSegments"));
+    cscSegtoRPC = std::make_unique<CSCSegtoRPC>(consumesCollector());
+  }
+  if (incltrack) {
+    tracks = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+    tracktoRPC = std::make_unique<TracktoRPC>(iConfig.getParameter<edm::ParameterSet>("TrackTransformer"),
+                                              iConfig.getParameter<edm::InputTag>("tracks"),
+                                              consumesCollector());
+  }
+
   produces<RPCRecHitCollection>("RPCDTExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCCSCExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCTrackExtrapolatedPoints");
 }
 
-void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if (incldt) {
     edm::Handle<DTRecSegment4DCollection> all4DSegments;
     iEvent.getByToken(dt4DSegments, all4DSegments);
     if (all4DSegments.isValid()) {
-      DTSegtoRPC DTClass(all4DSegments.product(), iSetup, debug, ExtrapolatedRegion);
-      iEvent.put(std::move(DTClass.thePoints()), "RPCDTExtrapolatedPoints");
+      iEvent.put(dtSegtoRPC->thePoints(all4DSegments.product(), iSetup, debug, ExtrapolatedRegion),
+                 "RPCDTExtrapolatedPoints");
     } else {
       if (debug)
         std::cout << "RPCHLT Invalid DTSegments collection" << std::endl;
@@ -61,8 +71,8 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     edm::Handle<CSCSegmentCollection> allCSCSegments;
     iEvent.getByToken(cscSegments, allCSCSegments);
     if (allCSCSegments.isValid()) {
-      CSCSegtoRPC CSCClass(allCSCSegments.product(), iSetup, debug, ExtrapolatedRegion);
-      iEvent.put(std::move(CSCClass.thePoints()), "RPCCSCExtrapolatedPoints");
+      iEvent.put(cscSegtoRPC->thePoints(allCSCSegments.product(), iSetup, debug, ExtrapolatedRegion),
+                 "RPCCSCExtrapolatedPoints");
     } else {
       if (debug)
         std::cout << "RPCHLT Invalid CSCSegments collection" << std::endl;
@@ -72,8 +82,7 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     edm::Handle<reco::TrackCollection> alltracks;
     iEvent.getByToken(tracks, alltracks);
     if (!(alltracks->empty())) {
-      TracktoRPC TrackClass(alltracks.product(), iSetup, debug, trackTransformerParam, tracks_);
-      iEvent.put(std::move(TrackClass.thePoints()), "RPCTrackExtrapolatedPoints");
+      iEvent.put(tracktoRPC->thePoints(alltracks.product(), iSetup, debug), "RPCTrackExtrapolatedPoints");
     } else {
       if (debug)
         std::cout << "RPCHLT Invalid Tracks collection" << std::endl;

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -90,7 +90,7 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
   theTrackerPropagatorName = par.getParameter<std::string>("TrackerPropagator");
 
   edm::ParameterSet trackTransformerPSet = par.getParameter<edm::ParameterSet>("TrackTransformer");
-  theTrackTransformer = new TrackTransformer(trackTransformerPSet);
+  theTrackTransformer = new TrackTransformer(trackTransformerPSet, iC);
 
   edm::ParameterSet regionBuilderPSet = par.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
 

--- a/RecoMuon/MuonIdentification/interface/MuonKinkFinder.h
+++ b/RecoMuon/MuonIdentification/interface/MuonKinkFinder.h
@@ -2,11 +2,12 @@
 #define RecoMuon_MuonIdentification_MuonKinkFinder_h
 
 #include "DataFormats/MuonReco/interface/MuonQuality.h"
+#include "FWCore/Framework/interface/FrameworkfwdMostUsed.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 
 class MuonKinkFinder {
 public:
-  MuonKinkFinder(const edm::ParameterSet &iConfig);
+  MuonKinkFinder(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC);
   ~MuonKinkFinder();
 
   // set event setup

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -148,7 +148,7 @@ MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
 
   if (fillTrackerKink_) {
     trackerKinkFinder_ =
-        std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"));
+        std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"), iC);
   }
 
   //create mesh holder

--- a/RecoMuon/MuonIdentification/src/MuonKinkFinder.cc
+++ b/RecoMuon/MuonIdentification/src/MuonKinkFinder.cc
@@ -2,10 +2,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-MuonKinkFinder::MuonKinkFinder(const edm::ParameterSet &iConfig)
+MuonKinkFinder::MuonKinkFinder(const edm::ParameterSet &iConfig, edm::ConsumesCollector &iC)
     : diagonalOnly_(iConfig.getParameter<bool>("diagonalOnly")),
       usePosition_(iConfig.getParameter<bool>("usePosition")),
-      refitter_(iConfig) {}
+      refitter_(iConfig, iC) {}
 
 MuonKinkFinder::~MuonKinkFinder() {}
 

--- a/TrackingTools/TrackRefitter/interface/TrackTransformer.h
+++ b/TrackingTools/TrackRefitter/interface/TrackTransformer.h
@@ -17,7 +17,9 @@
 
 #include "TrackingTools/TrackRefitter/interface/RefitDirection.h"
 
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -26,11 +28,6 @@
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-namespace edm {
-  class ParameterSet;
-  class EventSetup;
-  class ParameterSetDescription;
-}  // namespace edm
 namespace reco {
   class TransientTrack;
 }
@@ -40,11 +37,21 @@ class TrajectorySmoother;
 class Propagator;
 class TransientTrackingRecHitBuilder;
 class Trajectory;
+class GlobalTrackingGeometryRecord;
+class IdealMagneticFieldRecord;
+class TrajectoryFitterRecord;
+class TrackingComponentsRecord;
+class TransientRecHitRecord;
 
 class TrackTransformer final : public TrackTransformerBase {
 public:
-  /// Constructor
+  /// Constructor (for modules not yet migrated to ES-consumes)
   explicit TrackTransformer(const edm::ParameterSet&);
+
+  /// Constructor (for modules migrated to ES-consumes)
+  explicit TrackTransformer(const edm::ParameterSet&, edm::ConsumesCollector&);
+  explicit TrackTransformer(const edm::ParameterSet& parameterSet, edm::ConsumesCollector&& iC)
+      : TrackTransformer(parameterSet, iC) {}
 
   /// Destructor
   ~TrackTransformer() override;
@@ -92,9 +99,6 @@ public:
 private:
   RefitDirection::GeometricalDirection checkRecHitsOrdering(TransientTrackingRecHit::ConstRecHitContainer const&) const;
 
-  unsigned long long theCacheId_TC = 0;
-  unsigned long long theCacheId_GTG = 0;
-  unsigned long long theCacheId_MG = 0;
   unsigned long long theCacheId_TRH = 0;
 
   const bool theRPCInTheFit;
@@ -102,27 +106,35 @@ private:
   const bool theDoPredictionsOnly;
   const RefitDirection theRefitDirection;
 
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> theTrackingGeometryToken;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> theMGFieldToken;
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   edm::ESHandle<MagneticField> theMGField;
 
   const std::string theFitterName;
+  edm::ESGetToken<TrajectoryFitter, TrajectoryFitterRecord> theFitterToken;
   std::unique_ptr<TrajectoryFitter> theFitter;
 
   const std::string theSmootherName;
+  edm::ESGetToken<TrajectorySmoother, TrajectoryFitterRecord> theSmootherToken;
   std::unique_ptr<TrajectorySmoother> theSmoother;
 
   const std::string thePropagatorName;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> thePropagatorToken;
   edm::ESHandle<Propagator> const& propagator() const { return thePropagator; }
   edm::ESHandle<Propagator> thePropagator;
 
   const std::string theTrackerRecHitBuilderName;
-  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theTrackerRecHitBuilderToken;
+  const TransientTrackingRecHitBuilder* theTrackerRecHitBuilder;
   TkClonerImpl hitCloner;
 
   const std::string theMuonRecHitBuilderName;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theMuonRecHitBuilderToken;
   edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
   const std::string theMTDRecHitBuilderName;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> theMTDRecHitBuilderToken;
   bool theMtdAvailable;
   edm::ESHandle<TransientTrackingRecHitBuilder> theMTDRecHitBuilder;
 };

--- a/TrackingTools/TrackRefitter/plugins/TracksToTrajectories.cc
+++ b/TrackingTools/TrackRefitter/plugins/TracksToTrajectories.cc
@@ -2,6 +2,7 @@
 #include "TrackingTools/TrackRefitter/interface/TrackTransformerForGlobalCosmicMuons.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformerForCosmicMuons.h"
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -72,7 +73,7 @@ TracksToTrajectories::TracksToTrajectories(const ParameterSet& parameterSet, con
   string type = parameterSet.getParameter<string>("Type");
 
   if (type == "Default")
-    theTrackTransformer = std::make_unique<TrackTransformer>(trackTransformerParam);
+    theTrackTransformer = std::make_unique<TrackTransformer>(trackTransformerParam, consumesCollector());
   else if (type == "GlobalCosmicMuonsForAlignment")
     theTrackTransformer = std::make_unique<TrackTransformerForGlobalCosmicMuons>(trackTransformerParam);
   else if (type == "CosmicMuonsForAlignment")


### PR DESCRIPTION
#### PR description:

This PR is part of https://github.com/cms-sw/cmssw/issues/31061, and part of addressing failures in https://github.com/cms-sw/cmssw/pull/31746. It adds an EventSetup-consumes migrated code path to `TrackTransformer` helper class to allow getting (closer to) full migration of some Muon EDModules (IIRC this effort started form `MuonKinkFinder` helper class). Removing the non-ESGetToken code path is not feasible at this time, because `TrackTransformer` is used in Alignment in an EDLooper (which, as of today, can not declare consumption of ED nor ES products #31745).
 
#### PR validation:

Code compiles.