### PR TITLE
Add PDF sets to nano, prioritize by order in LHE file

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -846,8 +846,8 @@ public:
         std::stringstream pdfDoc;
         pdfDoc << "LHE pdf variation weights (w_var / w_nominal) for LHA IDs ";
         bool found = false;
-        for (uint32_t lhaid : preferredPDFLHAIDs_) {
-          for (const auto& pw : pdfSetWeightIDs) {
+        for (const auto& pw : pdfSetWeightIDs) {
+          for (uint32_t lhaid : preferredPDFLHAIDs_) {
             if (pw.lhaIDs.first != lhaid && pw.lhaIDs.first != (lhaid + 1))
               continue;  // sometimes the first weight is not saved if that PDF is the nominal one for the sample
             if (pw.wids.size() == 1)

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -5,12 +5,17 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     genLumiInfoHeader = cms.InputTag("generator"),
     lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
     preferredPDFs = cms.VPSet( # see https://lhapdf.hepforge.org/pdfsets.html
-        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
         cms.PSet( name = cms.string("NNPDF31_nnlo_hessian_pdfas"), lhaid = cms.uint32(306000) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_hessian"), lhaid = cms.uint32(304400) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_mc_hessian_pdfas"), lhaid = cms.uint32(325300) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_mc"), lhaid = cms.uint32(316200) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_nf_4_mc_hessian"), lhaid = cms.uint32(325500) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_nf_4"), lhaid = cms.uint32(320900) ),
         cms.PSet( name = cms.string("NNPDF30_nlo_as_0118"), lhaid = cms.uint32(260000) ), # for some 92X samples. Note that the nominal weight, 260000, is not included in the LHE ...
         cms.PSet( name = cms.string("NNPDF30_lo_as_0130"), lhaid = cms.uint32(262000) ), # some MLM 80X samples have only this (e.g. /store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/120000/02A210D6-F5C3-E611-B570-008CFA197BD4.root )
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
+        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
     ),
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -16,6 +16,8 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
         cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
+        cms.PSet( name = cms.string("PDF4LHC15_nlo_30_pdfas"), lhaid = cms.uint32(90400) ),
+        cms.PSet( name = cms.string("PDF4LHC15_nlo_30"), lhaid = cms.uint32(90900) ),
     ),
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),


### PR DESCRIPTION
#### PR description:

Switch loops in nanoaod producer so that PDF sets are prioritized
by the order in the file, not the order in the config. Now chooses the
first PDF set in the file which is part of the list of "approved" sets
in the config. Also adds additional sets to this list

#### PR validation:

Checked that the logic works in a few files