### PR TITLE
Remove obsolete MessageLogger configuration options

### DIFF
--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -665,7 +665,6 @@ namespace edm {
       msg << "  </PerformanceSummary>\n"
           << "</PerformanceReport>\n";
       msg << std::flush;
-      //LogInfo("FwkJob") << msg.str();
     }
   }
 
@@ -687,7 +686,6 @@ namespace edm {
       msg << "  </PerformanceModule>\n"
           << "</PerformanceReport>\n";
       msg << std::flush;
-      //LogInfo("FwkJob") << msg.str();
     }
   }
 

--- a/FWCore/MessageService/python/MessageLogger_ReleaseValidation_cfi.py
+++ b/FWCore/MessageService/python/MessageLogger_ReleaseValidation_cfi.py
@@ -34,9 +34,6 @@ MessageLogger = cms.Service("MessageLogger",
         Root_NoDictionary = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
         FwkSummary = cms.untracked.PSet(
             reportEvery = cms.untracked.int32(1),
             limit = cms.untracked.int32(10000000)
@@ -62,8 +59,7 @@ MessageLogger = cms.Service("MessageLogger",
         'cout', 
         'cerr'),
     debugModules = cms.untracked.vstring(),
-    categories = cms.untracked.vstring('FwkJob', 
-        'FwkReport', 
+    categories = cms.untracked.vstring('FwkReport', 
         'FwkSummary', 
         'Root_NoDictionary')
 )

--- a/FWCore/MessageService/python/MessageLogger_ReleaseValidation_cfi.py
+++ b/FWCore/MessageService/python/MessageLogger_ReleaseValidation_cfi.py
@@ -43,14 +43,6 @@ MessageLogger = cms.Service("MessageLogger",
         ),
         threshold = cms.untracked.string('INFO')
     ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(10000000)
-        )
-    ),
     suppressWarning = cms.untracked.vstring(),
     statistics = cms.untracked.vstring('cerr_stats'),
     cerr_stats = cms.untracked.PSet(
@@ -73,8 +65,7 @@ MessageLogger = cms.Service("MessageLogger",
     categories = cms.untracked.vstring('FwkJob', 
         'FwkReport', 
         'FwkSummary', 
-        'Root_NoDictionary'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport')
+        'Root_NoDictionary')
 )
 
 

--- a/FWCore/MessageService/python/MessageLogger_cfi.py
+++ b/FWCore/MessageService/python/MessageLogger_cfi.py
@@ -37,10 +37,6 @@ MessageLogger = cms.Service("MessageLogger",
             optionalPSet = cms.untracked.bool(True),
             limit = cms.untracked.int32(0)
         ),
-        FwkJob = cms.untracked.PSet(
-            optionalPSet = cms.untracked.bool(True),
-            limit = cms.untracked.int32(0)
-        ),
         FwkSummary = cms.untracked.PSet(
             optionalPSet = cms.untracked.bool(True),
             reportEvery = cms.untracked.int32(1),
@@ -70,8 +66,7 @@ MessageLogger = cms.Service("MessageLogger",
         'cout', 
         'cerr'),
     debugModules = cms.untracked.vstring(),
-    categories = cms.untracked.vstring('FwkJob', 
-        'FwkReport', 
+    categories = cms.untracked.vstring('FwkReport', 
         'FwkSummary', 
         'Root_NoDictionary')
 )

--- a/FWCore/MessageService/python/MessageLogger_cfi.py
+++ b/FWCore/MessageService/python/MessageLogger_cfi.py
@@ -21,7 +21,7 @@ MessageLogger = cms.Service("MessageLogger",
     ),
     cerr = cms.untracked.PSet(
         optionalPSet = cms.untracked.bool(True),
-	INFO = cms.untracked.PSet(
+    INFO = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),
         noTimeStamps = cms.untracked.bool(False),
@@ -48,16 +48,6 @@ MessageLogger = cms.Service("MessageLogger",
         ),
         threshold = cms.untracked.string('INFO')
     ),
-    FrameworkJobReport = cms.untracked.PSet(
-        optionalPSet = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            optionalPSet = cms.untracked.bool(True),
-            limit = cms.untracked.int32(10000000)
-        )
-    ),
     suppressWarning = cms.untracked.vstring(),
     statistics = cms.untracked.vstring('cerr_stats'),
     cerr_stats = cms.untracked.PSet(
@@ -83,8 +73,7 @@ MessageLogger = cms.Service("MessageLogger",
     categories = cms.untracked.vstring('FwkJob', 
         'FwkReport', 
         'FwkSummary', 
-        'Root_NoDictionary'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport')
+        'Root_NoDictionary')
 )
 
 

--- a/FWCore/MessageService/src/HardwiredDefaults.cc
+++ b/FWCore/MessageService/src/HardwiredDefaults.cc
@@ -79,16 +79,6 @@ namespace edm {
         destination["cerr"] = cerr;
       }
       {
-        Destination FrameworkJobReport;  // PSet FrameworkJobReport
-        Category default_for_dest;       // PSet default
-        default_for_dest.limit = 0;      // int32 limit = 0
-        FrameworkJobReport.category["default"] = default_for_dest;
-        Category FwkJob;          // PSet FwkJob
-        FwkJob.limit = 10000000;  // int32 limit = 10000000
-        FrameworkJobReport.category["FwkJob"] = FwkJob;
-        destination["FrameworkJobReport"] = FrameworkJobReport;
-      }
-      {
         Destination cerr_stats;            // PSet cerr_stats
         cerr_stats.threshold = "WARNING";  // string threshold = "WARNING"
         cerr_stats.output = "cerr";        // string output = "cerr"
@@ -132,16 +122,6 @@ namespace edm {
         Root_NoDictionary.limit = 0;  // int32 limit = 0
         cerr.category["Root_NoDictionary"] = Root_NoDictionary;
         destination["cerr"] = cerr;
-      }
-      {
-        Destination FrameworkJobReport;  // PSet FrameworkJobReport
-        Category default_for_dest;       // PSet default
-        default_for_dest.limit = 0;      // int32 limit = 0
-        FrameworkJobReport.category["default"] = default_for_dest;
-        Category FwkJob;          // PSet FwkJob
-        FwkJob.limit = 10000000;  // int32 limit = 10000000
-        FrameworkJobReport.category["FwkJob"] = FwkJob;
-        destination["FrameworkJobReport"] = FrameworkJobReport;
       }
       {
         Destination cerr_stats;         // PSet cerr_stats

--- a/FWCore/MessageService/src/HardwiredDefaults.cc
+++ b/FWCore/MessageService/src/HardwiredDefaults.cc
@@ -45,7 +45,6 @@ namespace edm {
     void MessageLoggerDefaults::hardwireGridJobMode() {
       //	std::cerr << " ======= hardwireGridJobMode() \n";
       destinations.push_back("cerr");
-      categories.push_back("FwkJob");
       categories.push_back("FwkReport");
       categories.push_back("FwkSummary");
       categories.push_back("Root_NoDictionary");
@@ -70,9 +69,6 @@ namespace edm {
         FwkSummary.limit = 10000000;  // int32 limit = 10000000
         FwkSummary.reportEvery = 1;   // int32 reportEvery = 1
         cerr.category["FwkSummary"] = FwkSummary;
-        Category FwkJob;   // PSet FwkJob
-        FwkJob.limit = 0;  // int32 limit = 0
-        cerr.category["FwkJob"] = FwkJob;
         Category Root_NoDictionary;   // PSet Root_NoDictionary
         Root_NoDictionary.limit = 0;  // int32 limit = 0
         cerr.category["Root_NoDictionary"] = Root_NoDictionary;
@@ -90,7 +86,6 @@ namespace edm {
     void MessageLoggerDefaults::hardwireReleaseValidationJobMode() {
       //	std::cerr << " ======= hardwireReleaseValidationJobMode() \n";
       destinations.push_back("cerr");
-      categories.push_back("FwkJob");
       categories.push_back("FwkReport");
       categories.push_back("FwkSummary");
       categories.push_back("Root_NoDictionary");
@@ -115,9 +110,6 @@ namespace edm {
         FwkSummary.limit = 10000000;  // int32 limit = 10000000
         FwkSummary.reportEvery = 1;   // int32 reportEvery = 1
         cerr.category["FwkSummary"] = FwkSummary;
-        Category FwkJob;   // PSet FwkJob
-        FwkJob.limit = 0;  // int32 limit = 0
-        cerr.category["FwkJob"] = FwkJob;
         Category Root_NoDictionary;   // PSet Root_NoDictionary
         Root_NoDictionary.limit = 0;  // int32 limit = 0
         cerr.category["Root_NoDictionary"] = Root_NoDictionary;
@@ -135,7 +127,6 @@ namespace edm {
     void MessageLoggerDefaults::hardwireAnalysisJobMode() {
       //	std::cerr << " ======= hardwireAnalysisJobMode() \n";
       destinations.push_back("warnings");
-      categories.push_back("FwkJob");
       categories.push_back("FwkReport");
       categories.push_back("FwkSummary");
       categories.push_back("Root_NoDictionary");
@@ -159,9 +150,6 @@ namespace edm {
         Category FwkSummary;          // PSet FwkSummary
         FwkSummary.limit = 10000000;  // int32 limit = 10000000
         warnings.category["FwkSummary"] = FwkSummary;
-        Category FwkJob;   // PSet FwkJob
-        FwkJob.limit = 0;  // int32 limit = 0
-        warnings.category["FwkJob"] = FwkJob;
         Category Root_NoDictionary;   // PSet Root_NoDictionary
         Root_NoDictionary.limit = 0;  // int32 limit = 0
         warnings.category["Root_NoDictionary"] = Root_NoDictionary;

--- a/FWCore/MessageService/src/MessageLoggerDefaults.h
+++ b/FWCore/MessageService/src/MessageLoggerDefaults.h
@@ -89,7 +89,6 @@ namespace edm {
 
       std::vector<std::string> categories;
       std::vector<std::string> destinations;
-      std::vector<std::string> fwkJobReports;
       std::vector<std::string> statistics;
       std::map<std::string, Destination> destination;
 

--- a/FWCore/MessageService/src/MessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/MessageLoggerScribe.cc
@@ -253,15 +253,6 @@ namespace edm {
       // grab list of categories
       vString categories = getAparameter<vString>(*job_pset_p, "categories", empty_vString);
 
-      // grab list of messageIDs -- these are a synonym for categories
-      // Note -- the use of messageIDs is deprecated in favor of categories
-      {
-        vString messageIDs = getAparameter<vString>(*job_pset_p, "messageIDs", empty_vString);
-
-        // combine the lists, not caring about possible duplicates (for now)
-        copy_all(messageIDs, std::back_inserter(categories));
-      }  // no longer need messageIDs
-
       // grab list of hardwired categories (hardcats) -- these are to be added
       // to the list of categories
       {

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -110,13 +110,6 @@ namespace edm {
       noDuplicates(categories, destinations, "MessageLogger", "categories", "destinations");
       noDuplicates(categories, statistics, "MessageLogger", "categories", "statistics");
 
-      messageIDs = check<vString>(pset, "MessageLogger", "messageIDs");
-      noDuplicates(messageIDs, "MessageLogger", "messageIDs");
-      noKeywords(messageIDs, "MessageLogger", "messageIDs");
-      noNonPSetUsage(pset, messageIDs, "MessageLogger", "messageIDs");
-      noDuplicates(messageIDs, destinations, "MessageLogger", "messageIDs", "destinations");
-      noDuplicates(messageIDs, statistics, "MessageLogger", "messageIDs", "statistics");
-
     }  // psetLists
 
     void edm::service::MessageServicePSetValidation::suppressionLists(ParameterSet const& pset) {
@@ -199,8 +192,6 @@ namespace edm {
       if (s == "destinations")
         return true;
       if (s == "categories")
-        return true;
-      if (s == "messageIDs")
         return true;
       if (s == "debugModules")
         return true;
@@ -305,8 +296,6 @@ namespace edm {
       if (word == "default")
         return false;
       if (word == "categories")
-        return false;
-      if (word == "messageIDs")
         return false;
       if (word == "destinations")
         return false;
@@ -414,8 +403,6 @@ namespace edm {
         if (lookForMatch(statistics, *i))
           continue;
         if (lookForMatch(categories, *i))
-          continue;
-        if (lookForMatch(messageIDs, *i))
           continue;
         if ((*i) == "default")
           continue;
@@ -620,8 +607,6 @@ namespace edm {
       vString::const_iterator end = psnames.end();
       for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
         if (lookForMatch(categories, *i))
-          continue;
-        if (lookForMatch(messageIDs, *i))
           continue;
         if ((*i) == "default")
           continue;

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -63,7 +63,6 @@ namespace edm {
       destinationPSets(pset);
       defaultPSet(pset);
       statisticsPSets(pset);
-      fwkJobReportPSets(pset);
       categoryPSets(pset, "MessageLogger");
 
       // No other PSets -- unless they contain optionalPSet or placeholder=True
@@ -104,20 +103,12 @@ namespace edm {
       noKeywords(statistics, "MessageLogger", "statistics");
       noNonPSetUsage(pset, statistics, "MessageLogger", "statistics");
 
-      fwkJobReports = check<vString>(pset, "MessageLogger", "fwkJobReports");
-      noDuplicates(fwkJobReports, "MessageLogger", "fwkJobReports");
-      noKeywords(fwkJobReports, "MessageLogger", "fwkJobReports");
-      noNonPSetUsage(pset, fwkJobReports, "MessageLogger", "fwkJobReports");
-      noDuplicates(fwkJobReports, destinations, "MessageLogger", "fwkJobReports", "destinations");
-      noDuplicates(fwkJobReports, statistics, "MessageLogger", "fwkJobReports", "statistics");
-
       categories = check<vString>(pset, "MessageLogger", "categories");
       noDuplicates(categories, "MessageLogger", "categories");
       noKeywords(categories, "MessageLogger", "categories");
       noNonPSetUsage(pset, categories, "MessageLogger", "categories");
       noDuplicates(categories, destinations, "MessageLogger", "categories", "destinations");
       noDuplicates(categories, statistics, "MessageLogger", "categories", "statistics");
-      noDuplicates(categories, fwkJobReports, "MessageLogger", "categories", "fwkJobReports");
 
       messageIDs = check<vString>(pset, "MessageLogger", "messageIDs");
       noDuplicates(messageIDs, "MessageLogger", "messageIDs");
@@ -125,8 +116,6 @@ namespace edm {
       noNonPSetUsage(pset, messageIDs, "MessageLogger", "messageIDs");
       noDuplicates(messageIDs, destinations, "MessageLogger", "messageIDs", "destinations");
       noDuplicates(messageIDs, statistics, "MessageLogger", "messageIDs", "statistics");
-      noDuplicates(messageIDs, fwkJobReports, "MessageLogger", "messageIDs", "fwkJobReports");
-      noDuplicates(messageIDs, fwkJobReports, "MessageLogger", "messageIDs", "categories");
 
     }  // psetLists
 
@@ -208,8 +197,6 @@ namespace edm {
       if (s == "statistics")
         return true;
       if (s == "destinations")
-        return true;
-      if (s == "fwkJobReports")
         return true;
       if (s == "categories")
         return true;
@@ -321,8 +308,6 @@ namespace edm {
         return false;
       if (word == "messageIDs")
         return false;
-      if (word == "fwkJobReports")
-        return false;
       if (word == "destinations")
         return false;
       if (word == "statistics")
@@ -427,8 +412,6 @@ namespace edm {
         if (lookForMatch(destinations, *i))
           continue;
         if (lookForMatch(statistics, *i))
-          continue;
-        if (lookForMatch(fwkJobReports, *i))
           continue;
         if (lookForMatch(categories, *i))
           continue;
@@ -629,54 +612,6 @@ namespace edm {
       noneExcept<std::string>(pset, psetName, "string", okstring);
 
     }  // statisticsPSet
-
-    void edm::service::MessageServicePSetValidation::fwkJobReportPSets(ParameterSet const& pset) {
-      ParameterSet empty_PSet;
-      std::vector<std::string>::const_iterator end = fwkJobReports.end();
-      for (std::vector<std::string>::const_iterator i = fwkJobReports.begin(); i != end; ++i) {
-        ParameterSet const& d = pset.getUntrackedParameterSet(*i, empty_PSet);
-        fwkJobReportPSet(d, *i);
-      }
-    }  // fwkJobReportPSets
-
-    void edm::service::MessageServicePSetValidation::fwkJobReportPSet(ParameterSet const& pset,
-                                                                      std::string const& psetName) {
-      // Category PSets
-
-      categoryPSets(pset, psetName);
-
-      // No other PSets -- unless they contain optionalPSet or placeholder=True
-
-      noNoncategoryPsets(pset, psetName);
-
-      // General parameters
-
-      check<bool>(pset, psetName, "placeholder");
-      std::string s = check<std::string>(pset, "psetName", "filename");
-      if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
-      }
-      s = check<std::string>(pset, "psetName", "extension");
-      if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of extension \n";
-      }
-      s = check<std::string>(pset, "psetName", "output");
-
-      // No other parameters
-
-      noneExcept<int>(pset, psetName, "int");
-
-      vString okbool;
-      okbool.push_back("placeholder");
-      okbool.push_back("optionalPSet");
-      noneExcept<bool>(pset, psetName, "bool", okbool);
-      vString okstring;
-      okstring.push_back("output");
-      okstring.push_back("filename");
-      okstring.push_back("extension");
-      noneExcept<std::string>(pset, psetName, "string", okstring);
-
-    }  // fwkJobReportPSet
 
     void edm::service::MessageServicePSetValidation::noNoncategoryPsets(ParameterSet const& pset,
                                                                         std::string const& psetName) {

--- a/FWCore/MessageService/src/MessageServicePSetValidation.h
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.h
@@ -81,8 +81,6 @@ namespace edm {
       void defaultPSet(ParameterSet const& main_pset);
       void statisticsPSets(ParameterSet const& pset);
       void statisticsPSet(ParameterSet const& pset, std::string const& psetName);
-      void fwkJobReportPSets(ParameterSet const& pset);
-      void fwkJobReportPSet(ParameterSet const& pset, std::string const& psetName);
       void categoryPSets(ParameterSet const& pset, std::string const& psetName);
       void categoryPSet(ParameterSet const& pset, std::string const& OuterPsetName, std::string const& categoryName);
       void catInts(ParameterSet const& pset, std::string const& psetName, std::string const& categoryName);
@@ -257,7 +255,6 @@ namespace edm {
       std::ostringstream flaws;
       std::vector<std::string> destinations;
       std::vector<std::string> statistics;
-      std::vector<std::string> fwkJobReports;
       std::vector<std::string> categories;
       std::vector<std::string> messageIDs;
       std::vector<std::string> debugModules;

--- a/FWCore/MessageService/src/MessageServicePSetValidation.h
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.h
@@ -256,7 +256,6 @@ namespace edm {
       std::vector<std::string> destinations;
       std::vector<std::string> statistics;
       std::vector<std::string> categories;
-      std::vector<std::string> messageIDs;
       std::vector<std::string> debugModules;
       std::vector<std::string> suppressInfo;
       std::vector<std::string> suppressFwkInfo;

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -234,15 +234,6 @@ namespace edm {
       // grab list of categories
       vString categories = getAparameter<vString>(*job_pset_p, "categories", empty_vString);
 
-      // grab list of messageIDs -- these are a synonym for categories
-      // Note -- the use of messageIDs is deprecated in favor of categories
-      {
-        vString messageIDs = getAparameter<vString>(*job_pset_p, "messageIDs", empty_vString);
-
-        // combine the lists, not caring about possible duplicates (for now)
-        copy_all(messageIDs, std::back_inserter(categories));
-      }  // no longer need messageIDs
-
       // grab list of hardwired categories (hardcats) -- these are to be added
       // to the list of categories -- change log 24
       {

--- a/FWCore/MessageService/test/messageLogger_cfg.py
+++ b/FWCore/MessageService/test/messageLogger_cfg.py
@@ -10,8 +10,6 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    messageIDs = cms.untracked.vstring('unimportant', 
-        'trkwarning'),
     default = cms.untracked.PSet(
         limit = cms.untracked.int32(100),
         timespan = cms.untracked.int32(60)
@@ -37,7 +35,8 @@ process.MessageLogger = cms.Service("MessageLogger",
         threshold = cms.untracked.string('ERROR')
     ),
     debugModules = cms.untracked.vstring('sendSomeMessages'),
-    categories = cms.untracked.vstring('postBeginJob'),
+    categories = cms.untracked.vstring('postBeginJob', 'unimportant',
+        'trkwarning'),
     destinations = cms.untracked.vstring('detailedInfo', 
         'critical')
 )


### PR DESCRIPTION
#### PR description:

- removed obsolete fwkJobReports parameter
- removed deprecated messageIDs parameter
- removed obsolete FwkJob category

#### PR validation:

Code compiles and relevant framework unit tests pass.