### PR TITLE
GEM unpacker: crash protection from bad FEDs

### DIFF
--- a/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
+++ b/EventFilter/GEMRawToDigi/plugins/GEMRawToDigiModule.cc
@@ -85,7 +85,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
     amc13Event->setAMC13Header(*(++word));
 
     bool unknownChamber = false, unknownVFat = false, badVfat = false;
-    
+
     // Readout out AMC headers
     for (uint8_t i = 0; i < amc13Event->nAMC(); ++i)
       amc13Event->addAMCheader(*(++word));
@@ -113,10 +113,10 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           LogDebug("GEMRawToDigiModule") << "InValid: amcNum " << int(amcNum) << " gebId " << int(gebId);
           continue;
         }
-        
+
         GEMROMapping::chamDC geb_dc = gemROMap->chamberPos(geb_ec);
         GEMDetId gemChId = geb_dc.detId;
-        
+
         for (uint16_t k = 0; k < gebData->vfatWordCnt() / 3; k++) {
           auto vfatData = std::make_unique<VFATdata>();
           vfatData->read_fw(*(++word));
@@ -139,8 +139,8 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
           if (vfatData->quality()) {
             badVfat = true;
             LogDebug("GEMRawToDigiModule")
-              << "Quality " << int(vfatData->quality()) << " b1010 " << int(vfatData->b1010()) << " b1100 "
-              << int(vfatData->b1100()) << " b1110 " << int(vfatData->b1110());
+                << "Quality " << int(vfatData->quality()) << " b1010 " << int(vfatData->b1010()) << " b1100 "
+                << int(vfatData->b1100()) << " b1110 " << int(vfatData->b1110());
             if (vfatData->crc() != vfatData->checkCRC()) {
               LogDebug("GEMRawToDigiModule") << "DIFFERENT CRC :" << vfatData->crc() << "   " << vfatData->checkCRC();
             }
@@ -215,7 +215,7 @@ void GEMRawToDigiModule::produce(edm::StreamID iID, edm::Event& iEvent, edm::Eve
       edm::LogWarning("GEMRawToDigiModule") << "unpacking error: unknown Chamber " << unknownChamber << " unknown VFat "
                                             << unknownVFat << " bad VFat " << badVfat;
     }
-    
+
   }  // end of amc13Event
 
   iEvent.put(std::move(outGEMDigis));


### PR DESCRIPTION
#### PR description:
GEM unpacker (GEMRawToDigiModule) was crashing run 337971 MWGR.
This was due to wrong DAQ setting producing invalid GEM chamber and vfat IDs.
It was fixed with #31863 and this is backporting the same fix. 
Not full backport due to many commits in 11_2_X.

#### PR validation:
- tested with wf 11611.0, 23211.0 and run 337971 MWGR data.
