### PR TITLE
[Pixel 3D Digitizer] Include charge generation underneath the n-column

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -322,7 +322,9 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
         const float pixel_x = current_pixel_int.first + (mc.x() + center_proxy_cell.x()) / pitch.first;
         const float pixel_y = current_pixel_int.second + (mc.y() + center_proxy_cell.y()) / pitch.second;
         const auto lp = pixdet->specificTopology().localPosition(MeasurementPoint(pixel_x, pixel_y));
-        mc.migrate_position(LocalPoint(lp.x(), lp.y(), mc.z()));
+	//Remember: the drift function will move the reference system to the bottom. We need to add what we previously subtract
+	//in order to avoid a double translation when calling the drift function once again below
+	mc.migrate_position(LocalPoint(lp.x(), lp.y(), mc.z() + center_proxy_cell.z()));
       }
       if (!migrated_charges.empty()) {
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "****************"

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -119,17 +119,17 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
   //          With the current sigma, this value is dependent of the thickness,
   //          Note that this formulae is coming from planar sensors, a similar
   //          study with data will be needed to extract the sigma for 3D
-  const float max_migration_radius_ = 0.4_um;
+  const float max_migration_radius = 0.4_um;
   // Need to know which axis is the relevant one
   int displ_ind = -1;
   float pitch = 0.0;
 
   // Check the group is near the edge of the pixel, so diffusion will
   // be relevant in order to migrate between pixel cells
-  if (std::abs(pos.x() - hpitches.first) < max_migration_radius_) {
+  if (std::abs(pos.x() - hpitches.first) < max_migration_radius) {
     displ_ind = 0;
     pitch = hpitches.first;
-  } else if (std::abs(pos.y() - hpitches.second) < max_migration_radius_) {
+  } else if (std::abs(pos.y() - hpitches.second) < max_migration_radius) {
     displ_ind = 1;
     pitch = hpitches.second;
   } else {
@@ -142,30 +142,30 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
   std::vector<DigitizerUtility::EnergyDepositUnit> migrated_charge;
 
   // FIXME -- DM
-  const float diffusion_step_ = 0.1_um;
+  const float diffusion_step = 0.1_um;
 
   // The position while drifting
   std::vector<float> pos_moving({pos.x(), pos.y(), pos.z()});
   // The drifting: drift field and steps
   std::function<std::vector<float>(int)> do_step =
-      [&pos_moving, &u_drift, diffusion_step_](int i) -> std::vector<float> {
+      [&pos_moving, &u_drift, diffusion_step](int i) -> std::vector<float> {
     auto dd = u_drift(pos_moving[0], pos_moving[1]);
     return std::vector<float>(
-        {i * diffusion_step_ * dd.x(), i * diffusion_step_ * dd.y(), i * diffusion_step_ * dd.z()});
+        {i * diffusion_step * dd.x(), i * diffusion_step * dd.y(), i * diffusion_step * dd.z()});
   };
 
   LogDebug("Pixel3DDigitizerAlgorithm::diffusion")
-      << "\nMax. radius from the pixel edge to migrate charge: " << max_migration_radius_ * 1.0_um_inv << " [um]"
+      << "\nMax. radius from the pixel edge to migrate charge: " << max_migration_radius * 1.0_um_inv << " [um]"
       << "\nMigration axis: " << displ_ind
       << "\n(super-)Charge distance to the pixel edge: " << (pitch - pos_moving[displ_ind]) * 1.0_um_inv << " [um]";
 
   // FIXME -- Sigma reference, DM?
-  const float distance0_ = 300.0_um;
-  const float sigma0_ = 3.4_um;
+  const float distance0 = 300.0_um;
+  const float sigma0 = 3.4_um;
   // FIXME -- Tolerance, DM?
-  const float TOL_ = 1e-6;
+  const float TOL = 1e-6;
   // How many sigmas (probably a configurable, to be decided not now)
-  const float N_SIGMA_ = 3.0;
+  const float N_SIGMA = 3.0;
 
   // Start the drift and check every step
   // initial position
@@ -178,7 +178,7 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
     std::transform(pos_moving.begin(), pos_moving.end(), do_step(i).begin(), pos_moving.begin(), std::plus<float>());
     distance_edge = std::abs(pos_moving[displ_ind] - pitch);
     // current diffusion value
-    double sigma = std::sqrt(i * diffusion_step_ / distance0_) * (distance0_ / thickness) * sigma0_;
+    double sigma = std::sqrt(i * diffusion_step / distance0) * (distance0 / thickness) * sigma0;
     // Get the amount of charge on the neighbor pixel: note the
     // transformation to a Normal
     float migrated_e = current_carriers * (1.0 - std::erf(distance_edge / sigma));
@@ -191,7 +191,7 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
     // No charge was migrated (ignore creation time)
     if (i != 0) {
       // At least 1 electron migrated
-      if ((migrated_e - TOL_) < 1.0) {
+      if ((migrated_e - TOL) < 1.0) {
         break;
       }
       // Move the migrated charge
@@ -202,12 +202,12 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
       // except the direction of migration
       std::vector<float> newpos(pos_moving);
       // Lest create the new charges around 3 sigmas away
-      newpos[displ_ind] += std::copysign(N_SIGMA_ * sigma, newpos[displ_ind]);
+      newpos[displ_ind] += std::copysign(N_SIGMA * sigma, newpos[displ_ind]);
       migrated_charge.push_back(DigitizerUtility::EnergyDepositUnit(migrated_e, newpos[0], newpos[1], newpos[2]));
     }
     // Next step
     ++i;
-  } while (std::abs(distance_edge) < max_migration_radius_);
+  } while (std::abs(distance_edge) < max_migration_radius);
 
   return migrated_charge;
 }
@@ -273,7 +273,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
 
   // Radiation damage limit of application
   // (XXX: No sense for 3D, let this be until decided what algorithm to use)
-  const float RAD_DAMAGE_ = 0.001;
+  const float RAD_DAMAGE = 0.001;
 
   for (const auto& super_charge : ionization_points) {
     // Extract the pixel cell
@@ -355,7 +355,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
     float energyOnCollector = nelectrons;
     // FIXME: is this correct?  Not for 3D...
 
-    if (pseudoRadDamage_ >= RAD_DAMAGE_) {
+    if (pseudoRadDamage_ >= RAD_DAMAGE) {
       const float module_radius = pixdet->surface().position().perp();
       if (module_radius <= pseudoRadDamageRadius_) {
         const float kValue = pseudoRadDamage_ / (module_radius * module_radius);

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -292,7 +292,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
     // Changing the reference frame to the proxy pixel cell
     LocalPoint position_at_pc(relative_position_at_pc.first - center_proxy_cell.x(),
                               relative_position_at_pc.second - center_proxy_cell.y(),
-                              super_charge.z());
+                              super_charge.z() - center_proxy_cell.z());
 
     LogDebug("Pixel3DDigitizerAlgorithm::drift")
         << "(super-)Charge\nlocal position: (" << super_charge.x() * 1.0_um_inv << ", " << super_charge.y() * 1.0_um_inv

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -53,9 +53,15 @@ void Pixel3DDigitizerAlgorithm::init(const edm::EventSetup& es) {
 Pixel3DDigitizerAlgorithm::Pixel3DDigitizerAlgorithm(const edm::ParameterSet& conf)
     : Phase2TrackerDigitizerAlgorithm(conf.getParameter<edm::ParameterSet>("AlgorithmCommon"),
                                       conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm")),
-      _np_column_radius((conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnRadius"))*1.0_um), 
-      _ohm_column_radius((conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("OhmicColumnRadius"))*1.0_um),
-      _np_column_gap((conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnGap"))*1.0_um) {
+      _np_column_radius(
+          (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnRadius")) *
+          1.0_um),
+      _ohm_column_radius(
+          (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("OhmicColumnRadius")) *
+          1.0_um),
+      _np_column_gap(
+          (conf.getParameter<edm::ParameterSet>("Pixel3DDigitizerAlgorithm").getParameter<double>("NPColumnGap")) *
+          1.0_um) {
   // XXX - NEEDED?
   pixelFlag_ = true;
 
@@ -80,7 +86,7 @@ bool Pixel3DDigitizerAlgorithm::select_hit(const PSimHit& hit, double tCorr, dou
   return (time >= theTofLowerCut_ && time < theTofUpperCut_);
 }
 
-const bool Pixel3DDigitizerAlgorithm::_is_inside_n_column(const LocalPoint& p, const float & sensor_thickness) const {
+const bool Pixel3DDigitizerAlgorithm::_is_inside_n_column(const LocalPoint& p, const float& sensor_thickness) const {
   // The insensitive volume of the column: sensor thickness - column gap distance
   return (p.perp() <= _np_column_radius && p.z() <= (sensor_thickness - _np_column_gap));
 }
@@ -323,9 +329,9 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
         const float pixel_x = current_pixel_int.first + (mc.x() + center_proxy_cell.x()) / pitch.first;
         const float pixel_y = current_pixel_int.second + (mc.y() + center_proxy_cell.y()) / pitch.second;
         const auto lp = pixdet->specificTopology().localPosition(MeasurementPoint(pixel_x, pixel_y));
-	//Remember: the drift function will move the reference system to the bottom. We need to add what we previously subtract
-	//in order to avoid a double translation when calling the drift function once again below
-	mc.migrate_position(LocalPoint(lp.x(), lp.y(), mc.z() + center_proxy_cell.z()));
+        //Remember: the drift function will move the reference system to the bottom. We need to add what we previously subtract
+        //in order to avoid a double translation when calling the drift function once again below
+        mc.migrate_position(LocalPoint(lp.x(), lp.y(), mc.z() + center_proxy_cell.z()));
       }
       if (!migrated_charges.empty()) {
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "****************"

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -150,8 +150,7 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
   std::function<std::vector<float>(int)> do_step =
       [&pos_moving, &u_drift, diffusion_step](int i) -> std::vector<float> {
     auto dd = u_drift(pos_moving[0], pos_moving[1]);
-    return std::vector<float>(
-        {i * diffusion_step * dd.x(), i * diffusion_step * dd.y(), i * diffusion_step * dd.z()});
+    return std::vector<float>({i * diffusion_step * dd.x(), i * diffusion_step * dd.y(), i * diffusion_step * dd.z()});
   };
 
   LogDebug("Pixel3DDigitizerAlgorithm::diffusion")

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -55,13 +55,15 @@ public:
                      const std::vector<DigitizerUtility::SignalPoint>& collection_points) override;
 
 private:
-  // Raidus of Column np and ohmic
-  float _np_column_radius;
-  float _ohm_column_radius;
+  // Radius of Column np and ohmic
+  const float _np_column_radius;
+  const float _ohm_column_radius;
+  // Gap of np column
+  const float _np_column_gap; 
 
   // Check if a carrier is inside the column: The point should
   // be described in the pixel cell frame
-  const bool _is_inside_n_column(const LocalPoint& p) const;
+  const bool _is_inside_n_column(const LocalPoint& p, const float & sensor_thickness) const;
   const bool _is_inside_ohmic_column(const LocalPoint& p, const std::pair<float, float>& pitch) const;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -59,11 +59,11 @@ private:
   const float _np_column_radius;
   const float _ohm_column_radius;
   // Gap of np column
-  const float _np_column_gap; 
+  const float _np_column_gap;
 
   // Check if a carrier is inside the column: The point should
   // be described in the pixel cell frame
-  const bool _is_inside_n_column(const LocalPoint& p, const float & sensor_thickness) const;
+  const bool _is_inside_n_column(const LocalPoint& p, const float& sensor_thickness) const;
   const bool _is_inside_ohmic_column(const LocalPoint& p, const std::pair<float, float>& pitch) const;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.h
@@ -56,14 +56,14 @@ public:
 
 private:
   // Radius of Column np and ohmic
-  const float _np_column_radius;
-  const float _ohm_column_radius;
+  const float np_column_radius_;
+  const float ohm_column_radius_;
   // Gap of np column
-  const float _np_column_gap;
+  const float np_column_gap_;
 
   // Check if a carrier is inside the column: The point should
   // be described in the pixel cell frame
-  const bool _is_inside_n_column(const LocalPoint& p, const float& sensor_thickness) const;
-  const bool _is_inside_ohmic_column(const LocalPoint& p, const std::pair<float, float>& pitch) const;
+  const bool is_inside_n_column_(const LocalPoint& p, const float& sensor_thickness) const;
+  const bool is_inside_ohmic_column_(const LocalPoint& p, const std::pair<float, float>& pitch) const;
 };
 #endif

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -84,7 +84,13 @@ phase2TrackerDigitizer = cms.PSet(
 #Pixel Digitizer Algorithm
     PixelDigitizerAlgorithm   = PixelDigitizerAlgorithmCommon.clone(),
 #Pixel-3D Digitizer Algorithm
-    Pixel3DDigitizerAlgorithm = PixelDigitizerAlgorithmCommon.clone(SigmaCoeff = cms.double(1.80)),
+    Pixel3DDigitizerAlgorithm = PixelDigitizerAlgorithmCommon.clone(
+        SigmaCoeff = cms.double(1.80),
+        NPColumnRadius = cms.double(4.0),
+        OhmicColumnRadius = cms.double(4.0),
+        NPColumnGap = cms.double(46.0)
+    ),
+
 #Pixel in PS Module
     PSPDigitizerAlgorithm = cms.PSet(
       ElectronPerAdc = cms.double(135.0),
@@ -202,11 +208,6 @@ phase2TrackerDigitizer = cms.PSet(
         CBCDeadTime = cms.double(0.0) # (2.7 ns deadtime in latched mode)
     )
 )
-
-# Add some additional parameters for 3D pixels
-phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.NPColumnRadius = cms.double(4.0)
-phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.OhmicColumnRadius = cms.double(4.0)
-phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.NPColumnGap = cms.double(46.0)
 
 # For premixing stage1
 # - add noise as by default

--- a/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
+++ b/SimTracker/SiPhase2Digitizer/python/phase2TrackerDigitizer_cfi.py
@@ -203,6 +203,11 @@ phase2TrackerDigitizer = cms.PSet(
     )
 )
 
+# Add some additional parameters for 3D pixels
+phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.NPColumnRadius = cms.double(4.0)
+phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.OhmicColumnRadius = cms.double(4.0)
+phase2TrackerDigitizer.Pixel3DDigitizerAlgorithm.NPColumnGap = cms.double(46.0)
+
 # For premixing stage1
 # - add noise as by default
 # - do not add noisy pixels (to be done in stage2)

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -20,7 +20,6 @@
 #include "DataFormats/Math/interface/CMSUnits.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/DetId/interface/DetId.h"
 
 // system
 #include <algorithm>
@@ -192,174 +191,153 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
     const int layer = topo->layer(detId);
     // Get the relevant histo key
     const auto& me_unit = meUnit_(tkDetUnit->type().isBarrel(), layer, topo->side(detId));
+    
+    // Get the id of the detector unit
+    const unsigned int detId_raw = detId.rawId();
 
-    // Find simulated digis links on this det unit
-    const auto& it_simdigilink = simdigis->find(detId);
-    if (it_simdigilink == simdigis->end()) {
-      // FIXME: CHeck if there is any digi ... Should not
+    // Loop over the simhits to obtain the list of PSimHits created
+    // in this detector unit
+    std::vector<const PSimHit*> it_simhits;
+
+    for (const auto* sh_c : simhits){
+      for (const auto& sh : *sh_c){
+	if (sh.detUnitId() == detId_raw){
+	  it_simhits.push_back(&sh); //insert and/or reserve (?)
+	}
+      }
+    }
+
+    if (it_simhits.size() == 0){
       continue;
     }
 
-    // Find created RAW digis on this det unit
+    // Find RAW digis (digis) created in this det unit
     const auto& it_digis = digis->find(detId);
-    /*if(it_digilink == digis->end())
-        {
-            // FIXME: CHeck if there is any digi ... Should not
-            //continue;
-        }*/
+
     //std::cout << "DETECTOR: " << tkDetUnit->type().name() << " ME UNIT: " << me_unit << std::endl;
 
-    // Loop over the simulated digi links to obtain the list channels
-    // illuminated by each trackId. Use the trackIds to get the PSimHit
-    // (the actual particle deposits per detector unit) and try to match them
-    // with the raw digi, using the channels associated with the trackIds
-    std::map<unsigned int, std::set<int>> stracks_channels;
-    for (const auto& dhsim : *it_simdigilink) {
-      const int current_channel = dhsim.channel();
-      // Already processed (ignoring fractions in the same pixel channel)
-      if (stracks_channels.find(dhsim.SimTrackId()) != stracks_channels.end()) {
-        if (stracks_channels[dhsim.SimTrackId()].find(current_channel) != stracks_channels[dhsim.SimTrackId()].end()) {
-          continue;
-        }
+    // Loop over the list of PSimHits (i.e. the deposits created
+    // by the primary+secundaries) to check if they are associated with
+    // some digi, that is, if the simdigi link exists and to obtain the list
+    // of channels illuminated
+    for (const auto* psh : it_simhits){
+
+      // Check user conditions to accept the hits
+      if (!use_this_track_(psh)) {
+        continue;
       }
-      // Create/update the list of channels created by this
-      // simtrackId: remember primaries and secondaries share the same id
-      stracks_channels[dhsim.SimTrackId()].insert(current_channel);
-    }
+      // Fill some sim histograms
+      const GlobalPoint tk_ep_gbl(dunit->surface().toGlobal(psh->entryPoint()));
+      vME_track_XYMap_->Fill(tk_ep_gbl.x(), tk_ep_gbl.y());
+      vME_track_RZMap_->Fill(tk_ep_gbl.z(), std::hypot(tk_ep_gbl.x(), tk_ep_gbl.y()));
+      vME_track_dxdzAngle_[me_unit]->Fill(std::atan2(psh->momentumAtEntry().x(), psh->momentumAtEntry().z()));
+      vME_track_dydzAngle_[me_unit]->Fill(std::atan2(psh->momentumAtEntry().y(), psh->momentumAtEntry().z()));
 
-    // Loop over each trackId to get the list of PSimHits (i.e. the deposits created
-    // by the primary+secundaries)
-    for (const auto& st_ch : stracks_channels) {
-      // -- Get the set of simulated hits from this trackid.
-      // -- Each Particle SimHit (PSimHit) is defining a particle passing through the detector unit
-      const std::vector<const PSimHit*> current_psimhits =
-          get_simhits_from_trackid_(st_ch.first, detId.rawId(), simhits);
-      //const auto current_pixel(PixelDigi::channelToPixel(ch));
+      // Obtain the detected position of the sim particle:
+      // the middle point between the entry and the exit
+      const auto psh_pos = tkDetUnit->specificTopology().measurementPosition(psh->localPosition());
 
-      // -- Loop over the PSimHits and match with the digi clusters
-      for (const auto* ps : current_psimhits) {
-        // Check user conditions to accept the hits
-        if (!use_this_track_(ps)) {
+      // MC Cluster finding: get the channels illuminated during digitization by this PSimHit
+      // based on MC truth info (simdigi links)
+      const auto psh_channels = get_illuminated_channels_(*psh, detId, simdigis);
+
+      // Get the total charge for this cluster size
+      // and obtain the center of the cluster using a charge-weighted mean
+      int cluster_tot = 0;
+      double cluster_tot_elec = 0.0;
+      int cluster_size = 0;
+      std::pair<std::set<int>, std::set<int>> cluster_size_xy;
+      std::pair<double, double> cluster_position({0.0, 0.0});
+      std::set<int> used_channel;
+      for (const auto& ch : psh_channels) {
+        // Not re-using the digi XXX
+        if (used_channel.find(ch) != used_channel.end()) {
           continue;
         }
-        // Fill some sim histograms
-        const GlobalPoint tk_ep_gbl(dunit->surface().toGlobal(ps->entryPoint()));
-        vME_track_XYMap_->Fill(tk_ep_gbl.x(), tk_ep_gbl.y());
-        vME_track_RZMap_->Fill(tk_ep_gbl.z(), std::hypot(tk_ep_gbl.x(), tk_ep_gbl.y()));
-        vME_track_dxdzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().x(), ps->momentumAtEntry().z()));
-        vME_track_dydzAngle_[me_unit]->Fill(std::atan2(ps->momentumAtEntry().y(), ps->momentumAtEntry().z()));
+        const PixelDigi& current_digi = get_digi_from_channel_(ch, it_digis);
+        used_channel.insert(ch);
+        // Fill the digi histograms
+        vME_digi_charge1D_[me_unit]->Fill(current_digi.adc());
+        // Fill maps: get the position in the sensor local frame to convert into global
+        const LocalPoint digi_local_pos(
+            tkDetUnit->specificTopology().localPosition(MeasurementPoint(current_digi.row(), current_digi.column())));
+        const GlobalPoint digi_global_pos(dunit->surface().toGlobal(digi_local_pos));
+        vME_digi_XYMap_->Fill(digi_global_pos.x(), digi_global_pos.y());
+        vME_digi_RZMap_->Fill(digi_global_pos.z(), std::hypot(digi_global_pos.x(), digi_global_pos.y()));
+        // Create the MC-cluster
+        cluster_tot += current_digi.adc();
+        // Add 0.5 to allow ToT = 0 (valid value)
+        cluster_tot_elec += (current_digi.adc() + 0.5) * electronsPerADC_;
+        // Use the center of the pixel
+        cluster_position.first += current_digi.adc() * (current_digi.row() + 0.5);
+        cluster_position.second += current_digi.adc() * (current_digi.column() + 0.5);
+        // Size
+        cluster_size_xy.first.insert(current_digi.row());
+        cluster_size_xy.second.insert(current_digi.column());
+        ++cluster_size;
+      }
 
-        // Obtain the detected position of the sim particle:
-        // the middle point between the entry and the exit
-        const auto psh_pos = tkDetUnit->specificTopology().measurementPosition(ps->localPosition());
+      // Be careful here, there is 1 entry per each simhit
+      vME_clsize1D_[me_unit]->Fill(cluster_size);
+      vME_clsize1Dx_[me_unit]->Fill(cluster_size_xy.first.size());
+      vME_clsize1Dy_[me_unit]->Fill(cluster_size_xy.second.size());
 
-        // Build the digi MC-truth clusters by matching each Particle
-        // sim hit position pixel cell. The matching condition:
-        //   - a digi is created by the i-PSimHit if PsimHit_{pixel}+-1
+      // mean weighted
+      cluster_position.first /= double(cluster_tot);
+      cluster_position.second /= double(cluster_tot);
 
-        // Get the total charge for this cluster size
-        // and obtain the center of the cluster using a charge-weighted mean
-        int cluster_tot = 0;
-        double cluster_tot_elec = 0.0;
-        int cluster_size = 0;
-        std::pair<std::set<int>, std::set<int>> cluster_size_xy;
-        std::pair<double, double> cluster_position({0.0, 0.0});
-        std::set<int> used_channel;
-        for (const auto& ch : st_ch.second) {
-          // Not re-using the digi
-          if (used_channel.find(ch) != used_channel.end()) {
-            continue;
-          }
-          // Digi was created by the current psimhit?
-          // Accepting +-2 pixel -- XXX: Actually the entryPoint-exitPoint
-          // could provide the extension of the cluster
-          //if( ! channel_iluminated_by_(psh_pos,ch,2.0) )
-          // XXX FIXME: CHANGE the loop in order to use get_illuminated_pixels_ XXX
-          if (!channel_iluminated_by_(*ps, ch, tkDetUnit)) {
-            continue;
-          }
-          const PixelDigi& current_digi = get_digi_from_channel_(ch, it_digis);
-          used_channel.insert(ch);
-          // Fill the digi histograms
-          vME_digi_charge1D_[me_unit]->Fill(current_digi.adc());
-          // Fill maps: get the position in the sensor local frame to convert into global
-          const LocalPoint digi_local_pos(
-              tkDetUnit->specificTopology().localPosition(MeasurementPoint(current_digi.row(), current_digi.column())));
-          const GlobalPoint digi_global_pos(dunit->surface().toGlobal(digi_local_pos));
-          vME_digi_XYMap_->Fill(digi_global_pos.x(), digi_global_pos.y());
-          vME_digi_RZMap_->Fill(digi_global_pos.z(), std::hypot(digi_global_pos.x(), digi_global_pos.y()));
-          // Create the MC-cluster
-          cluster_tot += current_digi.adc();
-          // Add 0.5 to allow ToT = 0 (valid value)
-          cluster_tot_elec += (current_digi.adc() + 0.5) * electronsPerADC_;
-          // Use the center of the pixel
-          cluster_position.first += current_digi.adc() * (current_digi.row() + 0.5);
-          cluster_position.second += current_digi.adc() * (current_digi.column() + 0.5);
-          // Size
-          cluster_size_xy.first.insert(current_digi.row());
-          cluster_size_xy.second.insert(current_digi.column());
-          ++cluster_size;
-        }
-        // Be careful here, there is 1 entry per each simhit
-        vME_clsize1D_[me_unit]->Fill(cluster_size);
-        vME_clsize1Dx_[me_unit]->Fill(cluster_size_xy.first.size());
-        vME_clsize1Dy_[me_unit]->Fill(cluster_size_xy.second.size());
+      // -- XXX Be careful, secondaries with already used the digis
+      //        are going the be lost (then lost on efficiency)
+      // Efficiency --> It was found a cluster of digis?
+      const bool is_cluster_present = (cluster_size > 0);
 
-        // mean weighted
-        cluster_position.first /= double(cluster_tot);
-        cluster_position.second /= double(cluster_tot);
-
-        // -- XXX Be careful, secondaries with already used the digis
-        //        are going the be lost (then lost on efficiency)
-        // Efficiency --> It was found a cluster of digis?
-        const bool is_cluster_present = (cluster_size > 0);
-
-        // Get topology info of the module sensor
-        //-const int n_rows = tkDetUnit->specificTopology().nrows();
-        //-const int n_cols = tkDetUnit->specificTopology().ncolumns();
-        const auto pitch = tkDetUnit->specificTopology().pitch();
-        // Residuals, convert them to longitud units (so far, in units of row, col)
-        const double dx_um = (psh_pos.x() - cluster_position.first) * pitch.first * 1.0_inv_um;
-        const double dy_um = (psh_pos.y() - cluster_position.second) * pitch.second * 1.0_inv_um;
+      // Get topology info of the module sensor
+      //-const int n_rows = tkDetUnit->specificTopology().nrows();
+      //-const int n_cols = tkDetUnit->specificTopology().ncolumns();
+      const auto pitch = tkDetUnit->specificTopology().pitch();
+      // Residuals, convert them to longitud units (so far, in units of row, col)
+      const double dx_um = (psh_pos.x() - cluster_position.first) * pitch.first * 1.0_inv_um;
+      const double dy_um = (psh_pos.y() - cluster_position.second) * pitch.second * 1.0_inv_um;
+      if (is_cluster_present) {
+        vME_charge1D_[me_unit]->Fill(cluster_tot);
+        vME_charge_elec1D_[me_unit]->Fill(cluster_tot_elec);
+        vME_dx1D_[me_unit]->Fill(dx_um);
+        vME_dy1D_[me_unit]->Fill(dy_um);
+        // The track energy loss corresponding to that cluster
+        vME_sim_cluster_charge_[me_unit]->Fill(psh->energyLoss() * 1.0_inv_keV, cluster_tot_elec);
+      }
+      // Histograms per cell
+      for (unsigned int i = 0; i < vME_position_cell_[me_unit].size(); ++i) {
+        // Convert the PSimHit center position to the IxI-cell
+        const std::pair<double, double> icell_psh = pixel_cell_transformation_(psh_pos, i, pitch);
+        // Efficiency: (PSimHit matched to a digi-cluster)/PSimHit
+        vME_eff_cell_[me_unit][i]->Fill(
+            icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, is_cluster_present);
+        vME_pshpos_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um);
+        // Digi clusters related histoos
         if (is_cluster_present) {
-          vME_charge1D_[me_unit]->Fill(cluster_tot);
-          vME_charge_elec1D_[me_unit]->Fill(cluster_tot_elec);
-          vME_dx1D_[me_unit]->Fill(dx_um);
-          vME_dy1D_[me_unit]->Fill(dy_um);
-          // The track energy loss corresponding to that cluster
-          vME_sim_cluster_charge_[me_unit]->Fill(ps->energyLoss() * 1.0_inv_keV, cluster_tot_elec);
-        }
-        // Histograms per cell
-        for (unsigned int i = 0; i < vME_position_cell_[me_unit].size(); ++i) {
-          // Convert the PSimHit center position to the IxI-cell
-          const std::pair<double, double> icell_psh = pixel_cell_transformation_(psh_pos, i, pitch);
-          // Efficiency: (PSimHit matched to a digi-cluster)/PSimHit
-          vME_eff_cell_[me_unit][i]->Fill(
-              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, is_cluster_present);
-          vME_pshpos_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um);
-          // Digi clusters related histoos
-          if (is_cluster_present) {
-            // Convert to the i-cell
-            //const std::pair<double,double> icell_digi_cluster   = pixel_cell_transformation_(cluster_position,i,pitch);
-            // Position
-            vME_position_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um);
-            // Residuals
-            vME_dx_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dx_um);
-            vME_dy_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dy_um);
-            // Charge
-            vME_charge_cell_[me_unit][i]->Fill(
-                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
-            vME_charge_elec_cell_[me_unit][i]->Fill(
-                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot_elec);
-            // Cluster size
-            vME_clsize_cell_[me_unit][i]->Fill(
-                icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
-          }
+          // Convert to the i-cell
+          //const std::pair<double,double> icell_digi_cluster   = pixel_cell_transformation_(cluster_position,i,pitch);
+          // Position
+          vME_position_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um);
+          // Residuals
+          vME_dx_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dx_um);
+          vME_dy_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dy_um);
+          // Charge
+          vME_charge_cell_[me_unit][i]->Fill(
+              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
+          vME_charge_elec_cell_[me_unit][i]->Fill(
+              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot_elec);
+          // Cluster size
+          vME_clsize_cell_[me_unit][i]->Fill(
+              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
         }
       }
     }
   }
 }
+
+
 
 //
 // -- Book Histograms
@@ -704,6 +682,26 @@ bool PixelTestBeamValidation::channel_iluminated_by_(const PSimHit& ps,
   }
   return false;
 }
+
+std::set<int> PixelTestBeamValidation::get_illuminated_channels_(const PSimHit& ps,
+								 const DetId& detid,
+								 const edm::DetSetVector<PixelDigiSimLink>* simdigis){
+  // Find simulated digi links (simdigis) created in this det unit
+  const auto& it_simdigilink = simdigis->find(detid);
+
+  if (it_simdigilink == simdigis->end()){
+    return std::set<int>();
+  }
+
+  std::set<int> channels;
+  for (const auto& hdsim : *it_simdigilink){
+    if (ps.trackId() == hdsim.SimTrackId()){
+      channels.insert(hdsim.channel());
+    }
+  }
+  return channels;
+}
+
 
 std::set<std::pair<int, int>> PixelTestBeamValidation::get_illuminated_pixels_(const PSimHit& ps,
                                                                                const PixelGeomDetUnit* tkDetUnit) {

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.cc
@@ -191,7 +191,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
     const int layer = topo->layer(detId);
     // Get the relevant histo key
     const auto& me_unit = meUnit_(tkDetUnit->type().isBarrel(), layer, topo->side(detId));
-    
+
     // Get the id of the detector unit
     const unsigned int detId_raw = detId.rawId();
 
@@ -199,15 +199,15 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
     // in this detector unit
     std::vector<const PSimHit*> it_simhits;
 
-    for (const auto* sh_c : simhits){
-      for (const auto& sh : *sh_c){
-	if (sh.detUnitId() == detId_raw){
-	  it_simhits.push_back(&sh); //insert and/or reserve (?)
-	}
+    for (const auto* sh_c : simhits) {
+      for (const auto& sh : *sh_c) {
+        if (sh.detUnitId() == detId_raw) {
+          it_simhits.push_back(&sh);  //insert and/or reserve (?)
+        }
       }
     }
 
-    if (it_simhits.size() == 0){
+    if (it_simhits.size() == 0) {
       continue;
     }
 
@@ -220,8 +220,7 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
     // by the primary+secundaries) to check if they are associated with
     // some digi, that is, if the simdigi link exists and to obtain the list
     // of channels illuminated
-    for (const auto* psh : it_simhits){
-
+    for (const auto* psh : it_simhits) {
       // Check user conditions to accept the hits
       if (!use_this_track_(psh)) {
         continue;
@@ -324,20 +323,16 @@ void PixelTestBeamValidation::analyze(const edm::Event& iEvent, const edm::Event
           vME_dx_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dx_um);
           vME_dy_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, dy_um);
           // Charge
-          vME_charge_cell_[me_unit][i]->Fill(
-              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
+          vME_charge_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot);
           vME_charge_elec_cell_[me_unit][i]->Fill(
               icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_tot_elec);
           // Cluster size
-          vME_clsize_cell_[me_unit][i]->Fill(
-              icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
+          vME_clsize_cell_[me_unit][i]->Fill(icell_psh.first * 1.0_inv_um, icell_psh.second * 1.0_inv_um, cluster_size);
         }
       }
     }
   }
 }
-
-
 
 //
 // -- Book Histograms
@@ -684,24 +679,23 @@ bool PixelTestBeamValidation::channel_iluminated_by_(const PSimHit& ps,
 }
 
 std::set<int> PixelTestBeamValidation::get_illuminated_channels_(const PSimHit& ps,
-								 const DetId& detid,
-								 const edm::DetSetVector<PixelDigiSimLink>* simdigis){
+                                                                 const DetId& detid,
+                                                                 const edm::DetSetVector<PixelDigiSimLink>* simdigis) {
   // Find simulated digi links (simdigis) created in this det unit
   const auto& it_simdigilink = simdigis->find(detid);
 
-  if (it_simdigilink == simdigis->end()){
+  if (it_simdigilink == simdigis->end()) {
     return std::set<int>();
   }
 
   std::set<int> channels;
-  for (const auto& hdsim : *it_simdigilink){
-    if (ps.trackId() == hdsim.SimTrackId()){
+  for (const auto& hdsim : *it_simdigilink) {
+    if (ps.trackId() == hdsim.SimTrackId()) {
       channels.insert(hdsim.channel());
     }
   }
   return channels;
 }
-
 
 std::set<std::pair<int, int>> PixelTestBeamValidation::get_illuminated_pixels_(const PSimHit& ps,
                                                                                const PixelGeomDetUnit* tkDetUnit) {

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -31,6 +31,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/DetId/interface/DetId.h"
 
 // system
 #include <string>
@@ -90,6 +91,11 @@ private:
   // the "tolerance" argument is quantifying 'close enough' in a square
   //bool channel_iluminated_by_(const MeasurementPoint & localpos,int channel, double tolerance) const;
   bool channel_iluminated_by_(const PSimHit &localpos, int channel, const PixelGeomDetUnit *tkDet);
+
+  // The list of channels illuminated by the PSimHit
+  std::set<int> get_illuminated_channels_(const PSimHit& ps,
+					  const DetId& detid,
+					  const edm::DetSetVector<PixelDigiSimLink>* simdigis);
 
   // The list of pixels illuminated by the PSimHit
   std::set<std::pair<int, int>> get_illuminated_pixels_(const PSimHit &ps, const PixelGeomDetUnit *tkDetUnit);

--- a/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
+++ b/SimTracker/SiPhase2Digitizer/test/PixelTestBeamValidation.h
@@ -93,9 +93,9 @@ private:
   bool channel_iluminated_by_(const PSimHit &localpos, int channel, const PixelGeomDetUnit *tkDet);
 
   // The list of channels illuminated by the PSimHit
-  std::set<int> get_illuminated_channels_(const PSimHit& ps,
-					  const DetId& detid,
-					  const edm::DetSetVector<PixelDigiSimLink>* simdigis);
+  std::set<int> get_illuminated_channels_(const PSimHit &ps,
+                                          const DetId &detid,
+                                          const edm::DetSetVector<PixelDigiSimLink> *simdigis);
 
   // The list of pixels illuminated by the PSimHit
   std::set<std::pair<int, int>> get_illuminated_pixels_(const PSimHit &ps, const PixelGeomDetUnit *tkDetUnit);


### PR DESCRIPTION
#### PR description:

Improve 3D pixel digitization: include charge generation underneath the n-column in the 3D Pixel Digitizer, by allowing the n-column to penetrate to a certain extent.

- Details here: https://indico.cern.ch/event/879046/contributions/3931488/attachments/2068866/3472667/20200703final.pdf

In addition, fix some issues in the provisional validator (remember it is not part of this package and will probably be removed or migrated to the Validator package once the main development is done).

Conveners of the Upgrade Simulation group, @emiglior and @skinnari , are aware and agree.
cc: @duartej 

#### PR validation:

Following PR instructions, a basic battery of tests was successfully run. Given that this PR is only affecting 3D pixels geometry (T23), some other tests were performed with workflows 30210.0, 30410.0, 30234.0 and 30434.0. The workflows 30410.0 and 30434.0, which include Pileup, fail launching the following error:

`An exception of category 'NoSecondaryFiles' occurred while`
`     [0] Constructing the EventProcessor`
`     [1] Constructing module: class=MixingModule label='mix'`
`Exception Message:`
`RootEmbeddedFileSequence no input files specified for secondary input source.`

Pileup files are not found in the expected repository, it is probably an issue with my config at lxplus... so I ignored it.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is not a backport
