### PR TITLE
fixed cmsLHEtoEOSManager and added unit test to test it

### DIFF
--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -235,11 +235,14 @@ if __name__ == '__main__':
         if reallyDoIt and options.compress:
           theList = theCompressedFilesList
         for f in theList:
-            exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f], stdout=subprocess.PIPE) 
-            getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
-            exeCheckSum.stdout.close()
-            output,err = getCheckSum.communicate()
-            theCheckSumList.append(output.strip())
+            try:
+                exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f], stdout=subprocess.PIPE)
+                getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
+                exeCheckSum.stdout.close()
+                output,err = getCheckSum.communicate()
+                theCheckSumList.append(output.strip())
+            except:
+                theCheckSumList.append("missing-adler32")
 
     newArt = 0
     uploadPath = ''

--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -11,10 +11,13 @@ import time
 import re
 
 defaultEOSRootPath = '/eos/cms/store/lhe'
+if "CMSEOS_LHE_ROOT_DIRECTORY" in os.environ:
+  defaultEOSRootPath = os.environ["CMSEOS_LHE_ROOT_DIRECTORY"]
 defaultEOSLoadPath = 'root://eoscms.cern.ch/'
 defaultEOSlistCommand = 'xrdfs '+defaultEOSLoadPath+' ls '
 defaultEOSmkdirCommand = 'xrdfs '+defaultEOSLoadPath+' mkdir '
 defaultEOSfeCommand = 'xrdfs '+defaultEOSLoadPath+' stat -q IsReadable '
+defaultEOSchecksumCommand = 'xrdfs '+defaultEOSLoadPath+' query checksum '
 defaultEOScpCommand = 'xrdcp -np '
 
 def findXrdDir(theDirRecord):
@@ -52,7 +55,7 @@ def lastArticle():
     return max(artList)
 
 
-def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt):
+def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt, force=False):
 
     inUploadScript = ''
     index = 0
@@ -65,7 +68,7 @@ def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt):
         theCommand = defaultEOSfeCommand+' '+newFileName
         exeFullList = subprocess.Popen(["/bin/sh","-c",theCommand], stdout=subprocess.PIPE)
         result = exeFullList.stdout.readlines()
-        if result[-1].rstrip('\n') == 'Query:  IsReadable':
+        if [line for line in result if ("flags:" in line.lower()) and ("isreadable" in line.lower())] and (not force):
             addFile = False
             print('File '+newFileName+' already exists: do you want to overwrite? [y/n]')
             reply = raw_input()
@@ -82,7 +85,7 @@ def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt):
             if reallyDoIt:
                 exeRealUpload = subprocess.Popen(["/bin/sh","-c",inUploadScript])
                 exeRealUpload.communicate()
-                eosCheckSumCommand = '/afs/cern.ch/project/eos/installation/0.3.15/bin/eos.select find --checksum ' + uploadPath + '/' + str(realFileName) + ' | awk \'{print $2}\' | cut -d= -f2'
+                eosCheckSumCommand = defaultEOSchecksumCommand + uploadPath + '/' + str(realFileName) + ' | awk \'{print $2}\' | cut -d= -f2'
                 exeEosCheckSum = subprocess.Popen(eosCheckSumCommand ,shell=True, stdout=subprocess.PIPE)
                 EosCheckSum = exeEosCheckSum.stdout.read()
                 assert exeEosCheckSum.wait() == 0
@@ -95,7 +98,7 @@ def fileUpload(uploadPath,lheList, checkSumList, reallyDoIt):
                     print('please try to re-upload file ' + str(realFileName) + ' to EOS.\n')
                 else:
                     print('Checksum OK for file ' + str(realFileName))
-        index = index+1            
+        index = index+1
  
 # launch the upload shell script        
 
@@ -149,6 +152,12 @@ if __name__ == '__main__':
                       action='store_true',
                       default=False,
                       dest='compress')
+
+    parser.add_option('--force',
+                      help='Force update if file already exists.',
+                      action='store_true',
+                      default=False,
+                      dest='force')
 
     (options,args) = parser.parse_args()
 
@@ -230,7 +239,7 @@ if __name__ == '__main__':
             getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
             exeCheckSum.stdout.close()
             output,err = getCheckSum.communicate()
-            theCheckSumList.append(output)
+            theCheckSumList.append(output.strip())
 
     newArt = 0
     uploadPath = ''
@@ -268,7 +277,7 @@ if __name__ == '__main__':
 
 
     if newArt > 0:
-        fileUpload(uploadPath,theList, theCheckSumList, reallyDoIt)
+        fileUpload(uploadPath,theList, theCheckSumList, reallyDoIt, options.force)
         listPath = defaultEOSRootPath+'/'+str(newArt)
         print('')
         print('Listing the '+str(newArt)+' article content after upload:')

--- a/GeneratorInterface/LHEInterface/test/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/test/BuildFile.xml
@@ -14,3 +14,5 @@
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="catch2"/>
 </bin>
+
+<test name="test_cmsLHEtoEOSManager" command="test_cmsLHEtoEOSManager.sh"/>

--- a/GeneratorInterface/LHEInterface/test/test_cmsLHEtoEOSManager.sh
+++ b/GeneratorInterface/LHEInterface/test/test_cmsLHEtoEOSManager.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -ex
+if [ $(klist | grep 'Default principal' | grep cmsbuild | wc -l) -eq 0 ] ; then
+  echo "Only run for cmsbuild user which has the rights to copy LHE files"
+fi
+CMSEOS_BASE="/eos/cms/store/user/cmsbuild/unittest/lhe"
+export CMSEOS_LHE_ROOT_DIRECTORY="${CMSEOS_BASE}/ref"
+LHEtoEOSManager=${CMSSW_BASE}/src/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+REF_FILE=$(${LHEtoEOSManager} -l 1 | grep 'lhe.xz$')
+if [ $REF_FILE = "" ] ; then
+  echo "ERROR: Unable to find reference LHE file"
+  exit 1
+fi
+ERR=0
+rm -rf test_cmsLHEtoEOSManager ; mkdir -p test_cmsLHEtoEOSManager
+pushd test_cmsLHEtoEOSManager
+  xrdcp root://eoscms.cern.ch/${CMSEOS_LHE_ROOT_DIRECTORY}/1/${REF_FILE} ${REF_FILE}
+  xz -d ${REF_FILE}
+  REF_FILE=$(echo $REF_FILE | sed 's|.xz$||')
+  UNQ_NAME=$(date +%s)-$(echo $(hostname) $$ | md5sum | sed 's| .*||').lhe
+  mv ${REF_FILE} ${UNQ_NAME}
+  export CMSEOS_LHE_ROOT_DIRECTORY="${CMSEOS_BASE}/ibs"
+  if ${LHEtoEOSManager} -u 1 --compress -f ${UNQ_NAME} ; then
+    ${LHEtoEOSManager} --force -u 1 -f ${UNQ_NAME}.xz || ERR=1
+  else
+    ERR=1
+  fi
+popd
+rm -rf test_cmsLHEtoEOSManager
+xrdfs root://eoscms.cern.ch/ rm    ${CMSEOS_LHE_ROOT_DIRECTORY}/1/${UNQ_NAME}.xz || true
+exit $ERR
+

--- a/GeneratorInterface/LHEInterface/test/test_cmsLHEtoEOSManager.sh
+++ b/GeneratorInterface/LHEInterface/test/test_cmsLHEtoEOSManager.sh
@@ -5,7 +5,7 @@ fi
 CMSEOS_BASE="/eos/cms/store/user/cmsbuild/unittest/lhe"
 export CMSEOS_LHE_ROOT_DIRECTORY="${CMSEOS_BASE}/ref"
 LHEtoEOSManager=${CMSSW_BASE}/src/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
-REF_FILE=$(${LHEtoEOSManager} -l 1 | grep 'lhe.xz$')
+REF_FILE=$(${LHEtoEOSManager} -l 1 | grep 'lhe.xz$' | tail -1)
 if [ $REF_FILE = "" ] ; then
   echo "ERROR: Unable to find reference LHE file"
   exit 1
@@ -28,4 +28,3 @@ popd
 rm -rf test_cmsLHEtoEOSManager
 xrdfs root://eoscms.cern.ch/ rm    ${CMSEOS_LHE_ROOT_DIRECTORY}/1/${UNQ_NAME}.xz || true
 exit $ERR
-


### PR DESCRIPTION
As reported https://hypernews.cern.ch/HyperNews/CMS/get/prep-ops/7320/1.html , cmsLHEtoEOSManager.py does not work for uploading the lhe files. This PR should fix the following issues
- checking of existence of file
- uploading the new LHE file
- fix the checksum commands use `xrdfs query checksum` instead of `eos checksum`

Also added the unit test to make sure that various commands for this scripts properly works. Unit test does the following
- list an existing LHE file and copy it locally
- copy a tmp copy of this file in to cmsbuild eos area
- update  the existing tmp copy
- Do not fail if adler32 is not available from AFS. For IBs and PR tests we do not have access to AFS, so unit test should not fail if it can ot run adler32. Looks like checksum checking is an optional thing https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py#L90-L97

Note that unit test only runs it user has `cmsbuild` token (so it should work for IBs and PR tests)