### PR TITLE
Replace mirrored finders in RecoMuon from TrackingTools/DetLayer with the original ones

### DIFF
--- a/RecoMuon/DetLayers/src/GeneralBinFinderInPhi.h
+++ b/RecoMuon/DetLayers/src/GeneralBinFinderInPhi.h
@@ -1,1 +1,0 @@
-#include "TrackingTools/DetLayers/interface/GeneralBinFinderInPhi.h"

--- a/RecoMuon/DetLayers/src/GeneralBinFinderInR.h
+++ b/RecoMuon/DetLayers/src/GeneralBinFinderInR.h
@@ -1,1 +1,0 @@
-#include "TrackingTools/DetLayers/interface/GeneralBinFinderInR.h"

--- a/RecoMuon/DetLayers/src/MuRingForwardLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRingForwardLayer.cc
@@ -3,17 +3,16 @@
  *  \author N. Amapane - CERN
  */
 
-#include <RecoMuon/DetLayers/interface/MuRingForwardLayer.h>
-#include <RecoMuon/DetLayers/interface/MuDetRing.h>
-#include <Geometry/CommonDetUnit/interface/GeomDet.h>
-#include <DataFormats/GeometrySurface/interface/SimpleDiskBounds.h>
-#include <TrackingTools/GeomPropagators/interface/Propagator.h>
-#include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
+#include "RecoMuon/DetLayers/interface/MuRingForwardLayer.h"
+#include "RecoMuon/DetLayers/interface/MuDetRing.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "DataFormats/GeometrySurface/interface/SimpleDiskBounds.h"
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
+#include "TrackingTools/DetLayers/interface/RBorderFinder.h"
+#include "TrackingTools/DetLayers/interface/GeneralBinFinderInR.h"
 
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
-
-#include "RBorderFinder.h"
-#include "GeneralBinFinderInR.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
 #include <iostream>

--- a/RecoMuon/DetLayers/src/MuRodBarrelLayer.cc
+++ b/RecoMuon/DetLayers/src/MuRodBarrelLayer.cc
@@ -8,14 +8,13 @@
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
+#include "TrackingTools/DetLayers/interface/GeneralBinFinderInPhi.h"
+#include "TrackingTools/DetLayers/interface/PhiBorderFinder.h"
 #include "Utilities/BinningTools/interface/PeriodicBinFinderInPhi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-#include <Utilities/General/interface/precomputed_value_sort.h>
+#include "Utilities/General/interface/precomputed_value_sort.h"
 #include "DataFormats/GeometrySurface/interface/GeometricSorting.h"
-
-#include "GeneralBinFinderInPhi.h"
-#include "PhiBorderFinder.h"
 
 #include <algorithm>
 #include <iostream>

--- a/RecoMuon/DetLayers/src/PhiBorderFinder.h
+++ b/RecoMuon/DetLayers/src/PhiBorderFinder.h
@@ -1,1 +1,0 @@
-#include "TrackingTools/DetLayers/interface/PhiBorderFinder.h"

--- a/RecoMuon/DetLayers/src/RBorderFinder.h
+++ b/RecoMuon/DetLayers/src/RBorderFinder.h
@@ -1,1 +1,0 @@
-#include "TrackingTools/DetLayers/interface/RBorderFinder.h"


### PR DESCRIPTION
#### PR description:

Following the resolution of the MTD related part of issue #24452 by PR #32026 (from @fabiocos), I address here the part of the [comment](https://github.com/cms-sw/cmssw/pull/24285#issuecomment-418102225) which referred to RecoMuon's instead, so that it is resolved as well.

The issue claimed that there was no reason to maintain all files like (e.g.) `RecoMuon/DetLayers/src/RBorderFinder.h` which just mirror (e.g.) `TrackingTools/DetLayers/interface/RBorderFinder.h`.

With this PR I'm going to replace their inclusion in `RecoMuon/DetLayers` with the one of the original headers from `TrackingTools/DetLayers`

#### PR validation:

It builds, that's enough
No changes expected