### PR TITLE
[DataFormats/L1TMuon] Fix version in iorules of l1t::RegionalMuonCand

### DIFF
--- a/DataFormats/L1TMuon/src/classes_def.xml
+++ b/DataFormats/L1TMuon/src/classes_def.xml
@@ -5,7 +5,7 @@
     <version ClassVersion="11" checksum="2292293737"/>
     <version ClassVersion="10" checksum="1070099328"/>
   </class>
-  <ioread sourceClass="l1t::RegionalMuonCand" targetClass="l1t::RegionalMuonCand" version="[-10]"  source="int m_hwPt2" target="m_hwPtUnconstrained">
+  <ioread sourceClass="l1t::RegionalMuonCand" targetClass="l1t::RegionalMuonCand" version="[10]"  source="int m_hwPt2" target="m_hwPtUnconstrained">
     <![CDATA[ m_hwPtUnconstrained = onfile.m_hwPt2; ]]>
   </ioread>
 


### PR DESCRIPTION
#### PR description:

Fix version number in iorules of l1t::RegionalMuonCand.
This PR fixes the segmentation fault obtained in wf `136.8391`.
See https://github.com/cms-sw/cmssw/pull/31608#issuecomment-709217145

#### PR validation:

`runTheMatrix.py -l 136.8391 -i all --ibeos`