### PR TITLE
add ZDC Digis to HI miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -149,7 +149,8 @@ _pp_on_AA_extraCommands = [
     'keep int_centralityBin_*_*',
     'keep recoHFFilterInfo_hiHFfilters_*_*',
     'keep *_hiEvtPlane_*_*',
-    'keep *_hiEvtPlaneFlat_*_*'
+    'keep *_hiEvtPlaneFlat_*_*',
+    'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
 ]
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3


### PR DESCRIPTION

The ZDC digis are currently stored in AOD.  This PR carries them over to miniAOD. 
The ZDC is small, so there's only a modest change to event size of real data (seen in 140.5611).  There is no change to MC, because the ZDC isn't simulated. 

