### PR TITLE
fix stray Global Tags post GeometricDetExtra Migration

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2093,7 +2093,7 @@ steps['ALCASPLITSIPIXELCAL']={'-s':'ALCAOUTPUT:SiPixelCalZeroBias,ALCA:PromptCal
 
 steps['ALCAHARVDHPBS']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdBeamSpotHP']),
                         #'--conditions':'auto:run2_data_promptlike',
-                        '--conditions':'92X_dataRun2_Express_v2_snapshotted', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
+                        '--conditions':'auto:run3_data_express', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run2_2017',
@@ -2102,7 +2102,7 @@ steps['ALCAHARVDHPBS']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdBeamSpotH
 
 steps['ALCAHARVDHPBSLOWPU']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdBeamSpotHPLowPU']),
                         #'--conditions':'auto:run2_data_promptlike',
-                        '--conditions':'92X_dataRun2_Express_v2_snapshotted', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
+                        '--conditions':'auto:run3_data_express', # to replaced with line above once run2_data_promptlike will contain DropBoxMetadata
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run2_2017',
@@ -2111,7 +2111,7 @@ steps['ALCAHARVDHPBSLOWPU']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdBeam
 
 
 steps['ALCAHARVDSIPIXELCAL']={'-s':'ALCAHARVEST:%s'%(autoPCL['PromptCalibProdSiPixel']),
-                        '--conditions':'100X_dataRun2_Express_v2',
+                        '--conditions':'auto:run3_data_express',
                         '--scenario':'pp',
                         '--data':'',
                         '--era':'Run2_2017',

--- a/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/beam_dqm_sourceclient-live_cfg.py
@@ -73,7 +73,7 @@ else:
     from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
     process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
     # you may need to set manually the GT in the line below
-    process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
+    #process.GlobalTag.globaltag = '100X_upgrade2018_realistic_v10'
 
 #----------------------------
 # BeamMonitor

--- a/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_autoExpress_cfi.py
@@ -7,7 +7,7 @@ from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
 # It should be kept in synch with Express processing at Tier0: what the url
 # https://cmsweb.cern.ch/t0wmadatasvc/prod/express_config
 # would tell you.
-GlobalTag.globaltag = "106X_dataRun3_Express_v2"
+GlobalTag.globaltag = "111X_dataRun3_Express_v4"
 
 # ===== auto -> Automatically get the GT string from current Tier0 configuration via a Tier0Das call.
 #       This needs a valid proxy to access the cern.ch network from the .cms one.

--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,3 +1,3 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import *
-GlobalTag.globaltag = "111X_dataRun3_HLT_GEMRecoGEO_v1"
+GlobalTag.globaltag = "111X_dataRun3_HLT_v3"


### PR DESCRIPTION
#### PR description:

After PR #31729 has been integrated, there have been falilures in 20 unit tests in `DQM/Integration` and exceptions in wf 1001.2, 1030.0, 1040.0, 1040.1 (as reported in issue:  #31869)

This PR fixes that state of affairs, by doing two things:
* fixes some stray GTs left around in relval tests and migrate them with the autoCond key: `auto:run3_data_express`
* updates the `DQM/Integration` code to use the new Express Reco GT: `111X_dataRun3_Express_v4`

#### PR validation:

I've run successfully :
   * unit tests: `scramv1 b runtests`
   * relval tests: `runTheMatrix.py -l 1001.2,1030.0,1040.0,1040.1 -t 4 -j 8`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport, no backport is needed.
