### PR TITLE
PPS Digi integration into cmssw (final)

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -19,8 +19,7 @@ from EventFilter.RawDataCollector.rawDataCollector_cfi import *
 from L1Trigger.Configuration.L1TDigiToRaw_cff import *
 from EventFilter.CTPPSRawToDigi.ctppsDigiToRaw_cff import *
 
-#DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, ctppsRawData, castorRawData, rawDataCollector)
-DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, castorRawData, rawDataCollector)
+DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, ctppsRawData, castorRawData, rawDataCollector)
 DigiToRaw = cms.Sequence(DigiToRawTask)
 
 ecalPacker.Label = 'simEcalDigis'

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -33,7 +33,7 @@ from SimGeneral.Configuration.SimGeneral_cff import *
 from Configuration.StandardSequences.Generator_cff import *
 from GeneratorInterface.Core.generatorSmeared_cfi import *
 
-doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask)#, ctppsDigiTask)
+doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask, ctppsDigiTask)
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 # premixing stage2 runs muon digis after PreMixingModule (configured in DataMixerPreMix_cff)
 premix_stage2.toReplaceWith(doAllDigiTask, doAllDigiTask.copyAndExclude([muonDigiTask]))


### PR DESCRIPTION
#### PR description:

PPS digi integration into cmssw. This is the last step towards the integration of PPS simulation into CMSSW and was delayed waiting for the new cms extended geometry (including PPS) to show up in the DB.

#### PR validation:

scram b runtests
scram b code-checks
scram b code-format

with no issue. 

As for runTheMatrix, it was run with the command below (hopefully only Run3 wf)
  
runTheMatrix.py --job-reports --ibeos -l 4.22,4.53,5.1,7.3,8.0,9.0,25.0,135.4,136.731,136.7611,136.793,136.8311,136.874,136.88811,140.53,140.56,158.0,158.01,1306.0,1325.7,1330.0,101.0,25202.0,1000.0,1001.0,10024.0,10042.0,10224.0,10824.0,11634.0,12434.0,23234.0,23434.999,28234.0,250202.181

which produced:
35 34 33 25 17 4 1 1 1 tests passed, 0 0 0 0 0 0 0 0 0 failed

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
