### PR TITLE
Move CaloL1 online DQM to Global

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -257,7 +257,7 @@ private:
                             std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &) const;
 
   bool isLaterMismatch(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &candidateMismatch,
-                       std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &higherOrderMismatch) const;
+                       std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &comparisonMismatch) const;
 
   int findIndex(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>,
                 std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>,

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -253,16 +253,16 @@ private:
       int mismatchType,
       std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &streamMismatches) const;
 
-  void collateMismatchLists(std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &,
+  void mergeMismatchVectors(std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &,
                             std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>> &) const;
 
   bool isLaterMismatch(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &candidateMismatch,
                        std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int> &higherOrderMismatch) const;
 
-  int findAppropriateInsertionIndex(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>,
-                                    std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>,
-                                    int lowerIndexToSearch,
-                                    int upperIndexToSearch) const;
+  int findIndex(std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>,
+                std::vector<std::tuple<edm::RunID, edm::LuminosityBlockID, edm::EventID, int>>,
+                int lowerIndexToSearch,
+                int upperIndexToSearch) const;
   // Input and config info
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecd_;
   std::string ecalTPSourceRecdLabel_;

--- a/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
+++ b/DQM/L1TMonitor/interface/L1TStage2CaloLayer1.h
@@ -5,6 +5,9 @@
 #include <memory>
 #include <string>
 #include <array>
+#include <map>
+
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -77,19 +80,124 @@ namespace ComparisonHelper {
   }
 }  // namespace ComparisonHelper
 
-class L1TStage2CaloLayer1 : public DQMOneEDAnalyzer<edm::one::WatchLuminosityBlocks> {
+namespace CaloL1Information {
+
+  struct monitoringDataHolder {
+    dqm::reco::MonitorElement *ecalDiscrepancy_;
+    dqm::reco::MonitorElement *ecalLinkError_;
+    dqm::reco::MonitorElement *ecalOccupancy_;
+    dqm::reco::MonitorElement *hcalDiscrepancy_;
+    dqm::reco::MonitorElement *hcalLinkError_;
+    dqm::reco::MonitorElement *hcalOccupancy_;
+
+    dqm::reco::MonitorElement *ecalOccEtDiscrepancy_;
+    dqm::reco::MonitorElement *ecalOccFgDiscrepancy_;
+    dqm::reco::MonitorElement *ecalOccLinkMasked_;
+    dqm::reco::MonitorElement *ecalOccRecdEtWgt_;
+    dqm::reco::MonitorElement *ecalOccRecdFgVB_;
+    dqm::reco::MonitorElement *ecalOccSentAndRecd_;
+    dqm::reco::MonitorElement *ecalOccSentFgVB_;
+    dqm::reco::MonitorElement *ecalOccSent_;
+    dqm::reco::MonitorElement *ecalOccTowerMasked_;
+    dqm::reco::MonitorElement *ecalTPRawEtCorrelation_;
+    dqm::reco::MonitorElement *ecalTPRawEtDiffNoMatch_;
+    dqm::reco::MonitorElement *ecalTPRawEtRecd_;
+    dqm::reco::MonitorElement *ecalTPRawEtSentAndRecd_;
+    dqm::reco::MonitorElement *ecalTPRawEtSent_;
+
+    dqm::reco::MonitorElement *ecalOccSentNotRecd_;
+    dqm::reco::MonitorElement *ecalOccRecdNotSent_;
+    dqm::reco::MonitorElement *ecalOccNoMatch_;
+
+    dqm::reco::MonitorElement *hcalOccEtDiscrepancy_;
+    dqm::reco::MonitorElement *hcalOccFbDiscrepancy_;
+    dqm::reco::MonitorElement *hcalOccFb2Discrepancy_;
+    dqm::reco::MonitorElement *hcalOccLinkMasked_;
+    dqm::reco::MonitorElement *hcalOccRecdEtWgt_;
+    dqm::reco::MonitorElement *hcalOccRecdFb_;
+    dqm::reco::MonitorElement *hcalOccRecdFb2_;
+    dqm::reco::MonitorElement *hcalOccSentAndRecd_;
+    dqm::reco::MonitorElement *hcalOccSentFb_;
+    dqm::reco::MonitorElement *hcalOccSentFb2_;
+    dqm::reco::MonitorElement *hcalOccSent_;
+    dqm::reco::MonitorElement *hcalOccTowerMasked_;
+    dqm::reco::MonitorElement *hcalTPRawEtCorrelationHBHE_;
+    dqm::reco::MonitorElement *hcalTPRawEtCorrelationHF_;
+    dqm::reco::MonitorElement *hcalTPRawEtDiffNoMatch_;
+    dqm::reco::MonitorElement *hcalTPRawEtRecd_;
+    dqm::reco::MonitorElement *hcalTPRawEtSentAndRecd_;
+    dqm::reco::MonitorElement *hcalTPRawEtSent_;
+
+    dqm::reco::MonitorElement *hcalOccSentNotRecd_;
+    dqm::reco::MonitorElement *hcalOccRecdNotSent_;
+    dqm::reco::MonitorElement *hcalOccNoMatch_;
+
+    dqm::reco::MonitorElement *ECALmismatchesPerBx_;
+    dqm::reco::MonitorElement *HBHEmismatchesPerBx_;
+    dqm::reco::MonitorElement *HFmismatchesPerBx_;
+
+    dqm::reco::MonitorElement *bxidErrors_;
+    dqm::reco::MonitorElement *l1idErrors_;
+    dqm::reco::MonitorElement *orbitErrors_;
+
+    dqm::reco::MonitorElement *ecalLinkErrorByLumi_;
+    dqm::reco::MonitorElement *ecalMismatchByLumi_;
+    dqm::reco::MonitorElement *hcalLinkErrorByLumi_;
+    dqm::reco::MonitorElement *hcalMismatchByLumi_;
+
+    dqm::reco::MonitorElement *maxEvtLinkErrorsByLumiECAL_;
+    dqm::reco::MonitorElement *maxEvtLinkErrorsByLumiHCAL_;
+    dqm::reco::MonitorElement *maxEvtLinkErrorsByLumi_;
+
+    dqm::reco::MonitorElement *maxEvtMismatchByLumiECAL_;
+    dqm::reco::MonitorElement *maxEvtMismatchByLumiHCAL_;
+    dqm::reco::MonitorElement *maxEvtMismatchByLumi_;
+
+    dqm::reco::MonitorElement *last20Mismatches_;
+
+    //these maps store the maximum number of evt and link mismatches per lumi section.
+    //they are read back at the end of runs
+    //Made std::unique_ptr's for better memory management
+    std::unique_ptr<std::map<std::string, int>> maxEvtLinkErrorsMapECAL{std::make_unique<std::map<std::string, int>>()};
+    std::unique_ptr<std::map<std::string, int>> maxEvtLinkErrorsMapHCAL{std::make_unique<std::map<std::string, int>>()};
+    std::unique_ptr<std::map<std::string, int>> maxEvtLinkErrorsMap{std::make_unique<std::map<std::string, int>>()};
+
+    std::unique_ptr<std::map<std::string, int>> maxEvtMismatchMapECAL{std::make_unique<std::map<std::string, int>>()};
+    std::unique_ptr<std::map<std::string, int>> maxEvtMismatchMapHCAL{std::make_unique<std::map<std::string, int>>()};
+    std::unique_ptr<std::map<std::string, int>> maxEvtMismatchMap{std::make_unique<std::map<std::string, int>>()};
+
+    std::unique_ptr<std::array<std::pair<std::string, int>, 20>> last20MismatchArray_{
+        std::make_unique<std::array<std::pair<std::string, int>, 20>>()};
+    std::unique_ptr<size_t> lastMismatchIndex_{std::make_unique<size_t>()};
+  };
+
+}  // namespace CaloL1Information
+
+class L1TStage2CaloLayer1 : public DQMGlobalEDAnalyzer<CaloL1Information::monitoringDataHolder> {
 public:
   L1TStage2CaloLayer1(const edm::ParameterSet &ps);
   ~L1TStage2CaloLayer1() override;
 
 protected:
-  void analyze(const edm::Event &e, const edm::EventSetup &c) override;
-  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
-  void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
-  void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &) override;
+  void dqmBeginRun(edm::Run const &, edm::EventSetup const &, CaloL1Information::monitoringDataHolder &) const override;
+  void bookHistograms(DQMStore::IBooker &ibooker,
+                      const edm::Run &,
+                      const edm::EventSetup &,
+                      CaloL1Information::monitoringDataHolder &eventMonitors) const override;
+  void dqmAnalyze(edm::Event const &,
+                  edm::EventSetup const &,
+                  CaloL1Information::monitoringDataHolder const &) const override;
+  void dqmEndRun(edm::Run const &,
+                 edm::EventSetup const &,
+                 CaloL1Information::monitoringDataHolder const &) const override;
 
 private:
-  void updateMismatch(const edm::Event &e, int mismatchType);
+  void updateMismatch(const edm::Event &e,
+                      int mismatchType,
+                      const CaloL1Information::monitoringDataHolder &eventMonitors) const;
+  void updateMaxErrorMapping(const edm::Event &, const std::unique_ptr<std::map<std::string, int>> &, const int) const;
+  void readBackMaxErrorMapping(const std::unique_ptr<std::map<std::string, int>> &theMap,
+                               dqm::reco::MonitorElement *monitorElement) const;
   // Input and config info
   edm::EDGetTokenT<EcalTrigPrimDigiCollection> ecalTPSourceRecd_;
   std::string ecalTPSourceRecdLabel_;
@@ -103,88 +211,6 @@ private:
   std::string histFolder_;
   int tpFillThreshold_;
   bool ignoreHFfbs_;
-
-  MonitorElement *ecalDiscrepancy_;
-  MonitorElement *ecalLinkError_;
-  MonitorElement *ecalOccupancy_;
-  MonitorElement *hcalDiscrepancy_;
-  MonitorElement *hcalLinkError_;
-  MonitorElement *hcalOccupancy_;
-
-  MonitorElement *ecalOccEtDiscrepancy_;
-  MonitorElement *ecalOccFgDiscrepancy_;
-  MonitorElement *ecalOccLinkMasked_;
-  MonitorElement *ecalOccRecdEtWgt_;
-  MonitorElement *ecalOccRecdFgVB_;
-  MonitorElement *ecalOccSentAndRecd_;
-  MonitorElement *ecalOccSentFgVB_;
-  MonitorElement *ecalOccSent_;
-  MonitorElement *ecalOccTowerMasked_;
-  MonitorElement *ecalTPRawEtCorrelation_;
-  MonitorElement *ecalTPRawEtDiffNoMatch_;
-  MonitorElement *ecalTPRawEtRecd_;
-  MonitorElement *ecalTPRawEtSentAndRecd_;
-  MonitorElement *ecalTPRawEtSent_;
-
-  MonitorElement *ecalOccSentNotRecd_;
-  MonitorElement *ecalOccRecdNotSent_;
-  MonitorElement *ecalOccNoMatch_;
-
-  MonitorElement *hcalOccEtDiscrepancy_;
-  MonitorElement *hcalOccFbDiscrepancy_;
-  MonitorElement *hcalOccFb2Discrepancy_;
-  MonitorElement *hcalOccLinkMasked_;
-  MonitorElement *hcalOccRecdEtWgt_;
-  MonitorElement *hcalOccRecdFb_;
-  MonitorElement *hcalOccRecdFb2_;
-  MonitorElement *hcalOccSentAndRecd_;
-  MonitorElement *hcalOccSentFb_;
-  MonitorElement *hcalOccSentFb2_;
-  MonitorElement *hcalOccSent_;
-  MonitorElement *hcalOccTowerMasked_;
-  MonitorElement *hcalTPRawEtCorrelationHBHE_;
-  MonitorElement *hcalTPRawEtCorrelationHF_;
-  MonitorElement *hcalTPRawEtDiffNoMatch_;
-  MonitorElement *hcalTPRawEtRecd_;
-  MonitorElement *hcalTPRawEtSentAndRecd_;
-  MonitorElement *hcalTPRawEtSent_;
-
-  MonitorElement *hcalOccSentNotRecd_;
-  MonitorElement *hcalOccRecdNotSent_;
-  MonitorElement *hcalOccNoMatch_;
-
-  MonitorElement *last20Mismatches_;
-  std::array<std::pair<std::string, int>, 20> last20MismatchArray_;
-  size_t lastMismatchIndex_{0};
-
-  MonitorElement *ecalLinkErrorByLumi_;
-  MonitorElement *ecalMismatchByLumi_;
-  MonitorElement *hcalLinkErrorByLumi_;
-  MonitorElement *hcalMismatchByLumi_;
-
-  MonitorElement *maxEvtLinkErrorsByLumiECAL_;
-  MonitorElement *maxEvtLinkErrorsByLumiHCAL_;
-  MonitorElement *maxEvtLinkErrorsByLumi_;
-  int maxEvtLinkErrorsECALCurrentLumi_{0};
-  int maxEvtLinkErrorsHCALCurrentLumi_{0};
-
-  MonitorElement *maxEvtMismatchByLumiECAL_;
-  MonitorElement *maxEvtMismatchByLumiHCAL_;
-  MonitorElement *maxEvtMismatchByLumi_;
-  int maxEvtMismatchECALCurrentLumi_{0};
-  int maxEvtMismatchHCALCurrentLumi_{0};
-
-  MonitorElement *ECALmismatchesPerBx_;
-  MonitorElement *HBHEmismatchesPerBx_;
-  MonitorElement *HFmismatchesPerBx_;
-
-  MonitorElement *bxidErrors_;
-  MonitorElement *l1idErrors_;
-  MonitorElement *orbitErrors_;
-
-  // Prevent reallocation per event
-  std::vector<std::pair<EcalTriggerPrimitiveDigi, EcalTriggerPrimitiveDigi> > ecalTPSentRecd_;
-  std::vector<std::pair<HcalTriggerPrimitiveDigi, HcalTriggerPrimitiveDigi> > hcalTPSentRecd_;
 };
 
 #endif

--- a/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
+++ b/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
@@ -276,6 +276,58 @@ private:
 };
 DEFINE_FWK_MODULE(TestDQMGlobalEDAnalyzer);
 
+class TestDQMGlobalRunSummaryEDAnalyzer : public DQMGlobalRunSummaryEDAnalyzer<TestHistograms, int> {
+public:
+  explicit TestDQMGlobalRunSummaryEDAnalyzer(const edm::ParameterSet& iConfig)
+      : folder_(iConfig.getParameter<std::string>("folder")),
+        howmany_(iConfig.getParameter<int>("howmany")),
+        myvalue_(iConfig.getParameter<double>("value")) {}
+  ~TestDQMGlobalRunSummaryEDAnalyzer() override{};
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("folder", "Global/testglobal")->setComment("Where to put all the histograms");
+    desc.add<int>("howmany", 1)->setComment("How many copies of each ME to put");
+    desc.add<double>("value", 1)->setComment("Which value to use on the third axis (first two are lumi and run)");
+    descriptions.add("testglobalrunsummary", desc);
+  }
+
+private:
+  std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+    return std::make_shared<int>(0);
+  }
+
+  void bookHistograms(DQMStore::IBooker& ibooker,
+                      edm::Run const&,
+                      edm::EventSetup const&,
+                      TestHistograms& h) const override {
+    h.folder = this->folder_;
+    h.howmany = this->howmany_;
+    h.bookall(ibooker);
+  }
+
+  void dqmAnalyze(edm::Event const& iEvent, edm::EventSetup const&, TestHistograms const& h) const override {
+    h.fillall(iEvent.luminosityBlock(), iEvent.run(), myvalue_);
+  }
+
+  void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int* runSummaryCache) const override {
+    (*runSummaryCache) += 1;
+  }
+
+  void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int* runSummaryCache) const override {}
+
+  void dqmEndRun(edm::Run const& run,
+                 edm::EventSetup const& setup,
+                 TestHistograms const& h,
+                 int const& runSummaryCache) const override {}
+
+private:
+  std::string folder_;
+  int howmany_;
+  double myvalue_;
+};
+DEFINE_FWK_MODULE(TestDQMGlobalRunSummaryEDAnalyzer);
+
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 class TestLegacyEDAnalyzer : public edm::EDAnalyzer {
 public:

--- a/DQMServices/Demo/test/run_analyzers_cfg.py
+++ b/DQMServices/Demo/test/run_analyzers_cfg.py
@@ -10,11 +10,13 @@ process.load("DQMServices.Demo.testonefillrun_cfi")
 process.load("DQMServices.Demo.testonelumi_cfi")
 process.load("DQMServices.Demo.testonelumifilllumi_cfi")
 process.load("DQMServices.Demo.testglobal_cfi")
+process.load("DQMServices.Demo.testglobalrunsummary_cfi")
 process.load("DQMServices.Demo.testlegacy_cfi")
 process.load("DQMServices.Demo.testlegacyfillrun_cfi")
 process.load("DQMServices.Demo.testlegacyfilllumi_cfi")
 process.test_general = cms.Sequence(process.test 
-                                  + process.testglobal)
+                                  + process.testglobal
+                                  + process.testglobalrunsummary)
 process.test_one     = cms.Sequence(process.testone
                                   + process.testonefillrun)
 process.test_legacy  = cms.Sequence(process.testonelumi + process.testonelumifilllumi
@@ -71,7 +73,7 @@ process.options = cms.untracked.PSet(
 if args.nConcurrent > 1:
   process.DQMStore.assertLegacySafe = cms.untracked.bool(False)
 
-for mod in [process.test, process.testglobal, process.testone, process.testonefillrun, process.testonelumi, process.testonelumifilllumi, process.testlegacy, process.testlegacyfillrun, process.testlegacyfilllumi]:
+for mod in [process.test, process.testglobal, process.testglobalrunsummary, process.testone, process.testonefillrun, process.testonelumi, process.testonelumifilllumi, process.testlegacy, process.testlegacyfillrun, process.testlegacyfilllumi]:
   mod.howmany = args.howmany
 
 if args.noone:

--- a/DQMServices/Demo/test/runtests.sh
+++ b/DQMServices/Demo/test/runtests.sh
@@ -19,7 +19,7 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=alltypes.root numberEventsIn
 # the scalar MEs should have the last lumi number (5) (5 float + 5 int)
 # testonefilllumi also should have 5 entries in the histograms (9 more)
 # the "fillrun" module should have one entry in the histograms (9 total) and 0 in the scalars (2 total)
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 27, 200: 9, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
 # per lumi we see 20 in most histograms (4*9), and the current lumi number in the scalars (6 modules * 2).
 # the two fillumi modules should have one entry in each of the lumi histograms, (2*9 total)
 [ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 1 --summary)" ]
@@ -42,7 +42,7 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=nolegacy-cl.root numberEvent
 # same math as above, just a few less modules, and more events.
 for f in nolegacy.root nolegacy-mt.root nolegacy-cl.root
 do
-  [ "0: 1, 0.0: 1, 1: 9, 1000: 27, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
+  [ "0: 1, 0.0: 1, 1: 9, 1000: 18, 2000: 9, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
   [ "1: 2, 1.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 1 --summary)" ]
   [ "2: 2, 2.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 2 --summary)" ]
   [ "200: 18, 3: 2, 3.0: 2" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 3 --summary)" ]
@@ -135,7 +135,7 @@ cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py outfile=edmtome.root inputFiles=met
 [ 66 = $(dqmiolistmes.py edmtome.root -r 1 | wc -l) ]
 [ 66 = $(dqmiolistmes.py edmtome.root -r 1 -l 1 | wc -l) ]
 # again, no legacy module (run) output here due to JOB scope for legacy modules
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 27, 200: 9, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
 [ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 1 --summary)" ]
 [ "1: 18, 2: 6, 2.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 2 --summary)" ]
 [ "1: 18, 20: 36, 3: 6, 3.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 3 --summary)" ]


### PR DESCRIPTION
#### PR description:

This PR modifies the CaloL1 DQM online module to become "Global" format to comply with the concurrent LS processing introduced for offline DQM as a part of #25090. This module preserves all monitoring elements (and therefore summary tests) by use of maps containing relevant luminosity block information as part of a CaloL1 namespace structure used as a part of the run cache. This PR should make PR #31678 obsolete.

#### PR validation:

All code compiles, and I have checked that a min bias data workflow reproduces the same histograms between the old online module and new online module. I have also verified that error plots between the old and new version of the online module yield the same error information in the same way by comparing on Run 315273 (a 2018 HI run with HCAL mismatches at CaloL1). Online monitoring should remain unchanged. As well, the PR seems to pass the basic test procedure suggested in the CMSSW PR instructions.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport