### PR TITLE
speedup: switch EgammaTools EnergyScaleCorrection scales and smearings to use std::map (backport of #32053)

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
+++ b/RecoEgamma/EgammaTools/interface/EnergyScaleCorrection.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <map>
 #include <cmath>
 #include <string>
 #include <bitset>
@@ -193,8 +194,8 @@ private:
 
   //data members
   FileFormat smearingType_;
-  std::vector<std::pair<CorrectionCategory, ScaleCorrection> > scales_;
-  std::vector<std::pair<CorrectionCategory, SmearCorrection> > smearings_;
+  std::map<CorrectionCategory, ScaleCorrection> scales_;
+  std::map<CorrectionCategory, SmearCorrection> smearings_;
 
   template <typename T1, typename T2>
   class Sorter {


### PR DESCRIPTION
backport of #32053

this is a technical PR to speedup the startup time of workflows using `CalibratedPhotonProducer` and `CalibratedElectronProducer` which use `EnergyScaleCorrection`

more details are available in https://github.com/cms-sw/cmssw/pull/32053#issue-517027691
