### PR TITLE
Including PPS digi into DigiCosmic_cff.py

### DIFF
--- a/Configuration/StandardSequences/python/DigiCosmics_cff.py
+++ b/Configuration/StandardSequences/python/DigiCosmics_cff.py
@@ -21,6 +21,10 @@ from SimCalorimetry.Configuration.SimCalorimetry_cff import *
 #
 from SimMuon.Configuration.SimMuon_cff import *
 #
+# PPS Digis
+# returns sequence "ctppsDigi"
+from SimPPS.Configuration.SimPPS_cff import *
+
 # include TrackingParticle Producer
 # NOTA BENE: it MUST be run here at the moment, since it depends 
 # of the availability of the CrossingFrame in the Event
@@ -51,7 +55,7 @@ simHcalDigis.HElevel = cms.int32(-10000)
 simHcalDigis.HOlevel   = cms.int32(-10000)
 simHcalDigis.HFlevel   = cms.int32(-10000)
 
-doAllDigiTask = cms.Task(calDigiTask, muonDigiTask)
+doAllDigiTask = cms.Task(calDigiTask, muonDigiTask ,ctppsDigiTask)
 pdigiTask = cms.Task(cms.TaskPlaceholder("randomEngineStateProducer"), cms.TaskPlaceholder("mix"), doAllDigiTask)
 
 doAllDigi = cms.Sequence(doAllDigiTask)


### PR DESCRIPTION
#### PR description:

This PR changes DigiCosmic_cff.py config file to include PPS in the Digi tasks ir order to solve a problem with PR #32003 as part of the process to include PPS simulation in cmssw.

#### PR validation:
All tests done sucessfully.  runTheMatrix.py --job-reports  -j 14 -l limited --ibeos
reported no issues (after running if 4 times due to timing and other problems, even in condor).
`
4.22        Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
4.53        Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
5.1         Step0-PASSED  Step1-PASSED  -             time          date          exit: 0 0
7.3         Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
8.0         Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
9.0         Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
25.0        Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
101.0       Step0-PASSED  -             time          date          Mon           exit: 0
135.4       Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
136.731     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
136.7611    Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
136.793     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
136.8311    Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
136.874     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
136.88811   Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
140.53      Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
140.56      Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
158.01      Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
312.0       Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
1000.0      Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
1001.0      Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0 0 0 0 0
1306.0      Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
1325.7      Step0-PASSED  Step1-PASSED  Step2-PASSED  -             time          exit: 0 0 0
1330.0      Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
10024.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0 0
10042.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0 0
10224.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
10824.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0 0
11634.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
12434.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
23234.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
23434.999   Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
25202.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0
28234.0     Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  -             exit: 0 0 0 0
250202.181  Step0-PASSED  Step1-PASSED  Step2-PASSED  Step3-PASSED  Step4-PASSED  exit: 0 0 0 0 0

`

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
