### PR TITLE
Add script to access gridpacks with xrdcp for ExternalLHEProducer

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_xrootd.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+echo "   ______________________________________     "
+
+if [ $# -lt 1 ]; then
+    echo "%MSG-ExternalLHEProducer-subprocess ERROR in external process. The gridpack path must be passed as an argument"
+fi
+if [[ $1 != "root://"* ]]; then
+    echo "%MSG-ExternalLHEProducer-subprocess ERROR in external process. Path must have format root://<xrd_path>/<path>"
+    exit 1
+fi 
+
+xrd_path=$1
+gridpack=$(basename $xrd_path)
+
+if [ -e $gridpack ]; then
+    echo "%MSG-ExternalLHEProducer-subprocess WARNING: File $gridpack already exists, it will be overwritten."
+    rm $gridpack
+fi
+
+echo "%MSG-ExternalLHEProducer-subprocess INFO: Copying gridpack $xrd_path locally using xrootd"
+xrdcp $xrd_path .
+
+path=`pwd`/$gridpack
+generic_script=$(dirname ${0})/run_generic_tarball_cvmfs.sh 
+. $generic_script $path ${@:2}


### PR DESCRIPTION
Make script executable

#### PR description:

Adds a script to be used by ExternalLHEProducer that copies gridpacks via xrootd before untarring locally and running. This is useful for private generation (or NanoGen) when the user doesn't have permission to copy to cvmfs, and when size limits prevent copying the gridpack via crab or to the cluster. In the past this has not been supported because central production cannot run like this, but it is now ensured by the request checking script that official samples are on /cvmfs, so this cannot subtly enter production

#### PR validation:

Tested using private gridpack production on crab and locally