### PR TITLE
Removed unused fwkJobReports from MessageLogger in Alignment Subsystem

### DIFF
--- a/Alignment/LaserAlignmentSimulation/test/LaserSimulation_cfg.py
+++ b/Alignment/LaserAlignmentSimulation/test/LaserSimulation_cfg.py
@@ -71,8 +71,7 @@ process.MessageLogger = cms.Service("MessageLogger",
         'HCalGeom', 
         'HcalSim', 
         'TrackerMapDDDtoID', 
-        'TrackerSimInfoNumbering'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport.xml')
+        'TrackerSimInfoNumbering')
 )
 
 


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.

#### PR validation:

