### PR TITLE
Backport #31927 (PuppiMET with PUPPIv15 and UL17 PUID)

### DIFF
--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -503,7 +503,8 @@ run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau3, expr = cms.string("
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, tau4 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n2b1 = None)
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, n3b1 = None)
-run2_jme_2016.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
+for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
+  modifier.toModify( fatJetTable.variables, jetId = Var("userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight"))
 
 run2_jme_2016.toModify( bjetNN, weightFile = cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb") )
 run2_jme_2016.toModify( bjetNN,outputFormulas = cms.vstring(["at(0)*0.31976690888404846+1.047176718711853","0.5*(at(2)-at(1))*0.31976690888404846"]))

--- a/PhysicsTools/NanoAOD/python/jets_cff.py
+++ b/PhysicsTools/NanoAOD/python/jets_cff.py
@@ -18,7 +18,7 @@ from RecoJets.JetProducers.ak4PFJetsBetaStar_cfi import *
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 
 chsForSATkJets = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string('charge()!=0 && pvAssociationQuality()>=5 && vertexRef().key()==0'))
-softActivityJets = ak4PFJets.clone(src = 'chsForSATkJets', doAreaFastjet = False, jetPtMin=1) 
+softActivityJets = ak4PFJets.clone(src = 'chsForSATkJets', doAreaFastjet = False, jetPtMin=1)
 softActivityJets10 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("softActivityJets"), cut = cms.string('pt>10'))
 softActivityJets5 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("softActivityJets"), cut = cms.string('pt>5'))
 softActivityJets2 = cms.EDFilter("CandPtrSelector", src = cms.InputTag("softActivityJets"), cut = cms.string('pt>2'))
@@ -128,7 +128,7 @@ bJetVars = cms.EDProducer("JetRegressionVarProducer",
 )
 
 jercVars = cms.EDProducer("BetaStarPackedCandidateVarProducer",
-    srcJet = cms.InputTag("updatedJets"),    
+    srcJet = cms.InputTag("updatedJets"),
     srcPF = cms.InputTag("packedPFCandidates"),
     maxDR = cms.double(0.4)
 )
@@ -154,16 +154,18 @@ updatedJetsWithUserData = cms.EDProducer("PATJetUserDataEmbedder",
          qgl = cms.InputTag('qgtagger:qgLikelihood'),
          puId94XDisc = cms.InputTag('pileupJetId94X:fullDiscriminant'),
          puId102XDisc = cms.InputTag('pileupJetId102X:fullDiscriminant'),
+         puId106XUL17Disc = cms.InputTag('pileupJetId106XUL17:fullDiscriminant'),
          chFPV0EF = cms.InputTag("jercVars:chargedFromPV0EnergyFraction"),
          chFPV1EF = cms.InputTag("jercVars:chargedFromPV1EnergyFraction"),
          chFPV2EF = cms.InputTag("jercVars:chargedFromPV2EnergyFraction"),
-         chFPV3EF = cms.InputTag("jercVars:chargedFromPV3EnergyFraction"),         
+         chFPV3EF = cms.InputTag("jercVars:chargedFromPV3EnergyFraction"),
          ),
      userInts = cms.PSet(
         tightId = cms.InputTag("tightJetId"),
         tightIdLepVeto = cms.InputTag("tightJetIdLepVeto"),
         vtxNtrk = cms.InputTag("bJetVars:vtxNtrk"),
         leptonPdgId = cms.InputTag("bJetVars:leptonPdgId"),
+        puId106XUL17Id = cms.InputTag('pileupJetId106XUL17:fullId'),
      ),
 )
 run2_jme_2016.toModify(updatedJetsWithUserData.userInts,
@@ -233,8 +235,8 @@ jetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
         btagDeepFlavCvL = Var("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probuds')+bDiscriminator('pfDeepFlavourJetTags:probg')):-1",float,doc="DeepJet c vs uds+g discriminator",precision=10),
         btagDeepFlavCvB = Var("?(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb'))>0?bDiscriminator('pfDeepFlavourJetTags:probc')/(bDiscriminator('pfDeepFlavourJetTags:probc')+bDiscriminator('pfDeepFlavourJetTags:probb')+bDiscriminator('pfDeepFlavourJetTags:probbb')+bDiscriminator('pfDeepFlavourJetTags:problepb')):-1",float,doc="DeepJet c vs b+bb+lepb discriminator",precision=10),
         btagDeepFlavQG = Var("?(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds'))>0?bDiscriminator('pfDeepFlavourJetTags:probg')/(bDiscriminator('pfDeepFlavourJetTags:probg')+bDiscriminator('pfDeepFlavourJetTags:probuds')):-1",float,doc="DeepJet g vs uds discriminator",precision=10),
-        puIdDisc = Var("userFloat('puId102XDisc')",float,doc="Pilup ID discriminant with 102X (2018) training",precision=10),
-        puId = Var("userInt('pileupJetId:fullId')",int,doc="Pilup ID flags with 80X (2016) training"),
+        puIdDisc = Var("userFloat('puId102XDisc')",float,doc="Pileup ID discriminant with 102X (2018) training",precision=10),
+        puId = Var("userInt('pileupJetId:fullId')",int,doc="Pileup ID flags for pre-UL trainings"),
         jetId = Var("userInt('tightId')*2+4*userInt('tightIdLepVeto')",int,doc="Jet ID flags bit1 is loose (always false in 2017 since it does not exist), bit2 is tight, bit3 is tightLepVeto"),
         qgl = Var("userFloat('qgl')",float,doc="Quark vs Gluon likelihood discriminator",precision=10),
         nConstituents = Var("numberOfDaughters()",int,doc="Number of particles in the jet"),
@@ -264,8 +266,13 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
     )
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016:
   modifier.toModify( jetTable.variables, jetId = Var("userInt('tightIdLepVeto')*4+userInt('tightId')*2+userInt('looseId')",int,doc="Jet ID flags bit1 is loose, bit2 is tight, bit3 is tightLepVeto"))
-run2_jme_2016.toModify( jetTable.variables, puIdDisc = Var("userFloat('pileupJetId:fullDiscriminant')",float,doc="Pilup ID discriminant with 80X (2016) training",precision=10))
-run2_jme_2017.toModify( jetTable.variables, puIdDisc = Var("userFloat('puId94XDisc')", float,doc="Pilup ID discriminant with 94X (2017) training",precision=10))
+run2_jme_2016.toModify( jetTable.variables, puIdDisc = Var("userFloat('pileupJetId:fullDiscriminant')",float,doc="Pileup ID discriminant with 80X (2016) training",precision=10))
+run2_jme_2017.toModify( jetTable.variables, puId = Var("userInt('puId106XUL17Id')", int,doc="Pileup ID flags with 106X (2017) training"))
+run2_jme_2017.toModify( jetTable.variables, puIdDisc = Var("userFloat('puId106XUL17Disc')", float,doc="Pileup ID discriminant with 106X (2017) training",precision=10))
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
+    modifier.toModify( jetTable.variables, puIdDisc = Var("userFloat('puId94XDisc')", float,doc="Pileup ID discriminant with 94X (2017) training",precision=10))
+    modifier.toModify( jetTable.variables, puId = Var("userInt('pileupJetId:fullId')",int,doc="Pileup ID flags for 2016/2017/2018 EOY trainings"))
+
 
 bjetNN= cms.EDProducer("BJetEnergyRegressionMVA",
     backend = cms.string("TF"),
@@ -465,7 +472,7 @@ fatJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
 		     doc="index of second subjet"),
 
 #        btagDeepC = Var("bDiscriminator('pfDeepCSVJetTags:probc')",float,doc="CMVA V2 btag discriminator",precision=10),
-#puIdDisc = Var("userFloat('pileupJetId:fullDiscriminant')",float,doc="Pilup ID discriminant",precision=10),
+#puIdDisc = Var("userFloat('pileupJetId:fullDiscriminant')",float,doc="Pileup ID discriminant",precision=10),
 #        nConstituents = Var("numberOfDaughters()",int,doc="Number of particles in the jet"),
 #        rawFactor = Var("1.-jecFactor('Uncorrected')",float,doc="1 - Factor to get back to raw pT",precision=6),
     ),
@@ -482,12 +489,12 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
   # Deprecated after 106X
   modifier.toModify( fatJetTable.variables,
     btagCMVA = Var("bDiscriminator('pfCombinedMVAV2BJetTags')",float,doc="CMVA V2 btag discriminator",precision=10),
-    btagDDBvL_noMD = Var("bDiscriminator('pfDeepDoubleBvLJetTags:probHbb')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->bb vs QCD",precision=10), 
-    btagDDCvL_noMD = Var("bDiscriminator('pfDeepDoubleCvLJetTags:probHcc')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->cc vs QCD",precision=10), 
-    btagDDCvB_noMD = Var("bDiscriminator('pfDeepDoubleCvBJetTags:probHcc')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->cc vs H(Z)->bb",precision=10), 
-    btagDDBvL = Var("bDiscriminator('pfMassIndependentDeepDoubleBvLJetTags:probHbb')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->bb vs QCD",precision=10), 
-    btagDDCvL = Var("bDiscriminator('pfMassIndependentDeepDoubleCvLJetTags:probHcc')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->cc vs QCD",precision=10), 
-    btagDDCvB = Var("bDiscriminator('pfMassIndependentDeepDoubleCvBJetTags:probHcc')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->cc vs H(Z)->bb",precision=10), 
+    btagDDBvL_noMD = Var("bDiscriminator('pfDeepDoubleBvLJetTags:probHbb')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->bb vs QCD",precision=10),
+    btagDDCvL_noMD = Var("bDiscriminator('pfDeepDoubleCvLJetTags:probHcc')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->cc vs QCD",precision=10),
+    btagDDCvB_noMD = Var("bDiscriminator('pfDeepDoubleCvBJetTags:probHcc')",float,doc="DeepDoubleX discriminator (no mass-decorrelation) for H(Z)->cc vs H(Z)->bb",precision=10),
+    btagDDBvL = Var("bDiscriminator('pfMassIndependentDeepDoubleBvLJetTags:probHbb')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->bb vs QCD",precision=10),
+    btagDDCvL = Var("bDiscriminator('pfMassIndependentDeepDoubleCvLJetTags:probHcc')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->cc vs QCD",precision=10),
+    btagDDCvB = Var("bDiscriminator('pfMassIndependentDeepDoubleCvBJetTags:probHcc')",float,doc="DeepDoubleX (mass-decorrelated) discriminator for H(Z)->cc vs H(Z)->bb",precision=10),
     )
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables, msoftdrop_chs = Var("userFloat('ak8PFJetsCHSSoftDropMass')",float, doc="Legacy uncorrected soft drop mass with CHS",precision=10))
 run2_miniAOD_80XLegacy.toModify( fatJetTable.variables.tau1, expr = cms.string("userFloat(\'ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau1\')"),)
@@ -522,7 +529,7 @@ subJetTable = cms.EDProducer("SimpleCandidateFlatTableProducer",
     variables = cms.PSet(P4Vars,
         btagDeepB = Var("bDiscriminator('pfDeepCSVJetTags:probb')+bDiscriminator('pfDeepCSVJetTags:probbb')",float,doc="DeepCSV b+bb tag discriminator",precision=10),
         btagCSVV2 = Var("bDiscriminator('pfCombinedInclusiveSecondaryVertexV2BJetTags')",float,doc=" pfCombinedInclusiveSecondaryVertexV2 b-tag discriminator (aka CSVV2)",precision=10),
-        rawFactor = Var("1.-jecFactor('Uncorrected')",float,doc="1 - Factor to get back to raw pT",precision=6),                 
+        rawFactor = Var("1.-jecFactor('Uncorrected')",float,doc="1 - Factor to get back to raw pT",precision=6),
         tau1 = Var("userFloat('NjettinessAK8Subjets:tau1')",float, doc="Nsubjettiness (1 axis)",precision=10),
         tau2 = Var("userFloat('NjettinessAK8Subjets:tau2')",float, doc="Nsubjettiness (2 axis)",precision=10),
         tau3 = Var("userFloat('NjettinessAK8Subjets:tau3')",float, doc="Nsubjettiness (3 axis)",precision=10),
@@ -691,13 +698,14 @@ run2_miniAOD_80XLegacy.toModify( genJetFlavourTable, jetFlavourInfos = cms.Input
 from RecoJets.JetProducers.QGTagger_cfi import  QGTagger
 qgtagger=QGTagger.clone(srcJets="updatedJets",srcVertexCollection="offlineSlimmedPrimaryVertices")
 
-from RecoJets.JetProducers.PileupJetID_cfi import pileupJetId, _chsalgos_94x, _chsalgos_102x
+from RecoJets.JetProducers.PileupJetID_cfi import pileupJetId, _chsalgos_94x, _chsalgos_102x, _chsalgos_106X_UL17
 pileupJetId94X=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_94x),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
 pileupJetId102X=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_102x),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
+pileupJetId106XUL17=pileupJetId.clone(jets="updatedJets",algos = cms.VPSet(_chsalgos_106X_UL17),inputIsCorrected=True,applyJec=False,vertexes="offlineSlimmedPrimaryVertices")
 
 
 #before cross linking
-jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+qgtagger+jercVars+pileupJetId94X+pileupJetId102X+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
+jetSequence = cms.Sequence(jetCorrFactorsNano+updatedJets+tightJetId+tightJetIdLepVeto+bJetVars+qgtagger+jercVars+pileupJetId94X+pileupJetId102X+pileupJetId106XUL17+updatedJetsWithUserData+jetCorrFactorsAK8+updatedJetsAK8+tightJetIdAK8+tightJetIdLepVetoAK8+updatedJetsAK8WithUserData+chsForSATkJets+softActivityJets+softActivityJets2+softActivityJets5+softActivityJets10+finalJets+finalJetsAK8)
 
 _jetSequence_2016 = jetSequence.copy()
 _jetSequence_2016.insert(_jetSequence_2016.index(tightJetId), looseJetId)
@@ -724,7 +732,7 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016, run2_nanoAOD_94XMi
   )
   modifier.toModify(updatedJetsWithUserData.userInts,
                     hfcentralEtaStripSize = cms.InputTag('hfJetShowerShapeforNanoAOD:centralEtaStripSize'),
-                    hfadjacentEtaStripsSize = cms.InputTag('hfJetShowerShapeforNanoAOD:adjacentEtaStripsSize'), 
+                    hfadjacentEtaStripsSize = cms.InputTag('hfJetShowerShapeforNanoAOD:adjacentEtaStripsSize'),
                   )
   modifier.toModify( jetTable.variables, hfsigmaEtaEta = Var("userFloat('hfsigmaEtaEta')",float,doc="sigmaEtaEta for HF jets (noise discriminating variable)",precision=10))
   modifier.toModify( jetTable.variables, hfsigmaPhiPhi = Var("userFloat('hfsigmaPhiPhi')",float,doc="sigmaPhiPhi for HF jets (noise discriminating variable)",precision=10))

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -69,7 +69,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     discNames = cms.vstring(
         "pfCombinedInclusiveSecondaryVertexV2BJetTags",
         "pfDeepCSVJetTags:probb+pfDeepCSVJetTags:probbb",       #if multiple MiniAOD branches need to be summed up (e.g., DeepCSV b+bb), separate them using '+' delimiter
-        "pfCombinedMVAV2BJetTags"        
+        "pfCombinedMVAV2BJetTags"
     ),
     discShortNames = cms.vstring(
         "CSVV2",
@@ -78,7 +78,7 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
     ),
     weightFiles = cms.vstring(                                  #default settings are for 2017 94X. toModify function is called later for other eras.
         btagSFdir+"CSVv2_94XSF_V2_B_F.csv",
-        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",                    
+        btagSFdir+"DeepCSV_94XSF_V2_B_F.csv",
         "unavailable"                                           #if SFs for an algorithm in an era is unavailable, the corresponding branch will not be stored
     ),
     operatingPoints = cms.vstring("3","3","3"),                 #loose = 0, medium = 1, tight = 2, reshaping = 3
@@ -89,12 +89,12 @@ btagWeightTable = cms.EDProducer("BTagSFProducer",
 )
 
 for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016: # to be updated when SF for Summer16MiniAODv3 MC will be available
-    modifier.toModify(btagWeightTable,                
+    modifier.toModify(btagWeightTable,
         cut = cms.string("pt > 25. && abs(eta) < 2.4"),             #80X corresponds to 2016, |eta| < 2.4
         weightFiles = cms.vstring(                                  #80X corresponds to 2016 SFs
-            btagSFdir+"CSVv2_Moriond17_B_H.csv",            
-            "unavailable",                    
-            btagSFdir+"cMVAv2_Moriond17_B_H.csv"                                            
+            btagSFdir+"CSVv2_Moriond17_B_H.csv",
+            "unavailable",
+            btagSFdir+"cMVAv2_Moriond17_B_H.csv"
         )
     )
 
@@ -102,7 +102,7 @@ for modifier in run2_miniAOD_80XLegacy, run2_nanoAOD_94X2016: # to be updated wh
 lheInfoTable = cms.EDProducer("LHETablesProducer",
     lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
     precision = cms.int32(14),
-    storeLHEParticles = cms.bool(True) 
+    storeLHEParticles = cms.bool(True)
 )
 
 l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Digis"), legacyL1=cms.bool(False),
@@ -111,7 +111,7 @@ l1bits=cms.EDProducer("L1TriggerResultsConverter", src=cms.InputTag("gtStage2Dig
 
 nanoSequenceCommon = cms.Sequence(
         nanoMetadata + jetSequence + muonSequence + tauSequence + electronSequence+photonSequence+vertexSequence+
-        isoTrackSequence + jetLepSequence + # must be after all the leptons 
+        isoTrackSequence + jetLepSequence + # must be after all the leptons
         linkedObjects  +
         jetTables + muonTables + tauTables + electronTables + photonTables +  globalTables +vertexTables+ metTables+simpleCleanerTable + isoTrackTables
         )
@@ -213,6 +213,35 @@ def nanoAOD_recalibrateMETs(process,isData):
     process.metTables += process.corrT1METJetTable
 #    makePuppiesFromMiniAOD(process,True) # call this before in the global customizer otherwise it would reset photon IDs in VID
     runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi")
+    nanoAOD_PuppiV15_switch = cms.PSet(
+            recoMetFromPFCs = cms.untracked.bool(False),
+            reclusterJets = cms.untracked.bool(False),
+            )
+    run2_nanoAOD_106Xv1.toModify(nanoAOD_PuppiV15_switch,recoMetFromPFCs=True,reclusterJets=True)
+    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
+    if nanoAOD_PuppiV15_switch.reclusterJets:
+        from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+        from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
+        task = getPatAlgosToolsTask(process)
+        addToProcessAndTask('ak4PuppiJets', ak4PFJets.clone (src = 'puppi', doAreaFastjet = True, jetPtMin = 10.), process, task)
+        from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
+        addJetCollection(process,
+                            labelName = 'Puppi',
+                            jetSource = cms.InputTag('ak4PuppiJets'),
+                            algo = 'AK', rParam=0.4,
+                            genJetCollection=cms.InputTag('slimmedGenJets'),
+                            jetCorrections = ('AK4PFPuppi', ['L1FastJet', 'L2Relative', 'L3Absolute','L2L3Residual'], 'None'),
+                            pfCandidates = cms.InputTag('packedPFCandidates'),
+                            pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                            svSource = cms.InputTag('slimmedSecondaryVertices'),
+                            muSource =cms.InputTag( 'slimmedMuons'),
+                            elSource = cms.InputTag('slimmedElectrons'),
+                            genParticles= cms.InputTag('prunedGenParticles'),
+                            getJetMCFlavour=False
+        )
+
+        process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
+        process.patJetsPuppi.addGenJetMatch = cms.bool(False)
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
     return process
 
@@ -367,7 +396,7 @@ def nanoAOD_customizeMC(process):
 
 ### Era dependent customization
 _80x_sequence = nanoSequenceCommon.copy()
-#remove stuff 
+#remove stuff
 _80x_sequence.remove(isoTrackTables)
 _80x_sequence.remove(isoTrackSequence)
 #add stuff

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -212,7 +212,6 @@ def nanoAOD_recalibrateMETs(process,isData):
         table.variables.muonSubtrFactor = Var("1-userFloat('muonSubtrRawPt')/(pt()*jecFactor('Uncorrected'))",float,doc="1-(muon-subtracted raw pt)/(raw pt)",precision=6)
     process.metTables += process.corrT1METJetTable
 #    makePuppiesFromMiniAOD(process,True) # call this before in the global customizer otherwise it would reset photon IDs in VID
-    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi")
     nanoAOD_PuppiV15_switch = cms.PSet(
             recoMetFromPFCs = cms.untracked.bool(False),
             reclusterJets = cms.untracked.bool(False),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -642,8 +642,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
-              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+            from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+                      cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
@@ -666,8 +668,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
             getattr(process, _myPatMet).srcPFCands= "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
-              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+            from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+                      cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else
@@ -844,7 +848,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                            )
             if self.getvalue("Puppi"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-              run2_miniAOD_UL.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
+              from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                 modifier.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 
@@ -856,8 +862,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                                 )
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
-              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
+              from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                  modifier.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
+                  modifier.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
@@ -869,7 +877,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               )
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
+              from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
@@ -881,7 +891,9 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               )
             if self.getvalue("Puppi"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-              run2_miniAOD_UL.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
+              from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
@@ -893,8 +905,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                               )
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-              run2_miniAOD_UL.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
-              run2_miniAOD_UL.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
+              from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
+                modifier.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1499,8 +1513,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, _myPatMet).metSource = cms.InputTag("pfMetT1"+postfix)
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
                 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-                run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
-                  cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+                from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+                for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                    modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+                            cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                                   cms.InputTag("pfeGammaToCandidate","electrons"),
                                 copy.copy(self.getvalue("muonCollection")),
                                 copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -519,8 +519,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-            run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
-              cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
+            from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+                        cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
                             copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -516,7 +516,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
             addToProcessAndTask(_myPatMet,  getattr(process,'patPFMet').clone(), process, task)
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
-            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
+            #getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
+            getattr(process, _myPatMet).srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
         if metType == "PF":
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
@@ -638,7 +639,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if "T1" in correctionLevel:
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
+            #getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
+            getattr(process, _myPatMet).srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
@@ -662,7 +664,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             _myPatMet = "patMETs"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
-            getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
+            #getattr(process, _myPatMet).srcPFCands=copy.copy(self.getvalue("pfCandCollection"))
+            getattr(process, _myPatMet).srcPFCands= "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             run2_miniAOD_UL.toModify(getattr(process, _myPatMet), srcLeptons = \
               cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
@@ -836,7 +839,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector",
-                                           src = pfCandCollection,
+                                           #src = pfCandCollection,
+                                           src = cms.InputTag("puppiForMET") if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")),
                                            veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
@@ -1647,7 +1651,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #puppi
             if self._parameters["Puppi"].value:
                 getattr(process, jetColName).src = cms.InputTag("puppi")
-                getattr(process, jetColName).applyWeights = True
 
             patMetModuleSequence += getattr(process, jetColName)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1478,7 +1478,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #raw MET
             from RecoMET.METProducers.PFMET_cfi import pfMet
             addToProcessAndTask("pfMet"+postfix, pfMet.clone(), process, task)
-            getattr(process, "pfMet"+postfix).src = pfCandCollection
+            getattr(process, "pfMet"+postfix).src = "puppiForMET" if self.getvalue("Puppi") else pfCandCollection
             getattr(process, "pfMet"+postfix).calculateSignificance = False
             patMetModuleSequence += getattr(process, "pfMet"+postfix)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -254,10 +254,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             self.setParameter('CHS',False),
 
         #enabling puppi flag
-        self.setParameter('Puppi',self._defaultParameters['Puppi'].value) 
+        self.setParameter('Puppi',self._defaultParameters['Puppi'].value)
         if metType == "Puppi":
-            self.setParameter('metType',"PF") 
-            self.setParameter('Puppi',True) 
+            self.setParameter('metType',"PF")
+            self.setParameter('Puppi',True)
 
         #jet energy scale uncertainty needs
         if manualJetConfig:
@@ -274,7 +274,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if fixEE2017:
             if recoMetFromPFCsIsNone: self.setParameter('recoMetFromPFCs',True)
             if reclusterJetsIsNone: self.setParameter('reclusterJets',False)
-        
+
         #met reprocessing and jet reclustering
         if recoMetFromPFCs and reclusterJetsIsNone and not fixEE2017:
             self.setParameter('reclusterJets',True)
@@ -317,11 +317,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         fixEE2017               = self._parameters['fixEE2017'].value
         fixEE2017Params         = self._parameters['fixEE2017Params'].value
         extractDeepMETs         = self._parameters['extractDeepMETs'].value
-        
+
         #prepare jet configuration
         jetUncInfos = { "jCorrPayload":jetFlavor, "jCorLabelUpToL3":jetCorLabelUpToL3,
                         "jCorLabelL3Res":jetCorLabelL3Res, "jecUncFile":jecUncertaintyFile,
-                        "jecUncTag":"Uncertainty" }     
+                        "jecUncTag":"Uncertainty" }
 
         if (jecUncertaintyFile!="" and jecUncertaintyTag==None):
             jetUncInfos[ "jecUncTag" ] = ""
@@ -343,8 +343,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         # recompute the MET (and thus the jets as well for correction) from scratch
         if recoMetFromPFCs:
-            self.recomputeRawMetFromPfcs(process, 
-                                         pfCandCollection, 
+            self.recomputeRawMetFromPfcs(process,
+                                         pfCandCollection,
                                          onMiniAOD,
                                          patMetModuleSequence,
                                          postfix)
@@ -355,7 +355,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #jet AK4 reclustering if needed for JECs
 
         if reclusterJets:
-            jetCollectionUnskimmed = self.ak4JetReclustering(process, pfCandCollection, 
+            jetCollectionUnskimmed = self.ak4JetReclustering(process, pfCandCollection,
                                                              patMetModuleSequence, postfix)
 
         # or reapplication of jecs
@@ -364,17 +364,17 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 jetCollectionUnskimmed = self.updateJECs(process, jetCollectionUnskimmed, patMetModuleSequence, postfix)
 
 
-        #getting the jet collection that will be used for corrections 
+        #getting the jet collection that will be used for corrections
         #and uncertainty computation
-        jetCollection = self.getJetCollectionForCorsAndUncs(process, 
+        jetCollection = self.getJetCollectionForCorsAndUncs(process,
                                                             jetCollectionUnskimmed,
                                                             jetSelection,
                                                             autoJetCleaning,
                                                             patMetModuleSequence,
                                                             postfix)
 
-        #pre-preparation to run over miniAOD 
-        if onMiniAOD:            
+        #pre-preparation to run over miniAOD
+        if onMiniAOD:
             self.miniAODConfigurationPre(process, patMetModuleSequence, pfCandCollection, postfix)
         else:
             from PhysicsTools.PatUtils.pfeGammaToCandidate_cfi import pfeGammaToCandidate
@@ -393,14 +393,14 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 
 
-        #preparation to run over miniAOD (met reproduction) 
+        #preparation to run over miniAOD (met reproduction)
         if onMiniAOD:
-            self.miniAODConfiguration(process, 
+            self.miniAODConfiguration(process,
                                       pfCandCollection,
                                       jetCollection,
                                       patMetModuleSequence,
                                       postfix
-                                      )        
+                                      )
 
         # correct the MET
         patMetCorrectionSequence, metModName = self.getCorrectedMET(process, metType, correctionLevel,
@@ -460,7 +460,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         else:
             if not len(configtools.listModules(patShiftedModuleSequence))==0:
                 setattr(process, metModName+"patShiftedModuleSequence"+postfix , patShiftedModuleSequence)
-                tmpSeq = getattr(process, "patShiftedModuleSequence"+postfix)              
+                tmpSeq = getattr(process, "patShiftedModuleSequence"+postfix)
                 tmpSeq += getattr(process, metModName+"patShiftedModuleSequence"+postfix)
 
         if not hasattr(process, "patMetModuleSequence"+postfix):
@@ -542,7 +542,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         metModuleSequence += getattr(process, _myPatMet )
 
 #====================================================================================================
-    def getCorrectedMET(self, process, metType, correctionLevel,produceIntermediateCorrections, 
+    def getCorrectedMET(self, process, metType, correctionLevel,produceIntermediateCorrections,
                         jetCollection, metModuleSequence, postfix ):
 
         # default outputs
@@ -602,13 +602,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #"T2":cms.InputTag('patPFMetT2Corr'+postfix,   'type2'),
             #"Txy": cms.InputTag('patPFMetTxyCorr'+postfix),
             #"Smear":cms.InputTag('patPFMetT1T2SmearCorr'+postfix, 'type1'),
-            #"T2Smear":cms.InputTag('patPFMetT2SmearCorr'+postfix, 'type2') 
+            #"T2Smear":cms.InputTag('patPFMetT2SmearCorr'+postfix, 'type2')
             "T0":['patPFMetT0Corr'+postfix,''],
             "T1":['patPFMetT1T2Corr'+postfix, 'type1'],
             "T2":['patPFMetT2Corr'+postfix,   'type2'],
             "Txy": ['patPFMetTxyCorr'+postfix,''],
             "Smear":['patPFMetT1T2SmearCorr'+postfix, 'type1'],
-            "T2Smear":['patPFMetT2SmearCorr'+postfix, 'type2'] 
+            "T2Smear":['patPFMetT2SmearCorr'+postfix, 'type2']
             }
 
         corScheme=""
@@ -677,7 +677,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         task = getPatAlgosToolsTask(process)
 
         #T1 parameter tuning when CHS jets are not used
-        if "T1" in correctionLevel and not self._parameters["CHS"].value:  
+        if "T1" in correctionLevel and not self._parameters["CHS"].value:
             addToProcessAndTask("corrPfMetType1"+postfix, getattr(process, "corrPfMetType1" ).clone(), process, task)
             getattr(process, "corrPfMetType1"+postfix).src =  cms.InputTag("ak4PFJets"+postfix)
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabel = cms.InputTag("ak4PFL1FastL2L3Corrector")
@@ -685,7 +685,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "corrPfMetType1"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
             getattr(process, "basicJetsForMet"+postfix).offsetCorrLabel = cms.InputTag("ak4PFL1FastjetCorrector")
 
-        if "T1" in correctionLevel and self._parameters["Puppi"].value:  
+        if "T1" in correctionLevel and self._parameters["Puppi"].value:
             addToProcessAndTask("corrPfMetType1"+postfix, getattr(process, "corrPfMetType1" ).clone(), process, task)
             getattr(process, "corrPfMetType1"+postfix).src =  cms.InputTag("ak4PFJets"+postfix)
             getattr(process, "corrPfMetType1"+postfix).jetCorrLabel = cms.InputTag("ak4PFPuppiL1FastL2L3Corrector")
@@ -802,8 +802,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 #====================================================================================================
     def getMETUncertainties(self, process, metType, metModName, electronCollection,
-                            photonCollection, muonCollection, tauCollection, 
-                            pfCandCollection, jetCollection, jetUncInfos, 
+                            photonCollection, muonCollection, tauCollection,
+                            pfCandCollection, jetCollection, jetUncInfos,
                             postfix):
 
 
@@ -818,7 +818,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #===================================================================================
         if not isValidInputTag(jetCollection): #or jetCollection=="":
             print("INFO : jet collection %s does not exists, no energy resolution shifting will be performed in MET uncertainty tools" % jetCollection)
-        else: 
+        else:
             preId=""
             if "Smear" in metModName:
                 preId="Smeared"
@@ -835,8 +835,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not hasattr(process, "pfCandsForUnclusteredUnc"+postfix):
 
             #Jet projection ==
-            pfCandsNoJets = cms.EDProducer("CandPtrProjector", 
-                                           src = pfCandCollection, 
+            pfCandsNoJets = cms.EDProducer("CandPtrProjector",
+                                           src = pfCandCollection,
                                            veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
                                            )
@@ -847,7 +847,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 
             #electron projection ==
-            pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector", 
+            pfCandsNoJetsNoEle = cms.EDProducer("CandPtrProjector",
                                                 src = cms.InputTag("pfCandsNoJets"+postfix),
                                                 veto = copy.copy(electronCollection),
                                                 useDeltaRforFootprint = cms.bool(False)
@@ -860,7 +860,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
             #muon projection ==
-            pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector", 
+            pfCandsNoJetsNoEleNoMu = cms.EDProducer("CandPtrProjector",
                                               src = cms.InputTag("pfCandsNoJetsNoEle"+postfix),
                                               veto = copy.copy(muonCollection),
                                               useDeltaRforFootprint = cms.bool(False)
@@ -872,7 +872,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
             #tau projection ==
-            pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector", 
+            pfCandsNoJetsNoEleNoMuNoTau = cms.EDProducer("CandPtrProjector",
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMu"+postfix),
                                               veto = copy.copy(tauCollection),
                                               useDeltaRforFootprint = cms.bool(False)
@@ -884,7 +884,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
             #photon projection ==
-            pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector", 
+            pfCandsForUnclusteredUnc = cms.EDProducer("CandPtrProjector",
                                               src = cms.InputTag("pfCandsNoJetsNoEleNoMuNoTau"+postfix),
                                               veto = copy.copy(photonCollection),
                                               useDeltaRforFootprint = cms.bool(False)
@@ -899,7 +899,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #===================================================================================
         # energy shifts
         #===================================================================================
-        # PFMuons, PFElectrons, PFPhotons, and PFTaus will be used 
+        # PFMuons, PFElectrons, PFPhotons, and PFTaus will be used
         # to calculate MET Uncertainties.
         #===================================================================================
         #--------------
@@ -958,7 +958,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         tauCollection      = cms.InputTag("pfTaus"+postfix)
         photonCollection   = cms.InputTag("pfPhotons"+postfix)
 
-        
+
         objectCollections = { "Jet":jetCollection,
                               "Electron":electronCollection,
                               "Photon":photonCollection,
@@ -1015,7 +1015,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                              shiftBy = cms.double(+1.*varyByNsigmas)
                                              )
 
-        if identifier == "Unclustered":        
+        if identifier == "Unclustered":
             shiftedModuleUp = cms.EDProducer("ShiftedParticleProducer",
                                              src = objectCollection,
                                              binning = cms.VPSet(
@@ -1122,11 +1122,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             "T0pcT1T2SmearTxy_25ns":metCors.patMultPhiCorrParams_T0pcT1T2SmearTxy_25ns
             }
 
-        getattr(process, "patPFMetTxyCorr"+postfix).parameters = xyTags[corScheme+"_25ns"] 
+        getattr(process, "patPFMetTxyCorr"+postfix).parameters = xyTags[corScheme+"_25ns"]
 
 
 #====================================================================================================
-    def getVariations(self, process, metModName, identifier,preId, objectCollection, varType, 
+    def getVariations(self, process, metModName, identifier,preId, objectCollection, varType,
                       metUncSequence, jetUncInfos=None, postfix="" ):
 
         # temporary hardcoded varyByNSigma value
@@ -1152,7 +1152,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             shiftedCollModules['Up'] = self.createShiftedJetResModule(process, smear, objectCollection, +1.*varyByNsigmas,
                                                                       "Up", postfix)
             shiftedCollModules['Down'] = self.createShiftedJetResModule(process, smear, objectCollection, -1.*varyByNsigmas,
-                                                                        "Down", postfix)       
+                                                                        "Down", postfix)
         else:
             shiftedCollModules['Up'] = self.createEnergyScaleShiftedUpModule(process, identifier, objectCollection, varyByNsigmas, jetUncInfos, postfix)
             shiftedCollModules['Down'] = shiftedCollModules['Up'].clone( shiftBy = cms.double(-1.*varyByNsigmas) )
@@ -1168,7 +1168,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if identifier=="Jet" and varType=="Res" and self._parameters["runOnData"].value:
             shiftedMetProducers = self.copyCentralMETProducer(process, shiftedCollModules, identifier, metModName, varType, postfix)
         else:
-            shiftedMetProducers = self.createShiftedModules(process, shiftedCollModules, identifier, preId, objectCollection, 
+            shiftedMetProducers = self.createShiftedModules(process, shiftedCollModules, identifier, preId, objectCollection,
                                                             metModName, varType, metUncSequence, postfix)
 
         return shiftedMetProducers
@@ -1197,7 +1197,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 
 #========================================================================================
-    def createShiftedModules(self, process, shiftedCollModules, identifier, preId, objectCollection, 
+    def createShiftedModules(self, process, shiftedCollModules, identifier, preId, objectCollection,
                              metModName, varType, metUncSequence, postfix):
 
         shiftedMetProducers = {}
@@ -1240,12 +1240,12 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #MM: FIXME MVA
             #MVA MET, duplication of the MVA MET producer ============================================
             #if "MVA" in metModName:
-            #    print "name: ",metModName, modName 
+            #    print "name: ",metModName, modName
             #    shiftedMETModule = self.createMVAMETModule(process, identifier, modName, True)
             #    modName = baseName+identifier+varType+mod+postfix
             #    setattr(process, modName, shiftedMETModule)
             #    shiftedMetProducers[ modName ] = shiftedMETModule
-            #    
+            #
             #     #pileupjetId and  =====
             #    if identifier == "Jet":
             #        #special collection replacement for the MVAMET for the jet case ======
@@ -1329,7 +1329,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             leptons.append = tauCollection
 
 
-        mvaMetProducer=getattr(process, "pfMVAMEt").clone( 
+        mvaMetProducer=getattr(process, "pfMVAMEt").clone(
             srcCorrJets = corJetCollection,
             srcUncorrJets = uncorJetCollection,
             srcPFCandidates = pfCandCollection,
@@ -1360,8 +1360,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         pfCandCollection = self._parameters["pfCandCollection"].value
 
         #top projection on jets
-        pfCandsNotInJets = cms.EDProducer("CandPtrProjector", 
-                                          src = pfCandCollection, 
+        pfCandsNotInJets = cms.EDProducer("CandPtrProjector",
+                                          src = pfCandCollection,
                                           veto = cms.InputTag("ak4PFJets")
                                           )
         setattr(process, "pfCandsNotInJetsUnclusteredEn"+var+postfix, pfCandsNotInJets)
@@ -1416,7 +1416,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 enabled = cms.bool(smear),
                 variation = cms.int32( int(varyByNsigmas) ),
                 genJets = genJetsCollection,
-                )    
+                )
 
         if self._parameters["Puppi"].value:
             smearedJetModule.algo = cms.string('AK4PFPuppi')
@@ -1542,8 +1542,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
         patJetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
             src = jetCollection if not self._parameters["Puppi"].value else cms.InputTag("slimmedJetsPuppi"),
-            levels = ['L1FastJet', 
-                      'L2Relative', 
+            levels = ['L1FastJet',
+                      'L2Relative',
                       'L3Absolute'],
             payload = 'AK4PFchs' if not self._parameters["Puppi"].value else 'AK4PFPuppi' ) # always CHS from miniAODs, except for puppi
 
@@ -1566,7 +1566,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         return  cms.InputTag("patJetsReapplyJEC"+postfix)
 
 
-    def getJetCollectionForCorsAndUncs(self, process, jetCollectionUnskimmed, 
+    def getJetCollectionForCorsAndUncs(self, process, jetCollectionUnskimmed,
                                        jetSelection, autoJetCleaning,patMetModuleSequence, postfix):
 
         task = getPatAlgosToolsTask(process)
@@ -1612,7 +1612,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             jetColName="ak4PFJetsCHS"
 
             pfCHS=None
-            if self._parameters["onMiniAOD"].value: 
+            if self._parameters["onMiniAOD"].value:
                 pfCHS = cms.EDFilter("CandPtrSelector", src = pfCandCollection, cut = cms.string("fromPV"))
                 pfCandColl = cms.InputTag("pfNoPileUpJME"+postfix)
                 addToProcessAndTask("pfNoPileUpJME"+postfix, pfCHS, process, task)
@@ -1627,7 +1627,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 configtools.cloneProcessingSnippet(process, getattr(process,"pfNoPileUpJMESequence"), postfix, addToTask = True )
                 getattr(process, "pfPileUpJME"+postfix).PFCandidates = cms.InputTag("tmpPFCandCollPtr"+postfix)
                 addToProcessAndTask("pfNoPileUpJME"+postfix,
-                        getattr(process, "pfNoPileUpJME"+postfix).clone( 
+                        getattr(process, "pfNoPileUpJME"+postfix).clone(
                         bottomCollection = cms.InputTag("tmpPFCandCollPtr"+postfix) ),
                         process, task )
                 pfCandColl = cms.InputTag("pfNoPileUpJME"+postfix)
@@ -1641,12 +1641,13 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
             #if chs:
             addToProcessAndTask(jetColName, ak4PFJets.clone(), process, task)
-            getattr(process, jetColName).src = pfCandColl 
+            getattr(process, jetColName).src = pfCandColl
             getattr(process, jetColName).doAreaFastjet = True
 
             #puppi
             if self._parameters["Puppi"].value:
                 getattr(process, jetColName).src = cms.InputTag("puppi")
+                getattr(process, jetColName).applyWeights = True
 
             patMetModuleSequence += getattr(process, jetColName)
 
@@ -1660,11 +1661,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                 postfix=postfix
                                 )
 
-            getattr(process,"patJets"+postfix).addGenJetMatch = False 
-            getattr(process,"patJets"+postfix).addGenPartonMatch = False 
-            getattr(process,"patJets"+postfix).addPartonJetMatch = False 
-            getattr(process,"patJets"+postfix).embedGenPartonMatch = False 
-            getattr(process,"patJets"+postfix).embedGenJetMatch = False 
+            getattr(process,"patJets"+postfix).addGenJetMatch = False
+            getattr(process,"patJets"+postfix).addGenPartonMatch = False
+            getattr(process,"patJets"+postfix).addPartonJetMatch = False
+            getattr(process,"patJets"+postfix).embedGenPartonMatch = False
+            getattr(process,"patJets"+postfix).embedGenJetMatch = False
             if self._parameters['onMiniAOD'].value:
                 del getattr(process,"patJets"+postfix).JetFlavourInfoSource
                 del getattr(process,"patJets"+postfix).JetPartonMapSource
@@ -1725,7 +1726,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                   alias = cms.string('pfMet'),
                                   globalThreshold = cms.double(0.0),
                                   calculateSignificance = cms.bool(False),
-                                  )            
+                                  )
 
         addToProcessAndTask("pfMetCHS", pfMetCHS, process, task)
 
@@ -1748,7 +1749,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                                   alias = cms.string('pfMet'),
                                   globalThreshold = cms.double(0.0),
                                   calculateSignificance = cms.bool(False),
-                                  )            
+                                  )
 
         addToProcessAndTask("pfMetTrk", pfMetTrk, process, task)
 
@@ -1777,11 +1778,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
 
     def miniAODConfiguration(self, process, pfCandCollection, jetCollection,
-                             patMetModuleSequence, postfix ):      
+                             patMetModuleSequence, postfix ):
         if self._parameters["metType"].value == "PF": # not hasattr(process, "pfMet"+postfix)
             if "T1" in self._parameters['correctionLevel'].value:
                 getattr(process, "patPFMet"+postfix).srcJets = jetCollection
-                getattr(process, "patPFMet"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value, 
+                getattr(process, "patPFMet"+postfix).srcLeptons = cms.VInputTag(self._parameters["electronCollection"].value,
                                                                                 self._parameters["muonCollection"].value,
                                                                                 self._parameters["photonCollection"].value,
                                                                                 )
@@ -1876,10 +1877,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         task = getPatAlgosToolsTask(process)
 
         if autoJetCleaning == "Full" : # auto clean taus, photons and jets
-            if isValidInputTag(tauCollection): 
+            if isValidInputTag(tauCollection):
                 process.load("PhysicsTools.PatAlgos.cleaningLayer1.tauCleaner_cfi")
                 task.add(process.cleanPatTaus)
-                cleanPatTauProducer = getattr(process, "cleanPatTaus").clone( 
+                cleanPatTauProducer = getattr(process, "cleanPatTaus").clone(
                     src = tauCollection
                     )
                 cleanPatTauProducer.checkOverlaps.electrons.src = electronCollection
@@ -1888,10 +1889,10 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 jetProductionSequence += getattr(process, "cleanedPatTaus"+postfix)
                 tauCollection = cms.InputTag("cleanedPatTaus"+postfix)
 
-            if isValidInputTag(photonCollection): 
+            if isValidInputTag(photonCollection):
                 process.load("PhysicsTools.PatAlgos.cleaningLayer1.photonCleaner_cfi")
                 task.add(process.cleanPatPhotons)
-                cleanPatPhotonProducer = getattr(process, "cleanPatPhotons").clone( 
+                cleanPatPhotonProducer = getattr(process, "cleanPatPhotons").clone(
                     src = photonCollection
                     )
                 cleanPatPhotonProducer.checkOverlaps.electrons.src = electronCollection
@@ -1902,7 +1903,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #jet cleaning
         have_cleanPatJets = hasattr(process, "cleanPatJets")
         process.load("PhysicsTools.PatAlgos.cleaningLayer1.jetCleaner_cfi")
-        cleanPatJetProducer = getattr(process, "cleanPatJets").clone( 
+        cleanPatJetProducer = getattr(process, "cleanPatJets").clone(
                      src = cms.InputTag(jetCollectionName)
             )
         #do not leave it hanging

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -1213,8 +1213,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #MM: FIXME MVA
             #if  "MVA" in metModName and identifier == "Jet": #dummy fix
             #    modName = "uncorrectedshiftedPat"+preId+identifier+varType+mod+postfix
-            if (identifier=="Photon" or identifier=="Unclustered") and self.getvalue("Puppi"):
-                shiftedCollModules[mod].srcWeights = cms.InputTag("puppiForMet")
             if not hasattr(process, modName):
                 addToProcessAndTask(modName, shiftedCollModules[mod], process, task)
                 metUncSequence += getattr(process, modName)
@@ -1226,8 +1224,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if "PF" in metModName:
                 #create the MET shifts and add them to the sequence
                 shiftedMETCorrModule = self.createShiftedMETModule(process, objectCollection, modName)
-                if (identifier=="Photon" or identifier=="Unclustered") and self.getvalue("Puppi"):
-                    shiftedMETCorrModule.srcWeights = cms.InputTag("puppiForMet")
                 modMETShiftName = "shiftedPatMETCorr"+preId+identifier+varType+mod+postfix
                 if not hasattr(process, modMETShiftName):
                     addToProcessAndTask(modMETShiftName, shiftedMETCorrModule, process, task)
@@ -1482,7 +1478,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             #raw MET
             from RecoMET.METProducers.PFMET_cfi import pfMet
             addToProcessAndTask("pfMet"+postfix, pfMet.clone(), process, task)
-            getattr(process, "pfMet"+postfix).src = "puppiForMET" if self.getvalue("Puppi") else pfCandCollection
+            getattr(process, "pfMet"+postfix).src = pfCandCollection
             getattr(process, "pfMet"+postfix).calculateSignificance = False
             patMetModuleSequence += getattr(process, "pfMet"+postfix)
 

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -516,6 +516,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             configtools.cloneProcessingSnippet(process, getattr(process,"producePatPFMETCorrections"), postfix, noClones = noClonesTmp, addToTask = True)
             addToProcessAndTask(_myPatMet,  getattr(process,'patPFMet').clone(), process, task)
             getattr(process, _myPatMet).metSource = cms.InputTag("pfMet"+postfix)
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
@@ -635,6 +636,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         #Txy parameter tuning
         if "Txy" in correctionLevel:
             self.tuneTxyParameters(process, corScheme, postfix)
+            getattr(process, "patPFMetTxyCorr"+postfix).srcPFlow = self._parameters["pfCandCollection"].value
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
@@ -645,6 +647,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if "T1" in correctionLevel:
             _myPatMet = "pat"+metType+"Met"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
@@ -671,6 +674,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
         if not self._parameters["onMiniAOD"].value and not postfix=="NoHF":
             _myPatMet = "patMETs"+postfix
             getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
+            getattr(process, _myPatMet).srcPFCands= copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
@@ -847,7 +851,6 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector",
-                                           #src = cms.InputTag("puppiForMET") if self.getvalue("Puppi") else pfCandCollection,
                                            src = pfCandCollection,
                                            veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
@@ -1502,6 +1505,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             from RecoMET.METProducers.PFMET_cfi import pfMet
             addToProcessAndTask("pfMet"+postfix, pfMet.clone(), process, task)
             getattr(process, "pfMet"+postfix).calculateSignificance = False
+            getattr(process, "pfMet"+postfix).src = pfCandCollection
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -648,7 +648,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
             (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")) )
-                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcLeptons = \
                       cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -519,13 +519,11 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify( getattr(process, _myPatMet), srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")) )
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify( getattr(process, _myPatMet), srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")) )
         if metType == "PF":
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcLeptons = \
                                                 cms.VInputTag( copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","electrons"),
                                                                 copy.copy(self.getvalue("muonCollection")),
                                                                 copy.copy(self.getvalue("photonCollection")) if self.getvalue("onMiniAOD") else cms.InputTag("pfeGammaToCandidate","photons")
@@ -639,8 +637,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "patPFMetTxyCorr"+postfix).srcPFlow = self._parameters["pfCandCollection"].value
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify( getattr(process, "patPFMetTxyCorr"+postfix), srcPFlow = "puppiForMET" if self.getvalue("Puppi") else self._parameters["pfCandCollection"].value )
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify( getattr(process, "patPFMetTxyCorr"+postfix), srcPFlow = "puppiForMET" if self.getvalue("Puppi") else self._parameters["pfCandCollection"].value )
 
 
         #Enable MET significance if the type1 MET is computed
@@ -650,8 +647,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).srcPFCands = copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(getattr(process, _myPatMet), srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")) )
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcPFCands = "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")) )
                 modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
                       cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
@@ -677,9 +673,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, _myPatMet).srcPFCands= copy.copy(self.getvalue("pfCandCollection"))
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(getattr(process, _myPatMet), srcPFCands= "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")))
-                modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcPFCands= "puppiForMET" if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")))
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcLeptons = \
                       cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                               cms.InputTag("pfeGammaToCandidate","electrons"),
                             copy.copy(self.getvalue("muonCollection")),
@@ -858,9 +853,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if self.getvalue("Puppi"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
               from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                 modifier.toModify(pfCandsNoJets, src = cms.InputTag('puppiForMET'))
-                 modifier.toModify(pfCandsNoJets, useDeltaRforFootprint = True)
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJets, src = cms.InputTag('puppiForMET'))
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJets, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJets"+postfix, pfCandsNoJets, process, task)
             metUncSequence += getattr(process, "pfCandsNoJets"+postfix)
 
@@ -873,9 +867,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
               from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                  modifier.toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
-                  modifier.toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJetsNoEle, useDeltaRforFootprint = True)
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJetsNoEle, veto = cms.InputTag("pfeGammaToCandidate","electrons"))
             addToProcessAndTask("pfCandsNoJetsNoEle"+postfix, pfCandsNoJetsNoEle, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEle"+postfix)
 
@@ -888,8 +881,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
               from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJetsNoEleNoMu, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMu"+postfix, pfCandsNoJetsNoEleNoMu, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMu"+postfix)
 
@@ -902,8 +894,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if self.getvalue("Puppi"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
               from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsNoJetsNoEleNoMuNoTau, useDeltaRforFootprint = True)
             addToProcessAndTask("pfCandsNoJetsNoEleNoMuNoTau"+postfix, pfCandsNoJetsNoEleNoMuNoTau, process, task)
             metUncSequence += getattr(process, "pfCandsNoJetsNoEleNoMuNoTau"+postfix)
 
@@ -916,9 +907,8 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             if not self.getvalue("onMiniAOD"):
               from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
               from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-              for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
-                modifier.toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsForUnclusteredUnc, useDeltaRforFootprint = True)
+              (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(pfCandsForUnclusteredUnc, veto = cms.InputTag("pfeGammaToCandidate","photons"))
             addToProcessAndTask("pfCandsForUnclusteredUnc"+postfix, pfCandsForUnclusteredUnc, process, task)
             metUncSequence += getattr(process, "pfCandsForUnclusteredUnc"+postfix)
 
@@ -1508,8 +1498,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
             getattr(process, "pfMet"+postfix).src = pfCandCollection
             from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
             from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-            for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                modifier.toModify( getattr(process, "pfMet"+postfix), src = "puppiForMET" if self.getvalue("Puppi") else pfCandCollection )
+            (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify( getattr(process, "pfMet"+postfix), src = "puppiForMET" if self.getvalue("Puppi") else pfCandCollection )
             patMetModuleSequence += getattr(process, "pfMet"+postfix)
 
             #PAT METs
@@ -1528,8 +1517,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
                 getattr(process, _myPatMet).computeMETSignificance = cms.bool(self.getvalue("computeMETSignificance"))
                 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
                 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-                for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-                    modifier.toModify(getattr(process, _myPatMet), srcLeptons = \
+                (run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(getattr(process, _myPatMet), srcLeptons = \
                             cms.VInputTag(copy.copy(self.getvalue("electronCollection")) if self.getvalue("onMiniAOD") else
                                   cms.InputTag("pfeGammaToCandidate","electrons"),
                                 copy.copy(self.getvalue("muonCollection")),

--- a/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runMETCorrectionsAndUncertainties.py
@@ -842,7 +842,7 @@ class RunMETCorrectionsAndUncertainties(ConfigToolBase):
 
             #Jet projection ==
             pfCandsNoJets = cms.EDProducer("CandPtrProjector",
-                                           src = cms.InputTag("puppiForMET") if self.getvalue("Puppi") else copy.copy(self.getvalue("pfCandCollection")),
+                                           src = cms.InputTag("puppiForMET") if self.getvalue("Puppi") else pfCandCollection,
                                            veto = copy.copy(jetCollection),
                                            useDeltaRforFootprint = cms.bool(False)
                                            )

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -4,7 +4,7 @@ METSignificanceParams = cms.PSet(
 
       # jet resolutions
       jetThreshold = cms.double(15),
-      
+
       #jet-lepton matching dR
       dRMatch = cms.double(0.4),
 
@@ -25,7 +25,7 @@ METSignificanceParams_Data=cms.PSet(
 
       # jet resolutions
       jetThreshold = cms.double(15),
-      
+
       #jet-lepton matching dR
       dRMatch = cms.double(0.4),
 
@@ -43,5 +43,7 @@ METSignificanceParams_Data=cms.PSet(
       )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-run2_miniAOD_UL.toModify(METSignificanceParams, useDeltaRforFootprint = True)
-run2_miniAOD_UL.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
+    modifier.toModify(METSignificanceParams, useDeltaRforFootprint = True)
+    modifier.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -44,6 +44,5 @@ METSignificanceParams_Data=cms.PSet(
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
 from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
-for modifier in run2_miniAOD_UL, run2_nanoAOD_106Xv1:
-    modifier.toModify(METSignificanceParams, useDeltaRforFootprint = True)
-    modifier.toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)
+(run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(METSignificanceParams, useDeltaRforFootprint = True)
+(run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(METSignificanceParams_Data, useDeltaRforFootprint = True)


### PR DESCRIPTION
#### PR description:

 * This PR only affects nanoAOD.
 * It includes the PuppiMET collection with the new PUPPIv15.
 * Additionally updates the training for PUID to UL17.
 * Fix jetID for FatJet in nanoAOD

This is a backport of #31927.