### PR TITLE
Removed FwkJob category from MessageLogger config

### DIFF
--- a/Calibration/EcalAlCaRecoProducers/test/alcaSkimming.py
+++ b/Calibration/EcalAlCaRecoProducers/test/alcaSkimming.py
@@ -187,10 +187,6 @@ process.MessageLogger.cerr = cms.untracked.PSet(
                  optionalPSet = cms.untracked.bool(True),
                  limit = cms.untracked.int32(0)
                  ),
-    FwkJob = cms.untracked.PSet(
-    optionalPSet = cms.untracked.bool(True),
-    limit = cms.untracked.int32(0)
-    ),
     FwkSummary = cms.untracked.PSet(
     optionalPSet = cms.untracked.bool(True),
     reportEvery = cms.untracked.int32(1),

--- a/DQM/CSCMonitorModule/python/test/csc_unpacker_dump.py
+++ b/DQM/CSCMonitorModule/python/test/csc_unpacker_dump.py
@@ -52,7 +52,6 @@ process.MessageLogger = cms.Service("MessageLogger",
     default = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
     Root_NoDictionary = cms.untracked.PSet(limit = cms.untracked.int32(0)),
     DEBUG = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-    FwkJob = cms.untracked.PSet(limit = cms.untracked.int32(0)),
     FwkSummary = cms.untracked.PSet(reportEvery = cms.untracked.int32(1), limit = cms.untracked.int32(10000000) ),
     threshold = cms.untracked.string('DEBUG')
   )

--- a/DQMOffline/CalibMuon/test/DTPreCalibTask_cfg.py
+++ b/DQMOffline/CalibMuon/test/DTPreCalibTask_cfg.py
@@ -63,9 +63,6 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         noLineBreaks = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG'),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         DEBUG = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )

--- a/DQMOffline/CalibMuon/test/DTnoiseDBValidation_ORCONsqlite_cfg.py
+++ b/DQMOffline/CalibMuon/test/DTnoiseDBValidation_ORCONsqlite_cfg.py
@@ -61,9 +61,6 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         noLineBreaks = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG'),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         DEBUG = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )

--- a/DQMOffline/CalibMuon/test/DTnoiseDBValidation_cfg.py
+++ b/DQMOffline/CalibMuon/test/DTnoiseDBValidation_cfg.py
@@ -57,9 +57,6 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         noLineBreaks = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG'),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         DEBUG = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )

--- a/DQMOffline/Muon/test/simMuAnalyzer_cfg.py
+++ b/DQMOffline/Muon/test/simMuAnalyzer_cfg.py
@@ -75,9 +75,6 @@ process.MessageLogger = cms.Service("MessageLogger",
         trackResidualsTest = cms.untracked.PSet(
             limit = cms.untracked.int32(10000000)
         ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         threshold = cms.untracked.string('DEBUG'),
         muRecoAnalyzer = cms.untracked.PSet(
             limit = cms.untracked.int32(10000000)

--- a/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtRecord_cfg.py
+++ b/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtRecord_cfg.py
@@ -431,7 +431,6 @@ process.MessageLogger.categories.append('L1GlobalTriggerRecord')
 process.MessageLogger.categories.append('L1GtTrigReport')
 
 process.MessageLogger.cerr.default.limit = 0
-process.MessageLogger.cerr.FwkJob.limit = 0
 process.MessageLogger.cerr.FwkReport.limit = 0
 process.MessageLogger.cerr.FwkSummary.limit = 0
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtTriggerMenuLite_cfg.py
+++ b/EventFilter/L1GlobalTriggerRawToDigi/test/L1GtTriggerMenuLite_cfg.py
@@ -59,7 +59,6 @@ process.MessageLogger.debugModules = ['l1GtTriggerMenuLite']
 process.MessageLogger.categories.append('L1GtTriggerMenuLiteProducer')
 
 process.MessageLogger.cerr.default.limit = 0
-process.MessageLogger.cerr.FwkJob.limit = 0
 process.MessageLogger.cerr.FwkReport.limit = 0
 process.MessageLogger.cerr.FwkSummary.limit = 0
 

--- a/L1Trigger/GlobalTriggerAnalyzer/test/L1GtAnalyzer_cfg.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/test/L1GtAnalyzer_cfg.py
@@ -166,7 +166,6 @@ process.MessageLogger.destinations = ['L1GtAnalyzer_error',
                                       ]
 
 process.MessageLogger.cerr.default.limit = 0
-process.MessageLogger.cerr.FwkJob.limit = 0
 process.MessageLogger.cerr.FwkReport.limit = 0
 process.MessageLogger.cerr.FwkSummary.limit = 0
 

--- a/L1Trigger/GlobalTriggerAnalyzer/test/L1GtPatternGenerator_overrideL1Menu_cfg.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/test/L1GtPatternGenerator_overrideL1Menu_cfg.py
@@ -265,7 +265,6 @@ process.MessageLogger.destinations = ['L1GtPatternGenerator_error',
                                       ]
 
 process.MessageLogger.cerr.default.limit = 0
-process.MessageLogger.cerr.FwkJob.limit = 0
 process.MessageLogger.cerr.FwkReport.limit = 0
 process.MessageLogger.cerr.FwkSummary.limit = 0
 

--- a/RecoTracker/CkfPattern/test/logger_cfi.py
+++ b/RecoTracker/CkfPattern/test/logger_cfi.py
@@ -17,7 +17,6 @@ MessageLogger = cms.Service("MessageLogger",
         default = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
         Root_NoDictionary = cms.untracked.PSet(limit = cms.untracked.int32(0)),
         DEBUG = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-        FwkJob = cms.untracked.PSet(limit = cms.untracked.int32(0)),
         FwkSummary = cms.untracked.PSet(reportEvery = cms.untracked.int32(1),limit = cms.untracked.int32(10000000) ),
         threshold = cms.untracked.string('DEBUG')
     )


### PR DESCRIPTION

#### PR description:

The FwkJob category has not been supported for many years.
These changes are needed to be able to remove the default setup of FwkJob from within MessageLogger itself. 

Other uses of FwkJob in CMSSW declare the category explicitly so are not dependent upon a change to MessageLogger.

#### PR validation:

