### PR TITLE
Add PbPb modifications to egamma sequences to Run 3 era

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -425,7 +425,7 @@ def miniAOD_customizeCommon(process):
     from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
     _rerun_puppijets_task = task.copy()
     _rerun_puppijets_task.add(process.puppi, process.ak4PFJetsPuppi)
-    (_run2_miniAOD_ANY | pA_2016 | pp_on_AA_2018).toReplaceWith(task, _rerun_puppijets_task)
+    (_run2_miniAOD_ANY | pA_2016 | pp_on_AA_2018 | pp_on_PbPb_run3 ).toReplaceWith(task, _rerun_puppijets_task)
 
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
     process.ak4PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -65,8 +65,9 @@ from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 #HI-specific products needed in pp scenario special configurations
-for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017, pp_on_PbPb_run3]:
     e.toModify( RecoEgammaAOD.outputCommands, 
                 func=lambda outputCommands: outputCommands.extend(['keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerppGED_*_*',
                                                                    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerpp_*_*',

--- a/RecoEgamma/Configuration/python/RecoEgamma_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_cff.py
@@ -36,6 +36,7 @@ from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 #HI-specific algorithms needed in pp scenario special configurations 
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerpp
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducerppGED
@@ -45,5 +46,5 @@ _egammaHighLevelRecoPostPF_HITask = egammaHighLevelRecoPostPFTask.copy()
 _egammaHighLevelRecoPostPF_HITask.add(photonIsolationHIProducerpp)
 _egammaHighLevelRecoPostPF_HITask.add(photonIsolationHIProducerppGED)
 _egammaHighLevelRecoPostPF_HITask.add(photonIsolationHIProducerppIsland)
-for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
+for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017, pp_on_PbPb_run3]:
     e.toReplaceWith(egammaHighLevelRecoPostPFTask, _egammaHighLevelRecoPostPF_HITask)

--- a/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/photonSequence_cff.py
@@ -26,5 +26,6 @@ from Configuration.Eras.Modifier_peripheralPbPb_cff import peripheralPbPb
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_ppRef_2017_cff import ppRef_2017
-for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017]:
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+for e in [pA_2016, peripheralPbPb, pp_on_AA_2018, pp_on_XeXe_2017, ppRef_2017, pp_on_PbPb_run3]:
     e.toReplaceWith(photonTask, _photonTaskWithIsland)


### PR DESCRIPTION
#### PR description:

This PR fixes the exception in 
https://github.com/cms-sw/cmssw/issues/31894

The issue arose in #31668 when I separated the pp_on_AA_2018 and pp_on_PbPb_run3 eras.  The modifications to the photon code for heavy ions were only in the former.  
This PR adds them to the latter.

Tested on 159.1 and 140.5611
