### PR TITLE
drop type specs in RecoHGCal

### DIFF
--- a/RecoHGCal/TICL/python/EMStep_cff.py
+++ b/RecoHGCal/TICL/python/EMStep_cff.py
@@ -18,7 +18,7 @@ filteredLayerClustersEM = _filteredLayerClustersProducer.clone(
 # CA - PATTERN RECOGNITION
 
 ticlTrackstersEM = _trackstersProducer.clone(
-    filtered_mask = cms.InputTag("filteredLayerClustersEM", "EM"),
+    filtered_mask = "filteredLayerClustersEM:EM",
     original_mask = 'ticlTrackstersTrk',
     seeding_regions = "ticlSeedingGlobal",
     filter_on_categories = [0, 1],
@@ -46,7 +46,7 @@ ticlEMStepTask = cms.Task(ticlSeedingGlobal
 
 filteredLayerClustersHFNoseEM = filteredLayerClustersEM.clone(
     LayerClusters = 'hgcalLayerClustersHFNose',
-    LayerClustersInputMask = cms.InputTag("hgcalLayerClustersHFNose","InitialLayerClustersMask"),
+    LayerClustersInputMask = "hgcalLayerClustersHFNose:InitialLayerClustersMask",
     iteration_label = "EMn",
     algo_number = 9
 #no tracking mask for EM for now
@@ -56,10 +56,10 @@ ticlTrackstersHFNoseEM = ticlTrackstersEM.clone(
     detector = "HFNose",
     layer_clusters = "hgcalLayerClustersHFNose",
     layer_clusters_hfnose_tiles = "ticlLayerTileHFNose",
-    original_mask = cms.InputTag("hgcalLayerClustersHFNose","InitialLayerClustersMask"),
-    filtered_mask = cms.InputTag("filteredLayerClustersHFNoseEM","EMn"),
+    original_mask = "hgcalLayerClustersHFNose:InitialLayerClustersMask",
+    filtered_mask = "filteredLayerClustersHFNoseEM:EMn",
     seeding_regions = "ticlSeedingGlobalHFNose",
-    time_layerclusters = cms.InputTag("hgcalLayerClustersHFNose","timeLayerCluster"),
+    time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
     min_clusters_per_ntuplet = 6
 )
 

--- a/RecoHGCal/TICL/python/HADStep_cff.py
+++ b/RecoHGCal/TICL/python/HADStep_cff.py
@@ -19,7 +19,7 @@ filteredLayerClustersHAD = _filteredLayerClustersProducer.clone(
 # CA - PATTERN RECOGNITION
 
 ticlTrackstersHAD = _trackstersProducer.clone(
-    filtered_mask = cms.InputTag("filteredLayerClustersHAD", "HAD"),
+    filtered_mask = "filteredLayerClustersHAD:HAD",
     original_mask = 'ticlTrackstersEM',
     seeding_regions = "ticlSeedingGlobal",
     # For the moment we mask everything w/o requirements since we are last

--- a/RecoHGCal/TICL/python/MIPStep_cff.py
+++ b/RecoHGCal/TICL/python/MIPStep_cff.py
@@ -18,7 +18,7 @@ filteredLayerClustersMIP = _filteredLayerClustersProducer.clone(
 # CA - PATTERN RECOGNITION
 
 ticlTrackstersMIP = _trackstersProducer.clone(
-    filtered_mask = cms.InputTag("filteredLayerClustersMIP", "MIP"),
+    filtered_mask = "filteredLayerClustersMIP:MIP",
     seeding_regions = "ticlSeedingGlobal",
     missing_layers = 3,
     min_clusters_per_ntuplet = 10,
@@ -42,7 +42,7 @@ ticlMIPStepTask = cms.Task(ticlSeedingGlobal
 
 filteredLayerClustersHFNoseMIP = filteredLayerClustersMIP.clone(
     LayerClusters = 'hgcalLayerClustersHFNose',
-    LayerClustersInputMask = cms.InputTag("hgcalLayerClustersHFNose","InitialLayerClustersMask"),
+    LayerClustersInputMask = "hgcalLayerClustersHFNose:InitialLayerClustersMask",
     iteration_label = "MIPn",
     algo_number = 9
 )
@@ -51,10 +51,10 @@ ticlTrackstersHFNoseMIP = ticlTrackstersMIP.clone(
     detector = "HFNose",
     layer_clusters = "hgcalLayerClustersHFNose",
     layer_clusters_hfnose_tiles = "ticlLayerTileHFNose",
-    original_mask = cms.InputTag("hgcalLayerClustersHFNose","InitialLayerClustersMask"),
-    filtered_mask = cms.InputTag("filteredLayerClustersHFNoseMIP","MIPn"),
+    original_mask = "hgcalLayerClustersHFNose:InitialLayerClustersMask",
+    filtered_mask = "filteredLayerClustersHFNoseMIP:MIPn",
     seeding_regions = "ticlSeedingGlobalHFNose",
-    time_layerclusters = cms.InputTag("hgcalLayerClustersHFNose","timeLayerCluster"),
+    time_layerclusters = "hgcalLayerClustersHFNose:timeLayerCluster",
     min_clusters_per_ntuplet = 6
 )
 

--- a/RecoHGCal/TICL/python/TrkStep_cff.py
+++ b/RecoHGCal/TICL/python/TrkStep_cff.py
@@ -17,7 +17,7 @@ filteredLayerClustersTrk = _filteredLayerClustersProducer.clone(
 # CA - PATTERN RECOGNITION
 
 ticlTrackstersTrk = _trackstersProducer.clone(
-  filtered_mask = cms.InputTag("filteredLayerClustersTrk", "Trk"),
+  filtered_mask = "filteredLayerClustersTrk:Trk",
   seeding_regions = "ticlSeedingTrk",
   filter_on_categories = [2, 4], # filter muons and charged hadrons
   pid_threshold = 0.0,

--- a/RecoHGCal/TICL/python/ticl_iterations.py
+++ b/RecoHGCal/TICL/python/ticl_iterations.py
@@ -39,7 +39,7 @@ def TICL_iterations_withReco(process):
   )
 
   process.trackstersTrk = trackstersProducer.clone(
-    filtered_mask = cms.InputTag("filteredLayerClustersTrk", "Trk"),
+    filtered_mask = "filteredLayerClustersTrk:Trk",
     seeding_regions = "ticlSeedingTrk",
     missing_layers = 3,
     min_clusters_per_ntuplet = 5,
@@ -64,7 +64,7 @@ def TICL_iterations_withReco(process):
   )
 
   process.trackstersMIP = trackstersProducer.clone(
-      filtered_mask = cms.InputTag("filteredLayerClustersMIP", "MIP"),
+      filtered_mask = "filteredLayerClustersMIP:MIP",
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 3,
       min_clusters_per_ntuplet = 15,
@@ -89,7 +89,7 @@ def TICL_iterations_withReco(process):
   process.trackstersEM = trackstersProducer.clone(
       max_out_in_hops = 4,
       original_mask = "trackstersMIP",
-      filtered_mask = cms.InputTag("filteredLayerClusters", "algo8"),
+      filtered_mask = "filteredLayerClusters:algo8",
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 1,
       min_clusters_per_ntuplet = 10,
@@ -103,7 +103,7 @@ def TICL_iterations_withReco(process):
 
 
   process.trackstersHAD = trackstersProducer.clone(
-      filtered_mask = cms.InputTag("filteredLayerClusters", "algo8"),
+      filtered_mask = "filteredLayerClusters:algo8",
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 2,
       min_clusters_per_ntuplet = 10,
@@ -144,9 +144,8 @@ def TICL_iterations_withReco(process):
   process.hgcalValidation.insert(-1, process.ticlPFValidation)
   
   if getattr(process,'hgcalValidator'):
-    process.hgcalValidator.label_lcl = cms.InputTag("hgcalLayerClusters")
-    process.hgcalValidator.label_mcl = cms.VInputTag(cms.InputTag("multiClustersFromTrackstersEM", "MultiClustersFromTracksterByCA"), cms.InputTag("multiClustersFromTrackstersHAD", "MultiClustersFromTracksterByCA"))
-
+    process.hgcalValidator.label_lcl = "hgcalLayerClusters"
+    process.hgcalValidator.label_mcl = ["multiClustersFromTrackstersEM:MultiClustersFromTracksterByCA", "multiClustersFromTrackstersHAD:MultiClustersFromTracksterByCA"]
     process.hgcalValidator.domulticlustersPlots = True
     
   return process
@@ -171,7 +170,7 @@ def TICL_iterations(process):
   )
 
   process.trackstersMIP = trackstersProducer.clone(
-      filtered_mask = cms.InputTag("filteredLayerClustersMIP", "MIP"),
+      filtered_mask = "filteredLayerClustersMIP:MIP",
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 3,
       min_clusters_per_ntuplet = 15,
@@ -192,7 +191,7 @@ def TICL_iterations(process):
 
   process.tracksters = trackstersProducer.clone(
       original_mask = "trackstersMIP",
-      filtered_mask = cms.InputTag("filteredLayerClusters", "algo8"),
+      filtered_mask = "filteredLayerClusters:algo8",
       seeding_regions = "ticlSeedingGlobal",
       missing_layers = 2,
       min_clusters_per_ntuplet = 15,


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389), [PR#31523](https://github.com/cms-sw/cmssw/pull/31523), [PR#31538](https://github.com/cms-sw/cmssw/pull/31538), [PR#31748](https://github.com/cms-sw/cmssw/pull/31748), [PR#31784](https://github.com/cms-sw/cmssw/pull/31784))

In this PR, total 5 files changed. 

- RecoHGCal/TICL : 5 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).