### PR TITLE
Introduce scenario for 2016 cosmics with realistic conditions

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
     'run2_mc'           :   '112X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_startup_deco_v1',
+    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '112X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2


### PR DESCRIPTION
#### PR description:

This PR permanently modifies the `auto:run2_mc_cosmics` key to represent realistic conditions, analogous to the 2017 and 2018 cosmic GTs, rather than the conditions at the startup of Run 2. As far as AlCa is able to determine, [no one is interested](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4342.html) using a cosmic GT with the conditions that were projected to represent the conditions at Run 2 startup. On the other hand, a cosmic GT that represents realistic conditions detector conditions is of interest to the tracker community in the context of the legacy reprocessing.

The GT diff with respect to the corresponding pp collision GT:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_asymptotic_v1/112X_mcRun2cosmics_asymptotic_deco_v1

shows that the only differences are the L1T tags and (irrelevant for cosmics) tau tags. The difference with respect to the GT modeling startup conditions involves only alignment and bad channel tags:

https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2cosmics_startup_deco_v1/112X_mcRun2cosmics_asymptotic_deco_v1

#### PR validation:

The change is one of definition so there isn't anything to validate, aside from a technical test: `runTheMatrix.py -l 7.22 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 10_6_X, as it is of interest to the legacy reprocessing.
