### PR TITLE
 online Beamspot monitor DQM client (backporting of PR 31904)

### DIFF
--- a/DQM/BeamMonitor/plugins/BuildFile.xml
+++ b/DQM/BeamMonitor/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DQMServices/Core"/>
+<use name="DataFormats/Scalers"/>
 <use name="DataFormats/TrackReco"/>
 <use name="FWCore/Framework"/>
 <use name="DataFormats/BeamSpot"/>
@@ -17,6 +18,10 @@
 </library>
 
 <library file="AlcaBeamMonitor.cc" name="AlcaBeamMonitor">
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library file="OnlineBeamMonitor.cc" name="OnlineBeamMonitor">
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -29,9 +29,12 @@ using namespace reco;
 //----------------------------------------------------------------------------------------------------------------------
 OnlineBeamMonitor::OnlineBeamMonitor(const ParameterSet& ps)
     : monitorName_(ps.getUntrackedParameter<string>("MonitorName")),
-      bsTransientToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
-      bsHLTToken_(esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
-      bsLegacyToken_(esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      bsTransientToken_(
+          esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      bsHLTToken_(
+          esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      bsLegacyToken_(
+          esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
       numberOfValuesToSave_(0) {
   if (!monitorName_.empty())
     monitorName_ = monitorName_ + "/";
@@ -57,10 +60,9 @@ OnlineBeamMonitor::OnlineBeamMonitor(const ParameterSet& ps)
   histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotLegacy"));
   histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotTransient"));
 
-  for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
-    for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
-         itM++) {
-      histosMap_[*itV][itM->first][itM->second] = nullptr;
+  for (const auto& itV : varNamesV_) {
+    for (const auto& itM : histoByCategoryNames_) {
+      histosMap_[itV][itM.first][itM.second] = nullptr;
     }
   }
 }
@@ -80,31 +82,28 @@ void OnlineBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker,
   string title;
   int firstLumi = 1;
   int lastLumi = 3000;
-  for (HistosContainer::iterator itM = histosMap_.begin(); itM != histosMap_.end(); itM++) {
+  for (auto& itM : histosMap_) {
     //Making histos per Lumi
     // x,y,z,sigmaX,sigmaY,sigmaZ
-    for (map<string, map<string, MonitorElement*> >::iterator itMM = itM->second.begin(); itMM != itM->second.end();
-         itMM++) {
-      if (itMM->first != "run") {
-        for (map<string, MonitorElement*>::iterator itMMM = itMM->second.begin(); itMMM != itMM->second.end();
-             itMMM++) {
-          name = string("h") + itM->first + itMMM->first;
-          title = itM->first + "_{0} " + itMMM->first;
-          if (itMM->first == "lumi") {
+    for (auto& itMM : itM.second) {
+      if (itMM.first != "run") {
+        for (auto& itMMM : itMM.second) {
+          name = string("h") + itM.first + itMMM.first;
+          title = itM.first + "_{0} " + itMMM.first;
+          if (itMM.first == "lumi") {
             ibooker.setCurrentFolder(monitorName_ + "Debug");
-            itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
-            itMMM->second->setEfficiencyFlag();
+            itMMM.second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
+            itMMM.second->setEfficiencyFlag();
           } else {
-            LogInfo("OnlineBeamMonitorClient") << "Unrecognized category " << itMM->first;
-            // assert(0);
+            LogInfo("OnlineBeamMonitorClient") << "Unrecognized category " << itMM.first;
           }
-          if (itMMM->second != nullptr) {
-            if (itMMM->first.find('-') != string::npos) {
-              itMMM->second->setAxisTitle(string("#Delta ") + itM->first + "_{0} (cm)", 2);
+          if (itMMM.second != nullptr) {
+            if (itMMM.first.find('-') != string::npos) {
+              itMMM.second->setAxisTitle(string("#Delta ") + itM.first + "_{0} (cm)", 2);
             } else {
-              itMMM->second->setAxisTitle(itM->first + "_{0} (cm)", 2);
+              itMMM.second->setAxisTitle(itM.first + "_{0} (cm)", 2);
             }
-            itMMM->second->setAxisTitle("Lumisection", 1);
+            itMMM.second->setAxisTitle("Lumisection", 1);
           }
         }
       }
@@ -133,48 +132,31 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
   ESHandle<BeamSpotOnlineObjects> bsHLTHandle;
   ESHandle<BeamSpotOnlineObjects> bsLegacyHandle;
   ESHandle<BeamSpotObjects> bsTransientHandle;
-  try {
-    bsHLTHandle = iSetup.getHandle(bsHLTToken_);
-  } catch (cms::Exception& exception) {
-    LogError("OnlineBeamMonitor") << exception.what();
-    return nullptr;
-  }
-  try {
-    bsLegacyHandle = iSetup.getHandle(bsLegacyToken_);
-  } catch (cms::Exception& exception) {
-    LogError("OnlineBeamMonitor") << exception.what();
-    return nullptr;
-  }
-  try {
-    bsTransientHandle = iSetup.getHandle(bsTransientToken_);
-  } catch (cms::Exception& exception) {
-    LogError("OnlineBeamMonitor") << exception.what();
-    return nullptr;
-  }
-  if (bsHLTHandle.isValid()) {  // check the product
-    const BeamSpotOnlineObjects* spotDB = bsHLTHandle.product();
+
+  if (auto bsHLTHandle = iSetup.getHandle(bsHLTToken_)) {
+    auto const& spotDB = *bsHLTHandle;
 
     // translate from BeamSpotObjects to reco::BeamSpot
-    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+    BeamSpot::Point apoint(spotDB.GetX(), spotDB.GetY(), spotDB.GetZ());
 
     BeamSpot::CovarianceMatrix matrix;
     for (int i = 0; i < 7; ++i) {
       for (int j = 0; j < 7; ++j) {
-        matrix(i, j) = spotDB->GetCovariance(i, j);
+        matrix(i, j) = spotDB.GetCovariance(i, j);
       }
     }
 
     beamSpotsMap_["HLT"] =
-        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+        BeamSpot(apoint, spotDB.GetSigmaZ(), spotDB.Getdxdz(), spotDB.Getdydz(), spotDB.GetBeamWidthX(), matrix);
 
     BeamSpot* aSpot = &(beamSpotsMap_["HLT"]);
 
-    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
-    aSpot->setEmittanceX(spotDB->GetEmittanceX());
-    aSpot->setEmittanceY(spotDB->GetEmittanceY());
-    aSpot->setbetaStar(spotDB->GetBetaStar());
+    aSpot->setBeamWidthY(spotDB.GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB.GetEmittanceX());
+    aSpot->setEmittanceY(spotDB.GetEmittanceY());
+    aSpot->setbetaStar(spotDB.GetBetaStar());
 
-    if (spotDB->GetBeamType() == 2) {
+    if (spotDB.GetBeamType() == 2) {
       aSpot->setType(reco::BeamSpot::Tracker);
     } else {
       aSpot->setType(reco::BeamSpot::Fake);
@@ -184,30 +166,29 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
   } else {
     LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
   }
-  if (bsLegacyHandle.isValid()) {  // check the product
-    const BeamSpotOnlineObjects* spotDB = bsLegacyHandle.product();
-
+  if (auto bsLegacyHandle = iSetup.getHandle(bsLegacyToken_)) {
+    auto const& spotDB = *bsLegacyHandle;
     // translate from BeamSpotObjects to reco::BeamSpot
-    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+    BeamSpot::Point apoint(spotDB.GetX(), spotDB.GetY(), spotDB.GetZ());
 
     BeamSpot::CovarianceMatrix matrix;
     for (int i = 0; i < 7; ++i) {
       for (int j = 0; j < 7; ++j) {
-        matrix(i, j) = spotDB->GetCovariance(i, j);
+        matrix(i, j) = spotDB.GetCovariance(i, j);
       }
     }
 
     beamSpotsMap_["Legacy"] =
-        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+        BeamSpot(apoint, spotDB.GetSigmaZ(), spotDB.Getdxdz(), spotDB.Getdydz(), spotDB.GetBeamWidthX(), matrix);
 
     BeamSpot* aSpot = &(beamSpotsMap_["Legacy"]);
 
-    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
-    aSpot->setEmittanceX(spotDB->GetEmittanceX());
-    aSpot->setEmittanceY(spotDB->GetEmittanceY());
-    aSpot->setbetaStar(spotDB->GetBetaStar());
+    aSpot->setBeamWidthY(spotDB.GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB.GetEmittanceX());
+    aSpot->setEmittanceY(spotDB.GetEmittanceY());
+    aSpot->setbetaStar(spotDB.GetBetaStar());
 
-    if (spotDB->GetBeamType() == 2) {
+    if (spotDB.GetBeamType() == 2) {
       aSpot->setType(reco::BeamSpot::Tracker);
     } else {
       aSpot->setType(reco::BeamSpot::Fake);
@@ -217,30 +198,30 @@ std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLumino
   } else {
     LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
   }
-  if (bsTransientHandle.isValid()) {  // check the product
-    const BeamSpotObjects* spotDB = bsTransientHandle.product();
+  if (auto bsTransientHandle = iSetup.getHandle(bsTransientToken_)) {
+    auto const& spotDB = *bsTransientHandle;
 
     // translate from BeamSpotObjects to reco::BeamSpot
-    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+    BeamSpot::Point apoint(spotDB.GetX(), spotDB.GetY(), spotDB.GetZ());
 
     BeamSpot::CovarianceMatrix matrix;
     for (int i = 0; i < 7; ++i) {
       for (int j = 0; j < 7; ++j) {
-        matrix(i, j) = spotDB->GetCovariance(i, j);
+        matrix(i, j) = spotDB.GetCovariance(i, j);
       }
     }
 
     beamSpotsMap_["Transient"] =
-        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+        BeamSpot(apoint, spotDB.GetSigmaZ(), spotDB.Getdxdz(), spotDB.Getdydz(), spotDB.GetBeamWidthX(), matrix);
 
     BeamSpot* aSpot = &(beamSpotsMap_["Transient"]);
 
-    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
-    aSpot->setEmittanceX(spotDB->GetEmittanceX());
-    aSpot->setEmittanceY(spotDB->GetEmittanceY());
-    aSpot->setbetaStar(spotDB->GetBetaStar());
+    aSpot->setBeamWidthY(spotDB.GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB.GetEmittanceX());
+    aSpot->setEmittanceY(spotDB.GetEmittanceY());
+    aSpot->setbetaStar(spotDB.GetBetaStar());
 
-    if (spotDB->GetBeamType() == 2) {
+    if (spotDB.GetBeamType() == 2) {
       aSpot->setType(reco::BeamSpot::Tracker);
     } else {
       aSpot->setType(reco::BeamSpot::Fake);
@@ -278,53 +259,50 @@ void OnlineBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, c
   map<std::string, pair<double, double> > resultsMap;
   vector<pair<double, double> > vertexResults;
   MonitorElement* histo = nullptr;
-  for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
+  for (const auto& itV : varNamesV_) {
     resultsMap.clear();
-    for (BeamSpotContainer::iterator itBS = beamSpotsMap_.begin(); itBS != beamSpotsMap_.end(); itBS++) {
-      if (itBS->second.type() == BeamSpot::Tracker) {
-        if (*itV == "x") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.x0(), itBS->second.x0Error());
-        } else if (*itV == "y") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.y0(), itBS->second.y0Error());
-        } else if (*itV == "z") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.z0(), itBS->second.z0Error());
-        } else if (*itV == "sigmaX") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.BeamWidthX(), itBS->second.BeamWidthXError());
-        } else if (*itV == "sigmaY") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.BeamWidthY(), itBS->second.BeamWidthYError());
-        } else if (*itV == "sigmaZ") {
-          resultsMap[itBS->first] = pair<double, double>(itBS->second.sigmaZ(), itBS->second.sigmaZ0Error());
+    for (const auto& itBS : beamSpotsMap_) {
+      if (itBS.second.type() == BeamSpot::Tracker) {
+        if (itV == "x") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.x0(), itBS.second.x0Error());
+        } else if (itV == "y") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.y0(), itBS.second.y0Error());
+        } else if (itV == "z") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.z0(), itBS.second.z0Error());
+        } else if (itV == "sigmaX") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.BeamWidthX(), itBS.second.BeamWidthXError());
+        } else if (itV == "sigmaY") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.BeamWidthY(), itBS.second.BeamWidthYError());
+        } else if (itV == "sigmaZ") {
+          resultsMap[itBS.first] = pair<double, double>(itBS.second.sigmaZ(), itBS.second.sigmaZ0Error());
         } else {
-          LogInfo("OnlineBeamMonitor") << "The histosMap_ has been built with the name " << *itV
+          LogInfo("OnlineBeamMonitor") << "The histosMap_ has been built with the name " << itV
                                        << " that I can't recognize!";
-          //assert(0);
         }
       }
     }
 
-    for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
-         itM++) {
-      if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr)
+    for (const auto& itM : histoByCategoryNames_) {
+      if ((histo = histosMap_[itV][itM.first][itM.second]) == nullptr)
         continue;
-      if (itM->second == "Lumibased BeamSpotHLT") {
+      if (itM.second == "Lumibased BeamSpotHLT") {
         if (resultsMap.find("HLT") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["HLT"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["HLT"].second);
         }
-      } else if (itM->second == "Lumibased BeamSpotLegacy") {
+      } else if (itM.second == "Lumibased BeamSpotLegacy") {
         if (resultsMap.find("Legacy") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["Legacy"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["Legacy"].second);
         }
-      } else if (itM->second == "Lumibased BeamSpotTransient") {
+      } else if (itM.second == "Lumibased BeamSpotTransient") {
         if (resultsMap.find("Transient") != resultsMap.end()) {
           histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["Transient"].first);
           histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["Transient"].second);
         }
       } else {
-        LogInfo("OnlineBeamMonitor") << "The histosMap_ have a histogram named " << itM->second
+        LogInfo("OnlineBeamMonitor") << "The histosMap_ have a histogram named " << itM.second
                                      << " that I can't recognize in this loop!";
-        //assert(0);
       }
     }
   }
@@ -340,55 +318,47 @@ void OnlineBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
   int firstLumi = *processedLumis_.begin();
   int lastLumi = *(--processedLumis_.end());
   bsChoice_->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
-  for (HistosContainer::iterator itH = histosMap_.begin(); itH != histosMap_.end(); itH++) {
-    for (map<string, map<string, MonitorElement*> >::iterator itHH = itH->second.begin(); itHH != itH->second.end();
-         itHH++) {
+  for (auto& itH : histosMap_) {
+    for (auto& itHH : itH.second) {
       double min = bigNumber;
       double max = -bigNumber;
-      //double minDelta = bigNumber;
-      //double maxDelta = -bigNumber;
-      //      double minDeltaProf = bigNumber;
-      //      double maxDeltaProf = -bigNumber;
-      if (itHH->first != "run") {
-        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
-             itHHH++) {
-          if (itHHH->second != nullptr) {
-            for (int bin = 1; bin <= itHHH->second->getTH1()->GetNbinsX(); bin++) {
-              if (itHHH->second->getTH1()->GetBinError(bin) != 0 || itHHH->second->getTH1()->GetBinContent(bin) != 0) {
-                if (itHHH->first == "Lumibased BeamSpotHLT" || itHHH->first == "Lumibased BeamSpotLegacy" ||
-                    itHHH->first == "Lumibased BeamSpotTransient") {
-                  if (min > itHHH->second->getTH1()->GetBinContent(bin)) {
-                    min = itHHH->second->getTH1()->GetBinContent(bin);
+      if (itHH.first != "run") {
+        for (auto& itHHH : itHH.second) {
+          if (itHHH.second != nullptr) {
+            for (int bin = 1; bin <= itHHH.second->getTH1()->GetNbinsX(); bin++) {
+              if (itHHH.second->getTH1()->GetBinError(bin) != 0 || itHHH.second->getTH1()->GetBinContent(bin) != 0) {
+                if (itHHH.first == "Lumibased BeamSpotHLT" || itHHH.first == "Lumibased BeamSpotLegacy" ||
+                    itHHH.first == "Lumibased BeamSpotTransient") {
+                  if (min > itHHH.second->getTH1()->GetBinContent(bin)) {
+                    min = itHHH.second->getTH1()->GetBinContent(bin);
                   }
-                  if (max < itHHH->second->getTH1()->GetBinContent(bin)) {
-                    max = itHHH->second->getTH1()->GetBinContent(bin);
+                  if (max < itHHH.second->getTH1()->GetBinContent(bin)) {
+                    max = itHHH.second->getTH1()->GetBinContent(bin);
                   }
                 } else {
-                  LogInfo("OnlineBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
+                  LogInfo("OnlineBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH.first
                                                      << " that I can't recognize in this loop!";
-                  // assert(0);
                 }
               }
             }
           }
         }
-        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
-             itHHH++) {
-          if (itHHH->second != nullptr) {
-            if (itHHH->first == "Lumibased BeamSpotHLT" || itHHH->first == "Lumibased BeamSpotLegacy" ||
-                itHHH->first == "Lumibased BeamSpotTransient") {
+        for (auto& itHHH : itHH.second) {
+          if (itHHH.second != nullptr) {
+            if (itHHH.first == "Lumibased BeamSpotHLT" || itHHH.first == "Lumibased BeamSpotLegacy" ||
+                itHHH.first == "Lumibased BeamSpotTransient") {
               if ((max == -bigNumber && min == bigNumber) || max - min == 0) {
-                itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
-                itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);
+                itHHH.second->getTH1()->SetMinimum(itHHH.second->getTH1()->GetMinimum() - 0.01);
+                itHHH.second->getTH1()->SetMaximum(itHHH.second->getTH1()->GetMaximum() + 0.01);
               } else {
-                itHHH->second->getTH1()->SetMinimum(min - 0.1 * (max - min));
-                itHHH->second->getTH1()->SetMaximum(max + 0.1 * (max - min));
+                itHHH.second->getTH1()->SetMinimum(min - 0.1 * (max - min));
+                itHHH.second->getTH1()->SetMaximum(max + 0.1 * (max - min));
               }
             } else {
-              LogInfo("OnlineBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
-                                                 << " that I can't recognize in this loop!";
+              LogInfo("OnlineBeamMonitorClient")
+                  << "The histosMap_ have a histogram named " << itHHH.first << " that I can't recognize in this loop!";
             }
-            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
+            itHHH.second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
           }
         }
       }

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.cc
@@ -1,0 +1,398 @@
+/*
+ * \file OnlineBeamMonitor.cc
+ * \author Lorenzo Uplegger/FNAL
+ * modified by Simone Gennai INFN/Bicocca
+ */
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DQM/BeamMonitor/plugins/OnlineBeamMonitor.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
+#include "RecoVertex/BeamSpotProducer/interface/PVFitter.h"
+#include <memory>
+
+#include <numeric>
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+//----------------------------------------------------------------------------------------------------------------------
+OnlineBeamMonitor::OnlineBeamMonitor(const ParameterSet& ps)
+    : monitorName_(ps.getUntrackedParameter<string>("MonitorName")),
+      bsTransientToken_(esConsumes<BeamSpotObjects, BeamSpotTransientObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      bsHLTToken_(esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      bsLegacyToken_(esConsumes<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd, edm::Transition::BeginLuminosityBlock>()),
+      numberOfValuesToSave_(0) {
+  if (!monitorName_.empty())
+    monitorName_ = monitorName_ + "/";
+
+  processedLumis_.clear();
+
+  varNamesV_.push_back("x");
+  varNamesV_.push_back("y");
+  varNamesV_.push_back("z");
+  varNamesV_.push_back("sigmaX");
+  varNamesV_.push_back("sigmaY");
+  varNamesV_.push_back("sigmaZ");
+
+  //histoByCategoryNames_.insert(pair<string, string>("run", "Coordinate"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-DataBase"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-BeamFit"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex fit-Scalers"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-DataBase"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-BeamFit"));
+  //histoByCategoryNames_.insert(pair<string, string>("run", "PrimaryVertex-Scalers"));
+
+  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotHLT"));
+  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotLegacy"));
+  histoByCategoryNames_.insert(pair<string, string>("lumi", "Lumibased BeamSpotTransient"));
+
+  for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
+    for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
+         itM++) {
+      histosMap_[*itV][itM->first][itM->second] = nullptr;
+    }
+  }
+}
+
+void OnlineBeamMonitor::fillDescriptions(edm::ConfigurationDescriptions& iDesc) {
+  edm::ParameterSetDescription ps;
+
+  ps.addUntracked<std::string>("MonitorName", "YourSubsystemName");
+  iDesc.addDefault(ps);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void OnlineBeamMonitor::bookHistograms(DQMStore::IBooker& ibooker,
+                                       edm::Run const& iRun,
+                                       edm::EventSetup const& iSetup) {
+  string name;
+  string title;
+  int firstLumi = 1;
+  int lastLumi = 3000;
+  for (HistosContainer::iterator itM = histosMap_.begin(); itM != histosMap_.end(); itM++) {
+    //Making histos per Lumi
+    // x,y,z,sigmaX,sigmaY,sigmaZ
+    for (map<string, map<string, MonitorElement*> >::iterator itMM = itM->second.begin(); itMM != itM->second.end();
+         itMM++) {
+      if (itMM->first != "run") {
+        for (map<string, MonitorElement*>::iterator itMMM = itMM->second.begin(); itMMM != itMM->second.end();
+             itMMM++) {
+          name = string("h") + itM->first + itMMM->first;
+          title = itM->first + "_{0} " + itMMM->first;
+          if (itMM->first == "lumi") {
+            ibooker.setCurrentFolder(monitorName_ + "Debug");
+            itMMM->second = ibooker.book1D(name, title, lastLumi - firstLumi + 1, firstLumi - 0.5, lastLumi + 0.5);
+            itMMM->second->setEfficiencyFlag();
+          } else {
+            LogInfo("OnlineBeamMonitorClient") << "Unrecognized category " << itMM->first;
+            // assert(0);
+          }
+          if (itMMM->second != nullptr) {
+            if (itMMM->first.find('-') != string::npos) {
+              itMMM->second->setAxisTitle(string("#Delta ") + itM->first + "_{0} (cm)", 2);
+            } else {
+              itMMM->second->setAxisTitle(itM->first + "_{0} (cm)", 2);
+            }
+            itMMM->second->setAxisTitle("Lumisection", 1);
+          }
+        }
+      }
+    }
+  }
+
+  // create and cd into new folder
+  ibooker.setCurrentFolder(monitorName_ + "Validation");
+  //Book histograms
+  bsChoice_ = ibooker.book1D("bsChoice",
+                             "Choice between HLT (+1) and Legacy (-1) BS",
+                             lastLumi - firstLumi + 1,
+                             firstLumi - 0.5,
+                             lastLumi + 0.5);
+  bsChoice_->setAxisTitle("Lumisection", 1);
+  bsChoice_->setAxisTitle("Choice", 2);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+std::shared_ptr<onlinebeammonitor::NoCache> OnlineBeamMonitor::globalBeginLuminosityBlock(
+    const LuminosityBlock& iLumi, const EventSetup& iSetup) const {
+  // Always create a beamspot group for each lumi weather we have results or not! Each Beamspot will be of unknown type!
+
+  processedLumis_.push_back(iLumi.id().luminosityBlock());
+  //Read BeamSpot from DB
+  ESHandle<BeamSpotOnlineObjects> bsHLTHandle;
+  ESHandle<BeamSpotOnlineObjects> bsLegacyHandle;
+  ESHandle<BeamSpotObjects> bsTransientHandle;
+  try {
+    bsHLTHandle = iSetup.getHandle(bsHLTToken_);
+  } catch (cms::Exception& exception) {
+    LogError("OnlineBeamMonitor") << exception.what();
+    return nullptr;
+  }
+  try {
+    bsLegacyHandle = iSetup.getHandle(bsLegacyToken_);
+  } catch (cms::Exception& exception) {
+    LogError("OnlineBeamMonitor") << exception.what();
+    return nullptr;
+  }
+  try {
+    bsTransientHandle = iSetup.getHandle(bsTransientToken_);
+  } catch (cms::Exception& exception) {
+    LogError("OnlineBeamMonitor") << exception.what();
+    return nullptr;
+  }
+  if (bsHLTHandle.isValid()) {  // check the product
+    const BeamSpotOnlineObjects* spotDB = bsHLTHandle.product();
+
+    // translate from BeamSpotObjects to reco::BeamSpot
+    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+
+    BeamSpot::CovarianceMatrix matrix;
+    for (int i = 0; i < 7; ++i) {
+      for (int j = 0; j < 7; ++j) {
+        matrix(i, j) = spotDB->GetCovariance(i, j);
+      }
+    }
+
+    beamSpotsMap_["HLT"] =
+        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+
+    BeamSpot* aSpot = &(beamSpotsMap_["HLT"]);
+
+    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB->GetEmittanceX());
+    aSpot->setEmittanceY(spotDB->GetEmittanceY());
+    aSpot->setbetaStar(spotDB->GetBetaStar());
+
+    if (spotDB->GetBeamType() == 2) {
+      aSpot->setType(reco::BeamSpot::Tracker);
+    } else {
+      aSpot->setType(reco::BeamSpot::Fake);
+    }
+    //LogInfo("OnlineBeamMonitor")
+    //  << *aSpot << std::endl;
+  } else {
+    LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
+  }
+  if (bsLegacyHandle.isValid()) {  // check the product
+    const BeamSpotOnlineObjects* spotDB = bsLegacyHandle.product();
+
+    // translate from BeamSpotObjects to reco::BeamSpot
+    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+
+    BeamSpot::CovarianceMatrix matrix;
+    for (int i = 0; i < 7; ++i) {
+      for (int j = 0; j < 7; ++j) {
+        matrix(i, j) = spotDB->GetCovariance(i, j);
+      }
+    }
+
+    beamSpotsMap_["Legacy"] =
+        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+
+    BeamSpot* aSpot = &(beamSpotsMap_["Legacy"]);
+
+    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB->GetEmittanceX());
+    aSpot->setEmittanceY(spotDB->GetEmittanceY());
+    aSpot->setbetaStar(spotDB->GetBetaStar());
+
+    if (spotDB->GetBeamType() == 2) {
+      aSpot->setType(reco::BeamSpot::Tracker);
+    } else {
+      aSpot->setType(reco::BeamSpot::Fake);
+    }
+    //LogInfo("OnlineBeamMonitor")
+    //  << *aSpot << std::endl;
+  } else {
+    LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
+  }
+  if (bsTransientHandle.isValid()) {  // check the product
+    const BeamSpotObjects* spotDB = bsTransientHandle.product();
+
+    // translate from BeamSpotObjects to reco::BeamSpot
+    BeamSpot::Point apoint(spotDB->GetX(), spotDB->GetY(), spotDB->GetZ());
+
+    BeamSpot::CovarianceMatrix matrix;
+    for (int i = 0; i < 7; ++i) {
+      for (int j = 0; j < 7; ++j) {
+        matrix(i, j) = spotDB->GetCovariance(i, j);
+      }
+    }
+
+    beamSpotsMap_["Transient"] =
+        BeamSpot(apoint, spotDB->GetSigmaZ(), spotDB->Getdxdz(), spotDB->Getdydz(), spotDB->GetBeamWidthX(), matrix);
+
+    BeamSpot* aSpot = &(beamSpotsMap_["Transient"]);
+
+    aSpot->setBeamWidthY(spotDB->GetBeamWidthY());
+    aSpot->setEmittanceX(spotDB->GetEmittanceX());
+    aSpot->setEmittanceY(spotDB->GetEmittanceY());
+    aSpot->setbetaStar(spotDB->GetBetaStar());
+
+    if (spotDB->GetBeamType() == 2) {
+      aSpot->setType(reco::BeamSpot::Tracker);
+    } else {
+      aSpot->setType(reco::BeamSpot::Fake);
+    }
+    //LogInfo("OnlineBeamMonitor")
+    //  << *aSpot << std::endl;
+  } else {
+    LogInfo("OnlineBeamMonitor") << "Database BeamSpot is not valid at lumi: " << iLumi.id().luminosityBlock();
+  }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void OnlineBeamMonitor::globalEndLuminosityBlock(const LuminosityBlock& iLumi, const EventSetup& iSetup) {
+  //Setting up the choice
+  if (beamSpotsMap_.find("Transient") != beamSpotsMap_.end()) {
+    if (beamSpotsMap_.find("HLT") != beamSpotsMap_.end() &&
+        beamSpotsMap_["Transient"].x0() == beamSpotsMap_["HLT"].x0()) {
+      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), 1);
+      bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
+    } else if (beamSpotsMap_.find("Legacy") != beamSpotsMap_.end() &&
+               beamSpotsMap_["Transient"].x0() == beamSpotsMap_["Legacy"].x0()) {
+      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), -1);
+      bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
+    } else {
+      bsChoice_->setBinContent(iLumi.id().luminosityBlock(), -10);
+      bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
+    }
+  } else {
+    bsChoice_->setBinContent(iLumi.id().luminosityBlock(), 0);
+    bsChoice_->setBinError(iLumi.id().luminosityBlock(), 0.05);
+  }
+
+  //    "PV,BF..."      Value,Error
+  map<std::string, pair<double, double> > resultsMap;
+  vector<pair<double, double> > vertexResults;
+  MonitorElement* histo = nullptr;
+  for (vector<string>::iterator itV = varNamesV_.begin(); itV != varNamesV_.end(); itV++) {
+    resultsMap.clear();
+    for (BeamSpotContainer::iterator itBS = beamSpotsMap_.begin(); itBS != beamSpotsMap_.end(); itBS++) {
+      if (itBS->second.type() == BeamSpot::Tracker) {
+        if (*itV == "x") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.x0(), itBS->second.x0Error());
+        } else if (*itV == "y") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.y0(), itBS->second.y0Error());
+        } else if (*itV == "z") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.z0(), itBS->second.z0Error());
+        } else if (*itV == "sigmaX") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.BeamWidthX(), itBS->second.BeamWidthXError());
+        } else if (*itV == "sigmaY") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.BeamWidthY(), itBS->second.BeamWidthYError());
+        } else if (*itV == "sigmaZ") {
+          resultsMap[itBS->first] = pair<double, double>(itBS->second.sigmaZ(), itBS->second.sigmaZ0Error());
+        } else {
+          LogInfo("OnlineBeamMonitor") << "The histosMap_ has been built with the name " << *itV
+                                       << " that I can't recognize!";
+          //assert(0);
+        }
+      }
+    }
+
+    for (multimap<string, string>::iterator itM = histoByCategoryNames_.begin(); itM != histoByCategoryNames_.end();
+         itM++) {
+      if ((histo = histosMap_[*itV][itM->first][itM->second]) == nullptr)
+        continue;
+      if (itM->second == "Lumibased BeamSpotHLT") {
+        if (resultsMap.find("HLT") != resultsMap.end()) {
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["HLT"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["HLT"].second);
+        }
+      } else if (itM->second == "Lumibased BeamSpotLegacy") {
+        if (resultsMap.find("Legacy") != resultsMap.end()) {
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["Legacy"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["Legacy"].second);
+        }
+      } else if (itM->second == "Lumibased BeamSpotTransient") {
+        if (resultsMap.find("Transient") != resultsMap.end()) {
+          histo->setBinContent(iLumi.id().luminosityBlock(), resultsMap["Transient"].first);
+          histo->setBinError(iLumi.id().luminosityBlock(), resultsMap["Transient"].second);
+        }
+      } else {
+        LogInfo("OnlineBeamMonitor") << "The histosMap_ have a histogram named " << itM->second
+                                     << " that I can't recognize in this loop!";
+        //assert(0);
+      }
+    }
+  }
+}
+
+void OnlineBeamMonitor::dqmEndRun(edm::Run const&, edm::EventSetup const&) {
+  if (processedLumis_.empty()) {
+    return;
+  }
+
+  const double bigNumber = 1000000.;
+  std::sort(processedLumis_.begin(), processedLumis_.end());
+  int firstLumi = *processedLumis_.begin();
+  int lastLumi = *(--processedLumis_.end());
+  bsChoice_->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
+  for (HistosContainer::iterator itH = histosMap_.begin(); itH != histosMap_.end(); itH++) {
+    for (map<string, map<string, MonitorElement*> >::iterator itHH = itH->second.begin(); itHH != itH->second.end();
+         itHH++) {
+      double min = bigNumber;
+      double max = -bigNumber;
+      //double minDelta = bigNumber;
+      //double maxDelta = -bigNumber;
+      //      double minDeltaProf = bigNumber;
+      //      double maxDeltaProf = -bigNumber;
+      if (itHH->first != "run") {
+        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
+             itHHH++) {
+          if (itHHH->second != nullptr) {
+            for (int bin = 1; bin <= itHHH->second->getTH1()->GetNbinsX(); bin++) {
+              if (itHHH->second->getTH1()->GetBinError(bin) != 0 || itHHH->second->getTH1()->GetBinContent(bin) != 0) {
+                if (itHHH->first == "Lumibased BeamSpotHLT" || itHHH->first == "Lumibased BeamSpotLegacy" ||
+                    itHHH->first == "Lumibased BeamSpotTransient") {
+                  if (min > itHHH->second->getTH1()->GetBinContent(bin)) {
+                    min = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                  if (max < itHHH->second->getTH1()->GetBinContent(bin)) {
+                    max = itHHH->second->getTH1()->GetBinContent(bin);
+                  }
+                } else {
+                  LogInfo("OnlineBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
+                                                     << " that I can't recognize in this loop!";
+                  // assert(0);
+                }
+              }
+            }
+          }
+        }
+        for (map<string, MonitorElement*>::iterator itHHH = itHH->second.begin(); itHHH != itHH->second.end();
+             itHHH++) {
+          if (itHHH->second != nullptr) {
+            if (itHHH->first == "Lumibased BeamSpotHLT" || itHHH->first == "Lumibased BeamSpotLegacy" ||
+                itHHH->first == "Lumibased BeamSpotTransient") {
+              if ((max == -bigNumber && min == bigNumber) || max - min == 0) {
+                itHHH->second->getTH1()->SetMinimum(itHHH->second->getTH1()->GetMinimum() - 0.01);
+                itHHH->second->getTH1()->SetMaximum(itHHH->second->getTH1()->GetMaximum() + 0.01);
+              } else {
+                itHHH->second->getTH1()->SetMinimum(min - 0.1 * (max - min));
+                itHHH->second->getTH1()->SetMaximum(max + 0.1 * (max - min));
+              }
+            } else {
+              LogInfo("OnlineBeamMonitorClient") << "The histosMap_ have a histogram named " << itHHH->first
+                                                 << " that I can't recognize in this loop!";
+            }
+            itHHH->second->getTH1()->GetXaxis()->SetRangeUser(firstLumi - 0.5, lastLumi + 0.5);
+          }
+        }
+      }
+    }
+  }
+}
+DEFINE_FWK_MODULE(OnlineBeamMonitor);

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
@@ -62,8 +62,6 @@ private:
   // MonitorElements:
   MonitorElement* bsChoice_;
 
-  //mutable MonitorElement* theValuesContainer_;
-
   //Containers
   mutable BeamSpotContainer beamSpotsMap_;
   HistosContainer histosMap_;

--- a/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/OnlineBeamMonitor.h
@@ -1,0 +1,75 @@
+#ifndef DQM_BeamMonitor_OnlineBeamMonitor_h
+#define DQM_BeamMonitor_OnlineBeamMonitor_h
+
+/** \class OnlineBeamMonitor
+ * *
+ *  \author   Simone Gennai INFN/Bicocca
+ */
+// C++
+#include <map>
+#include <vector>
+#include <string>
+// CMS
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotOnlineObjects.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineLegacyObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotOnlineHLTObjectsRcd.h"
+#include "CondFormats/DataRecord/interface/BeamSpotTransientObjectsRcd.h"
+
+namespace onlinebeammonitor {
+  struct NoCache {};
+}  // namespace onlinebeammonitor
+
+class OnlineBeamMonitor : public DQMOneEDAnalyzer<edm::LuminosityBlockCache<onlinebeammonitor::NoCache>> {
+public:
+  OnlineBeamMonitor(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+protected:
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
+  std::shared_ptr<onlinebeammonitor::NoCache> globalBeginLuminosityBlock(const edm::LuminosityBlock& iLumi,
+                                                                         const edm::EventSetup& iSetup) const override;
+  void globalEndLuminosityBlock(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup) override;
+  void dqmEndRun(edm::Run const&, edm::EventSetup const&) override;
+
+private:
+  //Typedefs
+  //                BF,BS...
+  typedef std::map<std::string, reco::BeamSpot> BeamSpotContainer;
+  //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name
+  typedef std::map<std::string, std::map<std::string, std::map<std::string, MonitorElement*>>> HistosContainer;
+  //                x,y,z,sigmax(y,z)... [run,lumi]          Histo name
+  typedef std::map<std::string, std::map<std::string, std::map<std::string, int>>> PositionContainer;
+
+  //Parameters
+  std::string monitorName_;
+  edm::ESGetToken<BeamSpotObjects, BeamSpotTransientObjectsRcd> bsTransientToken_;
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineHLTObjectsRcd> bsHLTToken_;
+  edm::ESGetToken<BeamSpotOnlineObjects, BeamSpotOnlineLegacyObjectsRcd> bsLegacyToken_;
+
+  //Service variables
+  int numberOfValuesToSave_;
+  mutable int numberOfProcessedLumis_;
+  mutable std::vector<int> processedLumis_;
+  // MonitorElements:
+  MonitorElement* bsChoice_;
+
+  //mutable MonitorElement* theValuesContainer_;
+
+  //Containers
+  mutable BeamSpotContainer beamSpotsMap_;
+  HistosContainer histosMap_;
+  PositionContainer positionsMap_;
+  std::vector<std::string> varNamesV_;                            //x,y,z,sigmax(y,z)
+  std::multimap<std::string, std::string> histoByCategoryNames_;  //run, lumi
+};
+
+#endif

--- a/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
+++ b/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
@@ -4,26 +4,30 @@ process = cms.Process("DQM")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
-                                        process.CondDBSetup,
-                                        toGet = cms.VPSet(
-                                            cms.PSet(
-                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
-                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
-                                                refreshTime = cms.uint64(1)
-                                            ),
-                                            cms.PSet(
-                                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
-                                                tag = cms.string("BeamSpotOnlineTestHLT"),
-                                                refreshTime = cms.uint64(1)
+#ESProducer                                                                                                                                                                                                      
+process.load("CondCore.CondDB.CondDB_cfi")                                                                                                                                                                       
+process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",                                                                                                                                                        
+                       process.CondDB,                                                                                                                                                                          
+                                        toGet = cms.VPSet(                                                                                                                                                       
+                            cms.PSet(                                                                                                                                                                            
+                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),                                                                                                                           
+                                tag = cms.string("BeamSpotOnlineTestLegacy"),                                                                                                                                    
+                                refreshTime = cms.uint64(1)                                                                                                                                                      
+                            ),                                                                                                                                                                                   
+                             cms.PSet(                                                                                                                                                                         
+                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),                                                                                                                              
+                                tag = cms.string("BeamSpotOnlineTestHLT"),                                                                                                                                       
+                                refreshTime = cms.uint64(1)                                                                                                                            
+                            ),                                                                                                                                                                                   
+                      )                                                                                                                                                                                          
+)                                                                                                                                                                                                                
+process.BeamSpotDBSource.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS')                                                                                                                     
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")                                                                                                                                          
 
-                                            ),
-                                ),
-                                        connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
 
-                                        )
-process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+
+
 
 # initialize MessageLogger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
+++ b/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
@@ -1,0 +1,80 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("DQM")
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+
+process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
+                                        process.CondDBSetup,
+                                        toGet = cms.VPSet(
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
+                                                refreshTime = cms.uint64(1)
+                                            ),
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestHLT"),
+                                                refreshTime = cms.uint64(1)
+
+                                            ),
+                                ),
+                                        connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+
+                                        )
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+# initialize MessageLogger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.categories = ["OnlineBeamMonitor"]
+process.MessageLogger.cerr = cms.untracked.PSet(placeholder = cms.untracked.bool(True))
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string('INFO'),
+    default = cms.untracked.PSet(
+       limit = cms.untracked.int32(0)
+    ),
+    OnlineBeamMonitor = cms.untracked.PSet(
+        reportEvery = cms.untracked.int32(1), # every 1000th only
+	limit = cms.untracked.int32(0)
+    )
+)
+#process.MessageLogger.statistics.append('cout')
+process.source = cms.Source("EmptySource")
+process.source.numberEventsInRun=cms.untracked.uint32(20)
+process.source.firstRun = cms.untracked.uint32(336055)
+process.source.firstLuminosityBlock = cms.untracked.uint32(49)
+process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(1)
+process.maxEvents = cms.untracked.PSet(
+            input = cms.untracked.int32(100)
+)
+
+#process.load("DQMServices.Core.DQMEDAnalyzer") 
+process.onlineBeamMonitor = cms.EDProducer("OnlineBeamMonitor",
+MonitorName = cms.untracked.string("onlineBeamMonitor"))
+
+
+# DQM Live Environment
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = 'BeamMonitor'
+process.dqmSaver.tag           = 'BeamMonitor'
+
+process.dqmEnvPixelLess = process.dqmEnv.clone()
+process.dqmEnvPixelLess.subSystemFolder = 'BeamMonitor_PixelLess'
+
+
+
+#import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
+#process.offlineBeamSpotForDQM = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+
+# # summary
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True),
+    numberOfThreads = cms.untracked.uint32(4),
+    numberOfStreams = cms.untracked.uint32 (4),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(2)
+
+    )
+
+process.pp = cms.Path(process.onlineBeamMonitor+process.dqmSaver)
+process.schedule = cms.Schedule(process.pp)

--- a/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
+++ b/DQM/BeamMonitor/test/Online_BeamMonitor_file.py
@@ -4,10 +4,27 @@ process = cms.Process("DQM")
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 
-#ESProducer                                                                                                                                                                                                      
-process.load("CondCore.CondDB.CondDB_cfi")                                                                                                                                                                       
-process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",                                                                                                                                                        
-                       process.CondDB,                                                                                                                                                                          
+process.load("CondCore.CondDB.CondDB_cfi")
+process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
+                                        process.CondDB,
+                                        toGet = cms.VPSet(
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestLegacy"),
+                                                refreshTime = cms.uint64(1)
+                                            ),
+                                            cms.PSet(
+                                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+                                                tag = cms.string("BeamSpotOnlineTestHLT"),
+                                                refreshTime = cms.uint64(1)
+
+                                            ),
+                                ),
+                                        )
+process.BeamSpotDBSource.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS') 
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+
                                         toGet = cms.VPSet(                                                                                                                                                       
                             cms.PSet(                                                                                                                                                                            
                                 record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),                                                                                                                           

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -1,0 +1,179 @@
+from __future__ import print_function
+import FWCore.ParameterSet.Config as cms
+
+# Define once the BeamSpotOnline record name,
+# will be used both in BeamMonitor setup and in payload creation/upload
+
+#from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+#process = cms.Process("BeamMonitor", Run2_2018) # FIMXE
+import sys
+from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
+process = cms.Process("OnlineBeamMonitor", Run2_2018)
+
+# Message logger
+#process.load("FWCore.MessageLogger.MessageLogger_cfi")
+#process.MessageLogger = cms.Service("MessageLogger",
+#    debugModules = cms.untracked.vstring('*'),
+#    cerr = cms.untracked.PSet(
+#        FwkReport = cms.untracked.PSet(
+#            optionalPSet = cms.untracked.bool(True),
+#            reportEvery = cms.untracked.int32(1000),
+#            limit = cms.untracked.int32(999999)
+#        )
+#    ),
+#    destinations = cms.untracked.vstring('cerr'),
+#)
+
+
+unitTest=False
+if 'unitTest=True' in sys.argv:
+  unitTest=True
+#-----------------------------
+if unitTest:
+  import FWCore.ParameterSet.VarParsing as VarParsing
+  options = VarParsing.VarParsing("analysis")
+
+  options.register(
+      "runkey",
+      "pp_run",
+      VarParsing.VarParsing.multiplicity.singleton,
+      VarParsing.VarParsing.varType.string,
+      "Run Keys of CMS"
+  )
+
+  options.register('runNumber',
+                  336055,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Run number. This run number has to be present in the dataset configured with the dataset option.")
+
+  options.register('dataset',
+                  '/ExpressCosmics/Commissioning2019-Express-v1/FEVT',
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Dataset name like '/ExpressCosmics/Commissioning2019-Express-v1/FEVT'")
+
+  options.register('maxLumi',
+                  2,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Only lumisections up to maxLumi are processed.")
+
+  options.register('minLumi',
+                  1,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "Only lumisections starting from minLumi are processed.")
+
+  options.register('lumiPattern',
+                  '*',
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.string,
+                  "Only lumisections with numbers matching lumiPattern are processed.")
+
+  options.register('eventsPerLumi',
+                  100,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "This number of last events in each lumisection will be processed.")
+
+  options.register('transDelay',
+                  0, #default value, int limit -3
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.int,
+                  "delay in seconds for the commit of the db transaction")
+
+  # This is used only by the online clients themselves. 
+  # We need to register it here because otherwise an error occurs saying that there is an unidentified option.
+  options.register('unitTest',
+                  True,
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "Required to avoid the error.")
+
+  options.register('noDB',
+                  True, # default value
+                  VarParsing.VarParsing.multiplicity.singleton,
+                  VarParsing.VarParsing.varType.bool,
+                  "Don't upload the BeamSpot conditions to the DB")
+
+  options.parseArguments()
+  
+  process.source = cms.Source("EmptySource")
+  process.source.numberEventsInRun=cms.untracked.uint32(100)
+  process.source.firstRun = cms.untracked.uint32(options.runNumber)
+  process.source.firstLuminosityBlock = cms.untracked.uint32(49)
+  process.source.numberEventsInLuminosityBlock = cms.untracked.uint32(2)
+  process.maxEvents = cms.untracked.PSet(
+              input = cms.untracked.int32(100)
+)
+
+else:
+  process.load("DQM.Integration.config.inputsource_cfi")
+  from DQM.Integration.config.inputsource_cfi import options
+  # for live online DQM in P5
+  # new stream label
+  process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
+
+#ESProducer
+process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
+                      process.CondDBSetup,
+                      toGet = cms.VPSet(
+                            cms.PSet(
+                                record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
+                                tag = cms.string("BeamSpotOnlineTestLegacy"),
+                                refreshTime = cms.uint64(1)
+                            ),
+                            cms.PSet(
+                                record = cms.string('BeamSpotOnlineHLTObjectsRcd'),
+                                tag = cms.string("BeamSpotOnlineTestHLT"),
+                                refreshTime = cms.uint64(1)
+
+                            ),
+                      ),
+                      connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+)
+process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
+
+#-----------------------------
+# DQM Live Environment
+#-----------------------------
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = 'TrackingHLTBeamspotStream'
+process.dqmSaver.tag           = 'TrackingHLTBeamspotStream'
+#process.dqmSaver.runNumber     = options.runNumber
+#process.dqmSaverPB.tag         = 'TrackingHLTBeamspotStream'
+#process.dqmSaverPB.runNumber   = options.runNumber
+
+#-----------------------------
+# BeamMonitor
+#-----------------------------
+process.dqmOnlineBeamMonitor = cms.EDProducer("OnlineBeamMonitor",
+MonitorName = cms.untracked.string("onlineBeamMonitor")
+)
+
+#---------------
+# Calibration
+#---------------
+# Condition for P5 cluster
+process.load("DQM.Integration.config.FrontierCondition_GT_cfi")
+# Condition for lxplus: change and possibly customise the GT
+#from Configuration.AlCa.GlobalTag import GlobalTag as gtCustomise
+#process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
+
+
+process.dqmcommon = cms.Sequence(process.dqmEnv
+                               * process.dqmSaver)
+
+process.monitor = cms.Sequence(process.dqmOnlineBeamMonitor)
+
+#-----------------------------------------------------------
+# process customizations included here
+from DQM.Integration.config.online_customizations_cfi import *
+process = customise(process)
+
+
+process.p = cms.Path( process.dqmcommon
+                        * process.monitor )
+

--- a/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py
@@ -116,9 +116,9 @@ else:
   process.source.streamLabel = cms.untracked.string('streamDQMOnlineBeamspot')
 
 #ESProducer
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
+process.load("CondCore.CondDB.CondDB_cfi")
 process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
-                      process.CondDBSetup,
+                      process.CondDB,
                       toGet = cms.VPSet(
                             cms.PSet(
                                 record = cms.string('BeamSpotOnlineLegacyObjectsRcd'),
@@ -131,11 +131,14 @@ process.BeamSpotDBSource = cms.ESSource("PoolDBESSource",
                                 refreshTime = cms.uint64(1)
 
                             ),
-                      ),
-                      connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS')
+                      )
+
 )
 process.BeamSpotESProducer = cms.ESProducer("OnlineBeamSpotESProducer")
-
+if unitTest == True:
+  process.BeamSpotDBSource.connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS') 
+else:
+  process.BeamSpotDBSource.connect = cms.string('oracle://cms_orcon_prod/CMS_CONDITIONS') 
 #-----------------------------
 # DQM Live Environment
 #-----------------------------

--- a/DQM/Integration/test/BuildFile.xml
+++ b/DQM/Integration/test/BuildFile.xml
@@ -22,6 +22,7 @@
 <test name="TestDQMOnlineClient-rpc_dqm_sourceclient" command="runtest.sh rpc_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-scal_dqm_sourceclient" command="runtest.sh scal_dqm_sourceclient-live_cfg.py"/>
 <test name="TestDQMOnlineClient-sistrip_dqm_sourceclient" command="runtest.sh sistrip_dqm_sourceclient-live_cfg.py"/>
+<test name="TestDQMOnlineClient-onlinebeammonitor_dqm_sourceclient" command="runtest.sh onlinebeammonitor_dqm_sourceclient-live_cfg.py"/>
 <!-- Need an HLT stream -->
 <!-- <test name="TestDQMOnlineClient-beamhlt_dqm_sourceclient" command="runtest.sh beamhlt_dqm_sourceclient-live_cfg.py" /> -->
 <!-- streamDQMCalibration is required -->


### PR DESCRIPTION
#### PR description:

With the new BeamSpot workflow in Run3 two clients will run in DQM producing two different beamspot payloads. An ESProducer is run at HLT to make a reproducible choice of which payload to use. This new client is monitoring the values of the two payloads as well as plotting which one of the two is chosen by the ESProducer logic.


#### PR validation:

I have run the DQM/Integration/python/clients/onlinebeammonitor_dqm_sourceclient-live_cfg.py with unitTest=True option.
The plots looks right.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

this is a backporting of https://github.com/cms-sw/cmssw/pull/31904, it is needed for next MWGR