### PR TITLE
DD4hep RelVal for Phase2: update geometry configuration and PyReleaseValidation 

### DIFF
--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021Reco_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-# Ideal geometry, needed for transient ECAL alignement
+# This config was generated automatically using generate2021Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
+
 from Configuration.Geometry.GeometryDD4hepExtended2021_cff import *
 
 # tracker

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterialReco_cff.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-# Ideal geometry, needed for transient ECAL alignement
+# This config was generated automatically using generate2021Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
+
 from Configuration.Geometry.GeometryDD4hepExtended2021ZeroMaterial_cff import *
 
 # tracker

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterial_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterial_cff.py
@@ -1,27 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-#
-# Geometry master configuration
-#
-# Ideal geometry, needed for simulation
-DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                    confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021ZeroMaterial.xml'),
-                                    appendToDataLabel = cms.string('')
-)
+# This config was generated automatically using generate2021Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
 
-DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                             appendToDataLabel = cms.string('')
-)
-
-DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                            appendToDataLabel = cms.string(''))
-
-DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                         appendToDataLabel = cms.string('')
-)
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2021ZeroMaterial.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
+

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterial_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021ZeroMaterial_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2021ZeroMaterial.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021ZeroMaterial.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2021.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2021_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2021_cff.py
@@ -1,27 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
-#
-# Geometry master configuration
-#
-# Ideal geometry, needed for simulation
-DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                    confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2021.xml'),
-                                    appendToDataLabel = cms.string('')
-)
+# This config was generated automatically using generate2021Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
 
-DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                             appendToDataLabel = cms.string('')
-)
-
-DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                            appendToDataLabel = cms.string(''))
-
-DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                         appendToDataLabel = cms.string('')
-)
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2021.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
+

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D49Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D49Reco_cff.py
@@ -51,8 +51,8 @@ from Geometry.ForwardGeometry.ForwardGeometry_cfi import *
 
 # timing
 from RecoMTD.DetLayers.mtdDetLayerGeometry_cfi import *
-from Geometry.MTDGeometryBuilder.mtdParameters_cfi import *
-from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *
+from Geometry.MTDGeometryBuilder.mtdParameters_cff import *
+from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *
 from Geometry.MTDNumberingBuilder.mtdTopology_cfi import *
 from Geometry.MTDGeometryBuilder.mtdGeometry_cfi import *
 from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D49.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D49.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
@@ -1,24 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-#
-# Geometry master configuration
-#
-# Ideal geometry, needed for simulation
-DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                    confGeomXMLFiles = cms.FileInPath('Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D49.xml'),
-                                    appendToDataLabel = cms.string('')
-)
+# This config was generated automatically using generate2026Geometry.py
+# If you notice a mistake, please update the generating script, not just this config
 
-DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
-                                             appendToDataLabel = cms.string('')
-)
-
-DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
-                                            appendToDataLabel = cms.string(''))
-
-DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
-                                         appendToDataLabel = cms.string('')
-)
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D49.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D49_cff.py
@@ -13,4 +13,4 @@ from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *
+from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D50Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D50Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D50_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D50_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D50_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D50.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D50_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D50_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D50.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D50.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D60Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D60Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D60_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D60.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D60.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D60_cff.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D60.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D64Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D64Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D64_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D64_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D64_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D64.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D64_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D64_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D64.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D64.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D65Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D65Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D65_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D65_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D65_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D65.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D65_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D65_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D65.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D65.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D66Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D66Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D66_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D66_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D66_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D66.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D66.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D66_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D66_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D66.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D67Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D67Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D67_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
@@ -45,7 +42,6 @@ from Geometry.EcalMapping.EcalMappingRecord_cfi import *
 from Geometry.MuonNumbering.muonNumberingInitialization_cfi import *
 from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.GEMGeometryBuilder.gemGeometry_cfi import *
-from Geometry.GEMGeometryBuilder.me0Geometry_cfi import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
 

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D67_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D67_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D67.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D67_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D67_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D67.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D67.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D68Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D68Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D68_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D68.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D68_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D68.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D68.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D69Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D69Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D69_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D69_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D69_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D69.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D69.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D69_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D69_cff.py
@@ -3,7 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D69.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D70Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D70Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D70_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D70.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D70_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D70.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D70.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D71Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D71Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D71_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D71_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D71_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D71.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D71.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D71_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D71_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D71.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D72Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D72Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D72_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D72_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D72_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D72.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D72_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D72_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D72.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D72.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D73Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D73Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D73_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D73_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D73_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D73.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D73.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D73_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D73_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D73.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D74Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D74Reco_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Configuration.Geometry.GeometryExtended2026D60_cff import *
+from Configuration.Geometry.GeometryDD4hepExtended2026D74_cff import *
 
 # tracker
 from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *
@@ -16,8 +16,6 @@ trackerGeometry.applyAlignment = cms.bool(False)
 # calo
 from Geometry.CaloEventSetup.HGCalV9Topology_cfi import *
 from Geometry.HGCalGeometry.HGCalGeometryESProducer_cfi import *
-from Geometry.CaloEventSetup.HFNoseTopology_cfi import *
-from Geometry.ForwardGeometry.HFNoseGeometryESProducer_cfi import *
 from Geometry.CaloEventSetup.CaloTopology_cfi import *
 from Geometry.CaloEventSetup.CaloGeometryBuilder_cfi import *
 CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
@@ -27,8 +25,7 @@ CaloGeometryBuilder = cms.ESProducer("CaloGeometryBuilder",
                                 "TOWER",
                                 "HGCalEESensitive",
                                 "HGCalHESiliconSensitive",
-                                "HGCalHEScintillatorSensitive",
-                                "HGCalHFNoseSensitive",
+                                "HGCalHEScintillatorSensitive"
     )
 )
 from Geometry.EcalAlgo.EcalBarrelGeometry_cfi import *
@@ -45,7 +42,6 @@ from Geometry.EcalMapping.EcalMappingRecord_cfi import *
 from Geometry.MuonNumbering.muonNumberingInitialization_cfi import *
 from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 from Geometry.GEMGeometryBuilder.gemGeometry_cfi import *
-from Geometry.GEMGeometryBuilder.me0Geometry_cfi import *
 from Geometry.CSCGeometryBuilder.idealForDigiCscGeometry_cff import *
 from Geometry.DTGeometryBuilder.idealForDigiDtGeometry_cff import *
 

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D74_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D74_cff.py
@@ -3,15 +3,14 @@ import FWCore.ParameterSet.Config as cms
 # This config was generated automatically using generate2026Geometry.py
 # If you notice a mistake, please update the generating script, not just this config
 
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D60XML_cfi import *
+from Configuration.Geometry.GeometryDD4hep_cff import *
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D74.xml")
+
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseParametersInitialization_cfi import *
-from Geometry.ForwardCommonData.hfnoseNumberingInitialization_cfi  import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-
 from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hepExtended2026D74_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hepExtended2026D74_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Configuration.Geometry.GeometryDD4hep_cff import *
-DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/python/cmsExtendedGeometry2026D74.xml")
+DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath("Geometry/CMSCommonData/data/dd4hep/cmsExtendedGeometry2026D74.xml")
 
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *

--- a/Configuration/Geometry/python/GeometryDD4hep_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hep_cff.py
@@ -1,5 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
 DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
-                                    confGeomXMLFiles = cms.FileInPath(cmsDD4hepXML),
+                                    confGeomXMLFiles = cms.FileInPath(''),
                                     appendToDataLabel = cms.string('')
 )
 

--- a/Configuration/Geometry/python/GeometryDD4hep_cff.py
+++ b/Configuration/Geometry/python/GeometryDD4hep_cff.py
@@ -1,0 +1,15 @@
+DDDetectorESProducer = cms.ESSource("DDDetectorESProducer",
+                                    confGeomXMLFiles = cms.FileInPath(cmsDD4hepXML),
+                                    appendToDataLabel = cms.string('')
+)
+
+DDSpecParRegistryESProducer = cms.ESProducer("DDSpecParRegistryESProducer",
+                                             appendToDataLabel = cms.string('')
+)
+
+DDVectorRegistryESProducer = cms.ESProducer("DDVectorRegistryESProducer",
+                                            appendToDataLabel = cms.string(''))
+
+DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
+                                         appendToDataLabel = cms.string('')
+)

--- a/Configuration/Geometry/python/GeometryExtended2021ZeroMaterial_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021ZeroMaterial_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2021ZeroMaterialXML_cfi import *
-from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2021_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2021_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # If you notice a mistake, please update the generating script, not just this config
 
 from Geometry.CMSCommonData.cmsExtendedGeometry2021XML_cfi import *
-from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
+from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *
 from Geometry.EcalCommonData.ecalSimulationParameters_cff import *
 from Geometry.HcalCommonData.hcalDDDSimConstants_cff import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D49Reco_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D49Reco_cff.py
@@ -51,8 +51,8 @@ from Geometry.ForwardGeometry.ForwardGeometry_cfi import *
 
 # timing
 from RecoMTD.DetLayers.mtdDetLayerGeometry_cfi import *
-from Geometry.MTDGeometryBuilder.mtdParameters_cfi import *
-from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *
+from Geometry.MTDGeometryBuilder.mtdParameters_cff import *
+from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *
 from Geometry.MTDNumberingBuilder.mtdTopology_cfi import *
 from Geometry.MTDGeometryBuilder.mtdGeometry_cfi import *
 from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *

--- a/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
+++ b/Configuration/Geometry/python/GeometryExtended2026D49_cff.py
@@ -11,4 +11,4 @@ from Geometry.HGCalCommonData.hgcalParametersInitialization_cfi import *
 from Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi import *
 from Geometry.MuonNumbering.muonGeometryConstants_cff import *
 from Geometry.MuonNumbering.muonOffsetESProducer_cff import *
-from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *
+from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *

--- a/Configuration/Geometry/python/dict2021Geometry.py
+++ b/Configuration/Geometry/python/dict2021Geometry.py
@@ -314,7 +314,7 @@ trackerDict = {
             'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         ],
         "sim" : [
-            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -516,7 +516,7 @@ trackerDict = {
             'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         ],
         "sim" : [
-            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -719,7 +719,7 @@ trackerDict = {
             'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         ],
         "sim" : [
-            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',
@@ -921,7 +921,7 @@ trackerDict = {
             'Geometry/TrackerSimData/data/trackerProdCutsBEAM.xml',
         ],
         "sim" : [
-            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *',
+            'from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cff import *',
         ],
         "reco" : [
             'from Geometry.CommonTopologies.globalTrackingGeometry_cfi import *',

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -1124,12 +1124,12 @@ timingDict = {
             'Geometry/MTDSimData/data/CrystalBarPhiFlat/mtdProdCuts.xml'
             ],
         "sim" : [
-            'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *',
+            'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *',
         ],
         "reco" :[
             'from RecoMTD.DetLayers.mtdDetLayerGeometry_cfi import *',
-            'from Geometry.MTDGeometryBuilder.mtdParameters_cfi import *',
-            'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi import *',
+            'from Geometry.MTDGeometryBuilder.mtdParameters_cff import *',
+            'from Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cff import *',
             'from Geometry.MTDNumberingBuilder.mtdTopology_cfi import *',
             'from Geometry.MTDGeometryBuilder.mtdGeometry_cfi import *',
             'from Geometry.MTDGeometryBuilder.idealForDigiMTDGeometry_cff import *',

--- a/Configuration/Geometry/python/generateGeometry.py
+++ b/Configuration/Geometry/python/generateGeometry.py
@@ -155,7 +155,7 @@ class GeometryGenerator(object):
         simDD4hepFile.write(preamble)
         # always need XML
         simDD4hepFile.write("from Configuration.Geometry.GeometryDD4hep_cff"+" import *"+"\n")
-        simDD4hepFile.write("cmsDD4hepXML=Geometry/CMSCommonData/data/python/"+os.path.basename(xmlDD4hepName)+"\n\n")
+        simDD4hepFile.write("DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath(\"Geometry/CMSCommonData/data/python/"+os.path.basename(xmlDD4hepName)+"\")\n\n")
         for iDict,aDict in enumerate(self.allDicts):
             if "sim" in aDict[detectorTuple[iDict]].keys():
                 simDD4hepFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["sim"] ])+"\n")
@@ -167,8 +167,8 @@ class GeometryGenerator(object):
         recoFile.write("from Configuration.Geometry."+os.path.basename(simName).replace(".py","")+" import *"+"\n\n")
         for iDict,aDict in enumerate(self.allDicts):
             if "reco" in aDict[detectorTuple[iDict]].keys():
-                recoFile.write("# "+aDict["name"]+"\n")
-                recoFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["reco"] ])+"\n\n")
+               recoFile.write("# "+aDict["name"]+"\n")
+               recoFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["reco"] ])+"\n\n")
         recoFile.close()
 
         # create recoDD4hep config

--- a/Configuration/Geometry/python/generateGeometry.py
+++ b/Configuration/Geometry/python/generateGeometry.py
@@ -55,7 +55,9 @@ class GeometryGenerator(object):
         xmlName = "cmsExtendedGeometry"+self.detectorYear+detectorVersion+"XML_cfi.py"
         xmlDD4hepName = "cmsExtendedGeometry"+self.detectorYear+detectorVersion+".xml"
         simName = "GeometryExtended"+self.detectorYear+detectorVersion+"_cff.py"
+        simDD4hepName = "GeometryDD4hepExtended"+self.detectorYear+detectorVersion+"_cff.py"
         recoName = "GeometryExtended"+self.detectorYear+detectorVersion+"Reco_cff.py"
+        recoDD4hepName = "GeometryDD4hepExtended"+self.detectorYear+detectorVersion+"Reco_cff.py"
 
         # check directories
         CMSSWBASE = os.getenv("CMSSW_BASE")
@@ -64,6 +66,7 @@ class GeometryGenerator(object):
         xmlDir = os.path.join(CMSSWBASE,"src","Geometry","CMSCommonData","python")
         xmlDD4hepDir = os.path.join(CMSSWBASE,"src","Geometry","CMSCommonData","data","dd4hep")
         simrecoDir = os.path.join(CMSSWBASE,"src","Configuration","Geometry","python")
+        simrecoDD4hepDir = os.path.join(CMSSWBASE,"src","Configuration","Geometry","python")
         if args.doTest:
             if not os.path.isdir(xmlDir):
                 xmlDir = os.path.join(CMSSWRELBASE,"src","Geometry","CMSCommonData","python")
@@ -84,6 +87,12 @@ class GeometryGenerator(object):
             else:
                 simName = os.path.join(simrecoDir,simName)
                 recoName = os.path.join(simrecoDir,recoName)
+            if not os.path.isdir(simrecoDD4hepDir):
+                mvCommands += "mv "+simDD4hepName+" "+simrecoDD4hepDir+"/\n"
+                mvCommands += "mv "+recoDD4hepName+" "+simrecoDD4hepDir+"/\n"
+            else:
+                simDD4hepName = os.path.join(simrecoDD4hepDir,simDD4hepName)
+                recoDD4hepName = os.path.join(simrecoDD4hepDir,recoDD4hepName)
             if len(mvCommands)>0:
                 print("Warning: some geometry packages not checked out.\nOnce they are available, please execute the following commands manually:\n"+mvCommands)
 
@@ -91,7 +100,9 @@ class GeometryGenerator(object):
         xmlFile = open(xmlName,'w')
         xmlDD4hepFile = open(xmlDD4hepName,'w')
         simFile = open(simName,'w')
+        simDD4hepFile = open(simDD4hepName,'w')
         recoFile = open(recoName,'w')
+        recoDD4hepFile = open(recoDD4hepName,'w')
 
         # common preamble
         preamble = "import FWCore.ParameterSet.Config as cms"+"\n"+"\n"
@@ -140,6 +151,16 @@ class GeometryGenerator(object):
                 simFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["sim"] ])+"\n")
         simFile.close()
 
+        # create simDD4hep config
+        simDD4hepFile.write(preamble)
+        # always need XML
+        simDD4hepFile.write("from Configuration.Geometry.GeometryDD4hep_cff"+" import *"+"\n")
+        simDD4hepFile.write("cmsDD4hepXML=Geometry/CMSCommonData/data/python/"+os.path.basename(xmlDD4hepName)+"\n\n")
+        for iDict,aDict in enumerate(self.allDicts):
+            if "sim" in aDict[detectorTuple[iDict]].keys():
+                simDD4hepFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["sim"] ])+"\n")
+        simDD4hepFile.close()
+
         # create reco config
         recoFile.write(preamble)
         # always need sim
@@ -149,6 +170,16 @@ class GeometryGenerator(object):
                 recoFile.write("# "+aDict["name"]+"\n")
                 recoFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["reco"] ])+"\n\n")
         recoFile.close()
+
+        # create recoDD4hep config
+        recoDD4hepFile.write(preamble)
+        # always need sim
+        recoDD4hepFile.write("from Configuration.Geometry."+os.path.basename(simDD4hepName).replace(".py","")+" import *"+"\n\n")
+        for iDict,aDict in enumerate(self.allDicts):
+            if "reco" in aDict[detectorTuple[iDict]].keys():
+                recoDD4hepFile.write("# "+aDict["name"]+"\n")
+                recoDD4hepFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["reco"] ])+"\n\n")
+        recoDD4hepFile.close()
 
         from Configuration.StandardSequences.GeometryConf import GeometryConf
         if not args.doTest: # todo: include these in unit test somehow
@@ -180,11 +211,21 @@ class GeometryGenerator(object):
                 errorList.append(simName+" missing")
             elif not filecmp.cmp(simName,simFile):
                 errorList.append(simName+" differs")
+            simDD4hepFile = os.path.join(simrecoDD4hepDir,simDD4hepName)
+            if not os.path.isfile(simDD4hepFile):
+                errorList.append(simDD4hepName+" missing")
+            elif not filecmp.cmp(simDD4hepName,simDD4hepFile):
+                errorList.append(simDD4hepName+" differs")
             recoFile = os.path.join(simrecoDir,recoName)
             if not os.path.isfile(recoFile):
                 errorList.append(recoName+" missing")
             elif not filecmp.cmp(recoName,recoFile):
                 errorList.append(recoName+" differs")
+            recoDD4hepFile = os.path.join(simrecoDD4hepDir,recoDD4hepName)
+            if not os.path.isfile(recoDD4hepFile):
+                errorList.append(recoDD4hepName+" missing")
+            elif not filecmp.cmp(recoDD4hepName,recoDD4hepFile):
+                errorList.append(recoDD4hepName+" differs")
             # test for Configuration/StandardSequences
             if not 'Extended'+self.detectorYear+detectorVersion in GeometryConf.keys():
                 errorList.append('Extended'+self.detectorYear+detectorVersion+" missing from GeometryConf")

--- a/Configuration/Geometry/python/generateGeometry.py
+++ b/Configuration/Geometry/python/generateGeometry.py
@@ -155,7 +155,7 @@ class GeometryGenerator(object):
         simDD4hepFile.write(preamble)
         # always need XML
         simDD4hepFile.write("from Configuration.Geometry.GeometryDD4hep_cff"+" import *"+"\n")
-        simDD4hepFile.write("DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath(\"Geometry/CMSCommonData/data/python/"+os.path.basename(xmlDD4hepName)+"\")\n\n")
+        simDD4hepFile.write("DDDetectorESProducer.confGeomXMLFiles = cms.FileInPath(\"Geometry/CMSCommonData/data/dd4hep/"+os.path.basename(xmlDD4hepName)+"\")\n\n")
         for iDict,aDict in enumerate(self.allDicts):
             if "sim" in aDict[detectorTuple[iDict]].keys():
                 simDD4hepFile.write('\n'.join([ aLine for aLine in aDict[detectorTuple[iDict]]["sim"] ])+"\n")

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -846,15 +846,27 @@ upgradeWFs['PMXS1S2PR'] = UpgradeWorkflowAdjustPU(
 
 class UpgradeWorkflow_DD4hep(UpgradeWorkflow):
     def setup_(self, step, stepName, stepDict, k, properties):
-        stepDict[stepName][k] = merge([{'--geometry': 'DD4hepExtended2021', '--era': 'Run3_dd4hep'}, stepDict[step][k]])
+        if 'Run3' in stepDict[step][k]['--era']:
+            stepDict[stepName][k] = merge([{'--geometry': 'DD4hepExtended2021', '--procModifiers': 'dd4hep'}, stepDict[step][k]])
+        elif 'Phase2' in stepDict[step][k]['--era']:
+            dd4hepGeom="DD4hep"
+            dd4hepGeom+=stepDict[step][k]['--geometry']
+            stepDict[stepName][k] = merge([{'--geometry' : dd4hepGeom, '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        return (fragment=='TTbar_13' or fragment=='ZMM_13' or fragment=='SingleMuPt10') and '2021' in key
+        if (fragment=='TTbar_13' or fragment=='ZMM_13' or fragment=='SingleMuPt10') and '2021' in key:
+            return True
+        if (fragment=='TTbar_14TeV' or fragment=='ZMM_14' or fragment=='SingleMuPt10') and '2026' in key:
+            return True
 upgradeWFs['DD4hep'] = UpgradeWorkflow_DD4hep(
     steps = [
         'GenSim',
+        'GenSimHLBeamSpot',
         'Digi',
+        'DigiTrigger',
         'Reco',
+        'RecoGlobal',
         'HARVEST',
+        'HARVESTGlobal',
         'ALCA',
     ],
     PU = [],

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -853,14 +853,13 @@ class UpgradeWorkflow_DD4hep(UpgradeWorkflow):
             dd4hepGeom+=stepDict[step][k]['--geometry']
             stepDict[stepName][k] = merge([{'--geometry' : dd4hepGeom, '--procModifiers': 'dd4hep'}, stepDict[step][k]])
     def condition(self, fragment, stepList, key, hasHarvest):
-        if (fragment=='TTbar_13' or fragment=='ZMM_13' or fragment=='SingleMuPt10') and '2021' in key:
-            return True
-        if (fragment=='TTbar_14TeV' or fragment=='ZMM_14' or fragment=='SingleMuPt10') and '2026' in key:
-            return True
+        return ((fragment=='TTbar_13' or fragment=='ZMM_13' or fragment=='SingleMuPt10') and '2021' in key) \
+            or ((fragment=='TTbar_14TeV' or fragment=='ZMM_14' or fragment=='SingleMuPt10') and '2026' in key)
 upgradeWFs['DD4hep'] = UpgradeWorkflow_DD4hep(
     steps = [
         'GenSim',
         'GenSimHLBeamSpot',
+        'GenSimHLBeamSpot14',
         'Digi',
         'DigiTrigger',
         'Reco',

--- a/Configuration/StandardSequences/python/GeometryConf.py
+++ b/Configuration/StandardSequences/python/GeometryConf.py
@@ -45,4 +45,5 @@ GeometryConf={
     'Extended2026D72' : 'Extended2026D72,Extended2026D72Reco',
     'Extended2026D73' : 'Extended2026D73,Extended2026D73Reco',
     'Extended2026D74' : 'Extended2026D74,Extended2026D74Reco',
+    'DD4hepExtended2026D49' : 'DD4hepExtended2026D49,DD4hepExtended2026D49Reco',
     }


### PR DESCRIPTION
#### PR description:

This PR extends #30003 introducing DD4hep geometry configurations and corresponding RelVal test workflows for Phase2 scenarios. In the initial version of this PR only the geometry D49 configuration is explicitly added (while workflows are possibly built for any Phase2 scenario). If there is agreement on this strategy I may update the PR by adding configurations for any active scenario, in any case the ```generateGeometry.py``` script is instructed to produce whatever Phase2 DD4hep configuration required. I add a few fixes to the geometry dictionaries to keep in synchrony them with the latest version available (for 2021) and have the dd4hep modifier available for MTD (other sub-detectors will have to check).

#### PR validation:

Code compiles and produces the desired configurations, tested for 2021 and 2026D49 both as compressed and expanded python configuration. The workflow list shows workflows for all scenarios, but their building fails but for D49, as the geometry configurations are not provided for the time being.