### PR TITLE
Temporarily remove from the matrix workflows for D72 and D73

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_2026.py
+++ b/Configuration/PyReleaseValidation/python/relval_2026.py
@@ -29,8 +29,6 @@ numWFIB.extend([31434.0]) #2026D68
 numWFIB.extend([31834.0]) #2026D69
 numWFIB.extend([32234.0]) #2026D70
 numWFIB.extend([32634.0]) #2026D71
-numWFIB.extend([33034.0]) #2026D72
-numWFIB.extend([33434.0]) #2026D73
 numWFIB.extend([33834.0]) #2026D74
 
 for numWF in numWFIB:


### PR DESCRIPTION
#### PR description:

#31842 activated in the matrix tests for scenarios D72 and D73 which cannot work until when #31765 is integrated, as the tracking layer geometry for the corresponding ETL design is implemented only in that PR. In order to prevent an innocuous but annoying crash in the IB I temporarily switch off them within the standard matrix.

#### PR validation:

```
11:21 farmui01 518> runTheMatrix.py -n | grep D7
32234.0 2026D70+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
32634.0 2026D71+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
33834.0 2026D74+TTbar_14TeV_TuneCP5_GenSimHLBeamSpot14+DigiTrigger+RecoGlobal+HARVESTGlobal 
```