### PR TITLE
Migration To DD4hep For CSC DB Loader

### DIFF
--- a/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/CSCRecoIdealDBLoader.cc
@@ -13,15 +13,26 @@
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class CSCRecoIdealDBLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  CSCRecoIdealDBLoader(edm::ParameterSet const&) {}
+  CSCRecoIdealDBLoader(edm::ParameterSet const&);
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
   void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {}
+
+private:
+  bool fromDD4Hep_;
 };
+
+CSCRecoIdealDBLoader::CSCRecoIdealDBLoader(const edm::ParameterSet& iC) {
+  fromDD4Hep_ = iC.getParameter<bool>("fromDD4Hep");
+}
 
 void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
   edm::LogInfo("CSCRecoIdealDBLoader") << "CSCRecoIdealDBLoader::beginRun";
@@ -34,15 +45,22 @@ void CSCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     return;
   }
 
-  edm::ESTransientHandle<DDCompactView> pDD;
   edm::ESHandle<MuonGeometryConstants> pMNDC;
-  es.get<IdealGeometryRecord>().get(pDD);
-  es.get<IdealGeometryRecord>().get(pMNDC);
-
-  const DDCompactView& cpv = *pDD;
   CSCGeometryParsFromDD cscgp;
 
-  cscgp.build(&cpv, *pMNDC, *rig, *rdp);
+  if (fromDD4Hep_) {
+    edm::ESTransientHandle<cms::DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    es.get<IdealGeometryRecord>().get(pMNDC);
+    const cms::DDCompactView& cpv = *pDD;
+    cscgp.build(&cpv, *pMNDC, *rig, *rdp);
+  } else {
+    edm::ESTransientHandle<DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    es.get<IdealGeometryRecord>().get(pMNDC);
+    const DDCompactView& cpv = *pDD;
+    cscgp.build(&cpv, *pMNDC, *rig, *rdp);
+  }
 
   if (mydbservice->isNewTagRequest("CSCRecoGeometryRcd")) {
     mydbservice->createNewIOV<RecoIdealGeometry>(

--- a/CondTools/Geometry/test/cscgeometrywriter.py
+++ b/CondTools/Geometry/test/cscgeometrywriter.py
@@ -4,6 +4,8 @@ process = cms.Process("CSCGeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.StandardSequences.GeometryExtended_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -12,7 +14,8 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader")
+process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader",
+                                           fromDD4Hep = cms.bool(False))
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')


### PR DESCRIPTION
**PR description:**

This PR (only for CSC) has been triggered by what @cvuosalo wrote in #31958 . 
The other Muon subsystems will be treated in separated PRs.

**PR validation:**

1) validation by "cmsRun CondTools/Geometry/test/cscgeometrywriter.py" (with DD4hep flag set False or True):

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 02-Nov-2020 12:05:42.758 CET

=============================================

MessageLogger Summary

Severity    # Occurrences   Total Occurrences

dropped waiting message count 0
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

 2) validation by runTheMatrix.py -l 25202.1 :

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Nov  2 12:38:32 2020-date Mon Nov  2 12:0\
9:43 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special
