### PR TITLE
Removed unused fwkJobReports from MessageLogger in IOMC Subsystem 

### DIFF
--- a/IOMC/Input/test/testWriter_cfg.py
+++ b/IOMC/Input/test/testWriter_cfg.py
@@ -18,7 +18,6 @@ process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.destinations = ['cerr']
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(5))
 


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.

#### PR validation:
