### PR TITLE
Update disp mu mu producer

### DIFF
--- a/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.cc
+++ b/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.cc
@@ -87,10 +87,12 @@ void HLTDisplacedmumuVtxProducer::produce(edm::StreamID, edm::Event& iEvent, con
 
   // get the objects passing the previous filter
   Handle<TriggerFilterObjectWithRefs> previousCands;
-  if(matchToPrevious_) iEvent.getByToken(previousCandToken_, previousCands);
+  if (matchToPrevious_)
+    iEvent.getByToken(previousCandToken_, previousCands);
 
   vector<RecoChargedCandidateRef> vPrevCands;
-  if(matchToPrevious_) previousCands->getObjects(TriggerMuon, vPrevCands);
+  if (matchToPrevious_)
+    previousCands->getObjects(TriggerMuon, vPrevCands);
 
   for (cand1 = mucands->begin(); cand1 != mucands->end(); cand1++) {
     TrackRef tk1 = cand1->get<TrackRef>();

--- a/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.cc
+++ b/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.cc
@@ -37,6 +37,7 @@ HLTDisplacedmumuVtxProducer::HLTDisplacedmumuVtxProducer(const edm::ParameterSet
       srcToken_(consumes<reco::RecoChargedCandidateCollection>(srcTag_)),
       previousCandTag_(iConfig.getParameter<edm::InputTag>("PreviousCandTag")),
       previousCandToken_(consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
+      matchToPrevious_(iConfig.getParameter<bool>("matchToPrevious")),
       maxEta_(iConfig.getParameter<double>("MaxEta")),
       minPt_(iConfig.getParameter<double>("MinPt")),
       minPtPair_(iConfig.getParameter<double>("MinPtPair")),
@@ -52,6 +53,7 @@ void HLTDisplacedmumuVtxProducer::fillDescriptions(edm::ConfigurationDescription
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("Src", edm::InputTag("hltL3MuonCandidates"));
   desc.add<edm::InputTag>("PreviousCandTag", edm::InputTag(""));
+  desc.add<bool>("matchToPrevious", true);
   desc.add<double>("MaxEta", 2.5);
   desc.add<double>("MinPt", 0.0);
   desc.add<double>("MinPtPair", 0.0);
@@ -85,10 +87,10 @@ void HLTDisplacedmumuVtxProducer::produce(edm::StreamID, edm::Event& iEvent, con
 
   // get the objects passing the previous filter
   Handle<TriggerFilterObjectWithRefs> previousCands;
-  iEvent.getByToken(previousCandToken_, previousCands);
+  if(matchToPrevious_) iEvent.getByToken(previousCandToken_, previousCands);
 
   vector<RecoChargedCandidateRef> vPrevCands;
-  previousCands->getObjects(TriggerMuon, vPrevCands);
+  if(matchToPrevious_) previousCands->getObjects(TriggerMuon, vPrevCands);
 
   for (cand1 = mucands->begin(); cand1 != mucands->end(); cand1++) {
     TrackRef tk1 = cand1->get<TrackRef>();
@@ -96,7 +98,7 @@ void HLTDisplacedmumuVtxProducer::produce(edm::StreamID, edm::Event& iEvent, con
                                        << ", eta= " << cand1->eta() << ", hits= " << tk1->numberOfValidHits();
 
     //first check if this muon passed the previous filter
-    if (!checkPreviousCand(tk1, vPrevCands))
+    if (matchToPrevious_ && !checkPreviousCand(tk1, vPrevCands))
       continue;
 
     // cuts
@@ -115,7 +117,7 @@ void HLTDisplacedmumuVtxProducer::produce(edm::StreamID, edm::Event& iEvent, con
           << " 2nd muon in loop: q*pt= " << cand2->charge() * cand2->pt() << ", eta= " << cand2->eta()
           << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0();
       //first check if this muon passed the previous filter
-      if (!checkPreviousCand(tk2, vPrevCands))
+      if (matchToPrevious_ && !checkPreviousCand(tk2, vPrevCands))
         continue;
 
       // cuts

--- a/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.h
+++ b/HLTrigger/btau/plugins/HLTDisplacedmumuVtxProducer.h
@@ -41,6 +41,7 @@ private:
   const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> srcToken_;
   const edm::InputTag previousCandTag_;
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
+  const bool matchToPrevious_;
   const double maxEta_;
   const double minPt_;
   const double minPtPair_;


### PR DESCRIPTION

#### PR description:

In its current version, the HLTDisplacedmumuVtxProducer requires matching of the input muons with objects passing a filter. It is not always useful to run a filter prior to the vertex producer I believe, and hence I make this optional.

This pull request is intended to remove the dependency of running a filter prior to the HLTDisplacedmumuVtxProducer

#### PR validation:

I checked compilation in 11_2_0_pre8, and functionality in CMSSW_11_1_0 where the same results for displaced vertices are present and muons are present before and after the change in the scouting event content.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
