### PR TITLE
(Backport for 11_1_X) Add plots for displaced muon quantities to uGMT DQM

### DIFF
--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -60,6 +60,7 @@ private:
     RPTUNCONSTR,
     RDXY
   };
+  int numErrBins_ { RIDX }; // In Run-2 we didn't have the last two bins. This is incremented in source file if we configure for Run-3.
   bool incBin[RDXY + 1];
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken1;

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -60,7 +60,8 @@ private:
     RPTUNCONSTR,
     RDXY
   };
-  int numErrBins_ { RIDX }; // In Run-2 we didn't have the last two bins. This is incremented in source file if we configure for Run-3.
+  int numErrBins_{
+      RIDX};  // In Run-2 we didn't have the last two bins. This is incremented in source file if we configure for Run-3.
   bool incBin[RDXY + 1];
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken1;

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -31,6 +31,8 @@ private:
     MUONALL,
     MUONGOOD,
     PTBAD,
+    PTUNCONSTRBAD,
+    DXYBAD,
     ETABAD,
     PHIBAD,
     ETAATVTXBAD,
@@ -46,6 +48,8 @@ private:
     RNMUON,
     RMUON,
     RPT,
+    RPTUNCONSTR,
+    RDXY,
     RETA,
     RPHI,
     RETAATVTX,
@@ -75,6 +79,8 @@ private:
   MonitorElement* muColl1BxRange;
   MonitorElement* muColl1nMu;
   MonitorElement* muColl1hwPt;
+  MonitorElement* muColl1hwPtUnconstrained;
+  MonitorElement* muColl1hwDXY;
   MonitorElement* muColl1hwEta;
   MonitorElement* muColl1hwPhi;
   MonitorElement* muColl1hwEtaAtVtx;
@@ -89,6 +95,8 @@ private:
   MonitorElement* muColl2BxRange;
   MonitorElement* muColl2nMu;
   MonitorElement* muColl2hwPt;
+  MonitorElement* muColl2hwPtUnconstrained;
+  MonitorElement* muColl2hwDXY;
   MonitorElement* muColl2hwEta;
   MonitorElement* muColl2hwPhi;
   MonitorElement* muColl2hwEtaAtVtx;

--- a/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
+++ b/DQM/L1TMonitor/interface/L1TStage2MuonComp.h
@@ -31,8 +31,6 @@ private:
     MUONALL,
     MUONGOOD,
     PTBAD,
-    PTUNCONSTRBAD,
-    DXYBAD,
     ETABAD,
     PHIBAD,
     ETAATVTXBAD,
@@ -41,15 +39,15 @@ private:
     CHARGEVALBAD,
     QUALBAD,
     ISOBAD,
-    IDXBAD
+    IDXBAD,
+    PTUNCONSTRBAD,
+    DXYBAD
   };
   enum ratioVariables {
     RBXRANGE = 1,
     RNMUON,
     RMUON,
     RPT,
-    RPTUNCONSTR,
-    RDXY,
     RETA,
     RPHI,
     RETAATVTX,
@@ -58,9 +56,11 @@ private:
     RCHARGEVAL,
     RQUAL,
     RISO,
-    RIDX
+    RIDX,
+    RPTUNCONSTR,
+    RDXY
   };
-  bool incBin[RIDX + 1];
+  bool incBin[RDXY + 1];
 
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken1;
   edm::EDGetTokenT<l1t::MuonBxCollection> muonToken2;
@@ -71,6 +71,7 @@ private:
   std::vector<int> ignoreBin;
   bool verbose;
   bool enable2DComp;  // Default value is false. Set to true in the configuration file for enabling 2D eta-phi histograms
+  bool displacedQuantities_;
 
   MonitorElement* summary;
   MonitorElement* errorSummaryNum;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -34,6 +34,7 @@ private:
   std::string monitorDir;
   bool emul;
   bool verbose;
+  bool displacedQuantities_;
 
   const float etaScale_;
   const float phiScale_;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMT.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMT.h
@@ -41,6 +41,8 @@ private:
   MonitorElement* ugmtBMTFBX;
   MonitorElement* ugmtBMTFnMuons;
   MonitorElement* ugmtBMTFhwPt;
+  MonitorElement* ugmtBMTFhwPtUnconstrained;
+  MonitorElement* ugmtBMTFhwDXY;
   MonitorElement* ugmtBMTFhwEta;
   MonitorElement* ugmtBMTFhwPhi;
   MonitorElement* ugmtBMTFglbPhi;
@@ -112,6 +114,8 @@ private:
   MonitorElement* ugmtnMuons;
   MonitorElement* ugmtMuonIndex;
   MonitorElement* ugmtMuonhwPt;
+  MonitorElement* ugmtMuonhwPtUnconstrained;
+  MonitorElement* ugmtMuonhwDXY;
   MonitorElement* ugmtMuonhwEta;
   MonitorElement* ugmtMuonhwPhi;
   MonitorElement* ugmtMuonhwEtaAtVtx;
@@ -122,6 +126,7 @@ private:
   MonitorElement* ugmtMuonhwIso;
 
   MonitorElement* ugmtMuonPt;
+  MonitorElement* ugmtMuonPtUnconstrained;
   MonitorElement* ugmtMuonEta;
   MonitorElement* ugmtMuonPhi;
   MonitorElement* ugmtMuonEtaAtVtx;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
@@ -32,6 +32,8 @@ private:
   MonitorElement* ugmtMuonBX;
   MonitorElement* ugmtnMuons;
   MonitorElement* ugmtMuonhwPt;
+  MonitorElement* ugmtMuonhwPtUnconstrained;
+  MonitorElement* ugmtMuonhwDXY;
   MonitorElement* ugmtMuonhwEta;
   MonitorElement* ugmtMuonhwPhi;
   MonitorElement* ugmtMuonhwEtaAtVtx;
@@ -41,6 +43,7 @@ private:
   MonitorElement* ugmtMuonhwQual;
 
   MonitorElement* ugmtMuonPt;
+  MonitorElement* ugmtMuonPtUnconstrained;
   MonitorElement* ugmtMuonEta;
   MonitorElement* ugmtMuonPhi;
   MonitorElement* ugmtMuonEtaAtVtx;

--- a/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
+++ b/DQM/L1TMonitor/interface/L1TStage2uGMTMuon.h
@@ -28,6 +28,7 @@ private:
   std::string titlePrefix;
   bool verbose;
   bool makeMuonAtVtxPlots;
+  bool displacedQuantities_;
 
   MonitorElement* ugmtMuonBX;
   MonitorElement* ugmtnMuons;

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -58,14 +58,14 @@ l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
                                       0x000001FF,
                                       0x00000000),
     # mask for outputs (pt==0 defines empty muon)
-    maskCapId2 = cms.untracked.vint32(0x0007FC00,
+    maskCapId2 = cms.untracked.vint32(0x00000000,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000),
     # mask for validation event outputs (pt==0 defines empty muon)
-    maskCapId3 = cms.untracked.vint32(0x0007FC00,
+    maskCapId3 = cms.untracked.vint32(0x00000000,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000,

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -100,6 +100,7 @@ l1tStage2BmtfOutVsuGMTIn = DQMEDAnalyzer(
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF output muons and uGMT input muons from BMTF"),
     ignoreBin = cms.untracked.vint32(ignoreBins['Bmtf']),
     verbose = cms.untracked.bool(False),
+    isBmtf = cms.untracked.bool(True),
 )
 
 # compares the unpacked OMTF output regional muon collection with the unpacked uGMT input regional muon collection from OMTF

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -125,8 +125,11 @@ l1tStage2BmtfOutVsuGMTIn = DQMEDAnalyzer(
     summaryTitle = cms.untracked.string("Summary of comparison between BMTF output muons and uGMT input muons from BMTF"),
     ignoreBin = cms.untracked.vint32(ignoreBins['Bmtf']),
     verbose = cms.untracked.bool(False),
-    isBmtf = cms.untracked.bool(True),
 )
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2BmtfOutVsuGMTIn, isBmtf = cms.untracked.bool(True))
 
 # compares the unpacked OMTF output regional muon collection with the unpacked uGMT input regional muon collection from OMTF
 # only muons that do not match are filled in the histograms

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cff.py
@@ -11,7 +11,12 @@ l1tStage2uGMTIntermediateBMTF = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateBMTF, displacedQuantities = cms.untracked.bool(True))
 
 l1tStage2uGMTIntermediateOMTFNeg = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
@@ -19,6 +24,7 @@ l1tStage2uGMTIntermediateOMTFNeg = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF neg. "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
 
 l1tStage2uGMTIntermediateOMTFPos = DQMEDAnalyzer(
@@ -27,6 +33,7 @@ l1tStage2uGMTIntermediateOMTFPos = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/OMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from OMTF pos. "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
 
 l1tStage2uGMTIntermediateEMTFNeg = DQMEDAnalyzer(
@@ -35,6 +42,7 @@ l1tStage2uGMTIntermediateEMTFNeg = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_neg"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF neg. "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
 
 l1tStage2uGMTIntermediateEMTFPos = DQMEDAnalyzer(
@@ -43,6 +51,7 @@ l1tStage2uGMTIntermediateEMTFPos = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/intermediate_muons/EMTF_pos"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from EMTF pos. "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
 
 # zero suppression DQM
@@ -58,14 +67,14 @@ l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
                                       0x000001FF,
                                       0x00000000),
     # mask for outputs (pt==0 defines empty muon)
-    maskCapId2 = cms.untracked.vint32(0x00000000,
+    maskCapId2 = cms.untracked.vint32(0x0007FC00,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000),
     # mask for validation event outputs (pt==0 defines empty muon)
-    maskCapId3 = cms.untracked.vint32(0x00000000,
+    maskCapId3 = cms.untracked.vint32(0x0007FC00,
                                       0x00000000,
                                       0x0007FC00,
                                       0x00000000,
@@ -76,6 +85,22 @@ l1tStage2uGMTZeroSupp = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT/zeroSuppression/AllEvts"),
     verbose = cms.untracked.bool(False),
 )
+
+## Era: Run3_2021; Changed data format for Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTZeroSupp, maskCapId2 = cms.untracked.vint32(0x00000000,
+                                                                                       0x00000000,
+                                                                                       0x0007FC00,
+                                                                                       0x00000000,
+                                                                                       0x0007FC00,
+                                                                                       0x00000000),
+                                                     # mask for validation event outputs (pt==0 defines empty muon)
+                                                     maskCapId3 = cms.untracked.vint32(0x00000000,
+                                                                                       0x00000000,
+                                                                                       0x0007FC00,
+                                                                                       0x00000000,
+                                                                                       0x0007FC00,
+                                                                                       0x00000000))
 
 # ZS of validation events (to be used after fat event filter)
 l1tStage2uGMTZeroSuppFatEvts = l1tStage2uGMTZeroSupp.clone()
@@ -143,7 +168,12 @@ l1tStage2uGMTMuonVsuGMTMuonCopy1 = DQMEDAnalyzer(
     muonCollection2Title = cms.untracked.string("uGMT muons copy 1"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT muon copy 1"),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTMuonVsuGMTMuonCopy1, displacedQuantities = cms.untracked.bool(True))
 
 l1tStage2uGMTMuonVsuGMTMuonCopy2 = l1tStage2uGMTMuonVsuGMTMuonCopy1.clone()
 l1tStage2uGMTMuonVsuGMTMuonCopy2.muonCollection2 = cms.InputTag("gmtStage2Digis", "MuonCopy2")

--- a/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TStage2uGMT_cfi.py
@@ -11,5 +11,9 @@ l1tStage2uGMT = DQMEDAnalyzer(
     monitorDir = cms.untracked.string("L1T/L1TStage2uGMT"),
     emulator = cms.untracked.bool(False),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False)
 )
 
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMT, displacedQuantities = cms.untracked.bool(True))

--- a/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
+++ b/DQM/L1TMonitor/python/L1TdeStage2uGMT_cff.py
@@ -27,7 +27,12 @@ l1tStage2uGMTIntermediateBMTFEmul = DQMEDAnalyzer(
     monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/BMTF"),
     titlePrefix = cms.untracked.string("uGMT intermediate muon from BMTF "),
     verbose = cms.untracked.bool(False),
+    displacedQuantities = cms.untracked.bool(False),
 )
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tStage2uGMTIntermediateBMTFEmul, displacedQuantities = cms.untracked.bool(True))
 
 l1tStage2uGMTIntermediateOMTFNegEmul = DQMEDAnalyzer(
     "L1TStage2uGMTMuon",
@@ -72,8 +77,13 @@ l1tdeStage2uGMT = DQMEDAnalyzer(
     muonCollection2Title = cms.untracked.string("uGMT emulator"),
     summaryTitle = cms.untracked.string("Summary of comparison between uGMT muons and uGMT emulator muons"),
     verbose = cms.untracked.bool(False),
-    enable2DComp = cms.untracked.bool(True), # When true eta-phi comparison plots are also produced 
+    enable2DComp = cms.untracked.bool(True), # When true eta-phi comparison plots are also produced
+    displacedQuantities = cms.untracked.bool(False),
 )
+
+## Era: Run3_2021; Displaced muons from BMTF used in uGMT from Run-3
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(l1tdeStage2uGMT, displacedQuantities = cms.untracked.bool(True))
 
 # compares the unpacked uGMT intermediate muon collection to the emulated uGMT intermediate muon collection
 # only muons that do not match are filled in the histograms
@@ -85,6 +95,7 @@ l1tdeStage2uGMTIntermediateBMTF.summaryTitle = cms.untracked.string("Summary of 
 l1tdeStage2uGMTIntermediateBMTF.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateOMTFNeg.displacedQuantities = cms.untracked.bool(False)
 l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFNeg")
 l1tdeStage2uGMTIntermediateOMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFNeg")
 l1tdeStage2uGMTIntermediateOMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_neg/data_vs_emulator_comparison")
@@ -92,6 +103,7 @@ l1tdeStage2uGMTIntermediateOMTFNeg.summaryTitle = cms.untracked.string("Summary 
 l1tdeStage2uGMTIntermediateOMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateOMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateOMTFPos.displacedQuantities = cms.untracked.bool(False)
 l1tdeStage2uGMTIntermediateOMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsOMTFPos")
 l1tdeStage2uGMTIntermediateOMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsOMTFPos")
 l1tdeStage2uGMTIntermediateOMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/OMTF_pos/data_vs_emulator_comparison")
@@ -99,6 +111,7 @@ l1tdeStage2uGMTIntermediateOMTFPos.summaryTitle = cms.untracked.string("Summary 
 l1tdeStage2uGMTIntermediateOMTFPos.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFNeg = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateEMTFNeg.displacedQuantities = cms.untracked.bool(False)
 l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFNeg")
 l1tdeStage2uGMTIntermediateEMTFNeg.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFNeg")
 l1tdeStage2uGMTIntermediateEMTFNeg.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_neg/data_vs_emulator_comparison")
@@ -106,6 +119,7 @@ l1tdeStage2uGMTIntermediateEMTFNeg.summaryTitle = cms.untracked.string("Summary 
 l1tdeStage2uGMTIntermediateEMTFNeg.ignoreBin = cms.untracked.vint32(ignoreBins)
 
 l1tdeStage2uGMTIntermediateEMTFPos = l1tdeStage2uGMTIntermediateBMTF.clone()
+l1tdeStage2uGMTIntermediateEMTFPos.displacedQuantities = cms.untracked.bool(False)
 l1tdeStage2uGMTIntermediateEMTFPos.muonCollection1 = cms.InputTag(unpackerModule, "imdMuonsEMTFPos")
 l1tdeStage2uGMTIntermediateEMTFPos.muonCollection2 = cms.InputTag(emulatorModule, "imdMuonsEMTFPos")
 l1tdeStage2uGMTIntermediateEMTFPos.monitorDir = cms.untracked.string(ugmtEmuImdMuDqmDir+"/EMTF_pos/data_vs_emulator_comparison")

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -47,7 +47,7 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   // Subsystem Monitoring and Muon Output
   ibooker.setCurrentFolder(monitorDir);
 
-  summary = ibooker.book1D("summary", summaryTitle.c_str(), 16, 1, 17);  // range to match bin numbering
+  summary = ibooker.book1D("summary", summaryTitle.c_str(), 18, 1, 19);  // range to match bin numbering
   summary->setBinLabel(BXRANGEGOOD, "BX range match", 1);
   summary->setBinLabel(BXRANGEBAD, "BX range mismatch", 1);
   summary->setBinLabel(NMUONGOOD, "muon collection size match", 1);
@@ -55,6 +55,8 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   summary->setBinLabel(MUONALL, "# muons", 1);
   summary->setBinLabel(MUONGOOD, "# matching muons", 1);
   summary->setBinLabel(PTBAD, "p_{T} mismatch", 1);
+  summary->setBinLabel(PTUNCONSTRBAD, "p_{T} unconstrained mismatch", 1);
+  summary->setBinLabel(DXYBAD, "dXY mismatch", 1);
   summary->setBinLabel(ETABAD, "#eta mismatch", 1);
   summary->setBinLabel(PHIBAD, "#phi mismatch", 1);
   summary->setBinLabel(ETAATVTXBAD, "#eta at vertex mismatch", 1);
@@ -65,11 +67,13 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   summary->setBinLabel(ISOBAD, "iso mismatch", 1);
   summary->setBinLabel(IDXBAD, "index mismatch", 1);
 
-  errorSummaryNum = ibooker.book1D("errorSummaryNum", summaryTitle.c_str(), 13, 1, 14);  // range to match bin numbering
+  errorSummaryNum = ibooker.book1D("errorSummaryNum", summaryTitle.c_str(), 15, 1, 16);  // range to match bin numbering
   errorSummaryNum->setBinLabel(RBXRANGE, "BX range mismatch", 1);
   errorSummaryNum->setBinLabel(RNMUON, "muon collection size mismatch", 1);
   errorSummaryNum->setBinLabel(RMUON, "mismatching muons", 1);
   errorSummaryNum->setBinLabel(RPT, "p_{T} mismatch", 1);
+  errorSummaryNum->setBinLabel(RPTUNCONSTR, "p_{T} unconstrained mismatch", 1);
+  errorSummaryNum->setBinLabel(RDXY, "dXY mismatch", 1);
   errorSummaryNum->setBinLabel(RETA, "#eta mismatch", 1);
   errorSummaryNum->setBinLabel(RPHI, "#phi mismatch", 1);
   errorSummaryNum->setBinLabel(RETAATVTX, "#eta at vertex mismatch", 1);
@@ -91,7 +95,7 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   // This needs to come after the calls to setBinLabel.
   errorSummaryNum->getTH1F()->GetXaxis()->SetCanExtend(false);
 
-  errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 13, 1, 14);  // range to match bin numbering
+  errorSummaryDen = ibooker.book1D("errorSummaryDen", "denominators", 15, 1, 16);  // range to match bin numbering
   errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
   errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
   for (int i = RMUON; i <= RIDX; ++i) {
@@ -106,6 +110,12 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   muColl1nMu->setAxisTitle("Muon multiplicity", 1);
   muColl1hwPt = ibooker.book1D("muHwPtColl1", (muonColl1Title + " mismatching muon p_{T}").c_str(), 512, -0.5, 511.5);
   muColl1hwPt->setAxisTitle("Hardware p_{T}", 1);
+  muColl1hwPtUnconstrained = ibooker.book1D(
+      "muHwPtUnconstrainedColl1", (muonColl1Title + " mismatching muon p_{T} unconstrained").c_str(), 512, -0.5, 511.5);
+  muColl1hwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+  muColl1hwDXY =
+      ibooker.book1D("muHwDXYColl1", (muonColl1Title + " mismatching impact parameter").c_str(), 4, -0.5, 3.5);
+  muColl1hwDXY->setAxisTitle("Hardware dXY", 1);
   muColl1hwEta =
       ibooker.book1D("muHwEtaColl1", (muonColl1Title + " mismatching muon #eta").c_str(), 461, -230.5, 230.5);
   muColl1hwEta->setAxisTitle("Hardware #eta", 1);
@@ -146,6 +156,12 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   muColl2nMu->setAxisTitle("Muon multiplicity", 1);
   muColl2hwPt = ibooker.book1D("muHwPtColl2", (muonColl2Title + " mismatching muon p_{T}").c_str(), 512, -0.5, 511.5);
   muColl2hwPt->setAxisTitle("Hardware p_{T}", 1);
+  muColl2hwPtUnconstrained = ibooker.book1D(
+      "muHwPtUnconstrainedColl2", (muonColl2Title + " mismatching muon p_{T} unconstrained").c_str(), 512, -0.5, 511.5);
+  muColl2hwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+  muColl2hwDXY =
+      ibooker.book1D("muHwDXYColl2", (muonColl2Title + " mismatching impact parameter").c_str(), 4, -0.5, 3.5);
+  muColl2hwDXY->setAxisTitle("Hardware dXY", 1);
   muColl2hwEta =
       ibooker.book1D("muHwEtaColl2", (muonColl2Title + " mismatching muon #eta").c_str(), 461, -230.5, 230.5);
   muColl2hwEta->setAxisTitle("Hardware #eta", 1);
@@ -254,8 +270,9 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           muColl2hwQual->Fill(muonIt2->hwQual());
           muColl2hwIso->Fill(muonIt2->hwIso());
           muColl2Index->Fill(muonIt2->tfMuonIndex());
-          if (enable2DComp)
+          if (enable2DComp) {
             muColl2EtaPhimap->Fill(muonIt2->eta(), muonIt2->phi());
+          }
         }
       }
     } else {
@@ -278,6 +295,22 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         if (incBin[RPT]) {
           muonSelMismatch = true;
           errorSummaryNum->Fill(RPT);
+        }
+      }
+      if (muonIt1->hwPtUnconstrained() != muonIt2->hwPtUnconstrained()) {
+        muonMismatch = true;
+        summary->Fill(PTUNCONSTRBAD);
+        if (incBin[RPTUNCONSTR]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RPTUNCONSTR);
+        }
+      }
+      if (muonIt1->hwDXY() != muonIt2->hwDXY()) {
+        muonMismatch = true;
+        summary->Fill(DXYBAD);
+        if (incBin[RDXY]) {
+          muonSelMismatch = true;
+          errorSummaryNum->Fill(RDXY);
         }
       }
       if (muonIt1->hwEta() != muonIt2->hwEta()) {
@@ -359,6 +392,8 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
 
       if (muonMismatch) {
         muColl1hwPt->Fill(muonIt1->hwPt());
+        muColl1hwPtUnconstrained->Fill(muonIt1->hwPtUnconstrained());
+        muColl1hwDXY->Fill(muonIt1->hwDXY());
         muColl1hwEta->Fill(muonIt1->hwEta());
         muColl1hwPhi->Fill(muonIt1->hwPhi());
         muColl1hwEtaAtVtx->Fill(muonIt1->hwEtaAtVtx());
@@ -372,6 +407,8 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
           muColl1EtaPhimap->Fill(muonIt1->eta(), muonIt1->phi());
 
         muColl2hwPt->Fill(muonIt2->hwPt());
+        muColl2hwPtUnconstrained->Fill(muonIt2->hwPtUnconstrained());
+        muColl2hwDXY->Fill(muonIt2->hwDXY());
         muColl2hwEta->Fill(muonIt2->hwEta());
         muColl2hwPhi->Fill(muonIt2->hwPhi());
         muColl2hwEtaAtVtx->Fill(muonIt2->hwEtaAtVtx());
@@ -381,9 +418,9 @@ void L1TStage2MuonComp::analyze(const edm::Event& e, const edm::EventSetup& c) {
         muColl2hwQual->Fill(muonIt2->hwQual());
         muColl2hwIso->Fill(muonIt2->hwIso());
         muColl2Index->Fill(muonIt2->tfMuonIndex());
-        if (enable2DComp)
+        if (enable2DComp) {
           muColl2EtaPhimap->Fill(muonIt2->eta(), muonIt2->phi());
-
+        }
       } else {
         summary->Fill(MUONGOOD);
       }

--- a/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
+++ b/DQM/L1TMonitor/src/L1TStage2MuonComp.cc
@@ -108,8 +108,8 @@ void L1TStage2MuonComp::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   // This needs to come after the calls to setBinLabel.
   errorSummaryNum->getTH1F()->GetXaxis()->SetCanExtend(false);
 
-  errorSummaryDen =
-      ibooker.book1D("errorSummaryDen", "denominators", numErrBins_, 1, numErrBins_ + 1);  // range to match bin numbering
+  errorSummaryDen = ibooker.book1D(
+      "errorSummaryDen", "denominators", numErrBins_, 1, numErrBins_ + 1);  // range to match bin numbering
   errorSummaryDen->setBinLabel(RBXRANGE, "# events", 1);
   errorSummaryDen->setBinLabel(RNMUON, "# muon collections", 1);
   for (int i = RMUON; i <= numErrBins_; ++i) {

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -5,6 +5,7 @@ L1TStage2uGMT::L1TStage2uGMT(const edm::ParameterSet& ps)
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir")),
       emul(ps.getUntrackedParameter<bool>("emulator")),
       verbose(ps.getUntrackedParameter<bool>("verbose")),
+      displacedQuantities_(ps.getUntrackedParameter<bool>("displacedQuantities")),
       etaScale_(0.010875),  // eta scale (CMS DN-2015/017)
       phiScale_(0.010908)   // phi scale (2*pi/576 HW values)
 {
@@ -29,6 +30,7 @@ void L1TStage2uGMT::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<bool>("emulator", false)
       ->setComment("Create histograms for muonProducer input only. xmtfProducer inputs are ignored.");
   desc.addUntracked<bool>("verbose", false);
+  desc.addUntracked<bool>("displacedQuantities", false);
   descriptions.add("l1tStage2uGMT", desc);
 }
 
@@ -46,12 +48,14 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     ugmtBMTFhwPt = ibooker.book1D("ugmtBMTFhwPt", "uGMT BMTF Input HW p_{T}", 512, -0.5, 511.5);
     ugmtBMTFhwPt->setAxisTitle("Hardware p_{T}", 1);
 
-    ugmtBMTFhwPtUnconstrained =
-        ibooker.book1D("ugmtBMTFhwPtUnconstrained", "uGMT BMTF Input HW p_{T} unconstrained", 256, -0.5, 255.5);
-    ugmtBMTFhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+    if (displacedQuantities_) {
+      ugmtBMTFhwPtUnconstrained =
+          ibooker.book1D("ugmtBMTFhwPtUnconstrained", "uGMT BMTF Input HW p_{T} unconstrained", 256, -0.5, 255.5);
+      ugmtBMTFhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
 
-    ugmtBMTFhwDXY = ibooker.book1D("ugmtBMTFhwDXY", "uGMT BMTF Input HW impact parameter", 4, -0.5, 3.5);
-    ugmtBMTFhwDXY->setAxisTitle("Hardware dXY", 1);
+      ugmtBMTFhwDXY = ibooker.book1D("ugmtBMTFhwDXY", "uGMT BMTF Input HW impact parameter", 4, -0.5, 3.5);
+      ugmtBMTFhwDXY->setAxisTitle("Hardware dXY", 1);
+    }
 
     ugmtBMTFhwEta = ibooker.book1D("ugmtBMTFhwEta", "uGMT BMTF Input HW #eta", 201, -100.5, 100.5);
     ugmtBMTFhwEta->setAxisTitle("Hardware #eta", 1);
@@ -334,12 +338,14 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", "uGMT Muon HW p_{T}", 512, -0.5, 511.5);
   ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
 
-  ugmtMuonhwPtUnconstrained =
-      ibooker.book1D("ugmtMuonhwPtUnconstrained", "uGMT Muon HW p_{T} unconstrained", 256, -0.5, 255.5);
-  ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+  if (displacedQuantities_) {
+    ugmtMuonhwPtUnconstrained =
+        ibooker.book1D("ugmtMuonhwPtUnconstrained", "uGMT Muon HW p_{T} unconstrained", 256, -0.5, 255.5);
+    ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
 
-  ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", "uGMT Muon HW impact parameter", 4, -0.5, 3.5);
-  ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+    ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", "uGMT Muon HW impact parameter", 4, -0.5, 3.5);
+    ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+  }
 
   ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", "uGMT Muon HW #eta", 461, -230.5, 230.5);
   ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
@@ -368,9 +374,11 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonPt = ibooker.book1D("ugmtMuonPt", "uGMT Muon p_{T}", 128, -0.5, 255.5);
   ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
 
-  ugmtMuonPtUnconstrained =
-      ibooker.book1D("ugmtMuonPtUnconstrained", "uGMT Muon p_{T} unconstrained", 128, -0.5, 255.5);
-  ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
+  if (displacedQuantities_) {
+    ugmtMuonPtUnconstrained =
+        ibooker.book1D("ugmtMuonPtUnconstrained", "uGMT Muon p_{T} unconstrained", 128, -0.5, 255.5);
+    ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
+  }
 
   ugmtMuonEta = ibooker.book1D("ugmtMuonEta", "uGMT Muon #eta", 52, -2.6, 2.6);
   ugmtMuonEta->setAxisTitle("#eta", 1);
@@ -678,8 +686,10 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
            ++BMTF) {
         ugmtBMTFBX->Fill(itBX);
         ugmtBMTFhwPt->Fill(BMTF->hwPt());
-        ugmtBMTFhwPtUnconstrained->Fill(BMTF->hwPtUnconstrained());
-        ugmtBMTFhwDXY->Fill(BMTF->hwDXY());
+        if (displacedQuantities_) {
+          ugmtBMTFhwPtUnconstrained->Fill(BMTF->hwPtUnconstrained());
+          ugmtBMTFhwDXY->Fill(BMTF->hwDXY());
+        }
         ugmtBMTFhwEta->Fill(BMTF->hwEta());
         ugmtBMTFhwPhi->Fill(BMTF->hwPhi());
         ugmtBMTFhwSign->Fill(BMTF->hwSign());
@@ -911,8 +921,10 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonBX->Fill(itBX);
       ugmtMuonIndex->Fill(tfMuonIndex);
       ugmtMuonhwPt->Fill(Muon->hwPt());
-      ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
-      ugmtMuonhwDXY->Fill(Muon->hwDXY());
+      if (displacedQuantities_) {
+        ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
+        ugmtMuonhwDXY->Fill(Muon->hwDXY());
+      }
       ugmtMuonhwEta->Fill(Muon->hwEta());
       ugmtMuonhwPhi->Fill(Muon->hwPhi());
       ugmtMuonhwEtaAtVtx->Fill(Muon->hwEtaAtVtx());
@@ -923,7 +935,9 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonhwIso->Fill(Muon->hwIso());
 
       ugmtMuonPt->Fill(Muon->pt());
-      ugmtMuonPtUnconstrained->Fill(Muon->ptUnconstrained());
+      if (displacedQuantities_) {
+        ugmtMuonPtUnconstrained->Fill(Muon->ptUnconstrained());
+      }
       ugmtMuonEta->Fill(Muon->eta());
       ugmtMuonPhi->Fill(Muon->phi());
       ugmtMuonEtaAtVtx->Fill(Muon->etaAtVtx());

--- a/DQM/L1TMonitor/src/L1TStage2uGMT.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMT.cc
@@ -46,6 +46,13 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
     ugmtBMTFhwPt = ibooker.book1D("ugmtBMTFhwPt", "uGMT BMTF Input HW p_{T}", 512, -0.5, 511.5);
     ugmtBMTFhwPt->setAxisTitle("Hardware p_{T}", 1);
 
+    ugmtBMTFhwPtUnconstrained =
+        ibooker.book1D("ugmtBMTFhwPtUnconstrained", "uGMT BMTF Input HW p_{T} unconstrained", 256, -0.5, 255.5);
+    ugmtBMTFhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+
+    ugmtBMTFhwDXY = ibooker.book1D("ugmtBMTFhwDXY", "uGMT BMTF Input HW impact parameter", 4, -0.5, 3.5);
+    ugmtBMTFhwDXY->setAxisTitle("Hardware dXY", 1);
+
     ugmtBMTFhwEta = ibooker.book1D("ugmtBMTFhwEta", "uGMT BMTF Input HW #eta", 201, -100.5, 100.5);
     ugmtBMTFhwEta->setAxisTitle("Hardware #eta", 1);
 
@@ -327,6 +334,13 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
   ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", "uGMT Muon HW p_{T}", 512, -0.5, 511.5);
   ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
 
+  ugmtMuonhwPtUnconstrained =
+      ibooker.book1D("ugmtMuonhwPtUnconstrained", "uGMT Muon HW p_{T} unconstrained", 256, -0.5, 255.5);
+  ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+
+  ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", "uGMT Muon HW impact parameter", 4, -0.5, 3.5);
+  ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+
   ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", "uGMT Muon HW #eta", 461, -230.5, 230.5);
   ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
 
@@ -353,6 +367,10 @@ void L1TStage2uGMT::bookHistograms(DQMStore::IBooker& ibooker, const edm::Run&, 
 
   ugmtMuonPt = ibooker.book1D("ugmtMuonPt", "uGMT Muon p_{T}", 128, -0.5, 255.5);
   ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
+
+  ugmtMuonPtUnconstrained =
+      ibooker.book1D("ugmtMuonPtUnconstrained", "uGMT Muon p_{T} unconstrained", 128, -0.5, 255.5);
+  ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
 
   ugmtMuonEta = ibooker.book1D("ugmtMuonEta", "uGMT Muon #eta", 52, -2.6, 2.6);
   ugmtMuonEta->setAxisTitle("#eta", 1);
@@ -660,6 +678,8 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
            ++BMTF) {
         ugmtBMTFBX->Fill(itBX);
         ugmtBMTFhwPt->Fill(BMTF->hwPt());
+        ugmtBMTFhwPtUnconstrained->Fill(BMTF->hwPtUnconstrained());
+        ugmtBMTFhwDXY->Fill(BMTF->hwDXY());
         ugmtBMTFhwEta->Fill(BMTF->hwEta());
         ugmtBMTFhwPhi->Fill(BMTF->hwPhi());
         ugmtBMTFhwSign->Fill(BMTF->hwSign());
@@ -891,6 +911,8 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonBX->Fill(itBX);
       ugmtMuonIndex->Fill(tfMuonIndex);
       ugmtMuonhwPt->Fill(Muon->hwPt());
+      ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
+      ugmtMuonhwDXY->Fill(Muon->hwDXY());
       ugmtMuonhwEta->Fill(Muon->hwEta());
       ugmtMuonhwPhi->Fill(Muon->hwPhi());
       ugmtMuonhwEtaAtVtx->Fill(Muon->hwEtaAtVtx());
@@ -901,6 +923,7 @@ void L1TStage2uGMT::analyze(const edm::Event& e, const edm::EventSetup& c) {
       ugmtMuonhwIso->Fill(Muon->hwIso());
 
       ugmtMuonPt->Fill(Muon->pt());
+      ugmtMuonPtUnconstrained->Fill(Muon->ptUnconstrained());
       ugmtMuonEta->Fill(Muon->eta());
       ugmtMuonPhi->Fill(Muon->phi());
       ugmtMuonEtaAtVtx->Fill(Muon->etaAtVtx());

--- a/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
@@ -33,6 +33,13 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", (titlePrefix + "HW p_{T}").c_str(), 512, -0.5, 511.5);
   ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
 
+  ugmtMuonhwPtUnconstrained =
+      ibooker.book1D("ugmtMuonhwPtUnconstrained", (titlePrefix + "HW p_{T} unconstrained").c_str(), 256, -0.5, 255.5);
+  ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+
+  ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", (titlePrefix + "HW impact parameter").c_str(), 4, -0.5, 3.5);
+  ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+
   ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", (titlePrefix + "HW #eta").c_str(), 461, -230.5, 230.5);
   ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
 
@@ -50,6 +57,10 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
 
   ugmtMuonPt = ibooker.book1D("ugmtMuonPt", (titlePrefix + "p_{T}").c_str(), 128, -0.5, 255.5);
   ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
+
+  ugmtMuonPtUnconstrained =
+      ibooker.book1D("ugmtMuonPtUnconstrained", (titlePrefix + "p_{T} unconstrained").c_str(), 128, -0.5, 255.5);
+  ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
 
   ugmtMuonEta = ibooker.book1D("ugmtMuonEta", (titlePrefix + "#eta").c_str(), 52, -2.6, 2.6);
   ugmtMuonEta->setAxisTitle("#eta", 1);
@@ -162,6 +173,8 @@ void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
          ++Muon) {
       ugmtMuonBX->Fill(itBX);
       ugmtMuonhwPt->Fill(Muon->hwPt());
+      ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
+      ugmtMuonhwDXY->Fill(Muon->hwDXY());
       ugmtMuonhwEta->Fill(Muon->hwEta());
       ugmtMuonhwPhi->Fill(Muon->hwPhi());
       ugmtMuonhwCharge->Fill(Muon->hwCharge());

--- a/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
+++ b/DQM/L1TMonitor/src/L1TStage2uGMTMuon.cc
@@ -5,7 +5,8 @@ L1TStage2uGMTMuon::L1TStage2uGMTMuon(const edm::ParameterSet& ps)
       monitorDir(ps.getUntrackedParameter<std::string>("monitorDir")),
       titlePrefix(ps.getUntrackedParameter<std::string>("titlePrefix")),
       verbose(ps.getUntrackedParameter<bool>("verbose")),
-      makeMuonAtVtxPlots(ps.getUntrackedParameter<bool>("makeMuonAtVtxPlots")) {}
+      makeMuonAtVtxPlots(ps.getUntrackedParameter<bool>("makeMuonAtVtxPlots")),
+      displacedQuantities_(ps.getUntrackedParameter<bool>("displacedQuantities")) {}
 
 L1TStage2uGMTMuon::~L1TStage2uGMTMuon() {}
 
@@ -17,6 +18,7 @@ void L1TStage2uGMTMuon::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.addUntracked<std::string>("titlePrefix", "")->setComment("Prefix text for the histogram titles.");
   desc.addUntracked<bool>("verbose", false);
   desc.addUntracked<bool>("makeMuonAtVtxPlots", false);
+  desc.addUntracked<bool>("displacedQuantities", false);
   descriptions.add("l1tStage2uGMTMuon", desc);
 }
 
@@ -33,12 +35,14 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonhwPt = ibooker.book1D("ugmtMuonhwPt", (titlePrefix + "HW p_{T}").c_str(), 512, -0.5, 511.5);
   ugmtMuonhwPt->setAxisTitle("Hardware p_{T}", 1);
 
-  ugmtMuonhwPtUnconstrained =
-      ibooker.book1D("ugmtMuonhwPtUnconstrained", (titlePrefix + "HW p_{T} unconstrained").c_str(), 256, -0.5, 255.5);
-  ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
+  if (displacedQuantities_) {
+    ugmtMuonhwPtUnconstrained =
+        ibooker.book1D("ugmtMuonhwPtUnconstrained", (titlePrefix + "HW p_{T} unconstrained").c_str(), 256, -0.5, 255.5);
+    ugmtMuonhwPtUnconstrained->setAxisTitle("Hardware p_{T} unconstrained", 1);
 
-  ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", (titlePrefix + "HW impact parameter").c_str(), 4, -0.5, 3.5);
-  ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+    ugmtMuonhwDXY = ibooker.book1D("ugmtMuonhwDXY", (titlePrefix + "HW impact parameter").c_str(), 4, -0.5, 3.5);
+    ugmtMuonhwDXY->setAxisTitle("Hardware dXY", 1);
+  }
 
   ugmtMuonhwEta = ibooker.book1D("ugmtMuonhwEta", (titlePrefix + "HW #eta").c_str(), 461, -230.5, 230.5);
   ugmtMuonhwEta->setAxisTitle("Hardware Eta", 1);
@@ -58,9 +62,11 @@ void L1TStage2uGMTMuon::bookHistograms(DQMStore::IBooker& ibooker, const edm::Ru
   ugmtMuonPt = ibooker.book1D("ugmtMuonPt", (titlePrefix + "p_{T}").c_str(), 128, -0.5, 255.5);
   ugmtMuonPt->setAxisTitle("p_{T} [GeV]", 1);
 
-  ugmtMuonPtUnconstrained =
-      ibooker.book1D("ugmtMuonPtUnconstrained", (titlePrefix + "p_{T} unconstrained").c_str(), 128, -0.5, 255.5);
-  ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
+  if (displacedQuantities_) {
+    ugmtMuonPtUnconstrained =
+        ibooker.book1D("ugmtMuonPtUnconstrained", (titlePrefix + "p_{T} unconstrained").c_str(), 128, -0.5, 255.5);
+    ugmtMuonPtUnconstrained->setAxisTitle("p_{T} unconstrained [GeV]", 1);
+  }
 
   ugmtMuonEta = ibooker.book1D("ugmtMuonEta", (titlePrefix + "#eta").c_str(), 52, -2.6, 2.6);
   ugmtMuonEta->setAxisTitle("#eta", 1);
@@ -173,8 +179,11 @@ void L1TStage2uGMTMuon::analyze(const edm::Event& e, const edm::EventSetup& c) {
          ++Muon) {
       ugmtMuonBX->Fill(itBX);
       ugmtMuonhwPt->Fill(Muon->hwPt());
-      ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
-      ugmtMuonhwDXY->Fill(Muon->hwDXY());
+      if (displacedQuantities_) {
+        ugmtMuonhwPtUnconstrained->Fill(Muon->hwPtUnconstrained());
+        ugmtMuonhwDXY->Fill(Muon->hwDXY());
+        ugmtMuonPtUnconstrained->Fill(Muon->ptUnconstrained());
+      }
       ugmtMuonhwEta->Fill(Muon->hwEta());
       ugmtMuonhwPhi->Fill(Muon->hwPhi());
       ugmtMuonhwCharge->Fill(Muon->hwCharge());


### PR DESCRIPTION
#### PR description:

In Run-3 displaced muon data are received from BMTF and forwarded to the uGT. This PR adds plots for these quantities to the uGMT DQM.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #31951 for upcoming MWGR