### PR TITLE
Removed unused fwkJobReports from MessageLogger in Geometry Subsystem

### DIFF
--- a/Geometry/CMSCommonData/test/runPrint_cfg.py
+++ b/Geometry/CMSCommonData/test/runPrint_cfg.py
@@ -6,18 +6,8 @@ process.load("Validation.CheckOverlap.testGeometry_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring('cout'),
-    categories = cms.untracked.vstring('FwkJob'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
-    ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
     )
 )
 


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.

#### PR validation:

