### PR TITLE
Protect against empty weight container from pythia8

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -896,6 +896,10 @@ bool Pythia8Hadronizer::residualDecay() {
 void Pythia8Hadronizer::finalizeEvent() {
   bool lhe = lheEvent() != nullptr;
 
+  // protection against empty weight container
+  if ((event()->weights()).empty())
+    (event()->weights()).push_back(1.);
+
   // now create the GenEventInfo product from the GenEvent and fill
   // the missing pieces
   eventInfo() = std::make_unique<GenEventInfoProduct>(event().get());


### PR DESCRIPTION
#### PR description:

Fix GeneratorInterface crash at the upgrade of pythia8 to 303

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
