### PR TITLE
L1TCaloLayer1 unpacker is modified to deal wirh 5BX readout for ECAL TPs

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
@@ -4,25 +4,14 @@
 
 namespace l1t {
   namespace stage2 {
-    CaloLayer1Collections::CaloLayer1Collections(edm::Event& e)
-        : UnpackerCollections(e),
-          ecalDigis_(new EcalTrigPrimDigiCollection()),
-          hcalDigis_(new HcalTrigPrimDigiCollection()),
-          caloRegions_(new L1CaloRegionCollection()) {
-      // Pre-allocate:
-      //  72 iPhi values
-      //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
-      //  2 hemispheres
-      ecalDigis_->reserve(72 * 28 * 2);
-      hcalDigis_->reserve(72 * 40 * 2);
-      // 7 regions * 18 cards * 2 hemispheres
-      caloRegions_->reserve(7 * 18 * 2);
-    }
-
     CaloLayer1Collections::~CaloLayer1Collections() {
       event_.put(std::move(ecalDigis_));
       event_.put(std::move(hcalDigis_));
       event_.put(std::move(caloRegions_));
+
+      for(int i=0; i<5;++i){
+        event_.put(std::move(ecalDigisBx_[i]), "EcalDigisBx" + std::to_string(i + 1));
+      }
     }
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.cc
@@ -9,7 +9,7 @@ namespace l1t {
       event_.put(std::move(hcalDigis_));
       event_.put(std::move(caloRegions_));
 
-      for(int i=0; i<5;++i){
+      for (int i = 0; i < 5; ++i) {
         event_.put(std::move(ecalDigisBx_[i]), "EcalDigisBx" + std::to_string(i + 1));
       }
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
@@ -12,20 +12,21 @@ namespace l1t {
     class CaloLayer1Collections : public L1TObjectCollections {
     public:
       CaloLayer1Collections(edm::Event& e)
-        : L1TObjectCollections(e),
-          ecalDigis_(new EcalTrigPrimDigiCollection()),
-          hcalDigis_(new HcalTrigPrimDigiCollection()),
-          caloRegions_(new L1CaloRegionCollection()){
-      // Pre-allocate:
-      //  72 iPhi values
-      //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
-      //  2 hemispheres
-      ecalDigis_->reserve(72 * 28 * 2);
-      hcalDigis_->reserve(72 * 40 * 2);
-      // 7 regions * 18 cards * 2 hemispheres
-      caloRegions_->reserve(7 * 18 * 2);
-      std::generate(ecalDigisBx_.begin(), ecalDigisBx_.end(), [] { return std::make_unique<EcalTrigPrimDigiCollection>(); });
-    };
+          : L1TObjectCollections(e),
+            ecalDigis_(new EcalTrigPrimDigiCollection()),
+            hcalDigis_(new HcalTrigPrimDigiCollection()),
+            caloRegions_(new L1CaloRegionCollection()) {
+        // Pre-allocate:
+        //  72 iPhi values
+        //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
+        //  2 hemispheres
+        ecalDigis_->reserve(72 * 28 * 2);
+        hcalDigis_->reserve(72 * 40 * 2);
+        // 7 regions * 18 cards * 2 hemispheres
+        caloRegions_->reserve(7 * 18 * 2);
+        std::generate(
+            ecalDigisBx_.begin(), ecalDigisBx_.end(), [] { return std::make_unique<EcalTrigPrimDigiCollection>(); });
+      };
 
       ~CaloLayer1Collections() override;
 
@@ -33,16 +34,16 @@ namespace l1t {
       inline HcalTrigPrimDigiCollection* getHcalDigis() { return hcalDigis_.get(); };
       inline L1CaloRegionCollection* getRegions() { return caloRegions_.get(); };
 
-      inline EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) override { return ecalDigisBx_[copy].get(); };
+      inline EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) override {
+        return ecalDigisBx_[copy].get();
+      };
 
     private:
       std::unique_ptr<EcalTrigPrimDigiCollection> ecalDigis_;
       std::unique_ptr<HcalTrigPrimDigiCollection> hcalDigis_;
       std::unique_ptr<L1CaloRegionCollection> caloRegions_;
 
-
-      std::array<std::unique_ptr<EcalTrigPrimDigiCollection>,5> ecalDigisBx_;
-
+      std::array<std::unique_ptr<EcalTrigPrimDigiCollection>, 5> ecalDigisBx_;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Collections.h
@@ -5,22 +5,44 @@
 #include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
+#include "L1TObjectCollections.h"
 
 namespace l1t {
   namespace stage2 {
-    class CaloLayer1Collections : public UnpackerCollections {
+    class CaloLayer1Collections : public L1TObjectCollections {
     public:
-      CaloLayer1Collections(edm::Event& e);
+      CaloLayer1Collections(edm::Event& e)
+        : L1TObjectCollections(e),
+          ecalDigis_(new EcalTrigPrimDigiCollection()),
+          hcalDigis_(new HcalTrigPrimDigiCollection()),
+          caloRegions_(new L1CaloRegionCollection()){
+      // Pre-allocate:
+      //  72 iPhi values
+      //  28 iEta values in Ecal, 28 + 12 iEta values in Hcal + HF
+      //  2 hemispheres
+      ecalDigis_->reserve(72 * 28 * 2);
+      hcalDigis_->reserve(72 * 40 * 2);
+      // 7 regions * 18 cards * 2 hemispheres
+      caloRegions_->reserve(7 * 18 * 2);
+      std::generate(ecalDigisBx_.begin(), ecalDigisBx_.end(), [] { return std::make_unique<EcalTrigPrimDigiCollection>(); });
+    };
+
       ~CaloLayer1Collections() override;
 
       inline EcalTrigPrimDigiCollection* getEcalDigis() { return ecalDigis_.get(); };
       inline HcalTrigPrimDigiCollection* getHcalDigis() { return hcalDigis_.get(); };
       inline L1CaloRegionCollection* getRegions() { return caloRegions_.get(); };
 
+      inline EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) override { return ecalDigisBx_[copy].get(); };
+
     private:
       std::unique_ptr<EcalTrigPrimDigiCollection> ecalDigis_;
       std::unique_ptr<HcalTrigPrimDigiCollection> hcalDigis_;
       std::unique_ptr<L1CaloRegionCollection> caloRegions_;
+
+
+      std::array<std::unique_ptr<EcalTrigPrimDigiCollection>,5> ecalDigisBx_;
+
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -55,6 +55,9 @@ namespace l1t {
       prod.produces<EcalTrigPrimDigiCollection>();
       prod.produces<HcalTrigPrimDigiCollection>();
       prod.produces<L1CaloRegionCollection>();
+      for(int i=0; i<5;++i){
+        prod.produces<EcalTrigPrimDigiCollection>("EcalDigisBx" + std::to_string(i + 1));
+      }
     }
 
     std::unique_ptr<UnpackerCollections> CaloLayer1Setup::getCollections(edm::Event& e) {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Setup.cc
@@ -55,7 +55,7 @@ namespace l1t {
       prod.produces<EcalTrigPrimDigiCollection>();
       prod.produces<HcalTrigPrimDigiCollection>();
       prod.produces<L1CaloRegionCollection>();
-      for(int i=0; i<5;++i){
+      for (int i = 0; i < 5; ++i) {
         prod.produces<EcalTrigPrimDigiCollection>("EcalDigisBx" + std::to_string(i + 1));
       }
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -21,29 +21,31 @@ namespace l1t {
       auto ctp7_phi = block.amc().getBoardID();
       const uint32_t* ptr = block.payload().data();
 
-      int N_BX = (block.header().getFlags()>>16)&0xf ;
-//      std::cout << " N_BX calculated " << N_BX << std::endl;
-       
-      if (N_BX == 1){
-         UCTCTP7RawData ctp7Data(ptr);
-         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-         makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-         makeRegions(ctp7_phi, ctp7Data, res->getRegions());}
-      else if (N_BX == 5){
-         const uint32_t* ptr5 = ptr ;
-         UCTCTP7RawData ctp7Data(ptr);
-         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-         makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-         makeRegions(ctp7_phi, ctp7Data, res->getRegions());
-         for (int i=0; i<5 ; i++){
-            UCTCTP7RawData ctp7Data(ptr5);
-            makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigisBx(i));
-            ptr5 += 192 ; }}
-      else {
-          LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
-          return false; }
+      int N_BX = (block.header().getFlags() >> 16) & 0xf;
+      //      std::cout << " N_BX calculated " << N_BX << std::endl;
+
+      if (N_BX == 1) {
+        UCTCTP7RawData ctp7Data(ptr);
+        makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+        makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+        makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+        makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+      } else if (N_BX == 5) {
+        const uint32_t* ptr5 = ptr;
+        UCTCTP7RawData ctp7Data(ptr);
+        makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+        makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+        makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+        makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+        for (int i = 0; i < 5; i++) {
+          UCTCTP7RawData ctp7Data(ptr5);
+          makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigisBx(i));
+          ptr5 += 192;
+        }
+      } else {
+        LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
+        return false;
+      }
 
       return true;
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/CaloLayer1Unpacker.cc
@@ -21,11 +21,29 @@ namespace l1t {
       auto ctp7_phi = block.amc().getBoardID();
       const uint32_t* ptr = block.payload().data();
 
-      UCTCTP7RawData ctp7Data(ptr);
-      makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
-      makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-      makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
-      makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+      int N_BX = (block.header().getFlags()>>16)&0xf ;
+//      std::cout << " N_BX calculated " << N_BX << std::endl;
+       
+      if (N_BX == 1){
+         UCTCTP7RawData ctp7Data(ptr);
+         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+         makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+         makeRegions(ctp7_phi, ctp7Data, res->getRegions());}
+      else if (N_BX == 5){
+         const uint32_t* ptr5 = ptr ;
+         UCTCTP7RawData ctp7Data(ptr);
+         makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigis());
+         makeHCalTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+         makeHFTPGs(ctp7_phi, ctp7Data, res->getHcalDigis());
+         makeRegions(ctp7_phi, ctp7Data, res->getRegions());
+         for (int i=0; i<5 ; i++){
+            UCTCTP7RawData ctp7Data(ptr5);
+            makeECalTPGs(ctp7_phi, ctp7Data, res->getEcalDigisBx(i));
+            ptr5 += 192 ; }}
+      else {
+          LogError("CaloLayer1Unpacker") << "Number of BXs to unpack is not 1 or 5, stop here !!! " << N_BX << std::endl;
+          return false; }
 
       return true;
     }

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -7,6 +7,8 @@
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/Muon.h"
 
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+
 #include "EventFilter/L1TRawToDigi/interface/UnpackerCollections.h"
 
 namespace l1t {
@@ -21,6 +23,8 @@ namespace l1t {
       virtual EtSumBxCollection* getEtSums(const unsigned int copy) { return nullptr; }
       virtual JetBxCollection* getJets(const unsigned int copy) { return nullptr; }
       virtual TauBxCollection* getTaus(const unsigned int copy) { return nullptr; }
+      
+      virtual EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) { return nullptr; };
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/L1TObjectCollections.h
@@ -23,7 +23,7 @@ namespace l1t {
       virtual EtSumBxCollection* getEtSums(const unsigned int copy) { return nullptr; }
       virtual JetBxCollection* getJets(const unsigned int copy) { return nullptr; }
       virtual TauBxCollection* getTaus(const unsigned int copy) { return nullptr; }
-      
+
       virtual EcalTrigPrimDigiCollection* getEcalDigisBx(const unsigned int copy) { return nullptr; };
     };
   }  // namespace stage2

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -226,7 +226,7 @@ namespace l1t {
     // Not sure how to map to generic BlockHeader variables, so just packing
     // it all in flags variable
     unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff);
-    unsigned blockSize = 192;
+    unsigned blockSize = 192*(int)bx_per_l1a_;
     return BlockHeader(blockId, blockSize, capId_, blockFlags, CTP7);
   }
 

--- a/EventFilter/L1TRawToDigi/src/Block.cc
+++ b/EventFilter/L1TRawToDigi/src/Block.cc
@@ -226,7 +226,7 @@ namespace l1t {
     // Not sure how to map to generic BlockHeader variables, so just packing
     // it all in flags variable
     unsigned blockFlags = ((bx_per_l1a_ & 0xf) << 16) | (calo_bxid_ & 0xfff);
-    unsigned blockSize = 192*(int)bx_per_l1a_;
+    unsigned blockSize = 192 * (int)bx_per_l1a_;
     return BlockHeader(blockId, blockSize, capId_, blockFlags, CTP7);
   }
 


### PR DESCRIPTION
#### PR description:

ECAL wants to see TPs for +/-2BX for fat events, the FW will be modified to do it, this unpacker should be able to unpack events where we have 5BX in CaloLayer1 to readout  

#### PR validation:

Ran on data events, simulated situation with 5BX payload 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
