### PR TITLE
Remove duplicate dependency from L1Trigger/CSCTriggerPrimitives BuildFile.xml

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/BuildFile.xml
+++ b/L1Trigger/CSCTriggerPrimitives/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="FWCore/Utilities"/>
 <use name="Geometry/CSCGeometry"/>
 <use name="Geometry/GEMGeometry"/>
-<use name="Geometry/CSCGeometry"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
#### PR description:

Remove duplicate
```xml
<use name="Geometry/CSCGeometry"/>
```
entry from `L1Trigger/CSCTriggerPrimitives/BuildFile.xml`.

#### PR validation:

None.