### PR TITLE
Add cluster compatibility filter to HI miniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -148,6 +148,7 @@ _pp_on_AA_extraCommands = [
     'keep recoCentrality_hiCentrality_*_*',
     'keep int_centralityBin_*_*',
     'keep recoHFFilterInfo_hiHFfilters_*_*',
+    'keep recoClusterCompatibility_hiClusterCompatibility_*_*',
     'keep *_offlineSlimmedPrimaryVerticesRecovery_*_*',
     'keep *_hiEvtPlane_*_*',
     'keep *_hiEvtPlaneFlat_*_*',


### PR DESCRIPTION
Add an event selection filter needed to select hadronic interactions to HI miniAOD.
Tested on wf 140.5611
The added event content is expected to be small.

@denerslemos
