### PR TITLE
[RecoEgamma/EgammaTools] Backport of UL 2018 scale and smearing corrections

### DIFF
--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -12,11 +12,13 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)
                                    )
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+
 from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
-run2_egamma_2017.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
+(run2_miniAOD_UL & run2_egamma_2017).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
 
 from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
-run2_egamma_2018.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2018UL)
+(run2_miniAOD_UL & run2_egamma_2018).toModify(calibratedEgammaSettings,correctionFile = _correctionFile2018UL)
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)

--- a/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
+++ b/RecoEgamma/EgammaTools/python/calibratedEgammas_cff.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 _correctionFile2016Legacy = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Legacy2016_07Aug2017_FineEtaR9_v3_ele_unc"
 _correctionFile2017Nov17 = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_17Nov2017_v1_ele_unc"
 _correctionFile2017UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2017_24Feb2020_runEtaR9Gain_v2"
+_correctionFile2018UL    = "EgammaAnalysis/ElectronTools/data/ScalesSmearings/Run2018_29Sep2020_RunFineEtaR9Gain"
 
 calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     semiDeterministic = cms.bool(True),
@@ -11,11 +12,14 @@ calibratedEgammaSettings = cms.PSet(minEtToCalibrate = cms.double(5.0),
                                     recHitCollectionEE = cms.InputTag('reducedEcalRecHitsEE'),
                                     produceCalibratedObjs = cms.bool(True)
                                    )
+from Configuration.Eras.Modifier_run2_egamma_2017_cff import run2_egamma_2017
+run2_egamma_2017.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
+
+from Configuration.Eras.Modifier_run2_egamma_2018_cff import run2_egamma_2018
+run2_egamma_2018.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2018UL)
+
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2016Legacy)
-
-from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-run2_miniAOD_UL.toModify(calibratedEgammaSettings,correctionFile = _correctionFile2017UL)
 
 calibratedEgammaPatSettings = calibratedEgammaSettings.clone(
     recHitCollectionEB = cms.InputTag('reducedEgamma','reducedEBRecHits'),


### PR DESCRIPTION
This is a backport of PR #31936 of UL2018 scale and smearing corrections. 
UL 2017 corrections were already in the backport but now we use run specific modifier
to activate these. 