### PR TITLE
Removed unused fwkJobReports from MessageLogger in Validation Subsystem

### DIFF
--- a/Validation/GlobalDigis/python/MessageLogger_cfi.py
+++ b/Validation/GlobalDigis/python/MessageLogger_cfi.py
@@ -822,15 +822,7 @@ MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(10000000)
         )
     ),
-    FrameworkJobReport = cms.untracked.PSet(
-        #untracked PSet default = 
-        #	{ untracked int32 limit = 0 }
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(10000000)
-        )
-    ),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
-    categories = cms.untracked.vstring('FwkJob', 
+    categories = cms.untracked.vstring( 
         'GlobalHitsProducer_GlobalHitsProducer', 
         'GlobalHitsProducer_endJob', 
         'GlobalHitsProducer_produce', 

--- a/Validation/GlobalHits/python/MessageLogger_cfi.py
+++ b/Validation/GlobalHits/python/MessageLogger_cfi.py
@@ -822,15 +822,7 @@ MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(10000000)
         )
     ),
-    FrameworkJobReport = cms.untracked.PSet(
-        #untracked PSet default = 
-        #	{ untracked int32 limit = 0 }
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(10000000)
-        )
-    ),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
-    categories = cms.untracked.vstring('FwkJob', 
+    categories = cms.untracked.vstring( 
         'GlobalHitsProducer_GlobalHitsProducer', 
         'GlobalHitsProducer_endJob', 
         'GlobalHitsProducer_produce', 

--- a/Validation/GlobalRecHits/python/MessageLogger_cfi.py
+++ b/Validation/GlobalRecHits/python/MessageLogger_cfi.py
@@ -822,15 +822,7 @@ MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(10000000)
         )
     ),
-    FrameworkJobReport = cms.untracked.PSet(
-        #untracked PSet default = 
-        #	{ untracked int32 limit = 0 }
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(10000000)
-        )
-    ),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
-    categories = cms.untracked.vstring('FwkJob', 
+    categories = cms.untracked.vstring( 
         'GlobalHitsProducer_GlobalHitsProducer', 
         'GlobalHitsProducer_endJob', 
         'GlobalHitsProducer_produce', 

--- a/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/benchmark_cfg.py
+++ b/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/benchmark_cfg.py
@@ -110,26 +110,12 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         ),
         threshold = cms.untracked.string('INFO'),
-        FwkJob = cms.untracked.PSet(
-            optionalPSet = cms.untracked.bool(True),
-            limit = cms.untracked.int32(0)
-        ),
         FwkSummary = cms.untracked.PSet(
             reportEvery = cms.untracked.int32(1),
             optionalPSet = cms.untracked.bool(True),
             limit = cms.untracked.int32(10000000)
         ),
         optionalPSet = cms.untracked.bool(True)
-    ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        optionalPSet = cms.untracked.bool(True),
-        FwkJob = cms.untracked.PSet(
-            optionalPSet = cms.untracked.bool(True),
-            limit = cms.untracked.int32(10000000)
-        )
     ),
     suppressWarning = cms.untracked.vstring(),
     errors = cms.untracked.PSet(
@@ -150,11 +136,9 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         placeholder = cms.untracked.bool(True)
     ),
-    categories = cms.untracked.vstring('FwkJob', 
-        'FwkReport', 
+    categories = cms.untracked.vstring('FwkReport', 
         'FwkSummary', 
-        'Root_NoDictionary'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport')
+        'Root_NoDictionary')
 )
 
 


### PR DESCRIPTION
#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.
The category 'FwkJob' also is not used anywhere in CMSSW (it was originally where the job report would send messages to the MessageLogger).


#### PR validation:
