### PR TITLE
[MillePedeAlignmentAlgorithm] Increase default constraints precision

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
+++ b/Alignment/MillePedeAlignmentAlgorithm/python/MillePedeAlignmentAlgorithm_cfi.py
@@ -68,10 +68,9 @@ MillePedeAlignmentAlgorithm = cms.PSet(
         # All this is determined from what is given as 
         # AlignmentProducer.ParameterBuilder.Selector, cf. Twiki page SWGuideMillepedeIIAlgorithm.
         Presigmas = cms.VPSet(),
-        minHieraConstrCoeff = cms.double(1.e-7), # min abs value of coeff. in hierarchy constr.
+        minHieraConstrCoeff = cms.double(1.e-10), # min abs value of coeff. in hierarchy constr.
         minHieraParPerConstr = cms.uint32(2), # ignore hierarchy constraints with less params
-        constrPrecision = cms.uint32(0), # use default precision for writing constraints to text file
-
+        constrPrecision = cms.uint32(10), # precision for writing constraints to text file. Default is 6 and can be setup with constrPrecision = cms.uint32(0)
         # specify additional steering files
         additionalSteerFiles = cms.vstring(), # obsolete - can be given as entries in 'options'
         


### PR DESCRIPTION
#### PR description:

This PR updates two configuration parameters for the MillePede alignment algorithm so that:
- the number of figures for the constraints is increased from the default (6) to 10
- the threshold, below which constraints are neglected, is lowered from 1.0e-7 to 1.0e-10.

This change has been discussed in the tracker alignment group in this presentation: 
https://indico.cern.ch/event/934825/#56-validation-of-new-pede-vers

#### PR validation:

A test alignment campaign has been run and only very small differences in the results are observed. Documented in the same presentation linked above. 

#### This PR is not a backport.

cc:
@mmusich @connorpa @adewit 