### PR TITLE
switch HI MC from a 2018 to a 2021 workflow  (158.0 -> 312.0) in the short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -73,8 +73,8 @@ if __name__ == '__main__':
                      136.874, #2018C EGamma
                      140.53, #2011 HI data
                      140.56, #2018 HI data
-                     158.0, #2018 HI MC with pp-like reco
                      158.01, #reMiniAOD of 2018 HI MC with pp-like reco
+                     312.0, #2021/Run3 HI MC Pyquen_ZeemumuJets_pt10 with pp-like reco
                      1306.0, #SingleMu Pt1 UP15
                      1325.7, #test NanoAOD from existing MINI
                      1330, #Run2 MC Zmm


### PR DESCRIPTION
after discussing with @mandrenguyen , a  sample using signal mixing is more appropriate and using Zeemm sample should cover more parts of reco.
Among a few available Run3 HI MC workflows, 159.0, 311.0, and 312.0 I found that the total time is about the same as 158.0 to within a couple of minutes (for a total of about 30 m on my somewhat slow machine).
