### PR TITLE
Logging service for Condition Workflows - port to 11_1_X

### DIFF
--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -15,6 +15,7 @@ namespace edm {
 namespace coral {
   class IConnectionServiceConfiguration;
   class ISessionProxy;
+  class IMsgReporter;
 }  // namespace coral
 
 namespace cond {
@@ -25,6 +26,9 @@ namespace cond {
 
   namespace persistency {
     //
+    class CoralMsgReporter;
+    class Logger;
+
     enum DbAuthenticationSystem { UndefinedAuthentication = 0, CondDbKey, CoralXMLFile };
 
     // a wrapper for the coral connection service.
@@ -34,6 +38,7 @@ namespace cond {
       ~ConnectionPool();
 
       void setMessageVerbosity(coral::MsgLevel level);
+      void setLogDestination(Logger& logger);
       void setAuthenticationPath(const std::string& p);
       void setAuthenticationSystem(int authSysCode);
       void setFrontierSecurity(const std::string& signature);
@@ -59,6 +64,7 @@ namespace cond {
       std::string m_authPath = std::string("");
       int m_authSys = 0;
       coral::MsgLevel m_messageLevel = coral::Error;
+      std::unique_ptr<CoralMsgReporter> m_msgReporter;
       bool m_loggingEnabled = false;
       //The frontier security option is turned on for all sessions
       //usig this wrapper of the CORAL connection setup for configuring the server access

--- a/CondCore/CondDB/interface/Logger.h
+++ b/CondCore/CondDB/interface/Logger.h
@@ -1,0 +1,137 @@
+#ifndef CondCore_CondDB_Logger_h
+#define CondCore_CondDB_Logger_h
+//
+// Package:     CondDB
+// Class  :     O2OLogger
+//
+/**\class Logger Logger.h CondCore/CondDB/interface/Logger.h
+   Description: utility for collecting log information and store them into the Condition DB.  
+*/
+//
+// Author:      Giacomo Govi
+// Created:     Sep 2020
+//
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+//
+#include <sstream>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+namespace cond {
+
+  namespace persistency {
+
+    class ConnectionPool;
+
+    template <typename EdmLogger>
+    class EchoedLogStream {
+    public:
+      EchoedLogStream() = delete;
+      explicit EchoedLogStream(const std::string& jobName, std::stringstream& buffer)
+          : m_edmLogger(jobName), m_buffer(&buffer) {}
+      virtual ~EchoedLogStream() {}
+      template <typename T>
+      EchoedLogStream& operator<<(const T& t) {
+        *m_buffer << t;
+        m_edmLogger << t;
+        return *this;
+      }
+      EchoedLogStream& operator<<(std::ostream& (*f)(std::ostream&)) {
+        *m_buffer << f;
+        m_edmLogger << f;
+        return *this;
+      }
+      EchoedLogStream& operator<<(std::ios_base& (*f)(std::ios_base&)) {
+        *m_buffer << f;
+        m_edmLogger << f;
+        return *this;
+      }
+
+    private:
+      EdmLogger m_edmLogger;
+      std::stringstream* m_buffer;
+    };
+
+    template <>
+    class EchoedLogStream<edm::LogDebug_> {
+    public:
+      EchoedLogStream() = delete;
+      explicit EchoedLogStream(const std::string& jobName, std::stringstream& buffer)
+          : m_edmLogger(jobName, __FILE__, __LINE__), m_buffer(&buffer) {}
+      virtual ~EchoedLogStream() {}
+      template <typename T>
+      EchoedLogStream& operator<<(const T& t) {
+        *m_buffer << t;
+        m_edmLogger << t;
+        return *this;
+      }
+      EchoedLogStream& operator<<(std::ostream& (*f)(std::ostream&)) {
+        *m_buffer << f;
+        m_edmLogger << f;
+        return *this;
+      }
+      EchoedLogStream& operator<<(std::ios_base& (*f)(std::ios_base&)) {
+        *m_buffer << f;
+        m_edmLogger << f;
+        return *this;
+      }
+
+    private:
+      edm::LogDebug_ m_edmLogger;
+      std::stringstream* m_buffer;
+    };
+
+    //
+    class Logger {
+    public:
+      // default constructor is suppressed
+      Logger() = delete;
+
+      // constructor
+      explicit Logger(const std::string& jobName);
+
+      //
+      virtual ~Logger();
+
+      //
+      void setDbDestination(const std::string& connectionString, ConnectionPool& connectionPool);
+
+      //
+      void start();
+
+      //
+      void end(int retCode);
+
+      //
+      void saveOnDb();
+
+      //
+      void saveOnFile();
+
+      //
+      void save();
+
+      //
+      std::iostream& log(const std::string& tag);
+
+      EchoedLogStream<edm::LogInfo> logInfo();
+      EchoedLogStream<edm::LogDebug_> logDebug();
+      EchoedLogStream<edm::LogError> logError();
+      EchoedLogStream<edm::LogWarning> logWarning();
+
+    private:
+      void clearBuffer();
+
+    private:
+      std::string m_jobName;
+      std::string m_connectionString;
+      ConnectionPool* m_sharedConnectionPool;
+      bool m_started;
+      boost::posix_time::ptime m_startTime;
+      boost::posix_time::ptime m_endTime;
+      int m_retCode;
+      std::stringstream m_log;
+    };
+
+  }  // namespace persistency
+}  // namespace cond
+#endif

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -2,6 +2,7 @@
 #include "DbConnectionString.h"
 #include "SessionImpl.h"
 #include "IOVSchema.h"
+#include "CoralMsgReporter.h"
 //
 #include "CondCore/CondDB/interface/CoralServiceManager.h"
 #include "CondCore/CondDB/interface/Auth.h"
@@ -15,8 +16,6 @@
 #include "CoralKernel/Context.h"
 #include "CoralKernel/IProperty.h"
 #include "CoralKernel/IPropertyManager.h"
-// externals
-#include <boost/filesystem/operations.hpp>
 
 namespace cond {
 
@@ -74,6 +73,11 @@ namespace cond {
       coralConfig.disableConnectionSharing();
       // message streaming
       coral::MessageStream::setMsgVerbosity(m_messageLevel);
+      if (m_msgReporter.get() != nullptr) {
+        m_msgReporter->setOutputLevel(m_messageLevel);
+        coral::MessageStream::installMsgReporter(static_cast<coral::IMsgReporter*>(m_msgReporter.get()));
+      }
+      // authentication
       std::string authServiceName("CORAL/Services/EnvironmentAuthenticationService");
       std::string authPath = m_authPath;
       // authentication
@@ -166,6 +170,10 @@ namespace cond {
     }
 
     void ConnectionPool::setMessageVerbosity(coral::MsgLevel level) { m_messageLevel = level; }
+
+    void ConnectionPool::setLogDestination(Logger& logger) {
+      m_msgReporter = std::make_unique<CoralMsgReporter>(logger);
+    }
 
   }  // namespace persistency
 }  // namespace cond

--- a/CondCore/CondDB/src/CoralMsgReporter.cc
+++ b/CondCore/CondDB/src/CoralMsgReporter.cc
@@ -1,0 +1,136 @@
+// Include files
+#include <cstdio>
+#include <cstring>   // fix bug #58581
+#include <iostream>  // fix bug #58581
+
+// Local include files
+#include "CondCore/CondDB/interface/Logger.h"
+#include "CoralMsgReporter.h"
+
+/// Default constructor
+cond::persistency::CoralMsgReporter::CoralMsgReporter(Logger& logger)
+    : m_logger(logger), m_level(coral::Error), m_format(0), m_mutex() {
+  // Use a non-default format?
+  //char* msgformat = getenv ( "CORAL_MSGFORMAT" );
+  if (getenv("CORAL_MESSAGEREPORTER_FORMATTED"))
+    m_format = 1;
+
+  // Use a non-default message level?
+  if (getenv("CORAL_MSGLEVEL")) {
+    // Check only the first char of the environment variable
+    switch (*getenv("CORAL_MSGLEVEL")) {
+      case '0':
+      case 'n':
+      case 'N':
+        m_level = coral::Nil;
+        break;
+
+      case '1':
+      case 'v':
+      case 'V':
+        m_level = coral::Verbose;
+        break;
+
+      case '2':
+      case 'd':
+      case 'D':
+        m_level = coral::Debug;
+        break;
+
+      case '3':
+      case 'i':
+      case 'I':
+        m_level = coral::Info;
+        break;
+
+      case '4':
+      case 'w':
+      case 'W':
+        m_level = coral::Warning;
+        break;
+
+      case '5':
+      case 'e':
+      case 'E':
+        m_level = coral::Error;
+        break;
+
+      case '6':
+      case 'f':
+      case 'F':
+        m_level = coral::Fatal;
+        break;
+
+      case '7':
+      case 'a':
+      case 'A':
+        m_level = coral::Always;
+        break;
+
+      default:
+        break;  // keep the default
+    }
+  }
+}
+
+/// Access output level
+coral::MsgLevel cond::persistency::CoralMsgReporter::outputLevel() const { return m_level; }
+
+/// Modify output level
+void cond::persistency::CoralMsgReporter::setOutputLevel(coral::MsgLevel lvl) { m_level = lvl; }
+
+/// Report message to stdout
+void cond::persistency::CoralMsgReporter::report(int lvl, const std::string& src, const std::string& msg) {
+  if (lvl < m_level)
+    return;
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+
+  std::stringstream out;
+  /**
+  if ( m_format == 1 ) // COOL format
+  {
+    // Formatted CORAL reporter (as in COOL)
+    //std::ostream& out = std::cout;
+    const std::string::size_type src_name_maxsize = 36;
+    if ( src.size() <= src_name_maxsize )
+    {
+      out << src << std::string( src_name_maxsize-src.size(), ' ' );
+    }
+    else
+    {
+      out << src.substr( 0, src_name_maxsize-3 ) << "...";
+    }
+    switch ( lvl )
+    {
+    case 0:  out << " Nil      "; break;
+    case 1:  out << " Verbose  "; break;
+    case 2:  out << " Debug    "; break;
+    case 3:  out << " Info     "; break;
+    case 4:  out << " Warning  "; break;
+    case 5:  out << " Error    "; break;
+    case 6:  out << " Fatal    "; break;
+    case 7:  out << " Always   "; break;
+    default: out << " Unknown  "; break;
+    }
+    out << msg << std::endl;
+  }
+  else{
+  **/
+  // Default CORAL reporter
+  switch (lvl) {
+    case coral::Nil:
+    case coral::Verbose:
+    case coral::Debug:
+      m_logger.logDebug() << "CORAL: " << msg;
+      break;
+    case coral::Info:
+      m_logger.logInfo() << "CORAL: " << msg;
+      break;
+    case coral::Warning:
+      m_logger.logWarning() << "CORAL: " << msg;
+      break;
+    case coral::Error:
+      m_logger.logError() << "CORAL: " << msg;
+      break;
+  }
+}

--- a/CondCore/CondDB/src/CoralMsgReporter.h
+++ b/CondCore/CondDB/src/CoralMsgReporter.h
@@ -1,0 +1,55 @@
+#ifndef CondCore_CondDB_CoralMsgReporter_h
+#define CondCore_CondDB_CoralMsgReporter_h
+
+//#include "CondCore/CondDB/interface/Logger.h"
+
+#include <mutex>
+#include "CoralBase/MessageStream.h"
+
+namespace cond {
+
+  namespace persistency {
+
+    class Logger;
+
+    class CoralMsgReporter : public coral::IMsgReporter {
+    public:
+      // Empty ctr is suppressed
+      CoralMsgReporter() = delete;
+
+      /// Default constructor
+      explicit CoralMsgReporter(Logger& logger);
+
+      /// Destructor
+      ~CoralMsgReporter() override {}
+
+      /// Release reference to reporter
+      void release() override { delete this; }
+
+      /// Access output level
+      coral::MsgLevel outputLevel() const override;
+
+      /// Modify output level
+      void setOutputLevel(coral::MsgLevel lvl) override;
+
+      /// Report a message
+      void report(int lvl, const std::string& src, const std::string& msg) override;
+
+    private:
+      // the destination of the streams...
+      Logger& m_logger;
+
+      /// The current message level threshold
+      coral::MsgLevel m_level;
+
+      /// Use a different format output
+      size_t m_format;
+
+      /// The mutex lock
+      std::recursive_mutex m_mutex;
+    };
+
+  }  // namespace persistency
+
+}  // namespace cond
+#endif

--- a/CondCore/CondDB/src/Logger.cc
+++ b/CondCore/CondDB/src/Logger.cc
@@ -1,0 +1,171 @@
+#include "CondCore/CondDB/interface/Logger.h"
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondCore/CondDB/interface/Exception.h"
+//
+#include "DbCore.h"
+#include "RelationalAccess/ITransaction.h"
+//
+#include <boost/date_time/posix_time/posix_time_io.hpp>
+#include <fstream>
+//
+namespace cond {
+
+  namespace persistency {
+
+    conddb_table(O2O_RUN) {
+      conddb_column(JOB_NAME, std::string);
+      conddb_column(START_TIME, boost::posix_time::ptime);
+      conddb_column(END_TIME, boost::posix_time::ptime);
+      conddb_column(STATUS_CODE, int);
+      conddb_column(LOG, std::string);
+      class Table {
+      public:
+        explicit Table(coral::ISchema& schema) : m_schema(schema) {}
+        ~Table() {}
+        void insert(const std::string& jobName,
+                    const boost::posix_time::ptime& start,
+                    const boost::posix_time::ptime& end,
+                    int retCode,
+                    const std::string& log) {
+          RowBuffer<JOB_NAME, START_TIME, END_TIME, STATUS_CODE, LOG> dataToInsert(
+              std::tie(jobName, start, end, retCode, log));
+          insertInTable(m_schema, tname, dataToInsert.get());
+        }
+
+      private:
+        coral::ISchema& m_schema;
+      };
+    }
+
+    void Logger::clearBuffer() {
+      m_log.str("");
+      m_log.clear();
+    }
+
+    Logger::Logger(const std::string& jobName)
+        : m_jobName(jobName),
+          m_connectionString(""),
+          m_sharedConnectionPool(nullptr),
+          m_started(false),
+          m_startTime(),
+          m_endTime(),
+          m_retCode(0),
+          m_log() {}
+
+    //
+    Logger::~Logger() {}
+
+    void Logger::setDbDestination(const std::string& connectionString, ConnectionPool& connectionPool) {
+      m_connectionString = connectionString;
+      m_sharedConnectionPool = &connectionPool;
+    }
+
+    //
+    void Logger::start() {
+      if (!m_started) {
+        if (!m_log.str().empty())
+          clearBuffer();
+        m_startTime = boost::posix_time::microsec_clock::universal_time();
+        m_started = true;
+        log("START_JOB") << " " << m_jobName;
+      }
+    }
+
+    //
+    void Logger::end(int retCode) {
+      if (m_started) {
+        m_endTime = boost::posix_time::microsec_clock::universal_time();
+        m_started = false;
+        m_retCode = retCode;
+        log("END_JOB") << ": return code:" << retCode;
+        save();
+        clearBuffer();
+      }
+    }
+
+    std::string print_timestamp(const boost::posix_time::ptime& t, const char* format_s = "%Y-%m-%d %H:%M:%S.%f") {
+      boost::posix_time::time_facet* facet = new boost::posix_time::time_facet();
+      facet->format(format_s);
+      std::stringstream timestamp;
+      timestamp.imbue(std::locale(std::locale::classic(), facet));
+      timestamp << t;
+      return timestamp.str();
+    }
+
+    std::string get_timestamp() {
+      auto now = boost::posix_time::microsec_clock::universal_time();
+      return print_timestamp(now);
+    }
+    std::string get_timestamp_for_filename() {
+      auto now = boost::posix_time::microsec_clock::universal_time();
+      return print_timestamp(now, "%Y-%m-%d_%H-%M-%S");
+    }
+
+    //
+    void Logger::saveOnFile() {
+      if (!m_log.str().empty()) {
+        std::string fileName(get_timestamp_for_filename() + ".log");
+        std::ofstream fout(fileName, std::ofstream::app);
+        fout << m_log.str() << std::endl;
+        fout.close();
+      }
+    }
+
+    //
+    void Logger::saveOnDb() {
+      if (!m_log.str().empty()) {
+        if (m_sharedConnectionPool == nullptr) {
+          throwException("Connection pool handle has not been provided.", "Logger::saveOnDb");
+        }
+        if (m_connectionString.empty()) {
+          throwException("Connection string for destination database has not been provided.", "Logger::saveOnDb");
+        }
+        auto coralSession = m_sharedConnectionPool->createCoralSession(m_connectionString, true);
+        coralSession->transaction().start(false);
+        try {
+          O2O_RUN::Table destinationTable(coralSession->nominalSchema());
+          destinationTable.insert(m_jobName, m_startTime, m_endTime, m_retCode, m_log.str());
+          coralSession->transaction().commit();
+        } catch (const std::exception& e) {
+          coralSession->transaction().rollback();
+          // dump on file on this circumstance...
+          logError() << e.what();
+          saveOnFile();
+          throwException(std::string("Failure while saving log on database:") + e.what(), "Logger::saveOnDb");
+        }
+      }
+    }
+
+    void Logger::save() {
+      if (!m_connectionString.empty())
+        saveOnDb();
+      else
+        saveOnFile();
+    }
+
+    std::iostream& Logger::log(const std::string& tag) {
+      if (std::size(m_log.str()) != 0)
+        m_log << std::endl;
+      m_log << "[" << get_timestamp() << "] " << tag << ": ";
+      return m_log;
+    }
+
+    EchoedLogStream<edm::LogInfo> Logger::logInfo() {
+      log("INFO");
+      return EchoedLogStream<edm::LogInfo>(m_jobName, m_log);
+    }
+    EchoedLogStream<edm::LogDebug_> Logger::logDebug() {
+      log("DEBUG");
+      return EchoedLogStream<edm::LogDebug_>(m_jobName, m_log);
+    }
+    EchoedLogStream<edm::LogError> Logger::logError() {
+      log("ERROR");
+      return EchoedLogStream<edm::LogError>(m_jobName, m_log);
+    }
+    EchoedLogStream<edm::LogWarning> Logger::logWarning() {
+      log("WARNING");
+      return EchoedLogStream<edm::LogWarning>(m_jobName, m_log);
+    }
+
+  }  // namespace persistency
+}  // namespace cond

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -29,6 +29,9 @@
 <bin file="testFrontier.cpp" name="testFrontier">
 </bin>
 
+<bin file="testLogger.cpp" name="testLogger">
+</bin>
+
 <bin file="testRunInfo.cpp" name="testRunInfo">
 </bin>
 

--- a/CondCore/CondDB/test/testLogger.cpp
+++ b/CondCore/CondDB/test/testLogger.cpp
@@ -1,0 +1,20 @@
+
+#include "CondCore/CondDB/interface/Logger.h"
+//
+#include <iostream>
+
+using namespace cond::persistency;
+
+int main(int argc, char** argv) {
+  Logger logger("TestO2O_gg_code");
+  logger.start();
+  std::string s("XYZ");
+  logger.logInfo() << "Step #" << 1 << " and string is [" << s << "]";
+  ::sleep(2);
+  logger.logError() << "Step #" << 2;
+  logger.logWarning() << "Step #" << 3;
+  logger.log("SPECIAL") << "Blabla val=" << 77 << " and more stuff: " << std::string("ciao");
+  logger.end(-1);
+  logger.saveOnFile();
+  return 0;
+}

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -4,6 +4,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondCore/CondDB/interface/ConnectionPool.h"
 #include "CondCore/CondDB/interface/Session.h"
+#include "CondCore/CondDB/interface/Logger.h"
 #include <string>
 #include <map>
 #include <mutex>
@@ -63,6 +64,7 @@ namespace cond {
         try {
           this->initDB();
           Record& myrecord = this->lookUpRecord(recordName);
+          m_logger.logInfo() << "Tag mapped to record " << recordName << ": " << myrecord.m_tag;
           bool newTag = isNewTagRequest(recordName);
           if (myrecord.m_onlyAppendUpdatePolicy && !newTag) {
             cond::TagInfo_t tInfo;
@@ -71,10 +73,11 @@ namespace cond {
             if (lastSince == cond::time::MAX_VAL)
               lastSince = 0;
             if (time <= lastSince) {
-              edm::LogInfo(MSGSOURCE) << "Won't append iov with since " << std::to_string(time)
-                                      << ", because is less or equal to last available since = " << lastSince;
+              m_logger.logInfo() << "Won't append iov with since " << std::to_string(time)
+                                 << ", because is less or equal to last available since = " << lastSince;
               if (m_autoCommit)
                 doCommitTransaction();
+              scope.close();
               return thePayloadHash;
             }
           }
@@ -87,7 +90,7 @@ namespace cond {
           }
           if (m_autoCommit) {
             if (m_writeTransactionDelay) {
-              edm::LogWarning(MSGSOURCE) << "Waiting " << m_writeTransactionDelay << "s before commit the changes...";
+              m_logger.logWarning() << "Waiting " << m_writeTransactionDelay << "s before commit the changes...";
               ::sleep(m_writeTransactionDelay);
             }
             doCommitTransaction();
@@ -183,6 +186,8 @@ namespace cond {
 
       void forceInit();
 
+      cond::persistency::Logger& logger() { return m_logger; }
+
     private:
       struct Record {
         Record()
@@ -230,7 +235,7 @@ namespace cond {
       cond::UserLogInfo& lookUpUserLogInfo(const std::string& recordName);
 
     private:
-      static constexpr const char* const MSGSOURCE = "PoolDBOuputService";
+      cond::persistency::Logger m_logger;
       std::recursive_mutex m_mutex;
       cond::TimeType m_timetype;
       std::vector<cond::Time_t> m_currentTimes;

--- a/CondCore/DBOutputService/src/OnlineDBOutputService.cc
+++ b/CondCore/DBOutputService/src/OnlineDBOutputService.cc
@@ -3,34 +3,13 @@
 #include <curl/curl.h>
 //
 
-cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::ParameterSet& iConfig,
-                                                            edm::ActivityRegistry& iAR)
-    : PoolDBOutputService(iConfig, iAR),
-      m_runNumber(iConfig.getUntrackedParameter<unsigned long long>("runNumber", 0)),
-      m_latencyInLumisections(iConfig.getUntrackedParameter<unsigned int>("latency", 1)),
-      m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
-      m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
-      m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
-  if (!m_lastLumiUrl.empty()) {
-    startTransaction();
-    auto lastRun = PoolDBOutputService::session().getLastRun();
-    if (lastRun.isOnGoing()) {
-      m_runNumber = lastRun.run;
-    }
-  } else {
-    m_lastLumiFile = iConfig.getUntrackedParameter<std::string>("lastLumiFile", "");
-  }
-}
-
-cond::service::OnlineDBOutputService::~OnlineDBOutputService() {}
-
 static size_t getHtmlCallback(void* contents, size_t size, size_t nmemb, void* ptr) {
   // Cast ptr to std::string pointer and append contents to that string
   ((std::string*)ptr)->append((char*)contents, size * nmemb);
   return size * nmemb;
 }
 
-bool getLatestLumiFromDAQ(const std::string& urlString, std::string& info) {
+bool getInfoFromDAQ(const std::string& urlString, std::string& info) {
   CURL* curl;
   CURLcode res;
   std::string htmlBuffer;
@@ -63,30 +42,91 @@ bool getLatestLumiFromDAQ(const std::string& urlString, std::string& info) {
   return ret;
 }
 
+namespace cond {
+
+  cond::Time_t getLatestLumiFromFile(const std::string& fileName) {
+    cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
+    std::ifstream lastLumiFile(fileName);
+    if (lastLumiFile) {
+      lastLumiFile >> lastLumiProcessed;
+    } else {
+      throw Exception(std::string("Can't access lastLumi file ") + fileName);
+    }
+    return lastLumiProcessed;
+  }
+
+  cond::Time_t getLastLumiFromOMS(const std::string& omsServiceUrl) {
+    cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
+    std::string info("");
+    if (!getInfoFromDAQ(omsServiceUrl, info))
+      throw Exception("Can't get data from OMS Service.");
+    std::istringstream sinfo(info);
+    std::string srun;
+    if (!std::getline(sinfo, srun, ',')) {
+      throw Exception("Can't get run runmber info from OMS Service.");
+    }
+    std::string slumi;
+    if (!std::getline(sinfo, slumi, ',')) {
+      throw Exception("Can't get lumi id from OMS Service.");
+    }
+    unsigned int run = boost::lexical_cast<unsigned int>(srun);
+    unsigned int lumi = boost::lexical_cast<unsigned int>(slumi);
+    lastLumiProcessed = cond::time::lumiTime(run, lumi);
+    return lastLumiProcessed;
+  }
+
+}  // namespace cond
+
+cond::service::OnlineDBOutputService::OnlineDBOutputService(const edm::ParameterSet& iConfig,
+                                                            edm::ActivityRegistry& iAR)
+    : PoolDBOutputService(iConfig, iAR),
+      m_runNumber(iConfig.getUntrackedParameter<unsigned long long>("runNumber", 0)),
+      m_latencyInLumisections(iConfig.getUntrackedParameter<unsigned int>("latency", 1)),
+      m_omsServiceUrl(iConfig.getUntrackedParameter<std::string>("omsServiceUrl", "")),
+      m_lastLumiUrl(iConfig.getUntrackedParameter<std::string>("lastLumiUrl", "")),
+      m_preLoadConnectionString(iConfig.getUntrackedParameter<std::string>("preLoadConnectionString", "")),
+      m_debug(iConfig.getUntrackedParameter<bool>("debugLogging", false)) {
+  if (m_omsServiceUrl.empty()) {
+    if (!m_lastLumiUrl.empty()) {
+      startTransaction();
+      auto lastRun = PoolDBOutputService::session().getLastRun();
+      if (lastRun.isOnGoing()) {
+        m_runNumber = lastRun.run;
+      }
+    } else {
+      m_lastLumiFile = iConfig.getUntrackedParameter<std::string>("lastLumiFile", "");
+    }
+  }
+}
+
+cond::service::OnlineDBOutputService::~OnlineDBOutputService() {}
+
 cond::Time_t cond::service::OnlineDBOutputService::getLastLumiProcessed() {
   cond::Time_t lastLumiProcessed = cond::time::MIN_VAL;
-  unsigned int lastL = 0;
-  if (!m_lastLumiUrl.empty()) {
-    std::string info("");
-    if (!getLatestLumiFromDAQ(m_lastLumiUrl, info))
-      throw Exception("Can't get last Lumisection from DAQ.");
-    lastL = boost::lexical_cast<unsigned int>(info);
-    lastLumiProcessed = cond::time::lumiTime(m_runNumber, lastL);
-    edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
-                            << " lumi id:" << lastL;
+  std::string info("");
+  if (!m_omsServiceUrl.empty()) {
+    lastLumiProcessed = cond::getLastLumiFromOMS(m_omsServiceUrl);
+    logger().logInfo() << "Last lumi: " << lastLumiProcessed
+                       << " Current run: " << cond::time::unpack(lastLumiProcessed).first
+                       << " lumi id:" << cond::time::unpack(lastLumiProcessed).second;
   } else {
-    if (m_lastLumiFile.empty()) {
-      //auto t1 = std::chrono::steady_clock::now();
-      //auto deltat = std::chrono::duration_cast<std::chrono::seconds>( t1 - m_startRunTime ).count();
-      //lastL = (unsigned int)(deltat/23);
-      //lastLumiProcessed = cond::time::lumiTime( m_runNumber, lastL );
-      //edm::LogInfo( MSGSOURCE ) << "Last lumi: "<<lastLumiProcessed<<" Current run: "<<m_runNumber<<" lumi id:"<<lastL;
-      throw Exception("File name for last lumi has not been provided.");
+    if (!m_lastLumiUrl.empty()) {
+      std::string info("");
+      if (!getInfoFromDAQ(m_lastLumiUrl, info))
+        throw Exception("Can't get last Lumisection from DAQ.");
+      unsigned int lastL = boost::lexical_cast<unsigned int>(info);
+      lastLumiProcessed = cond::time::lumiTime(m_runNumber, lastL);
+      logger().logInfo() << "Last lumi: " << lastLumiProcessed << " Current run: " << m_runNumber
+                         << " lumi id:" << lastL;
     } else {
-      lastLumiProcessed = cond::getLatestLumiFromFile(m_lastLumiFile);
-      auto upkTime = cond::time::unpack(lastLumiProcessed);
-      edm::LogInfo(MSGSOURCE) << "Last lumi: " << lastLumiProcessed << " Current run: " << upkTime.first
-                              << " lumi id:" << upkTime.second;
+      if (m_lastLumiFile.empty()) {
+        throw Exception("File name for last lumi has not been provided.");
+      } else {
+        lastLumiProcessed = cond::getLatestLumiFromFile(m_lastLumiFile);
+        auto upkTime = cond::time::unpack(lastLumiProcessed);
+        logger().logInfo() << "Last lumi: " << lastLumiProcessed << " Current run: " << upkTime.first
+                           << " lumi id:" << upkTime.second;
+      }
     }
   }
   return lastLumiProcessed;

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -35,7 +35,13 @@ void cond::service::PoolDBOutputService::fillRecord(edm::ParameterSet& recordPse
 }
 
 cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet& iConfig, edm::ActivityRegistry& iAR)
-    : m_currentTimes{}, m_session(), m_transactionActive(false), m_dbInitialised(false), m_records(), m_logheaders() {
+    : m_logger(iConfig.getUntrackedParameter<std::string>("jobName", "DBOutputService")),
+      m_currentTimes{},
+      m_session(),
+      m_transactionActive(false),
+      m_dbInitialised(false),
+      m_records(),
+      m_logheaders() {
   std::string timetypestr = iConfig.getUntrackedParameter<std::string>("timetype", "runnumber");
   m_timetype = cond::time::timeTypeFromName(timetypestr);
   m_autoCommit = iConfig.getUntrackedParameter<bool>("autoCommit", false);
@@ -43,9 +49,13 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet&
 
   edm::ParameterSet connectionPset = iConfig.getParameter<edm::ParameterSet>("DBParameters");
   m_connection.setParameters(connectionPset);
+  m_connection.setLogDestination(m_logger);
   m_connection.configure();
   std::string connectionString = iConfig.getParameter<std::string>("connect");
   m_session = m_connection.createSession(connectionString, true);
+  bool saveLogsOnDb = iConfig.getUntrackedParameter<bool>("saveLogsOnDB", false);
+  if (saveLogsOnDb)
+    m_logger.setDbDestination(connectionString, m_connection);
   // implicit start
   doStartTransaction();
 
@@ -189,8 +199,8 @@ void cond::service::PoolDBOutputService::createNewIOV(const std::string& firstPa
   if (!myrecord.m_isNewTag) {
     cond::throwException(myrecord.m_tag + " is not a new tag", "PoolDBOutputService::createNewIOV");
   }
-  edm::LogInfo(MSGSOURCE) << "Creating new tag " << myrecord.m_tag << ", adding iov with since " << firstSinceTime
-                          << " pointing to payload id " << firstPayloadId;
+  m_logger.logInfo() << "Creating new tag " << myrecord.m_tag << ", adding iov with since " << firstSinceTime
+                     << " pointing to payload id " << firstPayloadId;
   doStartTransaction();
   cond::persistency::TransactionScope scope(m_session.transaction());
   try {
@@ -212,8 +222,8 @@ void cond::service::PoolDBOutputService::createNewIOV(const std::string& firstPa
                                                       const std::string payloadType,
                                                       cond::Time_t firstSinceTime,
                                                       Record& myrecord) {
-  edm::LogInfo(MSGSOURCE) << "Creating new tag " << myrecord.m_tag << " for payload type " << payloadType
-                          << ", adding iov with since " << firstSinceTime;
+  m_logger.logInfo() << "Creating new tag " << myrecord.m_tag << " for payload type " << payloadType
+                     << ", adding iov with since " << firstSinceTime;
   // FIX ME: synchronization type and description have to be passed as the other parameters?
   cond::persistency::IOVEditor editor =
       m_session.createIov(payloadType, myrecord.m_tag, myrecord.m_timetype, cond::SYNCH_ANY);
@@ -248,7 +258,7 @@ bool cond::service::PoolDBOutputService::appendSinceTime(const std::string& payl
 bool cond::service::PoolDBOutputService::appendSinceTime(const std::string& payloadId,
                                                          cond::Time_t time,
                                                          Record& myrecord) {
-  edm::LogInfo(MSGSOURCE) << "Updating existing tag " << myrecord.m_tag << ", adding iov with since " << time;
+  m_logger.logInfo() << "Updating existing tag " << myrecord.m_tag << ", adding iov with since " << time;
   std::string payloadType("");
   try {
     cond::persistency::IOVEditor editor = m_session.editIov(myrecord.m_tag);
@@ -271,8 +281,8 @@ void cond::service::PoolDBOutputService::eraseSinceTime(const std::string& paylo
     cond::throwException(std::string("Cannot delete from non-existing tag ") + myrecord.m_tag,
                          "PoolDBOutputService::appendSinceTime");
   }
-  edm::LogInfo(MSGSOURCE) << "Updating existing tag " << myrecord.m_tag << ", removing iov with since " << sinceTime
-                          << " pointing to payload id " << payloadId;
+  m_logger.logInfo() << "Updating existing tag " << myrecord.m_tag << ", removing iov with since " << sinceTime
+                     << " pointing to payload id " << payloadId;
   doStartTransaction();
   cond::persistency::TransactionScope scope(m_session.transaction());
   try {
@@ -312,8 +322,7 @@ void cond::service::PoolDBOutputService::closeIOV(Time_t lastTill, const std::st
     cond::throwException(std::string("Cannot close non-existing tag ") + myrecord.m_tag,
                          "PoolDBOutputService::closeIOV");
   }
-  edm::LogInfo(MSGSOURCE) << "Updating existing tag " << myrecord.m_tag << ", closing with end of validity "
-                          << lastTill;
+  m_logger.logInfo() << "Updating existing tag " << myrecord.m_tag << ", closing with end of validity " << lastTill;
   doStartTransaction();
   cond::persistency::TransactionScope scope(m_session.transaction());
   try {
@@ -338,7 +347,7 @@ void cond::service::PoolDBOutputService::setLogHeaderForRecord(const std::string
 bool cond::service::PoolDBOutputService::getTagInfo(const std::string& recordName, cond::TagInfo_t& result) {
   Record& record = lookUpRecord(recordName);
   result.name = record.m_tag;
-  LogDebug(MSGSOURCE) << "Fetching tag info for " << record.m_tag;
+  m_logger.logDebug() << "Fetching tag info for " << record.m_tag;
   doStartTransaction();
   bool ret = false;
   cond::persistency::TransactionScope scope(m_session.transaction());

--- a/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
+++ b/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_COND_WEB'
+process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
 process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 #process.CondDB.DBParameters.messageLevel = cms.untracked.int32(3)
 

--- a/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_cfg.py
+++ b/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_cfg.py
@@ -8,15 +8,23 @@ process.source = cms.Source("EmptyIOVSource",
     interval = cms.uint64(11)
 )
 
+process.MessageLogger = cms.Service("MessageLogger",
+    cout = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG')),
+    destinations = cms.untracked.vstring('cout')
+)
+
 process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(2),
         authenticationPath = cms.untracked.string('.')
     ),
     #timetype = cms.untracked.string('runnumber'),
+    jobName = cms.untracked.string("TestLumiBasedUpdate"),
+    autoCommit = cms.untracked.bool(True),
     connect = cms.string('sqlite_file:test_lumi.db'),
     preLoadConnectionString = cms.untracked.string('sqlite_file:test_lumi.db'),
-    runNumber = cms.untracked.uint64(120000),
+    #omsServiceUrl = cms.untracked.string('http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection'),
+    lastLumiFile = cms.untracked.string('lastLumi.txt'),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('PedestalsRcd'),
         tag = cms.string('mytest'),
@@ -26,7 +34,9 @@ process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
 )
 
 process.mytest = cms.EDAnalyzer("LumiBasedUpdateAnalyzer",
-    record = cms.string('PedestalsRcd')
+    record = cms.string('PedestalsRcd'),
+    lastLumiFile = cms.untracked.string('lastLumi.txt')
+    #omsServiceUrl = cms.untracked.string('http://cmsoms-services.cms:9949/urn:xdaq-application:lid=100/getRunAndLumiSection')
 )
 
 process.p = cms.Path(process.mytest)

--- a/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_oracle.cfg.py
+++ b/CondCore/DBOutputService/test/python/testLumiBasedUpdateAnalyzer_oracle.cfg.py
@@ -29,16 +29,19 @@ process.MessageLogger = cms.Service("MessageLogger",
 
 process.OnlineDBOutputService = cms.Service("OnlineDBOutputService",
     DBParameters = cms.PSet(
-        messageLevel = cms.untracked.int32(0),
+        messageLevel = cms.untracked.int32(1),
         authenticationPath = cms.untracked.string('/build/gg')
     ),
     #timetype = cms.untracked.string('runnumber'),
+    jobName = cms.untracked.string("TestLumiBasedUpdate"),
     connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS'),
     preLoadConnectionString = cms.untracked.string('frontier://FrontierPrep/CMS_CONDITIONS'),
-                                            runNumber = cms.untracked.uint64(options.runNumber),
-                                            lastLumiFile = cms.untracked.string('/build/gg/last_lumi.txt'),
-                                            writeTransactionDelay = cms.untracked.uint32(options.transDelay),
+    runNumber = cms.untracked.uint64(options.runNumber),
+    #lastLumiFile = cms.untracked.string('/build/gg/last_lumi.txt'),
+    writeTransactionDelay = cms.untracked.uint32(options.transDelay),
     autoCommit = cms.untracked.bool(True),
+    lastLumiFile = cms.untracked.string('lastLumi.txt'),
+    saveLogsOnDB = cms.untracked.bool(True),
     toPut = cms.VPSet(cms.PSet(
         record = cms.string('PedestalsRcd'),
         tag = cms.string('BeamSpot_test_updateByLumi_00'),

--- a/CondCore/DBOutputService/test/python/writeInt_cfg.py
+++ b/CondCore/DBOutputService/test/python/writeInt_cfg.py
@@ -24,7 +24,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           )
 
 process.mytest = cms.EDAnalyzer("writeInt",
-                                Number=cms.int32(_CurrentRun_)
+                                Number=cms.int32(100000)
                                 )
 
 process.p = cms.Path(process.mytest)

--- a/CondCore/DBOutputService/test/python/writeMultipleRecords_oracle_cfg.py
+++ b/CondCore/DBOutputService/test/python/writeMultipleRecords_oracle_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 process.load("CondCore.CondDB.CondDB_cfi")
-process.CondDB.connect = cms.string('oracle://cms_orcoff_prep/CMS_COND_WEB')
-process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/test'
+process.CondDB.connect = cms.string('oracle://cms_orcoff_prep/CMS_CONDITIONS')
+process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.source = cms.Source("EmptyIOVSource",
     lastValue = cms.uint64(1),

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.cc
@@ -14,6 +14,7 @@ LumiBasedUpdateAnalyzer::LumiBasedUpdateAnalyzer(const edm::ParameterSet& iConfi
   std::cout << "LumiBasedUpdateAnalyzer::LumiBasedUpdateAnalyzer" << std::endl;
   m_prevLumi = 0;
   m_prevLumiTime = std::chrono::steady_clock::now();
+  m_omsServiceUrl = iConfig.getUntrackedParameter<std::string>("omsServiceUrl", "");
 }
 LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer() {
   std::cout << "LumiBasedUpdateAnalyzer::~LumiBasedUpdateAnalyzer" << std::endl;
@@ -25,27 +26,44 @@ void LumiBasedUpdateAnalyzer::analyze(const edm::Event& evt, const edm::EventSet
     std::cout << "Service is unavailable" << std::endl;
     return;
   }
+  mydbservice->logger().start();
   unsigned int irun = evt.id().run();
-  cond::Time_t lastLumi = cond::getLatestLumiFromFile(m_lastLumiFile);
-  if (lastLumi == m_prevLumi) {
-    return;
+  cond::Time_t lastLumi = cond::time::MIN_VAL;
+  if (!m_omsServiceUrl.empty()) {
+    lastLumi = cond::getLastLumiFromOMS(m_omsServiceUrl);
+  } else {
+    lastLumi = cond::getLatestLumiFromFile(m_lastLumiFile);
+    if (lastLumi == m_prevLumi) {
+      mydbservice->logger().logInfo() << "Last lumi:" << lastLumi << " Prev lumi:" << m_prevLumi;
+      mydbservice->logger().end(1);
+      return;
+    }
+    m_prevLumi = lastLumi;
+    m_prevLumiTime = std::chrono::steady_clock::now();
   }
-  m_prevLumi = lastLumi;
-  m_prevLumiTime = std::chrono::steady_clock::now();
   unsigned int lumiId = cond::time::unpack(lastLumi).second;
-  std::cout << "## last lumi: " << lastLumi << " run: " << cond::time::unpack(lastLumi).first << " lumiid:" << lumiId
-            << std::endl;
+  mydbservice->logger().logInfo() << "Last lumi: " << lastLumi << " run: " << cond::time::unpack(lastLumi).first
+                                  << " lumiid:" << lumiId;
   std::string tag = mydbservice->tag(m_record);
   std::cout << "tag " << tag << std::endl;
   std::cout << "run " << irun << std::endl;
+  mydbservice->logger().logDebug() << "Tag: " << tag << " Run: " << irun;
   BeamSpotObjects mybeamspot;
   mybeamspot.SetPosition(0.053, 0.1, 0.13);
   mybeamspot.SetSigmaZ(3.8);
   mybeamspot.SetType(int(lumiId));
   std::cout << mybeamspot.GetBeamType() << std::endl;
-
-  mydbservice->writeForNextLumisection(&mybeamspot, m_record);
+  mydbservice->logger().logDebug() << "BeamType: " << mybeamspot.GetBeamType();
+  int ret = 0;
+  try {
+    mydbservice->writeForNextLumisection(&mybeamspot, m_record);
+  } catch (const std::exception& e) {
+    std::cout << "Error:" << e.what() << std::endl;
+    mydbservice->logger().logError() << e.what();
+    ret = -1;
+  }
   //::sleep(13);
+  mydbservice->logger().end(ret);
 }
 void LumiBasedUpdateAnalyzer::endJob() {}
 DEFINE_FWK_MODULE(LumiBasedUpdateAnalyzer);

--- a/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
+++ b/CondCore/DBOutputService/test/stubs/LumiBasedUpdateAnalyzer.h
@@ -25,6 +25,7 @@ private:
   std::string m_lastLumiFile;
   cond::Time_t m_prevLumi;
   std::chrono::time_point<std::chrono::steady_clock> m_prevLumiTime;
+  std::string m_omsServiceUrl;
   // ----------member data ---------------------------
 };
 #endif

--- a/CondCore/Utilities/python/o2olib.py
+++ b/CondCore/Utilities/python/o2olib.py
@@ -14,7 +14,7 @@ import json
 import CondCore.Utilities.credentials as auth
 
 prod_db_service = ['cms_orcon_prod','cms_orcon_prod/cms_cond_general_w']
-dev_db_service = ['cms_orcoff_prep','cms_orcoff_prep/cms_test_conditions']
+dev_db_service = ['cms_orcoff_prep','cms_orcoff_prep/cms_cond_general_w']
 schema_name = 'CMS_CONDITIONS'
 sqlalchemy_tpl = 'oracle://%s:%s@%s'
 coral_tpl = 'oracle://%s/%s'


### PR DESCRIPTION
#### PR description:
 We are adding a new service to provide recollection of log messages, with the aim to store them in the database, related to the condition data stored in the same context.

The target and main use case for this implementation are the workflows providing the lumi-based conditions for HLT.

#### PR validation:

A dedicate unit tests validates the base Logger. Two integration tests are exercising the use case with an Oracle db destination.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Port of #31667 to 11_1_X branch, to allow the integration in the online operation during MWGR

