### PR TITLE
Restore "PPS Digi integration into cmssw (final)"

### DIFF
--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -19,8 +19,7 @@ from EventFilter.RawDataCollector.rawDataCollector_cfi import *
 from L1Trigger.Configuration.L1TDigiToRaw_cff import *
 from EventFilter.CTPPSRawToDigi.ctppsDigiToRaw_cff import *
 
-#DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, ctppsRawData, castorRawData, rawDataCollector)
-DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, castorRawData, rawDataCollector)
+DigiToRawTask = cms.Task(L1TDigiToRawTask, siPixelRawData, SiStripDigiToRaw, ecalPacker, esDigiToRaw, hcalRawDataTask, cscpacker, dtpacker, rpcpacker, ctppsRawData, castorRawData, rawDataCollector)
 DigiToRaw = cms.Sequence(DigiToRawTask)
 
 ecalPacker.Label = 'simEcalDigis'

--- a/Configuration/StandardSequences/python/Digi_cff.py
+++ b/Configuration/StandardSequences/python/Digi_cff.py
@@ -33,7 +33,7 @@ from SimGeneral.Configuration.SimGeneral_cff import *
 from Configuration.StandardSequences.Generator_cff import *
 from GeneratorInterface.Core.generatorSmeared_cfi import *
 
-doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask)#, ctppsDigiTask)
+doAllDigiTask = cms.Task(generatorSmeared, calDigiTask, muonDigiTask, ctppsDigiTask)
 from Configuration.ProcessModifiers.premix_stage2_cff import premix_stage2
 # premixing stage2 runs muon digis after PreMixingModule (configured in DataMixerPreMix_cff)
 premix_stage2.toReplaceWith(doAllDigiTask, doAllDigiTask.copyAndExclude([muonDigiTask]))


### PR DESCRIPTION
#### PR description:

PPS digi integration into cmssw. This is the last step towards the integration of PPS simulation into CMSSW and was delayed waiting for the new cms extended geometry (including PPS) to show up in the DB.

--------------------

Original PR:  #31943
Reverted with #31997
because of issue #31991 