### PR TITLE
Switch payloads of new phase 2 tau ID to GT

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -81,7 +81,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v10', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '112X_mcRun4_realistic_v3'
+    'phase2_realistic'         : '112X_mcRun4_realistic_v4'
 }
 
 aliases = {

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -44,7 +44,7 @@ tauIdDiscrMVA_trainings_run2_2017 = {
     'tauIdMVAIsoDBoldDMdR0p3wLT2017' : "tauIdMVAIsoDBoldDMdR0p3wLT2017",
 }
 tauIdDiscrMVA_trainings_phase2 = {
-    'tauIdMVAIsoPhase2' : "tauIdMVAIsoPhase2",
+    'tauIdMVAIsoPhase2_v1' : "tauIdMVAIsoPhase2",
 }
 tauIdDiscrMVA_WPs = {
     'tauIdMVAoldDMwoLT' : {
@@ -178,7 +178,7 @@ tauIdDiscrMVA_WPs_run2_2017 = {
     }
 }
 tauIdDiscrMVA_WPs_phase2 = {
-    'tauIdMVAIsoPhase2' : {
+    'tauIdMVAIsoPhase2_v1' : {
         'Eff95' : "Phase2Eff95",
         'Eff90' : "Phase2Eff90",
         'Eff80' : "Phase2Eff80",
@@ -212,7 +212,7 @@ tauIdDiscrMVA_mvaOutput_normalizations_run2_2017 = {
     'tauIdMVAIsoDBoldDMdR0p3wLT2017' : "mvaOutput_normalization"
 }
 tauIdDiscrMVA_mvaOutput_normalizations_phase2 = {
-    'tauIdMVAIsoPhase2' : "mvaOutput_normalization",
+    'tauIdMVAIsoPhase2_v1' : "mvaOutput_normalization",
 }
 
 tauIdDiscrMVA_version = "v1"
@@ -321,7 +321,7 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
         cms.PSet(
             record = cms.string('GBRWrapperRcd'),
             tag = cms.string("RecoTauTag_%s" % (gbrForestName)),
-            label = cms.untracked.string("RecoTauTag_%s" % (gbrForestName))
+            label = cms.untracked.string("RecoTauTag_%s" % (training))
         )
     )
     for WP in tauIdDiscrMVA_WPs_phase2[training].keys():
@@ -329,14 +329,14 @@ for training, gbrForestName in tauIdDiscrMVA_trainings_phase2.items():
             cms.PSet(
                 record = cms.string('PhysicsTGraphPayloadRcd'),
                 tag = cms.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP)),
-                label = cms.untracked.string("RecoTauTag_%s_WP%s" % (gbrForestName, WP))
+                label = cms.untracked.string("RecoTauTag_%s_WP%s" % (training, WP))
             )
          )
     loadRecoTauTagMVAsFromPrepDB.toGet.append(
         cms.PSet(
             record = cms.string('PhysicsTFormulaPayloadRcd'),
             tag = cms.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName)),
-            label = cms.untracked.string("RecoTauTag_%s_mvaOutput_normalization" % (gbrForestName))
+            label = cms.untracked.string("RecoTauTag_%s_mvaOutput_normalization" % (training))
        )
     )
 

--- a/RecoTauTag/RecoTau/python/tauDiscriminationAgainstElectronMVA6Phase2_mvaDefs_cff.py
+++ b/RecoTauTag/RecoTau/python/tauDiscriminationAgainstElectronMVA6Phase2_mvaDefs_cff.py
@@ -1,80 +1,81 @@
 import FWCore.ParameterSet.Config as cms
 
 # anti-e phase-2 tauID mva names
+_antiEMVABaseName = "RecoTauTag_antiElectronMVAPhase2"
 mvaNames_phase2 = dict(
-    mvaName_NoEleMatch_woGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_BL"),
-    mvaName_NoEleMatch_wGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_BL"),
-    mvaName_woGwGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_BL"),
-    mvaName_wGwGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_BL"),
-    mvaName_NoEleMatch_woGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_FWEC"),
-    mvaName_NoEleMatch_wGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_FWEC"),
-    mvaName_woGwGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_FWEC"),
-    mvaName_wGwGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_FWEC"),
-    mvaName_NoEleMatch_woGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_VFWEC"),
-    mvaName_NoEleMatch_wGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_VFWEC"),
-    mvaName_woGwGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_VFWEC"),
-    mvaName_wGwGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_VFWEC")
+    mvaName_NoEleMatch_woGwoGSF_BL = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_BL"),
+    mvaName_NoEleMatch_wGwoGSF_BL = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_BL"),
+    mvaName_woGwGSF_BL = cms.string(_antiEMVABaseName+"_woGwGSF_BL"),
+    mvaName_wGwGSF_BL = cms.string(_antiEMVABaseName+"_wGwGSF_BL"),
+    mvaName_NoEleMatch_woGwoGSF_EC = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_FWEC"),
+    mvaName_NoEleMatch_wGwoGSF_EC = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_FWEC"),
+    mvaName_woGwGSF_EC = cms.string(_antiEMVABaseName+"_woGwGSF_FWEC"),
+    mvaName_wGwGSF_EC = cms.string(_antiEMVABaseName+"_wGwGSF_FWEC"),
+    mvaName_NoEleMatch_woGwoGSF_VFEC = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_VFWEC"),
+    mvaName_NoEleMatch_wGwoGSF_VFEC = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_VFWEC"),
+    mvaName_woGwGSF_VFEC = cms.string(_antiEMVABaseName+"_woGwGSF_VFWEC"),
+    mvaName_wGwGSF_VFEC = cms.string(_antiEMVABaseName+"_wGwGSF_VFWEC")
 )
 # anti-e phase-2 tauID (WPs)
 mapping_phase2 = cms.VPSet(
     cms.PSet(
         category = cms.uint32(0), # minMVANoEleMatchWOgWOgsfBL
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_BL"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(2), # minMVANoEleMatchWgWOgsfBL
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_BL"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(5), # minMVAWOgWgsfBL
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_BL"),
+        cut = cms.string(_antiEMVABaseName+"_woGwGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(7), # minMVAWgWgsfBL
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_BL"),
+        cut = cms.string(_antiEMVABaseName+"_wGwGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(8), # minMVANoEleMatchWOgWOgsfEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_FWEC"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(9), # minMVANoEleMatchWOgWOgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_VFWEC"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_woGwoGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(10), # minMVANoEleMatchWgWOgsfEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_FWEC"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(11), # minMVANoEleMatchWgWOgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_VFWEC"),
+        cut = cms.string(_antiEMVABaseName+"_NoEleMatch_wGwoGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(13), # minMVAWOgWgsfEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_FWEC"),
+        cut = cms.string(_antiEMVABaseName+"_woGwGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(14), # minMVAWOgWgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_VFWEC"),
+        cut = cms.string(_antiEMVABaseName+"_woGwGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(15), # minMVAWgWgsfEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_FWEC"),
+        cut = cms.string(_antiEMVABaseName+"_wGwGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(16), # minMVAWgWgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_VFWEC"),
+        cut = cms.string(_antiEMVABaseName+"_wGwGSF_VFWEC"),
         variable = cms.string("pt")
     )
 )

--- a/RecoTauTag/RecoTau/python/tauDiscriminationAgainstElectronMVA6Phase2_mvaDefs_cff.py
+++ b/RecoTauTag/RecoTau/python/tauDiscriminationAgainstElectronMVA6Phase2_mvaDefs_cff.py
@@ -2,87 +2,87 @@ import FWCore.ParameterSet.Config as cms
 
 # anti-e phase-2 tauID mva names
 mvaNames_phase2 = dict(
-    mvaName_NoEleMatch_woGwoGSF_BL = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_BL"),
-    mvaName_NoEleMatch_wGwoGSF_BL = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_BL"),
-    mvaName_woGwGSF_BL = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_BL"),
-    mvaName_wGwGSF_BL = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_BL"),
-    mvaName_NoEleMatch_woGwoGSF_EC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_FWEC"),
-    mvaName_NoEleMatch_wGwoGSF_EC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_FWEC"),
-    mvaName_woGwGSF_EC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_FWEC"),
-    mvaName_wGwGSF_EC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_FWEC"),
-    mvaName_NoEleMatch_woGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_VFWEC"),
-    mvaName_NoEleMatch_wGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_VFWEC"),
-    mvaName_woGwGSF_VFEC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_VFWEC"),
-    mvaName_wGwGSF_VFEC = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_VFWEC")
+    mvaName_NoEleMatch_woGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_BL"),
+    mvaName_NoEleMatch_wGwoGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_BL"),
+    mvaName_woGwGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_BL"),
+    mvaName_wGwGSF_BL = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_BL"),
+    mvaName_NoEleMatch_woGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_FWEC"),
+    mvaName_NoEleMatch_wGwoGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_FWEC"),
+    mvaName_woGwGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_FWEC"),
+    mvaName_wGwGSF_EC = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_FWEC"),
+    mvaName_NoEleMatch_woGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_VFWEC"),
+    mvaName_NoEleMatch_wGwoGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_VFWEC"),
+    mvaName_woGwGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_VFWEC"),
+    mvaName_wGwGSF_VFEC = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_VFWEC")
 )
 # anti-e phase-2 tauID (WPs)
 mapping_phase2 = cms.VPSet(
     cms.PSet(
         category = cms.uint32(0), # minMVANoEleMatchWOgWOgsfBL
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_BL"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(2), # minMVANoEleMatchWgWOgsfBL
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_BL"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(5), # minMVAWOgWgsfBL
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_BL"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(7), # minMVAWgWgsfBL
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_BL"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_BL"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(8), # minMVANoEleMatchWOgWOgsfEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_FWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(9), # minMVANoEleMatchWOgWOgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_woGwoGSF_VFWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_woGwoGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(10), # minMVANoEleMatchWgWOgsfEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_FWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(11), # minMVANoEleMatchWgWOgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_NoEleMatch_wGwoGSF_VFWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_NoEleMatch_wGwoGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(13), # minMVAWOgWgsfEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_FWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(14), # minMVAWOgWgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_woGwGSF_VFWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_woGwGSF_VFWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(15), # minMVAWgWgsfEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_FWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_FWEC"),
         variable = cms.string("pt")
     ),
     cms.PSet(
         category = cms.uint32(16), # minMVAWgWgsfVFEC
-        cut = cms.string("RecoTauTag_antiElectronPhase2MVA6v1_gbr_wGwGSF_VFWEC"),
+        cut = cms.string("RecoTauTag_antiElectronMVAPhase2_wGwGSF_VFWEC"),
         variable = cms.string("pt")
     )
 )
 
 workingPoints_phase2 = cms.vstring(
-    "_WPEff98",
-    "_WPEff90",
-    "_WPEff80",
-    "_WPEff70",
-    "_WPEff60"
+    "_VLoose",
+    "_Loose",
+    "_Medium",
+    "_Tight",
+    "_VTight"
 )

--- a/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
+++ b/RecoTauTag/RecoTau/python/tools/runTauIdMVA.py
@@ -894,13 +894,13 @@ class TauIDEmbedder(object):
                     )
                 ),
                 workingPoints = cms.vstring(
-                    "_WPEff95",
-                    "_WPEff90",
-                    "_WPEff80",
-                    "_WPEff70",
-                    "_WPEff60",
-                    "_WPEff50",
-                    "_WPEff40"
+                    "_VVLoose",
+                    "_VLoose",
+                    "_Loose",
+                    "_Medium",
+                    "_Tight",
+                    "_VTight",
+                    "_VVTight"
                 )
             )
             self.process.rerunIsolationMVADBnewDMwLTPhase2Task = cms.Task(
@@ -911,13 +911,13 @@ class TauIDEmbedder(object):
             self.process.rerunMvaIsolationSequence += cms.Sequence(self.process.rerunIsolationMVADBnewDMwLTPhase2Task)
 
             tauIDSources.byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw")
-            tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95")
-            tauIDSources.byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff90")
-            tauIDSources.byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff80")
-            tauIDSources.byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff70")
-            tauIDSources.byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff60")
-            tauIDSources.byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff50")
-            tauIDSources.byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff40")
+            tauIDSources.byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VVLoose")
+            tauIDSources.byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VLoose")
+            tauIDSources.byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Loose")
+            tauIDSources.byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Medium")
+            tauIDSources.byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Tight")
+            tauIDSources.byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VTight")
+            tauIDSources.byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VVTight")
 
         if "againstElePhase2v1" in self.toKeep:
             if self.debug: print ("Adding anti-e Phase2v1 ID")
@@ -948,11 +948,11 @@ class TauIDEmbedder(object):
             _againstElectronTauIDPhase2v1Sources = cms.PSet(
                 againstElectronMVA6RawPhase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "raw"),
                 againstElectronMVA6categoryPhase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "category"),
-                againstElectronVLooseMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_WPEff98"),
-                againstElectronLooseMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_WPEff90"),
-                againstElectronMediumMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_WPEff80"),
-                againstElectronTightMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_WPEff70"),
-                againstElectronVTightMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_WPEff60")
+                againstElectronVLooseMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_VLoose"),
+                againstElectronLooseMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_Loose"),
+                againstElectronMediumMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_Medium"),
+                againstElectronTightMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_Tight"),
+                againstElectronVTightMVA6Phase2v1 = self.tauIDMVAinputs("patTauDiscriminationByElectronRejectionMVA6Phase2v1", "_VTight")
             )
             _tauIDSourcesWithAgainistElePhase2v1 = cms.PSet(
                 tauIDSources.clone(),

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -24,9 +24,11 @@ process.TFileService = cms.Service("TFileService",
 )
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
-### Load PoolDBESSource with mapping to payloads
-# Note: replace it by an appropriate GlobalTag when MVAIso phase-2 payloads are available via it
-process.load('RecoTauTag.Configuration.loadRecoTauTagMVAsFromPrepDB_cfi')
+### Load payloads via GlobalTag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '112X_mcRun4_realistic_Candidate_2020_09_17_13_57_14', '')
+
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *
 process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2raw = patDiscriminationByIsolationMVArun2v1raw.clone(
@@ -56,13 +58,13 @@ process.rerunDiscriminationByIsolationMVADBnewDMwLTPhase2 = patDiscriminationByI
         )
     ),
     workingPoints = cms.vstring(
-        "_WPEff95",
-        "_WPEff90",
-        "_WPEff80",
-        "_WPEff70",
-        "_WPEff60",
-        "_WPEff50",
-        "_WPEff40"
+        "_VVLoose",
+        "_VLoose",
+        "_Loose",
+        "_Medium",
+        "_Tight",
+        "_VTight",
+        "_VVTight"
     )
 )
 
@@ -78,13 +80,13 @@ embedID = cms.EDProducer("PATTauIDEmbedder",
     src = cms.InputTag('slimmedTaus'),
     tauIDSources = cms.PSet(
         byIsolationMVADBnewDMwLTPhase2raw = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "raw"),
-        byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff95"),
-        byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff90"),
-        byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff80"),
-        byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff70"),
-        byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff60"),
-        byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff50"),
-        byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_WPEff40")
+        byVVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VVLoose"),
+        byVLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VLoose"),
+        byLooseIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Loose"),
+        byMediumIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Medium"),
+        byTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_Tight"),
+        byVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VTight"),
+        byVVTightIsolationMVADBnewDMwLTPhase2 = tauIDMVAinputs("rerunDiscriminationByIsolationMVADBnewDMwLTPhase2", "_VVTight")
     ),
 )
 setattr(process, "newTauIDsEmbedded", embedID)

--- a/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
+++ b/RecoTauTag/RecoTau/test/rerunMVAIsolationOnMiniAOD_Phase2.py
@@ -27,7 +27,7 @@ from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
 ### Load payloads via GlobalTag
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '112X_mcRun4_realistic_Candidate_2020_09_17_13_57_14', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 
 from RecoTauTag.RecoTau.PATTauDiscriminationByMVAIsolationRun2_cff import *


### PR DESCRIPTION
#### PR description:

Changes payload labels of the recently added phase 2 tau ID and anti-ele ID such that payloads are loaded via Global Tag.
Builds on top of PR #31470 which is fully signed but not yet merged.
Requires GT 112X_mcRun4_realistic_Candidate_2020_09_17_13_57_14

#### PR validation:

- ran miniAOD sequence for phase2 with payloads loaded via the named GT
- code-checks and format pass
- unit tests pass
- limited matrix tests pass all but three. After adding above GT these do not fail due to missing payload anymore but I get an error of category 'DataCorrupt' from SiPixelRecHitConverter for unknown reasons, but does not seem to be related to this PR.