### PR TITLE
[HGCAL] Corrections in noise vector in CLUE

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -45,15 +45,11 @@ public:
         maxNumberOfThickIndices_(ps.getParameter<unsigned>("maxNumberOfThickIndices")),
         fcPerMip_(ps.getParameter<std::vector<double>>("fcPerMip")),
         fcPerEle_(ps.getParameter<double>("fcPerEle")),
-        nonAgedNoises_(ps.getParameter<edm::ParameterSet>("noises").getParameter<std::vector<double>>("values")),
+        nonAgedNoises_(ps.getParameter<std::vector<double>>("noises")),
         noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
         use2x2_(ps.getParameter<bool>("use2x2")),
-        initialized_(false) {
-    // repeat same noises for CE-H as well
-    if (!isNose_) {
-      nonAgedNoises_.insert(std::end(nonAgedNoises_), std::begin(nonAgedNoises_), std::end(nonAgedNoises_));
-    }
-  }
+        initialized_(false)
+        {}
 
   ~HGCalCLUEAlgoT() override {}
 
@@ -107,9 +103,7 @@ public:
     iDesc.add<unsigned>("maxNumberOfThickIndices", 6);
     iDesc.add<std::vector<double>>("fcPerMip", {});
     iDesc.add<double>("fcPerEle", 0.0);
-    edm::ParameterSetDescription descNestedNoises;
-    descNestedNoises.add<std::vector<double>>("values", {});
-    iDesc.add<edm::ParameterSetDescription>("noises", descNestedNoises);
+    iDesc.add<std::vector<double>>("noises", {});
     edm::ParameterSetDescription descNestedNoiseMIP;
     descNestedNoiseMIP.add<bool>("scaleByDose", false);
     descNestedNoiseMIP.add<unsigned int>("scaleByDoseAlgo", 0);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -48,8 +48,7 @@ public:
         nonAgedNoises_(ps.getParameter<std::vector<double>>("noises")),
         noiseMip_(ps.getParameter<edm::ParameterSet>("noiseMip").getParameter<double>("noise_MIP")),
         use2x2_(ps.getParameter<bool>("use2x2")),
-        initialized_(false)
-        {}
+        initialized_(false) {}
 
   ~HGCalCLUEAlgoT() override {}
 

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -11,31 +11,31 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, HGCA
 hgcalLayerClusters = hgcalLayerClusters_.clone(
     timeOffset = hgceeDigitizer.tofDelay,
     plugin = dict(
-        dEdXweights = dEdX.weights,
+        dEdXweights = dEdX.weights.value(),
         #With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
         #we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.
-        fcPerMip = HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP,
-        thicknessCorrection = HGCalRecHit.thicknessCorrection,
-        sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection,
-        deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac,
+        fcPerMip = HGCalUncalibRecHit.HGCEEConfig.fCPerMIP.value() + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP.value(),
+        thicknessCorrection = HGCalRecHit.thicknessCorrection.value(),
+        sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection.value(),
+        deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac.value(),
         fcPerEle = fC_per_ele,
         #Extending noises as fcPerMip, see comment above.
-        noises = HGCAL_noises.values + HGCAL_noises.values,
-        noiseMip = hgchebackDigitizer.digiCfg.noise
+        noises = HGCAL_noises.values.value() + HGCAL_noises.values.value(),
+        noiseMip = hgchebackDigitizer.digiCfg.noise.value()
     )
 )
 
 hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     detector = 'HFNose',
-    timeOffset = hfnoseDigitizer.tofDelay,
+    timeOffset = hfnoseDigitizer.tofDelay.value(),
     nHitsTime = 3,
     plugin = dict(
-        dEdXweights = dEdX.weightsNose,
+        dEdXweights = dEdX.weightsNose.value(),
         maxNumberOfThickIndices = 3,
-        fcPerMip = HGCalUncalibRecHit.HGCHFNoseConfig.fCPerMIP,
-        thicknessCorrection = HGCalRecHit.thicknessNoseCorrection,
+        fcPerMip = HGCalUncalibRecHit.HGCHFNoseConfig.fCPerMIP.value(),
+        thicknessCorrection = HGCalRecHit.thicknessNoseCorrection.value(),
         fcPerEle = fC_per_ele,
-        noises = HGCAL_noises.values,
-        noiseMip = hgchebackDigitizer.digiCfg.noise
+        noises = HGCAL_noises.values.value(),
+        noiseMip = hgchebackDigitizer.digiCfg.noise.value()
     )
 )

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -29,6 +29,7 @@ hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     nHitsTime = cms.uint32(3),
     plugin = dict(
         dEdXweights = dEdX.weightsNose,
+        maxNumberOfThickIndices = cms.uint32(3),
         fcPerMip = HGCalUncalibRecHit.HGCHFNoseConfig.fCPerMIP,
         thicknessCorrection = HGCalRecHit.thicknessNoseCorrection,
         fcPerEle = fC_per_ele,

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -12,11 +12,14 @@ hgcalLayerClusters = hgcalLayerClusters_.clone()
 
 hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
 hgcalLayerClusters.plugin.dEdXweights = cms.vdouble(dEdX.weights)
+#With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
+#we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.
 hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP)
 hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
 hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
 hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac
 hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
+#Extending noises as fcPerMip, see comment above.
 hgcalLayerClusters.plugin.noises = cms.vdouble(HGCAL_noises.values + HGCAL_noises.values)
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise
 

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -8,20 +8,22 @@ from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import HGCalUncalibR
 
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, HGCAL_noises, hgceeDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
-hgcalLayerClusters = hgcalLayerClusters_.clone()
-
-hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
-hgcalLayerClusters.plugin.dEdXweights = dEdX.weights
-#With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
-#we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.
-hgcalLayerClusters.plugin.fcPerMip = HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP
-hgcalLayerClusters.plugin.thicknessCorrection = HGCalRecHit.thicknessCorrection
-hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
-hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac
-hgcalLayerClusters.plugin.fcPerEle = fC_per_ele
-#Extending noises as fcPerMip, see comment above.
-hgcalLayerClusters.plugin.noises = HGCAL_noises.values + HGCAL_noises.values
-hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise
+hgcalLayerClusters = hgcalLayerClusters_.clone(
+    timeOffset = hgceeDigitizer.tofDelay,
+    plugin = dict(
+        dEdXweights = dEdX.weights,
+        #With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
+        #we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.
+        fcPerMip = HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP,
+        thicknessCorrection = HGCalRecHit.thicknessCorrection,
+        sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection,
+        deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac,
+        fcPerEle = fC_per_ele,
+        #Extending noises as fcPerMip, see comment above.
+        noises = HGCAL_noises.values + HGCAL_noises.values,
+        noiseMip = hgchebackDigitizer.digiCfg.noise
+    )
+)
 
 hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     detector = 'HFNose',

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -6,7 +6,7 @@ from RecoLocalCalo.HGCalRecProducers.HGCalRecHit_cfi import dEdX, HGCalRecHit
 
 from RecoLocalCalo.HGCalRecProducers.HGCalUncalibRecHit_cfi import HGCalUncalibRecHit
 
-from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, hgceeDigitizer, hgchebackDigitizer, hfnoseDigitizer
+from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, HGCAL_noises, hgceeDigitizer, hgchebackDigitizer, hfnoseDigitizer
 
 hgcalLayerClusters = hgcalLayerClusters_.clone()
 
@@ -17,7 +17,7 @@ hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknes
 hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
 hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac
 hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
-hgcalLayerClusters.plugin.noises = cms.PSet(refToPSet_ = cms.string('HGCAL_noises'))
+hgcalLayerClusters.plugin.noises = cms.vdouble(HGCAL_noises.values + HGCAL_noises.values)
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise
 
 hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
@@ -29,7 +29,7 @@ hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
         fcPerMip = HGCalUncalibRecHit.HGCHFNoseConfig.fCPerMIP,
         thicknessCorrection = HGCalRecHit.thicknessNoseCorrection,
         fcPerEle = fC_per_ele,
-        noises = dict(refToPSet_ = cms.string('HGCAL_noises')),
+        noises = cms.vdouble(HGCAL_noises.values),
         noiseMip = hgchebackDigitizer.digiCfg.noise
     )
 )

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cff.py
@@ -11,29 +11,29 @@ from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import fC_per_ele, HGCA
 hgcalLayerClusters = hgcalLayerClusters_.clone()
 
 hgcalLayerClusters.timeOffset = hgceeDigitizer.tofDelay
-hgcalLayerClusters.plugin.dEdXweights = cms.vdouble(dEdX.weights)
+hgcalLayerClusters.plugin.dEdXweights = dEdX.weights
 #With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator),
 #we extend fcPerMip (along with noises below) so that it is guaranteed that they have 6 entries.
-hgcalLayerClusters.plugin.fcPerMip = cms.vdouble(HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP)
-hgcalLayerClusters.plugin.thicknessCorrection = cms.vdouble(HGCalRecHit.thicknessCorrection)
+hgcalLayerClusters.plugin.fcPerMip = HGCalUncalibRecHit.HGCEEConfig.fCPerMIP + HGCalUncalibRecHit.HGCHEFConfig.fCPerMIP
+hgcalLayerClusters.plugin.thicknessCorrection = HGCalRecHit.thicknessCorrection
 hgcalLayerClusters.plugin.sciThicknessCorrection = HGCalRecHit.sciThicknessCorrection
 hgcalLayerClusters.plugin.deltasi_index_regemfac = HGCalRecHit.deltasi_index_regemfac
-hgcalLayerClusters.plugin.fcPerEle = cms.double(fC_per_ele)
+hgcalLayerClusters.plugin.fcPerEle = fC_per_ele
 #Extending noises as fcPerMip, see comment above.
-hgcalLayerClusters.plugin.noises = cms.vdouble(HGCAL_noises.values + HGCAL_noises.values)
+hgcalLayerClusters.plugin.noises = HGCAL_noises.values + HGCAL_noises.values
 hgcalLayerClusters.plugin.noiseMip = hgchebackDigitizer.digiCfg.noise
 
 hgcalLayerClustersHFNose = hgcalLayerClusters_.clone(
     detector = 'HFNose',
     timeOffset = hfnoseDigitizer.tofDelay,
-    nHitsTime = cms.uint32(3),
+    nHitsTime = 3,
     plugin = dict(
         dEdXweights = dEdX.weightsNose,
-        maxNumberOfThickIndices = cms.uint32(3),
+        maxNumberOfThickIndices = 3,
         fcPerMip = HGCalUncalibRecHit.HGCHFNoseConfig.fCPerMIP,
         thicknessCorrection = HGCalRecHit.thicknessNoseCorrection,
         fcPerEle = fC_per_ele,
-        noises = cms.vdouble(HGCAL_noises.values),
+        noises = HGCAL_noises.values,
         noiseMip = hgchebackDigitizer.digiCfg.noise
     )
 )


### PR DESCRIPTION
#### PR description:

With the introduction of 7 regional factors (6 for silicon plus 1 for scintillator), the fcPerMip and 
noises vectors should be guaranteed that they have 6 entries. We alter the way the noises vector is extended, since it uses the `isNose_` member variable before the variable is set, while the `insert` method should not be called using iterators that refer to the very same vector we are trying to extend.

#### PR validation:

No difference is observed to the printout information. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport. 