### PR TITLE
make VertexException inherit from cms::Exception

### DIFF
--- a/RecoVertex/VertexPrimitives/BuildFile.xml
+++ b/RecoVertex/VertexPrimitives/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="DataFormats/GeometryVector"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/Candidate"/>
+<use name="FWCore/Utilities"/>
 <use name="TrackingTools/TransientTrack"/>
 <export>
   <lib name="1"/>

--- a/RecoVertex/VertexPrimitives/interface/VertexException.h
+++ b/RecoVertex/VertexPrimitives/interface/VertexException.h
@@ -4,15 +4,15 @@
 #ifndef Vertex_Exceptions_H
 #define Vertex_Exceptions_H
 
-#include <exception>
+#include "FWCore/Utilities/interface/Exception.h"
 #include <string>
 
 /// Common base class
 
-class VertexException : public std::exception {
+class VertexException : public cms::Exception {
 public:
-  VertexException() throw() {}
-  VertexException(const std::string& message) throw() : theMessage(message) {}
+  VertexException() throw() : cms::Exception("VertexException") {}
+  VertexException(const std::string& message) throw() : cms::Exception("VertexException"), theMessage(message) {}
   ~VertexException() throw() override {}
   const char* what() const throw() override { return theMessage.c_str(); }
 


### PR DESCRIPTION
following the exception guidelines, exceptions should inherit from cms::Exception
https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEdmExceptionUse#Exception_classes