### PR TITLE
Removed unused fwkJobReports from MessageLogger in HLTrigger Subsystem

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -219,6 +219,8 @@ def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+
+    #introduced in pull request #31859
     process = customizeToDropObsoleteMessageLoggerOptions(process)
 
     return process

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -203,10 +203,22 @@ def customiseFor2018Input(process):
     process = synchronizeHCALHLTofflineRun3on2018data(process)
 
 
+def customizeToDropObsoleteMessageLoggerOptions(process):
+    if 'MessageLogger' in process.__dict__:
+        if not hasattr(process.MessageLogger, "fwkJobReports"):
+            return process
+        for config in process.MessageLogger.fwkJobReports.value():
+            if hasattr(process.MessageLogger, config):
+                delattr(process.MessageLogger, config)
+        delattr(process.MessageLogger, "fwkJobReports")
+    return process
+
+
 # CMSSW version specific customizations
 def customizeHLTforCMSSW(process, menuType="GRun"):
 
     # add call to action function in proper order: newest last!
     # process = customiseFor12718(process)
+    process = customizeToDropObsoleteMessageLoggerOptions(process)
 
     return process


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.
The new customize function removes the parameters if present.

#### PR validation:

The new customize function was tested manually both with and without the parameters and shown to work properly.