### PR TITLE
Propagate timing to PF TICL Candiates

### DIFF
--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -32,18 +32,6 @@ public:
 
   void setTime(float time) { time_ = time; };
   void setTimeError(float timeError) { timeError_ = timeError; }
-  void computeTime() {
-    auto time = 0.;
-    auto timeErr = 0.;
-    for (const auto& tr : tracksters_) {
-      time += tr->time() / pow(tr->timeError(), 2);
-      timeErr += pow(tr->timeError(), -2);
-    }
-    timeErr = sqrt(1 / timeErr);
-
-    setTime(time * pow(timeErr, 2));
-    setTimeError(timeErr);
-  }
 
   inline const edm::Ptr<reco::Track> trackPtr() const { return trackPtr_; }
   void setTrackPtr(const edm::Ptr<reco::Track>& trackPtr) { trackPtr_ = trackPtr; }

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -20,7 +20,12 @@ public:
   TICLCandidate() : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), idProbabilities_{} {}
 
   TICLCandidate(const edm::Ptr<ticl::Trackster>& trackster)
-      : LeafCandidate(), time_(trackster->time()), timeError_(trackster->timeError()), rawEnergy_(0.f), tracksters_({trackster}), idProbabilities_{} {}
+      : LeafCandidate(),
+        time_(trackster->time()),
+        timeError_(trackster->timeError()),
+        rawEnergy_(0.f),
+        tracksters_({trackster}),
+        idProbabilities_{} {}
 
   inline float time() const { return time_; }
   inline float timeError() const { return timeError_; }

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -20,7 +20,7 @@ public:
   TICLCandidate() : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), idProbabilities_{} {}
 
   TICLCandidate(const edm::Ptr<ticl::Trackster>& trackster)
-      : LeafCandidate(), time_(0.f), timeError_(-1.f), rawEnergy_(0.f), tracksters_({trackster}), idProbabilities_{} {}
+      : LeafCandidate(), time_(trackster->time()), timeError_(trackster->timeError()), rawEnergy_(0.f), tracksters_({trackster}), idProbabilities_{} {}
 
   inline float time() const { return time_; }
   inline float timeError() const { return timeError_; }

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -35,7 +35,7 @@ public:
   void computeTime() {
     auto time = 0.;
     auto timeErr = 0.;
-    for (const auto tr : tracksters_) {
+    for (const auto& tr : tracksters_) {
       time += tr->time() / pow(tr->timeError(), 2);
       timeErr += pow(tr->timeError(), -2);
     }

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -33,8 +33,8 @@ public:
   void setTime(float time) { time_ = time; };
   void setTimeError(float timeError) { timeError_ = timeError; }
   void computeTime() {
-    auto time = 0;
-    auto timeErr = 0;
+    auto time = 0.;
+    auto timeErr = 0.;
     for (const auto tr : tracksters_) {
       time += tr->time() / pow(tr->timeError(), 2);
       timeErr += pow(tr->timeError(), -2);

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -54,9 +54,7 @@ public:
   inline const std::vector<edm::Ptr<ticl::Trackster> > tracksters() const { return tracksters_; };
 
   void setTracksters(const std::vector<edm::Ptr<ticl::Trackster> >& tracksters) { tracksters_ = tracksters; }
-  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) { tracksters_.push_back(trackster);
-    computeTime();
-  }
+  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) { tracksters_.push_back(trackster); }
   // convenience method to return the ID probability for a certain particle type
   inline float id_probability(ParticleType type) const {
     // probabilities are stored in the same order as defined in the ParticleType enum

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -42,7 +42,11 @@ public:
   inline const std::vector<edm::Ptr<ticl::Trackster> > tracksters() const { return tracksters_; };
 
   void setTracksters(const std::vector<edm::Ptr<ticl::Trackster> >& tracksters) { tracksters_ = tracksters; }
-  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) { tracksters_.push_back(trackster); }
+  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) {
+    tracksters_.push_back(trackster);
+    time_ = trackster->time();
+    timeError_ = trackster->timeError();
+  }
   // convenience method to return the ID probability for a certain particle type
   inline float id_probability(ParticleType type) const {
     // probabilities are stored in the same order as defined in the ParticleType enum

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -32,6 +32,18 @@ public:
 
   void setTime(float time) { time_ = time; };
   void setTimeError(float timeError) { timeError_ = timeError; }
+  void computeTime() {
+    auto time = 0;
+    auto timeErr = 0;
+    for (const auto tr : tracksters_) {
+      time += tr->time() / pow(tr->timeError(), 2);
+      timeErr += pow(tr->timeError(), -2);
+    }
+    timeErr = sqrt(1 / timeErr);
+
+    setTime(time * pow(timeErr, 2));
+    setTimeError(timeErr);
+  }
 
   inline const edm::Ptr<reco::Track> trackPtr() const { return trackPtr_; }
   void setTrackPtr(const edm::Ptr<reco::Track>& trackPtr) { trackPtr_ = trackPtr; }
@@ -42,7 +54,9 @@ public:
   inline const std::vector<edm::Ptr<ticl::Trackster> > tracksters() const { return tracksters_; };
 
   void setTracksters(const std::vector<edm::Ptr<ticl::Trackster> >& tracksters) { tracksters_ = tracksters; }
-  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) { tracksters_.push_back(trackster); }
+  void addTrackster(const edm::Ptr<ticl::Trackster>& trackster) { tracksters_.push_back(trackster);
+    computeTime();
+  }
   // convenience method to return the ID probability for a certain particle type
   inline float id_probability(ParticleType type) const {
     // probabilities are stored in the same order as defined in the ParticleType enum

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -37,7 +37,7 @@ namespace ticl {
     Trackster()
         : seedIndex_(0),
           time_(0.f),
-          timeError_(0.f),
+          timeError_(-1.f),
           regressed_energy_(0.f),
           raw_energy_(0.f),
           raw_em_energy_(0.f),

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -136,13 +136,10 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
           // Compute weighted average between HGCAL and MTD timing
           timeE = sqrt(1 / (pow(timeEHGC, -2) + pow(timeEMTD, -2)));
           time = (timeHGC / pow(timeEHGC, 2) + timeMTD / pow(timeEMTD, 2)) * pow(timeE, 2);
-        } else if (timeEMTD > 0 && timeEHGC < 0) {
-          // Passthrough MTD timing if HGCAL is not available
-          timeE = timeEMTD;
+        } else if (timeEMTD > 0) {  // Ignore HGCal timing until it will be TOF corrected
           time = timeMTD;
+          timeE = timeEMTD;
         }
-        time = timeMTD;
-        timeE = timeEMTD;
       }
     }
     candidate.setTime(time, timeE);

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -132,7 +132,7 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
           const auto invTimeESqHGC = pow(timeEHGC, -2);
           const auto invTimeESqMTD = pow(timeEMTD, -2);
           timeE = (invTimeESqHGC * invTimeESqMTD) / (invTimeESqHGC + invTimeESqMTD);
-          time = (timeHGC * invTimeESqHGC + timeMTD * invTimeESqMTD)  * timeE;
+          time = (timeHGC * invTimeESqHGC + timeMTD * invTimeESqMTD) * timeE;
           timeE = sqrt(timeE);
         } else if (timeEMTD > 0) {  // Ignore HGCal timing until it will be TOF corrected
           time = timeMTD;

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -42,9 +42,8 @@ PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
       srcTrackTime_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap"))),
       srcTrackTimeError_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))),
       srcTrackTimeQuality_(useTimingQuality_
-                           ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
-                           : edm::EDGetTokenT<edm::ValueMap<float>>())
- {
+                               ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
+                               : edm::EDGetTokenT<edm::ValueMap<float>>()) {
   produces<reco::PFCandidateCollection>();
 }
 
@@ -125,7 +124,7 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
     auto time = ticl_cand.time();
     auto timeE = ticl_cand.timeError();
 
-    if (candidate.charge()) { // Check MTD timing availability
+    if (candidate.charge()) {  // Check MTD timing availability
       const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
       if (assocQuality) {
         const auto timeHGC = time;
@@ -133,11 +132,11 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
         const auto timeMTD = (*trackTimeH)[candidate.trackRef()];
         const auto timeEMTD = (*trackTimeErrH)[candidate.trackRef()];
 
-        if (useTimingAverage_ && (timeEMTD>0 && timeEHGC>0)) {
+        if (useTimingAverage_ && (timeEMTD > 0 && timeEHGC > 0)) {
           // Compute weighted average between HGCAL and MTD timing
-          timeE = sqrt(1 / (pow(timeEHGC,-2) + pow(timeEMTD,-2)));
-          time = (timeHGC/pow(timeEHGC,2) + timeMTD/pow(timeEMTD,2)) * pow(timeE,2);
-        } else if (timeEMTD>0 && timeEHGC<0) {
+          timeE = sqrt(1 / (pow(timeEHGC, -2) + pow(timeEMTD, -2)));
+          time = (timeHGC / pow(timeEHGC, 2) + timeMTD / pow(timeEMTD, 2)) * pow(timeE, 2);
+        } else if (timeEMTD > 0 && timeEHGC < 0) {
           // Passthrough MTD timing if HGCAL is not available
           timeE = timeEMTD;
           time = timeMTD;

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -23,20 +23,39 @@ public:
   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
+  // parameters
+  const bool useTimingQuality_, useTimingAverage_;
+  const float timingQualityThreshold_;
+
   // inputs
   const edm::EDGetTokenT<edm::View<TICLCandidate>> ticl_candidates_;
+  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_, srcTrackTimeQuality_;
 };
 
 DEFINE_FWK_MODULE(PFTICLProducer);
 
 PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
-    : ticl_candidates_(consumes<edm::View<TICLCandidate>>(conf.getParameter<edm::InputTag>("ticlCandidateSrc"))) {
+    : useTimingQuality_(conf.existsAs<edm::InputTag>("trackTimeQualityMap")),
+      useTimingAverage_(conf.existsAs<bool>("useTimingAverage") ? conf.getParameter<bool>("useTimingAverage") : false),
+      timingQualityThreshold_(useTimingQuality_ ? conf.getParameter<double>("timingQualityThreshold") : -99.),
+      ticl_candidates_(consumes<edm::View<TICLCandidate>>(conf.getParameter<edm::InputTag>("ticlCandidateSrc"))),
+      srcTrackTime_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap"))),
+      srcTrackTimeError_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))),
+      srcTrackTimeQuality_(useTimingQuality_
+                           ? consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))
+                           : edm::EDGetTokenT<edm::ValueMap<float>>())
+ {
   produces<reco::PFCandidateCollection>();
 }
 
 void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("ticlCandidateSrc", edm::InputTag("ticlTrackstersMerge"));
+  desc.add<edm::InputTag>("trackTimeValueMap", edm::InputTag("tofPID:t0"));
+  desc.add<edm::InputTag>("trackTimeErrorMap", edm::InputTag("tofPID:sigmat0"));
+  desc.add<edm::InputTag>("trackTimeQualityMap", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
+  desc.add<double>("timingQualityThreshold", 0.5);
+  desc.add<bool>("useTimingAverage", false);
   descriptions.add("pfTICLProducer", desc);
 }
 
@@ -45,6 +64,12 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
   edm::Handle<edm::View<TICLCandidate>> ticl_cand_h;
   evt.getByToken(ticl_candidates_, ticl_cand_h);
   const auto ticl_candidates = *ticl_cand_h;
+  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH;
+  evt.getByToken(srcTrackTime_, trackTimeH);
+  evt.getByToken(srcTrackTimeError_, trackTimeErrH);
+  if (useTimingQuality_) {
+    evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
+  }
 
   auto candidates = std::make_unique<reco::PFCandidateCollection>();
 
@@ -95,7 +120,33 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
       reco::TrackRef ref(ticl_cand.trackPtr().id(), int(ticl_cand.trackPtr().key()), &evt.productGetter());
       candidate.setTrackRef(ref);
     }
-    candidate.setTime(ticl_cand.time(), ticl_cand.timeError());
+
+    // HGCAL timing as default values
+    auto time = ticl_cand.time();
+    auto timeE = ticl_cand.timeError();
+
+    if (candidate.charge()) { // Check MTD timing availability
+      const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
+      if (assocQuality) {
+        const auto timeHGC = time;
+        const auto timeEHGC = timeE;
+        const auto timeMTD = (*trackTimeH)[candidate.trackRef()];
+        const auto timeEMTD = (*trackTimeErrH)[candidate.trackRef()];
+
+        if (useTimingAverage_ && (timeEMTD>0 && timeEHGC>0)) {
+          // Compute weighted average between HGCAL and MTD timing
+          timeE = sqrt(1 / (pow(timeEHGC,-2) + pow(timeEMTD,-2)));
+          time = (timeHGC/pow(timeEHGC,2) + timeMTD/pow(timeEMTD,2)) * pow(timeE,2);
+        } else if (timeEMTD>0 && timeEHGC<0) {
+          // Passthrough MTD timing if HGCAL is not available
+          timeE = timeEMTD;
+          time = timeMTD;
+        }
+        time = timeMTD;
+        timeE = timeEMTD;
+      }
+    }
+    candidate.setTime(time, timeE);
   }
 
   evt.put(std::move(candidates));

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -121,8 +121,8 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
 
     if (candidate.charge()) {
       // Ignore HGCAL timing until it will be TOF corrected
-      time = -1.;
-      timeE = -99.;
+      time = -99.;
+      timeE = -1.;
       // Check MTD timing availability
       const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
       if (assocQuality) {

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -119,7 +119,11 @@ void PFTICLProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSet
     auto time = ticl_cand.time();
     auto timeE = ticl_cand.timeError();
 
-    if (candidate.charge()) {  // Check MTD timing availability
+    if (candidate.charge()) {
+      // Ignore HGCAL timing until it will be TOF corrected
+      time = -1.;
+      timeE = -99.;
+      // Check MTD timing availability
       const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
       if (assocQuality) {
         const auto timeHGC = time;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -7,7 +7,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "PatternRecognitionbyCA.h"
-#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
 #include "TrackstersPCA.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -117,32 +116,13 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     tracksterId++;
 
     std::set<unsigned int> effective_cluster_idx;
-    std::pair<std::set<unsigned int>::iterator, bool> retVal;
-
-    std::vector<float> times;
-    std::vector<float> timeErrors;
 
     for (auto const &doublet : ntuplet) {
       auto innerCluster = doublets[doublet].innerClusterId();
       auto outerCluster = doublets[doublet].outerClusterId();
 
-      retVal = effective_cluster_idx.insert(innerCluster);
-      if (retVal.second) {
-        float time = input.layerClustersTime.get(innerCluster).first;
-        if (time > -99) {
-          times.push_back(time);
-          timeErrors.push_back(1. / pow(input.layerClustersTime.get(innerCluster).second, 2));
-        }
-      }
-
-      retVal = effective_cluster_idx.insert(outerCluster);
-      if (retVal.second) {
-        float time = input.layerClustersTime.get(outerCluster).first;
-        if (time > -99) {
-          times.push_back(time);
-          timeErrors.push_back(1. / pow(input.layerClustersTime.get(outerCluster).second, 2));
-        }
-      }
+      effective_cluster_idx.insert(innerCluster);
+      effective_cluster_idx.insert(outerCluster);
 
       if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
         LogDebug("HGCPatternRecoByCA") << " New doublet " << doublet << " for trackster: " << result.size()
@@ -210,7 +190,7 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     }
   }
   ticl::assignPCAtoTracksters(
-      tmpTracksters, input.layerClusters, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+			      tmpTracksters, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, tmpTracksters);
@@ -268,7 +248,8 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     tmp.swap(result);
   }
 
-  ticl::assignPCAtoTracksters(result, input.layerClusters, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+  ticl::assignPCAtoTracksters(result, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, result);
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -181,10 +181,6 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
       //if a seeding region does not lead to any trackster
       tmp.setSeed(input.regions[0].collectionID, seedIndices[tracksterId]);
 
-      std::pair<float, float> timeTrackster(-99., -1.);
-      hgcalsimclustertime::ComputeClusterTime timeEstimator;
-      timeTrackster = timeEstimator.fixSizeHighestDensity(times, timeErrors);
-      tmp.setTimeAndError(timeTrackster.first, timeTrackster.second);
       std::copy(std::begin(effective_cluster_idx), std::end(effective_cluster_idx), std::back_inserter(tmp.vertices()));
       tmpTracksters.push_back(tmp);
     }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -185,8 +185,10 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
       tmpTracksters.push_back(tmp);
     }
   }
-  ticl::assignPCAtoTracksters(
-			      tmpTracksters, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+  ticl::assignPCAtoTracksters(tmpTracksters,
+                              input.layerClusters,
+                              input.layerClustersTime,
+                              rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, tmpTracksters);
@@ -244,7 +246,8 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     tmp.swap(result);
   }
 
-  ticl::assignPCAtoTracksters(result, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+  ticl::assignPCAtoTracksters(
+      result, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, result);

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -528,6 +528,11 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
     }
   }
 
+  // Compute timing
+  for (auto &cand : *resultCandidates) {
+    cand.computeTime();
+  }
+
   evt.put(std::move(resultCandidates));
 }
 

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -547,20 +547,22 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
 
 void TrackstersMergeProducer::computeTime(std::vector<TICLCandidate> &resultCandidates) {
   for (auto &cand : resultCandidates) {
-    auto time = 0.;
-    auto timeErr = -1.;
-    for (const auto &tr : cand.tracksters()) {
-      if (tr->timeError() > 0) {
-        auto invTimeESq = pow(tr->timeError(), -2);
-        time += tr->time() * invTimeESq;
-        timeErr += invTimeESq;
+    if (cand.tracksters().size() > 1) {  // For single-trackster candidates the timing is already set
+      auto time = 0.;
+      auto timeErr = 0.;
+      for (const auto &tr : cand.tracksters()) {
+        if (tr->timeError() > 0) {
+          auto invTimeESq = pow(tr->timeError(), -2);
+          time += tr->time() * invTimeESq;
+          timeErr += invTimeESq;
+        }
       }
-    }
-    if (timeErr > 0) {
-      timeErr = 1. / timeErr;
+      if (timeErr > 0) {
+        timeErr = 1. / timeErr;
 
-      cand.setTime(time * timeErr);
-      cand.setTimeError(sqrt(timeErr));
+        cand.setTime(time * timeErr);
+        cand.setTimeError(sqrt(timeErr));
+      }
     }
   }
 }

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -38,7 +38,7 @@ private:
 
   void energyRegressionAndID(const std::vector<reco::CaloCluster> &layerClusters, std::vector<Trackster> &result) const;
   void printTrackstersDebug(const std::vector<Trackster> &, const char *label) const;
-  void computeTime(std::vector<TICLCandidate> &resultCandidates) const;
+  void assignTimeToCandidates(std::vector<TICLCandidate> &resultCandidates) const;
   void dumpTrackster(const Trackster &) const;
 
   const edm::EDGetTokenT<std::vector<Trackster>> tracksterstrkem_token_;
@@ -540,7 +540,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   }
 
   // Compute timing
-  computeTime(*resultCandidates);
+  assignTimeToCandidates(*resultCandidates);
 
   evt.put(std::move(resultCandidates));
 }
@@ -686,7 +686,7 @@ void TrackstersMergeProducer::energyRegressionAndID(const std::vector<reco::Calo
   }
 }
 
-void TrackstersMergeProducer::computeTime(std::vector<TICLCandidate> &resultCandidates) const {
+void TrackstersMergeProducer::assignTimeToCandidates(std::vector<TICLCandidate> &resultCandidates) const {
   for (auto &cand : resultCandidates) {
     if (cand.tracksters().size() > 1) {  // For single-trackster candidates the timing is already set
       float time = 0.f;

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -88,7 +88,8 @@ TrackstersMergeProducer::TrackstersMergeProducer(const edm::ParameterSet &ps, co
       trackstershad_token_(consumes<std::vector<Trackster>>(ps.getParameter<edm::InputTag>("trackstershad"))),
       seedingTrk_token_(consumes<std::vector<TICLSeedingRegion>>(ps.getParameter<edm::InputTag>("seedingTrk"))),
       clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layer_clusters"))),
-      clustersTime_token_(consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("layer_clustersTime"))),
+      clustersTime_token_(
+          consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("layer_clustersTime"))),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
       geometry_token_(esConsumes<CaloGeometry, CaloGeometryRecord>()),
       optimiseAcrossTracksters_(ps.getParameter<bool>("optimiseAcrossTracksters")),
@@ -192,7 +193,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
 
   edm::Handle<edm::ValueMap<std::pair<float, float>>> clustersTime_h;
   evt.getByToken(clustersTime_token_, clustersTime_h);
-  const auto& layerClustersTimes = *clustersTime_h;
+  const auto &layerClustersTimes = *clustersTime_h;
 
   edm::Handle<std::vector<Trackster>> trackstersem_h;
   evt.getByToken(trackstersem_token_, trackstersem_h);
@@ -263,7 +264,10 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
     iterMergedTracksters.push_back(TracksterIterIndex::HAD);
   }
 
-  assignPCAtoTracksters(*resultTrackstersMerged, layerClusters, layerClustersTimes, rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z());
+  assignPCAtoTracksters(*resultTrackstersMerged,
+                        layerClusters,
+                        layerClustersTimes,
+                        rhtools_.getPositionLayer(rhtools_.lastLayerEE()).z());
   energyRegressionAndID(layerClusters, *resultTrackstersMerged);
 
   printTrackstersDebug(*resultTrackstersMerged, "TrackstersMergeProducer");

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -1,4 +1,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 #include "TrackstersPCA.h"
 #include "TPrincipal.h"
 
@@ -62,7 +64,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       // Also compute timing
       if ((usedLC.insert(trackster.vertices(i))).second) {
         float timeE = layerClustersTime.get(trackster.vertices(i)).second;
-        if (timeE > -1.) {
+        if (timeE > 0.f) {
           times.push_back(layerClustersTime.get(trackster.vertices(i)).first);
           timeErrors.push_back(1. / pow(timeE, 2));
         }

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -9,6 +9,7 @@
 
 void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
                                  const std::vector<reco::CaloCluster> &layerClusters,
+				 const edm::ValueMap<std::pair<float, float>> &layerClustersTime,
                                  double z_limit_em,
                                  bool energyWeight) {
   LogDebug("TrackstersPCA_Eigen") << "------- Eigen -------" << std::endl;
@@ -40,6 +41,9 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
     sigmasEigen << 0., 0., 0.;
     Eigen::Matrix3d covM = Eigen::Matrix3d::Zero();
 
+    std::vector<float> times;
+    std::vector<float> timeErrors;
+
     for (size_t i = 0; i < N; ++i) {
       auto fraction = 1.f / trackster.vertex_multiplicity(i);
       trackster.addToRawEnergy(layerClusters[trackster.vertices(i)].energy() * fraction);
@@ -52,9 +56,20 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       fillPoint(layerClusters[trackster.vertices(i)], weight);
       for (size_t j = 0; j < 3; ++j)
         barycenter[j] += point[j];
+
+      // Also compute timing
+      float timeE = layerClustersTime.get(trackster.vertices(i)).second;
+      if (timeE > -1.) {
+	times.push_back(layerClustersTime.get(trackster.vertices(i)).first);
+	timeErrors.push_back(1. / pow(timeE, 2));
+      }
     }
     if (energyWeight && trackster.raw_energy())
       barycenter /= trackster.raw_energy();
+
+    std::pair<float, float> timeTrackster(-99., -1.);
+    hgcalsimclustertime::ComputeClusterTime timeEstimator;
+    timeTrackster = timeEstimator.fixSizeHighestDensity(times, timeErrors);
 
     // Compute the Covariance Matrix and the sum of the squared weights, used
     // to compute the correct normalization.
@@ -100,6 +115,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
 
     // Add trackster attributes
     trackster.setBarycenter(ticl::Trackster::Vector(barycenter));
+    trackster.setTimeAndError(timeTrackster.first, timeTrackster.second);
     trackster.fillPCAVariables(
         eigenvalues_fromEigen, eigenvectors_fromEigen, sigmas, sigmasEigen, 3, ticl::Trackster::PCAOrdering::ascending);
 
@@ -110,6 +126,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
     LogDebug("TrackstersPCA") << "raw_pt: " << trackster.raw_pt() << std::endl;
     LogDebug("TrackstersPCA") << "Means:          " << barycenter[0] << ", " << barycenter[1] << ", " << barycenter[2]
                               << std::endl;
+    LogDebug("TrackstersPCA") << "Time:          " << trackster.time() << " +/- " << trackster.timeError() << std::endl;
     LogDebug("TrackstersPCA") << "EigenValues from Eigen/Tr(cov): " << eigenvalues_fromEigen[2] / covM.trace() << ", "
                               << eigenvalues_fromEigen[1] / covM.trace() << ", "
                               << eigenvalues_fromEigen[0] / covM.trace() << std::endl;

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -60,9 +60,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
         barycenter[j] += point[j];
 
       // Also compute timing
-      auto before = usedLC.size();
-      usedLC.insert(trackster.vertices(i));
-      if (before + 1 == usedLC.size()) {
+      if ((usedLC.insert(trackster.vertices(i))).second) {
         float timeE = layerClustersTime.get(trackster.vertices(i)).second;
         if (timeE > -1.) {
           times.push_back(layerClustersTime.get(trackster.vertices(i)).first);

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -60,7 +60,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       for (size_t j = 0; j < 3; ++j)
         barycenter[j] += point[j];
 
-      // Also compute timing
+      // Add timing from layerClusters not already used
       if ((usedLC.insert(trackster.vertices(i))).second) {
         float timeE = layerClustersTime.get(trackster.vertices(i)).second;
         if (timeE > 0.f) {

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -10,7 +10,7 @@
 
 void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
                                  const std::vector<reco::CaloCluster> &layerClusters,
-				 const edm::ValueMap<std::pair<float, float>> &layerClustersTime,
+                                 const edm::ValueMap<std::pair<float, float>> &layerClustersTime,
                                  double z_limit_em,
                                  bool energyWeight) {
   LogDebug("TrackstersPCA_Eigen") << "------- Eigen -------" << std::endl;
@@ -62,12 +62,12 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       // Also compute timing
       auto before = usedLC.size();
       usedLC.insert(trackster.vertices(i));
-      if(before + 1 == usedLC.size()){
-	float timeE = layerClustersTime.get(trackster.vertices(i)).second;
-	if (timeE > -1.) {
-	  times.push_back(layerClustersTime.get(trackster.vertices(i)).first);
-	  timeErrors.push_back(1. / pow(timeE, 2));
-	}
+      if (before + 1 == usedLC.size()) {
+        float timeE = layerClustersTime.get(trackster.vertices(i)).second;
+        if (timeE > -1.) {
+          times.push_back(layerClustersTime.get(trackster.vertices(i)).first);
+          timeErrors.push_back(1. / pow(timeE, 2));
+        }
       }
     }
     if (energyWeight && trackster.raw_energy())

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -2,7 +2,6 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 #include "TrackstersPCA.h"
-#include "TPrincipal.h"
 
 #include <iostream>
 #include <set>

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -3,12 +3,14 @@
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 #include <vector>
 
 namespace ticl {
   void assignPCAtoTracksters(std::vector<Trackster> &,
                              const std::vector<reco::CaloCluster> &,
+			     const edm::ValueMap<std::pair<float, float>> &,
                              double,
                              bool energyWeight = true);
 }

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -10,7 +10,7 @@
 namespace ticl {
   void assignPCAtoTracksters(std::vector<Trackster> &,
                              const std::vector<reco::CaloCluster> &,
-			     const edm::ValueMap<std::pair<float, float>> &,
+                             const edm::ValueMap<std::pair<float, float>> &,
                              double,
                              bool energyWeight = true);
 }

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -3,8 +3,6 @@
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/Common/interface/ValueMap.h"
-#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 #include <vector>
 
 namespace ticl {


### PR DESCRIPTION
#### PR description:

This PR sets meaningful timing values for PF TICL Candidates.
A validation of the timing error for both MTD and HGCal is ongoing, hence the default value of the switch to compute the timing weighted average is currently set to false.
Study reported [here](https://docs.google.com/presentation/d/12r0rc-P2xNEAipo1jD_KZw53uVKH0NyKNHsgpzcWe24/edit?usp=sharing).

#### PR validation:

`runTheMatrix -l limited`