### PR TITLE
Make Alignment/OfflineValidation unit test less brittle

### DIFF
--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -558,17 +558,18 @@ private:
 
     edm::Handle<edm::TriggerResults> hltresults;
     event.getByToken(hltresultsToken, hltresults);
+    if (hltresults.isValid()) {
+      const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
+      int ntrigs = hltresults->size();
 
-    const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
-    int ntrigs = hltresults->size();
-
-    for (int itrig = 0; itrig != ntrigs; ++itrig) {
-      const string &trigName = triggerNames_.triggerName(itrig);
-      bool accept = hltresults->accept(itrig);
-      if (accept == 1) {
-        // emd::LogVerbatim("DMRChecker") << trigName << " " << accept << " ,track size: " << tC.size() << endl;
-        triggerMap_[trigName].first += 1;
-        triggerMap_[trigName].second += tC.size();
+      for (int itrig = 0; itrig != ntrigs; ++itrig) {
+        const string &trigName = triggerNames_.triggerName(itrig);
+        bool accept = hltresults->accept(itrig);
+        if (accept == 1) {
+          // emd::LogVerbatim("DMRChecker") << trigName << " " << accept << " ,track size: " << tC.size() << endl;
+          triggerMap_[trigName].first += 1;
+          triggerMap_[trigName].second += tC.size();
+        }
       }
     }
 
@@ -1533,7 +1534,8 @@ private:
 
     for (auto &bpixid : resDetailsBPixX_) {
       DMRBPixX_->Fill(bpixid.second.runningMeanOfRes_);
-      pixelmap->fillBarrelBin("DMRsX", bpixid.first, bpixid.second.runningMeanOfRes_);
+      if (phase_ == SiPixelPI::phase::one)
+        pixelmap->fillBarrelBin("DMRsX", bpixid.first, bpixid.second.runningMeanOfRes_);
 
       //auto myLocalTopo = PixelDMRS_x_ByLayer->getTheTopo();
       //edm::LogPrint("DMRChecker") << myLocalTopo->print(bpixid.first) << std::endl;
@@ -1555,7 +1557,8 @@ private:
 
     for (auto &bpixid : resDetailsBPixY_) {
       DMRBPixY_->Fill(bpixid.second.runningMeanOfRes_);
-      pixelmap->fillBarrelBin("DMRsY", bpixid.first, bpixid.second.runningMeanOfRes_);
+      if (phase_ == SiPixelPI::phase::one)
+        pixelmap->fillBarrelBin("DMRsY", bpixid.first, bpixid.second.runningMeanOfRes_);
       PixelDMRS_y_ByLayer->fill(bpixid.first, bpixid.second.runningMeanOfRes_);
 
       // split DMR
@@ -1573,7 +1576,8 @@ private:
 
     for (auto &fpixid : resDetailsFPixX_) {
       DMRFPixX_->Fill(fpixid.second.runningMeanOfRes_);
-      pixelmap->fillForwardBin("DMRsX", fpixid.first, fpixid.second.runningMeanOfRes_);
+      if (phase_ == SiPixelPI::phase::one)
+        pixelmap->fillForwardBin("DMRsX", fpixid.first, fpixid.second.runningMeanOfRes_);
       PixelDMRS_x_ByLayer->fill(fpixid.first, fpixid.second.runningMeanOfRes_);
 
       // split DMR
@@ -1591,7 +1595,8 @@ private:
 
     for (auto &fpixid : resDetailsFPixY_) {
       DMRFPixY_->Fill(fpixid.second.runningMeanOfRes_);
-      pixelmap->fillForwardBin("DMRsY", fpixid.first, fpixid.second.runningMeanOfRes_);
+      if (phase_ == SiPixelPI::phase::one)
+        pixelmap->fillForwardBin("DMRsY", fpixid.first, fpixid.second.runningMeanOfRes_);
       PixelDMRS_y_ByLayer->fill(fpixid.first, fpixid.second.runningMeanOfRes_);
 
       // split DMR
@@ -1670,24 +1675,26 @@ private:
     tmap->save(true, 0, 0, "StripHitMap.pdf");
     tmap->save(true, 0, 0, "StripHitMap.png");
 
-    gStyle->SetPalette(kRainBow);
-    pixelmap->beautifyAllHistograms();
+    if (phase_ == SiPixelPI::phase::one) {
+      gStyle->SetPalette(kRainBow);
+      pixelmap->beautifyAllHistograms();
 
-    TCanvas cBX("CanvXBarrel", "CanvXBarrel", 1200, 1000);
-    pixelmap->DrawBarrelMaps("DMRsX", cBX);
-    cBX.SaveAs("pixelBarrelDMR_x.png");
+      TCanvas cBX("CanvXBarrel", "CanvXBarrel", 1200, 1000);
+      pixelmap->DrawBarrelMaps("DMRsX", cBX);
+      cBX.SaveAs("pixelBarrelDMR_x.png");
 
-    TCanvas cFX("CanvXForward", "CanvXForward", 1600, 1000);
-    pixelmap->DrawForwardMaps("DMRsX", cFX);
-    cFX.SaveAs("pixelForwardDMR_x.png");
+      TCanvas cFX("CanvXForward", "CanvXForward", 1600, 1000);
+      pixelmap->DrawForwardMaps("DMRsX", cFX);
+      cFX.SaveAs("pixelForwardDMR_x.png");
 
-    TCanvas cBY("CanvYBarrel", "CanvYBarrel", 1200, 1000);
-    pixelmap->DrawBarrelMaps("DMRsY", cBY);
-    cBY.SaveAs("pixelBarrelDMR_y.png");
+      TCanvas cBY("CanvYBarrel", "CanvYBarrel", 1200, 1000);
+      pixelmap->DrawBarrelMaps("DMRsY", cBY);
+      cBY.SaveAs("pixelBarrelDMR_y.png");
 
-    TCanvas cFY("CanvXForward", "CanvXForward", 1600, 1000);
-    pixelmap->DrawForwardMaps("DMRsY", cFY);
-    cFY.SaveAs("pixelForwardDMR_y.png");
+      TCanvas cFY("CanvXForward", "CanvXForward", 1600, 1000);
+      pixelmap->DrawForwardMaps("DMRsY", cFY);
+      cFY.SaveAs("pixelForwardDMR_y.png");
+    }
 
     // take care now of the 1D histograms
     gStyle->SetOptStat("emr");

--- a/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
+++ b/Alignment/OfflineValidation/plugins/GeneralPurposeTrackAnalyzer.cc
@@ -316,24 +316,26 @@ private:
       edm::LogInfo("GeneralPurposeTrackAnalyzer") << "Reconstructed " << tC.size() << " tracks" << std::endl;
     }
     //int iCounter=0;
+
     edm::Handle<edm::TriggerResults> hltresults;
     event.getByToken(hltresultsToken, hltresults);
+    if (hltresults.isValid()) {
+      const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
+      int ntrigs = hltresults->size();
+      //const vector<std::string> &triggernames = triggerNames_.triggerNames();
 
-    const edm::TriggerNames &triggerNames_ = event.triggerNames(*hltresults);
-    int ntrigs = hltresults->size();
-    //const vector<std::string> &triggernames = triggerNames_.triggerNames();
-
-    for (int itrig = 0; itrig != ntrigs; ++itrig) {
-      const std::string &trigName = triggerNames_.triggerName(itrig);
-      bool accept = hltresults->accept(itrig);
-      if (accept == 1) {
-        if (DEBUG) {
-          edm::LogInfo("GeneralPurposeTrackAnalyzer")
-              << trigName << " " << accept << " ,track size: " << tC.size() << std::endl;
+      for (int itrig = 0; itrig != ntrigs; ++itrig) {
+        const std::string &trigName = triggerNames_.triggerName(itrig);
+        bool accept = hltresults->accept(itrig);
+        if (accept == 1) {
+          if (DEBUG) {
+            edm::LogInfo("GeneralPurposeTrackAnalyzer")
+                << trigName << " " << accept << " ,track size: " << tC.size() << std::endl;
+          }
+          triggerMap_[trigName].first += 1;
+          triggerMap_[trigName].second += tC.size();
+          // triggerInfo.push_back(pair <std::string, int> (trigName, accept));
         }
-        triggerMap_[trigName].first += 1;
-        triggerMap_[trigName].second += tC.size();
-        // triggerInfo.push_back(pair <std::string, int> (trigName, accept));
       }
     }
 
@@ -400,6 +402,7 @@ private:
           }
         }
       }
+
       hHit2D->Fill(nHit2D);
       hHit->Fill(track->numberOfValidHits());
       hnhpxb->Fill(track->hitPattern().numberOfValidPixelBarrelHits());
@@ -631,7 +634,7 @@ private:
       event.getByLabel("offlinePrimaryVertices", vertexHandle);
       double mindxy = 100.;
       double dz = 100;
-      if (vertexHandle.isValid()) {
+      if (vertexHandle.isValid() && !isCosmics_) {
         for (auto pvtx = vertexHandle->cbegin(); pvtx != vertexHandle->cend(); ++pvtx) {
           math::XYZPoint mypoint(pvtx->x(), pvtx->y(), pvtx->z());
           if (abs(mindxy) > abs(track->dxy(mypoint))) {
@@ -652,6 +655,10 @@ private:
         hdxyPV->Fill(100);
         hd0PV->Fill(100);
         hdzPV->Fill(100);
+
+        hd0vsphi->Fill(track->phi(), -track->dxy());
+        hd0vseta->Fill(track->eta(), -track->dxy());
+        hd0vspt->Fill(track->pt(), -track->dxy());
       }
 
       if (DEBUG) {

--- a/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVResolutionJobs.py
@@ -257,7 +257,7 @@ def main():
     parser.add_option('-e','--end',     help='ending point',        dest='end',         action='store',      default='999999')
     parser.add_option('-D','--Dataset', help='dataset to run upon', dest='DATASET',     action='store',      default='/StreamExpressAlignment/Run2017F-TkAlMinBias-Express-v1/ALCARECO')
     parser.add_option('-v','--verbose', help='verbose output',      dest='verbose',     action='store_true', default=False)
-    
+    parser.add_option('-u','--unitTest',help='unit tests?',         dest='isUnitTest',  action='store_true', default=False)
     (opts, args) = parser.parse_args()
 
     global CopyRights
@@ -309,8 +309,22 @@ def main():
     bashdir = os.path.join(cwd,"BASH")
 
     runs.sort()
-    # get from the DB the int luminosities
-    myLumiDB = getLuminosity(HOME,runs[0],runs[-1],True,opts.verbose)
+
+    ## check that the list of runs is not empty
+    if(len(runs)==0):
+        if(opts.isUnitTest):
+            print('\n')
+            print('=' * 70)
+            print("|| WARNING: won't run on any run, probably DAS returned an empty query,\n|| but that's fine because this is a unit test!")
+            print('=' * 70)
+            print('\n')
+            sys.exit(0)
+        else:
+            raise Exception('Will not run on any run.... please check again the configuration')
+    else:
+        # get from the DB the int luminosities
+        myLumiDB = getLuminosity(HOME,runs[0],runs[-1],True,opts.verbose)
+
     if(opts.verbose):
         pprint.pprint(myLumiDB)
 

--- a/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
+++ b/Alignment/OfflineValidation/scripts/submitPVValidationJobs.py
@@ -593,14 +593,15 @@ def main():
 
     desc="""This is a description of %prog."""
     parser = OptionParser(description=desc,version='%prog version 0.1')
-    parser.add_option('-s','--submit',    help='job submitted',    dest='submit',     action='store_true',  default=False)
-    parser.add_option('-j','--jobname',   help='task name',        dest='taskname',   action='store',       default='myTask')
-    parser.add_option('-D','--dataset',   help='selected dataset', dest='data',       action='store'      , default='')
-    parser.add_option('-r','--doRunBased',help='selected dataset', dest='doRunBased', action='store_true' , default=False)
+    parser.add_option('-s','--submit',    help='job submitted',         dest='submit',     action='store_true',  default=False)
+    parser.add_option('-j','--jobname',   help='task name',             dest='taskname',   action='store',       default='myTask')
+    parser.add_option('-D','--dataset',   help='selected dataset',      dest='data',       action='store',       default='')
+    parser.add_option('-r','--doRunBased',help='selected dataset',      dest='doRunBased', action='store_true' , default=False)
     parser.add_option('-i','--input',     help='set input configuration (overrides default)', dest='inputconfig',action='store',default=None)
-    parser.add_option('-b','--begin',  help='starting point',        dest='start',  action='store'     ,default='1')
-    parser.add_option('-e','--end',    help='ending point',          dest='end',    action='store'     ,default='999999')
-    parser.add_option('-v','--verbose', help='verbose output',      dest='verbose',     action='store_true', default=False)
+    parser.add_option('-b','--begin',     help='starting point',        dest='start',      action='store',       default='1')
+    parser.add_option('-e','--end',       help='ending point',          dest='end',        action='store',       default='999999')
+    parser.add_option('-v','--verbose',   help='verbose output',        dest='verbose',    action='store_true',  default=False)
+    parser.add_option('-u','--unitTest',  help='unit tests?',           dest='isUnitTest', action='store_true',  default=False)
 
     (opts, args) = parser.parse_args()
 
@@ -851,12 +852,22 @@ def main():
 
         od = collections.OrderedDict(sorted(file_info.items()))
         # print od
-            
-        # get from the DB the int luminosities
-        if(len(myRuns)==0):
-            raise Exception('Will not run on any run.... please check again the configuration')
 
-        myLumiDB = getLuminosity(HOME,myRuns[0],myRuns[-1],doRunBased,opts.verbose)
+        ## check that the list of runs is not empty
+        if(len(myRuns)==0):
+            if(opts.isUnitTest):
+                print('\n')
+                print('=' * 70)
+                print("|| WARNING: won't run on any run, probably DAS returned an empty query,\n|| but that's fine because this is a unit test!")
+                print('=' * 70)
+                print('\n')
+                sys.exit(0)
+            else:
+                raise Exception('Will not run on any run.... please check again the configuration')
+        else:
+            # get from the DB the int luminosities
+            myLumiDB = getLuminosity(HOME,myRuns[0],myRuns[-1],doRunBased,opts.verbose)
+
         if(opts.verbose):
             pprint.pprint(myLumiDB)
 

--- a/Alignment/OfflineValidation/test/test_all.sh
+++ b/Alignment/OfflineValidation/test/test_all.sh
@@ -157,9 +157,9 @@ validateAlignments.py -c validation_config.ini -N testingAllInOneTool --dryRun |
 printf "\n\n"
 
 echo " TESTING Primary Vertex Validation run-by-run submission ..."
-submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO -i ${LOCAL_TEST_DIR}/testPVValidation_Relvals_DATA.ini -r || die "Failure running PV Validation run-by-run submission" $?
+submitPVValidationJobs.py -j UNIT_TEST -D /HLTPhysics/Run2016C-TkAlMinBias-07Dec2018-v1/ALCARECO -i ${LOCAL_TEST_DIR}/testPVValidation_Relvals_DATA.ini -r --unitTest || die "Failure running PV Validation run-by-run submission" $?
 
 printf "\n\n"
 
 echo " TESTING Split Vertex Validation submission ..."
-submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -i ${LOCAL_TEST_DIR}/PVResolutionExample.ini || die "Failure running Split Vertex Validation submission" $?
+submitPVResolutionJobs.py -j UNIT_TEST -D /JetHT/Run2018C-TkAlMinBias-12Nov2019_UL2018-v2/ALCARECO -i ${LOCAL_TEST_DIR}/PVResolutionExample.ini --unitTest || die "Failure running Split Vertex Validation submission" $?


### PR DESCRIPTION
#### PR description:

It was pointed out to me in issue https://github.com/cms-sw/cmssw/issues/31889 that some of the processes test in the  `Alignment/OfflineValidation` unit tests (added in PR https://github.com/cms-sw/cmssw/pull/31694)  could fail as a result of an empty DAS query.
In this PR I make them less brittle (commit https://github.com/cms-sw/cmssw/pull/31901/commits/4b3e5f9476bf62b9419d0b279525974aec65c736), by exiting the test if the list of files to run upon is empty in the case of unit tests, while maintaining the feature for real validation work usage.
I profit of this PR to fix a couple of mistakes in the ALCARECO monitoring modules, which I noticed when using them recently (commit fa526c0 )

#### PR validation:

Run the unit tests, by inducing a failed DAS query and they still run successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.