### PR TITLE
add tcdsDigis to pixel online DQM client paths and migrate to MagneticField_cff

### DIFF
--- a/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/pixel_dqm_sourceclient-live_cfg.py
@@ -68,7 +68,7 @@ process.dqmSaverPB.runNumber = options.runNumber
 # Magnetic Field
 #-----------------------------
 
-process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 
 #-------------------------------------------------
 # GEOMETRY
@@ -116,7 +116,6 @@ if (process.runType.getRunType() == process.runType.hi_run):
 else :
     process.siPixelDigis.InputLabel   = cms.InputTag("rawDataCollector")
     process.siStripDigis.InputLabel   = cms.InputTag("rawDataCollector")
-
 
 ## Collision Reconstruction
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
@@ -186,6 +185,7 @@ if (process.runType.getRunType() == process.runType.cosmic_run or process.runTyp
                          ##### TRIGGER SELECTION #####
                          process.hltHighLevel*
                          process.scalersRawToDigi*
+                         process.tcdsDigis*
                          process.APVPhases*
                          process.consecutiveHEs*
                          process.hltTriggerTypeFilter*
@@ -231,6 +231,7 @@ if (process.runType.getRunType() == process.runType.pp_run or process.runType.ge
     process.p = cms.Path(
       process.hltHighLevel #trigger selection
      *process.scalersRawToDigi
+     *process.tcdsDigis
      *process.APVPhases
      *process.consecutiveHEs
      *process.Reco

--- a/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/sistrip_dqm_sourceclient-live_cfg.py
@@ -70,7 +70,7 @@ process.dqmEnvTr = DQMEDAnalyzer('DQMEventInfo',
 #-----------------------------
 # Magnetic Field
 #-----------------------------
-process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
 
 #-------------------------------------------------
 # GEOMETRY


### PR DESCRIPTION
#### PR description:

While checking the logs of unit tests in recent releases, I noticed that in `DQM/Integration` there were a lot of warning messages of the type:
```bash
%MSG-w L1AcceptBunchCrossingNoCollection:   EventWithHistoryProducerFromL1ABC:consecutiveHEs 26-Oct-2020 10:19:27 CET  Run: 334393 Event: 16285
 L1AcceptBunchCrossing with offset=0 not found  likely L1ABCCollection is empty 
%MSG
```
see e.g. [here](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_amd64_gcc820/CMSSW_11_2_X_2020-10-23-1100/unitTestLogs/DQM/Integration#/11953)

This is due to missing the TCDS unpacker in the path for the consumption of the Strip local reconstruction sequence, once the era is set to `Run3`. This has been missed in this PR https://github.com/cms-sw/cmssw/pull/30630.
I profit of this PR to migrate the Strip and Pixel clients to use 
```python
process.load('Configuration.StandardSequences.MagneticField_cff')
``` 
instead of:
```python
process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
```
as a continuation of https://github.com/cms-sw/cmssw/pull/31788.

#### PR validation:

Tested successfully the modified clients with:
```
voms-proxy-init -voms cms -rfc
cd DQM/Integration/python/clients
mkdir upload
cmsRun pixel_dqm_sourceclient-live_cfg.py unitTest=True
cmsRun sistrip_dqm_sourceclient-live_cfg.py unitTest=True
```

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
cc:
@arossi83 @sroychow 