### PR TITLE
Removed cout statements from BMTF packer

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
@@ -50,16 +50,6 @@ namespace l1t {
 
       blocks.push_back(block);
 
-      /*
-      //debug from here
-      std::cout << "block id : " << block.header().getID() << std::endl;
-
-      std::cout << "payload created : " << std::endl;
-      for (auto &word : block.payload())
-        std::cout << std::bitset<32>(word).to_string() << std::endl;
-      //debug up to here
-    */
-
       return blocks;
     }
 


### PR DESCRIPTION
#### PR description:
As promised in #31679 we're removing the (commented) cout statements from the BMTF packer.

attn @rekovic @jfernan2 @panoskatsoulis 

#### PR validation:
No validation needed because only commented code was removed.
