### PR TITLE
use smart pointers in SiStripClassToMonitorCondData

### DIFF
--- a/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripClassToMonitorCondData.h
@@ -74,15 +74,15 @@ private:
 
   std::string outPutFileName;
 
-  SiStripPedestalsDQM *pedestalsDQM_;
-  SiStripNoisesDQM *noisesDQM_;
-  SiStripQualityDQM *qualityDQM_;
-  SiStripApvGainsDQM *apvgainsDQM_;
-  SiStripLorentzAngleDQM *lorentzangleDQM_;
-  SiStripBackPlaneCorrectionDQM *bpcorrectionDQM_;
-  SiStripCablingDQM *cablingDQM_;
-  SiStripThresholdDQM *lowthresholdDQM_;
-  SiStripThresholdDQM *highthresholdDQM_;
+  std::unique_ptr<SiStripPedestalsDQM> pedestalsDQM_;
+  std::unique_ptr<SiStripNoisesDQM> noisesDQM_;
+  std::unique_ptr<SiStripQualityDQM> qualityDQM_;
+  std::unique_ptr<SiStripApvGainsDQM> apvgainsDQM_;
+  std::unique_ptr<SiStripLorentzAngleDQM> lorentzangleDQM_;
+  std::unique_ptr<SiStripBackPlaneCorrectionDQM> bpcorrectionDQM_;
+  std::unique_ptr<SiStripCablingDQM> cablingDQM_;
+  std::unique_ptr<SiStripThresholdDQM> lowthresholdDQM_;
+  std::unique_ptr<SiStripThresholdDQM> highthresholdDQM_;
 };
 
 #endif

--- a/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripClassToMonitorCondData.cc
@@ -74,35 +74,7 @@ SiStripClassToMonitorCondData::SiStripClassToMonitorCondData(edm::ParameterSet c
 //
 // ----- Destructor
 //
-SiStripClassToMonitorCondData::~SiStripClassToMonitorCondData() {
-  if (monitorPedestals_) {
-    delete pedestalsDQM_;
-  }
-  if (monitorNoises_) {
-    delete noisesDQM_;
-  }
-  if (monitorQuality_) {
-    delete qualityDQM_;
-  }
-  if (monitorApvGains_) {
-    delete apvgainsDQM_;
-  }
-  if (monitorLorentzAngle_) {
-    delete lorentzangleDQM_;
-  }
-  if (monitorBackPlaneCorrection_) {
-    delete bpcorrectionDQM_;
-  }
-  if (monitorLowThreshold_) {
-    delete lowthresholdDQM_;
-  }
-  if (monitorHighThreshold_) {
-    delete highthresholdDQM_;
-  }
-  if (monitorCabling_) {
-    delete cablingDQM_;
-  }
-}
+SiStripClassToMonitorCondData::~SiStripClassToMonitorCondData() {}
 // -----
 
 //
@@ -110,67 +82,72 @@ SiStripClassToMonitorCondData::~SiStripClassToMonitorCondData() {
 //
 void SiStripClassToMonitorCondData::beginRun(edm::RunNumber_t iRun, edm::EventSetup const &eSetup) {
   if (monitorPedestals_) {
-    pedestalsDQM_ = new SiStripPedestalsDQM(eSetup,
-                                            iRun,
-                                            conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
-                                            conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    pedestalsDQM_ =
+        std::make_unique<SiStripPedestalsDQM>(eSetup,
+                                              iRun,
+                                              conf_.getParameter<edm::ParameterSet>("SiStripPedestalsDQM_PSet"),
+                                              conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorNoises_) {
-    noisesDQM_ = new SiStripNoisesDQM(eSetup,
-                                      iRun,
-                                      conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
-                                      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    noisesDQM_ = std::make_unique<SiStripNoisesDQM>(eSetup,
+                                                    iRun,
+                                                    conf_.getParameter<edm::ParameterSet>("SiStripNoisesDQM_PSet"),
+                                                    conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorQuality_) {
-    qualityDQM_ = new SiStripQualityDQM(eSetup,
-                                        iRun,
-                                        conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
-                                        conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    qualityDQM_ = std::make_unique<SiStripQualityDQM>(eSetup,
+                                                      iRun,
+                                                      conf_.getParameter<edm::ParameterSet>("SiStripQualityDQM_PSet"),
+                                                      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorApvGains_) {
-    apvgainsDQM_ = new SiStripApvGainsDQM(eSetup,
-                                          iRun,
-                                          conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
-                                          conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    apvgainsDQM_ =
+        std::make_unique<SiStripApvGainsDQM>(eSetup,
+                                             iRun,
+                                             conf_.getParameter<edm::ParameterSet>("SiStripApvGainsDQM_PSet"),
+                                             conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorLorentzAngle_) {
-    lorentzangleDQM_ = new SiStripLorentzAngleDQM(eSetup,
-                                                  iRun,
-                                                  conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
-                                                  conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    lorentzangleDQM_ =
+        std::make_unique<SiStripLorentzAngleDQM>(eSetup,
+                                                 iRun,
+                                                 conf_.getParameter<edm::ParameterSet>("SiStripLorentzAngleDQM_PSet"),
+                                                 conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorBackPlaneCorrection_) {
-    bpcorrectionDQM_ =
-        new SiStripBackPlaneCorrectionDQM(eSetup,
-                                          iRun,
-                                          conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
-                                          conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    bpcorrectionDQM_ = std::make_unique<SiStripBackPlaneCorrectionDQM>(
+        eSetup,
+        iRun,
+        conf_.getParameter<edm::ParameterSet>("SiStripBackPlaneCorrectionDQM_PSet"),
+        conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorLowThreshold_) {
-    lowthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                               iRun,
-                                               conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
-                                               conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    lowthresholdDQM_ =
+        std::make_unique<SiStripThresholdDQM>(eSetup,
+                                              iRun,
+                                              conf_.getParameter<edm::ParameterSet>("SiStripLowThresholdDQM_PSet"),
+                                              conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorHighThreshold_) {
-    highthresholdDQM_ = new SiStripThresholdDQM(eSetup,
-                                                iRun,
-                                                conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
-                                                conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    highthresholdDQM_ =
+        std::make_unique<SiStripThresholdDQM>(eSetup,
+                                              iRun,
+                                              conf_.getParameter<edm::ParameterSet>("SiStripHighThresholdDQM_PSet"),
+                                              conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 
   if (monitorCabling_) {
-    cablingDQM_ = new SiStripCablingDQM(eSetup,
-                                        iRun,
-                                        conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
-                                        conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
+    cablingDQM_ = std::make_unique<SiStripCablingDQM>(eSetup,
+                                                      iRun,
+                                                      conf_.getParameter<edm::ParameterSet>("SiStripCablingDQM_PSet"),
+                                                      conf_.getParameter<edm::ParameterSet>("FillConditions_PSet"));
   }
 }  // beginRun
 // -----


### PR DESCRIPTION
#### PR description:

While investigating a crash reported in the SiStrip online client during the most recent MWGR, I stumbled upon this class.
Raw pointers can become smart pointers, for extra safety.

#### PR validation:

Run the SiStrip Online client:
```bash
cmsrel CMSSW_11_2_X_2020-10-22-2300
cd CMSSW_11_2_X_2020-10-22-2300/src/
cmsenv
git cms-addpkg DQM/Integration
# edit the sistrip_dqm_sourceclient-live_cfg.py file not to be in live mode
scramv1 b -j 8
voms-proxy-init -voms cms
mkdir upload
cmsRun DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py dataset=/ExpressCosmics/Commissioning2020-Express-v1/FEVT runNumber=337881
cmsRun DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py dataset=/ExpressCosmics/Commissioning2020-Express-v1/FEVT runNumber=337892
cmsRun DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py dataset=/ExpressCosmics/Commissioning2020-Express-v1/FEVT runNumber=337903 
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.

cc:
@sroychow @arossi83