### PR TITLE
Removed unused fwkJobReports from MessageLogger in L1Trigger* Subsystems

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/test/L1GtEmulTrigReport_cfg.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/test/L1GtEmulTrigReport_cfg.py
@@ -221,7 +221,6 @@ process.MessageLogger.destinations = ['L1GtEmulTrigReport_errors',
                                       'L1GtEmulTrigReport'
                                       ]
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.MessageLogger.L1GtEmulTrigReport_errors = cms.untracked.PSet( 
         threshold = cms.untracked.string('ERROR'),

--- a/L1TriggerConfig/L1GtConfigProducers/test/L1GtTester_cfg.py
+++ b/L1TriggerConfig/L1GtConfigProducers/test/L1GtTester_cfg.py
@@ -135,7 +135,6 @@ process.MessageLogger.destinations = ['L1GtTester_errors',
                                       'L1GtTester_debug'
                                       ]
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.MessageLogger.L1GtTester_errors = cms.untracked.PSet( 
         threshold = cms.untracked.string('ERROR'),

--- a/L1TriggerConfig/L1GtConfigProducers/test/L1GtTriggerMenuTester_cfg.py
+++ b/L1TriggerConfig/L1GtConfigProducers/test/L1GtTriggerMenuTester_cfg.py
@@ -119,7 +119,6 @@ process.MessageLogger.destinations = ['L1GtTriggerMenuTester_errors',
                                       'L1GtTriggerMenuTester_debug'
                                       ]
 process.MessageLogger.statistics = []
-process.MessageLogger.fwkJobReports = []
 
 process.MessageLogger.L1GtTriggerMenuTester_errors = cms.untracked.PSet( 
         threshold = cms.untracked.string('ERROR'),

--- a/L1TriggerOffline/L1Analyzer/test/BscTrigger_cfg.py
+++ b/L1TriggerOffline/L1Analyzer/test/BscTrigger_cfg.py
@@ -49,22 +49,11 @@ process.MessageLogger = cms.Service("MessageLogger",
         Root_NoDictionary = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         FwkSummary = cms.untracked.PSet(
             reportEvery = cms.untracked.int32(1),
             limit = cms.untracked.int32(10000000)
         ),
         threshold = cms.untracked.string('DEBUG')
-    ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(10000000)
-        )
     ),
     suppressWarning = cms.untracked.vstring(),
     statistics = cms.untracked.vstring('cerr_stats'),
@@ -85,11 +74,10 @@ process.MessageLogger = cms.Service("MessageLogger",
         'cout', 
         'cerr'),
     debugModules = cms.untracked.vstring('bscTrigger'),
-    categories = cms.untracked.vstring('BscSim','FwkJob', 
+    categories = cms.untracked.vstring('BscSim',
         'FwkReport', 
         'FwkSummary', 
-        'Root_NoDictionary'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport')
+        'Root_NoDictionary')
 )
 # import of standard configurations
 process.load('Configuration/StandardSequences/Services_cff')


### PR DESCRIPTION

#### PR description:

The parameter fwkJobReports is an obsolete parameter which has had no functionality for many years.
Removed 'FwkJob' category as it is no longer used either.

#### PR validation:

