### PR TITLE
[PPC] fix two unit tests in FWCore/MessageService

### DIFF
--- a/FWCore/MessageService/test/u2.sh
+++ b/FWCore/MessageService/test/u2.sh
@@ -10,8 +10,9 @@ status=0
 rm -f  u2_warnings.log u2_cerr.mout 
 
 cmsRun -p $LOCAL_TEST_DIR/u2_cfg.py 2> $LOCAL_TMP_DIR/u2_cerr.mout || exit $?
- 
-for file in u2_warnings.log u2_cerr.mout   
+sed -n '/Disabling gnu++: clang has no __float128 support on this target!/!p' u2_cerr.mout > tmpf && mv tmpf u2_cerr.mout # remove clang output
+
+for file in u2_warnings.log u2_cerr.mout
 do
   sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file
   diff $LOCAL_TEST_DIR/unit_test_outputs/$file $LOCAL_TMP_DIR/$file  

--- a/FWCore/MessageService/test/u20.sh
+++ b/FWCore/MessageService/test/u20.sh
@@ -10,7 +10,8 @@ status=0
 rm -f u20_cerr.log FrameworkJobReport.xml
 
 cmsRun -e -p $LOCAL_TEST_DIR/u20_cfg.py 2> u20_cerr.log || exit $?
- 
+sed -n '/Disabling gnu++: clang has no __float128 support on this target!/!p' u20_cerr.log > tmpf && mv tmpf u20_cerr.log # remove clang output
+
 for file in u20_cerr.log FrameworkJobReport.xml   
 do
   sed $SED_OPT -f $LOCAL_TEST_DIR/filter-timestamps.sed $file


### PR DESCRIPTION
#### PR description:

two tests are failing due to clang output getting into the log output and the output compared with a reference.
this removes the clang output from the logs.

#### PR validation:

the two unit tests run after this change

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

no backport this only concerns powerpc IBs 
