### PR TITLE
Speed up HI miniAOD by removing unneeded features

### DIFF
--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -174,3 +174,7 @@ PFBRECO = cms.Sequence(
     pfNoTauPFBRECO +
     pfMETPFBRECO
     )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(pfPileUpIsoPFBRECO, Enable = False)

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -6,6 +6,10 @@ from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 from CommonTools.ParticleFlow.pfPileUp_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoPileUp_cfi import *
 pfPileUpIsoPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(pfPileUpIsoPFBRECO, Enable = False)
+
 pfNoPileUpIsoPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpIsoPFBRECO',
                                          bottomCollection = 'particleFlowPtrs')
 pfNoPileUpIsoPFBRECOTask = cms.Task(
@@ -175,6 +179,3 @@ PFBRECO = cms.Sequence(
     pfMETPFBRECO
     )
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(pfPileUpIsoPFBRECO, Enable = False)

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -6,9 +6,8 @@ from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 from CommonTools.ParticleFlow.pfPileUp_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoPileUp_cfi import *
 pfPileUpIsoPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(pfPileUpIsoPFBRECO, Enable = False)
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(pfPileUpIsoPFBRECO, Enable = False)
 
 pfNoPileUpIsoPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpIsoPFBRECO',
                                          bottomCollection = 'particleFlowPtrs')
@@ -178,4 +177,3 @@ PFBRECO = cms.Sequence(
     pfNoTauPFBRECO +
     pfMETPFBRECO
     )
-

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -124,3 +124,7 @@ puppiNoLep = puppi.clone(
     puppiNoLep = True,
     PtMaxPhotons = 20.
     )
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(puppi, algos = [])

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -125,6 +125,5 @@ puppiNoLep = puppi.clone(
     PtMaxPhotons = 20.
     )
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(puppi, algos = [])
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(puppi, algos = [])

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -24,7 +24,6 @@ def applySubstructure( process, postfix="" ) :
     from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
     _run2_miniAOD_ANY = (run2_miniAOD_80XLegacy | run2_miniAOD_94XFall17 | run2_miniAOD_UL)
     from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
-    from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
     if postfix=='':
       # Avoid recomputing the PUPPI collections that are present in AOD
       _rerun_puppijets_task = task.copy()
@@ -32,7 +31,7 @@ def applySubstructure( process, postfix="" ) :
                                 getattr(process,'ak8PFJetsPuppiConstituents'),
                                 getattr(process,'ak8PFJetsPuppiSoftDrop'),
                                 getattr(process,'ak8PFJetsPuppiSoftDropMass'))
-      (_run2_miniAOD_ANY | pA_2016 | pp_on_AA).toReplaceWith(task, _rerun_puppijets_task)
+      (_run2_miniAOD_ANY | pA_2016 ).toReplaceWith(task, _rerun_puppijets_task)
     else:
       task.add(getattr(process,'ak8PFJetsPuppi'+postfix),
                getattr(process,'ak8PFJetsPuppiConstituents'+postfix),
@@ -52,8 +51,6 @@ def applySubstructure( process, postfix="" ) :
                                                clearDaughters = cms.bool(False), #False means rekeying
                                                dropSpecific = cms.bool(True),  # Save space
                                                ), process, task )
-
-    pp_on_AA.toModify( getattr(process,'slimmedGenJetsAK8SoftDropSubJets'), cut = 'pt<0', nLoose = 0)
 
     ## PATify puppi soft drop fat jets
     addJetCollection(
@@ -92,7 +89,8 @@ def applySubstructure( process, postfix="" ) :
     #too slow now ==> disable
     from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
     from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
-    for e in [pp_on_XeXe_2017, pp_on_AA, phase2_common]:
+
+    for e in [pp_on_XeXe_2017, phase2_common]:
         e.toModify(getattr(process,'nb1AK8PuppiSoftDrop'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
         e.toModify(getattr(process,'nb2AK8PuppiSoftDrop'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
 
@@ -107,7 +105,7 @@ def applySubstructure( process, postfix="" ) :
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN2','nb2AK8PuppiSoftDropSubjets'+postfix+':ecfN3']
     getattr(process,"patJetsAK8PFPuppiSoftDropSubjets"+postfix).userData.userFloats.src += ['NjettinessAK8Subjets'+postfix+':tau1','NjettinessAK8Subjets'+postfix+':tau2','NjettinessAK8Subjets'+postfix+':tau3','NjettinessAK8Subjets'+postfix+':tau4']
 
-    for e in [pp_on_XeXe_2017, pp_on_AA, phase2_common]:
+    for e in [pp_on_XeXe_2017, phase2_common]:
         e.toModify(getattr(process,'nb1AK8PuppiSoftDropSubjets'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
         e.toModify(getattr(process,'nb2AK8PuppiSoftDropSubjets'+postfix), cuts = ['pt > 999999', 'pt > 999999', 'pt > 999999'] )
 

--- a/RecoBTag/ImpactParameter/python/impactParameterTagInfos_cfi.py
+++ b/RecoBTag/ImpactParameter/python/impactParameterTagInfos_cfi.py
@@ -21,3 +21,4 @@ from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(impactParameterTagInfos, 
                   jetTracks = "ak5JetTracksAssociatorAtVertex",
                   computeGhostTrack = False)
+

--- a/RecoBTag/ImpactParameter/python/impactParameterTagInfos_cfi.py
+++ b/RecoBTag/ImpactParameter/python/impactParameterTagInfos_cfi.py
@@ -18,4 +18,6 @@ impactParameterTagInfos = cms.EDProducer("TrackIPProducer",
 )
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(impactParameterTagInfos, jetTracks = "ak5JetTracksAssociatorAtVertex")
+pp_on_AA.toModify(impactParameterTagInfos, 
+                  jetTracks = "ak5JetTracksAssociatorAtVertex",
+                  computeGhostTrack = False)

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -34,8 +34,8 @@ ca8PFJetsCHSprunedForBoostedTaus = boostedTaus2.ak4PFJets.clone(
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 (pp_on_XeXe_2017 | pp_on_AA).toModify(ca8PFJetsCHSprunedForBoostedTaus, 
-                                                             inputEtMin = 999999.0, src = "particleFlow", 
-                                                             doAreaFastjet = False)
+                                      inputEtMin = 999999.0, src = "particleFlow", 
+                                      doAreaFastjet = False)
 
 boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     subjetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTaus', 'subJetsForSeedingBoostedTaus'),

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -33,7 +33,9 @@ ca8PFJetsCHSprunedForBoostedTaus = boostedTaus2.ak4PFJets.clone(
 
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-(pp_on_XeXe_2017 | pp_on_AA).toModify(ca8PFJetsCHSprunedForBoostedTaus, inputEtMin = 999999.0, src = "particleFlow")
+(pp_on_XeXe_2017 | pp_on_AA).toModify(ca8PFJetsCHSprunedForBoostedTaus, 
+                                                             inputEtMin = 999999.0, src = "particleFlow", 
+                                                             doAreaFastjet = False)
 
 boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     subjetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTaus', 'subJetsForSeedingBoostedTaus'),


### PR DESCRIPTION
#### PR description:

Turns off several unused features in miniAOD:
- Disable pfPileUpIsoPFBRECO
- Remove algos from puppi, making puppi do nearly nothing
- no longer compute ghost tracks for impactParameterTagInfos
- Turn off area calculation for fat jet collection used for taus
CPU savings is around 10%
 
I also cleaned up pp_on_AA era statements in applySubstructure, which no longer do anything since applySubstructure is completely inactive for these eras

#### PR validation:

tested on 140.5611 and 300


