### PR TITLE
Migrate EcalClusterLazyTools to use ESGetToken

### DIFF
--- a/DQM/Physics/src/QcdPhotonsDQM.cc
+++ b/DQM/Physics/src/QcdPhotonsDQM.cc
@@ -26,21 +26,12 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 // For removing ECAL Spikes
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
-
-// geometry
-//#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-//#include "Geometry/Records/interface/CaloGeometryRecord.h"
-//#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-//#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
-//#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-//#include "Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h"
 
 // Math stuff
 #include "DataFormats/Math/interface/deltaR.h"
@@ -54,7 +45,7 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-QcdPhotonsDQM::QcdPhotonsDQM(const ParameterSet& parameters) {
+QcdPhotonsDQM::QcdPhotonsDQM(const ParameterSet& parameters) : ecalClusterToolsESGetTokens_{consumesCollector()} {
   // Get parameters from configuration file
   theTriggerPathToPass_ = parameters.getParameter<string>("triggerPathToPass");
   thePlotTheseTriggersToo_ = parameters.getParameter<vector<string> >("plotTheseTriggersToo");
@@ -341,7 +332,8 @@ void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {
   iEvent.getByToken(theBarrelRecHitToken_, EBReducedRecHits);
   Handle<EcalRecHitCollection> EEReducedRecHits;
   iEvent.getByToken(theEndcapRecHitToken_, EEReducedRecHits);
-  EcalClusterLazyTools lazyTool(iEvent, iSetup, theBarrelRecHitToken_, theEndcapRecHitToken_);
+  EcalClusterLazyTools lazyTool(
+      iEvent, ecalClusterToolsESGetTokens_.get(iSetup), theBarrelRecHitToken_, theEndcapRecHitToken_);
 
   // Find the highest et "decent" photon
   float photon_et = -9.0;

--- a/DQM/Physics/src/QcdPhotonsDQM.h
+++ b/DQM/Physics/src/QcdPhotonsDQM.h
@@ -19,6 +19,8 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+
 namespace reco {
   class Jet;
 }
@@ -62,6 +64,7 @@ private:
   edm::InputTag theEndcapRecHitTag_;
   edm::EDGetTokenT<EcalRecHitCollection> theBarrelRecHitToken_;
   edm::EDGetTokenT<EcalRecHitCollection> theEndcapRecHitToken_;
+  EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   // Histograms
   MonitorElement* h_triggers_passed;

--- a/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
@@ -65,7 +65,7 @@ public:
   Double_t mvaValue(const reco::GsfElectron& ele,
                     const reco::Vertex& vertex,
                     const TransientTrackBuilder& transientTrackBuilder,
-                    EcalClusterLazyTools myEcalCluster,
+                    EcalClusterLazyTools const& myEcalCluster,
                     bool printDebug = kFALSE);
 
   // for kTrigNoIP algorithm
@@ -73,7 +73,7 @@ public:
                     const reco::Vertex& vertex,
                     double rho,
                     //const TransientTrackBuilder& transientTrackBuilder,
-                    EcalClusterLazyTools myEcalCluster,
+                    EcalClusterLazyTools const& myEcalCluster,
                     bool printDebug = kFALSE);
 
   Double_t mvaValue(const pat::Electron& ele, double rho, bool printDebug = kFALSE);
@@ -97,7 +97,7 @@ public:
   Double_t IDIsoCombinedMvaValue(const reco::GsfElectron& ele,
                                  const reco::Vertex& vertex,
                                  const TransientTrackBuilder& transientTrackBuilder,
-                                 EcalClusterLazyTools myEcalCluster,
+                                 EcalClusterLazyTools const& myEcalCluster,
                                  const reco::PFCandidateCollection& PFCandidates,
                                  double Rho,
                                  ElectronEffectiveArea::ElectronEffectiveAreaTarget EATarget,

--- a/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/ElectronIdMVAProducer.cc
@@ -36,6 +36,7 @@ private:
   edm::EDGetTokenT<double> eventrhoToken_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEBRecHitCollectionToken_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEERecHitCollectionToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   double _Rho;
   std::string method_;
@@ -57,7 +58,8 @@ private:
 //
 // constructors and destructor
 //
-ElectronIdMVAProducer::ElectronIdMVAProducer(const edm::ParameterSet& iConfig) {
+ElectronIdMVAProducer::ElectronIdMVAProducer(const edm::ParameterSet& iConfig)
+    : ecalClusterToolsESGetTokens_{consumesCollector()} {
   verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
   vertexToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"));
   electronToken_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electronTag"));
@@ -128,7 +130,10 @@ bool ElectronIdMVAProducer::filter(edm::Event& iEvent, const edm::EventSetup& iS
     dummy = reco::Vertex(p, e, 0, 0, 0);
   }
 
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(iEvent,
+                                 ecalClusterToolsESGetTokens_.get(iSetup),
+                                 reducedEBRecHitCollectionToken_,
+                                 reducedEERecHitCollectionToken_);
 
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -954,7 +954,7 @@ Double_t EGammaMvaEleEstimator::isoMvaValue(Double_t Pt,
 Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
                                          const reco::Vertex& vertex,
                                          const TransientTrackBuilder& transientTrackBuilder,
-                                         EcalClusterLazyTools myEcalCluster,
+                                         EcalClusterLazyTools const& myEcalCluster,
                                          bool printDebug) {
   if (!fisInitialized) {
     std::cout << "Error: EGammaMvaEleEstimator not properly initialized.\n";
@@ -1066,7 +1066,7 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
                                          const reco::Vertex& vertex,
                                          double rho,
                                          //const TransientTrackBuilder& transientTrackBuilder,
-                                         EcalClusterLazyTools myEcalCluster,
+                                         EcalClusterLazyTools const& myEcalCluster,
                                          bool printDebug) {
   if (!fisInitialized) {
     std::cout << "Error: EGammaMvaEleEstimator not properly initialized.\n";
@@ -1619,7 +1619,7 @@ Double_t EGammaMvaEleEstimator::isoMvaValue(const reco::GsfElectron& ele,
 Double_t EGammaMvaEleEstimator::IDIsoCombinedMvaValue(const reco::GsfElectron& ele,
                                                       const reco::Vertex& vertex,
                                                       const TransientTrackBuilder& transientTrackBuilder,
-                                                      EcalClusterLazyTools myEcalCluster,
+                                                      EcalClusterLazyTools const& myEcalCluster,
                                                       const reco::PFCandidateCollection& PFCandidates,
                                                       double Rho,
                                                       ElectronEffectiveArea::ElectronEffectiveAreaTarget EATarget,

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -92,6 +92,7 @@ private:
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEBRecHitCollectionToken_;
   edm::EDGetTokenT<EcalRecHitCollection> reducedEERecHitCollectionToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterESGetTokens_;
 
   EGammaMvaEleEstimator* myMVATrigV0;
   EGammaMvaEleEstimator* myMVATrigNoIPV0;
@@ -179,7 +180,8 @@ ElectronTestAnalyzer::ElectronTestAnalyzer(const edm::ParameterSet& iConfig)
       eventrhoToken_(consumes<double>(edm::InputTag("kt6PFJets", "rho"))),
       muonToken_(consumes<reco::MuonCollection>(edm::InputTag("muons"))),
       reducedEBRecHitCollectionToken_(consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"))),
-      reducedEERecHitCollectionToken_(consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"))) {
+      reducedEERecHitCollectionToken_(consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"))),
+      ecalClusterESGetTokens_{consumesCollector()} {
   Bool_t manualCat = true;
 
   ev = 0;
@@ -294,7 +296,8 @@ void ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
     reco::Vertex::Point p(0, 0, 0);
     dummy = reco::Vertex(p, e, 0, 0, 0);
   }
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(
+      iEvent, ecalClusterESGetTokens_.get(iSetup), reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
 
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
@@ -687,7 +690,8 @@ void ElectronTestAnalyzer::evaluate_mvas(const edm::Event& iEvent, const edm::Ev
     IdentifiedMuons.push_back(*iM);
   }
 
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(
+      iEvent, ecalClusterESGetTokens_.get(iSetup), reducedEBRecHitCollectionToken_, reducedEERecHitCollectionToken_);
 
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);

--- a/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/test/ElectronTestAnalyzer.cc
@@ -75,7 +75,7 @@ private:
   virtual void myVar(const reco::GsfElectron& ele,
                      const reco::Vertex& vertex,
                      const TransientTrackBuilder& transientTrackBuilder,
-                     EcalClusterLazyTools myEcalCluster,
+                     EcalClusterLazyTools const& myEcalCluster,
                      bool printDebug = kFALSE);
   virtual void evaluate_mvas(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
@@ -446,7 +446,7 @@ void ElectronTestAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
 void ElectronTestAnalyzer::myVar(const reco::GsfElectron& ele,
                                  const reco::Vertex& vertex,
                                  const TransientTrackBuilder& transientTrackBuilder,
-                                 EcalClusterLazyTools myEcalCluster,
+                                 EcalClusterLazyTools const& myEcalCluster,
                                  bool printDebug) {
   bool validKF = false;
   reco::TrackRef myTrackRef = ele.closestCtfTrackRef();

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -86,6 +86,7 @@ PATElectronProducer::PATElectronProducer(const edm::ParameterSet& iConfig)
       reducedBarrelRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedBarrelRecHitCollection_)),
       reducedEndcapRecHitCollection_(iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection")),
       reducedEndcapRecHitCollectionToken_(mayConsume<EcalRecHitCollection>(reducedEndcapRecHitCollection_)),
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       // PFCluster Isolation maps
       addPFClusterIso_(iConfig.getParameter<bool>("addPFClusterIso")),
       addPuppiIsolation_(iConfig.getParameter<bool>("addPuppiIsolation")),
@@ -251,8 +252,10 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   edm::InputTag reducedEBRecHitCollection(string("reducedEcalRecHitsEB"));
   edm::InputTag reducedEERecHitCollection(string("reducedEcalRecHitsEE"));
   //EcalClusterLazyTools lazyTools(iEvent, iSetup, reducedEBRecHitCollection, reducedEERecHitCollection);
-  EcalClusterLazyTools lazyTools(
-      iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(iEvent,
+                                 ecalClusterToolsESGetTokens_.get(iSetup),
+                                 reducedBarrelRecHitCollectionToken_,
+                                 reducedEndcapRecHitCollectionToken_);
 
   // for conversion veto selection
   edm::Handle<reco::ConversionCollection> hConversions;

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
@@ -97,6 +97,7 @@ namespace pat {
     const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
     const edm::InputTag reducedEndcapRecHitCollection_;
     const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
+    const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
     const bool addPFClusterIso_;
     const bool addPuppiIsolation_;

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -8,7 +8,6 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
@@ -30,7 +29,10 @@
 using namespace pat;
 
 PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet &iConfig)
-    : isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
+    :
+
+      ecalClusterToolsESGetTokens_{consumesCollector()},
+      isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation")
                                                 : edm::ParameterSet(),
                 consumesCollector(),
                 false),
@@ -172,8 +174,10 @@ void PATPhotonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetu
   edm::Handle<reco::BeamSpot> beamSpotHandle;
   iEvent.getByToken(beamLineToken_, beamSpotHandle);
 
-  EcalClusterLazyTools lazyTools(
-      iEvent, iSetup, reducedBarrelRecHitCollectionToken_, reducedEndcapRecHitCollectionToken_);
+  EcalClusterLazyTools lazyTools(iEvent,
+                                 ecalClusterToolsESGetTokens_.get(iSetup),
+                                 reducedBarrelRecHitCollectionToken_,
+                                 reducedEndcapRecHitCollectionToken_);
 
   // prepare the MC matching
   std::vector<edm::Handle<edm::Association<reco::GenParticleCollection>>> genMatches(genMatchTokens_.size());

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -45,6 +45,8 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+
 namespace pat {
 
   class PATPhotonProducer : public edm::stream::EDProducer<> {
@@ -73,6 +75,8 @@ namespace pat {
     edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
     edm::InputTag reducedEndcapRecHitCollection_;
     edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
+
+    const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
     bool addPFClusterIso_;
     bool addPuppiIsolation_;

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -26,6 +26,8 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
+#include <optional>
+
 class CaloTopology;
 class CaloGeometry;
 class CaloSubdetectorTopology;
@@ -35,12 +37,8 @@ public:
   EcalClusterLazyToolsBase(const edm::Event &ev,
                            const edm::EventSetup &es,
                            edm::EDGetTokenT<EcalRecHitCollection> token1,
-                           edm::EDGetTokenT<EcalRecHitCollection> token2);
-  EcalClusterLazyToolsBase(const edm::Event &ev,
-                           const edm::EventSetup &es,
-                           edm::EDGetTokenT<EcalRecHitCollection> token1,
                            edm::EDGetTokenT<EcalRecHitCollection> token2,
-                           edm::EDGetTokenT<EcalRecHitCollection> token3);
+                           std::optional<edm::EDGetTokenT<EcalRecHitCollection>> token3);
 
   // get time of basic cluster seed crystal
   float BasicClusterSeedTime(const reco::BasicCluster &cluster);
@@ -86,15 +84,12 @@ protected:
 
   edm::EDGetTokenT<EcalRecHitCollection> esRHToken_;
 
-  std::shared_ptr<CaloSubdetectorTopology const> ecalPS_topology_;
+  std::unique_ptr<CaloSubdetectorTopology const> ecalPS_topology_ = nullptr;
 
   edm::ESHandle<EcalIntercalibConstants> ical;
   const EcalIntercalibConstantMap *icalMap;
   edm::ESHandle<EcalADCToGeVConstant> agc;
   edm::ESHandle<EcalLaserDbService> laser;
-  void getIntercalibConstants(const edm::EventSetup &es);
-  void getADCToGeV(const edm::EventSetup &es);
-  void getLaserDbService(const edm::EventSetup &es);
 
 private:
   void getESRecHits(const edm::Event &ev);
@@ -108,7 +103,7 @@ public:
                         const edm::EventSetup &es,
                         edm::EDGetTokenT<EcalRecHitCollection> token1,
                         edm::EDGetTokenT<EcalRecHitCollection> token2)
-      : EcalClusterLazyToolsBase(ev, es, token1, token2) {}
+      : EcalClusterLazyToolsBase(ev, es, token1, token2, std::nullopt) {}
 
   EcalClusterLazyToolsT(const edm::Event &ev,
                         const edm::EventSetup &es,
@@ -142,101 +137,101 @@ public:
   //                  note e3x2 does not have a definate eta/phi geometry, it
   //                  takes the maximum 3x2 block containing the seed regardless
   //                  of whether that 3 in eta or phi
-  float e1x3(const reco::BasicCluster &cluster) {
+  float e1x3(const reco::BasicCluster &cluster) const {
     return ClusterTools::e1x3(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e3x1(const reco::BasicCluster &cluster) {
+  float e3x1(const reco::BasicCluster &cluster) const {
     return ClusterTools::e3x1(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e1x5(const reco::BasicCluster &cluster) {
+  float e1x5(const reco::BasicCluster &cluster) const {
     return ClusterTools::e1x5(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e5x1(const reco::BasicCluster &cluster) {
+  float e5x1(const reco::BasicCluster &cluster) const {
     return ClusterTools::e5x1(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e2x2(const reco::BasicCluster &cluster) {
+  float e2x2(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x2(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e3x2(const reco::BasicCluster &cluster) {
+  float e3x2(const reco::BasicCluster &cluster) const {
     return ClusterTools::e3x2(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e3x3(const reco::BasicCluster &cluster) {
+  float e3x3(const reco::BasicCluster &cluster) const {
     return ClusterTools::e3x3(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e4x4(const reco::BasicCluster &cluster) {
+  float e4x4(const reco::BasicCluster &cluster) const {
     return ClusterTools::e4x4(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float e5x5(const reco::BasicCluster &cluster) {
+  float e5x5(const reco::BasicCluster &cluster) const {
     return ClusterTools::e5x5(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  int n5x5(const reco::BasicCluster &cluster) {
+  int n5x5(const reco::BasicCluster &cluster) const {
     return ClusterTools::n5x5(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
   // 2 crystals wide in eta, 5 wide in phi.
-  float e2x5Right(const reco::BasicCluster &cluster) {
+  float e2x5Right(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x5Right(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
-  float e2x5Left(const reco::BasicCluster &cluster) {
+  float e2x5Left(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x5Left(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // energy in the 5x2 strip above the max crystal (does not contain max crystal)
   // 5 crystals wide in eta, 2 wide in phi.
-  float e2x5Top(const reco::BasicCluster &cluster) {
+  float e2x5Top(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x5Top(cluster, getEcalRecHitCollection(cluster), topology_);
   }
 
   // energy in the 5x2 strip below the max crystal (does not contain max crystal)
-  float e2x5Bottom(const reco::BasicCluster &cluster) {
+  float e2x5Bottom(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x5Bottom(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // energy in a 2x5 strip containing the seed (max) crystal.
   // 2 crystals wide in eta, 5 wide in phi.
   // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
-  float e2x5Max(const reco::BasicCluster &cluster) {
+  float e2x5Max(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2x5Max(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
-  float eLeft(const reco::BasicCluster &cluster) {
+  float eLeft(const reco::BasicCluster &cluster) const {
     return ClusterTools::eLeft(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float eRight(const reco::BasicCluster &cluster) {
+  float eRight(const reco::BasicCluster &cluster) const {
     return ClusterTools::eRight(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float eTop(const reco::BasicCluster &cluster) {
+  float eTop(const reco::BasicCluster &cluster) const {
     return ClusterTools::eTop(cluster, getEcalRecHitCollection(cluster), topology_);
   }
-  float eBottom(const reco::BasicCluster &cluster) {
+  float eBottom(const reco::BasicCluster &cluster) const {
     return ClusterTools::eBottom(cluster, getEcalRecHitCollection(cluster), topology_);
   }
   // the energy of the most energetic crystal in the cluster
-  float eMax(const reco::BasicCluster &cluster) {
+  float eMax(const reco::BasicCluster &cluster) const {
     return ClusterTools::eMax(cluster, getEcalRecHitCollection(cluster));
   }
   // the energy of the second most energetic crystal in the cluster
-  float e2nd(const reco::BasicCluster &cluster) {
+  float e2nd(const reco::BasicCluster &cluster) const {
     return ClusterTools::e2nd(cluster, getEcalRecHitCollection(cluster));
   }
 
   // get the DetId and the energy of the maximum energy crystal of the input cluster
-  std::pair<DetId, float> getMaximum(const reco::BasicCluster &cluster) {
+  std::pair<DetId, float> getMaximum(const reco::BasicCluster &cluster) const {
     return ClusterTools::getMaximum(cluster, getEcalRecHitCollection(cluster));
   }
-  std::vector<float> energyBasketFractionEta(const reco::BasicCluster &cluster) {
+  std::vector<float> energyBasketFractionEta(const reco::BasicCluster &cluster) const {
     return ClusterTools::energyBasketFractionEta(cluster, getEcalRecHitCollection(cluster));
   }
-  std::vector<float> energyBasketFractionPhi(const reco::BasicCluster &cluster) {
+  std::vector<float> energyBasketFractionPhi(const reco::BasicCluster &cluster) const {
     return ClusterTools::energyBasketFractionPhi(cluster, getEcalRecHitCollection(cluster));
   }
 
   // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
-  std::vector<float> lat(const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7) {
+  std::vector<float> lat(const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7) const {
     return ClusterTools::lat(cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0);
   }
 
   // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-  std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) {
+  std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::covariances(cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0);
   }
 
@@ -249,16 +244,16 @@ public:
   // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
   // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
   // think there is but as it hasnt been heavily used, there might be one
-  std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7) {
+  std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::localCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
   }
-  std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) {
+  std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) const {
     return ClusterTools::scLocalCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
   }
-  double zernike20(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) {
+  double zernike20(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) const {
     return ClusterTools::zernike20(cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0);
   }
-  double zernike42(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) {
+  double zernike42(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) const {
     return ClusterTools::zernike42(cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0);
   }
 

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -45,15 +45,16 @@ private:
   const edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusterToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitToken_;
+
+  LazyTools::ESGetTokens esGetTokens_;
 };
 
 testEcalClusterLazyTools::testEcalClusterLazyTools(const edm::ParameterSet& ps)
-    : barrelClusterToken_(
-          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection"))),
-      endcapClusterToken_(
-          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection"))),
-      barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection"))),
-      endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection"))) {}
+    : barrelClusterToken_(consumes(ps.getParameter<edm::InputTag>("barrelClusterCollection"))),
+      endcapClusterToken_(consumes(ps.getParameter<edm::InputTag>("endcapClusterCollection"))),
+      barrelRecHitToken_(consumes(ps.getParameter<edm::InputTag>("barrelRecHitCollection"))),
+      endcapRecHitToken_(consumes(ps.getParameter<edm::InputTag>("endcapRecHitCollection"))),
+      esGetTokens_{consumesCollector()} {}
 
 void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSetup& es) {
   edm::Handle<reco::BasicClusterCollection> pEBClusters;
@@ -64,7 +65,7 @@ void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSet
   ev.getByToken(endcapClusterToken_, pEEClusters);
   const reco::BasicClusterCollection* eeClusters = pEEClusters.product();
 
-  LazyTools lazyTools(ev, es, barrelRecHitToken_, endcapRecHitToken_);
+  LazyTools lazyTools(ev, esGetTokens_.get(es), barrelRecHitToken_, endcapRecHitToken_);
 
   std::cout << "========== BARREL ==========" << std::endl;
   for (auto const& clus : *ebClusters) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/LowPtGsfElectronSeedProducer.cc
@@ -152,6 +152,7 @@ private:  // member data
   const edm::ESGetToken<TrajectoryFitter, TrajectoryFitter::Record> trajectoryFitterToken_;
   const edm::ESGetToken<TrajectorySmoother, TrajectoryFitter::Record> trajectorySmootherToken_;
   const edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> builderToken_;
+  const noZS::EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   const bool passThrough_;
   const bool usePfTracks_;
@@ -182,6 +183,7 @@ LowPtGsfElectronSeedProducer::LowPtGsfElectronSeedProducer(const edm::ParameterS
       trajectoryFitterToken_{esConsumes(conf.getParameter<edm::ESInputTag>("Fitter"))},
       trajectorySmootherToken_{esConsumes(conf.getParameter<edm::ESInputTag>("Smoother"))},
       builderToken_{esConsumes(conf.getParameter<edm::ESInputTag>("TTRHBuilder"))},
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       passThrough_(conf.getParameter<bool>("PassThrough")),
       usePfTracks_(conf.getParameter<bool>("UsePfTracks")),
       minPtThreshold_(conf.getParameter<double>("MinPtThreshold")),
@@ -313,7 +315,7 @@ void LowPtGsfElectronSeedProducer::loop(const edm::Handle<std::vector<T> >& hand
   auto ecalClusters = event.getHandle(ecalClusters_);
 
   // Utility to access to shower shape vars
-  noZS::EcalClusterLazyTools ecalTools(event, setup, ebRecHits_, eeRecHits_);
+  noZS::EcalClusterLazyTools ecalTools(event, ecalClusterToolsESGetTokens_.get(setup), ebRecHits_, eeRecHits_);
 
   // Ensure each cluster is only matched once to a track
   std::vector<int> matchedEcalClusters;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -40,14 +40,15 @@ private:
   const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateProducer_;
   const edm::EDGetTokenT<EcalRecHitCollection> ecalRechitEBToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> ecalRechitEEToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterLazyToolsESGetTokens_;
   const bool EtaOrIeta_;
 };
 
 EgammaHLTClusterShapeProducer::EgammaHLTClusterShapeProducer(const edm::ParameterSet& config)
-    : recoEcalCandidateProducer_(
-          consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
-      ecalRechitEBToken_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("ecalRechitEB"))),
-      ecalRechitEEToken_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("ecalRechitEE"))),
+    : recoEcalCandidateProducer_(consumes(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
+      ecalRechitEBToken_(consumes(config.getParameter<edm::InputTag>("ecalRechitEB"))),
+      ecalRechitEEToken_(consumes(config.getParameter<edm::InputTag>("ecalRechitEE"))),
+      ecalClusterLazyToolsESGetTokens_{consumesCollector()},
       EtaOrIeta_(config.getParameter<bool>("isIeta")) {
   //register your products
   produces<reco::RecoEcalCandidateIsolationMap>();
@@ -72,8 +73,10 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
   edm::Handle<reco::RecoEcalCandidateCollection> recoecalcandHandle;
   iEvent.getByToken(recoEcalCandidateProducer_, recoecalcandHandle);
 
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, ecalRechitEBToken_, ecalRechitEEToken_);
-  noZS::EcalClusterLazyTools lazyTools5x5(iEvent, iSetup, ecalRechitEBToken_, ecalRechitEEToken_);
+  auto const& ecalClusterLazyToolsESData = ecalClusterLazyToolsESGetTokens_.get(iSetup);
+
+  EcalClusterLazyTools lazyTools(iEvent, ecalClusterLazyToolsESData, ecalRechitEBToken_, ecalRechitEEToken_);
+  noZS::EcalClusterLazyTools lazyTools5x5(iEvent, ecalClusterLazyToolsESData, ecalRechitEBToken_, ecalRechitEEToken_);
 
   reco::RecoEcalCandidateIsolationMap clshMap(recoecalcandHandle);
   reco::RecoEcalCandidateIsolationMap clsh5x5Map(recoecalcandHandle);

--- a/RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h
@@ -15,6 +15,7 @@
 #include "RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h"
 #include "CommonTools/CandAlgos/interface/ModifyObjectValueBase.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
@@ -50,6 +51,7 @@ private:
   edm::InputTag endcapEcalHits_;
   edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHitsToken_;
   edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHitsToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   std::unique_ptr<EnergyUncertaintyPhotonSpecific> photonUncertaintyCalculator_;
 };

--- a/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
@@ -1,6 +1,5 @@
 #include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
@@ -11,7 +10,8 @@
 
 #include "RecoEgamma/EgammaPhotonAlgos/interface/EnergyUncertaintyPhotonSpecific.h"
 
-PhotonEnergyCorrector::PhotonEnergyCorrector(const edm::ParameterSet& config, edm::ConsumesCollector&& iC) {
+PhotonEnergyCorrector::PhotonEnergyCorrector(const edm::ParameterSet& config, edm::ConsumesCollector&& iC)
+    : ecalClusterToolsESGetTokens_{std::move(iC)} {
   minR9Barrel_ = config.getParameter<double>("minR9Barrel");
   minR9Endcap_ = config.getParameter<double>("minR9Endcap");
   // get the geometry from the event setup:
@@ -95,7 +95,8 @@ void PhotonEnergyCorrector::calculate(edm::Event& evt,
     minR9 = minR9Endcap_;
   }
 
-  EcalClusterLazyTools lazyTools(evt, iSetup, barrelEcalHitsToken_, endcapEcalHitsToken_);
+  EcalClusterLazyTools lazyTools(
+      evt, ecalClusterToolsESGetTokens_.get(iSetup), barrelEcalHitsToken_, endcapEcalHitsToken_);
 
   ////////////// Here default Ecal corrections based on electrons  ////////////////////////
   if (thePhoton.r9() > minR9) {

--- a/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h
@@ -114,6 +114,8 @@ private:
   edm::EDGetTokenT<edm::ValueMap<float>> phoPFECALClusIsolationToken_;
   edm::EDGetTokenT<edm::ValueMap<float>> phoPFHCALClusIsolationToken_;
 
+  const EcalClusterLazyTools::ESGetTokens ecalClusterESGetTokens_;
+
   std::string conversionProducer_;
   std::string conversionCollection_;
   std::string valueMapPFCandPhoton_;

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -56,7 +56,9 @@ GEDPhotonProducer::RecoStepInfo::RecoStepInfo(const std::string& step) : flags_(
 }
 
 GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config)
-    : recoStep_(config.getParameter<std::string>("reconstructionStep")), conf_(config) {
+    : ecalClusterESGetTokens_{consumesCollector()},
+      recoStep_(config.getParameter<std::string>("reconstructionStep")),
+      conf_(config) {
   // use configuration file to setup input/output collection names
   //
   photonProducer_ = conf_.getParameter<edm::InputTag>("photonProducer");
@@ -644,7 +646,8 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     }
 
     // fill preshower shapes
-    EcalClusterLazyTools toolsforES(evt, es, barrelEcalHits_, endcapEcalHits_, preshowerHits_);
+    EcalClusterLazyTools toolsforES(
+        evt, ecalClusterESGetTokens_.get(es), barrelEcalHits_, endcapEcalHits_, preshowerHits_);
     const float sigmaRR = toolsforES.eseffsirir(*scRef);
     showerShape.effSigmaRR = sigmaRR;
     newCandidate.setShowerShapeVariables(showerShape);

--- a/RecoEgamma/EgammaTools/plugins/EGEnergyAnalyzer.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGEnergyAnalyzer.cc
@@ -57,9 +57,11 @@ private:
   EGEnergyCorrector cordb;
 
   edm::EDGetTokenT<EcalRecHitCollection> ebRHToken_, eeRHToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 };
 
-EGEnergyAnalyzer::EGEnergyAnalyzer(const edm::ParameterSet& iConfig) {
+EGEnergyAnalyzer::EGEnergyAnalyzer(const edm::ParameterSet& iConfig)
+    : ecalClusterToolsESGetTokens_{consumesCollector()} {
   ebRHToken_ = consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEB"));
   eeRHToken_ = consumes<EcalRecHitCollection>(edm::InputTag("reducedEcalRecHitsEE"));
 }
@@ -91,7 +93,7 @@ void EGEnergyAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   Handle<reco::PhotonCollection> hPhotonProduct;
   iEvent.getByLabel("photons", hPhotonProduct);
 
-  EcalClusterLazyTools lazyTools(iEvent, iSetup, ebRHToken_, eeRHToken_);
+  EcalClusterLazyTools lazyTools(iEvent, ecalClusterToolsESGetTokens_.get(iSetup), ebRHToken_, eeRHToken_);
 
   Handle<reco::VertexCollection> hVertexProduct;
   iEvent.getByLabel("offlinePrimaryVerticesWithBS", hVertexProduct);

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVANtuplizer.cc
@@ -114,6 +114,8 @@ private:
   const edm::EDGetTokenT<EcalRecHitCollection> ebRecHits_;
   const edm::EDGetTokenT<EcalRecHitCollection> eeRecHits_;
 
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+
   // to hold ID decisions and categories
   std::vector<int> mvaPasses_;
   std::vector<float> mvaValues_;
@@ -166,6 +168,7 @@ ElectronMVANtuplizer::ElectronMVANtuplizer(const edm::ParameterSet& iConfig)
       genParticles_(consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles"))),
       ebRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection"))),
       eeRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection"))),
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       mvaPasses_(nEleMaps_),
       mvaValues_(nValMaps_),
       mvaCats_(nCats_),
@@ -249,7 +252,8 @@ void ElectronMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSet
   std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
   if (doEnergyMatrix_) {
     // Configure Lazy Tools, which will compute 5x5 quantities
-    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(
+        iEvent, ecalClusterToolsESGetTokens_.get(iSetup), ebRecHits_, eeRecHits_);
   }
 
   // Get MC only Handles, which are allowed to be non-valid

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVANtuplizer.cc
@@ -99,6 +99,8 @@ private:
   const edm::EDGetTokenT<EcalRecHitCollection> ebRecHits_;
   const edm::EDGetTokenT<EcalRecHitCollection> eeRecHits_;
 
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+
   // to hold ID decisions and categories
   std::vector<int> mvaPasses_;
   std::vector<float> mvaValues_;
@@ -173,6 +175,7 @@ PhotonMVANtuplizer::PhotonMVANtuplizer(const edm::ParameterSet& iConfig)
       genParticles_(consumes<edm::View<reco::GenParticle>>(iConfig.getParameter<edm::InputTag>("genParticles"))),
       ebRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("ebReducedRecHitCollection"))),
       eeRecHits_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("eeReducedRecHitCollection"))),
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       mvaPasses_(nPhoMaps_),
       mvaValues_(nValMaps_),
       mvaCats_(nCats_),
@@ -251,7 +254,8 @@ void PhotonMVANtuplizer::analyze(const edm::Event& iEvent, const edm::EventSetup
   std::unique_ptr<noZS::EcalClusterLazyTools> lazyTools;
   if (doEnergyMatrix_) {
     // Configure Lazy Tools, which will compute 5x5 quantities
-    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(iEvent, iSetup, ebRecHits_, eeRecHits_);
+    lazyTools = std::make_unique<noZS::EcalClusterLazyTools>(
+        iEvent, ecalClusterToolsESGetTokens_.get(iSetup), ebRecHits_, eeRecHits_);
   }
 
   // Fill with true number of pileup

--- a/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
@@ -56,6 +56,7 @@ private:
   edm::EDGetTokenT<reco::SuperClusterCollection> sCInputProducerToken_;
   edm::EDGetTokenT<EcalRecHitCollection> rHInputProducerBToken_;
   edm::EDGetTokenT<EcalRecHitCollection> rHInputProducerEToken_;
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   std::string outputCollection_;
   double TimingCut_;
@@ -63,7 +64,7 @@ private:
   double etCut_;
 };
 
-HiSpikeCleaner::HiSpikeCleaner(const edm::ParameterSet& iConfig) {
+HiSpikeCleaner::HiSpikeCleaner(const edm::ParameterSet& iConfig) : ecalClusterToolsESGetTokens_{consumesCollector()} {
   //register your products
   /* Examples
    produces<ExampleData2>();
@@ -133,7 +134,8 @@ void HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   // Create a pointer to the RecHits and raw SuperClusters
   const reco::SuperClusterCollection* rawClusters = pRawSuperClusters.product();
 
-  EcalClusterLazyTools lazyTool(iEvent, iSetup, rHInputProducerBToken_, rHInputProducerEToken_);
+  EcalClusterLazyTools lazyTool(
+      iEvent, ecalClusterToolsESGetTokens_.get(iSetup), rHInputProducerBToken_, rHInputProducerEToken_);
 
   // Define a collection of corrected SuperClusters to put back into the event
   auto corrClusters = std::make_unique<reco::SuperClusterCollection>();

--- a/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/photonIsolationHIProducer.cc
@@ -38,19 +38,22 @@ private:
   edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusters_;
   edm::EDGetTokenT<reco::TrackCollection> tracks_;
 
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+
   std::string trackQuality_;
 };
 
 photonIsolationHIProducer::photonIsolationHIProducer(const edm::ParameterSet& config)
-    : photonProducer_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photonProducer"))),
-      barrelEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("ebRecHitCollection"))),
-      endcapEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("eeRecHitCollection"))),
-      hbhe_(consumes<HBHERecHitCollection>(config.getParameter<edm::InputTag>("hbhe"))),
-      hf_(consumes<HFRecHitCollection>(config.getParameter<edm::InputTag>("hf"))),
-      ho_(consumes<HORecHitCollection>(config.getParameter<edm::InputTag>("ho"))),
-      barrelClusters_(consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterBarrel"))),
-      endcapClusters_(consumes<reco::BasicClusterCollection>(config.getParameter<edm::InputTag>("basicClusterEndcap"))),
-      tracks_(consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("trackCollection"))),
+    : photonProducer_(consumes(config.getParameter<edm::InputTag>("photonProducer"))),
+      barrelEcalHits_(consumes(config.getParameter<edm::InputTag>("ebRecHitCollection"))),
+      endcapEcalHits_(consumes(config.getParameter<edm::InputTag>("eeRecHitCollection"))),
+      hbhe_(consumes(config.getParameter<edm::InputTag>("hbhe"))),
+      hf_(consumes(config.getParameter<edm::InputTag>("hf"))),
+      ho_(consumes(config.getParameter<edm::InputTag>("ho"))),
+      barrelClusters_(consumes(config.getParameter<edm::InputTag>("basicClusterBarrel"))),
+      endcapClusters_(consumes(config.getParameter<edm::InputTag>("basicClusterEndcap"))),
+      tracks_(consumes(config.getParameter<edm::InputTag>("trackCollection"))),
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       trackQuality_(config.getParameter<std::string>("trackQuality")) {
   produces<reco::HIPhotonIsolationMap>();
 }
@@ -82,7 +85,7 @@ void photonIsolationHIProducer::produce(edm::Event& evt, const edm::EventSetup& 
   EcalClusterIsoCalculator CxC(evt, es, barrelClusters, endcapClusters);
   HcalRechitIsoCalculator RxC(evt, es, hbhe, hf, ho);
   TrackIsoCalculator TxC(*trackCollection, trackQuality_);
-  EcalClusterLazyTools lazyTool(evt, es, barrelEcalHits_, endcapEcalHits_);
+  EcalClusterLazyTools lazyTool(evt, ecalClusterToolsESGetTokens_.get(es), barrelEcalHits_, endcapEcalHits_);
 
   for (reco::PhotonCollection::const_iterator phoItr = photons->begin(); phoItr != photons->end(); ++phoItr) {
     reco::HIPhotonIsolation iso;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -45,6 +45,8 @@ private:
   edm::EDGetTokenT<EcalRecHitCollection> recHitsEE_;
   edm::EDGetTokenT<unsigned int> bunchSpacing_;
 
+  const EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
+
   std::vector<std::string> condnames_mean_;
   std::vector<std::string> condnames_sigma_;
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -12,7 +12,7 @@ namespace {
 }  // namespace
 
 PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
-    : calibrator_(new PFEnergyCalibration) {
+    : ecalClusterToolsESGetTokens_{std::move(cc)}, calibrator_(new PFEnergyCalibration) {
   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
   applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
   srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
@@ -148,7 +148,7 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
   }
 
   // Common objects for SRF-aware and old style corrections
-  EcalClusterLazyTools lazyTool(evt, es, recHitsEB_, recHitsEE_);
+  EcalClusterLazyTools lazyTool(evt, ecalClusterToolsESGetTokens_.get(es), recHitsEB_, recHitsEE_);
   EcalReadoutTools readoutTool(evt, es);
 
   if (!srfAwareCorrection_) {

--- a/Validation/EcalClusters/interface/EgammaSuperClusters.h
+++ b/Validation/EcalClusters/interface/EgammaSuperClusters.h
@@ -17,6 +17,8 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+
 #include "HistSpec.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
@@ -46,6 +48,8 @@ private:
   // collections of hits
   edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitCollectionToken_;
   edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitCollectionToken_;
+
+  EcalClusterLazyTools::ESGetTokens ecalClusterToolsESGetTokens_;
 
   HistSpec hsSize_;
   HistSpec hsNumBC_;

--- a/Validation/EcalClusters/src/EgammaSuperClusters.cc
+++ b/Validation/EcalClusters/src/EgammaSuperClusters.cc
@@ -4,8 +4,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
-
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
@@ -31,6 +29,7 @@ EgammaSuperClusters::EgammaSuperClusters(const edm::ParameterSet &ps)
           consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection"))),
       endcapRecHitCollectionToken_(
           consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection"))),
+      ecalClusterToolsESGetTokens_{consumesCollector()},
       hsSize_(ps, "Size"),
       hsNumBC_(ps, "NumBC"),
       hsET_(ps, "ET"),
@@ -419,7 +418,8 @@ void EgammaSuperClusters::analyze(const edm::Event &evt, const edm::EventSetup &
   if (skipBarrel || skipEndcap)
     return;
 
-  EcalClusterLazyTools lazyTool(evt, es, barrelRecHitCollectionToken_, endcapRecHitCollectionToken_);
+  EcalClusterLazyTools lazyTool(
+      evt, ecalClusterToolsESGetTokens_.get(es), barrelRecHitCollectionToken_, endcapRecHitCollectionToken_);
 
   // Get the BARREL collections
   const reco::SuperClusterCollection *barrelRawSuperClusters = pBarrelRawSuperClusters.product();


### PR DESCRIPTION
#### PR description:

Migrate EcalClusterLazyTools to use ESGetToken. After https://github.com/cms-sw/cmssw/pull/31700, this is the next step to migrate the `RecoEgamma/EgammaElectronProducers` package, but it also affects many other packages.

#### PR validation:

CMSSW compiles, local matrix tests pass.