### PR TITLE
UL2018 scale and smearing added

### DIFF
--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 _correctionFile2016Legacy = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
 _correctionFile2017Nov17 = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
 _correctionFile2017UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
+_correctionFile2018UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain"
 
 calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     semiDeterministic = cms.bool(True),
@@ -11,6 +12,13 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)
                                    )
+
+from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
+run2_egamma_2017.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
+
+from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
+run2_egamma_2018.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2018UL)
+
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)
 


### PR DESCRIPTION
This is just adding the UL2018 scale and smearing corrections to calibratedEgammas. 
Link to the presentations on this in e/gamma:
https://indico.cern.ch/event/879921/contributions/3825881/attachments/2022015/3381352/ul2018_validationSuite_v7.pdf
https://indico.cern.ch/event/890328/contributions/3801123/attachments/2013185/3364541/ul2018_validationSuite_VF.pdf

The final corrections put in are very close to as shown in the above presentations. The final validation plots using the corrections which are put in can be found here:
https://shilpi-afs.web.cern.ch/shilpi-afs/13TeV/2020/SSvalidation/UL2018/19Oct/
 
