### PR TITLE
Removed unused fwkJobReports from MessageLogger in EventFilter Subsystem

### DIFF
--- a/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtEvmUnpacker_cfg.py
+++ b/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtEvmUnpacker_cfg.py
@@ -96,7 +96,6 @@ process.MessageLogger.destinations = ['L1GtEvmUnpacker_errors',
                                       'L1GtEvmUnpacker'
                                       ]
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.MessageLogger.L1GtEvmUnpacker_errors = cms.untracked.PSet( 
         threshold = cms.untracked.string('ERROR'),

--- a/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtUnpacker_cfg.py
+++ b/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtUnpacker_cfg.py
@@ -126,7 +126,6 @@ process.MessageLogger.destinations = ['L1GtUnpacker_errors',
                                       'L1GtUnpacker'
                                       ]
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.MessageLogger.L1GtUnpacker_errors = cms.untracked.PSet( 
         threshold = cms.untracked.string('ERROR'),


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.

#### PR validation:

