### PR TITLE
Clean BuildFiles in GeneratorInterface etc

### DIFF
--- a/GeneratorInterface/GenExtensions/bin/BuildFile.xml
+++ b/GeneratorInterface/GenExtensions/bin/BuildFile.xml
@@ -1,10 +1,10 @@
 <library file="BCVEGPY/*.F,BCVEGPY/*.f" name="GeneratorInterfaceBCVEGPY">
-  <use name="GeneratorInterface/Pythia6Interface"/>
+  <use name="pythia6"/>
   <use name="f77compiler"/>
 </library>
 
 <bin file="BCVEGPY/main.cc" name="BcGenerator">
-  <use name="GeneratorInterface/Pythia6Interface"/>
+  <use name="pythia6"/>
   <use name="f77compiler"/>
   <lib name="GeneratorInterfaceBCVEGPY"/>
 </bin>

--- a/GeneratorInterface/GenFilters/plugins/BuildFile.xml
+++ b/GeneratorInterface/GenFilters/plugins/BuildFile.xml
@@ -3,7 +3,6 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/Utilities"/>
   <use name="SimDataFormats/GeneratorProducts"/>
-  <use name="GeneratorInterface/Pythia6Interface"/>
   <use name="GeneratorInterface/Core"/>
   <use name="SimGeneral/HepPDTRecord"/>
   <use name="DataFormats/GeometryVector"/>
@@ -25,6 +24,7 @@
   <use name="heppdt"/>
   <use name="clhep"/>
   <use name="rootcore"/>
+  <use name="pythia6"/>
   <use name="pythia8"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
+++ b/RecoEgamma/EgammaIsolationAlgos/BuildFile.xml
@@ -10,7 +10,6 @@
 <use name="DataFormats/HcalDetId"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="CondFormats/HcalObjects"/>
-<use name="CondFormats/DataRecord"/>
 <use name="RecoLocalCalo/EcalRecAlgos"/>
 <use name="CommonTools/Statistics"/>
 <export>

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/Utilities"/>
-<use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/TrackerRecHit2D"/>
 <use name="Geometry/CommonDetUnit"/>
 <use name="Geometry/TrackerGeometryBuilder"/>

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/test/BuildFile.xml
@@ -2,9 +2,12 @@
 <use   name="root"/>
 <use   name="classlib"/>
 <use   name="clhep"/>
-<use   name="SimDataFormats/TrackingHit"/>
+<use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/TrackerDigiSimLink"/>
-<use   name="SimDataFormats/CrossingFrame"/>
+<use   name="SimDataFormats/TrackingAnalysis"/>
+<use   name="SimDataFormats/TrackingHit"/>
+<use   name="SimDataFormats/Vertex"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="DataFormats/SiPixelDigi"/>
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="DataFormats/DetId"/>
@@ -14,13 +17,9 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="CommonTools/UtilAlgos"/>
-<use   name="DQMServices/Core"/>
 <use   name="DataFormats/Common"/>
-<use   name="FWCore/PluginManager"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="DataFormats/Phase2TrackerCluster"/>
-<use   name="DataFormats/ParticleFlowCandidate"/>
-<use   name="DataFormats/ParticleFlowReco"/>
 <use   name="RecoLocalTracker/SiPhase2VectorHitBuilder"/>
 <library   file="VectorHitsBuilderValidation.cc" name="VectorHitsBuilderValidation">
   <flags   EDM_PLUGIN="1"/>

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -22,4 +22,3 @@
 <use name="RecoLocalTracker/Phase2TrackerRecHits"/>
 <use name="TrackingTools/DetLayers"/>
 <use name="TrackingTools/MeasurementDet"/>
-<use name="RecoLocalTracker/SiPhase2VectorHitBuilder"/>

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -10,7 +10,6 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 #include "RecoLocalTracker/Phase2TrackerRecHits/interface/Phase2StripCPE.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
-#include "RecoLocalTracker/SiPhase2VectorHitBuilder/interface/VectorHitBuilderAlgorithm.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "RecoTracker/Record/interface/CkfComponentsRecord.h"

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
@@ -1,7 +1,6 @@
 #include "TkStackMeasurementDet.h"
 
 #include "TrackingTools/MeasurementDet/interface/MeasurementDetException.h"
-#include "RecoLocalTracker/SiPhase2VectorHitBuilder/interface/VectorHitBuilderAlgorithm.h"
 
 using namespace std;
 

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
@@ -5,7 +5,6 @@
 #include "TkPhase2OTMeasurementDet.h"
 
 #include "Geometry/CommonDetUnit/interface/StackGeomDet.h"
-#include "RecoLocalTracker/SiPhase2VectorHitBuilder/interface/VectorHitBuilderAlgorithm.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 
 #include "FWCore/Utilities/interface/Visibility.h"

--- a/SimG4CMS/Muon/test/BuildFile.xml
+++ b/SimG4CMS/Muon/test/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/MessageLogger"/>
-<use name="FWCore/PluginManager"/>
 <use name="SimDataFormats/TrackingHit"/>
 
 <library file="*.cc" name="SimG4CMSMuonTest">


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/31912).

This PR primarily targets some unused dependencies that have been in the GeneratorInterface subsystem for a long time but also considers some files in other areas that have recently changed and introduced new unused dependencies.

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
