### PR TITLE
Remove obsolete records [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -45,7 +45,7 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v2',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '111X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This is a purely technical PR, corresponding to the portion of #31780 that should be backported. In PR #31780, the obsolete records needed to be removed from all GTs in autoCond, including the Run 3 prompt GTs. But since the 11_1_X release series is currently used for online data taking, `auto:run3_data_promptlike` is an 11_1_X GT. Therefore, for bookkeeping consistency, the change should be backported to 11_1_X.

This change is purely technical and no changes in any distribution are expected from this change. The GT diff is as follows:

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v2/111X_dataRun3_Prompt_v4

#### PR validation:

`runTheMatrix.py -l 138.1 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

This PR corresponding to the portion of #31780 that should be backported.
