### PR TITLE
[PPC] Discard clang warning from test output

### DIFF
--- a/FWCore/Integration/test/run_SubProcess.sh
+++ b/FWCore/Integration/test/run_SubProcess.sh
@@ -13,7 +13,7 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/${test}_cfg.py >& ${test}.log 2>&1 || die "cmsRun ${test}_cfg.py" $?
   grep Doodad ${test}.log > testSubProcess.grep.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep.txt testSubProcess.grep.txt || die "comparing testSubProcess.grep.txt" $?
-  grep "++" ${test}.log > testSubProcess.grep2.txt
+  grep "++" ${test}.log | grep -v "Disabling gnu" > testSubProcess.grep2.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep2.txt testSubProcess.grep2.txt || die "comparing testSubProcess.grep2.txt" $?
 
   echo cmsRun readSubProcessOutput_cfg.py


### PR DESCRIPTION
#### PR description:

Fix this test 
https://cmssdt.cern.ch/SDT/cgi-bin/logreader/slc7_ppc64le_gcc820/CMSSW_11_2_X_2020-11-05-2300/unitTestLogs/FWCore/Integration#/8902
remove warning from log to not fail log to log comparison 

#### PR validation:

the test run 
