### PR TITLE
HGCAL: restore distance cut in CLUE position calculation

### DIFF
--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -215,7 +215,8 @@ math::XYZPoint HGCalCLUEAlgoT<T>::calculatePosition(const std::vector<int>& v, c
     float y_log = 0.f;
     for (auto i : v) {
       //for silicon only just use 1+6 cells = 1.3cm for all thicknesses
-      if (distance(i, maxEnergyIndex, layerId, false) > positionDeltaRho_) continue;
+      if (distance(i, maxEnergyIndex, layerId, false) > positionDeltaRho_)
+        continue;
       float rhEnergy = cellsOnLayer.weight[i];
       float Wi = std::max(thresholdW0_[thick] + std::log(rhEnergy / total_weight), 0.);
       x_log += cellsOnLayer.x[i] * Wi;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -215,7 +215,7 @@ math::XYZPoint HGCalCLUEAlgoT<T>::calculatePosition(const std::vector<int>& v, c
     float y_log = 0.f;
     for (auto i : v) {
       //for silicon only just use 1+6 cells = 1.3cm for all thicknesses
-      if (distance(i, maxEnergyIndex, layerId, false) > positionDeltaRho_)
+      if (distance2(i, maxEnergyIndex, layerId, false) > positionDeltaRho2_)
         continue;
       float rhEnergy = cellsOnLayer.weight[i];
       float Wi = std::max(thresholdW0_[thick] + std::log(rhEnergy / total_weight), 0.);

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.cc
@@ -214,6 +214,8 @@ math::XYZPoint HGCalCLUEAlgoT<T>::calculatePosition(const std::vector<int>& v, c
     float x_log = 0.f;
     float y_log = 0.f;
     for (auto i : v) {
+      //for silicon only just use 1+6 cells = 1.3cm for all thicknesses
+      if (distance(i, maxEnergyIndex, layerId, false) > positionDeltaRho_) continue;
       float rhEnergy = cellsOnLayer.weight[i];
       float Wi = std::max(thresholdW0_[thick] + std::log(rhEnergy / total_weight), 0.);
       x_log += cellsOnLayer.x[i] * Wi;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -34,6 +34,7 @@ public:
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
             reco::CaloCluster::undefined),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
+        positionDeltaRho_(ps.getParameter<double>("positionDeltaRho")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),
         kappa_(ps.getParameter<double>("kappa")),
         ecut_(ps.getParameter<double>("ecut")),
@@ -89,6 +90,7 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9});
+    iDesc.add<double>("positionDeltaRho", 1.3);
     iDesc.add<std::vector<double>>("deltac",
                                    {
                                        1.3,
@@ -126,6 +128,7 @@ public:
 private:
   // To compute the cluster position
   std::vector<double> thresholdW0_;
+  double positionDeltaRho_;
 
   // The two parameters used to identify clusters
   std::vector<double> vecDeltas_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -34,7 +34,7 @@ public:
             (HGCalClusteringAlgoBase::VerbosityLevel)ps.getUntrackedParameter<unsigned int>("verbosity", 3),
             reco::CaloCluster::undefined),
         thresholdW0_(ps.getParameter<std::vector<double>>("thresholdW0")),
-        positionDeltaRho_(ps.getParameter<double>("positionDeltaRho")),
+        positionDeltaRho2_(ps.getParameter<double>("positionDeltaRho2")),
         vecDeltas_(ps.getParameter<std::vector<double>>("deltac")),
         kappa_(ps.getParameter<double>("kappa")),
         ecut_(ps.getParameter<double>("ecut")),
@@ -90,7 +90,7 @@ public:
 
   static void fillPSetDescription(edm::ParameterSetDescription& iDesc) {
     iDesc.add<std::vector<double>>("thresholdW0", {2.9, 2.9, 2.9});
-    iDesc.add<double>("positionDeltaRho", 1.3);
+    iDesc.add<double>("positionDeltaRho2", 1.69);
     iDesc.add<std::vector<double>>("deltac",
                                    {
                                        1.3,
@@ -128,7 +128,7 @@ public:
 private:
   // To compute the cluster position
   std::vector<double> thresholdW0_;
-  double positionDeltaRho_;
+  double positionDeltaRho2_;
 
   // The two parameters used to identify clusters
   std::vector<double> vecDeltas_;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalCLUEAlgo.h
@@ -128,7 +128,7 @@ public:
 private:
   // To compute the cluster position
   std::vector<double> thresholdW0_;
-  double positionDeltaRho2_;
+  const double positionDeltaRho2_;
 
   // The two parameters used to identify clusters
   std::vector<double> vecDeltas_;


### PR DESCRIPTION
This PR reintroduce the cut on the cells distance selected to compute the layer cluster position, that was probably lost in the migration from ImagingAlgo to CLUE.

For the record:
- the cut is 1.3cm for all silicon cells 
- the study was presented in the past in 
https://indico.cern.ch/event/776790/contributions/3230583/attachments/1761511/2865143/positionResolutionFor2DClusters_amartell_29Nov.pdf


This PR also addresses the open issue #31552 
