### PR TITLE
Make SiPixelStatusProducer a stream EDProducer for concurrent lumiblock processing

### DIFF
--- a/CalibTracker/SiPixelQuality/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/BuildFile.xml
@@ -1,11 +1,23 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="DataFormats/SiPixelDetId"/>
+<use name="CondFormats/SiPixelObjects"/>
 <use name="DataFormats/Common"/>
+<use name="DataFormats/DetId"/>
+<use name="DataFormats/FEDRawData"/>
 <use name="DataFormats/Provenance"/>
+<use name="DataFormats/SiPixelCluster"/>
+<use name="DataFormats/SiPixelDetId"/>
+<use name="DataFormats/SiPixelDigi"/>
+<use name="DataFormats/TrackerCommon"/>
+<use name="DataFormats/TrackerRecHit2D"/>
+<use name="DataFormats/TrackingRecHit"/>
+<use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>
-<use name="clhep"/>
-<use name="root"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/CommonDetUnit"/>
+<use name="Geometry/CommonTopologies"/>
+<use name="Geometry/TrackerGeometryBuilder"/>
+<use name="rootcling"/>
+<use name="rootrflx"/>
 <export>
   <lib name="1"/>
 </export>
+

--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -13,85 +13,78 @@ public:
   SiPixelDetectorStatus();
   ~SiPixelDetectorStatus();
 
+  // reset
+  void resetDetectorStatus();
+  // combine detector status
+  void updateDetectorStatus(SiPixelDetectorStatus newData);
+
   // file I/O
   void readFromFile(std::string filename);
   void dumpToFile(std::string filename);
+
+  /*|||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
 
   // add SiPixelModuleStatus for detID, specifying nrocs
   void addModule(int detid, int nrocs);
   // add a SiPixelModuleStatus obj for detID
   void addModule(int detid, SiPixelModuleStatus a);
+  // get a Module
+  bool findModule(int detid);
+  SiPixelModuleStatus* getModule(int detid);
 
   // fill hit in double idc in ROC roc into module detid
   void fillDIGI(int detid, int roc);
   // fill FEDerror25 info
   void fillFEDerror25(int detid, PixelFEDChannel ch);
 
-  std::map<int, std::vector<int>> getFEDerror25Rocs();
 
+  // detector status : std:map - collection of module status
+  std::map<int, SiPixelModuleStatus> getDetectorStatus() { return fModules_; }
+  // list of ROCs with FEDerror25
+  std::map<int, std::vector<int>> getFEDerror25Rocs();
+  // total number of DIGIs
+  unsigned long int digiOccDET() { return fDetHits_; }
+  // total processed events
+  void setNevents(unsigned long int N) { ftotalevents_ = N; }
+  unsigned long int getNevents() { return ftotalevents_; }
+
+  // number of modules in detector
+  int nmodules();
   // determine detector average nhits and RMS
   double perRocDigiOcc();
   double perRocDigiOccVar();
 
-  unsigned long int digiOccDET() { return fDetHits; }
 
-  // number of modules in detector
-  int nmodules();
+  // set the time stamps
+  void setRunRange(int run0, int run1) {
+    fRun0_ = run0;
+    fRun1_ = run1;
+  }
+  std::pair<int, int> getRunRange() { return std::make_pair(fRun0_, fRun1_); }
+  //////////////////////////////////////////////////////////////////////////////////
+  void setLSRange(int ls0, int ls1) { fLS0_ = ls0; fLS1_ = ls1; }
+  std::pair<int, int> getLSRange() { return std::make_pair(fLS0_, fLS1_); }
 
-  // get a Module
-  bool findModule(int detid);
-  SiPixelModuleStatus* getModule(int detid);
 
   // provide for iterating over the entire detector
   std::map<int, SiPixelModuleStatus>::iterator begin();
   std::map<int, SiPixelModuleStatus>::iterator next();
   std::map<int, SiPixelModuleStatus>::iterator end();
 
-  // set the time stamps
-  void setRunRange(int run0, int run1) {
-    fRun0 = run0;
-    fRun1 = run1;
-  }
-  std::pair<int, int> getRunRange() { return std::make_pair(fRun0, fRun1); }
-  void setLSRange(int ls0, int ls1) {
-    fLS0 = ls0;
-    fLS1 = ls1;
-  }
-  std::pair<int, int> getLSRange() { return std::make_pair(fLS0, fLS1); }
-
-  // total processed events
-  void setNevents(unsigned long int N) { fNevents = N; }
-  unsigned long int getNevents() { return fNevents; }
-
-  void resetDetectorStatus() {
-    fModules.clear();
-    fDetHits = 0;
-    fNevents = 0;
-    fRun0 = 99999999;
-    fRun1 = 0;
-    fLS0 = 99999999;
-    fLS1 = 0;
-  }
-
-  // combine detector status
-  void updateDetectorStatus(SiPixelDetectorStatus newData);
-
-  // detector status
-  std::map<int, SiPixelModuleStatus> getDetectorStatus() { return fModules; }
-
 private:
-  std::map<int, SiPixelModuleStatus> fModules;
+
+  std::map<int, SiPixelModuleStatus> fModules_;
 
   // first and last lumisection seen in this instance
-  int fLS0, fLS1;
-  // first and last run seen in this instance (should be the same number!)
-  int fRun0, fRun1;
+  int fLS0_, fLS1_;
+  // first and last run (should be the same number! as currently only perform Single Run Harvestor)
+  int fRun0_, fRun1_;
 
   // number of events processed
-  unsigned long int fNevents;
+  unsigned long int ftotalevents_;
 
   // total hits in detector
-  unsigned long int fDetHits;
+  unsigned long int fDetHits_;
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -37,7 +37,6 @@ public:
   // fill FEDerror25 info
   void fillFEDerror25(int detid, PixelFEDChannel ch);
 
-
   // detector status : std:map - collection of module status
   std::map<int, SiPixelModuleStatus> getDetectorStatus() { return fModules_; }
   // list of ROCs with FEDerror25
@@ -54,7 +53,6 @@ public:
   double perRocDigiOcc();
   double perRocDigiOccVar();
 
-
   // set the time stamps
   void setRunRange(int run0, int run1) {
     fRun0_ = run0;
@@ -62,9 +60,11 @@ public:
   }
   std::pair<int, int> getRunRange() { return std::make_pair(fRun0_, fRun1_); }
   //////////////////////////////////////////////////////////////////////////////////
-  void setLSRange(int ls0, int ls1) { fLS0_ = ls0; fLS1_ = ls1; }
+  void setLSRange(int ls0, int ls1) {
+    fLS0_ = ls0;
+    fLS1_ = ls1;
+  }
   std::pair<int, int> getLSRange() { return std::make_pair(fLS0_, fLS1_); }
-
 
   // provide for iterating over the entire detector
   std::map<int, SiPixelModuleStatus>::iterator begin();
@@ -72,7 +72,6 @@ public:
   std::map<int, SiPixelModuleStatus>::iterator end();
 
 private:
-
   std::map<int, SiPixelModuleStatus> fModules_;
 
   // first and last lumisection seen in this instance

--- a/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h
@@ -20,7 +20,7 @@ public:
 
   // file I/O
   void readFromFile(std::string filename);
-  void dumpToFile(std::string filename);
+  void dumpToFile(std::ofstream& outFile);
 
   /*|||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
@@ -9,20 +9,24 @@
 // ----------------------------------------------------------------------
 class SiPixelModuleStatus {
 public:
-  SiPixelModuleStatus(int det = 0, int nrocs = 16);
+  SiPixelModuleStatus(int det = 0, int nrocs = 16); // default for Phase-1
   ~SiPixelModuleStatus();
 
-  /// fill with online coordinates
+  /// fill digi
   void fillDIGI(int iroc);
-
-  /// fill with online coordinates (nhit > 1)
-  void updateDIGI(int iroc, unsigned int nhit);
-
   /// fill FEDerror25
   void fillFEDerror25(PixelFEDChannel ch);
 
+  /// update digi (nhit > 1)
+  void updateDIGI(int iroc, unsigned int nhit);
+  /// update FEDerror25
+  void updateFEDerror25(int iroc, bool FEDerror25);
+
   /// return ROC status (= hits on ROC iroc)
   unsigned int digiOccROC(int iroc);
+
+  /// return ROC FEDerror25
+  bool fedError25(int iroc);
 
   /// return module status (= hits on module)
   unsigned int digiOccMOD();
@@ -33,6 +37,7 @@ public:
   /// accessors and setters
   int detid();
   int nrocs();
+  void setDetId(int detid);
   void setNrocs(int iroc);
 
   /// calculate (averaged over this module's ROCs) mean hit number and its sigma
@@ -44,8 +49,9 @@ public:
   void updateModuleStatus(SiPixelModuleStatus newData);
 
 private:
-  int fDetid, fNrocs;
-  std::vector<SiPixelRocStatus> fRocs;
+  int fDetid_, fNrocs_;
+  std::vector<SiPixelRocStatus> fRocs_;
+
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h
@@ -9,7 +9,7 @@
 // ----------------------------------------------------------------------
 class SiPixelModuleStatus {
 public:
-  SiPixelModuleStatus(int det = 0, int nrocs = 16); // default for Phase-1
+  SiPixelModuleStatus(int det = 0, int nrocs = 16);  // default for Phase-1
   ~SiPixelModuleStatus();
 
   /// fill digi
@@ -51,7 +51,6 @@ public:
 private:
   int fDetid_, fNrocs_;
   std::vector<SiPixelRocStatus> fRocs_;
-
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
@@ -6,19 +6,22 @@ class SiPixelRocStatus {
 public:
   SiPixelRocStatus();
   ~SiPixelRocStatus();
+
   void fillDIGI();
-  void updateDIGI(unsigned int hits);
   void fillFEDerror25();
 
-  // stuckTBM
-  bool isFEDerror25() { return isFEDerror25_; }
+  void updateDIGI(unsigned int hits);
+  void updateFEDerror25(bool fedError25);
 
   // occpancy
   unsigned int digiOccROC();
+  // FEDerror25 for stuckTBM
+  bool isFEDerror25();
 
 private:
-  unsigned int fDC;
+  unsigned int fDC_;
   bool isFEDerror25_;
+
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelRocStatus.h
@@ -21,7 +21,6 @@ public:
 private:
   unsigned int fDC_;
   bool isFEDerror25_;
-
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
@@ -20,8 +20,8 @@ public:
   SiPixelTopoFinder();
   virtual ~SiPixelTopoFinder();
 
-  void init(const TrackerTopology* trackerTopology,
-              const TrackerGeometry* trackerGeometry,
+  void init(const TrackerGeometry* trackerGeometry,
+              const TrackerTopology* trackerTopology,
               const SiPixelFedCablingMap* siPixelFedCablingMap);
 
   std::vector<int> getDetIds() { return fDetIds_; }

--- a/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
@@ -24,15 +24,15 @@ public:
               const TrackerTopology* trackerTopology,
               const SiPixelFedCablingMap* siPixelFedCablingMap);
 
-  std::vector<int> getDetIds() { return fDetIds_; }
+  std::vector<int> getDetIds() const { return fDetIds_; }
 
-  std::map<int, std::pair<int, int>> getSensors() { return fSensors_; }
+  std::map<int, std::pair<int, int>> getSensors() const { return fSensors_; }
 
-  std::map<int, std::pair<int, int>> getSensorLayout() { return fSensorLayout_; }
+  std::map<int, std::pair<int, int>> getSensorLayout() const { return fSensorLayout_; }
 
-  std::unordered_map<uint32_t, unsigned int> getFedIds() { return fFedIds_; }
+  std::unordered_map<uint32_t, unsigned int> getFedIds() const { return fFedIds_; }
 
-  std::map<int, std::map<int, int>> getRocIds() { return fRocIds_; }
+  std::map<int, std::map<int, int>> getRocIds() const { return fRocIds_; }
 
 private:
 

--- a/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
@@ -13,16 +13,14 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 
-
 class SiPixelTopoFinder {
-
 public:
   SiPixelTopoFinder();
   ~SiPixelTopoFinder();
 
   void init(const TrackerGeometry* trackerGeometry,
-              const TrackerTopology* trackerTopology,
-              const SiPixelFedCablingMap* siPixelFedCablingMap);
+            const TrackerTopology* trackerTopology,
+            const SiPixelFedCablingMap* siPixelFedCablingMap);
 
   std::vector<int> getDetIds() const { return fDetIds_; }
 
@@ -35,7 +33,6 @@ public:
   std::map<int, std::map<int, int>> getRocIds() const { return fRocIds_; }
 
 private:
-
   // initialize with nullptr
   int phase_ = -1;
 
@@ -55,8 +52,14 @@ private:
   std::map<int, std::map<int, int>> fRocIds_;
 
   // conversion between online(local, per-ROC) row/column and offline(global, per-Module) row/column
-  void onlineRocColRow(const DetId& detId, const SiPixelFedCablingMap* cablingMap, int fedId,
-                       int offlineRow, int offlineCol, int& roc, int& row, int& col);
+  void onlineRocColRow(const DetId& detId,
+                       const SiPixelFedCablingMap* cablingMap,
+                       int fedId,
+                       int offlineRow,
+                       int offlineCol,
+                       int& roc,
+                       int& row,
+                       int& col);
 
   int indexROC(int irow, int icol, int nROCcolumns);
 
@@ -64,7 +67,6 @@ private:
   int quadrant(const DetId& detid);
   int side(const DetId& detid);
   int half(const DetId& detid);
-
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
@@ -18,7 +18,7 @@ class SiPixelTopoFinder {
 
 public:
   SiPixelTopoFinder();
-  virtual ~SiPixelTopoFinder();
+  ~SiPixelTopoFinder();
 
   void init(const TrackerGeometry* trackerGeometry,
               const TrackerTopology* trackerTopology,
@@ -38,8 +38,9 @@ private:
 
   // initialize with nullptr
   int phase_ = -1;
-  const TrackerTopology* tTopo_ = nullptr;
-  const TrackerGeometry* tGeom_ = nullptr;
+
+  const TrackerTopology* tkTopo_ = nullptr;
+  const TrackerGeometry* tkGeom_ = nullptr;
   const SiPixelFedCablingMap* cablingMap_ = nullptr;
 
   // List of <int> DetIds

--- a/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
+++ b/CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h
@@ -1,0 +1,69 @@
+#ifndef SiPixelTopoFinder_H
+#define SiPixelTopoFinder_H
+// -*- C++ -*-
+//
+// Class:      SiPixelTopoFinder
+//
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
+
+
+class SiPixelTopoFinder {
+
+public:
+  SiPixelTopoFinder();
+  virtual ~SiPixelTopoFinder();
+
+  void init(const TrackerTopology* trackerTopology,
+              const TrackerGeometry* trackerGeometry,
+              const SiPixelFedCablingMap* siPixelFedCablingMap);
+
+  std::vector<int> getDetIds() { return fDetIds_; }
+
+  std::map<int, std::pair<int, int>> getSensors() { return fSensors_; }
+
+  std::map<int, std::pair<int, int>> getSensorLayout() { return fSensorLayout_; }
+
+  std::unordered_map<uint32_t, unsigned int> getFedIds() { return fFedIds_; }
+
+  std::map<int, std::map<int, int>> getRocIds() { return fRocIds_; }
+
+private:
+
+  // initialize with nullptr
+  int phase_ = -1;
+  const TrackerTopology* tTopo_ = nullptr;
+  const TrackerGeometry* tGeom_ = nullptr;
+  const SiPixelFedCablingMap* cablingMap_ = nullptr;
+
+  // List of <int> DetIds
+  std::vector<int> fDetIds_;
+  // ROC size (number of row, number of columns for each det id)
+  std::map<int, std::pair<int, int>> fSensors_;
+  // the roc layout on a module
+  std::map<int, std::pair<int, int>> fSensorLayout_;
+  // fedId as a function of detId
+  std::unordered_map<uint32_t, unsigned int> fFedIds_;
+  // map the index ROC to rocId
+  std::map<int, std::map<int, int>> fRocIds_;
+
+  // conversion between online(local, per-ROC) row/column and offline(global, per-Module) row/column
+  void onlineRocColRow(const DetId& detId, const SiPixelFedCablingMap* cablingMap, int fedId,
+                       int offlineRow, int offlineCol, int& roc, int& row, int& col);
+
+  int indexROC(int irow, int icol, int nROCcolumns);
+
+  // some helper function for pixel naming
+  int quadrant(const DetId& detid);
+  int side(const DetId& detid);
+  int half(const DetId& detid);
+
+};
+
+#endif

--- a/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
  <use name="FWCore/MessageLogger"/>
  <use name="FWCore/ParameterSet"/>
  <use name="FWCore/Utilities"/>
+ <use name="FWCore/Concurrency"/>
  <use name="Geometry/CommonDetUnit"/>
  <use name="Geometry/Records"/>
  <use name="Geometry/TrackerGeometryBuilder"/>

--- a/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelQuality/plugins/BuildFile.xml
@@ -1,20 +1,43 @@
-<use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
-<use name="DataFormats/DetId"/>
-<use name="Geometry/TrackerGeometryBuilder"/>
-<use name="Geometry/Records"/>
-<use name="DataFormats/SiPixelDetId"/>
-<use name="DataFormats/FEDRawData"/>
-<use name="CondFormats/DataRecord"/>
-<use name="CondFormats/RunInfo"/>
-<use name="CondFormats/SiPixelObjects"/>
-<use name="DQM/SiPixelPhase1Common"/>
-<use name="CalibTracker/SiPixelQuality"/>
-<use name="root"/>
-<library file="SiPixelStatusProducer.cc" name="SiPixelStatusProducer">
-  <flags EDM_PLUGIN="1"/>
+<library name="SiPixelStatusProducer" file="SiPixelStatusProducer.cc">
+ <use name="CalibTracker/SiPixelQuality"/>
+ <use name="CondFormats/DataRecord"/>
+ <use name="CondFormats/RunInfo"/>
+ <use name="CondFormats/SiPixelObjects"/>
+ <use name="DQM/SiPixelPhase1Common"/>
+ <use name="DataFormats/Common"/>
+ <use name="DataFormats/DetId"/>
+ <use name="DataFormats/FEDRawData"/>
+ <use name="DataFormats/SiPixelCluster"/>
+ <use name="DataFormats/SiPixelDetId"/>
+ <use name="DataFormats/SiPixelDigi"/>
+ <use name="DataFormats/TrackerCommon"/>
+ <use name="FWCore/Framework"/>
+ <use name="FWCore/MessageLogger"/>
+ <use name="FWCore/ParameterSet"/>
+ <use name="FWCore/Utilities"/>
+ <use name="Geometry/CommonDetUnit"/>
+ <use name="Geometry/Records"/>
+ <use name="Geometry/TrackerGeometryBuilder"/>
+ <use name="rootcling"/>
+ <flags EDM_PLUGIN="1"/>
 </library>
-
-<library file="SiPixelStatusHarvester.cc" name="SiPixelStatusHarvester">
-  <flags EDM_PLUGIN="1"/>
+<library name="SiPixelStatusHarvester" file="SiPixelStatusHarvester.cc">
+ <use name="CalibTracker/SiPixelQuality"/>
+ <use name="CondCore/DBOutputService"/>
+ <use name="CondFormats/DataRecord"/>
+ <use name="CondFormats/SiPixelObjects"/>
+ <use name="DQM/SiPixelPhase1Common"/>
+ <use name="DQMServices/Core"/>
+ <use name="DataFormats/Common"/>
+ <use name="DataFormats/TrackerCommon"/>
+ <use name="FWCore/Framework"/>
+ <use name="FWCore/MessageLogger"/>
+ <use name="FWCore/ParameterSet"/>
+ <use name="FWCore/ServiceRegistry"/>
+ <use name="FWCore/Utilities"/>
+ <use name="Geometry/CommonDetUnit"/>
+ <use name="Geometry/Records"/>
+ <use name="Geometry/TrackerGeometryBuilder"/>
+ <use name="rootcling"/>
+ <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -46,9 +46,25 @@ SiPixelStatusProducer::SiPixelStatusProducer(const edm::ParameterSet& iConfig,  
   produces<SiPixelDetectorStatus, edm::Transition::EndLuminosityBlock>("siPixelStatus");
 }
 
-//--------------------------------------------------------------------------------------------------
 SiPixelStatusProducer::~SiPixelStatusProducer() {}
 
+//--------------------------------------------------------------------------------------------------
+
+void SiPixelStatusProducer::beginRun(edm::Run const&, edm::EventSetup const&) {
+
+  /* update the std::map for pixel geo/topo */
+  /* vector of all <int> detIds */
+  fDetIds_ = runCache()->getDetIds();//getDetIds();
+  /* ROC size (number of row, number of columns for each det id) */
+  fSensors_ = runCache()->getSensors();
+  /* the roc layout on a module */
+  fSensorLayout_ = runCache()->getSensorLayout();
+  /* fedId as a function of detId */
+  fFedIds_ = runCache()->getFedIds();
+  /* map the index ROC to rocId */
+  fRocIds_ = runCache()->getRocIds();
+
+}
 
 
 void SiPixelStatusProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -42,6 +42,8 @@ SiPixelStatusProducer::SiPixelStatusProducer(const edm::ParameterSet& iConfig,  
                             .getUntrackedParameter<edm::InputTag>("pixelClusterLabel");
   fSiPixelClusterToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(fPixelClusterLabel_);
 
+  //debug_ = iConfig.getUntrackedParameter<bool>("debug");
+
   /* register products */
   produces<SiPixelDetectorStatus, edm::Transition::EndLuminosityBlock>("siPixelStatus");
 }
@@ -55,6 +57,7 @@ void SiPixelStatusProducer::beginRun(edm::Run const&, edm::EventSetup const&) {
    /*Is it good to pass the objects stored in runCache to set class private members values  *
      or just call runCahche every time in the calss function?*/
 
+  edm::LogInfo("SiPixelStatusProducer") << "beginRun: update the std::map for pixel geo/topo " << std::endl;
   /* update the std::map for pixel geo/topo */
   /* vector of all <int> detIds */
   fDetIds_ = runCache()->getDetIds();//getDetIds();
@@ -71,7 +74,7 @@ void SiPixelStatusProducer::beginRun(edm::Run const&, edm::EventSetup const&) {
 
 
 void SiPixelStatusProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-     edm::LogInfo("SiPixelStatusProducer") << "beginlumi instance setup " << std::endl;
+     edm::LogInfo("SiPixelStatusProducer") << "beginlumi instance" << std::endl;
 
      /* initialize fDet_ with a set of modules(detIds) and clean the fFEDerror25_ */
      fDet_ = SiPixelDetectorStatus();
@@ -93,8 +96,8 @@ void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, edm::EventSetup
   ftotalevents_++;
 
   /* ----------------------------------------------------------------------
- *      -- Pixel cluster analysis
- *        ----------------------------------------------------------------------*/
+     -- Pixel cluster analysis
+     ----------------------------------------------------------------------*/
 
   edm::Handle<edmNew::DetSetVector<SiPixelCluster>> hClusterColl;
   if (!iEvent.getByToken(fSiPixelClusterToken_, hClusterColl)) {
@@ -231,10 +234,10 @@ void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, edm::EventSetup
   }  /* look over different resouces of takens */
 
   /* Caveat
- *      no per-event collection put into iEvent
- *           If use produce() function and no collection is put into iEvent, produce() will not run in unScheduled mode
- *                Now since CMSSW_10_1_X, the accumulate() function will run whatsoever in the unScheduled mode
- *                     Accumulate() is NOT available for releases BEFORE CMSSW_10_1_X */
+     no per-event collection put into iEvent
+     If use produce() function and no collection is put into iEvent, produce() will not run in unScheduled mode
+     Now since CMSSW_10_1_X, the accumulate() function will run whatsoever in the unScheduled mode
+     Accumulate() is NOT available for releases BEFORE CMSSW_10_1_X */
 }
 
 
@@ -275,9 +278,10 @@ void SiPixelStatusProducer::endLuminosityBlockSummary(edm::LuminosityBlock const
 /* helper function */
 int SiPixelStatusProducer::indexROC(int irow, int icol, int nROCcolumns) {
   return int(icol + irow * nROCcolumns);
-  // generate the folling roc index that is going to map with ROC id as
-  // 8  9  10 11 12 13 14 15
-  // 0  1  2  3  4  5  6  7
+
+  /* generate the folling roc index that is going to map with ROC id as
+     8  9  10 11 12 13 14 15
+     0  1  2  3  4  5  6  7 */
 }
 
 DEFINE_FWK_MODULE(SiPixelStatusProducer);

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -5,12 +5,7 @@
 // CMSSW FW
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/Transition.h"
 // CMSSW DataFormats
 #include "DataFormats/Common/interface/ConditionsInEdm.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -33,12 +28,7 @@
 #include "CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h"
 
 
-SiPixelStatusProducer::SiPixelStatusProducer(const edm::ParameterSet& iConfig)
-    : trackerGeometryToken_(
-          esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginLuminosityBlock>()),
-      trackerTopologyToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginLuminosityBlock>()),
-      siPixelFedCablingMapToken_(
-          esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd, edm::Transition::BeginLuminosityBlock>()) {
+SiPixelStatusProducer::SiPixelStatusProducer(const edm::ParameterSet& iConfig,  SiPixelTopoCache const*){
 
   /* badPixelFEDChannelCollections */
   std::vector<edm::InputTag> badPixelFEDChannelCollectionLabels =

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -1,9 +1,3 @@
-/**_________________________________________________________________
-   class:   SiPixelStatusProducer.cc
-   package: CalibTracker/SiPixelQuality
-
-   ________________________________________________________________**/
-
 // C++ standard
 #include <string>
 // ROOT
@@ -34,375 +28,40 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-// EDProducer related dataformat
-#include "DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h"
-#include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
-// header file
+
+// Header file
 #include "CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h"
 
-using namespace std;
 
-//--------------------------------------------------------------------------------------------------
-SiPixelStatusProducer::SiPixelStatusProducer(const edm::ParameterSet& iConfig)
-    : trackerGeometryToken_(
-          esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginLuminosityBlock>()),
-      trackerTopologyToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginLuminosityBlock>()),
-      siPixelFedCablingMapToken_(
-          esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd, edm::Transition::BeginLuminosityBlock>()) {
-  // get parameter
 
-  // badPixelFEDChannelCollections
-  std::vector<edm::InputTag> badPixelFEDChannelCollectionLabels_ =
-      iConfig.getParameter<edm::ParameterSet>("SiPixelStatusProducerParameters")
-          .getParameter<std::vector<edm::InputTag>>("badPixelFEDChannelCollections");
-  for (auto& t : badPixelFEDChannelCollectionLabels_)
-    theBadPixelFEDChannelsTokens_.push_back(consumes<PixelFEDChannelCollection>(t));
-  //  badPixelFEDChannelCollections = cms.VInputTag(cms.InputTag('siPixelDigis'))
-
-  fPixelClusterLabel_ = iConfig.getParameter<edm::ParameterSet>("SiPixelStatusProducerParameters")
-                            .getUntrackedParameter<edm::InputTag>("pixelClusterLabel");
-  fSiPixelClusterToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(fPixelClusterLabel_);
-  resetNLumi_ = iConfig.getParameter<edm::ParameterSet>("SiPixelStatusProducerParameters")
-                    .getUntrackedParameter<int>("resetEveryNLumi", 1);
-
-  ftotalevents = 0;
-  countLumi_ = 0;
-
-  beginLumi_ = endLumi_ = -1;
-  endLumi_ = endRun_ = -1;
-
-  produces<SiPixelDetectorStatus, edm::Transition::EndLuminosityBlock>("siPixelStatus");
+SiPixelStatusProducer::SiPixelStatusProducer(edm::ParameterSet const& iPSet){
+      
+      //we need to register the fact that we will make the BeamSpot object
+      produces<SiPixelDetectorStatus, edm::Transition::EndLuminosityBlock>();
 }
 
 //--------------------------------------------------------------------------------------------------
 SiPixelStatusProducer::~SiPixelStatusProducer() {}
 
-//--------------------------------------------------------------------------------------------------
-void SiPixelStatusProducer::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup& iSetup) {
-  edm::LogInfo("SiPixelStatusProducer") << "beginlumi setup " << endl;
 
-  if (countLumi_ == 0 && resetNLumi_ > 0) {
-    beginLumi_ = lumiSeg.luminosityBlock();
-    beginRun_ = lumiSeg.run();
-    ftotalevents = 0;
-  }
 
-  // The es watcher is acutally not needed if run parallel jobs for each lumi section
-  if (siPixelFedCablingMapWatcher_.check(iSetup) || trackerDIGIGeoWatcher_.check(iSetup) ||
-      trackerTopoWatcher_.check(iSetup)) {
-    trackerGeometry_ = &iSetup.getData(trackerGeometryToken_);
-    const TrackerTopology* trackerTopology = &iSetup.getData(trackerTopologyToken_);
-    fCablingMap_ = &iSetup.getData(siPixelFedCablingMapToken_);
-
-    coord_.init(trackerTopology, trackerGeometry_, fCablingMap_);
-
-    fFedIds = fCablingMap_->det2fedMap();
-
-  }  // if conditionWatcher_.check(iSetup)
-
-  // init the SiPixelDetectorStatus fDet and sensor size fSensors in the begining (when countLumi is zero)
-  if (countLumi_ == 0) {
-    for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry_->dets().begin();
-         it != trackerGeometry_->dets().end();
-         it++) {
-      const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
-      if (pgdu == nullptr)
-        continue;
-      DetId detId = (*it)->geographicalId();
-      int detid = detId.rawId();
-
-      // don't want to use magic number row 80 column 52
-      const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
-      int rowsperroc = topo->rowsperroc();
-      int colsperroc = topo->colsperroc();
-
-      int nROCrows = pgdu->specificTopology().nrows() / rowsperroc;
-      int nROCcolumns = pgdu->specificTopology().ncolumns() / colsperroc;
-      int nrocs = nROCrows * nROCcolumns;
-
-      fDet.addModule(detid, nrocs);
-
-      fSensors[detid] = std::make_pair(rowsperroc, colsperroc);
-      fSensorLayout[detid] = std::make_pair(nROCrows, nROCcolumns);
-
-      std::map<int, int> rocIdMap;
-      for (int irow = 0; irow < nROCrows; irow++) {
-        for (int icol = 0; icol < nROCcolumns; icol++) {
-          int dummyOfflineRow = (rowsperroc / 2 - 1) + irow * rowsperroc;
-          int dummeOfflineColumn = (colsperroc / 2 - 1) + icol * colsperroc;
-          // encode irow, icol
-          int key = indexROC(irow, icol, nROCcolumns);
-
-          int roc(-1), rocR(-1), rocC(-1);
-          onlineRocColRow(detId, dummyOfflineRow, dummeOfflineColumn, roc, rocR, rocC);
-
-          int value = roc;
-          rocIdMap[key] = value;
-        }
-      }
-
-      fRocIds[detid] = rocIdMap;
-    }
-
-  }  // init when countLumi = 0
-
-  FEDerror25_.clear();
-  countLumi_++;
+void SiPixelStatusProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
+        fDet_ = SiPixelDetectorStatus();
 }
 
-//--------------------------------------------------------------------------------------------------
-void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, const edm::EventSetup&) {
-  ftotalevents++;
+   //void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {}
 
-  edm::LogInfo("SiPixelStatusProducer") << "start cluster analyzer " << endl;
+void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {}
 
-  // ----------------------------------------------------------------------
-  // -- Pixel cluster analysis
-  // ----------------------------------------------------------------------
 
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> hClusterColl;
-  if (!iEvent.getByToken(fSiPixelClusterToken_, hClusterColl)) {
-    edm::LogWarning("SiPixelStatusProducer")
-        << " edmNew::DetSetVector<SiPixelCluster> " << fPixelClusterLabel_ << " does not exist!" << endl;
-    return;
-  }
-
-  iEvent.getByToken(fSiPixelClusterToken_, hClusterColl);
-
-  if (hClusterColl.isValid()) {
-    for (const auto& clusters : *hClusterColl) {  //loop over different clusters in a clusters vector (module)
-      for (const auto& clu : clusters) {          // loop over cluster in a given detId (module)
-        int detid = clusters.detId();
-        int rowsperroc = fSensors[detid].first;
-        int colsperroc = fSensors[detid].second;
-
-        int nROCcolumns = fSensorLayout[detid].second;
-
-        int roc(-1);
-        std::map<int, int> fRocIds_detid;
-        if (fRocIds.find(detid) != fRocIds.end()) {
-          fRocIds_detid = fRocIds[detid];
-        }
-
-        const vector<SiPixelCluster::Pixel>& pixvector = clu.pixels();
-        for (unsigned int i = 0; i < pixvector.size(); ++i) {
-          int mr0 = pixvector[i].x;  // constant column direction is along x-axis,
-          int mc0 = pixvector[i].y;  // constant row direction is along y-axis
-
-          int irow = mr0 / rowsperroc;
-          int icol = mc0 / colsperroc;
-
-          int key = indexROC(irow, icol, nROCcolumns);
-          if (fRocIds_detid.find(key) != fRocIds_detid.end()) {
-            roc = fRocIds_detid[key];
-          }
-
-          fDet.fillDIGI(detid, roc);
-
-        }  // loop over pixels in a given cluster
-
-      }  // loop over cluster in a given detId (module)
-
-    }  // loop over detId-grouped clusters in cluster detId-grouped clusters-vector
-
-  }  // hClusterColl.isValid()
-  else {
-    edm::LogWarning("SiPixelStatusProducer")
-        << " edmNew::DetSetVector<SiPixelCluster> " << fPixelClusterLabel_ << " is NOT Valid!" << endl;
-  }
-  //////////////////////////////////////////////////////////////////////
-
-  // FEDerror25 per-ROC per-event
-  edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-
-  // look over different resouces of takens
-  for (const edm::EDGetTokenT<PixelFEDChannelCollection>& tk : theBadPixelFEDChannelsTokens_) {
-    // collection has to exist
-    if (!iEvent.getByToken(tk, pixelFEDChannelCollectionHandle)) {
-      edm::LogWarning("SiPixelStatusProducer")
-          << " PixelFEDChannelCollection with index " << tk.index() << " does NOT exist!" << std::endl;
-      continue;
-    }
-    iEvent.getByToken(tk, pixelFEDChannelCollectionHandle);
-    // collection has to be valid
-    if (!pixelFEDChannelCollectionHandle.isValid()) {
-      edm::LogWarning("SiPixelStatusProducer")
-          << " PixelFEDChannelCollection with index " << tk.index() << " is NOT valid!" << endl;
-      continue;
-    }
-    // FEDerror channels for the current events
-    std::map<int, std::vector<PixelFEDChannel>> tmpFEDerror25;
-    for (const auto& disabledChannels : *pixelFEDChannelCollectionHandle) {
-      //loop over different PixelFED in a PixelFED vector (module)
-      for (const auto& ch : disabledChannels) {
-        DetId detId = disabledChannels.detId();
-        int detid = detId.rawId();
-
-        if (ftotalevents == 1) {
-          // FEDerror25 channels for the first event in the lumi section
-          FEDerror25_[detid].push_back(ch);
-        } else
-          tmpFEDerror25[detid].push_back(ch);
-
-      }  // loop over different PixelFED in a PixelFED vector (different channel for a given module)
-
-    }  // loop over different (different DetId) PixelFED vectors in PixelFEDChannelCollection
-
-    // Compare the current FEDerror list with the first event's FEDerror list
-    // and save the common channels
-    if (!tmpFEDerror25.empty() && !FEDerror25_.empty()) {  // non-empty FEDerror lists
-
-      std::map<int, std::vector<PixelFEDChannel>>::iterator itFEDerror25;
-      for (itFEDerror25 = FEDerror25_.begin(); itFEDerror25 != FEDerror25_.end(); itFEDerror25++) {
-        int detid = itFEDerror25->first;
-        if (tmpFEDerror25.find(detid) != tmpFEDerror25.end()) {
-          std::vector<PixelFEDChannel> chs = itFEDerror25->second;
-          std::vector<PixelFEDChannel> chs_tmp = tmpFEDerror25[detid];
-
-          std::vector<PixelFEDChannel> chs_common;
-          for (unsigned int ich = 0; ich < chs.size(); ich++) {
-            PixelFEDChannel ch = chs[ich];
-            // look over the current FEDerror25 channels, save the common FED channels
-            for (unsigned int ich_tmp = 0; ich_tmp < chs_tmp.size(); ich_tmp++) {
-              PixelFEDChannel ch_tmp = chs_tmp[ich_tmp];
-              if ((ch.fed == ch_tmp.fed) && (ch.link == ch_tmp.link)) {  // the same FED channel
-                chs_common.push_back(ch);
-                break;
-              }
-            }
-          }
-          // remove the full module from FEDerror25 list if no common channels are left
-          if (chs_common.empty())
-            FEDerror25_.erase(itFEDerror25);
-          // otherwise replace with the common channels
-          else {
-            FEDerror25_[detid].clear();
-            FEDerror25_[detid] = chs_common;
-          }
-        } else {  // remove the full module from FEDerror25 list if the module doesn't appear in the current event's FEDerror25 list
-          FEDerror25_.erase(itFEDerror25);
-        }
-
-      }  // loop over modules that have FEDerror25 in the first event in the lumi section
-
-    }  // non-empty FEDerror lists
-
-  }  // look over different resouces of takens
-
-  // no per-event collection put into iEvent
-  // If use produce() function and no collection is put into iEvent, produce() will not run in unScheduled mode
-  // Now since CMSSW_10_1_X, the accumulate() function will run whatsoever in the unScheduled mode
-  // But accumulate() is NOT available and will NOT be available for releases before CMSSW_10_1_X
+void SiPixelStatusProducer::endLuminosityBlockSummary(edm::LuminosityBlock const& iLumi, edm::EventSetup const&, 
+                                  std::vector<SiPixelDetectorStatus>* iPoints) const{
+      //add the Stream's partial information to the full information
+      iPoints->push_back(fDet_);
+      
 }
 
-//--------------------------------------------------------------------------------------------------
-void SiPixelStatusProducer::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup&) {}
 
-//--------------------------------------------------------------------------------------------------
-void SiPixelStatusProducer::endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) {
-  edm::LogInfo("SiPixelStatusProducer") << "endlumi producer " << endl;
 
-  endLumi_ = lumiSeg.luminosityBlock();
-  endRun_ = lumiSeg.run();
-
-  // check if countLumi_ is large enough to read out/save data and reset for the next round
-  if (resetNLumi_ == -1)
-    return;
-  if (countLumi_ < resetNLumi_)
-    return;
-
-  // set the FEDerror25 flag to be true for ROCs send out FEDerror25 for all events in the lumi section
-  if (!FEDerror25_.empty()) {
-    std::map<int, std::vector<PixelFEDChannel>>::iterator itFEDerror25;
-    for (itFEDerror25 = FEDerror25_.begin(); itFEDerror25 != FEDerror25_.end(); itFEDerror25++) {
-      int detid = itFEDerror25->first;
-      std::vector<PixelFEDChannel> chs = itFEDerror25->second;
-      for (unsigned int ich = 0; ich < chs.size(); ich++) {
-        fDet.fillFEDerror25(detid, chs[ich]);
-      }
-    }
-  }
-
-  fDet.setRunRange(beginRun_, endRun_);
-  fDet.setLSRange(beginLumi_, endLumi_);
-  fDet.setNevents(ftotalevents);
-
-  // save result
-  auto result = std::make_unique<SiPixelDetectorStatus>();
-  *result = fDet;
-
-  // only save for the lumi sections with NON-ZERO events
-  lumiSeg.put(std::move(result), std::string("siPixelStatus"));
-  edm::LogInfo("SiPixelStatusProducer") << "new lumi-based data stored for run " << beginRun_ << " lumi from "
-                                        << beginLumi_ << " to " << endLumi_ << std::endl;
-
-  // reset detector status and lumi-counter
-  fDet.resetDetectorStatus();
-  countLumi_ = 0;
-  ftotalevents = 0;
-  FEDerror25_.clear();
-}
-
-//--------------------------------------------------------------------------------------------------
-void SiPixelStatusProducer::onlineRocColRow(
-    const DetId& detId, int offlineRow, int offlineCol, int& roc, int& row, int& col) {
-  int fedId = fFedIds[detId.rawId()];
-
-  // from detector to cabling
-  sipixelobjects::ElectronicIndex cabling;
-  sipixelobjects::DetectorIndex detector;  //{detId.rawId(), offlineRow, offlineCol};
-  detector.rawId = detId.rawId();
-  detector.row = offlineRow;
-  detector.col = offlineCol;
-
-  SiPixelFrameConverter converter(fCablingMap_, fedId);
-  converter.toCabling(cabling, detector);
-
-  // then one can construct local pixel
-  sipixelobjects::LocalPixel::DcolPxid loc;
-  loc.dcol = cabling.dcol;
-  loc.pxid = cabling.pxid;
-  // and get local(online) row/column
-  sipixelobjects::LocalPixel locpixel(loc);
-  col = locpixel.rocCol();
-  row = locpixel.rocRow();
-  //sipixelobjects::CablingPathToDetUnit path = {(unsigned int) fedId, (unsigned int)cabling.link, (unsigned int)cabling.roc};
-  //const sipixelobjects::PixelROC *theRoc = fCablingMap_->findItem(path);
-  const sipixelobjects::PixelROC* theRoc = converter.toRoc(cabling.link, cabling.roc);
-  roc = theRoc->idInDetUnit();
-
-  // has to be BPIX; has to be minus side; has to be half module
-  // for phase-I, there is no half module
-  if (detId.subdetId() == PixelSubdetector::PixelBarrel && coord_.side(detId) == 1 && coord_.half(detId)) {
-    roc += 8;
-  }
-}
-
-//--------------------------------------------------------------------------------------------------
-int SiPixelStatusProducer::indexROC(int irow, int icol, int nROCcolumns) {
-  return int(icol + irow * nROCcolumns);
-
-  // generate the folling roc index that is going to map with ROC id as
-  // 8  9  10 11 12 13 14 15
-  // 0  1  2  3  4  5  6  7
-}
-
-//--------------------------------------------------------------------------------------------------
-//edmPythonConfigToCppValidation CalibTracker/SiPixelQuality/python/SiPixelStatusProducer_cfi.py
-void SiPixelStatusProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  // siPixelStatusProducer
-  edm::ParameterSetDescription desc;
-  {
-    edm::ParameterSetDescription psd0;
-    psd0.addUntracked<int>("resetEveryNLumi", 1);
-    psd0.addUntracked<edm::InputTag>("pixelClusterLabel", edm::InputTag("siPixelClusters", "", "RECO"));
-    psd0.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollections",
-                                         {
-                                             edm::InputTag("siPixelDigis"),
-                                         });
-    desc.add<edm::ParameterSetDescription>("SiPixelStatusProducerParameters", psd0);
-  }
-  descriptions.add("siPixelStatusProducer", desc);
-}
 
 DEFINE_FWK_MODULE(SiPixelStatusProducer);

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.cc
@@ -52,6 +52,9 @@ SiPixelStatusProducer::~SiPixelStatusProducer() {}
 
 void SiPixelStatusProducer::beginRun(edm::Run const&, edm::EventSetup const&) {
 
+   /*Is it good to pass the objects stored in runCache to set class private members values  *
+     or just call runCahche every time in the calss function?*/
+
   /* update the std::map for pixel geo/topo */
   /* vector of all <int> detIds */
   fDetIds_ = runCache()->getDetIds();//getDetIds();
@@ -68,18 +71,203 @@ void SiPixelStatusProducer::beginRun(edm::Run const&, edm::EventSetup const&) {
 
 
 void SiPixelStatusProducer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
-        fDet_ = SiPixelDetectorStatus();
+     edm::LogInfo("SiPixelStatusProducer") << "beginlumi instance setup " << std::endl;
+
+     /* initialize fDet_ with a set of modules(detIds) and clean the fFEDerror25_ */
+     fDet_ = SiPixelDetectorStatus();
+     for (unsigned int itDetId = 0; itDetId < fDetIds_.size(); ++itDetId) {
+          int detid = fDetIds_[itDetId];
+          int nrocs = fSensorLayout_[detid].first * fSensorLayout_[detid].second;
+
+          fDet_.addModule(detid, nrocs);
+     }
+
+     fFEDerror25_.clear();
+     ftotalevents_ = 0;
 }
 
-   //void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {}
+void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, edm::EventSetup const&) {
+  edm::LogInfo("SiPixelStatusProducer") << "start cluster analyzer " << std::endl;
 
-void SiPixelStatusProducer::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {}
+  /* count number of events for the current module instance in the luminosityBlock */
+  ftotalevents_++;
+
+  /* ----------------------------------------------------------------------
+ *      -- Pixel cluster analysis
+ *        ----------------------------------------------------------------------*/
+
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> hClusterColl;
+  if (!iEvent.getByToken(fSiPixelClusterToken_, hClusterColl)) {
+    edm::LogWarning("SiPixelStatusProducer")
+        << " edmNew::DetSetVector<SiPixelCluster> " << fPixelClusterLabel_ << " does not exist!" << std::endl;
+    return;
+  }
+
+  iEvent.getByToken(fSiPixelClusterToken_, hClusterColl);
+
+  if (hClusterColl.isValid()) {
+    for (const auto& clusters : *hClusterColl) {  /*loop over different clusters in a clusters vector (module)*/
+      for (const auto& clu : clusters) {          /*loop over cluster in a given detId (module)*/
+        int detid = clusters.detId();
+        int rowsperroc = fSensors_[detid].first;
+        int colsperroc = fSensors_[detid].second;
+
+        //int nROCrows    = fSensorLayout_[detid].first;
+        int nROCcolumns = fSensorLayout_[detid].second;
+
+        int roc(-1);
+        std::map<int, int> rocIds_detid;
+        if (fRocIds_.find(detid) != fRocIds_.end()) {
+           rocIds_detid = fRocIds_[detid];
+        }
+
+        /* A module is made with a few ROCs
+           Need to convert global row/column (on a module) to local row/column (on a ROC) */
+        const std::vector<SiPixelCluster::Pixel>& pixvector = clu.pixels();
+        for (unsigned int i = 0; i < pixvector.size(); ++i) {
+          int mr0 = pixvector[i].x;  /* constant column direction is along x-axis */
+          int mc0 = pixvector[i].y;  /* constant row direction is along y-axis */
+
+          int irow = mr0 / rowsperroc;
+          int icol = mc0 / colsperroc;
+
+          int key = indexROC(irow, icol, nROCcolumns);
+          if (rocIds_detid.find(key) != rocIds_detid.end()) {
+              roc = rocIds_detid[key];
+          }
+
+          fDet_.fillDIGI(detid, roc);
+
+        }  /* loop over pixels in a cluster */
+
+      }  /* loop over cluster in a detId (module) */
+
+    }  /* loop over detId-grouped clusters in cluster detId-grouped clusters-vector* */
+
+  }  /* hClusterColl.isValid() */
+  else {
+    edm::LogWarning("SiPixelStatusProducer")
+        << " edmNew::DetSetVector<SiPixelCluster> " << fPixelClusterLabel_ << " is NOT Valid!" << std::endl;
+  }
+
+  /*|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
+
+  /* FEDerror25 per-ROC per-event */
+  edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
+
+  /* look over different resouces of tokens */
+  for (const edm::EDGetTokenT<PixelFEDChannelCollection>& tk : theBadPixelFEDChannelsTokens_) {
+
+    if (!iEvent.getByToken(tk, pixelFEDChannelCollectionHandle)) {
+      edm::LogWarning("SiPixelStatusProducer")
+          << " PixelFEDChannelCollection with index " << tk.index() << " does NOT exist!" << std::endl;
+      continue;
+    }
+
+    iEvent.getByToken(tk, pixelFEDChannelCollectionHandle);
+    if (!pixelFEDChannelCollectionHandle.isValid()) {
+      edm::LogWarning("SiPixelStatusProducer")
+          << " PixelFEDChannelCollection with index " << tk.index() << " is NOT valid!" << std::endl;
+      continue;
+    }
+
+    /* FEDerror channels for the current events */
+    std::map<int, std::vector<PixelFEDChannel>> tmpFEDerror25;
+    for (const auto& disabledChannels : *pixelFEDChannelCollectionHandle) {
+      /* loop over different PixelFED in a PixelFED vector (module) */
+      for (const auto& ch : disabledChannels) {
+        DetId detId = disabledChannels.detId();
+        int detid = detId.rawId();
+
+        if (ftotalevents_ == 1) {
+          /* FEDerror25 channels for the "first" event in the lumi section (first for the current instance of the module) */
+          fFEDerror25_[detid].push_back(ch);
+        } else
+          tmpFEDerror25[detid].push_back(ch);
+
+      }  /* loop over different PixelFED in a PixelFED vector (different channel for a module) */
+
+    }  /* loop over different (different DetId) PixelFED vectors in PixelFEDChannelCollection */
+
+    /* Compare the current FEDerror list with the first event's FEDerror list
+ *        and save the common channels */
+    if (!tmpFEDerror25.empty() && !fFEDerror25_.empty()) {
+
+      std::map<int, std::vector<PixelFEDChannel>>::iterator itFEDerror25;
+      for (itFEDerror25 = fFEDerror25_.begin(); itFEDerror25 != fFEDerror25_.end(); itFEDerror25++) {
+        int detid = itFEDerror25->first;
+        if (tmpFEDerror25.find(detid) != tmpFEDerror25.end()) {
+          std::vector<PixelFEDChannel> chs = itFEDerror25->second;
+          std::vector<PixelFEDChannel> chs_tmp = tmpFEDerror25[detid];
+
+          std::vector<PixelFEDChannel> chs_common;
+          for (unsigned int ich = 0; ich < chs.size(); ich++) {
+            PixelFEDChannel ch = chs[ich];
+            /* loop over the current FEDerror25 channels, save the common FED channels */
+            for (unsigned int ich_tmp = 0; ich_tmp < chs_tmp.size(); ich_tmp++) {
+              PixelFEDChannel ch_tmp = chs_tmp[ich_tmp];
+              if ((ch.fed == ch_tmp.fed) && (ch.link == ch_tmp.link)) {  /* the same FED channel */
+                chs_common.push_back(ch);
+                break;
+              }
+            }
+          }
+          /* remove the full module from FEDerror25 list if no common channels are left */
+          if (chs_common.empty())
+             fFEDerror25_.erase(itFEDerror25);
+          /* otherwise replace with the common channels */
+          else {
+            fFEDerror25_[detid].clear();
+            fFEDerror25_[detid] = chs_common;
+          }
+        } else {  /* remove the full module from FEDerror25 list if the module doesn't appear in the current event's FEDerror25 list */
+          fFEDerror25_.erase(itFEDerror25);
+        }
+
+      }  /* loop over modules that have FEDerror25 in the first event in the lumi section */
+
+    }  /* non-empty FEDerror lists */
+
+  }  /* look over different resouces of takens */
+
+  /* Caveat
+ *      no per-event collection put into iEvent
+ *           If use produce() function and no collection is put into iEvent, produce() will not run in unScheduled mode
+ *                Now since CMSSW_10_1_X, the accumulate() function will run whatsoever in the unScheduled mode
+ *                     Accumulate() is NOT available for releases BEFORE CMSSW_10_1_X */
+}
+
+
+void SiPixelStatusProducer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {
+
+  /* set total number of events through ftotalevents_ */
+  fDet_.setNevents(ftotalevents_);
+
+  if( ftotalevents_>0 ) {
+    /* Add FEDerror25 information into SiPixelDetectorStatus fDet_ for FED channels stored in fFEDerror25_ */
+    if (!fFEDerror25_.empty()) { // non-empty FEDerror25
+       std::map<int, std::vector<PixelFEDChannel>>::iterator itFEDerror25;
+       for (itFEDerror25 = fFEDerror25_.begin(); itFEDerror25 != fFEDerror25_.end(); itFEDerror25++) { // loop over detIds
+            int detid = itFEDerror25->first;
+            std::vector<PixelFEDChannel> chs = itFEDerror25->second;
+            for (unsigned int ich = 0; ich < chs.size(); ich++) {
+              fDet_.fillFEDerror25(detid, chs[ich]);
+            }
+       } // loop over detIds
+    } // if non-empty FEDerror25
+
+  } // only for non-zero events
+}
+
 
 
 void SiPixelStatusProducer::endLuminosityBlockSummary(edm::LuminosityBlock const& iLumi, edm::EventSetup const&, 
-                                  std::vector<SiPixelDetectorStatus>* iPoints) const{
-      //add the Stream's partial information to the full information
-      iPoints->push_back(fDet_);
+                                  std::vector<SiPixelDetectorStatus>* siPixelDetectorStatusVtr) const{
+      /*add the Stream's partial information to the full information*/
+
+      /* only save for the lumi sections with NON-ZERO events */
+      if ( ftotalevents_ > 0 )
+         siPixelDetectorStatusVtr->push_back(fDet_);
       
 }
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -10,8 +10,10 @@
 
 // C++ standard
 #include <cstring>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <memory>
+
 #include <string>
 // // CMS FW
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -132,7 +134,7 @@ class SiPixelStatusProducer :
 public:
 
    SiPixelStatusProducer(edm::ParameterSet const& iPSet, SiPixelTopoCache const*);
-   ~SiPixelStatusProducer();
+   ~SiPixelStatusProducer() override;
 
    /* module description */
    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -166,7 +168,7 @@ public:
 
    static std::unique_ptr<SiPixelTopoCache> initializeGlobalCache(edm::ParameterSet const& iPSet) {
           edm::LogInfo("SiPixelStatusProducer") << "Init global Cache " << std::endl;
-          return std::unique_ptr<SiPixelTopoCache>(new SiPixelTopoCache(iPSet));
+          return std::make_unique<SiPixelTopoCache>(iPSet);
    }
 
    static std::shared_ptr<SiPixelTopoFinder> globalBeginRun(edm::Run const& iRun, edm::EventSetup const& iSetup,
@@ -210,7 +212,7 @@ public:
                edm::LogInfo("SiPixelStatusProducer") << "Global endlumi producer " << std::endl;
 
                // only save result for non-zero event lumi block              
-               if ( siPixelDetectorStatusVtr->size() > 0 ){
+               if ( !siPixelDetectorStatusVtr->empty() ){
   	           int lumi = iLumi.luminosityBlock();
                    int run  = iLumi.run();
 

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -246,7 +246,7 @@ private:
   virtual int indexROC(int irow, int icol, int nROCcolumns) final;
 
   /* ParameterSet */
-  static const bool debug_ = true;
+  static const bool debug_ = false;
 
   edm::InputTag fPixelClusterLabel_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> fSiPixelClusterToken_;

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -167,6 +167,8 @@ public:
 
    /*|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
 
+   void beginRun(edm::Run const&, edm::EventSetup const&) final; 
+
    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final;
    //void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {}
 
@@ -211,6 +213,32 @@ private:
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
   edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
   */
+
+  /*|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
+  /* private data member, one instance per stream */
+
+  /* per-Run data (The pixel topo cannot be changed during a Run) */
+  /* vector of all <int> detIds */
+  std::vector<int> fDetIds_;
+  /* ROC size (number of row, number of columns for each det id) */
+  std::map<int, std::pair<int, int>> fSensors_;
+  /* the roc layout on a module */
+  std::map<int, std::pair<int, int>> fSensorLayout_;
+  /* fedId as a function of detId */
+  std::unordered_map<uint32_t, unsigned int> fFedIds_;
+  /* map the index ROC to rocId */
+  std::map<int, std::map<int, int>> fRocIds_;
+
+  /* per-LuminosityBlock data */
+  unsigned long int ftotalevents_;
+
+  int beginLumi_;
+  int endLumi_;
+  int beginRun_;
+  int endRun_;
+
+  /* Channels always have FEDerror25 for all events in the lumisection */
+  std::map<int, std::vector<PixelFEDChannel>> fFEDerror25_;
 
   // Producer production (output collection)
   SiPixelDetectorStatus fDet_;

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -2,22 +2,26 @@
 #define CalibTracker_SiPixelQuality_SiPixelStatusProducer_h
 
 /**_________________________________________________________________
-   class:   SiPixelStatusProducer.h
-   package: CalibTracker/SiPixelQuality
+ *    class:   SiPixelStatusProducer.h
+ *       package: CalibTracker/SiPixelQuality
+ *          reference : https://twiki.cern.ch/twiki/bin/view/CMSPublic/FWMultithreadedFrameworkStreamModuleInterface
+ *________________________________________________________________**/
 
-________________________________________________________________**/
 
 // C++ standard
 #include <string>
-// CMS FW
+// // CMS FW
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/ESGetToken.h"
-
-// Pixel data format
+//
+#include "FWCore/Utilities/interface/ReusableObjectHolder.h"
+#include "FWCore/Concurrency/interface/SerialTaskQueue.h"
+//
+// // Pixel data format
 #include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
@@ -25,79 +29,63 @@ ________________________________________________________________**/
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 // Tracker Geo
-#include "DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
+//
+// SiPixelTopoFinder
+#include "CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h"
+// SiPixelDetectorStatus
+#include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
 
-class SiPixelStatusProducer
-    : public edm::one::EDProducer<edm::EndLuminosityBlockProducer, edm::one::WatchLuminosityBlocks, edm::Accumulator> {
+class SiPixelStatusProducer : 
+
+      public edm::stream::EDProducer<edm::LuminosityBlockSummaryCache<std::vector<SiPixelDetectorStatus>>, 
+                                     edm::EndLuminosityBlockProducer,
+                                     edm::Accumulator> {
 public:
-  explicit SiPixelStatusProducer(const edm::ParameterSet&);
-  ~SiPixelStatusProducer() override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+   SiPixelStatusProducer(edm::ParameterSet const& iPSet);
+   ~SiPixelStatusProducer();
+
+
+   static std::shared_ptr<std::vector<SiPixelDetectorStatus>> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, 
+                                                                                  edm::EventSetup const&, 
+                                                                                  LuminosityBlockContext const*){
+
+                        return std::make_shared<std::vector<SiPixelDetectorStatus>>();
+   }
+
+   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final;
+   //void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) final {}
+
+   void accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) final;
+
+
+   void endLuminosityBlockSummary(edm::LuminosityBlock const& iLumi, edm::EventSetup const&, 
+                                  std::vector<SiPixelDetectorStatus>* siPixelDetectorStatusVtr) const override;
+
+   static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&,
+                                               edm::EventSetup const&,
+                                               LuminosityBlockContext const* iContext,
+                                               std::vector<SiPixelDetectorStatus>*) {
+      //Nothing to do
+   }
+
+   static void globalEndLuminosityBlockProduce(edm::LuminosityBlock& iLumi,
+                                               edm::EventSetup const&,
+                                               LuminosityBlockContext const* iContext,
+                                               std::vector<SiPixelDetectorStatus> const* siPixelDetectorStatusVtr) {
+      //
+   }                           
 
 private:
-  void beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup&) final;
-  void endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, const edm::EventSetup&) final;
-  void endLuminosityBlockProduce(edm::LuminosityBlock& lumiSeg, const edm::EventSetup&) final;
-  void accumulate(edm::Event const&, const edm::EventSetup&) final;
-
-  virtual void onlineRocColRow(const DetId& detId, int offlineRow, int offlineCol, int& roc, int& row, int& col) final;
-
-  virtual int indexROC(int irow, int icol, int nROCcolumns) final;
-
-  // time granularity control
-  unsigned long int ftotalevents;
-  int resetNLumi_;
-  int countLumi_;  //counter
-
-  int beginLumi_;
-  int endLumi_;
-  int beginRun_;
-  int endRun_;
-
-  // condition watchers
-  // CablingMaps
-  edm::ESWatcher<SiPixelFedCablingMapRcd> siPixelFedCablingMapWatcher_;
-  const SiPixelFedCablingMap* fCablingMap_ = nullptr;
-
-  // TrackerDIGIGeo
-  edm::ESWatcher<TrackerDigiGeometryRecord> trackerDIGIGeoWatcher_;
-  const TrackerGeometry* trackerGeometry_ = nullptr;
-
-  // TrackerTopology
-  edm::ESWatcher<TrackerTopologyRcd> trackerTopoWatcher_;
-
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeometryToken_;
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopologyToken_;
-  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> siPixelFedCablingMapToken_;
-
-  // SiPixel offline<->online conversion
-  // -- map (for each detid) of the map from offline col/row to the online roc/col/row
-  SiPixelCoordinates coord_;
-
-  // ROC size (number of row, number of columns for each det id)
-  std::map<int, std::pair<int, int>> fSensors;
-  // the roc layout on a module
-  std::map<int, std::pair<int, int>> fSensorLayout;
-  // fedId as a function of detId
-  std::unordered_map<uint32_t, unsigned int> fFedIds;
-  // map the index ROC to rocId
-  std::map<int, std::map<int, int>> fRocIds;
-
-  // Producer inputs / controls
-  edm::InputTag fPixelClusterLabel_;
-  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> fSiPixelClusterToken_;
-  std::vector<edm::EDGetTokenT<PixelFEDChannelCollection>> theBadPixelFEDChannelsTokens_;
-
-  // Channels always have FEDerror25 for the full lumi section
-  std::map<int, std::vector<PixelFEDChannel>> FEDerror25_;
 
   // Producer production (output collection)
-  SiPixelDetectorStatus fDet;
+  SiPixelDetectorStatus fDet_;
+
+
 };
 
 #endif

--- a/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
+++ b/CalibTracker/SiPixelQuality/plugins/SiPixelStatusProducer.h
@@ -80,7 +80,7 @@ public:
         //const TrackerTopology* trackerTopology = &iSetup.getData(trackerTopologyToken);
         //const SiPixelFedCablingMap* cablingMap = &iSetup.getData(siPixelFedCablingMapToken);
 
-        returnValue = m_holder.makeOrGet([this]() { return new SiPixelTopoFinder(); });
+        returnValue = m_holder.makeOrGet([]() { return new SiPixelTopoFinder(); });
         returnValue->init(trackerGeometry, trackerTopology, cablingMap);
 
         m_mostRecentSiPixelTopoFinder_ = returnValue;

--- a/CalibTracker/SiPixelQuality/python/ALCARECOSiPixelCalZeroBias_cff.py
+++ b/CalibTracker/SiPixelQuality/python/ALCARECOSiPixelCalZeroBias_cff.py
@@ -23,8 +23,6 @@ ALCARECOSiPixelCalZeroBiasDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsst
 
 # SiPixelStatus producer
 from CalibTracker.SiPixelQuality.SiPixelStatusProducer_cfi import *
-# fit as function of lumi sections
-siPixelStatusProducer.SiPixelStatusProducerParameters.resetEveryNLumi = 1
 
 # Sequence #
 seqALCARECOSiPixelCalZeroBias = cms.Sequence(ALCARECOSiPixelCalZeroBiasHLT*ALCARECOSiPixelCalZeroBiasDCSFilter*siPixelStatusProducer)

--- a/CalibTracker/SiPixelQuality/python/SiPixelStatusProducer_cfi.py
+++ b/CalibTracker/SiPixelQuality/python/SiPixelStatusProducer_cfi.py
@@ -4,7 +4,6 @@ siPixelStatusProducer = cms.EDProducer("SiPixelStatusProducer",
     SiPixelStatusProducerParameters = cms.PSet(
         badPixelFEDChannelCollections = cms.VInputTag(cms.InputTag('siPixelDigis')),
         pixelClusterLabel = cms.untracked.InputTag("siPixelClusters::RECO"),
-        resetEveryNLumi = cms.untracked.int32( 1 )
     )
 )
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
@@ -60,12 +60,12 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
       nroc = roc;
     if (detid != oldDetId) {
       if (pMod) {
-        pMod->setNrocs(nroc + 1); // roc ranges from 0, "+1" to get number of rocs per module
+        pMod->setNrocs(nroc + 1);  // roc ranges from 0, "+1" to get number of rocs per module
       }
 
       oldDetId = detid;
       if (getModule(detid) == nullptr) {
-        addModule(detid, nroc + 1); // roc ranges from 0, "+1" to get number of rocs per module
+        addModule(detid, nroc + 1);  // roc ranges from 0, "+1" to get number of rocs per module
       }
 
       pMod = getModule(detid);
@@ -76,7 +76,6 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
       fDetHits_ += hits;
       pMod->updateModuleDIGI(roc, hits);
     }
-
   }
 
   INS.close();
@@ -93,43 +92,39 @@ void SiPixelDetectorStatus::dumpToFile(std::ofstream& OD) {
        it != SiPixelDetectorStatus::end();
        ++it) {
     for (int iroc = 0; iroc < it->second.nrocs(); ++iroc) {
-        OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << std::endl;
+      OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << std::endl;
     }
   }
   OD << "# SiPixelDetectorStatus END" << std::endl;
 }
 
-
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::addModule(int detid, int nrocs) {
   // only need to add NEW modules
-  if(fModules_.find(detid) == fModules_.end()){
-     SiPixelModuleStatus a(detid, nrocs);
-     fModules_.insert(std::make_pair(detid, a));
+  if (fModules_.find(detid) == fModules_.end()) {
+    SiPixelModuleStatus a(detid, nrocs);
+    fModules_.insert(std::make_pair(detid, a));
   }
 }
-
 
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::addModule(int detid, SiPixelModuleStatus a) { fModules_.insert(std::make_pair(detid, a)); }
 
-
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::fillDIGI(int detid, int roc) {
-     ++fDetHits_;
-     fModules_[detid].fillDIGI(roc);
+  ++fDetHits_;
+  fModules_[detid].fillDIGI(roc);
 }
 
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::fillFEDerror25(int detid, PixelFEDChannel ch) {
   if (fModules_.find(detid) != fModules_.end()) {
-      fModules_[detid].fillFEDerror25(ch);
+    fModules_[detid].fillFEDerror25(ch);
   }
 }
 
 // FEDerror25 effected ROCs in for each module
 std::map<int, std::vector<int>> SiPixelDetectorStatus::getFEDerror25Rocs() {
-
   std::map<int, std::vector<int>> badRocLists;
 
   for (std::map<int, SiPixelModuleStatus>::iterator itMod = SiPixelDetectorStatus::begin();
@@ -210,25 +205,27 @@ double SiPixelDetectorStatus::perRocDigiOccVar() {
 
 // combine status from different data (coming from different run/lumi)
 void SiPixelDetectorStatus::updateDetectorStatus(SiPixelDetectorStatus newData) {
-     // loop over new data status
-     for (std::map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != newData.end(); ++it) {
-          int detid = it->first;
+  // loop over new data status
+  for (std::map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != newData.end(); ++it) {
+    int detid = it->first;
 
-          if (fModules_.find(detid) != fModules_.end()) {  // if the detid is in the module lists
-             fModules_[detid].updateModuleStatus(*(newData.getModule(detid)));
-          } else { // if new module, add(insert) the module data
-             fModules_.insert(std::make_pair(detid, *(newData.getModule(detid))));
-          }
-     }
+    if (fModules_.find(detid) != fModules_.end()) {  // if the detid is in the module lists
+      fModules_[detid].updateModuleStatus(*(newData.getModule(detid)));
+    } else {  // if new module, add(insert) the module data
+      fModules_.insert(std::make_pair(detid, *(newData.getModule(detid))));
+    }
+  }
 
-     fDetHits_     = fDetHits_ + newData.digiOccDET();
-     ftotalevents_ = ftotalevents_ + newData.getNevents();
+  fDetHits_ = fDetHits_ + newData.digiOccDET();
+  ftotalevents_ = ftotalevents_ + newData.getNevents();
 }
 
 void SiPixelDetectorStatus::resetDetectorStatus() {
   fModules_.clear();
   fDetHits_ = 0;
   ftotalevents_ = 0;
-  fRun0_ = 99999999; fRun1_ = 0;
-  fLS0_ = 99999999;  fLS1_ = 0;
+  fRun0_ = 99999999;
+  fRun1_ = 0;
+  fLS0_ = 99999999;
+  fLS1_ = 0;
 }

--- a/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
@@ -83,8 +83,7 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
 }
 
 // ----------------------------------------------------------------------
-void SiPixelDetectorStatus::dumpToFile(std::string filename) {
-  std::ofstream OD(filename.c_str());
+void SiPixelDetectorStatus::dumpToFile(std::ofstream& OD) {
   OD << "# SiPixelDetectorStatus START" << std::endl;
   OD << "# SiPixelDetectorStatus for LS  " << fLS0_ << " .. " << fLS1_ << std::endl;
   OD << "# SiPixelDetectorStatus for run " << fRun0_ << " .. " << fRun1_ << std::endl;
@@ -94,14 +93,10 @@ void SiPixelDetectorStatus::dumpToFile(std::string filename) {
        it != SiPixelDetectorStatus::end();
        ++it) {
     for (int iroc = 0; iroc < it->second.nrocs(); ++iroc) {
-      for (int idc = 0; idc < 26; ++idc) {
-        //
         OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << std::endl;
-      }
     }
   }
   OD << "# SiPixelDetectorStatus END" << std::endl;
-  OD.close();
 }
 
 

--- a/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelDetectorStatus.cc
@@ -11,9 +11,9 @@
 #include "CalibTracker/SiPixelQuality/interface/SiPixelDetectorStatus.h"
 
 // ----------------------------------------------------------------------
-SiPixelDetectorStatus::SiPixelDetectorStatus() : fLS0(99999999), fLS1(0), fRun0(99999999), fRun1(0) {
-  fDetHits = 0;
-  fNevents = 0;
+SiPixelDetectorStatus::SiPixelDetectorStatus() : fLS0_(99999999), fLS1_(0), fRun0_(99999999), fRun1_(0) {
+  fDetHits_ = 0;
+  ftotalevents_ = 0;
 }
 
 // ----------------------------------------------------------------------
@@ -43,15 +43,15 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
     }
 
     if (sline.find("# SiPixelDetectorStatus for LS") != std::string::npos) {
-      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for LS  %d .. %d", &fLS0, &fLS1);
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for LS  %d .. %d", &fLS0_, &fLS1_);
       continue;
     }
     if (sline.find("# SiPixelDetectorStatus for run") != std::string::npos) {
-      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for run %d .. %d", &fRun0, &fRun1);
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus for run %d .. %d", &fRun0_, &fRun1_);
       continue;
     }
     if (sline.find("# SiPixelDetectorStatus total hits = ") != std::string::npos) {
-      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus total hits = %ld", &fDetHits);
+      std::sscanf(sline.c_str(), "# SiPixelDetectorStatus total hits = %ld", &fDetHits_);
       continue;
     }
 
@@ -60,21 +60,23 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
       nroc = roc;
     if (detid != oldDetId) {
       if (pMod) {
-        pMod->setNrocs(nroc + 1);
+        pMod->setNrocs(nroc + 1); // roc ranges from 0, "+1" to get number of rocs per module
       }
 
       oldDetId = detid;
       if (getModule(detid) == nullptr) {
-        addModule(detid, nroc + 1);
+        addModule(detid, nroc + 1); // roc ranges from 0, "+1" to get number of rocs per module
       }
 
       pMod = getModule(detid);
       nroc = 0;
     }
-    if (pMod) {
-      fDetHits += hits;
+    // for existing module, update its content
+    if (pMod != nullptr) {
+      fDetHits_ += hits;
       pMod->updateModuleDIGI(roc, hits);
     }
+
   }
 
   INS.close();
@@ -84,15 +86,16 @@ void SiPixelDetectorStatus::readFromFile(std::string filename) {
 void SiPixelDetectorStatus::dumpToFile(std::string filename) {
   std::ofstream OD(filename.c_str());
   OD << "# SiPixelDetectorStatus START" << std::endl;
-  OD << "# SiPixelDetectorStatus for LS  " << fLS0 << " .. " << fLS1 << std::endl;
-  OD << "# SiPixelDetectorStatus for run " << fRun0 << " .. " << fRun1 << std::endl;
-  OD << "# SiPixelDetectorStatus total hits = " << fDetHits << std::endl;
+  OD << "# SiPixelDetectorStatus for LS  " << fLS0_ << " .. " << fLS1_ << std::endl;
+  OD << "# SiPixelDetectorStatus for run " << fRun0_ << " .. " << fRun1_ << std::endl;
+  OD << "# SiPixelDetectorStatus total hits = " << fDetHits_ << std::endl;
 
   for (std::map<int, SiPixelModuleStatus>::iterator it = SiPixelDetectorStatus::begin();
        it != SiPixelDetectorStatus::end();
        ++it) {
     for (int iroc = 0; iroc < it->second.nrocs(); ++iroc) {
       for (int idc = 0; idc < 26; ++idc) {
+        //
         OD << Form("%10d %2d %3d", it->first, iroc, int(it->second.getRoc(iroc)->digiOccROC())) << std::endl;
       }
     }
@@ -101,31 +104,38 @@ void SiPixelDetectorStatus::dumpToFile(std::string filename) {
   OD.close();
 }
 
-// ----------------------------------------------------------------------
-void SiPixelDetectorStatus::addModule(int detid, int nrocs) {
-  SiPixelModuleStatus a(detid, nrocs);
-  fModules.insert(std::make_pair(detid, a));
-}
 
 // ----------------------------------------------------------------------
-void SiPixelDetectorStatus::addModule(int detid, SiPixelModuleStatus a) { fModules.insert(std::make_pair(detid, a)); }
+void SiPixelDetectorStatus::addModule(int detid, int nrocs) {
+  // only need to add NEW modules
+  if(fModules_.find(detid) == fModules_.end()){
+     SiPixelModuleStatus a(detid, nrocs);
+     fModules_.insert(std::make_pair(detid, a));
+  }
+}
+
+
+// ----------------------------------------------------------------------
+void SiPixelDetectorStatus::addModule(int detid, SiPixelModuleStatus a) { fModules_.insert(std::make_pair(detid, a)); }
+
 
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::fillDIGI(int detid, int roc) {
-  ++fDetHits;
-  fModules[detid].fillDIGI(roc);
+     ++fDetHits_;
+     fModules_[detid].fillDIGI(roc);
 }
 
 // ----------------------------------------------------------------------
 void SiPixelDetectorStatus::fillFEDerror25(int detid, PixelFEDChannel ch) {
-  if (fModules.find(detid) != fModules.end()) {
-    fModules[detid].fillFEDerror25(ch);
+  if (fModules_.find(detid) != fModules_.end()) {
+      fModules_[detid].fillFEDerror25(ch);
   }
 }
 
 // FEDerror25 effected ROCs in for each module
 std::map<int, std::vector<int>> SiPixelDetectorStatus::getFEDerror25Rocs() {
-  std::map<int, std::vector<int>> badRocLists_;
+
+  std::map<int, std::vector<int>> badRocLists;
 
   for (std::map<int, SiPixelModuleStatus>::iterator itMod = SiPixelDetectorStatus::begin();
        itMod != SiPixelDetectorStatus::end();
@@ -139,37 +149,32 @@ std::map<int, std::vector<int>> SiPixelDetectorStatus::getFEDerror25Rocs() {
       if (roc->isFEDerror25()) {
         list.push_back(iroc);
       }
-      badRocLists_[detid] = list;
+      badRocLists[detid] = list;
     }
   }
 
-  return badRocLists_;
+  return badRocLists;
 }
 
 // ----------------------------------------------------------------------
-std::map<int, SiPixelModuleStatus>::iterator SiPixelDetectorStatus::begin() { return fModules.begin(); }
+std::map<int, SiPixelModuleStatus>::iterator SiPixelDetectorStatus::begin() { return fModules_.begin(); }
 
 // ----------------------------------------------------------------------
-//map<int, SiPixelModuleStatus>::iterator SiPixelDetectorStatus::next() {
-//  return fNext++;
-//}
+std::map<int, SiPixelModuleStatus>::iterator SiPixelDetectorStatus::end() { return fModules_.end(); }
 
 // ----------------------------------------------------------------------
-std::map<int, SiPixelModuleStatus>::iterator SiPixelDetectorStatus::end() { return fModules.end(); }
-
-// ----------------------------------------------------------------------
-int SiPixelDetectorStatus::nmodules() { return static_cast<int>(fModules.size()); }
+int SiPixelDetectorStatus::nmodules() { return static_cast<int>(fModules_.size()); }
 
 // ----------------------------------------------------------------------
 SiPixelModuleStatus* SiPixelDetectorStatus::getModule(int detid) {
-  if (fModules.find(detid) == fModules.end()) {
+  if (fModules_.find(detid) == fModules_.end()) {
     return nullptr;
   }
-  return &(fModules[detid]);
+  return &(fModules_[detid]);
 }
 
 bool SiPixelDetectorStatus::findModule(int detid) {
-  if (fModules.find(detid) == fModules.end())
+  if (fModules_.find(detid) == fModules_.end())
     return false;
   else
     return true;
@@ -206,18 +211,29 @@ double SiPixelDetectorStatus::perRocDigiOccVar() {
   return TMath::Sqrt(fDetSigma);
 }
 
+/*|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||*/
+
 // combine status from different data (coming from different run/lumi)
 void SiPixelDetectorStatus::updateDetectorStatus(SiPixelDetectorStatus newData) {
-  // loop over new data status
-  for (std::map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != newData.end(); ++it) {
-    int detid = it->first;
-    if (fModules.find(detid) != fModules.end()) {  // if the detid is in the module lists
-      fModules[detid].updateModuleStatus(*(newData.getModule(detid)));
-    } else {
-      fModules.insert(std::make_pair(detid, *(newData.getModule(detid))));
-    }
-  }
+     // loop over new data status
+     for (std::map<int, SiPixelModuleStatus>::iterator it = newData.begin(); it != newData.end(); ++it) {
+          int detid = it->first;
 
-  fDetHits = fDetHits + newData.digiOccDET();
-  fNevents = fNevents + newData.getNevents();
+          if (fModules_.find(detid) != fModules_.end()) {  // if the detid is in the module lists
+             fModules_[detid].updateModuleStatus(*(newData.getModule(detid)));
+          } else { // if new module, add(insert) the module data
+             fModules_.insert(std::make_pair(detid, *(newData.getModule(detid))));
+          }
+     }
+
+     fDetHits_     = fDetHits_ + newData.digiOccDET();
+     ftotalevents_ = ftotalevents_ + newData.getNevents();
+}
+
+void SiPixelDetectorStatus::resetDetectorStatus() {
+  fModules_.clear();
+  fDetHits_ = 0;
+  ftotalevents_ = 0;
+  fRun0_ = 99999999; fRun1_ = 0;
+  fLS0_ = 99999999;  fLS1_ = 0;
 }

--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -9,10 +9,10 @@
 #include "CalibTracker/SiPixelQuality/interface/SiPixelModuleStatus.h"
 
 // ----------------------------------------------------------------------
-SiPixelModuleStatus::SiPixelModuleStatus(int detId, int nrocs) : fDetid(detId), fNrocs(nrocs) {
-  for (int i = 0; i < fNrocs; ++i) {
+SiPixelModuleStatus::SiPixelModuleStatus(int detId, int nrocs) : fDetid_(detId), fNrocs_(nrocs) {
+  for (int i = 0; i < fNrocs_; ++i) {
     SiPixelRocStatus a;
-    fRocs.push_back(a);
+    fRocs_.push_back(a);
   }
 };
 
@@ -21,94 +21,99 @@ SiPixelModuleStatus::~SiPixelModuleStatus(){};
 
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::fillDIGI(int iroc) {
-  if (iroc < fNrocs)
-    fRocs[iroc].fillDIGI();
+  if (iroc < fNrocs_)
+    fRocs_[iroc].fillDIGI();
 }
-
-// ----------------------------------------------------------------------
-void SiPixelModuleStatus::updateDIGI(int iroc, unsigned int nhit) {
-  if (iroc < fNrocs)
-    fRocs[iroc].updateDIGI(nhit);
-}
-
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::fillFEDerror25(PixelFEDChannel ch) {
   int roc_first = int(ch.roc_first);
   int roc_last = int(ch.roc_last);
-  for (int iroc = 0; iroc < fNrocs; iroc++) {
+  for (int iroc = 0; iroc < fNrocs_; iroc++) {
     if (iroc >= roc_first && iroc <= roc_last) {
-      fRocs[iroc].fillFEDerror25();
+      fRocs_[iroc].fillFEDerror25();
     }
   }
 }
+// ----------------------------------------------------------------------
+int SiPixelModuleStatus::detid() { return fDetid_; }
+// ----------------------------------------------------------------------
+int SiPixelModuleStatus::nrocs() { return fNrocs_; }
+// ----------------------------------------------------------------------
+void SiPixelModuleStatus::setDetId(int detid) { fDetid_ = detid; }
+// ----------------------------------------------------------------------
+void SiPixelModuleStatus::setNrocs(int nRoc) { fNrocs_ = nRoc; }
+
 
 // ----------------------------------------------------------------------
-unsigned int SiPixelModuleStatus::digiOccROC(int iroc) { return (iroc < fNrocs ? fRocs[iroc].digiOccROC() : -1); }
+void SiPixelModuleStatus::updateDIGI(int iroc, unsigned int nhit) {
+  if (iroc < fNrocs_) fRocs_[iroc].updateDIGI(nhit);
+}
+// ----------------------------------------------------------------------
+void SiPixelModuleStatus::updateFEDerror25(int iroc, bool fedError25) {
+  if (iroc < fNrocs_) fRocs_[iroc].updateFEDerror25(fedError25);
+}
 
+// ----------------------------------------------------------------------
+unsigned int SiPixelModuleStatus::digiOccROC(int iroc) { return (iroc < fNrocs_ ? fRocs_[iroc].digiOccROC() : 0); }
+// ----------------------------------------------------------------------
+bool SiPixelModuleStatus::fedError25(int iroc) { return (iroc < fNrocs_ ? fRocs_[iroc].isFEDerror25() : false); }
 // ----------------------------------------------------------------------
 unsigned int SiPixelModuleStatus::digiOccMOD() {
   unsigned int count(0);
-  for (int iroc = 0; iroc < fNrocs; ++iroc) {
+  for (int iroc = 0; iroc < fNrocs_; ++iroc) {
     count += digiOccROC(iroc);
   }
   return count;
 }
 
 // ----------------------------------------------------------------------
-int SiPixelModuleStatus::detid() { return fDetid; }
-
-// ----------------------------------------------------------------------
-int SiPixelModuleStatus::nrocs() { return fNrocs; }
-
-// ----------------------------------------------------------------------
-void SiPixelModuleStatus::setNrocs(int iroc) { fNrocs = iroc; }
-
-// ----------------------------------------------------------------------
 double SiPixelModuleStatus::perRocDigiOcc() {
   unsigned int ave(0);
-  for (int iroc = 0; iroc < fNrocs; ++iroc) {
+  for  (int iroc = 0; iroc < fNrocs_; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     ave += inc;
   }
-  return (1.0 * ave) / fNrocs;
+  return (1.0 * ave) / fNrocs_;
 }
 
 double SiPixelModuleStatus::perRocDigiOccVar() {
   double fModAverage = SiPixelModuleStatus::perRocDigiOcc();
 
   double sig = 1.0;
-  for (int iroc = 0; iroc < fNrocs; ++iroc) {
+  for (int iroc = 0; iroc < fNrocs_; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     sig += (fModAverage - inc) * (fModAverage - inc);
   }
 
-  double fModSigma = sig / (fNrocs - 1);
+  double fModSigma = sig / (fNrocs_ - 1);
   return TMath::Sqrt(fModSigma);
 }
 
-// ----------------------------------------------------------------------
-// Be careful : return the address not the value of ROC status
-SiPixelRocStatus* SiPixelModuleStatus::getRoc(int i) { return &fRocs[i]; }
 
 // ----------------------------------------------------------------------
-void SiPixelModuleStatus::updateModuleDIGI(int iroc, unsigned int nhits) { fRocs[iroc].updateDIGI(nhits); }
+// Return the address not the value of ROC status
+SiPixelRocStatus* SiPixelModuleStatus::getRoc(int iroc) { return (iroc < fNrocs_ ? &fRocs_[iroc] : nullptr); }
 
+// ----------------------------------------------------------------------
+void SiPixelModuleStatus::updateModuleDIGI(int iroc, unsigned int nhits) {
+  if (iroc<fNrocs_) fRocs_[iroc].updateDIGI(nhits);
+}
+// ----------------------------------------------------------------------
 void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
   bool isSameModule = true;
-  if (fDetid != newData.detid() || fNrocs != newData.nrocs()) {
+  if (fDetid_ != newData.detid() || fNrocs_ != newData.nrocs()) {
     isSameModule = false;
   }
 
   if (isSameModule) {
-    for (int iroc = 0; iroc < fNrocs; ++iroc) {
+    for (int iroc = 0; iroc < fNrocs_; ++iroc) { // loop over rocs
       //update occupancy
-      fRocs[iroc].updateDIGI(newData.digiOccROC(iroc));
+      fRocs_[iroc].updateDIGI(newData.digiOccROC(iroc));
       //update FEDerror25
-      SiPixelRocStatus* rocStatus = newData.getRoc(iroc);
-      if (rocStatus->isFEDerror25()) {
-        fRocs[iroc].fillFEDerror25();
-      }
-    }
+      fRocs_[iroc].updateFEDerror25(newData.fedError25(iroc));
+
+    } // loop over rocs
 
   }  // if same module
+
 }

--- a/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelModuleStatus.cc
@@ -43,14 +43,15 @@ void SiPixelModuleStatus::setDetId(int detid) { fDetid_ = detid; }
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::setNrocs(int nRoc) { fNrocs_ = nRoc; }
 
-
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::updateDIGI(int iroc, unsigned int nhit) {
-  if (iroc < fNrocs_) fRocs_[iroc].updateDIGI(nhit);
+  if (iroc < fNrocs_)
+    fRocs_[iroc].updateDIGI(nhit);
 }
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::updateFEDerror25(int iroc, bool fedError25) {
-  if (iroc < fNrocs_) fRocs_[iroc].updateFEDerror25(fedError25);
+  if (iroc < fNrocs_)
+    fRocs_[iroc].updateFEDerror25(fedError25);
 }
 
 // ----------------------------------------------------------------------
@@ -69,7 +70,7 @@ unsigned int SiPixelModuleStatus::digiOccMOD() {
 // ----------------------------------------------------------------------
 double SiPixelModuleStatus::perRocDigiOcc() {
   unsigned int ave(0);
-  for  (int iroc = 0; iroc < fNrocs_; ++iroc) {
+  for (int iroc = 0; iroc < fNrocs_; ++iroc) {
     unsigned int inc = digiOccROC(iroc);
     ave += inc;
   }
@@ -89,14 +90,14 @@ double SiPixelModuleStatus::perRocDigiOccVar() {
   return TMath::Sqrt(fModSigma);
 }
 
-
 // ----------------------------------------------------------------------
 // Return the address not the value of ROC status
 SiPixelRocStatus* SiPixelModuleStatus::getRoc(int iroc) { return (iroc < fNrocs_ ? &fRocs_[iroc] : nullptr); }
 
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::updateModuleDIGI(int iroc, unsigned int nhits) {
-  if (iroc<fNrocs_) fRocs_[iroc].updateDIGI(nhits);
+  if (iroc < fNrocs_)
+    fRocs_[iroc].updateDIGI(nhits);
 }
 // ----------------------------------------------------------------------
 void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
@@ -106,14 +107,13 @@ void SiPixelModuleStatus::updateModuleStatus(SiPixelModuleStatus newData) {
   }
 
   if (isSameModule) {
-    for (int iroc = 0; iroc < fNrocs_; ++iroc) { // loop over rocs
+    for (int iroc = 0; iroc < fNrocs_; ++iroc) {  // loop over rocs
       //update occupancy
       fRocs_[iroc].updateDIGI(newData.digiOccROC(iroc));
       //update FEDerror25
       fRocs_[iroc].updateFEDerror25(newData.fedError25(iroc));
 
-    } // loop over rocs
+    }  // loop over rocs
 
   }  // if same module
-
 }

--- a/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelRocStatus.cc
@@ -9,7 +9,7 @@ using namespace std;
 
 // ----------------------------------------------------------------------
 SiPixelRocStatus::SiPixelRocStatus() {
-  fDC = 0;
+  fDC_ = 0;
   isFEDerror25_ = false;
 }
 
@@ -17,13 +17,17 @@ SiPixelRocStatus::SiPixelRocStatus() {
 SiPixelRocStatus::~SiPixelRocStatus() {}
 
 // ----------------------------------------------------------------------
-void SiPixelRocStatus::fillDIGI() { fDC++; }
-
-// ----------------------------------------------------------------------
-void SiPixelRocStatus::updateDIGI(unsigned int hits) { fDC += hits; }
-
+void SiPixelRocStatus::fillDIGI() { fDC_++; }
 // ----------------------------------------------------------------------
 void SiPixelRocStatus::fillFEDerror25() { isFEDerror25_ = true; }
 
 // ----------------------------------------------------------------------
-unsigned int SiPixelRocStatus::digiOccROC() { return fDC; }
+void SiPixelRocStatus::updateDIGI(unsigned int hits) { fDC_ += hits; }
+// ----------------------------------------------------------------------
+/*AND logic to update FEDerror25*/
+void SiPixelRocStatus::updateFEDerror25(bool fedError25) { isFEDerror25_ = isFEDerror25_ && fedError25; }
+
+// ----------------------------------------------------------------------
+unsigned int SiPixelRocStatus::digiOccROC() { return fDC_; }
+// ----------------------------------------------------------------------
+bool SiPixelRocStatus::isFEDerror25() { return isFEDerror25_; }

--- a/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
@@ -9,8 +9,8 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
 
-void SiPixelTopoFinder::init(const TrackerTopology* trackerTopology,
-                               const TrackerGeometry* trackerGeometry,
+void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
+                               const TrackerTopology* trackerTopology,
                                const SiPixelFedCablingMap* siPixelFedCablingMap)
 {
     phase_ = -1;

--- a/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
@@ -23,6 +23,8 @@ void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
     tkGeom_ = trackerGeometry;
     tkTopo_ = trackerTopology;
     cablingMap_ = siPixelFedCablingMap;
+    // from cabling map to FedIds
+    fFedIds_ = cablingMap_->det2fedMap();
 
     // clear data
     fDetIds_.clear();
@@ -31,7 +33,7 @@ void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
     fRocIds_.clear();
 
     // loop over tracker geometry
-    for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry->dets().begin();
+    for (TrackerGeometry::DetContainer::const_iterator it = tkGeom_->dets().begin();
          it != tkGeom_->dets().end(); it++){// tracker geo
 
              const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
@@ -113,11 +115,9 @@ void SiPixelTopoFinder::onlineRocColRow(const DetId& detId, const SiPixelFedCabl
 int SiPixelTopoFinder::indexROC(int irow, int icol, int nROCcolumns) {
   return int(icol + irow * nROCcolumns);
 
-  // generate the folling roc index that is going to map with ROC id as
-  //   // 8  9  10 11 12 13 14 15
-  //     // 0  1  2  3  4  5  6  7
-  //     }
-  //
+  /*generate the folling roc index that is going to map with ROC id as
+     8  9  10 11 12 13 14 15
+     0  1  2  3  4  5  6  7  */
 }
 
 // The following three functions copied from DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc

--- a/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
@@ -9,14 +9,19 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
 
+
+SiPixelTopoFinder::SiPixelTopoFinder() {}
+
+SiPixelTopoFinder::~SiPixelTopoFinder() {}
+
 void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
                                const TrackerTopology* trackerTopology,
                                const SiPixelFedCablingMap* siPixelFedCablingMap)
 {
     phase_ = -1;
 
-    tTopo_ = trackerTopology;
-    tGeom_ = trackerGeometry;
+    tkGeom_ = trackerGeometry;
+    tkTopo_ = trackerTopology;
     cablingMap_ = siPixelFedCablingMap;
 
     // clear data
@@ -27,7 +32,7 @@ void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
 
     // loop over tracker geometry
     for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry->dets().begin();
-         it != tGeom_->dets().end(); it++){// tracker geo
+         it != tkGeom_->dets().end(); it++){// tracker geo
 
              const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
              if (pgdu == nullptr) continue;
@@ -118,9 +123,9 @@ int SiPixelTopoFinder::indexROC(int irow, int icol, int nROCcolumns) {
 // The following three functions copied from DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc
 int SiPixelTopoFinder::quadrant(const DetId& detid) {
     if (detid.subdetId() == PixelSubdetector::PixelBarrel)
-      return PixelBarrelName(detid, tTopo_, phase_).shell();
+      return PixelBarrelName(detid, tkTopo_, phase_).shell();
     else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
-      return PixelEndcapName(detid, tTopo_, phase_).halfCylinder();
+      return PixelEndcapName(detid, tkTopo_, phase_).halfCylinder();
     else return -9999;
 }
 
@@ -128,12 +133,12 @@ int SiPixelTopoFinder::side(const DetId& detid) {
     if (detid.subdetId() == PixelSubdetector::PixelBarrel)
        return 1 + (SiPixelTopoFinder::quadrant(detid) > 2);
     else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
-       return tTopo_->pxfSide(detid);
+       return tkTopo_->pxfSide(detid);
     else return -9999;
 }
 
 int SiPixelTopoFinder::half(const DetId& detid) {
     if (detid.subdetId() == PixelSubdetector::PixelBarrel)
-       return PixelBarrelName(detid, tTopo_, phase_).isHalfModule();
+       return PixelBarrelName(detid, tkTopo_, phase_).isHalfModule();
     else return -9999;   
 }

--- a/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
@@ -1,0 +1,139 @@
+
+#include "CalibTracker/SiPixelQuality/interface/SiPixelTopoFinder.h"
+
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
+#include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
+
+
+void SiPixelTopoFinder::init(const TrackerTopology* trackerTopology,
+                               const TrackerGeometry* trackerGeometry,
+                               const SiPixelFedCablingMap* siPixelFedCablingMap)
+{
+    phase_ = -1;
+
+    tTopo_ = trackerTopology;
+    tGeom_ = trackerGeometry;
+    cablingMap_ = siPixelFedCablingMap;
+
+    // clear data
+    fDetIds_.clear();
+    fSensors_.clear();
+    fSensorLayout_.clear();
+    fRocIds_.clear();
+
+    // loop over tracker geometry
+    for (TrackerGeometry::DetContainer::const_iterator it = trackerGeometry->dets().begin();
+         it != tGeom_->dets().end(); it++){// tracker geo
+
+             const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
+             if (pgdu == nullptr) continue;
+             // get detId for a module
+             DetId detId = (*it)->geographicalId();
+             int detid = detId.rawId();
+             fDetIds_.push_back(detid);
+
+             // don't want to use magic number row 80 column 52 for Phase-1
+             const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
+             int rowsperroc = topo->rowsperroc();
+             int colsperroc = topo->colsperroc();
+
+             int nROCrows = pgdu->specificTopology().nrows() / rowsperroc;
+             int nROCcolumns = pgdu->specificTopology().ncolumns() / colsperroc;
+
+             fSensors_[detid] = std::make_pair(rowsperroc, colsperroc);
+             fSensorLayout_[detid] = std::make_pair(nROCrows, nROCcolumns);
+
+             std::map<int, int> rocIdMap;
+             for (int irow = 0; irow < nROCrows; irow++) { // row
+                 for (int icol = 0; icol < nROCcolumns; icol++) { // column
+                      int dummyOfflineRow = (rowsperroc / 2 - 1) + irow * rowsperroc;
+                      int dummeOfflineColumn = (colsperroc / 2 - 1) + icol * colsperroc;
+                      int fedId = fFedIds_[detId.rawId()];
+
+                      int roc(-1), rocR(-1), rocC(-1);
+                      SiPixelTopoFinder::onlineRocColRow(detId, cablingMap_, fedId, dummyOfflineRow, dummeOfflineColumn, roc, rocR, rocC);
+
+                      // encode irow, icol
+                      int key = SiPixelTopoFinder::indexROC(irow, icol, nROCcolumns);
+                      int value = roc;
+                      rocIdMap[key] = value;
+                 } // column
+             } // row
+
+      fRocIds_[detid] = rocIdMap;
+
+    }// tracker geo
+
+}
+
+void SiPixelTopoFinder::onlineRocColRow(const DetId& detId, const SiPixelFedCablingMap* cablingMap, int fedId,
+       int offlineRow, int offlineCol, int& roc, int& row, int& col) {
+
+    // from detector to cabling
+    sipixelobjects::ElectronicIndex cabling;
+    sipixelobjects::DetectorIndex detector;  //{detId.rawId(), offlineRow, offlineCol};
+    detector.rawId = detId.rawId();
+    detector.row = offlineRow;
+    detector.col = offlineCol;
+
+    SiPixelFrameConverter converter(cablingMap, fedId);
+    converter.toCabling(cabling, detector);
+
+    // then one can construct local pixel
+    sipixelobjects::LocalPixel::DcolPxid loc;
+    loc.dcol = cabling.dcol;
+    loc.pxid = cabling.pxid;
+    // and get local(online) row/column
+    sipixelobjects::LocalPixel locpixel(loc);
+    col = locpixel.rocCol();
+    row = locpixel.rocRow();
+    //sipixelobjects::CablingPathToDetUnit path = {(unsigned int) fedId, (unsigned int)cabling.link, (unsigned int)cabling.roc};
+    //const sipixelobjects::PixelROC *theRoc = fCablingMap_->findItem(path);
+    const sipixelobjects::PixelROC* theRoc = converter.toRoc(cabling.link, cabling.roc);
+    roc = theRoc->idInDetUnit();
+
+    // has to be BPIX; has to be minus side; has to be half module
+    // for phase-I, there is no half module
+    if (detId.subdetId() == PixelSubdetector::PixelBarrel
+        && SiPixelTopoFinder::side(detId) == 1 && SiPixelTopoFinder::half(detId)) {
+       roc += 8;
+    }
+
+  }
+
+int SiPixelTopoFinder::indexROC(int irow, int icol, int nROCcolumns) {
+  return int(icol + irow * nROCcolumns);
+
+  // generate the folling roc index that is going to map with ROC id as
+  //   // 8  9  10 11 12 13 14 15
+  //     // 0  1  2  3  4  5  6  7
+  //     }
+  //
+}
+
+// The following three functions copied from DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc
+int SiPixelTopoFinder::quadrant(const DetId& detid) {
+    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+      return PixelBarrelName(detid, tTopo_, phase_).shell();
+    else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
+      return PixelEndcapName(detid, tTopo_, phase_).halfCylinder();
+    else return -9999;
+}
+
+int SiPixelTopoFinder::side(const DetId& detid) {
+    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+       return 1 + (SiPixelTopoFinder::quadrant(detid) > 2);
+    else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
+       return tTopo_->pxfSide(detid);
+    else return -9999;
+}
+
+int SiPixelTopoFinder::half(const DetId& detid) {
+    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+       return PixelBarrelName(detid, tTopo_, phase_).isHalfModule();
+    else return -9999;   
+}

--- a/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
+++ b/CalibTracker/SiPixelQuality/src/SiPixelTopoFinder.cc
@@ -8,109 +8,111 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 
-
-
 SiPixelTopoFinder::SiPixelTopoFinder() {}
 
 SiPixelTopoFinder::~SiPixelTopoFinder() {}
 
 void SiPixelTopoFinder::init(const TrackerGeometry* trackerGeometry,
-                               const TrackerTopology* trackerTopology,
-                               const SiPixelFedCablingMap* siPixelFedCablingMap)
-{
-    phase_ = -1;
+                             const TrackerTopology* trackerTopology,
+                             const SiPixelFedCablingMap* siPixelFedCablingMap) {
+  phase_ = -1;
 
-    tkGeom_ = trackerGeometry;
-    tkTopo_ = trackerTopology;
-    cablingMap_ = siPixelFedCablingMap;
-    // from cabling map to FedIds
-    fFedIds_ = cablingMap_->det2fedMap();
+  tkGeom_ = trackerGeometry;
+  tkTopo_ = trackerTopology;
+  cablingMap_ = siPixelFedCablingMap;
+  // from cabling map to FedIds
+  fFedIds_ = cablingMap_->det2fedMap();
 
-    // clear data
-    fDetIds_.clear();
-    fSensors_.clear();
-    fSensorLayout_.clear();
-    fRocIds_.clear();
+  // clear data
+  fDetIds_.clear();
+  fSensors_.clear();
+  fSensorLayout_.clear();
+  fRocIds_.clear();
 
-    // loop over tracker geometry
-    for (TrackerGeometry::DetContainer::const_iterator it = tkGeom_->dets().begin();
-         it != tkGeom_->dets().end(); it++){// tracker geo
+  // loop over tracker geometry
+  for (TrackerGeometry::DetContainer::const_iterator it = tkGeom_->dets().begin(); it != tkGeom_->dets().end();
+       it++) {  // tracker geo
 
-             const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
-             if (pgdu == nullptr) continue;
-             // get detId for a module
-             DetId detId = (*it)->geographicalId();
-             int detid = detId.rawId();
-             fDetIds_.push_back(detid);
+    const PixelGeomDetUnit* pgdu = dynamic_cast<const PixelGeomDetUnit*>((*it));
+    if (pgdu == nullptr)
+      continue;
+    // get detId for a module
+    DetId detId = (*it)->geographicalId();
+    int detid = detId.rawId();
+    fDetIds_.push_back(detid);
 
-             // don't want to use magic number row 80 column 52 for Phase-1
-             const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
-             int rowsperroc = topo->rowsperroc();
-             int colsperroc = topo->colsperroc();
+    // don't want to use magic number row 80 column 52 for Phase-1
+    const PixelTopology* topo = static_cast<const PixelTopology*>(&pgdu->specificTopology());
+    int rowsperroc = topo->rowsperroc();
+    int colsperroc = topo->colsperroc();
 
-             int nROCrows = pgdu->specificTopology().nrows() / rowsperroc;
-             int nROCcolumns = pgdu->specificTopology().ncolumns() / colsperroc;
+    int nROCrows = pgdu->specificTopology().nrows() / rowsperroc;
+    int nROCcolumns = pgdu->specificTopology().ncolumns() / colsperroc;
 
-             fSensors_[detid] = std::make_pair(rowsperroc, colsperroc);
-             fSensorLayout_[detid] = std::make_pair(nROCrows, nROCcolumns);
+    fSensors_[detid] = std::make_pair(rowsperroc, colsperroc);
+    fSensorLayout_[detid] = std::make_pair(nROCrows, nROCcolumns);
 
-             std::map<int, int> rocIdMap;
-             for (int irow = 0; irow < nROCrows; irow++) { // row
-                 for (int icol = 0; icol < nROCcolumns; icol++) { // column
-                      int dummyOfflineRow = (rowsperroc / 2 - 1) + irow * rowsperroc;
-                      int dummeOfflineColumn = (colsperroc / 2 - 1) + icol * colsperroc;
-                      int fedId = fFedIds_[detId.rawId()];
+    std::map<int, int> rocIdMap;
+    for (int irow = 0; irow < nROCrows; irow++) {       // row
+      for (int icol = 0; icol < nROCcolumns; icol++) {  // column
+        int dummyOfflineRow = (rowsperroc / 2 - 1) + irow * rowsperroc;
+        int dummeOfflineColumn = (colsperroc / 2 - 1) + icol * colsperroc;
+        int fedId = fFedIds_[detId.rawId()];
 
-                      int roc(-1), rocR(-1), rocC(-1);
-                      SiPixelTopoFinder::onlineRocColRow(detId, cablingMap_, fedId, dummyOfflineRow, dummeOfflineColumn, roc, rocR, rocC);
+        int roc(-1), rocR(-1), rocC(-1);
+        SiPixelTopoFinder::onlineRocColRow(
+            detId, cablingMap_, fedId, dummyOfflineRow, dummeOfflineColumn, roc, rocR, rocC);
 
-                      // encode irow, icol
-                      int key = SiPixelTopoFinder::indexROC(irow, icol, nROCcolumns);
-                      int value = roc;
-                      rocIdMap[key] = value;
-                 } // column
-             } // row
+        // encode irow, icol
+        int key = SiPixelTopoFinder::indexROC(irow, icol, nROCcolumns);
+        int value = roc;
+        rocIdMap[key] = value;
+      }  // column
+    }    // row
 
-      fRocIds_[detid] = rocIdMap;
+    fRocIds_[detid] = rocIdMap;
 
-    }// tracker geo
-
+  }  // tracker geo
 }
 
-void SiPixelTopoFinder::onlineRocColRow(const DetId& detId, const SiPixelFedCablingMap* cablingMap, int fedId,
-       int offlineRow, int offlineCol, int& roc, int& row, int& col) {
+void SiPixelTopoFinder::onlineRocColRow(const DetId& detId,
+                                        const SiPixelFedCablingMap* cablingMap,
+                                        int fedId,
+                                        int offlineRow,
+                                        int offlineCol,
+                                        int& roc,
+                                        int& row,
+                                        int& col) {
+  // from detector to cabling
+  sipixelobjects::ElectronicIndex cabling;
+  sipixelobjects::DetectorIndex detector;  //{detId.rawId(), offlineRow, offlineCol};
+  detector.rawId = detId.rawId();
+  detector.row = offlineRow;
+  detector.col = offlineCol;
 
-    // from detector to cabling
-    sipixelobjects::ElectronicIndex cabling;
-    sipixelobjects::DetectorIndex detector;  //{detId.rawId(), offlineRow, offlineCol};
-    detector.rawId = detId.rawId();
-    detector.row = offlineRow;
-    detector.col = offlineCol;
+  SiPixelFrameConverter converter(cablingMap, fedId);
+  converter.toCabling(cabling, detector);
 
-    SiPixelFrameConverter converter(cablingMap, fedId);
-    converter.toCabling(cabling, detector);
+  // then one can construct local pixel
+  sipixelobjects::LocalPixel::DcolPxid loc;
+  loc.dcol = cabling.dcol;
+  loc.pxid = cabling.pxid;
+  // and get local(online) row/column
+  sipixelobjects::LocalPixel locpixel(loc);
+  col = locpixel.rocCol();
+  row = locpixel.rocRow();
+  //sipixelobjects::CablingPathToDetUnit path = {(unsigned int) fedId, (unsigned int)cabling.link, (unsigned int)cabling.roc};
+  //const sipixelobjects::PixelROC *theRoc = fCablingMap_->findItem(path);
+  const sipixelobjects::PixelROC* theRoc = converter.toRoc(cabling.link, cabling.roc);
+  roc = theRoc->idInDetUnit();
 
-    // then one can construct local pixel
-    sipixelobjects::LocalPixel::DcolPxid loc;
-    loc.dcol = cabling.dcol;
-    loc.pxid = cabling.pxid;
-    // and get local(online) row/column
-    sipixelobjects::LocalPixel locpixel(loc);
-    col = locpixel.rocCol();
-    row = locpixel.rocRow();
-    //sipixelobjects::CablingPathToDetUnit path = {(unsigned int) fedId, (unsigned int)cabling.link, (unsigned int)cabling.roc};
-    //const sipixelobjects::PixelROC *theRoc = fCablingMap_->findItem(path);
-    const sipixelobjects::PixelROC* theRoc = converter.toRoc(cabling.link, cabling.roc);
-    roc = theRoc->idInDetUnit();
-
-    // has to be BPIX; has to be minus side; has to be half module
-    // for phase-I, there is no half module
-    if (detId.subdetId() == PixelSubdetector::PixelBarrel
-        && SiPixelTopoFinder::side(detId) == 1 && SiPixelTopoFinder::half(detId)) {
-       roc += 8;
-    }
-
+  // has to be BPIX; has to be minus side; has to be half module
+  // for phase-I, there is no half module
+  if (detId.subdetId() == PixelSubdetector::PixelBarrel && SiPixelTopoFinder::side(detId) == 1 &&
+      SiPixelTopoFinder::half(detId)) {
+    roc += 8;
   }
+}
 
 int SiPixelTopoFinder::indexROC(int irow, int icol, int nROCcolumns) {
   return int(icol + irow * nROCcolumns);
@@ -122,23 +124,26 @@ int SiPixelTopoFinder::indexROC(int irow, int icol, int nROCcolumns) {
 
 // The following three functions copied from DQM/SiPixelPhase1Common/src/SiPixelCoordinates.cc
 int SiPixelTopoFinder::quadrant(const DetId& detid) {
-    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
-      return PixelBarrelName(detid, tkTopo_, phase_).shell();
-    else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
-      return PixelEndcapName(detid, tkTopo_, phase_).halfCylinder();
-    else return -9999;
+  if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+    return PixelBarrelName(detid, tkTopo_, phase_).shell();
+  else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
+    return PixelEndcapName(detid, tkTopo_, phase_).halfCylinder();
+  else
+    return -9999;
 }
 
 int SiPixelTopoFinder::side(const DetId& detid) {
-    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
-       return 1 + (SiPixelTopoFinder::quadrant(detid) > 2);
-    else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
-       return tkTopo_->pxfSide(detid);
-    else return -9999;
+  if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+    return 1 + (SiPixelTopoFinder::quadrant(detid) > 2);
+  else if (detid.subdetId() == PixelSubdetector::PixelEndcap)
+    return tkTopo_->pxfSide(detid);
+  else
+    return -9999;
 }
 
 int SiPixelTopoFinder::half(const DetId& detid) {
-    if (detid.subdetId() == PixelSubdetector::PixelBarrel)
-       return PixelBarrelName(detid, tkTopo_, phase_).isHalfModule();
-    else return -9999;   
+  if (detid.subdetId() == PixelSubdetector::PixelBarrel)
+    return PixelBarrelName(detid, tkTopo_, phase_).isHalfModule();
+  else
+    return -9999;
 }

--- a/CalibTracker/SiPixelQuality/src/classes_def.xml
+++ b/CalibTracker/SiPixelQuality/src/classes_def.xml
@@ -1,15 +1,15 @@
 <lcgdict>
-   <class name="SiPixelRocStatus" ClassVersion="8">
-    <version ClassVersion="8" checksum="4171659340"/>
+   <class name="SiPixelRocStatus" ClassVersion="9">
+    <version ClassVersion="9" checksum="3300278911"/>
    </class>
    <class name="std::vector<SiPixelRocStatus>"/>
-   <class name="SiPixelModuleStatus" ClassVersion="7">
-    <version ClassVersion="7" checksum="4251883507"/>
+   <class name="SiPixelModuleStatus" ClassVersion="8">
+    <version ClassVersion="8" checksum="1925804520"/>
    </class>
    <class name="std::pair<int, SiPixelModuleStatus>"/>
    <class name="std::map<int, SiPixelModuleStatus>"/>
-   <class name="SiPixelDetectorStatus" ClassVersion="9">
-    <version ClassVersion="9" checksum="525778380"/>
+   <class name="SiPixelDetectorStatus" ClassVersion="10">
+    <version ClassVersion="10" checksum="1337720643"/>
    </class>
    <class name="edm::Wrapper<SiPixelDetectorStatus>"/>
 </lcgdict>

--- a/CalibTracker/SiPixelQuality/test/step3_SiPixelCalZeroBias_RAW2DIGI_RECO_ALCA.py
+++ b/CalibTracker/SiPixelQuality/test/step3_SiPixelCalZeroBias_RAW2DIGI_RECO_ALCA.py
@@ -495,13 +495,14 @@ associatePatAlgosToolsTask(process)
 
 #Setup FWK for multithreaded
 process.options.numberOfThreads=cms.untracked.uint32(8)
-process.options.numberOfStreams=cms.untracked.uint32(0)
-process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(1)
+process.options.numberOfStreams=cms.untracked.uint32(4)
+process.options.numberOfConcurrentLuminosityBlocks=cms.untracked.uint32(2)
 
 
 # Customisation from command line
 
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+
 #Have logErrorHarvester wait for the same EDProducers to finish as those providing data for the OutputModule
 from FWCore.Modules.logErrorHarvester_cff import customiseLogErrorHarvesterUsingOutputCommands
 process = customiseLogErrorHarvesterUsingOutputCommands(process)

--- a/CalibTracker/SiPixelQuality/test/step3_SiPixelCalZeroBias_RAW2DIGI_RECO_ALCA.py
+++ b/CalibTracker/SiPixelQuality/test/step3_SiPixelCalZeroBias_RAW2DIGI_RECO_ALCA.py
@@ -6,7 +6,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Run2_2017_cff import Run2_2017
-process = cms.Process('ALCAHARVEST',Run2_2017)
+process = cms.Process('RECO',Run2_2017)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
#### PR description:
SiPixelStatusProducer was first written as a One EDProducer to produce SiPixelCalZeroBias ALCARECO in ExpressPhysics stream.
To make it compatible with concurrent lumiblock processing, this PR changes it to be a stream module.
Parameters such as "resetNlumi" are obsolete and removed after moving to stream EDProducer,
as the module will now only put product to each lumi block not combining product for several lumiblock sections.

SiPixelTopoFinder class is design to contain maps that contains the tracker FED, geometry and topology.
GlobalCache is contructed to make sure these maps will only be produced when tracker FED, geometry or topology changes across run.

globalEndLumiBlockSummary is used to summarize partial digi occupancy and FED error information from each instance of the module and globalEndLumiBlockProducer combines particle information and put the product into current Lumiblock.

The rest of the codes are basically the same as they were, just change of the structures.

#### PR validation:

The product of the EDProducer, digi occupancy, can be dumped into text file for each lumi section.
The text file is the same before and after this PR, and the same when changing the concurrentLlumiBlock from one to two in the SiPixelCalZeroBias production using the config file in CalibTracker/SiPixelQuality/test/step3_SiPixelCalZeroBias_RAW2DIGI_RECO_ALCA.py.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
