### PR TITLE
Update of the Scenario 2021 after that the Muon Subtraction Solids have been fixed

### DIFF
--- a/Configuration/Geometry/python/dict2021Geometry.py
+++ b/Configuration/Geometry/python/dict2021Geometry.py
@@ -1025,7 +1025,7 @@ muonDict = {
             'Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml',
             'Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml',
             'Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml',
-            'Geometry/MuonCommonData/data/csc/2021/v2/csc.xml',
+            'Geometry/MuonCommonData/data/csc/2021/v3/csc.xml',
             'Geometry/MuonCommonData/data/mfshield/2017/v2/mfshield.xml',
         ],
         2 : [

--- a/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml
+++ b/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <DDDefinition>
   <open_geometry/>
-  <!--close_geometry/-->
+  <close_geometry/>
 
   <IncludeSection>
     <Include ref='Geometry/CMSCommonData/data/materials/2021/v2/materials.xml'/>
@@ -246,7 +246,7 @@
     <Include ref='Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/csc/2021/v2/csc.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/csc/2021/v3/csc.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mfshield/2017/v2/mfshield.xml'/>
     <Include ref='Geometry/MuonCommonData/data/muonNumbering/2021/v3/muonNumbering.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/forward/2021/v1/forward.xml'/>

--- a/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021ZeroMaterial.xml
+++ b/Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021ZeroMaterial.xml
@@ -245,7 +245,7 @@
     <Include ref='Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml'/>
     <Include ref='Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml'/>
-    <Include ref='Geometry/MuonCommonData/data/csc/2021/v2/csc.xml'/>
+    <Include ref='Geometry/MuonCommonData/data/csc/2021/v3/csc.xml'/>
     <Include ref='Geometry/MuonCommonData/data/mfshield/2017/v2/mfshield.xml'/>
     <Include ref='Geometry/MuonCommonData/data/muonNumbering/2021/v3/muonNumbering.xml'/>
     <Include ref='Geometry/ForwardCommonData/data/forward/2021/v1/forward.xml'/>

--- a/Geometry/CMSCommonData/python/cmsExtendedGeometry2021XML_cfi.py
+++ b/Geometry/CMSCommonData/python/cmsExtendedGeometry2021XML_cfi.py
@@ -247,7 +247,7 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml',
         'Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml',
         'Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml',
-        'Geometry/MuonCommonData/data/csc/2021/v2/csc.xml',
+        'Geometry/MuonCommonData/data/csc/2021/v3/csc.xml',
         'Geometry/MuonCommonData/data/mfshield/2017/v2/mfshield.xml',
     )+
     cms.vstring(

--- a/Geometry/CMSCommonData/python/cmsExtendedGeometry2021ZeroMaterialXML_cfi.py
+++ b/Geometry/CMSCommonData/python/cmsExtendedGeometry2021ZeroMaterialXML_cfi.py
@@ -246,7 +246,7 @@ XMLIdealGeometryESSource = cms.ESSource("XMLIdealGeometryESSource",
         'Geometry/MuonCommonData/data/rpcf/2015/v1/rpcf.xml',
         'Geometry/MuonCommonData/data/gemf/TDR_BaseLine/gemf.xml',
         'Geometry/MuonCommonData/data/gem11/TDR_BaseLine/gem11.xml',
-        'Geometry/MuonCommonData/data/csc/2021/v2/csc.xml',
+        'Geometry/MuonCommonData/data/csc/2021/v3/csc.xml',
         'Geometry/MuonCommonData/data/mfshield/2017/v2/mfshield.xml',
     )+
     cms.vstring(


### PR DESCRIPTION
**PR description:**

This PR followed what I made in PR #31903 (merged). 

As requested by @cvuosalo and @civanch this PR is necessary in order to create payloads for Run3.

@bsunanda @ianna @kpedro88 : FYI 

**PR validation:**

1) validation by "cmsShow.exe -c overlaps.fwc --sim-geom-file cmsDD4HepGeom.root --tgeo-name=CMS"
The attached picture shows, after this PR, no Muon overlaps.

2) validation by "nohup cmsRun SimG4Core/PrintGeomInfo/test/python/g4OverlapCheckDD4Hep_cfg.py >& overlaps.out &" 
Muon's volumes are not present in the overlaps.out file.
 
3) validation by runTheMatrix.py -l 25202.1 :

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Fri Oct 23 10:18:54 2020-date Fri Oct 23 09:58:17 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

![overlapsScenario2021_23 10 2020](https://user-images.githubusercontent.com/28751695/96976006-913e1f80-151b-11eb-8a8c-e6926235f095.png)
