### PR TITLE
Mini-PR: Fix Z side in Preshower

### DIFF
--- a/Geometry/EcalCommonData/src/EcalPreshowerNumberingScheme.cc
+++ b/Geometry/EcalCommonData/src/EcalPreshowerNumberingScheme.cc
@@ -90,10 +90,15 @@ EcalPreshowerNumberingScheme::~EcalPreshowerNumberingScheme() {
   edm::LogVerbatim("EcalGeom") << "Deleting EcalPreshowerNumberingScheme";
 }
 
+/*
+ * Compute the Ecal Preshower DetId.
+ * General NB: if possible, it would be way better to just access the DetID from a hash map from G4 Volume, 
+ * rather than recomputing it for each SimHit - see Tracker.
+ */
 uint32_t EcalPreshowerNumberingScheme::getUnitID(const EcalBaseNumber& baseNumber) const {
-  int level = baseNumber.getLevels();
+  const int numberOfHierarchyLevels = baseNumber.getLevels();
   uint32_t intIndex = 0;
-  if (level > 0) {
+  if (numberOfHierarchyLevels > 0) {
     // depth index - silicon layer 1-st or 2-nd
     int layer = 0;
     if (baseNumber.getLevelName(0).find("SFSX") != std::string::npos) {
@@ -105,18 +110,25 @@ uint32_t EcalPreshowerNumberingScheme::getUnitID(const EcalBaseNumber& baseNumbe
                                   << " of Presh. Si. Strip : " << baseNumber.getLevelName(0);
     }
 
+    // Access different hierarchy levels
+    static constexpr int stripHierachyLevel = 0;
+    static constexpr int boxHierachyLevel = 2;
+    static constexpr int ladderHierachyLevel = 3;
+    static constexpr int regionHierachyLevel = 5;
+
     // Z index +Z = 1 ; -Z = 2
-    int zs = baseNumber.getCopyNumber(5);
+
+    int zs = baseNumber.getCopyNumber(regionHierachyLevel);
     int zside = 2 * (1 - zs) + 1;
 
     // box number
-    int box = baseNumber.getCopyNumber(2);
+    int box = baseNumber.getCopyNumber(boxHierachyLevel);
 
     int x = 0, y = 0, ix, iy, id;
     int mapX[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     int mapY[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
     const std::string& ladd = baseNumber.getLevelName(3).substr(0, 6);
-    int ladd_copy = baseNumber.getCopyNumber(3);
+    int ladd_copy = baseNumber.getCopyNumber(ladderHierachyLevel);
 
     if (ladd == "SFLX0a" || ladd == "SFLY0a") {
       mapX[5] = mapX[6] = mapX[7] = mapX[8] = mapX[9] = 1;
@@ -397,7 +409,7 @@ uint32_t EcalPreshowerNumberingScheme::getUnitID(const EcalBaseNumber& baseNumbe
     }
 
     // strip number inside wafer
-    int strip = baseNumber.getCopyNumber(0);
+    int strip = baseNumber.getCopyNumber(stripHierachyLevel);
 
     if (layer == 1) {
       if (zside > 0 && y <= 20)
@@ -419,7 +431,7 @@ uint32_t EcalPreshowerNumberingScheme::getUnitID(const EcalBaseNumber& baseNumbe
                                  << " layer " << layer << " strip " << strip << " UnitID 0x" << std::hex << intIndex
                                  << std::dec;
 
-    for (int ich = 0; ich < level; ich++)
+    for (int ich = 0; ich < numberOfHierarchyLevels; ich++)
       edm::LogVerbatim("EcalGeom") << "Name = " << baseNumber.getLevelName(ich)
                                    << " copy = " << baseNumber.getCopyNumber(ich);
 #endif

--- a/Geometry/EcalCommonData/src/EcalPreshowerNumberingScheme.cc
+++ b/Geometry/EcalCommonData/src/EcalPreshowerNumberingScheme.cc
@@ -106,7 +106,7 @@ uint32_t EcalPreshowerNumberingScheme::getUnitID(const EcalBaseNumber& baseNumbe
     }
 
     // Z index +Z = 1 ; -Z = 2
-    int zs = baseNumber.getCopyNumber("EREG");
+    int zs = baseNumber.getCopyNumber(5);
     int zside = 2 * (1 - zs) + 1;
 
     // box number


### PR DESCRIPTION
`getCopyNumber("EREG")` does not work in dd4hep case because of the trailing copy number in the **EREG** name.

No need to modify the bahavior of ECAL BaseNumber (which would also affect old DD / not work in case different hierarchy levels contain the same name).
Nor to play with string parsing.

Much simpler is to just restore access to EREG hierarchy level. Now that old ECAL algo is restored, the hierarchy levels are the same for old DD and DD4hep anyway.
