### PR TITLE
[DD4hep] Convert production cuts from ROOT/CMS units convention to Geant4 units convention

### DIFF
--- a/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
@@ -3,6 +3,7 @@
 #include "FWCore/Framework/interface/ESTransientHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "DetectorDescription/DDCMS/interface/DDVectorRegistry.h"
 #include "Geometry/Records/interface/DDVectorRegistryRcd.h"
@@ -27,6 +28,7 @@ using namespace std;
 using namespace cms;
 using namespace edm;
 using namespace dd4hep;
+using geant_units::operators::convertCmToMm;
 
 namespace {
   bool sortByName(const std::pair<G4LogicalVolume*, const dd4hep::SpecPar*>& p1,
@@ -160,18 +162,20 @@ void DD4hepTestDDDWorld::update() {
     // you must have four of them: e+ e- gamma proton
     //
     auto gammacutStr = it.second->strValue("ProdCutsForGamma");
-    double gammacut = dd4hep::_toDouble({gammacutStr.data(), gammacutStr.size()});
+
+    // Geant4 expects mm units. DD4hep returns cm, so must convert to mm.
+    double gammacut = convertCmToMm(dd4hep::_toDouble({gammacutStr.data(), gammacutStr.size()}));
 
     auto electroncutStr = it.second->strValue("ProdCutsForElectrons");
-    double electroncut = dd4hep::_toDouble({electroncutStr.data(), electroncutStr.size()});
+    double electroncut = convertCmToMm(dd4hep::_toDouble({electroncutStr.data(), electroncutStr.size()}));
 
     auto positroncutStr = it.second->strValue("ProdCutsForPositrons");
-    double positroncut = dd4hep::_toDouble({positroncutStr.data(), positroncutStr.size()});
+    double positroncut = convertCmToMm(dd4hep::_toDouble({positroncutStr.data(), positroncutStr.size()}));
 
     double protoncut = 0.0;
     auto protoncutStr = it.second->strValue("ProdCutsForProtons");
     if (it.second->hasValue("ProdCutsForProtons")) {
-      protoncut = dd4hep::_toDouble({protoncutStr.data(), protoncutStr.size()});
+      protoncut = convertCmToMm(dd4hep::_toDouble({protoncutStr.data(), protoncutStr.size()}));
     } else {
       protoncut = electroncut;
     }


### PR DESCRIPTION
#### PR description:

DD4hep returns values with the ROOT/CMS units convention, where lengths are in cm. Geant4 uses its own units convention, where lengths are in mm. When values obtained from DD4hep are sent to Geant4, they need to be converted.

Production cuts were being passed to Geant4 without conversion. This PR fixes that problem. So far, we have not found other code that interfaces to Geant4 that has a similar problem.

In the long term, the plan is to change DD4hep configuration so that it returns units following the Geant4 convention. Then these conversions, including in this PR, can be removed from our code. However, this change will require changing a fair amount of CMSSW code, so it has to be scheduled when other priorities are not pressing. Issue #31979 provides more details.


#### PR validation:
Debug output before this PR:

MakeRegions: added rpcf:REF3 to region MuonSensitive_RPC
ProdCutsForPositrons =  2.5*m
ProdCutsForElectrons =  8.*mm
ProdCutsForGamma =  8.5*m

DDG4ProductionCuts : Setting cuts for MuonSensitive_RPC
    Electrons: 0.8
    Positrons: 250
    Gamma    : 850
_The values are in cm when they should be mm._ 

With this PR:

MakeRegions: added rpcf:REF3 to region MuonSensitive_RPC
ProdCutsForPositrons =  2.5*m
ProdCutsForElectrons =  8.*mm
ProdCutsForGamma =  8.5*m

DDG4ProductionCuts : Setting cuts for MuonSensitive_RPC
    Electrons: 8
    Positrons: 2500
    Gamma    : 8500
_The values are correctly in mm._

A check was made that DD4hep simulation (`SimG4Core/Configuration/test/dd4hep_ZMM_Run3_Step1_cfg.py`) continues to run successfully with this PR and produce hits.


No backport is needed.