### PR TITLE
Store EW parameter weights in NanoAOD of W mass samples

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -745,6 +745,7 @@ public:
             // I aplogize to contributing the rampant copy paste of code
             } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
               if (lheDebug)
+                std::cout << ">>> Looks like an EW parameter weight" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {
                 if (lheDebug)
                   std::cout << "    " << lines[iLine];

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -742,8 +742,8 @@ public:
                   break;
                 }
               }
-            // I aplogize to contributing the rampant copy paste of code
-            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
+            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" ||
+                       groupname == "width_variation") {
               if (lheDebug)
                 std::cout << ">>> Looks like an EW parameter weight" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {
@@ -760,7 +760,7 @@ public:
                 } else if (std::regex_search(lines[iLine], endweightgroup)) {
                   if (lheDebug)
                     std::cout << ">>> Looks like the end of a weight group" << std::endl;
-                } 
+                }
               }
             } else {
               for (++iLine; iLine < nLines; ++iLine) {

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -742,6 +742,25 @@ public:
                   break;
                 }
               }
+            // I aplogize to contributing the rampant copy paste of code
+            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
+              if (lheDebug)
+              for (++iLine; iLine < nLines; ++iLine) {
+                if (lheDebug)
+                  std::cout << "    " << lines[iLine];
+                if (std::regex_search(lines[iLine], groups, rwgt)) {
+                  std::string rwgtID = groups.str(1);
+                  if (lheDebug)
+                    std::cout << "    >>> LHE reweighting weight: " << rwgtID << std::endl;
+                  if (std::find(lheReweighingIDs.begin(), lheReweighingIDs.end(), rwgtID) == lheReweighingIDs.end()) {
+                    // we're only interested in the beggining of the block
+                    lheReweighingIDs.emplace_back(rwgtID);
+                  }
+                } else if (std::regex_search(lines[iLine], endweightgroup)) {
+                  if (lheDebug)
+                    std::cout << ">>> Looks like the end of a weight group" << std::endl;
+                } 
+              }
             } else {
               for (++iLine; iLine < nLines; ++iLine) {
                 if (lheDebug)


### PR DESCRIPTION
#### PR description:

Explicitly stores the EW parameter weights in the NanoAOD for the W mass Drell-Yan and W MC samples. Adds 43 weights for the DYJetsToMuMu_M-50_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos and 33 fro the W*JetsToMuNu_TuneCP5_13TeV-powhegMiNNLO-pythia8-photos samples. The weights include mV and sintheta variations that are essential to the analysis. No other samples are affected.

#### PR validation:

Confirmed that the weights are added correctly for these samples and that others are unaffected.
