### PR TITLE
[DD4hep] do not use namespace for navigation

### DIFF
--- a/DetectorDescription/DDCMS/interface/DDFilteredView.h
+++ b/DetectorDescription/DDCMS/interface/DDFilteredView.h
@@ -144,6 +144,9 @@ namespace cms {
     // Name of current node
     std::string_view name() const;
 
+    // Name of current node with namespace
+    std::string_view fullName() const;
+
     // Copy number of current node
     unsigned short copyNum() const;
 

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -455,7 +455,7 @@ bool DDFilteredView::sibling() {
   it_.back().SetType(1);
   Node* node = nullptr;
   while ((node = it_.back().Next())) {
-    if (dd4hep::dd::accepted(currentFilter_, node->GetVolume()->GetName())) {
+    if (dd4hep::dd::accepted(currentFilter_, noNamespace(node->GetVolume()->GetName()))) {
       node_ = node;
       return true;
     }
@@ -471,7 +471,7 @@ bool DDFilteredView::checkChild() {
   it_.back().SetType(1);
   Node* node = nullptr;
   while ((node = it_.back().Next())) {
-    if (dd4hep::dd::accepted(currentFilter_, node->GetVolume()->GetName())) {
+    if (dd4hep::dd::accepted(currentFilter_, noNamespace(node->GetVolume()->GetName()))) {
       return true;
     }
   }

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -856,6 +856,10 @@ double DDFilteredView::getNextValue(const std::string& key) const {
 }
 
 std::string_view DDFilteredView::name() const {
+  return (node_ == nullptr ? std::string_view() : (dd4hep::dd::noNamespace(volume().volume().name())));
+}
+
+std::string_view DDFilteredView::fullName() const {
   return (node_ == nullptr ? std::string_view() : (volume().volume().name()));
 }
 

--- a/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.find.cppunit.cc
@@ -92,7 +92,7 @@ void testDDFilteredViewFind::checkFilteredView() {
   fview.goTo({0, 0, 8});
   printMe(fview);
 
-  CPPUNIT_ASSERT(fview.name() == "muonBase:MUON");
+  CPPUNIT_ASSERT(fview.fullName() == "muonBase:MUON");
 
   // Go to the first daughter
   fview.next(0);
@@ -129,7 +129,7 @@ void testDDFilteredViewFind::checkFilteredView() {
   std::cout << "\n==== Let's do it again, go to Muon\n";
   fview.goTo({0, 0, 8});
   printMe(fview);
-  CPPUNIT_ASSERT(fview.name() == "muonBase:MUON");
+  CPPUNIT_ASSERT(fview.name() == "MUON");
 
   // Go to the first daughter
   fview.next(0);

--- a/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.get.cppunit.cc
@@ -95,7 +95,7 @@ void testDDFilteredViewGet::checkFilteredView() {
   fview.goTo({0, 0, 8});
   printMe(fview);
 
-  CPPUNIT_ASSERT(fview.name() == "muonBase:MUON");
+  CPPUNIT_ASSERT(fview.fullName() == "muonBase:MUON");
 
   // Go to the first daughter
   fview.next(0);
@@ -132,7 +132,7 @@ void testDDFilteredViewGet::checkFilteredView() {
   std::cout << "\n==== Let's do it again, go to Muon\n";
   fview.goTo({0, 0, 8});
   printMe(fview);
-  CPPUNIT_ASSERT(fview.name() == "muonBase:MUON");
+  CPPUNIT_ASSERT(fview.name() == "MUON");
 
   // Go to the first daughter
   fview.next(0);

--- a/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.goto.cppunit.cc
@@ -86,7 +86,7 @@ void testDDFilteredViewGoTo::checkFilteredView() {
   // Start with Tracker
   std::cout << "\n==== Let's go to Tracker\n";
   fview.goTo({0, 0, 6});
-  CPPUNIT_ASSERT(fview.name() == "tracker:Tracker");
+  CPPUNIT_ASSERT(fview.fullName() == "tracker:Tracker");
   printMe(fview);
 
   // Go to the first daughter
@@ -123,7 +123,7 @@ void testDDFilteredViewGoTo::checkFilteredView() {
 
   std::cout << "\n==== Let's do it again, go to Tracker\n";
   fview.goTo({0, 0, 6});
-  CPPUNIT_ASSERT(fview.name() == "tracker:Tracker");
+  CPPUNIT_ASSERT(fview.name() == "Tracker");
   printMe(fview);
 
   // Go to the first daughter

--- a/Geometry/MTDNumberingBuilder/test/DD4hep_MTDTopologyAnalyzer.cc
+++ b/Geometry/MTDNumberingBuilder/test/DD4hep_MTDTopologyAnalyzer.cc
@@ -212,7 +212,7 @@ void DD4hep_MTDTopologyAnalyzer::theBaseNumber(cms::DDFilteredView& fv) {
   thisN_.setSize(fv.copyNos().size());
 
   for (uint ii = 0; ii < fv.copyNos().size(); ii++) {
-    std::string name((fv.geoHistory()[ii])->GetName());
+    std::string name(dd4hep::dd::noNamespace((fv.geoHistory()[ii])->GetName()));
     name.assign(name.erase(name.rfind('_')));
     int copyN(fv.copyNos()[ii]);
     thisN_.addLevel(name, copyN);


### PR DESCRIPTION
#### PR description:

* Strip a namespace off in a name comparison when navigate siblings
* Introduce `cms::DDFilteredView::fullName` that will return a current node name with a namespace
* Make `cms::DDFilteredView::name` return a current node name without a namespace

@fabiocos and @silviodonato - this fixes DT geometry unit test

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
