### PR TITLE
CSC RecHit Builder updates

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -476,7 +476,7 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
       // - enough consecutive strips with signal
       // - strip charge distribution looks abnormal
 
-      if (i > 2 && i < (thePulseHeightMap.size() - 3) && numberOfConsecutiveStrips > 3) {
+      if (i > 2 && i  +3 < thePulseHeightMap.size() && numberOfConsecutiveStrips > 3) {
         //try to look for additional maxima at the left side from the main maxima
 
         if (((thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i - 1].phmax() &&

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -471,59 +471,67 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
       }
        
       bool additional_maxima_found = false;
-      // search for additional maxima if: 
-	  // - hit is closer than 3 strips from the edge
-	  // - enough consecutive strips with signal
-	  // - strip charge distribution looks abnormal
-      
-      if ( i > 2 && i < (thePulseHeightMap.size()-3) && numberOfConsecutiveStrips > 3){
-	//try to look for additional maxima at the left side from the main maxima
+      // search for additional maxima if:
+      // - hit is closer than 3 strips from the edge
+      // - enough consecutive strips with signal
+      // - strip charge distribution looks abnormal
 
-if(((thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-1].phmax() &&
-	    thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-2].phmax() &&
-	    thePulseHeightMap[i+2].phmax() <= thePulseHeightMap[i-2].phmax())|| 
-	   (thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-1].phmax() &&
-	    thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-2].phmax())) && 
-	   thePulseHeightMap[i-1].phmax() >= thePulseHeightMap[i-2].phmax() &&//to avoid close maxima delimitation (this is already present in the code)
-	   thePulseHeightMap[i-2].phmax() > 20){//no need in a small charge maxima (might need adjustment)
+      if (i > 2 && i < (thePulseHeightMap.size() - 3) && numberOfConsecutiveStrips > 3) {
+        //try to look for additional maxima at the left side from the main maxima
 
-	  additional_maxima_found = true;
-	  theMaxima.push_back(i-2);//insert left maxima first
-	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
-	  theMaxima.push_back(i);//insert main maxima
-	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
-	  
-	}//looking for additional maxima on the left
-	
-	//try to look for additional maxima at the right side from the main maxima
-if(((thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-1].phmax() &&
-	    thePulseHeightMap[i+2].phmax() >= thePulseHeightMap[i-1].phmax()) || 
-	   (thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-1].phmax() &&
-	    thePulseHeightMap[i+2].phmax() <= thePulseHeightMap[i-1].phmax() &&
-	    thePulseHeightMap[i+2].phmax() >= thePulseHeightMap[i-2].phmax())) && 
-	   thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i+2].phmax() &&//to avoid close maxima delimitation (this is already present in the code)
-	   thePulseHeightMap[i+2].phmax() > 20){//no need in a small charge maxima (might need adjustment)
-	
-	  additional_maxima_found = true;
-	  theMaxima.push_back(i);//insert main maxima first
-	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
-	  theMaxima.push_back(i+2);//insert right maxima
-	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
-	  
-	}//looking for additional maxima on the right
-    
-	//if nothing additional found fill the maxima
-	if(!additional_maxima_found){
-	  theMaxima.push_back(i);
-	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
-	}
-  }else{//not the case for looking for the additional maxima
-    theMaxima.push_back(i);
-    theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
-  }
-    }//if maximafound
-  }//all pulses
-}//find maxima procedure
+        if (((thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i - 1].phmax() &&
+              thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i - 2].phmax() &&
+              thePulseHeightMap[i + 2].phmax() <= thePulseHeightMap[i - 2].phmax()) ||
+             (thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 1].phmax() &&
+              thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 2].phmax())) &&
+            thePulseHeightMap[i - 1].phmax() >=
+                thePulseHeightMap[i - 2]
+                    .phmax() &&  //to avoid close maxima delimitation (this is already present in the code)
+            thePulseHeightMap[i - 2].phmax() > 20) {  //no need in a small charge maxima (might need adjustment)
+
+          additional_maxima_found = true;
+          theMaxima.push_back(i - 2);  //insert left maxima first
+          theConsecutiveStrips.push_back(
+              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+          theMaxima.push_back(i);          //insert main maxima
+          theConsecutiveStrips.push_back(
+              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+
+        }  //looking for additional maxima on the left
+
+        //try to look for additional maxima at the right side from the main maxima
+        if (((thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i - 1].phmax() &&
+              thePulseHeightMap[i + 2].phmax() >= thePulseHeightMap[i - 1].phmax()) ||
+             (thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 1].phmax() &&
+              thePulseHeightMap[i + 2].phmax() <= thePulseHeightMap[i - 1].phmax() &&
+              thePulseHeightMap[i + 2].phmax() >= thePulseHeightMap[i - 2].phmax())) &&
+            thePulseHeightMap[i + 1].phmax() >=
+                thePulseHeightMap[i + 2]
+                    .phmax() &&  //to avoid close maxima delimitation (this is already present in the code)
+            thePulseHeightMap[i + 2].phmax() > 20) {  //no need in a small charge maxima (might need adjustment)
+
+          additional_maxima_found = true;
+          theMaxima.push_back(i);  //insert main maxima first
+          theConsecutiveStrips.push_back(
+              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+          theMaxima.push_back(i + 2);  //insert right maxima
+          theConsecutiveStrips.push_back(
+              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+
+        }  //looking for additional maxima on the right
+
+        //if nothing additional found fill the maxima
+        if (!additional_maxima_found) {
+          theMaxima.push_back(i);
+          theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
+        }
+      } else {  //not the case for looking for the additional maxima
+        theMaxima.push_back(i);
+        theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
+      }
+    }  //if maximafound
+  }    //all pulses
+}  //find maxima procedure
 
 bool CSCHitFromStripOnly::isPeakOK(int iStrip, float heightCluster) {
   int i = iStrip;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -468,8 +468,8 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
         if (!signalPresent) {
           break;
         }
-      }        
-      
+      }
+
       bool additional_maxima_found = false;
       // search for additional maxima if:
       // - hit is closer than 3 strips from the edge

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -468,8 +468,8 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
         if (!signalPresent) {
           break;
         }
-      }
-       
+      }        
+      
       bool additional_maxima_found = false;
       // search for additional maxima if:
       // - hit is closer than 3 strips from the edge

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -484,9 +484,8 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
               thePulseHeightMap[i + 2].phmax() <= thePulseHeightMap[i - 2].phmax()) ||
              (thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 1].phmax() &&
               thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 2].phmax())) &&
-            thePulseHeightMap[i - 1].phmax() >=
-                thePulseHeightMap[i - 2]
-                    .phmax() &&  //to avoid close maxima delimitation (this is already present in the code)
+            //to avoid close maxima delimitation (this is already present in the code)
+            thePulseHeightMap[i - 1].phmax() >= thePulseHeightMap[i - 2].phmax() &&
             thePulseHeightMap[i - 2].phmax() > 20) {  //no need in a small charge maxima (might need adjustment)
 
           additional_maxima_found = true;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -475,8 +475,8 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
       // - hit is closer than 3 strips from the edge
       // - enough consecutive strips with signal
       // - strip charge distribution looks abnormal
-
-      if (i > 2 && i  +3 < thePulseHeightMap.size() && numberOfConsecutiveStrips > 3) {
+        
+      if (i > 2 && i + 3 < thePulseHeightMap.size() && numberOfConsecutiveStrips > 3) {
         //try to look for additional maxima at the left side from the main maxima
 
         if (((thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i - 1].phmax() &&

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -490,8 +490,8 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
 
           additional_maxima_found = true;
           theMaxima.push_back(i - 2);  //insert left maxima first
-          theConsecutiveStrips.push_back(
-              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+           //insert the same number of cosecutive strips, because they belong to both maximas
+          theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
           theMaxima.push_back(i);          //insert main maxima
           theConsecutiveStrips.push_back(
               numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -488,12 +488,11 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
             thePulseHeightMap[i - 1].phmax() >= thePulseHeightMap[i - 2].phmax() &&
             //no need in a small charge maxima (might need adjustment)
             thePulseHeightMap[i - 2].phmax() > 20) {
-            
           additional_maxima_found = true;
           theMaxima.push_back(i - 2);  //insert left maxima first
           //insert the same number of cosecutive strips, because they belong to both maximas
           theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
-          theMaxima.push_back(i);          //insert main maxima
+          theMaxima.push_back(i);  //insert main maxima
           //insert the same number of cosecutive strips, because they belong to both maximas
           theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
 
@@ -506,10 +505,9 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
               thePulseHeightMap[i + 2].phmax() <= thePulseHeightMap[i - 1].phmax() &&
               thePulseHeightMap[i + 2].phmax() >= thePulseHeightMap[i - 2].phmax())) &&
             //to avoid close maxima delimitation (this is already present in the code)
-            thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i + 2].phmax() && 
+            thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i + 2].phmax() &&
             //no need in a small charge maxima (might need adjustment)
             thePulseHeightMap[i + 2].phmax() > 20) {
-            
           additional_maxima_found = true;
           theMaxima.push_back(i);  //insert main maxima first
           //insert the same number of cosecutive strips, because they belong to both maximas

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -423,7 +423,6 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
         heightCluster = thePulseHeightMap[i].phmax() + thePulseHeightMap[i + 1].phmax();
         // Have found a strip Hit if...
         if (thePulseHeightMap[i].phmax() >= thePulseHeightMap[i + 1].phmax() && isPeakOK(i, heightCluster)) {
-          theMaxima.push_back(i);
           maximumFound = true;
         }
         // Right edge of chamber
@@ -431,7 +430,6 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
         heightCluster = thePulseHeightMap[i - 1].phmax() + thePulseHeightMap[i].phmax();
         // Have found a strip Hit if...
         if (thePulseHeightMap[i].phmax() > thePulseHeightMap[i - 1].phmax() && isPeakOK(i, heightCluster)) {
-          theMaxima.push_back(i);
           maximumFound = true;
         }
         // Any other strips
@@ -441,7 +439,6 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
         // Have found a strip Hit if...
         if (thePulseHeightMap[i].phmax() > thePulseHeightMap[i - 1].phmax() &&
             thePulseHeightMap[i].phmax() >= thePulseHeightMap[i + 1].phmax() && isPeakOK(i, heightCluster)) {
-          theMaxima.push_back(i);
           maximumFound = true;
         }
       }
@@ -472,11 +469,61 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
           break;
         }
       }
-      theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
-    }
+       
+      bool additional_maxima_found = false;
+      // search for additional maxima if: 
+	  // - hit is closer than 3 strips from the edge
+	  // - enough consecutive strips with signal
+	  // - strip charge distribution looks abnormal
+      
+      if ( i > 2 && i < (thePulseHeightMap.size()-3) && numberOfConsecutiveStrips > 3){
+	//try to look for additional maxima at the left side from the main maxima
+
+if(((thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-1].phmax() &&
+	    thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-2].phmax() &&
+	    thePulseHeightMap[i+2].phmax() <= thePulseHeightMap[i-2].phmax())|| 
+	   (thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-1].phmax() &&
+	    thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-2].phmax())) && 
+	   thePulseHeightMap[i-1].phmax() >= thePulseHeightMap[i-2].phmax() &&//to avoid close maxima delimitation (this is already present in the code)
+	   thePulseHeightMap[i-2].phmax() > 20){//no need in a small charge maxima (might need adjustment)
+
+	  additional_maxima_found = true;
+	  theMaxima.push_back(i-2);//insert left maxima first
+	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
+	  theMaxima.push_back(i);//insert main maxima
+	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
+	  
+	}//looking for additional maxima on the left
+	
+	//try to look for additional maxima at the right side from the main maxima
+if(((thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i-1].phmax() &&
+	    thePulseHeightMap[i+2].phmax() >= thePulseHeightMap[i-1].phmax()) || 
+	   (thePulseHeightMap[i+1].phmax() <= thePulseHeightMap[i-1].phmax() &&
+	    thePulseHeightMap[i+2].phmax() <= thePulseHeightMap[i-1].phmax() &&
+	    thePulseHeightMap[i+2].phmax() >= thePulseHeightMap[i-2].phmax())) && 
+	   thePulseHeightMap[i+1].phmax() >= thePulseHeightMap[i+2].phmax() &&//to avoid close maxima delimitation (this is already present in the code)
+	   thePulseHeightMap[i+2].phmax() > 20){//no need in a small charge maxima (might need adjustment)
+	
+	  additional_maxima_found = true;
+	  theMaxima.push_back(i);//insert main maxima first
+	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
+	  theMaxima.push_back(i+2);//insert right maxima
+	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);//insert the same number of cosecutive strips, because they belong to both maximas
+	  
+	}//looking for additional maxima on the right
+    
+	//if nothing additional found fill the maxima
+	if(!additional_maxima_found){
+	  theMaxima.push_back(i);
+	  theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
+	}
+  }else{//not the case for looking for the additional maxima
+    theMaxima.push_back(i);
+    theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
   }
-}
-//
+    }//if maximafound
+  }//all pulses
+}//find maxima procedure
 
 bool CSCHitFromStripOnly::isPeakOK(int iStrip, float heightCluster) {
   int i = iStrip;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -475,7 +475,7 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
       // - hit is closer than 3 strips from the edge
       // - enough consecutive strips with signal
       // - strip charge distribution looks abnormal
-        
+
       if (i > 2 && i + 3 < thePulseHeightMap.size() && numberOfConsecutiveStrips > 3) {
         //try to look for additional maxima at the left side from the main maxima
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCHitFromStripOnly.cc
@@ -486,15 +486,16 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
               thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 2].phmax())) &&
             //to avoid close maxima delimitation (this is already present in the code)
             thePulseHeightMap[i - 1].phmax() >= thePulseHeightMap[i - 2].phmax() &&
-            thePulseHeightMap[i - 2].phmax() > 20) {  //no need in a small charge maxima (might need adjustment)
-
+            //no need in a small charge maxima (might need adjustment)
+            thePulseHeightMap[i - 2].phmax() > 20) {
+            
           additional_maxima_found = true;
           theMaxima.push_back(i - 2);  //insert left maxima first
-           //insert the same number of cosecutive strips, because they belong to both maximas
+          //insert the same number of cosecutive strips, because they belong to both maximas
           theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
           theMaxima.push_back(i);          //insert main maxima
-          theConsecutiveStrips.push_back(
-              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+          //insert the same number of cosecutive strips, because they belong to both maximas
+          theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
 
         }  //looking for additional maxima on the left
 
@@ -504,18 +505,18 @@ void CSCHitFromStripOnly::findMaxima(const CSCDetId& id) {
              (thePulseHeightMap[i + 1].phmax() <= thePulseHeightMap[i - 1].phmax() &&
               thePulseHeightMap[i + 2].phmax() <= thePulseHeightMap[i - 1].phmax() &&
               thePulseHeightMap[i + 2].phmax() >= thePulseHeightMap[i - 2].phmax())) &&
-            thePulseHeightMap[i + 1].phmax() >=
-                thePulseHeightMap[i + 2]
-                    .phmax() &&  //to avoid close maxima delimitation (this is already present in the code)
-            thePulseHeightMap[i + 2].phmax() > 20) {  //no need in a small charge maxima (might need adjustment)
-
+            //to avoid close maxima delimitation (this is already present in the code)
+            thePulseHeightMap[i + 1].phmax() >= thePulseHeightMap[i + 2].phmax() && 
+            //no need in a small charge maxima (might need adjustment)
+            thePulseHeightMap[i + 2].phmax() > 20) {
+            
           additional_maxima_found = true;
           theMaxima.push_back(i);  //insert main maxima first
-          theConsecutiveStrips.push_back(
-              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+          //insert the same number of cosecutive strips, because they belong to both maximas
+          theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
           theMaxima.push_back(i + 2);  //insert right maxima
-          theConsecutiveStrips.push_back(
-              numberOfConsecutiveStrips);  //insert the same number of cosecutive strips, because they belong to both maximas
+          //insert the same number of cosecutive strips, because they belong to both maximas
+          theConsecutiveStrips.push_back(numberOfConsecutiveStrips);
 
         }  //looking for additional maxima on the right
 

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -141,14 +141,14 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   int quality = -1;
   LocalPoint lp0(0., 0.);
   int wglo = wg_left;
-  int wghi = wg_right;  
+  int wghi = wg_right;
   float ymiddle;
 
   // First wire of first wiregroup in cluster
-  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);  
+  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
   // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)
   wghi = layergeom_->middleWireOfGroup(wghi) - 0.5 + 0.5 * layergeom_->numberOfWiresPerGroup(wghi);
-  
+
   float stripWidth = -99.f;
   // If at the edge, then used 1 strip cluster only
   if (centerStrip == 1 || centerStrip == specs_->nStrips() || nStrip < 2) {

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -140,37 +140,48 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   float sigmaWithinTheStrip = -99.;
   int quality = -1;
   LocalPoint lp0(0., 0.);
+  int wglo = wg_left;
+  int wghi = wg_right;
+  
+  float ymiddle;
 
+  // First wire of first wiregroup in cluster
+  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 
+    - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
+
+  // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)
+  wghi = layergeom_->middleWireOfGroup(wghi) - 0.5 
+    + 0.5 * layergeom_->numberOfWiresPerGroup(wghi);
+  
   float stripWidth = -99.f;
   // If at the edge, then used 1 strip cluster only
   if (centerStrip == 1 || centerStrip == specs_->nStrips() || nStrip < 2) {
-    lp0 = layergeom_->stripWireIntersection(centerStrip, centerWire);
+    lp0 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wilo, wihi )).first;
+    ymiddle = lp0.y();
     positionWithinTheStrip = 0.f;
     stripWidth = layergeom_->stripPitch(lp0);
     sigmaWithinTheStrip = stripWidth * inv_sqrt_12;
     quality = 2;
   } else {
     // If not at the edge, used cluster of size ClusterSize:
-    LocalPoint lp11 = layergeom_->stripWireIntersection(centerStrip, centerWire);
+    LocalPoint lp11 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wglo, wghi )).first;
+    ymiddle = lp11.y();
     stripWidth = layergeom_->stripPitch(lp11);
 
     //---- Calculate local position within the strip
     float xWithinChamber = lp11.x();
     quality = 0;
-    if (layergeom_->inside(lp11)) {  // save time; this hit is to be discarded anyway - see isHitInFiducial(...)
-
-      xMatchGatti_->findXOnStrip(id,
-                                 layer_,
-                                 sHit,
-                                 centerStrip,
-                                 xWithinChamber,
-                                 stripWidth,
-                                 tpeak,
-                                 positionWithinTheStrip,
-                                 sigmaWithinTheStrip,
-                                 quality);
-    }
-    lp0 = LocalPoint(xWithinChamber, layergeom_->yOfWire(centerWire, xWithinChamber));
+    xMatchGatti_->findXOnStrip(id,
+                               layer_,
+                               sHit,
+                               centerStrip,
+                               xWithinChamber,
+                               stripWidth,
+                               tpeak,
+                               positionWithinTheStrip,
+                               sigmaWithinTheStrip,
+                               quality);
+    lp0 = LocalPoint( xWithinChamber, ymiddle );
   }
 
   // compute the errors in local x and y

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -145,8 +145,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   float ymiddle;
 
   // First wire of first wiregroup in cluster
-  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
-  
+  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);  
   // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)
   wghi = layergeom_->middleWireOfGroup(wghi) - 0.5 + 0.5 * layergeom_->numberOfWiresPerGroup(wghi);
   

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -142,7 +142,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   LocalPoint lp0(0., 0.);
   int wglo = wg_left;
   int wghi = wg_right;
-  
+
   // First wire of first wiregroup in cluster
   wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
   // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -146,17 +146,15 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   float ymiddle;
 
   // First wire of first wiregroup in cluster
-  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 
-    - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
-
+  wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
+  
   // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)
-  wghi = layergeom_->middleWireOfGroup(wghi) - 0.5 
-    + 0.5 * layergeom_->numberOfWiresPerGroup(wghi);
+  wghi = layergeom_->middleWireOfGroup(wghi) - 0.5 + 0.5 * layergeom_->numberOfWiresPerGroup(wghi);
   
   float stripWidth = -99.f;
   // If at the edge, then used 1 strip cluster only
   if (centerStrip == 1 || centerStrip == specs_->nStrips() || nStrip < 2) {
-    lp0 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wglo, wghi )).first;
+    lp0 = (layergeom_->possibleRecHitPosition(float(centerStrip) - 0.5, wglo, wghi)).first;
     ymiddle = lp0.y();
     positionWithinTheStrip = 0.f;
     stripWidth = layergeom_->stripPitch(lp0);
@@ -164,7 +162,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
     quality = 2;
   } else {
     // If not at the edge, used cluster of size ClusterSize:
-    LocalPoint lp11 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wglo, wghi )).first;
+    LocalPoint lp11 = (layergeom_->possibleRecHitPosition(float(centerStrip) - 0.5, wglo, wghi)).first;
     ymiddle = lp11.y();
     stripWidth = layergeom_->stripPitch(lp11);
 
@@ -181,7 +179,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
                                positionWithinTheStrip,
                                sigmaWithinTheStrip,
                                quality);
-    lp0 = LocalPoint( xWithinChamber, ymiddle );
+    lp0 = LocalPoint(xWithinChamber, ymiddle);
   }
 
   // compute the errors in local x and y

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -156,7 +156,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   float stripWidth = -99.f;
   // If at the edge, then used 1 strip cluster only
   if (centerStrip == 1 || centerStrip == specs_->nStrips() || nStrip < 2) {
-    lp0 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wilo, wihi )).first;
+    lp0 = (layergeom_->possibleRecHitPosition( float(centerStrip) - 0.5, wglo, wghi )).first;
     ymiddle = lp0.y();
     positionWithinTheStrip = 0.f;
     stripWidth = layergeom_->stripPitch(lp0);

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -142,8 +142,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   LocalPoint lp0(0., 0.);
   int wglo = wg_left;
   int wghi = wg_right;
-  float ymiddle;
-
+  
   // First wire of first wiregroup in cluster
   wglo = layergeom_->middleWireOfGroup(wglo) + 0.5 - 0.5 * layergeom_->numberOfWiresPerGroup(wglo);
   // Last wire in last wiregroup of cluster (OK if only 1 wiregroup too)
@@ -153,7 +152,6 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   // If at the edge, then used 1 strip cluster only
   if (centerStrip == 1 || centerStrip == specs_->nStrips() || nStrip < 2) {
     lp0 = (layergeom_->possibleRecHitPosition(float(centerStrip) - 0.5, wglo, wghi)).first;
-    ymiddle = lp0.y();
     positionWithinTheStrip = 0.f;
     stripWidth = layergeom_->stripPitch(lp0);
     sigmaWithinTheStrip = stripWidth * inv_sqrt_12;
@@ -161,7 +159,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   } else {
     // If not at the edge, used cluster of size ClusterSize:
     LocalPoint lp11 = (layergeom_->possibleRecHitPosition(float(centerStrip) - 0.5, wglo, wghi)).first;
-    ymiddle = lp11.y();
+    float ymiddle = lp11.y();
     stripWidth = layergeom_->stripPitch(lp11);
 
     //---- Calculate local position within the strip

--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -141,8 +141,7 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
   int quality = -1;
   LocalPoint lp0(0., 0.);
   int wglo = wg_left;
-  int wghi = wg_right;
-  
+  int wghi = wg_right;  
   float ymiddle;
 
   // First wire of first wiregroup in cluster

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -133,7 +133,7 @@ void CSCRecHitDBuilder::build(const CSCStripDigiCollection* stripdc,
           isInFiducial = true;
         } else {
           isInFiducial = make2DHits_->isHitInFiducial(layer, rechit);
-        }        
+        }
         if (isInFiducial) {
           hitsInLayer.push_back(rechit);
           hits_in_layer++;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -129,7 +129,7 @@ void CSCRecHitDBuilder::build(const CSCStripDigiCollection* stripdc,
         LocalPoint rhitlocal = rechit.localPosition();
         float yreco = rhitlocal.y();
         bool isInFiducial = false;
-        //in me1/1 chambers the strip cut region is at local y = 30 cm, +-5 cm area around it proved to be a suitabla region for omiting the check 
+        //in me1/1 chambers the strip cut region is at local y = 30 cm, +-5 cm area around it proved to be a suitabla region for omiting the check
         if ((sDetId.station() == 1) && (sDetId.ring() == 1 || sDetId.ring() == 4) && (fabs(yreco + 30.) < 5.)) {
           isInFiducial = true;
         } else {

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -11,6 +11,7 @@
 #include <Geometry/CSCGeometry/interface/CSCChamberSpecs.h>
 #include <Geometry/CSCGeometry/interface/CSCLayer.h>
 #include <Geometry/CSCGeometry/interface/CSCGeometry.h>
+#include <Geometry/CSCGeometry/interface/CSCLayerGeometry.h>
 
 #include <DataFormats/MuonDetId/interface/CSCDetId.h>
 
@@ -124,8 +125,16 @@ void CSCRecHitDBuilder::build(const CSCStripDigiCollection* stripdc,
     for (auto const& s_hit : cscStripHit) {
       for (auto const& w_hit : cscWireHit) {
         CSCRecHit2D rechit = make2DHits_->hitFromStripAndWire(sDetId, layer, w_hit, s_hit);
-
-        bool isInFiducial = make2DHits_->isHitInFiducial(layer, rechit);
+        
+       	// Store rechit as a Local Point:
+	      LocalPoint rhitlocal = rechit.localPosition();  
+	      float yreco = rhitlocal.y();
+	      bool isInFiducial = false;
+	      if((sDetId.station() == 1) && (sDetId.ring() == 1 || sDetId.ring() == 4) && (fabs(yreco+30.)<5.)){
+	   	    isInFiducial = true;
+        }else{
+	        isInFiducial = make2DHits_->isHitInFiducial( layer, rechit );
+	      }
         if (isInFiducial) {
           hitsInLayer.push_back(rechit);
           hits_in_layer++;

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -129,6 +129,7 @@ void CSCRecHitDBuilder::build(const CSCStripDigiCollection* stripdc,
         LocalPoint rhitlocal = rechit.localPosition();
         float yreco = rhitlocal.y();
         bool isInFiducial = false;
+        //in me1/1 chambers the strip cut region is at local y = 30 cm, +-5 cm area around it proved to be a suitabla region for omiting the check 
         if ((sDetId.station() == 1) && (sDetId.ring() == 1 || sDetId.ring() == 4) && (fabs(yreco + 30.) < 5.)) {
           isInFiducial = true;
         } else {

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDBuilder.cc
@@ -125,16 +125,15 @@ void CSCRecHitDBuilder::build(const CSCStripDigiCollection* stripdc,
     for (auto const& s_hit : cscStripHit) {
       for (auto const& w_hit : cscWireHit) {
         CSCRecHit2D rechit = make2DHits_->hitFromStripAndWire(sDetId, layer, w_hit, s_hit);
-        
-       	// Store rechit as a Local Point:
-	      LocalPoint rhitlocal = rechit.localPosition();  
-	      float yreco = rhitlocal.y();
-	      bool isInFiducial = false;
-	      if((sDetId.station() == 1) && (sDetId.ring() == 1 || sDetId.ring() == 4) && (fabs(yreco+30.)<5.)){
-	   	    isInFiducial = true;
-        }else{
-	        isInFiducial = make2DHits_->isHitInFiducial( layer, rechit );
-	      }
+        // Store rechit as a Local Point:
+        LocalPoint rhitlocal = rechit.localPosition();
+        float yreco = rhitlocal.y();
+        bool isInFiducial = false;
+        if ((sDetId.station() == 1) && (sDetId.ring() == 1 || sDetId.ring() == 4) && (fabs(yreco + 30.) < 5.)) {
+          isInFiducial = true;
+        } else {
+          isInFiducial = make2DHits_->isHitInFiducial(layer, rechit);
+        }        
         if (isInFiducial) {
           hitsInLayer.push_back(rechit);
           hits_in_layer++;


### PR DESCRIPTION
#### PR description:

This PR adds some features to the CSC RecHit Builder.

The addressed problems are:
- simple two overlapped signals delimitation in terms of the strip coordinate;
- improvement of the hit reconstruction in the extreme wire groups of chamber(best improvement for ME11);
- ME11 transition region hit reconstruction improvement.

For details see:
https://indico.cern.ch/event/968978/contributions/4078288/attachments/2133771/3594383/20_10_30-Voytishin_Palichik-CSC_rh_builder_improvement_updates.pdf



