### PR TITLE
Logging of BeamSpotOnline

### DIFF
--- a/DQM/BeamMonitor/plugins/BeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.h
@@ -24,6 +24,7 @@
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "RecoVertex/BeamSpotProducer/interface/BSTrkParameters.h"
 #include "RecoVertex/BeamSpotProducer/interface/BeamFitter.h"
+#include "CondCore/DBOutputService/interface/OnlineDBOutputService.h"
 #include <fstream>
 
 //
@@ -71,8 +72,10 @@ private:
   std::string recordName_;                  // output BeamSpotOnline Record name
   edm::EDGetTokenT<reco::BeamSpot> bsSrc_;  // beam spot
   edm::EDGetTokenT<reco::TrackCollection> tracksLabel_;
-  edm::EDGetTokenT<reco::VertexCollection> pvSrc_;  // primary vertex
-  edm::EDGetTokenT<edm::TriggerResults> hltSrc_;    //hlt collection
+  edm::EDGetTokenT<reco::VertexCollection> pvSrc_;                      // primary vertex
+  edm::EDGetTokenT<edm::TriggerResults> hltSrc_;                        //hlt collection
+  edm::Service<cond::service::OnlineDBOutputService> onlineDbService_;  // DB service
+  int DBloggerReturn_;                                                  // DB logger return value
 
   int fitNLumi_;
   int fitPVNLumi_;

--- a/DQM/BeamMonitor/plugins/FakeBeamMonitor.h
+++ b/DQM/BeamMonitor/plugins/FakeBeamMonitor.h
@@ -23,6 +23,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
+#include "CondCore/DBOutputService/interface/OnlineDBOutputService.h"
 #include <fstream>
 #include "TRandom3.h"
 
@@ -70,7 +71,9 @@ private:
   const double dzMin_;
   const double dzMax_;
   std::string monitorName_;
-  std::string recordName_;  // output BeamSpotOnline Record name
+  std::string recordName_;                                              // output BeamSpotOnline Record name
+  edm::Service<cond::service::OnlineDBOutputService> onlineDbService_;  // DB service
+  int DBloggerReturn_;                                                  // DB logger return value
 
   int fitNLumi_;
   int fitPVNLumi_;


### PR DESCRIPTION
#### PR description:
Added logging to DB of BeamSpot fit results and information both in `BeamMonitor` and `FakeBeamMonitor`.
- No changes are expected in the BeamSpot itself
- Most of the information that usually is dumped in `edm::LogInfo` is now also logged to the DB 
- Updated the BeamSpotOnline creation time from `PoolDBOutputService->currentTime()` to a more universal time: epochs expressed in microseconds.

#### PR validation:
The changes have been tested privately both running on some local files (`BeamMonitor`) and using fake beamspot values (`FakeBeamMonitor`). This PR should probably be tested at the P5 DQM playback.

#### Backporting
Backport to 11_1_X is provided in #32095