### PR TITLE
speedup: switch EgammaTools EnergyScaleCorrection scales and smearings to use std::map

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
+++ b/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <map>
 #include <cmath>
 #include <string>
 #include <bitset>
@@ -193,8 +194,8 @@ private:
 
   //data members
   FileFormat smearingType_;
-  std::vector<std::pair<CorrectionCategory, ScaleCorrection> > scales_;
-  std::vector<std::pair<CorrectionCategory, SmearCorrection> > smearings_;
+  std::map<CorrectionCategory, ScaleCorrection> scales_;
+  std::map<CorrectionCategory, SmearCorrection> smearings_;
 
   template <typename T1, typename T2>
   class Sorter {


### PR DESCRIPTION
the technical regression became more obvious after a recent update in the scale/smearing introduced in #31936. E.g. the start time of a 2018 UL re-miniAOD workflow 136.88811 went up to about 10 mins.

Apparently the EnergyScaleCorrection used an equivalent of a std::map implemented via a vector with repeated calls to sort during insertion, which lead to the startup time explosion

job start time for wf a 2018 UL re-miniAOD workflow 136.88811 went down by about a factor of 10
from https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-11-04-1100-orig.136.88811.step2.1.pp/9
to https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-11-04-1100-sign1111.136.88811.step2.1.pp/26
(the profile links are for 1 event processed).

the time cost of calling `EnergyScaleCorrection::addScale` went down by almost 4 orders of magnitude
https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-11-04-1100-orig.136.88811.step2.1.pp/21 => 
https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/CMSSW_11_2_X_2020-11-04-1100-sign1111.136.88811.step2.1.pp/1011
