### PR TITLE
[DD4hep] Automated Comparison of TrackerParameters DD vs DD4hep

### DIFF
--- a/DetectorDescription/DDCMS/plugins/test/DDTestCompactView.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestCompactView.cc
@@ -29,6 +29,17 @@ void DDTestCompactView::analyze(const Event&, const EventSetup& iEventSetup) {
   ESTransientHandle<DDCompactView> cpv;
   iEventSetup.get<IdealGeometryRecord>().get(m_tag, cpv);
 
+  std::cout << "Get trackerParameters:detIdShifts:\n";
+  auto const& vec = cpv->getVector<int>("detIdShifts");
+  for (const auto& i : vec)
+    std::cout << i << ", ";
+  std::cout << ";\ndone\n";
+
+  auto const& v = cpv->detector()->vectors().at("trackerParameters:detIdShifts");
+  for (const auto& i : v)
+    std::cout << i << ", ";
+  std::cout << ";\ndone\n";
+
   LogVerbatim("Geometry") << "DDTestCompactView::analyze done.";
 }
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
@@ -30,12 +30,19 @@ void DDTestVectors::analyze(const Event&, const EventSetup& iEventSetup) {
   iEventSetup.get<DDVectorRegistryRcd>().get(m_tag, registry);
 
   LogVerbatim("Geometry").log([&registry](auto& log) {
-    log << "DD Vector Registry size: " << registry->vectors.size();
+    log << "DD Vector Registry size: " << registry->vectors.size() << "\n";
     for (const auto& p : registry->vectors) {
       log << " " << p.first << " => ";
       for (const auto& i : p.second)
         log << i << ", ";
+      log << "\n";
     }
+    for (const auto& j : registry->vectors.at("trackerParameters:Subdetector4"))
+      log << j << ", ";
+    log << "\n";
+    for (const auto& k : registry->vectors.at("trackerParameters:detIdShifts"))
+      log << k << ", ";
+    log << "\n";
   });
 }
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestVectors.cc
@@ -37,12 +37,6 @@ void DDTestVectors::analyze(const Event&, const EventSetup& iEventSetup) {
         log << i << ", ";
       log << "\n";
     }
-    for (const auto& j : registry->vectors.at("trackerParameters:Subdetector4"))
-      log << j << ", ";
-    log << "\n";
-    for (const auto& k : registry->vectors.at("trackerParameters:detIdShifts"))
-      log << k << ", ";
-    log << "\n";
   });
 }
 

--- a/DetectorDescription/DDCMS/test/python/testDDVectors.py
+++ b/DetectorDescription/DDCMS/test/python/testDDVectors.py
@@ -41,7 +41,7 @@ process.MessageLogger = cms.Service(
 
 process.DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
                                             appendToDataLabel = cms.string('CMS'),
-                                            confGeomXMLFiles = cms.FileInPath('DetectorDescription/DDCMS/data/cms-test-ddvectors.xml')
+                                            confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml')
                                             )
 
 process.DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",

--- a/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerParametersFromDD.cc
@@ -23,35 +23,18 @@ bool TrackerParametersFromDD::build(const DDCompactView* cvp, PTrackerParameters
   return true;
 }
 
-bool TrackerParametersFromDD::build(const cms::DDCompactView* cvp, PTrackerParameters& ptp) {
-  const auto& vmap = cvp->detector()->vectors();
+bool TrackerParametersFromDD::build(const cms::DDCompactView* cpv, PTrackerParameters& ptp) {
+  const auto& vmap = cpv->detector()->vectors();
   for (int subdet = 1; subdet <= 6; ++subdet) {
-    std::stringstream sstm;
-    sstm << "Subdetector" << subdet;
-    std::string name = sstm.str();
-    for (auto const& it : vmap) {
-      if (dd4hep::dd::compareEqual(dd4hep::dd::noNamespace(it.first), name)) {
-        std::vector<int> subdetPars;
-        for (const auto& i : it.second)
-          subdetPars.emplace_back(std::round(i));
-        putOne(subdet, subdetPars, ptp);
-      }
-    }
+    const auto& v = vmap.at("trackerParameters:Subdetector" + std::to_string(subdet));
+    std::vector<int> subdetPars;
+    std::transform(v.begin(), v.end(), std::back_inserter(subdetPars), [](int i) -> int { return std::round(i); });
+    putOne(subdet, subdetPars, ptp);
   }
 
   // get "vPars" parameter block from XMLs.
-  const std::string& vPars = "trackerParameters:vPars";
-  for (auto const& parameterXMLBlock : vmap) {
-    const std::string& parameterName = parameterXMLBlock.first;
-    // Look for vPars parameter XML block.
-    if (dd4hep::dd::compareEqual(vPars, parameterName)) {
-      const std::vector<double>& parameterValues = parameterXMLBlock.second;
-      for (const auto& value : parameterValues) {
-        ptp.vpars.emplace_back(std::round(value));
-      }
-      break;  // Same logic as old DD: it should be found only once.
-    }
-  }
+  const auto& vPars = vmap.at("trackerParameters:vPars");
+  std::transform(vPars.begin(), vPars.end(), std::back_inserter(ptp.vpars), [](int i) -> int { return std::round(i); });
 
   return true;
 }

--- a/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
+++ b/Geometry/TrackerGeometryBuilder/test/TrackerParametersAnalyzer.cc
@@ -19,7 +19,7 @@ public:
 };
 
 void TrackerParametersAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  edm::LogInfo("TrackerParametersAnalyzer") << "Here I am";
+  edm::LogVerbatim("TrackerParametersAnalyzer") << "Here I am";
 
   edm::ESHandle<PTrackerParameters> ptp;
   iSetup.get<PTrackerParametersRcd>().get(ptp);

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDD4hep_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDD4hep_cfg.py
@@ -6,6 +6,47 @@ process.load('Configuration.Geometry.GeometryDD4hepExtended2021Reco_cff')
 
 if 'MessageLogger' in process.__dict__:
      process.MessageLogger.categories.append('TrackerParametersAnalyzer')
+     process.MessageLogger.destinations.append('cout')
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout'),
+    categories = cms.untracked.vstring('TrackerParametersAnalyzer'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        TrackerParametersAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    trackerParametersDD4hep = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        FWKINFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        TrackerParametersAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'trackerParametersDD4hep')
+)
      
 process.source = cms.Source("EmptySource")
 

--- a/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDDD_cfg.py
+++ b/Geometry/TrackerGeometryBuilder/test/python/testTrackerParametersFromDDD_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TrackerParametersTest")
-process.load('Configuration.Geometry.GeometryExtended_cff')
-process.load('Configuration.Geometry.GeometryExtendedReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Configuration.Geometry.GeometryExtended2021Reco_cff')
 
 process.trackerGeometry.applyAlignment = cms.bool(False)
 
@@ -12,7 +12,50 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    statistics = cms.untracked.vstring('cout'),
+    categories = cms.untracked.vstring('TrackerParametersAnalyzer'),
+    cout = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        TrackerParametersAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        noLineBreaks = cms.untracked.bool(True)
+        ),
+    trackerParametersDDD = cms.untracked.PSet(
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        FWKINFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        noLineBreaks = cms.untracked.bool(True),
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        WARNING = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        ERROR = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+            ),
+        threshold = cms.untracked.string('INFO'),
+        TrackerParametersAnalyzer = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+            ),
+        ),
+    destinations = cms.untracked.vstring('cout',
+                                         'trackerParametersDDD')
+)
+
 process.test = cms.EDAnalyzer("TrackerParametersAnalyzer")
+
+process.Timing = cms.Service("Timing")
+process.SimpleMemoryCheck = cms.Service("SimpleMemoryCheck")
 
 process.p1 = cms.Path(process.test)
 

--- a/Geometry/TrackerGeometryBuilder/test/runTest.sh
+++ b/Geometry/TrackerGeometryBuilder/test/runTest.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 
 function die { echo $1: status $2 ; exit $2; }
+function checkDiff {
+    FSIZE=$(stat -c%s "$1")
+    echo "The output diff is $FSIZE:"
+    cat $1;
+    if [ $FSIZE -gt 500 ]
+    then
+	exit -1;
+    fi
+}
 
 echo " testing Geometry/TrackerGeomtryBuilder"
 
@@ -9,3 +18,12 @@ do
   echo "===== Test \"cmsRun $entry \" ===="
   (cmsRun $entry) || die "Failure using cmsRun $entry" $?
 done
+
+FILE1=trackerParametersDD4hep.log
+FILE2=trackerParametersDDD.log
+FILE3=diff.log
+
+echo "===== Compare Tracker Parameters for DD and DD4hep ===="
+(diff -B -w $FILE1 $FILE2 >& $FILE3;
+    [ -s $FILE3 ] && checkDiff $FILE3 || echo "OK") || die "Failure comparing Tracker Parameters for DD and DD4hep" $?
+    


### PR DESCRIPTION
#### PR description:

* Automated comparison for `TrackerParameters` produced with `DD4hep` vs `DD`
* Faster retrieval of the parameters from a map

When a namespace is not required:
```c++
auto const& vec = cpv->getVector<int>("detIdShifts");
```
It gives an identical result as the following, but using a namespace:
```c++
auto const& v = cpv->detector()->vectors().at("trackerParameters:detIdShifts");
std::vector<int> subdetPars;
std::transform(v.begin(), v.end(), std::back_inserter(subdetPars), [](int i) -> int { return std::round(i); });
```

TrackerParameters producer DD4hep vs DD:
```
TimeModule> 1 1 test TrackerParametersAnalyzer 1.94412
TimeModule> 1 1 p1 PathStatusInserter 5.19753e-05
TimeModule> 1 1 TriggerResults TriggerResultInserter 1.97887e-05
TimeEvent> 1 1 1.94451
MemoryReport> Peak virtual size 806.32 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 806.32 deltaVsize = 0 rss = 285.715 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 806.32 deltaVsize = 0 rss = 285.715 delta = 0
TimeReport> Time report complete in 6.36567 seconds
 Time Summary: 
 - Min event:   1.94451
 - Max event:   1.94451
 - Avg event:   1.94451
 - Total loop:  1.94565
 - Total init:  4.41856
 - Total job:   6.36567
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.513968 ev/s
 CPU Summary: 
 - Total loop:  1.81109
 - Total init:  2.43381
 - Total extra: 0
 - Total job:   4.24624
 Processing Summary: 
 - Number of Events:  1
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1

```
```
TimeModule> 1 1 test TrackerParametersAnalyzer 1.27393
TimeModule> 1 1 p1 PathStatusInserter 4.79221e-05
TimeModule> 1 1 TriggerResults TriggerResultInserter 2.09808e-05
TimeEvent> 1 1 1.27431
MemoryReport> Peak virtual size 714.941 Mbytes
 Key events increasing vsize: 
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 714.941 deltaVsize = 0 rss = 231.512 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[0] run: 0 lumi: 0 event: 0  vsize = 0 deltaVsize = 0 rss = 0 delta = 0
[1] run: 1 lumi: 1 event: 1  vsize = 714.941 deltaVsize = 0 rss = 231.512 delta = 0
TimeReport> Time report complete in 4.63043 seconds
 Time Summary: 
 - Min event:   1.27431
 - Max event:   1.27431
 - Avg event:   1.27431
 - Total loop:  1.27532
 - Total init:  3.35362
 - Total job:   4.63043
 - EventSetup Lock:   0
 - EventSetup Get:   0
 Event Throughput: 0.784119 ev/s
 CPU Summary: 
 - Total loop:  1.19313
 - Total init:  2.11341
 - Total extra: 0
 - Total job:   3.30792
 Processing Summary: 
 - Number of Events:  1
 - Number of Global Begin Lumi Calls:  1
 - Number of Global Begin Run Calls: 1
```

@ghugo83 - This PR does not solve the problem with a TOB DetId, just one more automated check for an IB integration.
```
%MSG-w TkAccumulatingSensitiveDetector::createHit:  OscarMTProducer:g4SimHits  26-Oct-2020 16:47:56 CET Run: 1 Event: 1
 theDetUnitId is not valid for TrackerHitsTOB
%MSG
----- Begin Fatal Exception 26-Oct-2020 16:47:56 CET-----------------------
An exception of category 'TkAccumulatingSensitiveDetector::createHit' occurred while
   [0] Processing  Event run: 1 lumi: 1 event: 1 stream: 0
   [1] Running path 'FEVTDEBUGoutput_step'
   [2] Prefetching for module PoolOutputModule/'FEVTDEBUGoutput'
   [3] Calling method for module OscarMTProducer/'g4SimHits'
Exception Message:
cannot get theDetUnitId for G4Track 5834
----- End Fatal Exception -------------------------------------------------

```
<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
