### PR TITLE
drop type specs in RecoHI {HiEgammaAlgos,HiJetAlgos,HiMuonAlgos}

### DIFF
--- a/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
@@ -19,16 +19,16 @@ hiEcalClusteringSequence = cms.Sequence(hiEcalClusteringTask)
 from RecoEgamma.EgammaPhotonProducers.photonSequence_cff import *
 
 # use island for the moment
-photonCore.scHybridBarrelProducer = cms.InputTag("correctedIslandBarrelSuperClusters")
-photonCore.scIslandEndcapProducer = cms.InputTag("correctedIslandEndcapSuperClusters")
-photonCore.minSCEt = cms.double(8.0)
-photons.minSCEtBarrel = cms.double(5.0)
-photons.minSCEtEndcap = cms.double(15.0)
-photons.minR9Barrel = cms.double(10.)  #0.94
-photons.minR9Endcap = cms.double(10.)   #0.95
-photons.maxHoverEEndcap = cms.double(0.5)  #0.5
-photons.maxHoverEBarrel = cms.double(0.99)  #0.5
-photons.primaryVertexProducer = cms.InputTag('hiSelectedVertex') # replace the primary vertex
+photonCore.scHybridBarrelProducer = "correctedIslandBarrelSuperClusters"
+photonCore.scIslandEndcapProducer = "correctedIslandEndcapSuperClusters"
+photonCore.minSCEt    = 8.0
+photons.minSCEtBarrel = 5.0
+photons.minSCEtEndcap = 15.0
+photons.minR9Barrel   = 10.  #0.94
+photons.minR9Endcap   = 10.  #0.95
+photons.maxHoverEEndcap = 0.5   #0.5
+photons.maxHoverEBarrel = 0.99  #0.5
+photons.primaryVertexProducer = 'hiSelectedVertex' # replace the primary vertex
 photons.isolationSumsCalculatorSet.trackProducer = isolationInputParameters.track    # cms.InputTag("highPurityTracks")
 
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducer
@@ -45,7 +45,7 @@ hiEgammaSequence = cms.Sequence(hiEgammaTask)
 import RecoHI.HiEgammaAlgos.hiSpikeCleaner_cfi
 hiSpikeCleanedSC = RecoHI.HiEgammaAlgos.hiSpikeCleaner_cfi.hiSpikeCleaner.clone()
 cleanPhotonCore = photonCore.clone(
-    scHybridBarrelProducer = cms.InputTag("hiSpikeCleanedSC")
+    scHybridBarrelProducer = "hiSpikeCleanedSC"
 )
 cleanPhotons = photons.clone(
     photonCoreProducer = cms.InputTag("cleanPhotonCore")

--- a/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
+++ b/RecoHI/HiEgammaAlgos/python/photonIsolationHIProducer_cfi.py
@@ -15,15 +15,15 @@ photonIsolationHIProducer = cms.EDProducer(
 )
 
 photonIsolationHIProducerpp = photonIsolationHIProducer.clone(
-trackCollection = cms.InputTag("generalTracks")
+    trackCollection = "generalTracks"
 )
 
 photonIsolationHIProducerppGED = photonIsolationHIProducerpp.clone(
-photonProducer=cms.InputTag("gedPhotons")
+    photonProducer = "gedPhotons"
 )
 
 photonIsolationHIProducerppIsland = photonIsolationHIProducerpp.clone(
-photonProducer=cms.InputTag("islandPhotons")
+    photonProducer = "islandPhotons"
 )
 
 from RecoEcal.EgammaClusterProducers.islandBasicClusters_cfi import *

--- a/RecoHI/HiJetAlgos/python/HiGenCleaner_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiGenCleaner_cff.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 from PhysicsTools.JetMCAlgos.SelectPartons_cff import myPartons
 genPartons = myPartons.clone(
-    src = cms.InputTag("hiGenParticles")
-    )
+    src = "hiGenParticles"
+)
 
 hiPartons = cms.EDProducer('HiPartonCleaner',
                            src = cms.InputTag('genPartons'),

--- a/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
@@ -11,8 +11,8 @@ iterativeCone5HiGenJets = cms.EDProducer("SubEventGenJetProducer",
                                          rParam = cms.double(0.5)
                                          )
 
-iterativeCone5HiGenJets.doAreaFastjet = cms.bool(True)
-iterativeCone5HiGenJets.doRhoFastjet  = cms.bool(False)
+iterativeCone5HiGenJets.doAreaFastjet = True
+iterativeCone5HiGenJets.doRhoFastjet  = False
 
 iterativeCone7HiGenJets = iterativeCone5HiGenJets.clone(rParam=0.7)
 
@@ -23,8 +23,8 @@ ak5HiGenJets = cms.EDProducer("SubEventGenJetProducer",
                               rParam = cms.double(0.5)
                               )
 
-ak5HiGenJets.doAreaFastjet = cms.bool(True)
-ak5HiGenJets.doRhoFastjet  = cms.bool(False)
+ak5HiGenJets.doAreaFastjet = True
+ak5HiGenJets.doRhoFastjet  = False
 
 ak1HiGenJets = ak5HiGenJets.clone(rParam = 0.1)
 ak2HiGenJets = ak5HiGenJets.clone(rParam = 0.2)
@@ -40,8 +40,8 @@ kt4HiGenJets = cms.EDProducer("SubEventGenJetProducer",
                               rParam = cms.double(0.4)
                               )
 
-kt4HiGenJets.doAreaFastjet = cms.bool(True)
-kt4HiGenJets.doRhoFastjet  = cms.bool(False)
+kt4HiGenJets.doAreaFastjet = True
+kt4HiGenJets.doRhoFastjet  = False
 
 kt6HiGenJets = kt4HiGenJets.clone(rParam=0.6)
 

--- a/RecoHI/HiJetAlgos/python/HiPFJetParameters_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiPFJetParameters_cff.py
@@ -9,7 +9,6 @@ HiPFJetDefaults = RecoJets.JetProducers.PFJetParameters_cfi.PFJetParameters.clon
     doPVCorrection = False,
     jetPtMin       = 10,
     Ghost_EtaMax   = 6.5,
-    # this parameter is missing from PFJetParameters for some reason
     Rho_EtaMax     = 4.5
 )
 

--- a/RecoHI/HiJetAlgos/python/HiPFJetParameters_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiPFJetParameters_cff.py
@@ -4,13 +4,13 @@ import FWCore.ParameterSet.Config as cms
 import RecoJets.JetProducers.PFJetParameters_cfi
 HiPFJetDefaults = RecoJets.JetProducers.PFJetParameters_cfi.PFJetParameters.clone(
     doPUOffsetCorr = False,
-    doAreaFastjet = True,
-    doRhoFastjet = True,
+    doAreaFastjet  = True,
+    doRhoFastjet   = True,
     doPVCorrection = False,
-    jetPtMin = 10,
-    Ghost_EtaMax = 6.5,
+    jetPtMin       = 10,
+    Ghost_EtaMax   = 6.5,
     # this parameter is missing from PFJetParameters for some reason
-    Rho_EtaMax = cms.double(4.5)
+    Rho_EtaMax     = 4.5
 )
 
 ## add non-uniform fastjet settings

--- a/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
@@ -65,6 +65,7 @@ akPu5CaloJets = cms.EDProducer(
     rParam       = cms.double(0.5)
     )
 akPu5CaloJets.radiusPU = 0.5
+akPu5CaloJets.puPtMin  = cms.double(10)
 
 akPu7CaloJets = cms.EDProducer(
     "FastjetJetProducer",
@@ -76,14 +77,12 @@ akPu7CaloJets = cms.EDProducer(
     )
 akPu7CaloJets.radiusPU = 0.7
 
-
-akPu5CaloJets.puPtMin = cms.double(10)
-akPu1CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.1), puPtMin = 4)
-akPu2CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.2), puPtMin = 4)
-akPu3CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.3), puPtMin = 6)
-akPu4CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.4), puPtMin = 8)
-akPu6CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.6), puPtMin = 12)
-akPu7CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.7), puPtMin = 14)
+akPu1CaloJets = akPu5CaloJets.clone(rParam = 0.1, puPtMin = 4)
+akPu2CaloJets = akPu5CaloJets.clone(rParam = 0.2, puPtMin = 4)
+akPu3CaloJets = akPu5CaloJets.clone(rParam = 0.3, puPtMin = 6)
+akPu4CaloJets = akPu5CaloJets.clone(rParam = 0.4, puPtMin = 8)
+akPu6CaloJets = akPu5CaloJets.clone(rParam = 0.6, puPtMin = 12)
+akPu7CaloJets = akPu5CaloJets.clone(rParam = 0.7, puPtMin = 14)
 
 ak5CaloJets = cms.EDProducer(
     "FastjetJetProducer",
@@ -94,12 +93,13 @@ ak5CaloJets = cms.EDProducer(
     rParam       = cms.double(0.5)
     )
 ak5CaloJets.doPUOffsetCorr = False
-ak1CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.1))
-ak2CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.2))
-ak3CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.3))
-ak4CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.4))
-ak6CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.6))
-ak7CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.7))
+
+ak1CaloJets = ak5CaloJets.clone(rParam = 0.1)
+ak2CaloJets = ak5CaloJets.clone(rParam = 0.2)
+ak3CaloJets = ak5CaloJets.clone(rParam = 0.3)
+ak4CaloJets = ak5CaloJets.clone(rParam = 0.4)
+ak6CaloJets = ak5CaloJets.clone(rParam = 0.6)
+ak7CaloJets = ak5CaloJets.clone(rParam = 0.7)
 
 
 ## Default Sequence

--- a/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
@@ -65,17 +65,7 @@ akPu5CaloJets = cms.EDProducer(
     rParam       = cms.double(0.5)
     )
 akPu5CaloJets.radiusPU = 0.5
-akPu5CaloJets.puPtMin  = cms.double(10)
-
-akPu7CaloJets = cms.EDProducer(
-    "FastjetJetProducer",
-    HiCaloJetParameters,
-    AnomalousCellParameters,
-    MultipleAlgoIteratorBlock,
-    jetAlgorithm = cms.string("AntiKt"),
-    rParam       = cms.double(0.7)
-    )
-akPu7CaloJets.radiusPU = 0.7
+akPu5CaloJets.puPtMin  = 10
 
 akPu1CaloJets = akPu5CaloJets.clone(rParam = 0.1, puPtMin = 4)
 akPu2CaloJets = akPu5CaloJets.clone(rParam = 0.2, puPtMin = 4)
@@ -83,6 +73,7 @@ akPu3CaloJets = akPu5CaloJets.clone(rParam = 0.3, puPtMin = 6)
 akPu4CaloJets = akPu5CaloJets.clone(rParam = 0.4, puPtMin = 8)
 akPu6CaloJets = akPu5CaloJets.clone(rParam = 0.6, puPtMin = 12)
 akPu7CaloJets = akPu5CaloJets.clone(rParam = 0.7, puPtMin = 14)
+akPu7CaloJets.radiusPU = 0.7
 
 ak5CaloJets = cms.EDProducer(
     "FastjetJetProducer",

--- a/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoJets_cff.py
@@ -73,7 +73,6 @@ akPu3CaloJets = akPu5CaloJets.clone(rParam = 0.3, puPtMin = 6)
 akPu4CaloJets = akPu5CaloJets.clone(rParam = 0.4, puPtMin = 8)
 akPu6CaloJets = akPu5CaloJets.clone(rParam = 0.6, puPtMin = 12)
 akPu7CaloJets = akPu5CaloJets.clone(rParam = 0.7, puPtMin = 14)
-akPu7CaloJets.radiusPU = 0.7
 
 ak5CaloJets = cms.EDProducer(
     "FastjetJetProducer",

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -51,9 +51,9 @@ ak4PFJetsForFlow = akPu5PFJets.clone(
    Rho_EtaMax   = 4.4,
    doRhoFastjet = False,
    jetPtMin     = 15.0,
-   nSigmaPU     = cms.double(1.0),
+   nSigmaPU     = 1.0,
    rParam       = 0.4,
-   radiusPU     = cms.double(0.5),
+   radiusPU     = 0.5,
    src          = "hiPFCandCleanerforJets",
 )
 

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -12,7 +12,7 @@ PFTowers = _mod.particleTowerProducer.clone(useHF = True)
 pfEmptyCollection = cms.EDFilter('GenericPFCandidateSelector',
                                  src = cms.InputTag('particleFlow'),
                                  cut = cms.string("pt<0")
-                             )
+                                )
 
 ak5PFJets = cms.EDProducer(
     "FastjetJetProducer",
@@ -21,27 +21,25 @@ ak5PFJets = cms.EDProducer(
     MultipleAlgoIteratorBlock,
     jetAlgorithm = cms.string("AntiKt"),
     rParam       = cms.double(0.5)
-    )
-ak5PFJets.src = cms.InputTag('particleFlow')
+)
+ak5PFJets.src = 'particleFlow'
 
 akPu5PFJets = ak5PFJets.clone(
-    jetType = cms.string('BasicJet'),
+    jetType        = 'BasicJet',
     doPVCorrection = False,
     doPUOffsetCorr = True,
-    subtractorName = cms.string("MultipleAlgoIterator"),    
-    src = cms.InputTag('PFTowers'),
-    doAreaFastjet = False
-    )
+    subtractorName = "MultipleAlgoIterator",
+    src            = 'PFTowers',
+    doAreaFastjet  = False,
+    puPtMin        = cms.double(25)
+)
 
-
-
-akPu5PFJets.puPtMin = cms.double(25)
-akPu1PFJets = akPu5PFJets.clone(rParam       = cms.double(0.1), puPtMin = 10)
-akPu2PFJets = akPu5PFJets.clone(rParam       = cms.double(0.2), puPtMin = 10)
-akPu3PFJets = akPu5PFJets.clone(rParam       = cms.double(0.3), puPtMin = 15)
-akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
-akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
-akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
+akPu1PFJets = akPu5PFJets.clone(rParam = 0.1, puPtMin = 10)
+akPu2PFJets = akPu5PFJets.clone(rParam = 0.2, puPtMin = 10)
+akPu3PFJets = akPu5PFJets.clone(rParam = 0.3, puPtMin = 15)
+akPu4PFJets = akPu5PFJets.clone(rParam = 0.4, puPtMin = 20)
+akPu6PFJets = akPu5PFJets.clone(rParam = 0.6, puPtMin = 30)
+akPu7PFJets = akPu5PFJets.clone(rParam = 0.7, puPtMin = 35)
 
 hiPFCandCleanerforJets = cms.EDFilter('GenericPFCandidateSelector',
                                 src = cms.InputTag('particleFlow'),
@@ -50,13 +48,13 @@ hiPFCandCleanerforJets = cms.EDFilter('GenericPFCandidateSelector',
 
 ak4PFJetsForFlow = akPu5PFJets.clone(
    Ghost_EtaMax = 5.0,
-   Rho_EtaMax = 4.4,
+   Rho_EtaMax   = 4.4,
    doRhoFastjet = False,
-   jetPtMin = 15.0,
-   nSigmaPU = cms.double(1.0),
-   rParam = 0.4,
-   radiusPU = cms.double(0.5),
-   src = "hiPFCandCleanerforJets",
+   jetPtMin     = 15.0,
+   nSigmaPU     = cms.double(1.0),
+   rParam       = 0.4,
+   radiusPU     = cms.double(0.5),
+   src          = "hiPFCandCleanerforJets",
 )
 
 kt4PFJetsForRho = cms.EDProducer(
@@ -66,11 +64,10 @@ kt4PFJetsForRho = cms.EDProducer(
     jetAlgorithm = cms.string("Kt"),
     rParam       = cms.double(0.4)
 )
-
-kt4PFJetsForRho.src = cms.InputTag('particleFlow')
-kt4PFJetsForRho.doAreaFastjet = cms.bool(True)
-kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
-kt4PFJetsForRho.GhostArea     = cms.double(0.005)
+kt4PFJetsForRho.src           = 'particleFlow'
+kt4PFJetsForRho.doAreaFastjet = True
+kt4PFJetsForRho.jetPtMin      = 0.0
+kt4PFJetsForRho.GhostArea     = 0.005
 
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
 
@@ -96,13 +93,13 @@ akCs4PFJets = cms.EDProducer(
     rhoFlowFitParams = cms.InputTag('hiFJRhoFlowModulation', 'rhoFlowFitParams'),
     jetCollInstanceName = cms.string("pfParticlesCs"),
 )
-akCs4PFJets.src           = cms.InputTag('particleFlow')
-akCs4PFJets.doAreaFastjet = cms.bool(True)
-akCs4PFJets.jetPtMin      = cms.double(0.0)
+akCs4PFJets.src               = 'particleFlow'
+akCs4PFJets.doAreaFastjet     = True
+akCs4PFJets.jetPtMin          = 0.0
 akCs4PFJets.useExplicitGhosts = cms.bool(True)
-akCs4PFJets.GhostArea     = cms.double(0.005)
+akCs4PFJets.GhostArea         = 0.005
 
-akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
+akCs3PFJets = akCs4PFJets.clone(rParam = 0.3)
 
 hiRecoPFJetsTask = cms.Task(
                            PFTowers,

--- a/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
@@ -5,11 +5,11 @@ from RecoHI.HiJetAlgos.HiRecoJets_cff import akPu4CaloJets
 from JetMETCorrections.Configuration.DefaultJEC_cff import *
 
 
-hiCaloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbheprereco'))
-akPu4CaloJetsForTrk = akPu4CaloJets.clone( srcPVs = cms.InputTag('hiSelectedPixelVertex'), src= cms.InputTag('hiCaloTowerForTrk'))
+hiCaloTowerForTrk  = calotowermaker.clone( hbheInput = 'hbheprereco')
+akPu4CaloJetsForTrk = akPu4CaloJets.clone( srcPVs = 'hiSelectedPixelVertex', src = 'hiCaloTowerForTrk')
 
 akPu4CaloJetsCorrected  = ak4CaloJetsL2L3.clone(
-    src = cms.InputTag("akPu4CaloJetsForTrk")
+    src = "akPu4CaloJetsForTrk"
 )
 
 akPu4CaloJetsSelected = cms.EDFilter( "LargestEtCaloJetSelector",

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -12,4 +12,4 @@ hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
 )
 
 from Configuration.Eras.Modifier_pA_2016_cff import pA_2016
-pA_2016.toModify(hiFJRhoProducer, etaRanges = cms.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.))
+pA_2016.toModify(hiFJRhoProducer, etaRanges = [-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.])

--- a/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
@@ -5,21 +5,21 @@ from RecoMuon.Configuration.RecoMuonPPonly_cff import *
 hiTracks = 'hiGeneralTracks' #heavy ion track label
 
 # replace with heavy ion track label
-hiMuons1stStep = muons1stStep.clone()
-hiMuons1stStep.inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuons:UpdatedAtVtx','tevMuons:firstHit','tevMuons:picky','tevMuons:dyt']
-hiMuons1stStep.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt']
-hiMuons1stStep.TrackExtractorPSet.inputTrackCollection = hiTracks
-hiMuons1stStep.minPt = cms.double(0.8)
-#iso deposits are not used in HI
-hiMuons1stStep.writeIsoDeposits = False
-#hiMuons1stStep.fillGlobalTrackRefits = False
+hiMuons1stStep = muons1stStep.clone(
+    inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuons:UpdatedAtVtx','tevMuons:firstHit','tevMuons:picky','tevMuons:dyt'],
+    inputCollectionTypes  = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt'],
+    TrackExtractorPSet    = dict(inputTrackCollection = hiTracks),
+    minPt                 = 0.8,
+    #iso deposits are not used in HI
+    writeIsoDeposits      = False,
+    #fillGlobalTrackRefits = False
+)
+
 muonEcalDetIds.inputCollection = "hiMuons1stStep"
-
-muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:tracker"))
-muIsoDepositJets. inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:jets"))
-muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:ecal"), cms.InputTag("hiMuons1stStep:hcal"), cms.InputTag("hiMuons1stStep:ho"))
-
-muonShowerInformation.muonCollection = "hiMuons1stStep"
+muIsoDepositTk.inputTags       = ["hiMuons1stStep:tracker"]
+muIsoDepositJets.inputTags     = ["hiMuons1stStep:jets"]
+muIsoDepositCalByAssociatorTowers.inputTags = ["hiMuons1stStep:ecal", "hiMuons1stStep:hcal", "hiMuons1stStep:ho"]
+muonShowerInformation.muonCollection        = "hiMuons1stStep"
 
 #don't modify somebody else's sequence, create a new one if needed
 #standalone muon tracking is already done... so remove standalonemuontracking from muontracking
@@ -38,21 +38,23 @@ muonreco_plus_isolation_PbPb = cms.Sequence(muonreco_plus_isolation_PbPbTask)
 globalMuons.TrackerCollectionLabel = hiTracks
 
 # replace with heavy ion jet label
-hiMuons1stStep.JetExtractorPSet.JetCollectionLabel = cms.InputTag("iterativeConePu5CaloJets")
+hiMuons1stStep.JetExtractorPSet.JetCollectionLabel = "iterativeConePu5CaloJets"
 
 # turn off calo muons for timing considerations
-hiMuons1stStep.minPCaloMuon = cms.double( 1.0E9 )
+hiMuons1stStep.minPCaloMuon = 1.0E9
 
 # high level reco
 from RecoMuon.MuonIdentification.muons_cfi import muons
-muons.InputMuons = cms.InputTag("hiMuons1stStep")
-muons.PFCandidates = cms.InputTag("particleFlowTmp")
-muons.FillDetectorBasedIsolation = cms.bool(False)
-muons.FillPFIsolation = cms.bool(False)
-muons.FillSelectorMaps = cms.bool(False)
-muons.FillShoweringInfo = cms.bool(False)
-muons.FillCosmicsIdMap = cms.bool(False)
-muons.vertices = cms.InputTag("hiSelectedVertex")
+muons = muons.clone(
+    InputMuons          = "hiMuons1stStep",
+    PFCandidates        = "particleFlowTmp",
+    FillDetectorBasedIsolation = False,
+    FillPFIsolation     = False,
+    FillSelectorMaps    = False,
+    FillShoweringInfo   = False,
+    FillCosmicsIdMap    = False,
+    vertices            = "hiSelectedVertex"
+)
 muonRecoHighLevelPbPbTask = cms.Task(muons)
 
 # HI muon sequence (passed to RecoHI.Configuration.Reconstruction_HI_cff)

--- a/RecoHI/HiMuonAlgos/python/HiRegionalRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegionalRecoMuon_cff.py
@@ -7,44 +7,46 @@ from RecoHI.HiMuonAlgos.hiMuonIterativeTk_cff import *
 hiReMuTracks = "hiGeneralAndRegitMuTracks" 
 
 # global muon track
-reglobalMuons = globalMuons.clone()
-reglobalMuons.TrackerCollectionLabel =  hiReMuTracks
-
+reglobalMuons = globalMuons.clone(
+    TrackerCollectionLabel =  hiReMuTracks
+)
 # tevMuons tracks
-retevMuons    = tevMuons.clone()
-retevMuons.MuonCollectionLabel = cms.InputTag("reglobalMuons")
-
+retevMuons    = tevMuons.clone(
+    MuonCollectionLabel = "reglobalMuons"
+)
 
 # trackquality collections
-reglbTrackQual = glbTrackQual.clone()
-reglbTrackQual.InputCollection      = cms.InputTag("reglobalMuons")
-reglbTrackQual.InputLinksCollection = cms.InputTag("reglobalMuons")
-
+reglbTrackQual = glbTrackQual.clone(
+    InputCollection      = "reglobalMuons",
+    InputLinksCollection = "reglobalMuons"
+)
 
 #recoMuons
-remuons       = muons1stStep.clone()
-remuons.inputCollectionLabels                   = [hiReMuTracks, 'reglobalMuons', 'standAloneMuons:UpdatedAtVtx','retevMuons:firstHit','retevMuons:picky','retevMuons:dyt']
-remuons.globalTrackQualityInputTag              = cms.InputTag('reglbTrackQual')
-remuons.JetExtractorPSet.JetCollectionLabel     = cms.InputTag("iterativeConePu5CaloJets")
-remuons.TrackExtractorPSet.inputTrackCollection = hiReMuTracks
-remuons.minPt = cms.double(0.8)
-
-remuonEcalDetIds = muonEcalDetIds.clone()
-remuonEcalDetIds.inputCollection                = "remuons"
-
+remuons = muons1stStep.clone(
+    inputCollectionLabels      = [hiReMuTracks, 'reglobalMuons', 'standAloneMuons:UpdatedAtVtx','retevMuons:firstHit','retevMuons:picky','retevMuons:dyt'],
+    globalTrackQualityInputTag = 'reglbTrackQual',
+    JetExtractorPSet           = dict( JetCollectionLabel   = "iterativeConePu5CaloJets"),
+    TrackExtractorPSet         = dict( inputTrackCollection = hiReMuTracks),
+    minPt                      = 0.8
+)
+remuonEcalDetIds = muonEcalDetIds.clone(
+    inputCollection = "remuons"
+)
 #muons.fillGlobalTrackRefits = False
 
 # deposits
-remuIsoDepositTk = muIsoDepositTk.clone()
-remuIsoDepositTk.inputTags                    = cms.VInputTag(cms.InputTag("remuons:tracker"))
-remuIsoDepositJets = muIsoDepositJets.clone()
-remuIsoDepositJets.inputTags                  = cms.VInputTag(cms.InputTag("remuons:jets"))
-remuIsoDepositCalByAssociatorTowers = muIsoDepositCalByAssociatorTowers.clone()
-remuIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag("remuons:ecal"), cms.InputTag("remuons:hcal"), cms.InputTag("remuons:ho"))
-
-remuonShowerInformation                       = muonShowerInformation.clone()
-remuonShowerInformation.muonCollection        = "remuons"
-
+remuIsoDepositTk = muIsoDepositTk.clone(
+    inputTags = ["remuons:tracker"]
+)
+remuIsoDepositJets = muIsoDepositJets.clone(
+    inputTags = ["remuons:jets"]
+)
+remuIsoDepositCalByAssociatorTowers = muIsoDepositCalByAssociatorTowers.clone(
+    inputTags = ["remuons:ecal", "remuons:hcal", "remuons:ho"]
+)
+remuonShowerInformation = muonShowerInformation.clone(
+    muonCollection = "remuons"
+)
 # replace the new names
 
 remuonIdProducerTask      = cms.Task(reglbTrackQual,remuons,remuonEcalDetIds,remuonShowerInformation)

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -21,7 +21,7 @@ hiRegitMuDetachedTripletStepTrackingRegions = HiTrackingRegionFactoryFromSTAMuon
         Pt_min        = 0.9,
         DeltaR        = 2.0, # default = 0.2
         DeltaZ        = 2.0, # this give you the length
-        Rescale_Dz    = 4., # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
+        Rescale_Dz    = 4.,  # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
     )
 )
 
@@ -34,109 +34,113 @@ hiRegitMuDetachedTripletStepClusters = _trackClusterRemover.clone(
     maxChi2                                  = 9.0,
     pixelClusters                            = "siPixelClusters",
     stripClusters                            = "siStripClusters",
-    trajectories          		     = cms.InputTag("hiRegitMuPixelLessStepTracks"),
-    overrideTrkQuals      		     = cms.InputTag('hiRegitMuPixelLessStepSelector','hiRegitMuPixelLessStep'),
+    trajectories          		     = "hiRegitMuPixelLessStepTracks",
+    overrideTrkQuals      		     = 'hiRegitMuPixelLessStepSelector:hiRegitMuPixelLessStep',
     TrackQuality                             = 'tight',
-    trackClassifier       		     = cms.InputTag(''),
+    trackClassifier       		     = '',
     minNumberOfLayersWithMeasBeforeFiltering = 0
 )
 
 
 # SEEDING LAYERS
-hiRegitMuDetachedTripletStepSeedLayers =  RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.clone()
-hiRegitMuDetachedTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('hiRegitMuDetachedTripletStepClusters')
-hiRegitMuDetachedTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('hiRegitMuDetachedTripletStepClusters')
+hiRegitMuDetachedTripletStepSeedLayers =  RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.clone(
+    BPix = dict( skipClusters = 'hiRegitMuDetachedTripletStepClusters'),
+    FPix = dict( skipClusters = 'hiRegitMuDetachedTripletStepClusters')
+)
 
 # seeding
 hiRegitMuDetachedTripletStepHitDoublets = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepHitDoublets.clone(
-    seedingLayers = "hiRegitMuDetachedTripletStepSeedLayers",
+    seedingLayers   = "hiRegitMuDetachedTripletStepSeedLayers",
     trackingRegions = "hiRegitMuDetachedTripletStepTrackingRegions",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck    = "hiRegitMuClusterCheck",
 )
+
 hiRegitMuDetachedTripletStepHitTriplets = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepHitTriplets.clone(
     doublets = "hiRegitMuDetachedTripletStepHitDoublets"
 )
-hiRegitMuDetachedTripletStepSeeds     = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.clone(
+
+hiRegitMuDetachedTripletStepSeeds = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.clone(
     seedingHitSets = "hiRegitMuDetachedTripletStepHitTriplets"
 )
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 
 
 # building: feed the new-named seeds
-hiRegitMuDetachedTripletStepTrajectoryFilterBase = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilterBase.clone()
-hiRegitMuDetachedTripletStepTrajectoryFilterBase.minPt = 0.8 # after each new hit, apply pT cut for traj w/ at least minHitsMinPt = cms.int32(3),
+hiRegitMuDetachedTripletStepTrajectoryFilterBase = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilterBase.clone(
+    minPt = 0.8 # after each new hit, apply pT cut for traj w/ at least minHitsMinPt = cms.int32(3),
+)
 
-hiRegitMuDetachedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilter.clone()
-hiRegitMuDetachedTripletStepTrajectoryFilter.filters = cms.VPSet(
+hiRegitMuDetachedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryFilter.clone(
+    filters = cms.VPSet(
       cms.PSet( refToPSet_ = cms.string('hiRegitMuDetachedTripletStepTrajectoryFilterBase')),
       cms.PSet( refToPSet_ = cms.string('detachedTripletStepTrajectoryFilterShape')))
+)
 
 hiRegitMuDetachedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrajectoryBuilder.clone(
-    clustersToSkip       = cms.InputTag('hiRegitMuDetachedTripletStepClusters')
+    clustersToSkip = cms.InputTag('hiRegitMuDetachedTripletStepClusters')
 )
 
-hiRegitMuDetachedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrackCandidates.clone(
-    src               = cms.InputTag('hiRegitMuDetachedTripletStepSeeds'),
+hiRegitMuDetachedTripletStepTrackCandidates = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTrackCandidates.clone(
+    src               = 'hiRegitMuDetachedTripletStepSeeds',
     TrajectoryBuilder = 'hiRegitMuDetachedTripletStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag("hiRegitMuDetachedTripletStepClusters")
-    )
+    clustersToSkip    = cms.InputTag("hiRegitMuDetachedTripletStepClusters")
+)
 
 # fitting: feed new-names
-hiRegitMuDetachedTripletStepTracks                 = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTracks.clone(
-    AlgorithmName = cms.string('hiRegitMuDetachedTripletStep'),
-    src                 = 'hiRegitMuDetachedTripletStepTrackCandidates'
+hiRegitMuDetachedTripletStepTracks = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTracks.clone(
+    AlgorithmName = 'hiRegitMuDetachedTripletStep',
+    src = 'hiRegitMuDetachedTripletStepTrackCandidates'
 )
-
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-    src                 ='hiRegitMuDetachedTripletStepTracks',
-    vertices            = cms.InputTag("hiSelectedPixelVertex"),
-    useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter7'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
-    trackSelectors= cms.VPSet(
+    src            = 'hiRegitMuDetachedTripletStepTracks',
+    vertices       = "hiSelectedPixelVertex",
+    useAnyMVA      = True,
+    GBRForestLabel = 'HIMVASelectorIter7',
+    GBRForestVars  = ['chi2perdofperlayer', 'nhits', 'nlayers', 'eta'],
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuDetachedTripletStepLoose',
-           min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuDetachedTripletStepLoose',
+            min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuDetachedTripletStepTight',
+            name          = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuDetachedTripletStep',
+            name          = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.09
             )
-        ) #end of vpset
-    )
+    ) #end of vpset
+)
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuDetachedTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuDetachedTripletStepSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuDetachedTripletStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuDetachedTripletStepLoose',
-           min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuDetachedTripletStepLoose',
+            min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuDetachedTripletStepTight',
+            name          = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuDetachedTripletStep',
+            name          = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.09
             )
         )
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -41,20 +41,20 @@ trackingPhase1.toModify(hiRegitMuInitialStepHitDoublets, layerPairs = [0])
 hiRegitMuInitialStepHitTriplets = RecoTracker.IterativeTracking.InitialStep_cff.initialStepHitTriplets.clone(
     doublets = "hiRegitMuInitialStepHitDoublets"
 )
-hiRegitMuInitialStepSeeds     = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.clone(
+hiRegitMuInitialStepSeeds = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.clone(
     seedingHitSets = "hiRegitMuInitialStepHitTriplets"
 )
 
 
 # building: feed the new-named seeds
-hiRegitMuInitialStepTrajectoryFilterBase = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilterBase.clone()
-hiRegitMuInitialStepTrajectoryFilterBase.minPt = 2.5 # after each new hit, apply pT cut for traj w/ at least minHitsMinPt = cms.int32(3),
-
-hiRegitMuInitialStepTrajectoryFilter = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilter.clone()
-hiRegitMuInitialStepTrajectoryFilter.filters = cms.VPSet(
+hiRegitMuInitialStepTrajectoryFilterBase = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilterBase.clone(
+    minPt = 2.5 # after each new hit, apply pT cut for traj w/ at least minHitsMinPt = cms.int32(3),
+)
+hiRegitMuInitialStepTrajectoryFilter = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryFilter.clone(
+    filters = cms.VPSet(
       cms.PSet( refToPSet_ = cms.string('hiRegitMuInitialStepTrajectoryFilterBase')),
       cms.PSet( refToPSet_ = cms.string('initialStepTrajectoryFilterShape')))
-
+)
 
 hiRegitMuInitialStepTrajectoryBuilder = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(
@@ -63,70 +63,70 @@ hiRegitMuInitialStepTrajectoryBuilder = RecoTracker.IterativeTracking.InitialSte
 )
 
 # track candidates
-hiRegitMuInitialStepTrackCandidates        =  RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrackCandidates.clone(
-    src               = cms.InputTag('hiRegitMuInitialStepSeeds'),
+hiRegitMuInitialStepTrackCandidates = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTrackCandidates.clone(
+    src               = 'hiRegitMuInitialStepSeeds',
     TrajectoryBuilderPSet = cms.PSet(
        refToPSet_ = cms.string('hiRegitMuInitialStepTrajectoryBuilder')
        ),
-    maxNSeeds         = cms.uint32(1000000)
-    )
+    maxNSeeds         = 1000000
+)
 
 # fitting: feed new-names
-hiRegitMuInitialStepTracks                 = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTracks.clone(
-    AlgorithmName = cms.string('hiRegitMuInitialStep'),
-    src                 = 'hiRegitMuInitialStepTrackCandidates'
+hiRegitMuInitialStepTracks = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTracks.clone(
+    AlgorithmName = 'hiRegitMuInitialStep',
+    src           = 'hiRegitMuInitialStepTrackCandidates'
 )
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-    src                 ='hiRegitMuInitialStepTracks',
-    vertices            = cms.InputTag("hiSelectedPixelVertex"),
-    useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter4'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
-    trackSelectors= cms.VPSet(
+    src            ='hiRegitMuInitialStepTracks',
+    vertices       = "hiSelectedPixelVertex",
+    useAnyMVA      = True,
+    GBRForestLabel = 'HIMVASelectorIter4',
+    GBRForestVars  = ['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta'],
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
-           min_nhits = cms.uint32(8)
+           min_nhits = 8
             ), #end of pset
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.38)
+            min_nhits = 8,
+            useMVA = True,
+            minMVA = -0.38
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.77)
+            min_nhits = 8,
+            useMVA = True,
+            minMVA = -0.77
             ),
         ) #end of vpset
     )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuInitialStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuInitialStepSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuInitialStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
-           min_nhits = cms.uint32(8)
+           min_nhits = 8
             ), #end of pset
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.38)
+            min_nhits = 8,
+            useMVA = False,
+            minMVA = -0.38
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.77)
+            min_nhits = 8,
+            useMVA = False,
+            minMVA = -0.77
             ),
         )
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -33,66 +33,70 @@ from RecoTracker.IterativeTracking.MixedTripletStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
 hiRegitMuMixedTripletStepClusters = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepClusters.clone(
-    oldClusterRemovalInfo = cms.InputTag("hiRegitMuPixelPairStepClusters"),
-    trajectories          = cms.InputTag("hiRegitMuPixelPairStepTracks"),
-    overrideTrkQuals      = cms.InputTag('hiRegitMuPixelPairStepSelector','hiRegitMuPixelPairStep'),
-    trackClassifier       = cms.InputTag(''),
-    TrackQuality          = cms.string('tight')
+    #oldClusterRemovalInfo = cms.InputTag("hiRegitMuPixelPairStepClusters"),
+    #trajectories          = cms.InputTag("hiRegitMuPixelPairStepTracks"),
+    #overrideTrkQuals      = cms.InputTag('hiRegitMuPixelPairStepSelector','hiRegitMuPixelPairStep'),
+    #trackClassifier       = cms.InputTag(''),
+    #TrackQuality          = cms.string('tight')
+    oldClusterRemovalInfo = "hiRegitMuPixelPairStepClusters",
+    trajectories          = "hiRegitMuPixelPairStepTracks",
+    overrideTrkQuals      = 'hiRegitMuPixelPairStepSelector:hiRegitMuPixelPairStep',
+    trackClassifier       = '',
+    TrackQuality          = 'tight'
 )
 
 
 # SEEDING LAYERS A
-hiRegitMuMixedTripletStepSeedLayersA =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.clone()
-hiRegitMuMixedTripletStepSeedLayersA.BPix.skipClusters = cms.InputTag('hiRegitMuMixedTripletStepClusters')
-hiRegitMuMixedTripletStepSeedLayersA.FPix.skipClusters = cms.InputTag('hiRegitMuMixedTripletStepClusters')
-hiRegitMuMixedTripletStepSeedLayersA.TEC.skipClusters  = cms.InputTag('hiRegitMuMixedTripletStepClusters')
-
+hiRegitMuMixedTripletStepSeedLayersA =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.clone(
+    BPix = dict(skipClusters = 'hiRegitMuMixedTripletStepClusters'),
+    FPix = dict(skipClusters = 'hiRegitMuMixedTripletStepClusters'),
+    TEC  = dict(skipClusters = 'hiRegitMuMixedTripletStepClusters')
+)
 # SEEDS A
 hiRegitMuMixedTripletStepHitDoubletsA = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepHitDoubletsA.clone(
-    seedingLayers = "hiRegitMuMixedTripletStepSeedLayersA",
+    seedingLayers   = "hiRegitMuMixedTripletStepSeedLayersA",
     trackingRegions = "hiRegitMuMixedTripletStepTrackingRegionsA",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck    = "hiRegitMuClusterCheck",
 )
 hiRegitMuMixedTripletStepHitTripletsA = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepHitTripletsA.clone(
     doublets = "hiRegitMuMixedTripletStepHitDoubletsA"
 )
-hiRegitMuMixedTripletStepSeedsA     = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.clone(
+hiRegitMuMixedTripletStepSeedsA = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.clone(
     seedingHitSets = "hiRegitMuMixedTripletStepHitTripletsA"
 )
 
 # SEEDING LAYERS B
-hiRegitMuMixedTripletStepSeedLayersB =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.clone()
-hiRegitMuMixedTripletStepSeedLayersB.BPix.skipClusters = cms.InputTag('hiRegitMuMixedTripletStepClusters')
-hiRegitMuMixedTripletStepSeedLayersB.TIB.skipClusters  = cms.InputTag('hiRegitMuMixedTripletStepClusters')
-
+hiRegitMuMixedTripletStepSeedLayersB =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.clone(
+    BPix = dict(skipClusters = 'hiRegitMuMixedTripletStepClusters'),
+    TIB  = dict(skipClusters = 'hiRegitMuMixedTripletStepClusters')
+)
 
 hiRegitMuMixedTripletStepHitDoubletsB = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepHitDoubletsB.clone(
-    seedingLayers = "hiRegitMuMixedTripletStepSeedLayersB",
+    seedingLayers   = "hiRegitMuMixedTripletStepSeedLayersB",
     trackingRegions = "hiRegitMuMixedTripletStepTrackingRegionsB",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck    = "hiRegitMuClusterCheck",
 )
 hiRegitMuMixedTripletStepHitTripletsB = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepHitTripletsB.clone(
     doublets = "hiRegitMuMixedTripletStepHitDoubletsB"
 )
-hiRegitMuMixedTripletStepSeedsB     = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.clone(
+hiRegitMuMixedTripletStepSeedsB = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.clone(
     seedingHitSets = "hiRegitMuMixedTripletStepHitTripletsB"
 )
 
 # combine seeds
 hiRegitMuMixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeeds.clone(
-    seedCollections = cms.VInputTag(
-        cms.InputTag('hiRegitMuMixedTripletStepSeedsA'),
-        cms.InputTag('hiRegitMuMixedTripletStepSeedsB'),
-        )
-    )
+    seedCollections = [
+        'hiRegitMuMixedTripletStepSeedsA',
+        'hiRegitMuMixedTripletStepSeedsB',
+        ]
+)
 
 # track building
-hiRegitMuMixedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrajectoryFilter.clone()
-
-hiRegitMuMixedTripletStepTrajectoryFilter.minPt = 1.
-hiRegitMuMixedTripletStepTrajectoryFilter.minimumNumberOfHits = 6
-hiRegitMuMixedTripletStepTrajectoryFilter.minHitsMinPt        = 4
-
+hiRegitMuMixedTripletStepTrajectoryFilter = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrajectoryFilter.clone(
+    minPt               = 1.,
+    minimumNumberOfHits = 6,
+    minHitsMinPt        = 4
+)
 
  # after each new hit, apply pT cut for traj w/ at least minHitsMinPt = cms.int32(3),
 
@@ -103,17 +107,17 @@ hiRegitMuMixedTripletStepTrajectoryBuilder = RecoTracker.IterativeTracking.Mixed
     minNrOfHitsForRebuild = 6 #change from default 4
 )
 
-hiRegitMuMixedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrackCandidates.clone(
-    src               = cms.InputTag('hiRegitMuMixedTripletStepSeeds'),
+hiRegitMuMixedTripletStepTrackCandidates = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTrackCandidates.clone(
+    src               = 'hiRegitMuMixedTripletStepSeeds',
     TrajectoryBuilderPSet = cms.PSet(
        refToPSet_ = cms.string('hiRegitMuMixedTripletStepTrajectoryBuilder')
        ),
-    clustersToSkip       = cms.InputTag('hiRegitMuMixedTripletStepClusters'), 
-    maxNSeeds         = cms.uint32(1000000)
-    )
+    clustersToSkip    = 'hiRegitMuMixedTripletStepClusters', 
+    maxNSeeds         = 1000000
+)
 
 # fitting: feed new-names
-hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTracks.clone(
+hiRegitMuMixedTripletStepTracks  = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTracks.clone(
     AlgorithmName = cms.string('hiRegitMuMixedTripletStep'),
     src                 = 'hiRegitMuMixedTripletStepTrackCandidates',
 )
@@ -123,52 +127,52 @@ hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-    src                 = 'hiRegitMuMixedTripletStepTracks',
-    vertices            = cms.InputTag("hiSelectedPixelVertex"),
-    useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter7'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
-    trackSelectors= cms.VPSet(
+    src            = 'hiRegitMuMixedTripletStepTracks',
+    vertices       = "hiSelectedPixelVertex",
+    useAnyMVA      = True,
+    GBRForestLabel = 'HIMVASelectorIter7',
+    GBRForestVars  = ['chi2perdofperlayer', 'nhits', 'nlayers', 'eta'],
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuMixedTripletStepLoose',
-           min_nhits = cms.uint32(8)
+           name      = 'hiRegitMuMixedTripletStepLoose',
+           min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuMixedTripletStepTight',
+            name      = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.2)
+            min_nhits = 8,
+            useMVA    = True,
+            minMVA    = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuMixedTripletStep',
+            name      = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.09)
+            min_nhits = 8,
+            useMVA    = True,
+            minMVA    = -0.09
             )
         ) #end of vpset
-    ) #end of clone
+) #end of clone
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuMixedTripletStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuMixedTripletStepSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuMixedTripletStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuMixedTripletStepLoose',
-           min_nhits = cms.uint32(8)
+           name      = 'hiRegitMuMixedTripletStepLoose',
+           min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuMixedTripletStepTight',
+            name      = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.2)
+            min_nhits = 8,
+            useMVA    = False,
+            minMVA    = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuMixedTripletStep',
+            name      = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.09)
+            min_nhits = 8,
+            useMVA    = False,
+            minMVA    = -0.09
             )
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -21,7 +21,7 @@ hiRegitMuMixedTripletStepTrackingRegionsA = HiTrackingRegionFactoryFromSTAMuonsE
         Pt_min        = 1.3,
         DeltaR        = 0.5, # default = 0.2
         DeltaZ        = 0.5, # this give you the length
-        Rescale_Dz    = 4., # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
+        Rescale_Dz    = 4.,  # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
     )
 )
 hiRegitMuMixedTripletStepTrackingRegionsB = hiRegitMuMixedTripletStepTrackingRegionsA.clone(
@@ -33,11 +33,6 @@ from RecoTracker.IterativeTracking.MixedTripletStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
 hiRegitMuMixedTripletStepClusters = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepClusters.clone(
-    #oldClusterRemovalInfo = cms.InputTag("hiRegitMuPixelPairStepClusters"),
-    #trajectories          = cms.InputTag("hiRegitMuPixelPairStepTracks"),
-    #overrideTrkQuals      = cms.InputTag('hiRegitMuPixelPairStepSelector','hiRegitMuPixelPairStep'),
-    #trackClassifier       = cms.InputTag(''),
-    #TrackQuality          = cms.string('tight')
     oldClusterRemovalInfo = "hiRegitMuPixelPairStepClusters",
     trajectories          = "hiRegitMuPixelPairStepTracks",
     overrideTrkQuals      = 'hiRegitMuPixelPairStepSelector:hiRegitMuPixelPairStep',
@@ -118,10 +113,9 @@ hiRegitMuMixedTripletStepTrackCandidates = RecoTracker.IterativeTracking.MixedTr
 
 # fitting: feed new-names
 hiRegitMuMixedTripletStepTracks  = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTracks.clone(
-    AlgorithmName = cms.string('hiRegitMuMixedTripletStep'),
-    src                 = 'hiRegitMuMixedTripletStepTrackCandidates',
+    AlgorithmName = 'hiRegitMuMixedTripletStep',
+    src           = 'hiRegitMuMixedTripletStepTrackCandidates',
 )
-
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -20,7 +20,7 @@ hiRegitMuPixelLessStepTrackingRegions = HiTrackingRegionFactoryFromSTAMuonsEDPro
         Pt_min        = 2.0,
         DeltaR        = 0.2, # default = 0.2
         DeltaZ        = 0.2, # this give you the length
-        Rescale_Dz    = 4., # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
+        Rescale_Dz    = 4.,  # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
     )
 )
 
@@ -29,43 +29,43 @@ from RecoTracker.IterativeTracking.PixelLessStep_cff import *
 
 # remove previously used clusters
 hiRegitMuPixelLessStepClusters = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepClusters.clone(
-    oldClusterRemovalInfo = cms.InputTag("hiRegitMuMixedTripletStepClusters"),
-    trajectories     = cms.InputTag("hiRegitMuMixedTripletStepTracks"),
-    overrideTrkQuals = cms.InputTag('hiRegitMuMixedTripletStepSelector','hiRegitMuMixedTripletStep'),
-    trackClassifier       = cms.InputTag(''),
-    TrackQuality          = cms.string('tight')
+    oldClusterRemovalInfo = "hiRegitMuMixedTripletStepClusters",
+    trajectories          = "hiRegitMuMixedTripletStepTracks",
+    overrideTrkQuals      = 'hiRegitMuMixedTripletStepSelector:hiRegitMuMixedTripletStep',
+    trackClassifier       = '',
+    TrackQuality          = 'tight'
 )
 
 # SEEDING LAYERS
-hiRegitMuPixelLessStepSeedLayers =  RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.clone()
-hiRegitMuPixelLessStepSeedLayers.TIB.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-hiRegitMuPixelLessStepSeedLayers.TID.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-hiRegitMuPixelLessStepSeedLayers.TEC.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-hiRegitMuPixelLessStepSeedLayers.MTIB.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-hiRegitMuPixelLessStepSeedLayers.MTID.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-hiRegitMuPixelLessStepSeedLayers.MTEC.skipClusters = cms.InputTag('hiRegitMuPixelLessStepClusters')
-
+hiRegitMuPixelLessStepSeedLayers =  RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.clone(
+    TIB  = dict(skipClusters = 'hiRegitMuPixelLessStepClusters'),
+    TID  = dict(skipClusters = 'hiRegitMuPixelLessStepClusters'),
+    TEC  = dict(skipClusters = 'hiRegitMuPixelLessStepClusters'),
+    MTIB = dict(skipClusters = 'hiRegitMuPixelLessStepClusters'),
+    MTID = dict(skipClusters = 'hiRegitMuPixelLessStepClusters'),
+    MTEC = dict(skipClusters = 'hiRegitMuPixelLessStepClusters')
+)
 
 # seeding
 hiRegitMuPixelLessStepHitDoublets = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepHitDoublets.clone(
-    seedingLayers = "hiRegitMuPixelLessStepSeedLayers",
+    seedingLayers   = "hiRegitMuPixelLessStepSeedLayers",
     trackingRegions = "hiRegitMuPixelLessStepTrackingRegions",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck    = "hiRegitMuClusterCheck",
 )
 hiRegitMuPixelLessStepHitTriplets = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepHitTriplets.clone(
     doublets = "hiRegitMuPixelLessStepHitDoublets"
 )
-hiRegitMuPixelLessStepSeeds     = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.clone(
+hiRegitMuPixelLessStepSeeds = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.clone(
     seedingHitSets = "hiRegitMuPixelLessStepHitTriplets"
 )
 
 
 # building: feed the new-named seeds
-hiRegitMuPixelLessStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTrajectoryFilter.clone()
-hiRegitMuPixelLessStepTrajectoryFilter.minPt                = 1.7
-hiRegitMuPixelLessStepTrajectoryFilter.minimumNumberOfHits  = 6
-hiRegitMuPixelLessStepTrajectoryFilter.minHitsMinPt         = 4
-
+hiRegitMuPixelLessStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTrajectoryFilter.clone(
+    minPt                = 1.7,
+    minimumNumberOfHits  = 6,
+    minHitsMinPt         = 4
+)
 hiRegitMuPixelLessStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(
        refToPSet_ = cms.string('hiRegitMuPixelLessStepTrajectoryFilter')
@@ -73,70 +73,70 @@ hiRegitMuPixelLessStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelLes
     minNrOfHitsForRebuild = 6 #change from default 4
 )
 
-hiRegitMuPixelLessStepTrackCandidates        =  RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTrackCandidates.clone(
-    src               = cms.InputTag('hiRegitMuPixelLessStepSeeds'),
+hiRegitMuPixelLessStepTrackCandidates =  RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTrackCandidates.clone(
+    src               = 'hiRegitMuPixelLessStepSeeds',
     TrajectoryBuilderPSet = cms.PSet(
        refToPSet_ = cms.string('hiRegitMuPixelLessStepTrajectoryBuilder')
        ),
-    clustersToSkip       = cms.InputTag('hiRegitMuPixelLessStepClusters'),
-    maxNSeeds         = cms.uint32(1000000)
-    )
+    clustersToSkip    = 'hiRegitMuPixelLessStepClusters',
+    maxNSeeds         = 1000000
+)
 
 # fitting: feed new-names
-hiRegitMuPixelLessStepTracks                 = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTracks.clone(
-    AlgorithmName = cms.string('hiRegitMuPixelLessStep'),
-    src                 = 'hiRegitMuPixelLessStepTrackCandidates'
+hiRegitMuPixelLessStepTracks = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTracks.clone(
+    AlgorithmName = 'hiRegitMuPixelLessStep',
+    src           = 'hiRegitMuPixelLessStepTrackCandidates'
 )
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-    src                 ='hiRegitMuPixelLessStepTracks',
-    vertices            = cms.InputTag("hiSelectedPixelVertex"),
-    useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter7'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+    src            = 'hiRegitMuPixelLessStepTracks',
+    vertices       = "hiSelectedPixelVertex",
+    useAnyMVA      = True,
+    GBRForestLabel = 'HIMVASelectorIter7',
+    GBRForestVars  = ['chi2perdofperlayer', 'nhits', 'nlayers', 'eta'],
     trackSelectors = cms.VPSet(  
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuPixelLessStepLoose',
-           min_nhits = cms.uint32(8)
+           name      = 'hiRegitMuPixelLessStepLoose',
+           min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuPixelLessStepTight',
+            name          = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuPixelLessStep',
+            name          = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.09
             ),
         ) #end of vpset
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuPixelLessStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuPixelLessStepSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuPixelLessStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuPixelLessStepLoose',
-           min_nhits = cms.uint32(8)
+           name      = 'hiRegitMuPixelLessStepLoose',
+           min_nhits = 8
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuPixelLessStepTight',
+            name          = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.2
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuPixelLessStep',
+            name          = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.09
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -21,7 +21,7 @@ hiRegitMuPixelPairStepTrackingRegions = HiTrackingRegionFactoryFromSTAMuonsEDPro
         Pt_min          = 1.0,
         DeltaR          = 0.01, # default = 0.2
         DeltaZ          = 0.09, # this give you the length
-        Rescale_Dz      = 0. # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
+        Rescale_Dz      = 0.    # max(DeltaZ_Region,Rescale_Dz*vtx->zError())
     )
 )
 
@@ -30,26 +30,25 @@ from RecoTracker.IterativeTracking.PixelPairStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
 hiRegitMuPixelPairStepClusters = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepClusters.clone(
-    trajectories          = cms.InputTag("hiRegitMuInitialStepTracks"),
-		overrideTrkQuals      = cms.InputTag('hiRegitMuInitialStepSelector','hiRegitMuInitialStep'),
-                trackClassifier       = cms.InputTag(''),
-		oldClusterRemovalInfo = cms.InputTag(""),
-		TrackQuality          = cms.string('tight')
+    trajectories          = "hiRegitMuInitialStepTracks",
+    overrideTrkQuals      = 'hiRegitMuInitialStepSelector:hiRegitMuInitialStep',
+    trackClassifier       = '',
+    oldClusterRemovalInfo = "",
+    TrackQuality          = 'tight'
 )
 
 
 # SEEDING LAYERS
-hiRegitMuPixelPairStepSeedLayers =  RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.clone()
-hiRegitMuPixelPairStepSeedLayers.BPix.skipClusters = cms.InputTag('hiRegitMuPixelPairStepClusters')
-hiRegitMuPixelPairStepSeedLayers.FPix.skipClusters = cms.InputTag('hiRegitMuPixelPairStepClusters')
-
-
+hiRegitMuPixelPairStepSeedLayers =  RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.clone(
+    BPix = dict(skipClusters = 'hiRegitMuPixelPairStepClusters'),
+    FPix = dict(skipClusters = 'hiRegitMuPixelPairStepClusters')
+)
 
 # seeding
 hiRegitMuPixelPairStepHitDoublets = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepHitDoublets.clone(
-    seedingLayers = "hiRegitMuPixelPairStepSeedLayers",
+    seedingLayers   = "hiRegitMuPixelPairStepSeedLayers",
     trackingRegions = "hiRegitMuPixelPairStepTrackingRegions",
-    clusterCheck = "hiRegitMuClusterCheck",
+    clusterCheck    = "hiRegitMuClusterCheck",
 )
 
 hiRegitMuPixelPairStepSeeds     = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedsA.clone(
@@ -58,16 +57,16 @@ hiRegitMuPixelPairStepSeeds     = RecoTracker.IterativeTracking.PixelPairStep_cf
 
 
 # building: feed the new-named seeds
-hiRegitMuPixelPairStepTrajectoryFilterBase = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilterBase.clone()
-hiRegitMuPixelPairStepTrajectoryFilterBase.minPt                = 0.8
-hiRegitMuPixelPairStepTrajectoryFilterBase.minimumNumberOfHits  = 6
-hiRegitMuPixelPairStepTrajectoryFilterBase.minHitsMinPt         = 4
-
-hiRegitMuPixelPairStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilter.clone()
-hiRegitMuPixelPairStepTrajectoryFilter.filters = cms.VPSet(
+hiRegitMuPixelPairStepTrajectoryFilterBase = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilterBase.clone(
+    minPt                = 0.8,
+    minimumNumberOfHits  = 6,
+    minHitsMinPt         = 4
+)
+hiRegitMuPixelPairStepTrajectoryFilter = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryFilter.clone(
+    filters = cms.VPSet(
       cms.PSet( refToPSet_ = cms.string('hiRegitMuPixelPairStepTrajectoryFilterBase')),
       cms.PSet( refToPSet_ = cms.string('pixelPairStepTrajectoryFilterShape')))
-
+)
 
 hiRegitMuPixelPairStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(
@@ -77,70 +76,70 @@ hiRegitMuPixelPairStepTrajectoryBuilder = RecoTracker.IterativeTracking.PixelPai
 )
 
 # trackign candidate
-hiRegitMuPixelPairStepTrackCandidates        =  RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrackCandidates.clone(
-    src               = cms.InputTag('hiRegitMuPixelPairStepSeeds'),
+hiRegitMuPixelPairStepTrackCandidates = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTrackCandidates.clone(
+    src               = 'hiRegitMuPixelPairStepSeeds',
     TrajectoryBuilder = 'hiRegitMuPixelPairStepTrajectoryBuilder',
-    clustersToSkip = cms.InputTag("hiRegitMuPixelPairStepClusters"),
-    maxNSeeds         = cms.uint32(1000000)
-    )
+    clustersToSkip    = "hiRegitMuPixelPairStepClusters",
+    maxNSeeds         = 1000000
+)
 
 # fitting: feed new-names
-hiRegitMuPixelPairStepTracks                 = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTracks.clone(
-    AlgorithmName = cms.string('hiRegitMuPixelPairStep'),
-    src                 = 'hiRegitMuPixelPairStepTrackCandidates',
-    clustersToSkip       = cms.InputTag('hiRegitMuPixelPairStepClusters'),
+hiRegitMuPixelPairStepTracks = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTracks.clone(
+    AlgorithmName   = 'hiRegitMuPixelPairStep',
+    src             = 'hiRegitMuPixelPairStepTrackCandidates',
+    clustersToSkip  = cms.InputTag('hiRegitMuPixelPairStepClusters'),
 )
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-    src                 ='hiRegitMuPixelPairStepTracks',
-    vertices            = cms.InputTag("hiSelectedPixelVertex"),
-    useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter6'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
-    trackSelectors= cms.VPSet(
+    src            ='hiRegitMuPixelPairStepTracks',
+    vertices       = "hiSelectedPixelVertex",
+    useAnyMVA      = True,
+    GBRForestLabel = 'HIMVASelectorIter6',
+    GBRForestVars  = ['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta'],
+    trackSelectors = cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuPixelPairStepLoose',
-           min_nhits = cms.uint32(8)
-            ), #end of pset
+            name      = 'hiRegitMuPixelPairStepLoose',
+            min_nhits = 8
+            ), 
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuPixelPairStepTight',
+            name          = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.58)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.58
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuPixelPairStep',
+            name          = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(0.77)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = 0.77
             ),
         ) #end of vpset
 )
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuPixelPairStepSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuPixelPairStepSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuPixelPairStepSelector, trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-           name = 'hiRegitMuPixelPairStepLoose',
-           min_nhits = cms.uint32(8)
-            ), #end of pset
+           name      = 'hiRegitMuPixelPairStepLoose',
+           min_nhits = 8
+            ), 
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuPixelPairStepTight',
+            name          = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.58)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.58
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuPixelPairStep',
+            name          = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(0.77)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = 0.77
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -5,30 +5,31 @@ from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
-                      cms.InputTag('hiDetachedTripletStepTracks'),
-                      cms.InputTag('hiLowPtTripletStepTracks'),
-                      cms.InputTag('hiPixelPairGlobalPrimTracks'),
-                      cms.InputTag('hiJetCoreRegionalStepTracks'),
-                      cms.InputTag('hiRegitMuInitialStepTracks'),
-                      cms.InputTag('hiRegitMuPixelPairStepTracks'),
-                      cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
-                      cms.InputTag('hiRegitMuDetachedTripletStepTracks')
-                     ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1),
-    selectedTrackQuals = cms.VInputTag(
-    cms.InputTag("hiInitialStepSelector","hiInitialStep"),
-    cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
-    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
-    cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
-    cms.InputTag("hiJetCoreRegionalStepSelector","hiJetCoreRegionalStep"),
-    cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
-    cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
-    cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
-    cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep")
-    ),                    
+    TrackProducers = [
+	'hiGlobalPrimTracks',
+        'hiDetachedTripletStepTracks',
+        'hiLowPtTripletStepTracks',
+        'hiPixelPairGlobalPrimTracks',
+        'hiJetCoreRegionalStepTracks',
+        'hiRegitMuInitialStepTracks',
+        'hiRegitMuPixelPairStepTracks',
+        'hiRegitMuMixedTripletStepTracks',
+        'hiRegitMuPixelLessStepTracks',
+        'hiRegitMuDetachedTripletStepTracks'
+         ],
+    hasSelector = [1,1,1,1,1,1,1,1,1,1],
+    selectedTrackQuals = [
+	"hiInitialStepSelector:hiInitialStep",
+	"hiDetachedTripletStepSelector:hiDetachedTripletStep",
+	"hiLowPtTripletStepSelector:hiLowPtTripletStep",
+	"hiPixelPairStepSelector:hiPixelPairStep",
+	"hiJetCoreRegionalStepSelector:hiJetCoreRegionalStep",
+	"hiRegitMuInitialStepSelector:hiRegitMuInitialStepLoose",
+	"hiRegitMuPixelPairStepSelector:hiRegitMuPixelPairStep",
+	"hiRegitMuMixedTripletStepSelector:hiRegitMuMixedTripletStep",
+	"hiRegitMuPixelLessStepSelector:hiRegitMuPixelLessStep",
+	"hiRegitMuDetachedTripletStepSelector:hiRegitMuDetachedTripletStep"
+     	 ],
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
@@ -36,135 +37,135 @@ hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.track
     )
 
 hiEarlyMuons = earlyMuons.clone(
-      inputCollectionLabels = cms.VInputTag(cms.InputTag("hiEarlyGeneralTracks"),cms.InputTag("standAloneMuons","UpdatedAtVtx"))
-      )
+    inputCollectionLabels = ["hiEarlyGeneralTracks", "standAloneMuons:UpdatedAtVtx"]
+)
 
 ###### SEEDER MODELS ######
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 import RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi
 hiRegitMuonSeededSeedsOutIn = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-      src = "hiEarlyMuons",
-      )
+    src = "hiEarlyMuons",
+)
 hiRegitMuonSeededSeedsInOut = RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi.inOutSeedsFromTrackerMuons.clone(
-      src = "hiEarlyMuons",
-      )
+    src = "hiEarlyMuons",
+)
 
 hiRegitMuonSeededTrackCandidatesInOut = muonSeededTrackCandidatesInOut.clone(
-      src = cms.InputTag("hiRegitMuonSeededSeedsInOut")
-      )
+    src = "hiRegitMuonSeededSeedsInOut"
+)
 hiRegitMuonSeededTrackCandidatesOutIn = muonSeededTrackCandidatesOutIn.clone(
-      src = cms.InputTag("hiRegitMuonSeededSeedsOutIn")
-      )
+    src = "hiRegitMuonSeededSeedsOutIn"
+)
 
 hiRegitMuonSeededTracksOutIn = muonSeededTracksOutIn.clone(
-      src = cms.InputTag("hiRegitMuonSeededTrackCandidatesOutIn"),
-      AlgorithmName = cms.string('hiRegitMuMuonSeededStepOutIn') 
-      )
+    src = "hiRegitMuonSeededTrackCandidatesOutIn",
+    AlgorithmName = 'hiRegitMuMuonSeededStepOutIn'
+)
 hiRegitMuonSeededTracksInOut = muonSeededTracksInOut.clone(
-      src = cms.InputTag("hiRegitMuonSeededTrackCandidatesInOut"),
-      AlgorithmName = cms.string('hiRegitMuMuonSeededStepInOut') 
-      )
+    src = "hiRegitMuonSeededTrackCandidatesInOut",
+    AlgorithmName = 'hiRegitMuMuonSeededStepInOut'
+)
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-      src='hiRegitMuonSeededTracksInOut',
-      vertices            = cms.InputTag("hiSelectedPixelVertex"),
-      useAnyMVA = cms.bool(True),
-      GBRForestLabel = cms.string('HIMVASelectorIter7'),
-      GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
-      trackSelectors= cms.VPSet(
+      src            = 'hiRegitMuonSeededTracksInOut',
+      vertices       = "hiSelectedPixelVertex",
+      useAnyMVA      = True,
+      GBRForestLabel = 'HIMVASelectorIter7',
+      GBRForestVars  = ['chi2perdofperlayer', 'nhits', 'nlayers', 'eta'],
+      trackSelectors = cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutLoose',
-            min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = 8
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutTight',
+            name          = 'hiRegitMuonSeededTracksInOutTight',
             preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.2
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutHighPurity',
+            name          = 'hiRegitMuonSeededTracksInOutHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksInOutTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.09
             ),
          ) #end of vpset
-      ) #end of clone
+) #end of clone
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuonSeededTracksInOutSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuonSeededTracksInOutSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuonSeededTracksInOutSelector, trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutLoose',
-            min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = 8
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutTight',
+            name          = 'hiRegitMuonSeededTracksInOutTight',
             preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.2
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuonSeededTracksInOutHighPurity',
+            name          = 'hiRegitMuonSeededTracksInOutHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksInOutTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.09
             ),
          ) #end of vpset
 )
 
 hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
-      src='hiRegitMuonSeededTracksOutIn',
-      vertices            = cms.InputTag("hiSelectedPixelVertex"),
-      useAnyMVA = cms.bool(True),
-      GBRForestLabel = cms.string('HIMVASelectorIter7'),
-      GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
-      trackSelectors= cms.VPSet(
+      src            = 'hiRegitMuonSeededTracksOutIn',
+      vertices       = "hiSelectedPixelVertex",
+      useAnyMVA      = True,
+      GBRForestLabel = 'HIMVASelectorIter7',
+      GBRForestVars  = ['chi2perdofperlayer', 'nhits', 'nlayers', 'eta'],
+      trackSelectors = cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInLoose',
-            min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = 8
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInTight',
+            name          = 'hiRegitMuonSeededTracksOutInTight',
             preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.2
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInHighPurity',
+            name          = 'hiRegitMuonSeededTracksOutInHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksOutInTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(True),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = True,
+            minMVA        = -0.09
             ),
          ) #end of vpset
-      ) #end of clone
+) #end of clone
 from Configuration.Eras.Modifier_trackingPhase1_cff import trackingPhase1
-trackingPhase1.toModify(hiRegitMuonSeededTracksOutInSelector, useAnyMVA = cms.bool(False))
+trackingPhase1.toModify(hiRegitMuonSeededTracksOutInSelector, useAnyMVA = False)
 trackingPhase1.toModify(hiRegitMuonSeededTracksOutInSelector, trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInLoose',
-            min_nhits = cms.uint32(8)
+            name      = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = 8
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInTight',
+            name          = 'hiRegitMuonSeededTracksOutInTight',
             preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.2)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.2
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
-            name = 'hiRegitMuonSeededTracksOutInHighPurity',
+            name          = 'hiRegitMuonSeededTracksOutInHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksOutInTight',
-            min_nhits = cms.uint32(8),
-            useMVA = cms.bool(False),
-            minMVA = cms.double(-0.09)
+            min_nhits     = 8,
+            useMVA        = False,
+            minMVA        = -0.09
             ),
          ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
+++ b/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
@@ -15,27 +15,29 @@ from RecoHI.HiMuonAlgos.HiRegitMuonSeededStep_cff import *
 from RecoTracker.FinalTrackSelectors.trackAlgoPriorityOrder_cfi import trackAlgoPriorityOrder
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
-    TrackProducers = (cms.InputTag('hiRegitMuInitialStepTracks'),
-                      cms.InputTag('hiRegitMuPixelPairStepTracks'),
-                      cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
-                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuonSeededTracksOutIn'),
-                      cms.InputTag('hiRegitMuonSeededTracksInOut')
-                      ),
-    selectedTrackQuals = cms.VInputTag(cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
-                                       cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
-                                       cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-                                       cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
-                                       cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
-                                       cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
-                                       cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
-                                       ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1),
+    TrackProducers = [
+	'hiRegitMuInitialStepTracks',
+	'hiRegitMuPixelPairStepTracks',
+	'hiRegitMuMixedTripletStepTracks',
+	'hiRegitMuPixelLessStepTracks',
+	'hiRegitMuDetachedTripletStepTracks',
+	'hiRegitMuonSeededTracksOutIn',
+	'hiRegitMuonSeededTracksInOut'
+	],
+    selectedTrackQuals = [
+	"hiRegitMuInitialStepSelector:hiRegitMuInitialStepLoose",
+	"hiRegitMuPixelPairStepSelector:hiRegitMuPixelPairStep",
+	"hiRegitMuMixedTripletStepSelector:hiRegitMuMixedTripletStep",
+	"hiRegitMuPixelLessStepSelector:hiRegitMuPixelLessStep",
+	"hiRegitMuDetachedTripletStepSelector:hiRegitMuDetachedTripletStep",
+	"hiRegitMuonSeededTracksOutInSelector:hiRegitMuonSeededTracksOutInHighPurity",
+	"hiRegitMuonSeededTracksInOutSelector:hiRegitMuonSeededTracksInOutHighPurity"
+        ],
+    hasSelector = [1,1,1,1,1,1,1],
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True))),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
-    )
+)
 
 hiRegitMuTrackingTask = cms.Task(hiRegitMuClusterCheck
                                  ,hiRegitMuonInitialStepTask

--- a/RecoJets/JetProducers/python/PFJetParameters_cfi.py
+++ b/RecoJets/JetProducers/python/PFJetParameters_cfi.py
@@ -11,8 +11,8 @@ PFJetParameters = cms.PSet(
     # pileup with offset correction
     doPUOffsetCorr = cms.bool(False),
     # if pileup is false, these are not read:
-    #nSigmaPU = cms.double(1.0),
-    #radiusPU = cms.double(0.5),  
+    nSigmaPU       = cms.double(1.0),
+    radiusPU       = cms.double(0.5),  
     # fastjet-style pileup     
     doAreaFastjet       = cms.bool( True ),
     doRhoFastjet        = cms.bool( False),


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR were [PR#31162](https://github.com/cms-sw/cmssw/pull/31162),[PR#31243](https://github.com/cms-sw/cmssw/pull/31243),[PR#31332](https://github.com/cms-sw/cmssw/pull/31332), [PR#31389](https://github.com/cms-sw/cmssw/pull/31389), [PR#31523](https://github.com/cms-sw/cmssw/pull/31523), [PR#31538](https://github.com/cms-sw/cmssw/pull/31538), [PR#31748](https://github.com/cms-sw/cmssw/pull/31748), [PR#31784](https://github.com/cms-sw/cmssw/pull/31784), [PR#31881](https://github.com/cms-sw/cmssw/pull/31881))

In this PR, total 17 files changed. 

- RecoHI/HiEgammaAlgos : 2 files
- RecoHI/HiJetAlgos           : 6 files
- RecoHI/HiMuonAlgos      : 9 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).