### PR TITLE
modernize Alignment/OfflineValidation: migration to esConsumes

### DIFF
--- a/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
+++ b/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
@@ -33,9 +33,8 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -58,7 +57,7 @@
 // class decleration
 //
 
-class CosmicSplitterValidation : public edm::EDAnalyzer {
+class CosmicSplitterValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit CosmicSplitterValidation(const edm::ParameterSet&);
   ~CosmicSplitterValidation() override;
@@ -414,6 +413,7 @@ CosmicSplitterValidation::CosmicSplitterValidation(const edm::ParameterSet& iCon
       phiErr_orm_(0),
       ptErr_orm_(0),
       qoverptErr_orm_(0) {
+  usesResource(TFileService::kSharedResource);
   edm::ConsumesCollector&& iC = consumesCollector();
   splitTracksToken_ = iC.consumes<std::vector<reco::Track>>(splitTracks_);
   originalTracksToken_ = iC.consumes<std::vector<reco::Track>>(originalTracks_);

--- a/Alignment/OfflineValidation/plugins/DMRChecker.cc
+++ b/Alignment/OfflineValidation/plugins/DMRChecker.cc
@@ -494,11 +494,10 @@ private:
     event.getByToken(theTrackCollectionToken, trackCollection);
 
     // magnetic field setup
-    edm::ESHandle<MagneticField> magneticField_ = setup.getHandle(magFieldToken_);
-    float B_ = magneticField_.product()->inTesla(GlobalPoint(0, 0, 0)).mag();
+    const MagneticField *magneticField_ = &setup.getData(magFieldToken_);
+    float B_ = magneticField_->inTesla(GlobalPoint(0, 0, 0)).mag();
 
-    edm::ESHandle<RunInfo> runInfo = setup.getHandle(runInfoToken_);
-    const RunInfo *summary = runInfo.product();
+    const RunInfo *summary = &setup.getData(runInfoToken_);
     time_t start_time = summary->m_start_time_ll;
     ctime(&start_time);
     time_t end_time = summary->m_stop_time_ll;
@@ -511,15 +510,14 @@ private:
       << " end_time "   << end_time   << "( " << summary->m_stop_time_str  <<" )" << std::endl;
     */
 
-    double seconds = difftime(end_time, start_time) / 1.0e+6;
+    double seconds = difftime(end_time, start_time) / 1.0e+6;  // convert from micros-seconds
     //edm::LogVerbatim("DMRChecker")<<" diff: "<< seconds << "s" << std::endl;
     timeMap_[event.run()] = seconds;
 
     // topology setup
-    edm::ESHandle<TrackerTopology> tTopoHandle = setup.getHandle(topoToken_);
-    const TrackerTopology *const tTopo = tTopoHandle.product();
+    const TrackerTopology *const tTopo = &setup.getData(topoToken_);
 
-    edm::ESHandle<SiStripLatency> apvlat = setup.getHandle(latencyToken_);
+    const SiStripLatency *apvlat = &setup.getData(latencyToken_);
     if (apvlat->singleReadOutMode() == 1) {
       mode = 1;  // peak mode
     } else if (apvlat->singleReadOutMode() == 0) {
@@ -530,8 +528,7 @@ private:
     conditionsMap_[event.run()].second = B_;
 
     // geometry setup
-    edm::ESHandle<TrackerGeometry> geometry = setup.getHandle(geomToken_);
-    const TrackerGeometry *theGeometry = &(*geometry);
+    const TrackerGeometry *theGeometry = &setup.getData(geomToken_);
 
     if (firstEvent_) {
       if (theGeometry->isThere(GeomDetEnumerators::P2PXB) || theGeometry->isThere(GeomDetEnumerators::P2PXEC)) {
@@ -620,7 +617,7 @@ private:
           // fill DMRs and DrNRs
           if (subid == StripSubdetector::TIB) {
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
-            vOrientation = gVDirection.z() - gPModule.z() >= 0 ? +1.F : -1.F;
+            //vOrientation = gVDirection.z() - gPModule.z() >= 0 ? +1.F : -1.F; // not used for Strips
 
             // if the detid has never occcurred yet, set the local orientations
             if (resDetailsTIB_.find(detid_db) == resDetailsTIB_.end()) {
@@ -637,7 +634,7 @@ private:
 
           } else if (subid == StripSubdetector::TOB) {
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
-            vOrientation = gVDirection.z() - gPModule.z() >= 0 ? +1.F : -1.F;
+            //vOrientation = gVDirection.z() - gPModule.z() >= 0 ? +1.F : -1.F; // not used for Strips
 
             hTOBResXPrime->Fill(uOrientation * resX * 10000);
             hTOBResXPull->Fill(pullX);
@@ -654,7 +651,7 @@ private:
 
           } else if (subid == StripSubdetector::TID) {
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
-            vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F;
+            //vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F; // not used for Strips
 
             hTIDResXPrime->Fill(uOrientation * resX * 10000);
             hTIDResXPull->Fill(pullX);
@@ -664,7 +661,7 @@ private:
 
           } else if (subid == StripSubdetector::TEC) {
             uOrientation = deltaPhi(gUDirection.barePhi(), gPModule.barePhi()) >= 0. ? +1.F : -1.F;
-            vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F;
+            //vOrientation = gVDirection.perp() - gPModule.perp() >= 0. ? +1.F : -1.F; // not used for Strips
 
             hTECResXPrime->Fill(uOrientation * resX * 10000);
             hTECResXPull->Fill(pullX);
@@ -1874,11 +1871,9 @@ private:
       }
 
       unsigned int side = -1;
-      unsigned int plane = i;
-
       if (detType.find("FPix") != std::string::npos) {
         side = (i - 1) / 3 + 1;
-        plane = (i - 1) % 3 + 1;
+        unsigned int plane = (i - 1) % 3 + 1;
 
         std::string theSide = "";
         if (side == 1) {

--- a/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
+++ b/Alignment/OfflineValidation/plugins/EopTreeWriter.cc
@@ -19,11 +19,10 @@
 
 // framework include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -65,7 +64,7 @@
 // class decleration
 //
 
-class EopTreeWriter : public edm::EDAnalyzer {
+class EopTreeWriter : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   explicit EopTreeWriter(const edm::ParameterSet&);
   ~EopTreeWriter() override;
@@ -101,6 +100,7 @@ private:
 //
 EopTreeWriter::EopTreeWriter(const edm::ParameterSet& iConfig)
     : src_(iConfig.getParameter<edm::InputTag>("src")), geometryToken_(esConsumes()) {
+  usesResource(TFileService::kSharedResource);
   //now do what ever initialization is needed
 
   // TrackAssociator parameters

--- a/Alignment/OfflineValidation/plugins/MuonAlignmentAnalyzer.h
+++ b/Alignment/OfflineValidation/plugins/MuonAlignmentAnalyzer.h
@@ -13,17 +13,20 @@
  */
 
 // Base Class Headers
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "TrackingTools/GeomPropagators/interface/Propagator.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include <vector>
 
 namespace edm {
@@ -37,7 +40,7 @@ class TH2F;
 typedef std::vector<std::vector<int> > intDVector;
 typedef std::vector<TrackingRecHit *> RecHitVector;
 
-class MuonAlignmentAnalyzer : public edm::EDAnalyzer {
+class MuonAlignmentAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   /// Constructor
   MuonAlignmentAnalyzer(const edm::ParameterSet &pset);
@@ -54,6 +57,8 @@ public:
 
 protected:
 private:
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeometryToken_;
   RecHitVector doMatching(const reco::Track &,
                           edm::Handle<DTRecSegment4DCollection> &,
                           edm::Handle<CSCSegmentCollection> &,

--- a/Alignment/OfflineValidation/plugins/ResidualRefitting.h
+++ b/Alignment/OfflineValidation/plugins/ResidualRefitting.h
@@ -14,7 +14,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
@@ -36,7 +36,7 @@
 
 class TrackerTopology;
 
-class ResidualRefitting : public edm::EDAnalyzer {
+class ResidualRefitting : public edm::one::EDAnalyzer<> {
   static const int N_MAX_STORED = 10;
   static const int N_MAX_STORED_HIT = 1000;
 
@@ -320,6 +320,11 @@ public:
                          ResidualRefitting::storage_muon& storeTrk,
                          ResidualRefitting::storage_trackExtrap& storeExtrap,
                          int omitSystem);
+
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> trackingGeometryToken_;
+  const edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
 
   // output histogram file name
   std::string outputFileName_;

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -30,6 +30,7 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -1080,7 +1081,7 @@ statmode::fitParams SplitVertexResolution::fitResiduals(TH1* hist, bool singleTi
   float mean = hist->GetMean();
   float sigma = hist->GetRMS();
 
-  if (TMath::IsNaN(mean) || TMath::IsNaN(sigma)) {
+  if (edm::isNotFinite(mean) || edm::isNotFinite(sigma)) {
     mean = 0;
     //sigma= - hist->GetXaxis()->GetBinLowEdge(1) + hist->GetXaxis()->GetBinLowEdge(hist->GetNbinsX()+1);
     sigma = -minHist + maxHist;

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.h
@@ -5,15 +5,6 @@
  *
  * Module that reads survey info from DB and prints them out.
  *
- * Usage:
- *   module comparator = TrackerGeometryCompare {
- *
- *   lots of stuff  
- *
- *   }
- *   path p = { comparator }
- *
- *
  *  $Date: 2012/12/02 22:13:12 $
  *  $Revision: 1.14 $
  *  \author Nhan Tran
@@ -24,7 +15,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Alignment/TrackerAlignment/interface/AlignableTracker.h"
@@ -37,6 +28,9 @@
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 //***************************************************
 
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "DetectorDescription/Core/interface/DDCompactView.h"
+
 #include <algorithm>
 #include <string>
 #include "TTree.h"
@@ -45,7 +39,7 @@
 class AlignTransform;
 class TrackerTopology;
 
-class TrackerGeometryCompare : public edm::EDAnalyzer {
+class TrackerGeometryCompare : public edm::one::EDAnalyzer<> {
 public:
   typedef AlignTransform SurveyValue;
   typedef Alignments SurveyValues;
@@ -90,6 +84,14 @@ private:
   void setCommonTrackerSystem();
   void diffCommonTrackerSystem(Alignable* refAli, Alignable* curAli);
   bool passIdCut(uint32_t);
+
+  const edm::ESGetToken<DDCompactView, IdealGeometryRecord> cpvTokenDDD_;
+  const edm::ESGetToken<cms::DDCompactView, IdealGeometryRecord> cpvTokenDD4Hep_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<SiPixelQuality, SiPixelQualityRcd> pixQualityToken_;
+  const edm::ESGetToken<SiStripQuality, SiStripQualityRcd> stripQualityToken_;
 
   AlignableTracker* referenceTracker;
   AlignableTracker* dummyTracker;

--- a/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryIntoNtuples.cc
@@ -23,7 +23,7 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -33,9 +33,9 @@
 #include "TTree.h"
 #include "TFile.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 
 #include "CondFormats/Alignment/interface/DetectorGlobalPosition.h"
 #include "CondFormats/Alignment/interface/Alignments.h"
@@ -71,7 +71,7 @@
 // class decleration
 //
 
-class TrackerGeometryIntoNtuples : public edm::EDAnalyzer {
+class TrackerGeometryIntoNtuples : public edm::one::EDAnalyzer<> {
 public:
   explicit TrackerGeometryIntoNtuples(const edm::ParameterSet&);
   ~TrackerGeometryIntoNtuples() override;
@@ -82,6 +82,14 @@ private:
   void addBranches();
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrorToken_;
+  const edm::ESGetToken<AlignmentSurfaceDeformations, TrackerSurfaceDeformationRcd> surfDefToken_;
+  const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
+
   //std::vector<AlignTransform> m_align;
   AlignableTracker* theCurrentTracker;
 
@@ -121,7 +129,14 @@ private:
 // constructors and destructor
 //
 TrackerGeometryIntoNtuples::TrackerGeometryIntoNtuples(const edm::ParameterSet& iConfig)
-    : theCurrentTracker(nullptr),
+    : topoToken_(esConsumes()),
+      geomDetToken_(esConsumes()),
+      ptpToken_(esConsumes()),
+      aliToken_(esConsumes()),
+      aliErrorToken_(esConsumes()),
+      surfDefToken_(esConsumes()),
+      gprToken_(esConsumes()),
+      theCurrentTracker(nullptr),
       m_rawid(0),
       m_x(0.),
       m_y(0.),
@@ -162,37 +177,29 @@ TrackerGeometryIntoNtuples::~TrackerGeometryIntoNtuples() { delete theCurrentTra
 // ------------ method called to for each event  ------------
 void TrackerGeometryIntoNtuples::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
 
   edm::LogInfo("beginJob") << "Begin Job";
 
   //accessing the initial geometry
-  edm::ESHandle<GeometricDet> theGeometricDet;
-  iSetup.get<IdealGeometryRecord>().get(theGeometricDet);
-  edm::ESHandle<PTrackerParameters> ptp;
-  iSetup.get<PTrackerParametersRcd>().get(ptp);
+  const GeometricDet* theGeometricDet = &iSetup.getData(geomDetToken_);
+  const PTrackerParameters* ptp = &iSetup.getData(ptpToken_);
+
   TrackerGeomBuilderFromGeometricDet trackerBuilder;
   //currernt tracker
-  TrackerGeometry* theCurTracker = trackerBuilder.build(&*theGeometricDet, *ptp, tTopo);
+  TrackerGeometry* theCurTracker = trackerBuilder.build(theGeometricDet, *ptp, tTopo);
 
   //build the tracker
-  edm::ESHandle<Alignments> alignments;
-  edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  edm::ESHandle<AlignmentSurfaceDeformations> surfaceDeformations;
-
-  iSetup.get<TrackerAlignmentRcd>().get(alignments);
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
-  iSetup.get<TrackerSurfaceDeformationRcd>().get(surfaceDeformations);
+  const Alignments* alignments = &iSetup.getData(aliToken_);
+  const AlignmentErrorsExtended* alignmentErrors = &iSetup.getData(aliErrorToken_);
+  const AlignmentSurfaceDeformations* surfaceDeformations = &iSetup.getData(surfDefToken_);
 
   //apply the latest alignments
-  edm::ESHandle<Alignments> globalPositionRcd;
-  iSetup.get<TrackerDigiGeometryRecord>().getRecord<GlobalPositionRcd>().get(globalPositionRcd);
+  const Alignments* globalPositionRcd = &iSetup.getData(gprToken_);
   GeometryAligner aligner;
   aligner.applyAlignments<TrackerGeometry>(&(*theCurTracker),
-                                           &(*alignments),
-                                           &(*alignmentErrors),
+                                           alignments,
+                                           alignmentErrors,
                                            align::DetectorGlobalPosition(*globalPositionRcd, DetId(DetId::Tracker)));
   aligner.attachSurfaceDeformations<TrackerGeometry>(&(*theCurTracker), &(*surfaceDeformations));
 

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -40,7 +40,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -75,7 +75,7 @@
 //
 // class declaration
 //
-class TrackerOfflineValidation : public edm::EDAnalyzer {
+class TrackerOfflineValidation : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   typedef dqm::legacy::DQMStore DQMStore;
   explicit TrackerOfflineValidation(const edm::ParameterSet&);
@@ -94,6 +94,9 @@ public:
   };
 
 private:
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+
   struct ModuleHistos {
     ModuleHistos()
         : ResHisto(),
@@ -468,7 +471,9 @@ TH1* TrackerOfflineValidation::DirectoryWrapper::make<TH2F>(const char* name,
 // constructors and destructor
 //
 TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iConfig)
-    : parSet_(iConfig),
+    : geomToken_(esConsumes()),
+      topoToken_(esConsumes()),
+      parSet_(iConfig),
       bareTkGeomPtr_(nullptr),
       lCoorHistOn_(parSet_.getParameter<bool>("localCoorHistosOn")),
       moduleLevelHistsTransient_(parSet_.getParameter<bool>("moduleLevelHistsTransient")),
@@ -482,7 +487,9 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
       chargeCut_(parSet_.getParameter<int>("chargeCut")),
       nTracks_(0),
       maxTracks_(parSet_.getParameter<unsigned long long>("maxTracks")),
-      avalidator_(iConfig, consumesCollector()) {}
+      avalidator_(iConfig, consumesCollector()) {
+  usesResource(TFileService::kSharedResource);
+}
 
 TrackerOfflineValidation::~TrackerOfflineValidation() {
   // do anything here that needs to be done at desctruction time
@@ -497,17 +504,16 @@ TrackerOfflineValidation::~TrackerOfflineValidation() {
 
 // ------------ method called once each job just before starting event loop  ------------
 void TrackerOfflineValidation::checkBookHists(const edm::EventSetup& es) {
-  es.get<TrackerDigiGeometryRecord>().get(tkGeom_);
+  tkGeom_ = es.getHandle(geomToken_);
   const TrackerGeometry* newBareTkGeomPtr = &(*tkGeom_);
+
   if (newBareTkGeomPtr == bareTkGeomPtr_)
     return;  // already booked hists, nothing changed
 
   if (!bareTkGeomPtr_) {  // pointer not yet set: called the first time => book hists
 
     //Retrieve tracker topology from geometry
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    es.get<TrackerTopologyRcd>().get(tTopoHandle);
-    const TrackerTopology* const tTopo = tTopoHandle.product();
+    const TrackerTopology* const tTopo = &es.getData(topoToken_);
 
     // construct alignable tracker to get access to alignable hierarchy
     alignableTracker_ = std::make_unique<AlignableTracker>(&(*tkGeom_), tTopo);

--- a/Alignment/OfflineValidation/plugins/Tracker_OldtoNewConverter.cc
+++ b/Alignment/OfflineValidation/plugins/Tracker_OldtoNewConverter.cc
@@ -18,7 +18,7 @@
 //
 
 // system include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -35,7 +35,7 @@
 // class decleration
 //
 
-class Tracker_OldtoNewConverter : public edm::EDAnalyzer {
+class Tracker_OldtoNewConverter : public edm::one::EDAnalyzer<> {
 public:
   explicit Tracker_OldtoNewConverter(const edm::ParameterSet&);
   ~Tracker_OldtoNewConverter() override;

--- a/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.h
+++ b/Alignment/OfflineValidation/plugins/ValidationMisalignedTracker.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 
 //
@@ -16,6 +16,10 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 #include "TTree.h"
 #include "TFile.h"
@@ -30,7 +34,7 @@
 // class decleration
 //
 
-class ValidationMisalignedTracker : public edm::EDAnalyzer {
+class ValidationMisalignedTracker : public edm::one::EDAnalyzer<> {
 public:
   explicit ValidationMisalignedTracker(const edm::ParameterSet&);
   ~ValidationMisalignedTracker() override;
@@ -40,6 +44,9 @@ private:
   void endJob() override;
 
   // ----------member data ---------------------------
+
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
 
   std::string simobject, trackassociator;
   bool selection_eff, selection_fake, ZmassSelection_;
@@ -88,7 +95,6 @@ private:
   double chi2tmp;
   float fractiontmp;
   bool onlyDiag;
-  edm::ESHandle<MagneticField> theMF;
   std::vector<std::string> associators;
 
   std::vector<edm::InputTag> label;


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to modernize the `Alignment/OfflineValidation` subsystem, points addressed are:
 * remove legacy `EDModules` types,
 * esConsumes migration:  part of #31061
 * remove few other static analyzer warnings.

#### PR validation:

Branch compiles and run the unit tests successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed.
