### PR TITLE
Migration of pixel code to esConsumes

### DIFF
--- a/CalibTracker/SiPixelConnectivity/interface/SiPixelFedCablingMapBuilder.h
+++ b/CalibTracker/SiPixelConnectivity/interface/SiPixelFedCablingMapBuilder.h
@@ -1,9 +1,12 @@
 #ifndef SiPixelFedCablingMapBuilder_H
 #define SiPixelFedCablingMapBuilder_H
 
-#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingTree.h"
-#include "DataFormats/DetId/interface/DetId.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <vector>
 #include <string>
@@ -14,7 +17,7 @@ class PixelGeomDetUnit;
 class SiPixelFedCablingMapBuilder {
 public:
   //SiPixelFedCablingMapBuilder(const std::string & associatorName);
-  SiPixelFedCablingMapBuilder(const std::string fileName, const bool phase1 = false);
+  SiPixelFedCablingMapBuilder(edm::ConsumesCollector&& iCC, const std::string fileName, const bool phase1 = false);
   SiPixelFedCablingTree* produce(const edm::EventSetup& setup);
 
 private:
@@ -27,6 +30,9 @@ private:
   std::string fileName_;
   std::string myprint(const PixelGeomDetUnit* pxUnit);
   bool phase1_;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 };
 
 #endif

--- a/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
+++ b/CalibTracker/SiPixelConnectivity/src/SiPixelFedCablingMapBuilder.cc
@@ -1,11 +1,8 @@
 #include <iostream>
 
 #include "CalibTracker/SiPixelConnectivity/interface/SiPixelFedCablingMapBuilder.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <ostream>
 #include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
@@ -30,16 +27,19 @@
 using namespace std;
 using namespace sipixelobjects;
 
-SiPixelFedCablingMapBuilder::SiPixelFedCablingMapBuilder(const string fileName,
+SiPixelFedCablingMapBuilder::SiPixelFedCablingMapBuilder(edm::ConsumesCollector&& iCC,
+                                                         const string fileName,
                                                          const bool phase1)
     : fileName_(fileName)  //, phase1_(phase1) not used anymore
-{}
+{
+  trackerTopoToken_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = iCC.esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+}
 
 SiPixelFedCablingTree* SiPixelFedCablingMapBuilder::produce(const edm::EventSetup& setup) {
   // Access geometry
   edm::LogInfo("read tracker geometry...");
-  edm::ESHandle<TrackerGeometry> pDD;
-  setup.get<TrackerDigiGeometryRecord>().get(pDD);
+  edm::ESHandle<TrackerGeometry> pDD = setup.getHandle(trackerGeomToken_);
   edm::LogInfo("tracker geometry read") << "There are: " << pDD->dets().size() << " detectors";
 
   // Test new TrackerGeometry features
@@ -86,8 +86,7 @@ SiPixelFedCablingTree* SiPixelFedCablingMapBuilder::produce(const edm::EventSetu
   edm::LogInfo(" version ") << version << endl;
 
   // Access topology
-  edm::ESHandle<TrackerTopology> tTopo;
-  setup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = setup.getHandle(trackerTopoToken_);
   const TrackerTopology* tt = tTopo.product();
 
   typedef TrackerGeometry::DetContainer::const_iterator ITG;

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter.cc
@@ -61,7 +61,7 @@ void SiPixelFedCablingMapWriter::analyze(const edm::Event& iEvent, const edm::Ev
     //std::cout << "-------HERE-----------" << endl;
     //cabling = SiPixelFedCablingMapBuilder(pixelToFedAssociator_).produce(iSetup);
     //cabling = SiPixelFedCablingMapBuilder(fileName_,phase1_).produce(iSetup);
-    cabling = SiPixelFedCablingMapBuilder(fileName_).produce(iSetup);
+    cabling = SiPixelFedCablingMapBuilder(consumesCollector(), fileName_).produce(iSetup);
     //std::cout << "-------Print Map ----------- DOES NOT WORK for phase1 " << endl;
     edm::LogInfo("PRINTING MAP (Does not work for phase1: ") << cabling->print(3);
   }

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h
@@ -19,6 +19,8 @@
 //
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -34,6 +36,7 @@ private:
   void analyze(const edm::Event &, const edm::EventSetup &) override;
 
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
   std::ofstream outputFile_;
   std::string filePath_;
 };

--- a/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixelDetInfoFileWriter.cc
@@ -6,11 +6,8 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelDetInfoFileWriter.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -21,6 +18,7 @@ using namespace std;
 SiPixelDetInfoFileWriter::SiPixelDetInfoFileWriter(const edm::ParameterSet &iConfig) {
   edm::LogInfo("SiPixelDetInfoFileWriter::SiPixelDetInfoFileWriter");
 
+  trackerGeomTokenBeginRun_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
   filePath_ = iConfig.getUntrackedParameter<std::string>("FilePath", std::string("SiPixelDetInfo.dat"));
 }
 
@@ -32,9 +30,7 @@ void SiPixelDetInfoFileWriter::beginRun(const edm::Run &run, const edm::EventSet
   outputFile_.open(filePath_.c_str());
 
   if (outputFile_.is_open()) {
-    edm::ESHandle<TrackerGeometry> pDD;
-
-    iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+    edm::ESHandle<TrackerGeometry> pDD = iSetup.getHandle(trackerGeomTokenBeginRun_);
 
     edm::LogInfo("SiPixelDetInfoFileWriter::beginJob - got geometry  ") << std::endl;
     edm::LogInfo("SiPixelDetInfoFileWriter") << " There are " << pDD->detUnits().size() << " detectors" << std::endl;

--- a/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
@@ -22,13 +22,15 @@ private:
   // ----------member data ---------------------------
   const bool printdebug_;
   const std::string formatedOutput_;
-  edm::ESGetToken<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd> pixelFEDChannelCollectionMapToken_;
+  edm::ESGetToken<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd>
+      pixelFEDChannelCollectionMapToken_;
 };
 
 PixelFEDChannelCollectionMapTestReader::PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p)
     : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
       formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")),
-      pixelFEDChannelCollectionMapToken_(esConsumes<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd>()) {
+      pixelFEDChannelCollectionMapToken_(
+          esConsumes<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd>()) {
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "PixelFEDChannelCollectionMapTestReader" << std::endl;
 }
 
@@ -52,7 +54,8 @@ void PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const 
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<PixelFEDChannelCollectionMap> PixelFEDChannelCollectionMapHandle = context.getHandle(pixelFEDChannelCollectionMapToken_);
+  edm::ESHandle<PixelFEDChannelCollectionMap> PixelFEDChannelCollectionMapHandle =
+      context.getHandle(pixelFEDChannelCollectionMapToken_);
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got eshandle and context" << std::endl;
 
   const PixelFEDChannelCollectionMap* thePixelFEDChannelCollectionMap = PixelFEDChannelCollectionMapHandle.product();

--- a/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/PixelFEDChannelCollectionMapTestReader.cc
@@ -2,12 +2,9 @@
 #include <iostream>
 #include <map>
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/SiPixelDetId/interface/PixelFEDChannel.h"
 #include "CalibTracker/Records/interface/SiPixelFEDChannelContainerESProducerRcd.h"
 
@@ -25,11 +22,13 @@ private:
   // ----------member data ---------------------------
   const bool printdebug_;
   const std::string formatedOutput_;
+  edm::ESGetToken<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd> pixelFEDChannelCollectionMapToken_;
 };
 
 PixelFEDChannelCollectionMapTestReader::PixelFEDChannelCollectionMapTestReader(edm::ParameterSet const& p)
     : printdebug_(p.getUntrackedParameter<bool>("printDebug", true)),
-      formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")) {
+      formatedOutput_(p.getUntrackedParameter<std::string>("outputFile", "")),
+      pixelFEDChannelCollectionMapToken_(esConsumes<PixelFEDChannelCollectionMap, SiPixelFEDChannelContainerESProducerRcd>()) {
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "PixelFEDChannelCollectionMapTestReader" << std::endl;
 }
 
@@ -53,11 +52,8 @@ void PixelFEDChannelCollectionMapTestReader::analyze(const edm::Event& e, const 
   }
 
   //this part gets the handle of the event source and the record (i.e. the Database)
-  edm::ESHandle<PixelFEDChannelCollectionMap> PixelFEDChannelCollectionMapHandle;
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got eshandle" << std::endl;
-
-  context.get<SiPixelFEDChannelContainerESProducerRcd>().get(PixelFEDChannelCollectionMapHandle);
-  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got context" << std::endl;
+  edm::ESHandle<PixelFEDChannelCollectionMap> PixelFEDChannelCollectionMapHandle = context.getHandle(pixelFEDChannelCollectionMapToken_);
+  edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got eshandle and context" << std::endl;
 
   const PixelFEDChannelCollectionMap* thePixelFEDChannelCollectionMap = PixelFEDChannelCollectionMapHandle.product();
   edm::LogInfo("PixelFEDChannelCollectionMapTestReader") << "got SiPixelFEDChannelContainer* " << std::endl;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.cc
@@ -3,11 +3,12 @@
 #include "CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 namespace cms {
   SiPixelFakeGainForHLTReader::SiPixelFakeGainForHLTReader(const edm::ParameterSet& conf)
       : conf_(conf),
+        trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+        trackerGeomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
         SiPixelGainCalibrationForHLTService_(conf),
         filename_(conf.getParameter<std::string>("fileName")) {}
 
@@ -17,13 +18,8 @@ namespace cms {
     fFile->cd();
 
     // Get the Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    edm::ESHandle<TrackerGeometry> tkgeom = iSetup.getHandle(trackerGeomToken_);
     edm::LogInfo("SiPixelFakeGainForHLTReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
-
-    // Get the calibrationForHLT data
-    //iSetup.get<SiPixelGainCalibrationForHLTRcd>().get(SiPixelGainCalibrationForHLT_);
-    //edm::LogInfo("SiPixelFakeGainForHLTReader") << "[SiPixelFakeGainForHLTReader::analyze] End Reading FakeGainForHLTects" << std::endl;
-    //SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
 
     //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
     //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
@@ -85,17 +81,14 @@ namespace cms {
       char name[128];
 
       // Get Geometry
-      iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+      edm::ESHandle<TrackerGeometry> tkgeom = iSetup.getHandle(trackerGeomTokenBeginRun_);
 
       // Get the calibrationForHLT data
-      //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
-      //iSetup.get<SiPixelGainCalibrationRcd>().get(SiPixelGainCalibration_);
       SiPixelGainCalibrationForHLTService_.setESObjects(iSetup);
       edm::LogInfo("SiPixelFakeGainForHLTReader")
           << "[SiPixelFakeGainForHLTReader::beginJob] End Reading FakeGainForHLTects" << std::endl;
       // Get the list of DetId's
       std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationForHLTService_.getDetIds();
-      //SiPixelGainCalibrationForHLT_->getDetIds(vdetId_);
       // Loop over DetId's
       for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
            detid_iter++) {

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainForHLTReader.h
@@ -19,13 +19,9 @@
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h"
 
 #include "TROOT.h"
@@ -47,8 +43,8 @@ namespace cms {
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
-    //edm::ESHandle<SiPixelGainCalibrationForHLT> SiPixelGainCalibrationForHLT_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
     SiPixelGainCalibrationForHLTService SiPixelGainCalibrationForHLTService_;
 
     std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.cc
@@ -3,12 +3,13 @@
 #include "CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
 namespace cms {
   SiPixelFakeGainOfflineReader::SiPixelFakeGainOfflineReader(const edm::ParameterSet& conf)
       : conf_(conf),
         SiPixelGainCalibrationOfflineService_(conf),
+        trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
+        trackerGeomTokenBeginRun_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
         filename_(conf.getParameter<std::string>("fileName")) {}
 
   void SiPixelFakeGainOfflineReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -17,13 +18,8 @@ namespace cms {
     fFile->cd();
 
     // Get the Geometry
-    iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+    edm::ESHandle<TrackerGeometry> tkgeom = iSetup.getHandle(trackerGeomToken_);
     edm::LogInfo("SiPixelFakeGainOfflineReader") << " There are " << tkgeom->dets().size() << " detectors" << std::endl;
-
-    // Get the calibrationOffline data
-    //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
-    //edm::LogInfo("SiPixelFakeGainOfflineReader") << "[SiPixelFakeGainOfflineReader::analyze] End Reading FakeGainOfflineects" << std::endl;
-    //SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
 
     //  for(TrackerGeometry::DetContainer::const_iterator it = tkgeom->dets().begin(); it != tkgeom->dets().end(); it++){
     //   if( dynamic_cast<PixelGeomDetUnit*>((*it))!=0){
@@ -91,17 +87,14 @@ namespace cms {
       char name[128];
 
       // Get Geometry
-      iSetup.get<TrackerDigiGeometryRecord>().get(tkgeom);
+      edm::ESHandle<TrackerGeometry> tkgeom = iSetup.getHandle(trackerGeomTokenBeginRun_);
 
       // Get the calibrationOffline data
-      //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
-      //iSetup.get<SiPixelGainCalibrationOfflineRcd>().get(SiPixelGainCalibrationOffline_);
       SiPixelGainCalibrationOfflineService_.setESObjects(iSetup);
       edm::LogInfo("SiPixelFakeGainOfflineReader")
           << "[SiPixelFakeGainOfflineReader::beginJob] End Reading FakeGainOfflineects" << std::endl;
       // Get the list of DetId's
       std::vector<uint32_t> vdetId_ = SiPixelGainCalibrationOfflineService_.getDetIds();
-      //SiPixelGainCalibrationOffline_->getDetIds(vdetId_);
       // Loop over DetId's
       for (std::vector<uint32_t>::const_iterator detid_iter = vdetId_.begin(); detid_iter != vdetId_.end();
            detid_iter++) {

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainOfflineReader.h
@@ -19,13 +19,9 @@
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationOfflineService.h"
 
 #include "TROOT.h"
@@ -47,10 +43,10 @@ namespace cms {
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
-    //edm::ESHandle<SiPixelGainCalibrationOffline> SiPixelGainCalibrationOffline_;
-    SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
 
+    SiPixelGainCalibrationOfflineService SiPixelGainCalibrationOfflineService_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
     std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;
     std::map<uint32_t, TH1F*> _TH1F_Gains_m;
     std::string filename_;

--- a/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
+++ b/CalibTracker/SiPixelESProducers/test/SiPixelFakeGainReader.h
@@ -19,13 +19,9 @@
 //
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-//#include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
 
 #include "TROOT.h"
@@ -47,8 +43,8 @@ namespace cms {
 
   private:
     edm::ParameterSet conf_;
-    edm::ESHandle<TrackerGeometry> tkgeom;
-    //edm::ESHandle<SiPixelGainCalibration> SiPixelGainCalibration_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
     SiPixelGainCalibrationService SiPixelGainCalibrationService_;
 
     std::map<uint32_t, TH1F*> _TH1F_Pedestals_m;

--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -77,6 +77,9 @@ private:
   edm::EDGetTokenT<SiPixelRecHitCollection> tPixRecHitCollection;
   edm::EDGetTokenT<edm::SimTrackContainer> tSimTrackContainer;
   edm::EDGetTokenT<reco::TrackCollection> tTrackCollection;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magneticFieldToken_;
   std::string outputFile_;
   std::string src_;
   bool checkType_;         // do we check that the simHit associated with recHit is of the expected particle type ?

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -53,6 +53,9 @@ SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps)
   tPixRecHitCollection = consumes<SiPixelRecHitCollection>(edm::InputTag("siPixelRecHits"));
   tSimTrackContainer = consumes<edm::SimTrackContainer>(edm::InputTag("g4SimHits"));
   tTrackCollection = consumes<reco::TrackCollection>(src_);
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+  magneticFieldToken_ = esConsumes<MagneticField, IdealMagneticFieldRecord>();
 }
 
 SiPixelErrorEstimation::~SiPixelErrorEstimation() {}
@@ -370,8 +373,7 @@ void SiPixelErrorEstimation::endJob() {
 
 void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = es.getHandle(trackerTopoToken_);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   using namespace edm;
@@ -392,14 +394,12 @@ void SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup&
   std::vector<PSimHit> matched;
   TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  es.get<TrackerDigiGeometryRecord>().get(pDD);
+  edm::ESHandle<TrackerGeometry> pDD = es.getHandle(trackerGeomToken_);
   const TrackerGeometry* tracker = &(*pDD);
 
   //cout << "...1..." << endl;
 
-  edm::ESHandle<MagneticField> magneticField;
-  es.get<IdealMagneticFieldRecord>().get(magneticField);
+  edm::ESHandle<MagneticField> magneticField = es.getHandle(magneticFieldToken_);
   //const MagneticField* magField_ = magFieldHandle.product();
 
   edm::FileInPath FileInPath_;

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.cc
@@ -61,6 +61,10 @@ SiPixelCalibDigiProducer::SiPixelCalibDigiProducer(const edm::ParameterSet& iCon
   produces<edm::DetSetVector<SiPixelCalibDigi>>();
   if (includeErrors_)
     produces<edm::DetSetVector<SiPixelCalibDigiError>>();
+
+  calibToken_ = esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+  cablingMapToken_ = esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>();
 }
 
 SiPixelCalibDigiProducer::~SiPixelCalibDigiProducer() {
@@ -249,9 +253,9 @@ void SiPixelCalibDigiProducer::setPattern() {
 void SiPixelCalibDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //  edm::LogInfo("SiPixelCalibDigiProducer") <<"in produce() " << std::endl;
   using namespace edm;
-  iSetup.get<SiPixelCalibConfigurationRcd>().get(calib_);
-  iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry_);
-  iSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap_);
+  calib_ = iSetup.getHandle(calibToken_);
+  theGeometry_ = iSetup.getHandle(trackerGeomToken_);
+  theCablingMap_ = iSetup.getHandle(cablingMapToken_);
   pattern_repeat_ = calib_->getNTriggers() * calib_->nVCal();
   if (use_realeventnumber_) {
     iEventCounter_ = iEvent.id().event() - 1;

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelCalibDigiProducer.h
@@ -26,7 +26,6 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -86,6 +85,10 @@ private:
   edm::ESHandle<SiPixelCalibConfiguration> calib_;  // keeps track of the calibration constants
   edm::ESHandle<TrackerGeometry> theGeometry_;      // the tracker geometry
   edm::ESHandle<SiPixelFedCablingMap> theCablingMap_;
+
+  edm::ESGetToken<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd> calibToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 
   // worker variables
   std::map<pixelstruct, SiPixelCalibDigi>

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -9,7 +9,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -63,6 +62,8 @@ SiPixelLorentzAngle::SiPixelLorentzAngle(edm::ParameterSet const& conf)
   max_drift_ = 1000.;   //400.;
 
   t_trajTrack = consumes<TrajTrackAssociationCollection>(conf.getParameter<edm::InputTag>("src"));
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 
 // Virtual destructor needed.
@@ -175,25 +176,20 @@ void SiPixelLorentzAngle::beginJob() {
   hitCounter_ = 0;
   usedHitCounter_ = 0;
   pixelTracksCounter_ = 0;
-  //   edm::ESHandle<TrackerGeometry> estracker; //this block should not be in beginJob()
-  //   c.get<TrackerDigiGeometryRecord>().get(estracker);
-  //   tracker=&(* estracker);
 }
 
 // Functions that gets called by framework every event
 void SiPixelLorentzAngle::analyze(const edm::Event& e, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  es.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = es.getHandle(trackerTopoToken_);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   event_counter_++;
   // 	if(event_counter_ % 500 == 0) cout << "event number " << event_counter_ << endl;
   cout << "event number " << event_counter_ << endl;
 
-  edm::ESHandle<TrackerGeometry> estracker;
-  es.get<TrackerDigiGeometryRecord>().get(estracker);
-  tracker = &(*estracker);
+  edm::ESHandle<TrackerGeometry> estracker = es.getHandle(trackerGeomToken_);
+  const TrackerGeometry *tracker = &(*estracker);
 
   std::unique_ptr<TrackerHitAssociator> associate;
   if (simData_)

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -189,7 +189,7 @@ void SiPixelLorentzAngle::analyze(const edm::Event& e, const edm::EventSetup& es
   cout << "event number " << event_counter_ << endl;
 
   edm::ESHandle<TrackerGeometry> estracker = es.getHandle(trackerGeomToken_);
-  const TrackerGeometry *tracker = &(*estracker);
+  const TrackerGeometry* tracker = &(*estracker);
 
   std::unique_ptr<TrackerHitAssociator> associate;
   if (simData_)

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
@@ -186,10 +186,10 @@ namespace analyzer {
     const TransientTrackingRecHitBuilder *RHBuilder;
     const KFTrajectorySmoother *theSmoother;
     const KFTrajectoryFitter *theFitter;
-    const TrackerGeometry *tracker;
-    const MagneticField *magfield;
     TrajectoryStateTransform tsTransform;
     edm::EDGetTokenT<TrajTrackAssociationCollection> t_trajTrack;
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   };
 }  // namespace analyzer
 

--- a/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
 #include "CondFormats/SiPixelObjects/interface/ElectronicIndex.h"
 #include "CondFormats/SiPixelObjects/interface/LocalPixel.h"

--- a/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
+++ b/CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h
@@ -26,12 +26,6 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-//#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -52,6 +46,7 @@
 #include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 
 #include <map>
@@ -113,6 +108,11 @@ protected:
   edm::ESHandle<SiPixelCalibConfiguration> calib_;
   edm::ESHandle<TrackerGeometry> geom_;
   edm::ESHandle<SiPixelFedCablingMap> theCablingMap_;
+
+  edm::ESGetToken<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd> calibTokenBeginRun_;
+  edm::ESGetToken<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd> calibToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 
   std::string calibrationMode_;
   short nTriggers_;

--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.cc
@@ -22,13 +22,7 @@
 #include "SiPixelErrorsDigisToCalibDigis.h"
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 //
 // constants, enums and typedefs
@@ -52,6 +46,8 @@ SiPixelErrorsDigisToCalibDigis::SiPixelErrorsDigisToCalibDigis(const edm::Parame
 
   tPixelCalibDigiError = consumes<edm::DetSetVector<SiPixelCalibDigiError> >(siPixelProducerLabel_);
 
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+
   //  std::cout<<"siPixelProducerLabel_ = "<<siPixelProducerLabel_<<std::endl;
   //  std::cout<<"createOutputFile_= "<< createOutputFile_<<std::endl;
   //  std::cout<<"outpuFilename_= "<< outputFilename_<< std::endl;
@@ -73,7 +69,7 @@ void SiPixelErrorsDigisToCalibDigis::analyze(const edm::Event& iEvent, const edm
   static int first(1);
   if (1 == first) {
     first = 0;
-    iSetup.get<TrackerDigiGeometryRecord>().get(geom_);
+    geom_ = iSetup.getHandle(trackerGeomToken_);
     theHistogramIdWorker_ = new SiPixelHistogramId(siPixelProducerLabel_.label());
   }
 

--- a/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
+++ b/CalibTracker/SiPixelTools/plugins/SiPixelErrorsDigisToCalibDigis.h
@@ -18,11 +18,6 @@ Description: Create monitorElements for the Errors in created in the reduction o
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -72,6 +67,8 @@ public:
   bool setDQMDirectory(uint32_t detID);  //automatically create directory hierachy based on DetID
 protected:
   edm::ESHandle<TrackerGeometry> geom_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 
 private:
   void beginJob() override;

--- a/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
+++ b/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
@@ -43,11 +43,11 @@ SiPixelOfflineCalibAnalysisBase::SiPixelOfflineCalibAnalysisBase(const edm::Para
   folderMaker_ = new SiPixelFolderOrganizer();
   tPixelCalibDigi = consumes<edm::DetSetVector<SiPixelCalibDigi> >(siPixelCalibDigiProducer_);
 
-  calibTokenBeginRun_ = esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd, edm::Transition::BeginRun>();
+  calibTokenBeginRun_ =
+      esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd, edm::Transition::BeginRun>();
   calibToken_ = esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd>();
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   cablingMapToken_ = esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>();
-
 }
 
 SiPixelOfflineCalibAnalysisBase::SiPixelOfflineCalibAnalysisBase() {

--- a/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
+++ b/CalibTracker/SiPixelTools/src/SiPixelOfflineCalibAnalysisBase.cc
@@ -17,11 +17,12 @@
 //
 //
 
+#include "FWCore/Framework/interface/MakerMacros.h"
+
 #include "CalibTracker/SiPixelTools/interface/SiPixelOfflineCalibAnalysisBase.h"
 
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "CondFormats/SiPixelObjects/interface/SiPixelFrameConverter.h"
 #include "CondFormats/SiPixelObjects/interface/ElectronicIndex.h"
@@ -41,6 +42,12 @@ SiPixelOfflineCalibAnalysisBase::SiPixelOfflineCalibAnalysisBase(const edm::Para
   daqBE_ = &*edm::Service<DQMStore>();
   folderMaker_ = new SiPixelFolderOrganizer();
   tPixelCalibDigi = consumes<edm::DetSetVector<SiPixelCalibDigi> >(siPixelCalibDigiProducer_);
+
+  calibTokenBeginRun_ = esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd, edm::Transition::BeginRun>();
+  calibToken_ = esConsumes<SiPixelCalibConfiguration, SiPixelCalibConfigurationRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+  cablingMapToken_ = esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>();
+
 }
 
 SiPixelOfflineCalibAnalysisBase::SiPixelOfflineCalibAnalysisBase() {
@@ -60,9 +67,9 @@ SiPixelOfflineCalibAnalysisBase::~SiPixelOfflineCalibAnalysisBase() {}
 void SiPixelOfflineCalibAnalysisBase::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom_);
-  iSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap_);
-  iSetup.get<SiPixelCalibConfigurationRcd>().get(calib_);
+  calib_ = iSetup.getHandle(calibToken_);
+  geom_ = iSetup.getHandle(trackerGeomToken_);
+  theCablingMap_ = iSetup.getHandle(cablingMapToken_);
   if (eventCounter_ == 0)
     this->calibrationSetup(iSetup);
   eventCounter_++;
@@ -111,13 +118,11 @@ void SiPixelOfflineCalibAnalysisBase::analyze(const edm::Event& iEvent, const ed
 
 void SiPixelOfflineCalibAnalysisBase::beginRun(const edm::Run&, const edm::EventSetup& iSetup) {
   //load the calibration information from the database
-  iSetup.get<SiPixelCalibConfigurationRcd>().get(calib_);
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom_);
-  iSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap_);
+  edm::ESHandle<SiPixelCalibConfiguration> calib = iSetup.getHandle(calibTokenBeginRun_);
 
-  calibrationMode_ = calib_->getCalibrationMode();
-  nTriggers_ = calib_->getNTriggers();
-  vCalValues_ = calib_->getVCalValues();
+  calibrationMode_ = calib->getCalibrationMode();
+  nTriggers_ = calib->getNTriggers();
+  vCalValues_ = calib->getVCalValues();
   std::cout << "!!!! in beginRun" << std::endl;
   edm::LogInfo("SiPixelOfflineCalibAnalysisBase")
       << "Calibration file loaded. Mode: " << calibrationMode_ << " nTriggers: " << nTriggers_

--- a/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelActionExecutor.h
@@ -8,10 +8,6 @@
 #include "DQM/SiPixelMonitorClient/interface/SiPixelConfigParser.h"
 #include "DQM/SiPixelMonitorClient/interface/SiPixelConfigWriter.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <fstream>
 #include <map>
 #include <string>
@@ -112,7 +108,6 @@ private:
 
   SiPixelConfigParser *configParser_;
   SiPixelConfigWriter *configWriter_;
-  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
 
   std::vector<std::string> summaryMENames;
   std::vector<std::string> tkMapMENames;

--- a/DQM/SiPixelMonitorClient/interface/SiPixelCertification.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelCertification.h
@@ -6,20 +6,8 @@
 #include <iostream>
 #include <memory>
 
-// FWCore
-#include "DQMServices/Core/interface/DQMEDHarvester.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
 // DQM
-#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 
 class SiPixelCertification : public DQMEDHarvester {
 public:

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDaqInfo.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDaqInfo.h
@@ -9,6 +9,8 @@
 // DQM
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 
+#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
+#include "CondFormats/RunInfo/interface/RunInfo.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 class SiPixelDaqInfo : public DQMEDHarvester {
@@ -41,6 +43,7 @@ private:
 
   // define Token(-s)
   edm::EDGetTokenT<FEDRawDataCollection> daqSourceToken_;
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
 };
 
 #endif

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDaqInfo.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDaqInfo.h
@@ -6,20 +6,8 @@
 #include <iostream>
 #include <memory>
 
-// FWCore
-#include "DQMServices/Core/interface/DQMEDHarvester.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
 // DQM
-#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
@@ -53,7 +53,7 @@ public:
   void fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
                              DQMStore::IGetter &iGetter,
                              bool init,
-                             const SiPixelFedCablingMap* theCablingMap,
+                             const SiPixelFedCablingMap *theCablingMap,
                              int nFEDs,
                              bool Tier0Flag,
                              int lumisec);

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
@@ -7,11 +7,6 @@
 #include "DQM/SiPixelMonitorClient/interface/SiPixelLayoutParser.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
@@ -82,7 +77,6 @@ private:
   std::ofstream myfile_;
   int nevents_;
   bool endOfModules_;
-  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
 
   // Final combined Data Quality Flags:
   MonitorElement *SummaryReportMap;

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
@@ -53,7 +53,7 @@ public:
   void fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
                              DQMStore::IGetter &iGetter,
                              bool init,
-                             edm::ESHandle<SiPixelFedCablingMap> theCablingMap,
+                             const SiPixelFedCablingMap* theCablingMap,
                              int nFEDs,
                              bool Tier0Flag,
                              int lumisec);

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDcsInfo.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDcsInfo.h
@@ -6,20 +6,8 @@
 #include <iostream>
 #include <memory>
 
-// FWCore
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
 // DQM
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 class SiPixelDcsInfo : public DQMEDHarvester {
 public:

--- a/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
@@ -74,6 +74,8 @@ private:
 
   edm::EDGetTokenT<FEDRawDataCollection> inputSourceToken_;
   edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
+
+  edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 };
 
 #endif

--- a/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelEDAClient.h
@@ -3,7 +3,6 @@
 
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
@@ -73,7 +72,7 @@ private:
   std::ostringstream html_out_;
 
   edm::EDGetTokenT<FEDRawDataCollection> inputSourceToken_;
-  edm::ESHandle<SiPixelFedCablingMap> theCablingMap;
+  SiPixelFedCablingMap theCablingMap;
 
   edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 };

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -59,7 +59,7 @@ public:
                        bool init,
                        float noiseRate,
                        int noiseRateDenominator,
-                       edm::ESHandle<SiPixelFedCablingMap> theCablingMap);
+                       const SiPixelFedCablingMap* theCablingMap);
 
 private:
   void getItemList(const std::multimap<std::string, std::string> &req_map,

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -8,11 +8,6 @@
 #include "DQM/SiPixelMonitorClient/interface/SiPixelConfigWriter.h"
 #include "DQM/SiPixelMonitorClient/interface/SiPixelLayoutParser.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
 #include "CondFormats/SiPixelObjects/interface/DetectorIndex.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -59,7 +59,7 @@ public:
                        bool init,
                        float noiseRate,
                        int noiseRateDenominator,
-                       const SiPixelFedCablingMap* theCablingMap);
+                       const SiPixelFedCablingMap *theCablingMap);
 
 private:
   void getItemList(const std::multimap<std::string, std::string> &req_map,

--- a/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
@@ -1,6 +1,4 @@
-#include "CondFormats/DataRecord/interface/RunSummaryRcd.h"
-#include "CondFormats/RunInfo/interface/RunInfo.h"
-#include "CondFormats/RunInfo/interface/RunSummary.h"
+
 #include "DQM/SiPixelMonitorClient/interface/SiPixelDaqInfo.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
@@ -23,6 +21,7 @@ SiPixelDaqInfo::SiPixelDaqInfo(const edm::ParameterSet &ps) {
 
   // set Token(-s)
   daqSourceToken_ = consumes<FEDRawDataCollection>(ps.getUntrackedParameter<string>("daqSource", "source"));
+  runInfoToken_ = esConsumes<RunInfo, RunInfoRcd, edm::Transition::EndLuminosityBlock>();
 }
 
 SiPixelDaqInfo::~SiPixelDaqInfo() {}
@@ -42,10 +41,8 @@ void SiPixelDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
     firstLumi = false;
   }
 
-  if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
+  if ( edm::ESHandle<RunInfo> sumFED = iSetup.getHandle(runInfoToken_) ) {
     // get fed summary information
-    ESHandle<RunInfo> sumFED;
-    runInfoRec->get(sumFED);
     vector<int> FedsInIds = sumFED->m_fed_in;
 
     int FedCount = 0;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
@@ -41,9 +41,10 @@ void SiPixelDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
     firstLumi = false;
   }
 
-  if ( edm::ESHandle<RunInfo> sumFED = iSetup.getHandle(runInfoToken_) ) {
+  if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     // get fed summary information
-    vector<int> FedsInIds = sumFED->m_fed_in;
+    const RunInfo& sumFED = runInfoRec->get(runInfoToken_);
+    vector<int> FedsInIds = sumFED.m_fed_in;
 
     int FedCount = 0;
     int FedCountBarrel = 0;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDaqInfo.cc
@@ -43,7 +43,7 @@ void SiPixelDaqInfo::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
 
   if (auto runInfoRec = iSetup.tryToGet<RunInfoRcd>()) {
     // get fed summary information
-    const RunInfo& sumFED = runInfoRec->get(runInfoToken_);
+    const RunInfo &sumFED = runInfoRec->get(runInfoToken_);
     vector<int> FedsInIds = sumFED.m_fed_in;
 
     int FedCount = 0;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
@@ -790,7 +790,7 @@ void SiPixelDataQuality::computeGlobalQualityFlagByLumi(DQMStore::IGetter &iGett
 void SiPixelDataQuality::fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
                                                DQMStore::IGetter &iGetter,
                                                bool init,
-                                               const SiPixelFedCablingMap* theCablingMap,
+                                               const SiPixelFedCablingMap *theCablingMap,
                                                int nFEDs,
                                                bool Tier0Flag,
                                                int lumisec) {

--- a/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
@@ -790,7 +790,7 @@ void SiPixelDataQuality::computeGlobalQualityFlagByLumi(DQMStore::IGetter &iGett
 void SiPixelDataQuality::fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
                                                DQMStore::IGetter &iGetter,
                                                bool init,
-                                               edm::ESHandle<SiPixelFedCablingMap> theCablingMap,
+                                               const SiPixelFedCablingMap* theCablingMap,
                                                int nFEDs,
                                                bool Tier0Flag,
                                                int lumisec) {
@@ -916,7 +916,7 @@ void SiPixelDataQuality::fillGlobalQualityPlot(DQMStore::IBooker &iBooker,
             modCounter_++;
             detId = getDetId(me);
             for (int fedid = 0; fedid != 40; ++fedid) {
-              SiPixelFrameConverter converter(theCablingMap.product(), fedid);
+              SiPixelFrameConverter converter(theCablingMap, fedid);
               uint32_t newDetId = detId;
               if (converter.hasDetUnit(newDetId)) {
                 fedId = fedid;

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -203,7 +203,8 @@ void SiPixelEDAClient::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
           nFEDs_ += mefed->getBinContent(i + 1);
       }
     }
-    theCablingMap = *(eSetup.getHandle(cablingMapToken_).product());
+    // copy is intentional to allow using the SiPixelFedCablingMap in dqmEndJob() where accessing EventSetup products is not allowed
+    theCablingMap = eSetup.getData(cablingMapToken_);
 
     firstLumi = false;
   }

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -96,6 +96,7 @@ SiPixelEDAClient::SiPixelEDAClient(const edm::ParameterSet &ps) {
   sipixelDataQuality_ = new SiPixelDataQuality(offlineXMLfile_);
 
   inputSourceToken_ = consumes<FEDRawDataCollection>(ps.getUntrackedParameter<string>("inputSource", "source"));
+  cablingMapToken_ = esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd, edm::Transition::EndLuminosityBlock>();
   // cout<<"...leaving  SiPixelEDAClient::SiPixelEDAClient. "<<endl;
 }
 
@@ -202,7 +203,7 @@ void SiPixelEDAClient::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
           nFEDs_ += mefed->getBinContent(i + 1);
       }
     }
-    eSetup.get<SiPixelFedCablingMapRcd>().get(theCablingMap);
+    theCablingMap = eSetup.getHandle(cablingMapToken_);
 
     firstLumi = false;
   }

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -203,7 +203,7 @@ void SiPixelEDAClient::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
           nFEDs_ += mefed->getBinContent(i + 1);
       }
     }
-    theCablingMap = eSetup.getHandle(cablingMapToken_);
+    theCablingMap = *(eSetup.getHandle(cablingMapToken_).product());
 
     firstLumi = false;
   }
@@ -235,11 +235,11 @@ void SiPixelEDAClient::dqmEndLuminosityBlock(DQMStore::IBooker &iBooker,
     init = true;
     iBooker.cd();
     iGetter.cd();
-    sipixelDataQuality_->fillGlobalQualityPlot(iBooker, iGetter, init, theCablingMap, nFEDs_, Tier0Flag_, nLumiSecs_);
+    sipixelDataQuality_->fillGlobalQualityPlot(iBooker, iGetter, init, &theCablingMap, nFEDs_, Tier0Flag_, nLumiSecs_);
     init = true;
     if (noiseRate_ >= 0.)
       sipixelInformationExtractor_->findNoisyPixels(
-          iBooker, iGetter, init, noiseRate_, noiseRateDenominator_, theCablingMap);
+          iBooker, iGetter, init, noiseRate_, noiseRateDenominator_, &theCablingMap);
   }
 
   // cout<<"...leaving SiPixelEDAClient::endLuminosityBlock. "<<endl;
@@ -274,10 +274,10 @@ void SiPixelEDAClient::dqmEndJob(DQMStore::IBooker &iBooker, DQMStore::IGetter &
     iBooker.cd();
     iGetter.cd();
 
-    sipixelDataQuality_->fillGlobalQualityPlot(iBooker, iGetter, init, theCablingMap, nFEDs_, Tier0Flag_, nLumiSecs_);
+    sipixelDataQuality_->fillGlobalQualityPlot(iBooker, iGetter, init, &theCablingMap, nFEDs_, Tier0Flag_, nLumiSecs_);
     init = true;
     if (noiseRate_ >= 0.)
       sipixelInformationExtractor_->findNoisyPixels(
-          iBooker, iGetter, init, noiseRate_, noiseRateDenominator_, theCablingMap);
+          iBooker, iGetter, init, noiseRate_, noiseRateDenominator_, &theCablingMap);
   }
 }

--- a/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractor.cc
@@ -348,7 +348,7 @@ void SiPixelInformationExtractor::findNoisyPixels(DQMStore::IBooker &iBooker,
                                                   bool init,
                                                   float noiseRate_,
                                                   int noiseRateDenominator_,
-                                                  edm::ESHandle<SiPixelFedCablingMap> theCablingMap) {
+                                                  const SiPixelFedCablingMap* theCablingMap) {
   if (init) {
     endOfModules_ = false;
     nevents_ = noiseRateDenominator_;
@@ -447,7 +447,7 @@ void SiPixelInformationExtractor::findNoisyPixels(DQMStore::IBooker &iBooker,
         std::vector<std::pair<std::pair<int, int>, float>> noisyPixels = (*it).second;
         // now convert into online conventions:
         for (int fedid = 0; fedid <= 40; ++fedid) {
-          SiPixelFrameConverter converter(theCablingMap.product(), fedid);
+          SiPixelFrameConverter converter(theCablingMap, fedid);
           uint32_t newDetId = detid;
           if (converter.hasDetUnit(newDetId)) {
             realfedID = fedid;
@@ -486,7 +486,7 @@ void SiPixelInformationExtractor::findNoisyPixels(DQMStore::IBooker &iBooker,
             counter++;
 
             sipixelobjects::ElectronicIndex cabling;
-            SiPixelFrameConverter formatter(theCablingMap.product(), realfedID);
+            SiPixelFrameConverter formatter(theCablingMap, realfedID);
             sipixelobjects::DetectorIndex detector = {detid, offlineRow, offlineColumn};
             formatter.toCabling(cabling, detector);
             // cabling should now contain cabling.roc and cabling.dcol  and

--- a/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractor.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelInformationExtractor.cc
@@ -348,7 +348,7 @@ void SiPixelInformationExtractor::findNoisyPixels(DQMStore::IBooker &iBooker,
                                                   bool init,
                                                   float noiseRate_,
                                                   int noiseRateDenominator_,
-                                                  const SiPixelFedCablingMap* theCablingMap) {
+                                                  const SiPixelFedCablingMap *theCablingMap) {
   if (init) {
     endOfModules_ = false;
     nevents_ = noiseRateDenominator_;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -39,7 +39,7 @@ public:
   /// Constructor with raw DetId
   SiPixelClusterModule(const uint32_t &id);
   /// Constructor with raw DetId and sensor size
-  SiPixelClusterModule(edm::ConsumesCollector&& iCC, const uint32_t &id, const int &ncols, const int &nrows);
+  SiPixelClusterModule(edm::ConsumesCollector &&iCC, const uint32_t &id, const int &ncols, const int &nrows);
   /// Destructor
   ~SiPixelClusterModule();
 

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -19,7 +19,6 @@
 //
 //  Updated by: Lukas Wehrli
 //  for pixel offline DQM
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
@@ -39,7 +38,7 @@ public:
   /// Constructor with raw DetId
   SiPixelClusterModule(const uint32_t &id);
   /// Constructor with raw DetId and sensor size
-  SiPixelClusterModule(edm::ConsumesCollector &&iCC, const uint32_t &id, const int &ncols, const int &nrows);
+  SiPixelClusterModule(const uint32_t &id, const int &ncols, const int &nrows);
   /// Destructor
   ~SiPixelClusterModule();
 
@@ -47,7 +46,7 @@ public:
 
   /// Book histograms
   void book(const edm::ParameterSet &iConfig,
-            const edm::EventSetup &iSetup,
+            const TrackerTopology *pTT,
             DQMStore::IBooker &iBooker,
             int type = 0,
             bool twoD = true,
@@ -55,6 +54,7 @@ public:
             bool isUpgrade = false);
   /// Fill histograms
   int fill(const edmNew::DetSetVector<SiPixelCluster> &input,
+           const TrackerTopology *pTT,
            const TrackerGeometry *tracker,
            int *barrelClusterTotal,
            int *fpixPClusterTotal,
@@ -75,8 +75,6 @@ public:
            bool isUpgrade = false);
 
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
-  const TrackerTopology *pTT;
   uint32_t id_;
   int ncols_;
   int nrows_;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -22,19 +22,9 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include <cstdint>
 
 class SiPixelClusterModule {

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h
@@ -19,10 +19,12 @@
 //
 //  Updated by: Lukas Wehrli
 //  for pixel offline DQM
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include <cstdint>
@@ -37,7 +39,7 @@ public:
   /// Constructor with raw DetId
   SiPixelClusterModule(const uint32_t &id);
   /// Constructor with raw DetId and sensor size
-  SiPixelClusterModule(const uint32_t &id, const int &ncols, const int &nrows);
+  SiPixelClusterModule(edm::ConsumesCollector&& iCC, const uint32_t &id, const int &ncols, const int &nrows);
   /// Destructor
   ~SiPixelClusterModule();
 
@@ -73,6 +75,7 @@ public:
            bool isUpgrade = false);
 
 private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   const TrackerTopology *pTT;
   uint32_t id_;
   int ncols_;

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -23,36 +23,9 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
 #include "DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h"
-
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include <cstdint>
 
 class SiPixelClusterSource : public DQMEDAnalyzer {

--- a/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
+++ b/DQM/SiPixelMonitorCluster/interface/SiPixelClusterSource.h
@@ -26,6 +26,10 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQM/SiPixelMonitorCluster/interface/SiPixelClusterModule.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
 class SiPixelClusterSource : public DQMEDAnalyzer {
@@ -96,6 +100,11 @@ private:
   // define Token(-s)
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> srcToken_;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> digisrcToken_;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
 };
 
 #endif

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -46,13 +46,10 @@ SiPixelClusterModule::SiPixelClusterModule() : id_(0), ncols_(416), nrows_(160) 
 ///
 SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(edm::ConsumesCollector &&iCC,
-                                           const uint32_t &id,
+SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id,
                                            const int &ncols,
                                            const int &nrows)
-    : id_(id), ncols_(ncols), nrows_(nrows) {
-  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-}
+    : id_(id), ncols_(ncols), nrows_(nrows) {}
 //
 // Destructor
 //
@@ -61,15 +58,12 @@ SiPixelClusterModule::~SiPixelClusterModule() {}
 // Book histograms
 //
 void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
-                                const edm::EventSetup &iSetup,
+                                const TrackerTopology *pTT,
                                 DQMStore::IBooker &iBooker,
                                 int type,
                                 bool twoD,
                                 bool reducedSet,
                                 bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  pTT = tTopoHandle.product();
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;
@@ -543,6 +537,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
 // Fill histograms
 //
 int SiPixelClusterModule::fill(const edmNew::DetSetVector<SiPixelCluster> &input,
+                               const TrackerTopology *pTT,
                                const TrackerGeometry *tracker,
                                int *barrelClusterTotal,
                                int *fpixPClusterTotal,

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -46,8 +46,11 @@ SiPixelClusterModule::SiPixelClusterModule() : id_(0), ncols_(416), nrows_(160) 
 ///
 SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id, const int &ncols, const int &nrows)
-    : id_(id), ncols_(ncols), nrows_(nrows) {}
+SiPixelClusterModule::SiPixelClusterModule(edm::ConsumesCollector&& iCC, const uint32_t &id, const int &ncols, const int &nrows)
+    : id_(id), ncols_(ncols), nrows_(nrows) {
+
+  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
+}
 //
 // Destructor
 //
@@ -62,8 +65,7 @@ void SiPixelClusterModule::book(const edm::ParameterSet &iConfig,
                                 bool twoD,
                                 bool reducedSet,
                                 bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
   pTT = tTopoHandle.product();
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -46,9 +46,7 @@ SiPixelClusterModule::SiPixelClusterModule() : id_(0), ncols_(416), nrows_(160) 
 ///
 SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id,
-                                           const int &ncols,
-                                           const int &nrows)
+SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id, const int &ncols, const int &nrows)
     : id_(id), ncols_(ncols), nrows_(nrows) {}
 //
 // Destructor

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterModule.cc
@@ -46,9 +46,11 @@ SiPixelClusterModule::SiPixelClusterModule() : id_(0), ncols_(416), nrows_(160) 
 ///
 SiPixelClusterModule::SiPixelClusterModule(const uint32_t &id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelClusterModule::SiPixelClusterModule(edm::ConsumesCollector&& iCC, const uint32_t &id, const int &ncols, const int &nrows)
+SiPixelClusterModule::SiPixelClusterModule(edm::ConsumesCollector &&iCC,
+                                           const uint32_t &id,
+                                           const int &ncols,
+                                           const int &nrows)
     : id_(id), ncols_(ncols), nrows_(nrows) {
-
   trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
 }
 //

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -22,6 +22,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -339,7 +340,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
           int layer = PixelBarrelName(DetId(id), pTT, isUpgrade).layerName();
           if (layer > noOfLayers)
             noOfLayers = layer;
-          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(consumesCollector(), id, ncols, nrows);
           thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
         } else if (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
           LogDebug("PixelDQM") << " ---> Adding Endcap Module " << detId.rawId() << endl;
@@ -369,7 +370,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
           mask = false;
           if (isPIB && mask)
             continue;
-          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(consumesCollector(), id, ncols, nrows);
           thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
         }
       }

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -21,6 +21,7 @@
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -397,7 +397,7 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventS
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology* pTT = tTopoHandle.product();
+  const TrackerTopology *pTT = tTopoHandle.product();
 
   for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms

--- a/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
+++ b/DQM/SiPixelMonitorCluster/src/SiPixelClusterSource.cc
@@ -22,7 +22,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -253,6 +252,7 @@ void SiPixelClusterSource::analyze(const edm::Event &iEvent, const edm::EventSet
   for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     int numberOfFpixClusters = (*struct_iter)
                                    .second->fill(*input,
+                                                 pTT,
                                                  tracker,
                                                  &nEventsBarrel,
                                                  &nEventsFPIXp,
@@ -340,7 +340,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
           int layer = PixelBarrelName(DetId(id), pTT, isUpgrade).layerName();
           if (layer > noOfLayers)
             noOfLayers = layer;
-          SiPixelClusterModule *theModule = new SiPixelClusterModule(consumesCollector(), id, ncols, nrows);
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
           thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
         } else if (detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap)) {
           LogDebug("PixelDQM") << " ---> Adding Endcap Module " << detId.rawId() << endl;
@@ -370,7 +370,7 @@ void SiPixelClusterSource::buildStructure(const edm::EventSetup &iSetup) {
           mask = false;
           if (isPIB && mask)
             continue;
-          SiPixelClusterModule *theModule = new SiPixelClusterModule(consumesCollector(), id, ncols, nrows);
+          SiPixelClusterModule *theModule = new SiPixelClusterModule(id, ncols, nrows);
           thePixelStructure.insert(pair<uint32_t, SiPixelClusterModule *>(id, theModule));
         }
       }
@@ -396,11 +396,14 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventS
 
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
+  const TrackerTopology* pTT = tTopoHandle.product();
+
   for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms
     if (modOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 0, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 0, twoDimOn, reducedSet, isUpgrade);
       } else {
         if (!isPIB)
           throw cms::Exception("LogicError") << "[SiPixelClusterSource::bookMEs] Creation of DQM folder "
@@ -409,49 +412,49 @@ void SiPixelClusterSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventS
     }
     if (ladOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 1, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 1, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if (layOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 2, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 2, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if (phiOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 3, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 3, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if (bladeOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 4, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 4, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if (diskOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 5, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 5, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if (ringOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 6, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 6, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }
     }
     if (smileyOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 7, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iSetup, iBooker, 7, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 7, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BARREL-FOLDER\n";
       }

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -23,6 +23,9 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include <cstdint>
 
 class SiPixelDigiModule {
@@ -35,7 +38,7 @@ public:
   /// Constructor with raw DetId
   SiPixelDigiModule(const uint32_t& id);
   /// Constructor with raw DetId and sensor size
-  SiPixelDigiModule(const uint32_t& id, const int& ncols, const int& nrows);
+  SiPixelDigiModule(edm::ConsumesCollector&& iCC, const uint32_t& id, const int& ncols, const int& nrows);
   /// Destructor
   ~SiPixelDigiModule();
 
@@ -58,7 +61,7 @@ public:
   //           bool twoD=true, bool reducedSet=false, bool twoDimModOn = true, bool twoDimOnlyLayDisk = false,
   //           int &nDigisA, int &nDigisB);
   int fill(const edm::DetSetVector<PixelDigi>& input,
-           const edm::EventSetup& iSetup,
+           const TrackerTopology* pTT,
            MonitorElement* combBarrel,
            MonitorElement* chanBarrel,
            std::vector<MonitorElement*>& chanBarrelL,
@@ -81,6 +84,7 @@ public:
   resetRocMap();  // This is to move the rocmap reset from the Source to the Module where the map is booked. Necessary for multithread safety.
   std::pair<int, int> getZeroLoEffROCs();  // Moved from Souce.cc. Gets number of zero and low eff ROCs from each module.
 private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   int ncols_;
   int nrows_;

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -23,22 +23,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
-#include "CondFormats/DataRecord/interface/SiPixelFedCablingMapRcd.h"
-#include "CondFormats/SiPixelObjects/interface/SiPixelFrameReverter.h"
-#include "CondFormats/SiPixelObjects/interface/GlobalPixel.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/CommonDetUnit/interface/GluedGeomDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetType.h"
 #include <cstdint>
 
 class SiPixelDigiModule {

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h
@@ -25,7 +25,6 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include <cstdint>
 
 class SiPixelDigiModule {
@@ -38,7 +37,7 @@ public:
   /// Constructor with raw DetId
   SiPixelDigiModule(const uint32_t& id);
   /// Constructor with raw DetId and sensor size
-  SiPixelDigiModule(edm::ConsumesCollector&& iCC, const uint32_t& id, const int& ncols, const int& nrows);
+  SiPixelDigiModule(const uint32_t& id, const int& ncols, const int& nrows);
   /// Destructor
   ~SiPixelDigiModule();
 
@@ -46,7 +45,7 @@ public:
 
   /// Book histograms
   void book(const edm::ParameterSet& iConfig,
-            const edm::EventSetup& iSetup,
+            const TrackerTopology* pTT,
             DQMStore::IBooker& iBooker,
             int type = 0,
             bool twoD = true,
@@ -84,7 +83,6 @@ public:
   resetRocMap();  // This is to move the rocmap reset from the Source to the Module where the map is booked. Necessary for multithread safety.
   std::pair<int, int> getZeroLoEffROCs();  // Moved from Souce.cc. Gets number of zero and low eff ROCs from each module.
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   int ncols_;
   int nrows_;

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -21,6 +21,10 @@
 #include <memory>
 
 // user include files
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
 #include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h"
 
@@ -223,6 +227,9 @@ private:
 
   //define Token(-s)
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi> > srcToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
   int noOfLayers;
   int noOfDisks;
 };

--- a/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
+++ b/DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h
@@ -21,26 +21,9 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
-
 #include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiModule.h"
 
-#include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
 class SiPixelDigiSource : public DQMOneLumiEDAnalyzer<> {

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
@@ -27,9 +27,11 @@ SiPixelDigiModule::SiPixelDigiModule() : id_(0), ncols_(416), nrows_(160) {}
 ///
 SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelDigiModule::SiPixelDigiModule(edm::ConsumesCollector&& iCC, const uint32_t& id, const int& ncols, const int& nrows)
+SiPixelDigiModule::SiPixelDigiModule(edm::ConsumesCollector&& iCC,
+                                     const uint32_t& id,
+                                     const int& ncols,
+                                     const int& nrows)
     : id_(id), ncols_(ncols), nrows_(nrows) {
-
   trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
 }
 //
@@ -340,7 +342,6 @@ int SiPixelDigiModule::fill(const edm::DetSetVector<PixelDigi>& input,
                             int& nDigisA,
                             int& nDigisB,
                             bool isUpgrade) {
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
@@ -27,13 +27,10 @@ SiPixelDigiModule::SiPixelDigiModule() : id_(0), ncols_(416), nrows_(160) {}
 ///
 SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelDigiModule::SiPixelDigiModule(edm::ConsumesCollector&& iCC,
-                                     const uint32_t& id,
+SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id,
                                      const int& ncols,
                                      const int& nrows)
-    : id_(id), ncols_(ncols), nrows_(nrows) {
-  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-}
+    : id_(id), ncols_(ncols), nrows_(nrows) {}
 //
 // Destructor
 //
@@ -42,7 +39,7 @@ SiPixelDigiModule::~SiPixelDigiModule() {}
 // Book histograms
 //
 void SiPixelDigiModule::book(const edm::ParameterSet& iConfig,
-                             const edm::EventSetup& iSetup,
+                             const TrackerTopology* pTT,
                              DQMStore::IBooker& iBooker,
                              int type,
                              bool twoD,
@@ -50,9 +47,6 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig,
                              bool reducedSet,
                              bool additInfo,
                              bool isUpgrade) {
-  //isUpgrade = iConfig.getUntrackedParameter<bool>("isUpgrade");
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology* pTT = tTopoHandle.product();
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiModule.cc
@@ -27,9 +27,7 @@ SiPixelDigiModule::SiPixelDigiModule() : id_(0), ncols_(416), nrows_(160) {}
 ///
 SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id) : id_(id), ncols_(416), nrows_(160) {}
 ///
-SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id,
-                                     const int& ncols,
-                                     const int& nrows)
+SiPixelDigiModule::SiPixelDigiModule(const uint32_t& id, const int& ncols, const int& nrows)
     : id_(id), ncols_(ncols), nrows_(nrows) {}
 //
 // Destructor
@@ -47,7 +45,6 @@ void SiPixelDigiModule::book(const edm::ParameterSet& iConfig,
                              bool reducedSet,
                              bool additInfo,
                              bool isUpgrade) {
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -1278,8 +1278,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker& iBooker, const edm::EventSetu
     }
     if (layOn || twoDimOnlyLayDisk) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2, isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, pTT, iBooker, 2, twoDimOn, hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 2, twoDimOn, hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
@@ -1301,8 +1300,7 @@ void SiPixelDigiSource::bookMEs(DQMStore::IBooker& iBooker, const edm::EventSetu
     }
     if (diskOn || twoDimOnlyLayDisk) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5, isUpgrade)) {
-        (*struct_iter)
-            .second->book(conf_, pTT, iBooker, 5, twoDimOn, hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
+        (*struct_iter).second->book(conf_, pTT, iBooker, 5, twoDimOn, hiRes, reducedSet, twoDimOnlyLayDisk, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }

--- a/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
+++ b/DQM/SiPixelMonitorDigi/src/SiPixelDigiSource.cc
@@ -17,6 +17,7 @@
 //
 #include "DQM/SiPixelMonitorDigi/interface/SiPixelDigiSource.h"
 // Framework
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelHLTSource.h
@@ -23,25 +23,15 @@
 #include <memory>
 
 // user include files
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 class SiPixelHLTSource : public DQMEDAnalyzer {
 public:
@@ -57,7 +47,7 @@ private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<FEDRawDataCollection> rawin_;
   edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError>> errin_;
-  edm::ESHandle<TrackerGeometry> pDD;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   bool saveFile;
   bool slowDown;
   std::string dirName_;

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -28,25 +28,10 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DQMServices/Core/interface/DQMOneEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
 #include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h"
-
 #include "DataFormats/Common/interface/DetSetVector.h"
-#include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
-
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
 class SiPixelRawDataErrorSource : public DQMOneLumiEDAnalyzer<> {

--- a/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
+++ b/DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorSource.h
@@ -32,6 +32,10 @@
 #include "DQM/SiPixelMonitorRawData/interface/SiPixelRawDataErrorModule.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
 class SiPixelRawDataErrorSource : public DQMOneLumiEDAnalyzer<> {
@@ -52,6 +56,8 @@ private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<edm::DetSetVector<SiPixelRawDataError>> src_;
   edm::EDGetTokenT<FEDRawDataCollection> inputSourceToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
   std::string topFolderName_;
   bool saveFile;
   bool isPIB;

--- a/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelHLTSource.cc
@@ -20,6 +20,7 @@
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
@@ -50,6 +51,7 @@ SiPixelHLTSource::SiPixelHLTSource(const edm::ParameterSet &iConfig)
     : conf_(iConfig),
       rawin_(consumes<FEDRawDataCollection>(conf_.getParameter<edm::InputTag>("RawInput"))),
       errin_(consumes<edm::DetSetVector<SiPixelRawDataError>>(conf_.getParameter<edm::InputTag>("ErrorInput"))),
+      trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()),
       saveFile(conf_.getUntrackedParameter<bool>("saveFile", false)),
       slowDown(conf_.getUntrackedParameter<bool>("slowDown", false)),
       dirName_(conf_.getUntrackedParameter<string>("DirName", "Pixel/FEDIntegrity/")) {
@@ -65,7 +67,7 @@ SiPixelHLTSource::~SiPixelHLTSource() {
 
 void SiPixelHLTSource::dqmBeginRun(const edm::Run &r, const edm::EventSetup &iSetup) {
   LogInfo("PixelDQM") << " SiPixelHLTSource::beginJob - Initialisation ... " << std::endl;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+
   if (firstRun) {
     eventNo = 0;
 
@@ -83,6 +85,7 @@ void SiPixelHLTSource::bookHistograms(DQMStore::IBooker &iBooker, edm::Run const
 //------------------------------------------------------------------
 void SiPixelHLTSource::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   eventNo++;
+  edm::ESHandle<TrackerGeometry> pDD = iSetup.getHandle(trackerGeomToken_);
   // get raw input data
   edm::Handle<FEDRawDataCollection> rawinput;
   iEvent.getByToken(rawin_, rawinput);

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -26,6 +26,7 @@
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -34,10 +34,7 @@
 
 // Geometry
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 // DataFormats
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
@@ -70,6 +67,8 @@ SiPixelRawDataErrorSource::SiPixelRawDataErrorSource(const edm::ParameterSet &iC
                       << endl;
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   inputSourceToken_ = consumes<FEDRawDataCollection>(conf_.getUntrackedParameter<string>("inputSource", "source"));
+  trackerTopoTokenBeginRun_ = esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
+  trackerGeomTokenBeginRun_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
 }
 
 SiPixelRawDataErrorSource::~SiPixelRawDataErrorSource() {
@@ -186,12 +185,9 @@ void SiPixelRawDataErrorSource::analyze(const edm::Event &iEvent, const edm::Eve
 void SiPixelRawDataErrorSource::buildStructure(const edm::EventSetup &iSetup) {
   LogInfo("PixelDQM") << " SiPixelRawDataErrorSource::buildStructure";
 
-  edm::ESHandle<TrackerGeometry> pDD;
-  edm::ESHandle<TrackerTopology> tTopoHandle;
+  edm::ESHandle<TrackerGeometry> pDD = iSetup.getHandle(trackerGeomTokenBeginRun_);
 
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
   const TrackerTopology *pTT = tTopoHandle.product();
 
   LogVerbatim("PixelDQM") << " *** Geometry node for TrackerGeom is  " << &(*pDD) << std::endl;

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -29,6 +29,9 @@ detector segment (detID)
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
 class SiPixelRecHitModule {
@@ -39,7 +42,7 @@ public:
   /// Default constructor
   SiPixelRecHitModule();
   /// Constructor with raw DetId
-  SiPixelRecHitModule(const uint32_t &id);
+  SiPixelRecHitModule(edm::ConsumesCollector&& iCC, const uint32_t &id);
   /// Destructor
   ~SiPixelRecHitModule();
 
@@ -79,6 +82,7 @@ public:
              bool ringon = false);
 
 private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   MonitorElement *meXYPos_;
   MonitorElement *meXYPos_px_;

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -50,7 +50,7 @@ public:
   /// Book histograms
   void book(const edm::ParameterSet &iConfig,
             DQMStore::IBooker &iBooker,
-            const TrackerTopology* pTT,
+            const TrackerTopology *pTT,
             int type = 0,
             bool twoD = true,
             bool reducedSet = false,

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -29,7 +29,6 @@ detector segment (detID)
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
@@ -42,7 +41,7 @@ public:
   /// Default constructor
   SiPixelRecHitModule();
   /// Constructor with raw DetId
-  SiPixelRecHitModule(edm::ConsumesCollector &&iCC, const uint32_t &id);
+  SiPixelRecHitModule(const uint32_t &id);
   /// Destructor
   ~SiPixelRecHitModule();
 
@@ -51,7 +50,7 @@ public:
   /// Book histograms
   void book(const edm::ParameterSet &iConfig,
             DQMStore::IBooker &iBooker,
-            const edm::EventSetup &iSetup,
+            const TrackerTopology* pTT,
             int type = 0,
             bool twoD = true,
             bool reducedSet = false,
@@ -82,7 +81,6 @@ public:
              bool ringon = false);
 
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   MonitorElement *meXYPos_;
   MonitorElement *meXYPos_px_;

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h
@@ -42,7 +42,7 @@ public:
   /// Default constructor
   SiPixelRecHitModule();
   /// Constructor with raw DetId
-  SiPixelRecHitModule(edm::ConsumesCollector&& iCC, const uint32_t &id);
+  SiPixelRecHitModule(edm::ConsumesCollector &&iCC, const uint32_t &id);
   /// Destructor
   ~SiPixelRecHitModule();
 

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -33,6 +33,10 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
 class SiPixelRecHitSource : public DQMEDAnalyzer {
@@ -54,6 +58,8 @@ public:
 private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<SiPixelRecHitCollection> src_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
 
   bool saveFile;
   bool isPIB;

--- a/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
+++ b/DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitSource.h
@@ -25,12 +25,7 @@
 #include <memory>
 
 // user include files
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
 
 #include "DQM/SiPixelMonitorRecHit/interface/SiPixelRecHitModule.h"
 
@@ -38,14 +33,6 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <cstdint>
 
 class SiPixelRecHitSource : public DQMEDAnalyzer {

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -17,18 +17,16 @@
 #include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 // Constructors
 //
 SiPixelRecHitModule::SiPixelRecHitModule() : id_(0) {}
 ///
-SiPixelRecHitModule::SiPixelRecHitModule(const uint32_t &id) : id_(id) {}
+SiPixelRecHitModule::SiPixelRecHitModule(edm::ConsumesCollector&& iCC, const uint32_t &id) : id_(id) {
+
+  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
+}
 
 //
 // Destructor
@@ -44,8 +42,7 @@ void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
                                bool twoD,
                                bool reducedSet,
                                bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
   const TrackerTopology *pTT = tTopoHandle.product();
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -18,13 +18,11 @@
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-
 // Constructors
 //
 SiPixelRecHitModule::SiPixelRecHitModule() : id_(0) {}
 ///
-SiPixelRecHitModule::SiPixelRecHitModule(edm::ConsumesCollector&& iCC, const uint32_t &id) : id_(id) {
-
+SiPixelRecHitModule::SiPixelRecHitModule(edm::ConsumesCollector &&iCC, const uint32_t &id) : id_(id) {
   trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
 }
 

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -22,9 +22,7 @@
 //
 SiPixelRecHitModule::SiPixelRecHitModule() : id_(0) {}
 ///
-SiPixelRecHitModule::SiPixelRecHitModule(edm::ConsumesCollector &&iCC, const uint32_t &id) : id_(id) {
-  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-}
+SiPixelRecHitModule::SiPixelRecHitModule(const uint32_t &id) : id_(id) {}
 
 //
 // Destructor
@@ -35,14 +33,11 @@ SiPixelRecHitModule::~SiPixelRecHitModule() {}
 //
 void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
                                DQMStore::IBooker &iBooker,
-                               const edm::EventSetup &iSetup,
+                               const TrackerTopology* pTT,
                                int type,
                                bool twoD,
                                bool reducedSet,
                                bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology *pTT = tTopoHandle.product();
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -24,12 +24,6 @@
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/Framework/interface/EventSetup.h"
 // Constructors
 //
 SiPixelRecHitModule::SiPixelRecHitModule() : id_(0) {}

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitModule.cc
@@ -33,7 +33,7 @@ SiPixelRecHitModule::~SiPixelRecHitModule() {}
 //
 void SiPixelRecHitModule::book(const edm::ParameterSet &iConfig,
                                DQMStore::IBooker &iBooker,
-                               const TrackerTopology* pTT,
+                               const TrackerTopology *pTT,
                                int type,
                                bool twoD,
                                bool reducedSet,

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -26,7 +26,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
@@ -198,7 +197,7 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup &iSetup) {
           if (isPIB)
             continue;
           LogDebug("PixelDQM") << " ---> Adding Barrel Module " << detId.rawId() << endl;
-          SiPixelRecHitModule *theModule = new SiPixelRecHitModule(consumesCollector(), id);
+          SiPixelRecHitModule *theModule = new SiPixelRecHitModule(id);
           thePixelStructure.insert(pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
 
         } else if ((detId.subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap))) {
@@ -228,7 +227,7 @@ void SiPixelRecHitSource::buildStructure(const edm::EventSetup &iSetup) {
           if (isPIB && mask)
             continue;
 
-          SiPixelRecHitModule *theModule = new SiPixelRecHitModule(consumesCollector(), id);
+          SiPixelRecHitModule *theModule = new SiPixelRecHitModule(id);
           thePixelStructure.insert(pair<uint32_t, SiPixelRecHitModule *>(id, theModule));
         }
       }
@@ -245,11 +244,14 @@ void SiPixelRecHitSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventSe
 
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
+  const TrackerTopology* pTT = tTopoHandle.product();
+
   for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms
     if (modOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 0, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 0, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 0, twoDimOn, reducedSet, isUpgrade);
       } else {
         if (!isPIB)
           throw cms::Exception("LogicError") << "[SiPixelDigiSource::bookMEs] Creation of DQM folder failed";
@@ -257,42 +259,42 @@ void SiPixelRecHitSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventSe
     }
     if (ladOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 1, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 1, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 1, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LADDER-FOLDER\n";
       }
     }
     if (layOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 2, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 2, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 2, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH LAYER-FOLDER\n";
       }
     }
     if (phiOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 3, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 3, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 3, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH PHI-FOLDER\n";
       }
     }
     if (bladeOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 4, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 4, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 4, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH BLADE-FOLDER\n";
       }
     }
     if (diskOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 5, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 5, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 5, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH DISK-FOLDER\n";
       }
     }
     if (ringOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*struct_iter).first, 6, isUpgrade)) {
-        (*struct_iter).second->book(conf_, iBooker, iSetup, 6, twoDimOn, reducedSet, isUpgrade);
+        (*struct_iter).second->book(conf_, iBooker, pTT, 6, twoDimOn, reducedSet, isUpgrade);
       } else {
         LogDebug("PixelDQM") << "PROBLEM WITH RING-FOLDER\n";
       }

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -245,7 +245,7 @@ void SiPixelRecHitSource::bookMEs(DQMStore::IBooker &iBooker, const edm::EventSe
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology* pTT = tTopoHandle.product();
+  const TrackerTopology *pTT = tTopoHandle.product();
 
   for (struct_iter = thePixelStructure.begin(); struct_iter != thePixelStructure.end(); struct_iter++) {
     /// Create folder tree and book histograms

--- a/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
+++ b/DQM/SiPixelMonitorRecHit/src/SiPixelRecHitSource.cc
@@ -25,6 +25,7 @@
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 // DQM Framework
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQMServices/Core/interface/DQMStore.h"

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -15,10 +15,10 @@
 
 #include <utility>
 
-//#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include <cstdint>
@@ -33,7 +33,7 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelHitEfficiencyModule();
-  SiPixelHitEfficiencyModule(const uint32_t);
+  SiPixelHitEfficiencyModule(edm::ConsumesCollector&& iCC, const uint32_t);
   ~SiPixelHitEfficiencyModule();
 
   void book(
@@ -58,6 +58,7 @@ public:
   std::pair<double, double> eff(double nValid, double nMissing);
 
 private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   bool bBookTracks;
   bool debug_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -15,7 +15,6 @@
 
 #include <utility>
 
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
@@ -33,11 +32,11 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelHitEfficiencyModule();
-  SiPixelHitEfficiencyModule(edm::ConsumesCollector &&iCC, const uint32_t);
+  SiPixelHitEfficiencyModule(const uint32_t);
   ~SiPixelHitEfficiencyModule();
 
   void book(
-      const edm::ParameterSet &, edm::EventSetup const &, DQMStore::IBooker &, int type = 0, bool isUpgrade = false);
+      const edm::ParameterSet &, const TrackerTopology *, DQMStore::IBooker &, int type = 0, bool isUpgrade = false);
   void fill(const TrackerTopology *pTT,
             const LocalTrajectoryParameters &ltp,
             bool isHitValid,
@@ -58,7 +57,6 @@ public:
   std::pair<double, double> eff(double nValid, double nMissing);
 
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   bool bBookTracks;
   bool debug_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h
@@ -33,7 +33,7 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelHitEfficiencyModule();
-  SiPixelHitEfficiencyModule(edm::ConsumesCollector&& iCC, const uint32_t);
+  SiPixelHitEfficiencyModule(edm::ConsumesCollector &&iCC, const uint32_t);
   ~SiPixelHitEfficiencyModule();
 
   void book(

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -71,6 +71,7 @@ private:
   edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> chi2MeasurementEstimatorBaseToken_;
   edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
   edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> pixelClusterParameterEstimatorToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
 
   bool applyEdgeCut_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h
@@ -17,12 +17,6 @@
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 // Files added for monitoring track quantities
 #include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
@@ -38,6 +32,17 @@
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+
 #include <cstdint>
 
 class SiPixelHitEfficiencySource : public DQMEDAnalyzer {
@@ -59,6 +64,14 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> clusterCollectionToken_;
 
   edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken_;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerToken_;
+  edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> chi2MeasurementEstimatorBaseToken_;
+  edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+  edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> pixelClusterParameterEstimatorToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
 
   bool applyEdgeCut_;
   double nSigma_EdgeCut_;

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -14,8 +14,6 @@
 #ifndef SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 #define SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 
-// #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
@@ -33,11 +31,11 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelTrackResidualModule();
-  SiPixelTrackResidualModule(edm::ConsumesCollector &&iCC, const uint32_t);
+  SiPixelTrackResidualModule(const uint32_t);
   ~SiPixelTrackResidualModule();
 
   void book(const edm::ParameterSet &,
-            edm::EventSetup const &,
+            const TrackerTopology *,
             DQMStore::IBooker &,
             bool reducedSet = true,
             int type = 0,
@@ -74,7 +72,6 @@ public:
              bool ringon);
 
 private:
-  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   bool bBookTracks;
 

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -14,10 +14,13 @@
 #ifndef SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 #define SiPixelMonitorTrack_SiPixelTrackResidualModule_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+// #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementVector.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include <cstdint>
 
 namespace edm {
@@ -30,7 +33,7 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelTrackResidualModule();
-  SiPixelTrackResidualModule(const uint32_t);
+  SiPixelTrackResidualModule(edm::ConsumesCollector&& iCC, const uint32_t);
   ~SiPixelTrackResidualModule();
 
   void book(const edm::ParameterSet &,
@@ -71,6 +74,7 @@ public:
              bool ringon);
 
 private:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
   uint32_t id_;
   bool bBookTracks;
 

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h
@@ -33,7 +33,7 @@ public:
   typedef dqm::reco::MonitorElement MonitorElement;
 
   SiPixelTrackResidualModule();
-  SiPixelTrackResidualModule(edm::ConsumesCollector&& iCC, const uint32_t);
+  SiPixelTrackResidualModule(edm::ConsumesCollector &&iCC, const uint32_t);
   ~SiPixelTrackResidualModule();
 
   void book(const edm::ParameterSet &,

--- a/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
+++ b/DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualSource.h
@@ -19,28 +19,26 @@
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 
 // Files added for monitoring track quantities
 #include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
-//#include "DataFormats/SiPixelDetId/interface/PixelBarrelNameWrapper.h"
 #include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelBarrelNameUpgrade.h"
 #include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 
 #include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
 #include <cstdint>
@@ -89,6 +87,13 @@ private:
   std::string vtxsrc_;
   edm::InputTag digisrc_;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> digisrcToken_;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderToken_;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoTokenBeginRun_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomTokenBeginRun_;
 
   bool debug_;
   bool modOn;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -16,11 +16,6 @@
 #include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencyModule.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-
 // Data Formats
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
@@ -28,16 +23,17 @@
 #include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
 #include "DataFormats/SiPixelDetId/interface/PixelEndcapNameUpgrade.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 using namespace std;
 
 SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule() : id_(0) { bBookTracks = true; }
 
-SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(uint32_t id) : id_(id) { bBookTracks = true; }
+SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(edm::ConsumesCollector&& iCC, uint32_t id) : id_(id) {
+  bBookTracks = true;
+  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
+}
 
 SiPixelHitEfficiencyModule::~SiPixelHitEfficiencyModule() {}
 
@@ -46,8 +42,7 @@ void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
                                       DQMStore::IBooker &iBooker,
                                       int type,
                                       bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
   const TrackerTopology *pTT = tTopoHandle.product();
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -30,21 +30,15 @@ using namespace std;
 
 SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule() : id_(0) { bBookTracks = true; }
 
-SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(edm::ConsumesCollector &&iCC, uint32_t id) : id_(id) {
-  bBookTracks = true;
-  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-}
+SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(uint32_t id) : id_(id) { bBookTracks = true; }
 
 SiPixelHitEfficiencyModule::~SiPixelHitEfficiencyModule() {}
 
 void SiPixelHitEfficiencyModule::book(const edm::ParameterSet &iConfig,
-                                      edm::EventSetup const &iSetup,
+                                      const TrackerTopology *pTT,
                                       DQMStore::IBooker &iBooker,
                                       int type,
                                       bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology *pTT = tTopoHandle.product();
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencyModule.cc
@@ -30,7 +30,7 @@ using namespace std;
 
 SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule() : id_(0) { bBookTracks = true; }
 
-SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(edm::ConsumesCollector&& iCC, uint32_t id) : id_(id) {
+SiPixelHitEfficiencyModule::SiPixelHitEfficiencyModule(edm::ConsumesCollector &&iCC, uint32_t id) : id_(id) {
   bBookTracks = true;
   trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
 }

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -162,16 +162,14 @@ void SiPixelHitEfficiencySource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   // TrackerGeometry
   for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin(); pxb != TG->detsPXB().end(); pxb++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxb)) != nullptr) {
-      SiPixelHitEfficiencyModule *module =
-          new SiPixelHitEfficiencyModule((*pxb)->geographicalId().rawId());
+      SiPixelHitEfficiencyModule *module = new SiPixelHitEfficiencyModule((*pxb)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelHitEfficiencyModule *>((*pxb)->geographicalId().rawId(), module));
     }
   }
   for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); pxf != TG->detsPXF().end(); pxf++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxf)) != nullptr) {
-      SiPixelHitEfficiencyModule *module =
-          new SiPixelHitEfficiencyModule((*pxf)->geographicalId().rawId());
+      SiPixelHitEfficiencyModule *module = new SiPixelHitEfficiencyModule((*pxf)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelHitEfficiencyModule *>((*pxf)->geographicalId().rawId(), module));
     }
@@ -187,7 +185,7 @@ void SiPixelHitEfficiencySource::bookHistograms(DQMStore::IBooker &iBooker,
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology* pTT = tTopoHandle.product();
+  const TrackerTopology *pTT = tTopoHandle.product();
 
   for (std::map<uint32_t, SiPixelHitEfficiencyModule *>::iterator pxd = theSiPixelStructure.begin();
        pxd != theSiPixelStructure.end();

--- a/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelHitEfficiencySource.cc
@@ -47,7 +47,6 @@
 #include "DQM/SiPixelCommon/interface/SiPixelFolderOrganizer.h"
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelHitEfficiencySource.h"
 
-
 using namespace std;
 using namespace edm;
 
@@ -78,9 +77,11 @@ SiPixelHitEfficiencySource::SiPixelHitEfficiencySource(const edm::ParameterSet &
   trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   measurementTrackerToken_ = esConsumes<MeasurementTracker, CkfComponentsRecord>();
-  chi2MeasurementEstimatorBaseToken_ = esConsumes<Chi2MeasurementEstimatorBase, TrackingComponentsRecord>(edm::ESInputTag("", "Chi2"));
+  chi2MeasurementEstimatorBaseToken_ =
+      esConsumes<Chi2MeasurementEstimatorBase, TrackingComponentsRecord>(edm::ESInputTag("", "Chi2"));
   propagatorToken_ = esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", "PropagatorWithMaterial"));
-  pixelClusterParameterEstimatorToken_ = esConsumes<PixelClusterParameterEstimator, TkPixelCPERecord>(edm::ESInputTag("", "PixelCPEGeneric"));
+  pixelClusterParameterEstimatorToken_ =
+      esConsumes<PixelClusterParameterEstimator, TkPixelCPERecord>(edm::ESInputTag("", "PixelCPEGeneric"));
   trackerGeomTokenBeginRun_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
 
   firstRun = true;
@@ -161,14 +162,16 @@ void SiPixelHitEfficiencySource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   // TrackerGeometry
   for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin(); pxb != TG->detsPXB().end(); pxb++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxb)) != nullptr) {
-      SiPixelHitEfficiencyModule *module = new SiPixelHitEfficiencyModule(consumesCollector(), (*pxb)->geographicalId().rawId());
+      SiPixelHitEfficiencyModule *module =
+          new SiPixelHitEfficiencyModule(consumesCollector(), (*pxb)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelHitEfficiencyModule *>((*pxb)->geographicalId().rawId(), module));
     }
   }
   for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); pxf != TG->detsPXF().end(); pxf++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxf)) != nullptr) {
-      SiPixelHitEfficiencyModule *module = new SiPixelHitEfficiencyModule(consumesCollector(), (*pxf)->geographicalId().rawId());
+      SiPixelHitEfficiencyModule *module =
+          new SiPixelHitEfficiencyModule(consumesCollector(), (*pxf)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelHitEfficiencyModule *>((*pxf)->geographicalId().rawId(), module));
     }
@@ -722,7 +725,8 @@ void SiPixelHitEfficiencySource::analyze(const edm::Event &iEvent, const edm::Ev
           float dx_cl[2];
           float dy_cl[2];
           dx_cl[0] = dx_cl[1] = dy_cl[0] = dy_cl[1] = -9999.;
-          edm::ESHandle<PixelClusterParameterEstimator> cpEstimator = iSetup.getHandle(pixelClusterParameterEstimatorToken_);
+          edm::ESHandle<PixelClusterParameterEstimator> cpEstimator =
+              iSetup.getHandle(pixelClusterParameterEstimatorToken_);
           if (cpEstimator.isValid()) {
             const PixelClusterParameterEstimator &cpe(*cpEstimator);
             edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
@@ -29,22 +29,16 @@ using namespace edm;
 
 SiPixelTrackResidualModule::SiPixelTrackResidualModule() : id_(0) { bBookTracks = true; }
 
-SiPixelTrackResidualModule::SiPixelTrackResidualModule(edm::ConsumesCollector &&iCC, uint32_t id) : id_(id) {
-  bBookTracks = true;
-  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
-}
+SiPixelTrackResidualModule::SiPixelTrackResidualModule(uint32_t id) : id_(id) { bBookTracks = true; }
 
 SiPixelTrackResidualModule::~SiPixelTrackResidualModule() {}
 
 void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
-                                      edm::EventSetup const &iSetup,
+                                      const TrackerTopology *pTT,
                                       DQMStore::IBooker &iBooker,
                                       bool reducedSet,
                                       int type,
                                       bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology *pTT = tTopoHandle.product();
-
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);
   bool endcap = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelEndcap);
   bool isHalfModule = false;

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
@@ -29,7 +29,7 @@ using namespace edm;
 
 SiPixelTrackResidualModule::SiPixelTrackResidualModule() : id_(0) { bBookTracks = true; }
 
-SiPixelTrackResidualModule::SiPixelTrackResidualModule(edm::ConsumesCollector&& iCC, uint32_t id) : id_(id) {
+SiPixelTrackResidualModule::SiPixelTrackResidualModule(edm::ConsumesCollector &&iCC, uint32_t id) : id_(id) {
   bBookTracks = true;
   trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
 }

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualModule.cc
@@ -15,13 +15,6 @@
 
 #include "DQM/SiPixelCommon/interface/SiPixelHistogramId.h"
 #include "DQM/SiPixelMonitorTrack/interface/SiPixelTrackResidualModule.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 // Data Formats
 #include "DataFormats/DetId/interface/DetId.h"
@@ -36,7 +29,10 @@ using namespace edm;
 
 SiPixelTrackResidualModule::SiPixelTrackResidualModule() : id_(0) { bBookTracks = true; }
 
-SiPixelTrackResidualModule::SiPixelTrackResidualModule(uint32_t id) : id_(id) { bBookTracks = true; }
+SiPixelTrackResidualModule::SiPixelTrackResidualModule(edm::ConsumesCollector&& iCC, uint32_t id) : id_(id) {
+  bBookTracks = true;
+  trackerTopoTokenBeginRun_ = iCC.esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
+}
 
 SiPixelTrackResidualModule::~SiPixelTrackResidualModule() {}
 
@@ -46,8 +42,7 @@ void SiPixelTrackResidualModule::book(const edm::ParameterSet &iConfig,
                                       bool reducedSet,
                                       int type,
                                       bool isUpgrade) {
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
   const TrackerTopology *pTT = tTopoHandle.product();
 
   bool barrel = DetId(id_).subdetId() == static_cast<int>(PixelSubdetector::PixelBarrel);

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -82,8 +82,10 @@ SiPixelTrackResidualSource::SiPixelTrackResidualSource(const edm::ParameterSet &
 
   trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
-  transientTrackBuilderToken_ = esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
-  transientTrackingRecHitBuilderToken_ = esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", ttrhbuilder_));
+  transientTrackBuilderToken_ =
+      esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
+  transientTrackingRecHitBuilderToken_ =
+      esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", ttrhbuilder_));
   trackerTopoTokenBeginRun_ = esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>();
   trackerGeomTokenBeginRun_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>();
 
@@ -121,7 +123,8 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   // TrackerGeometry
   for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin(); pxb != TG->detsPXB().end(); pxb++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxb)) != nullptr) {
-      SiPixelTrackResidualModule *module = new SiPixelTrackResidualModule(consumesCollector(), (*pxb)->geographicalId().rawId());
+      SiPixelTrackResidualModule *module =
+          new SiPixelTrackResidualModule(consumesCollector(), (*pxb)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxb)->geographicalId().rawId(), module));
       // int DBlayer = PixelBarrelNameWrapper(pSet_,
@@ -133,7 +136,8 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   }
   for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); pxf != TG->detsPXF().end(); pxf++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxf)) != nullptr) {
-      SiPixelTrackResidualModule *module = new SiPixelTrackResidualModule(consumesCollector(), (*pxf)->geographicalId().rawId());
+      SiPixelTrackResidualModule *module =
+          new SiPixelTrackResidualModule(consumesCollector(), (*pxf)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxf)->geographicalId().rawId(), module));
       int DBdisk;
@@ -894,7 +898,8 @@ void SiPixelTrackResidualSource::analyze(const edm::Event &iEvent, const edm::Ev
 
   // get the TransienTrackingRecHitBuilder needed for extracting the global
   // position of the hits in the pixel
-  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder = iSetup.getHandle(transientTrackingRecHitBuilderToken_);
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder =
+      iSetup.getHandle(transientTrackingRecHitBuilderToken_);
 
   // check that tracks are valid
   if (TracksForRes.failedToGet())

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -122,8 +122,7 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   // TrackerGeometry
   for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin(); pxb != TG->detsPXB().end(); pxb++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxb)) != nullptr) {
-      SiPixelTrackResidualModule *module =
-          new SiPixelTrackResidualModule((*pxb)->geographicalId().rawId());
+      SiPixelTrackResidualModule *module = new SiPixelTrackResidualModule((*pxb)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxb)->geographicalId().rawId(), module));
       // int DBlayer = PixelBarrelNameWrapper(pSet_,
@@ -135,8 +134,7 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   }
   for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); pxf != TG->detsPXF().end(); pxf++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxf)) != nullptr) {
-      SiPixelTrackResidualModule *module =
-          new SiPixelTrackResidualModule((*pxf)->geographicalId().rawId());
+      SiPixelTrackResidualModule *module = new SiPixelTrackResidualModule((*pxf)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxf)->geographicalId().rawId(), module));
       int DBdisk;
@@ -156,7 +154,7 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker &iBooker,
   SiPixelFolderOrganizer theSiPixelFolder(false);
 
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
-  const TrackerTopology* pTT = tTopoHandle.product();
+  const TrackerTopology *pTT = tTopoHandle.product();
 
   std::stringstream nameX, titleX, nameY, titleY;
 

--- a/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
+++ b/DQM/SiPixelMonitorTrack/src/SiPixelTrackResidualSource.cc
@@ -19,7 +19,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 
@@ -124,7 +123,7 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   for (TrackerGeometry::DetContainer::const_iterator pxb = TG->detsPXB().begin(); pxb != TG->detsPXB().end(); pxb++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxb)) != nullptr) {
       SiPixelTrackResidualModule *module =
-          new SiPixelTrackResidualModule(consumesCollector(), (*pxb)->geographicalId().rawId());
+          new SiPixelTrackResidualModule((*pxb)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxb)->geographicalId().rawId(), module));
       // int DBlayer = PixelBarrelNameWrapper(pSet_,
@@ -137,7 +136,7 @@ void SiPixelTrackResidualSource::dqmBeginRun(const edm::Run &r, edm::EventSetup 
   for (TrackerGeometry::DetContainer::const_iterator pxf = TG->detsPXF().begin(); pxf != TG->detsPXF().end(); pxf++) {
     if (dynamic_cast<PixelGeomDetUnit const *>((*pxf)) != nullptr) {
       SiPixelTrackResidualModule *module =
-          new SiPixelTrackResidualModule(consumesCollector(), (*pxf)->geographicalId().rawId());
+          new SiPixelTrackResidualModule((*pxf)->geographicalId().rawId());
       theSiPixelStructure.insert(
           pair<uint32_t, SiPixelTrackResidualModule *>((*pxf)->geographicalId().rawId(), module));
       int DBdisk;
@@ -155,6 +154,10 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker &iBooker,
   // book residual histograms in theSiPixelFolder - one (x,y) pair of histograms
   // per det
   SiPixelFolderOrganizer theSiPixelFolder(false);
+
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoTokenBeginRun_);
+  const TrackerTopology* pTT = tTopoHandle.product();
+
   std::stringstream nameX, titleX, nameY, titleY;
 
   if (ladOn) {
@@ -180,43 +183,43 @@ void SiPixelTrackResidualSource::bookHistograms(DQMStore::IBooker &iBooker,
        pxd++) {
     if (modOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 0, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 0, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 0, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Folder Creation Failed! ";
     }
     if (ladOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 1, isUpgrade)) {
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 1, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 1, isUpgrade);
       } else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource ladder Folder Creation Failed! ";
     }
     if (layOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 2, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 2, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 2, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource layer Folder Creation Failed! ";
     }
     if (phiOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 3, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 3, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 3, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource phi Folder Creation Failed! ";
     }
     if (bladeOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 4, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 4, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 4, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Blade Folder Creation Failed! ";
     }
     if (diskOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 5, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 5, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 5, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Disk Folder Creation Failed! ";
     }
     if (ringOn) {
       if (theSiPixelFolder.setModuleFolder(iBooker, (*pxd).first, 6, isUpgrade))
-        (*pxd).second->book(pSet_, iSetup, iBooker, reducedSet, 6, isUpgrade);
+        (*pxd).second->book(pSet_, pTT, iBooker, reducedSet, 6, isUpgrade);
       else
         throw cms::Exception("LogicError") << "SiPixelTrackResidualSource Ring Folder Creation Failed! ";
     }

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1DeadFEDChannels.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1DeadFEDChannels.cc
@@ -47,6 +47,8 @@ namespace {
 
   private:
     edm::EDGetTokenT<PixelFEDChannelCollection> pixelFEDChannelCollectionToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<SiPixelFedCablingMap, SiPixelFedCablingMapRcd> cablingMapToken_;
 
     bool firstEvent_;
     const TrackerGeometry* trackerGeometry_ = nullptr;
@@ -56,6 +58,8 @@ namespace {
   SiPixelPhase1DeadFEDChannels::SiPixelPhase1DeadFEDChannels(const edm::ParameterSet& iConfig)
       : SiPixelPhase1Base(iConfig) {
     pixelFEDChannelCollectionToken_ = consumes<PixelFEDChannelCollection>(edm::InputTag("siPixelDigis"));
+    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+    cablingMapToken_ = esConsumes<SiPixelFedCablingMap, SiPixelFedCablingMapRcd>();
     firstEvent_ = true;
   };
 
@@ -64,12 +68,10 @@ namespace {
       return;
 
     if (firstEvent_) {
-      edm::ESHandle<TrackerGeometry> tmpTkGeometry;
-      iSetup.get<TrackerDigiGeometryRecord>().get(tmpTkGeometry);
+      edm::ESHandle<TrackerGeometry> tmpTkGeometry = iSetup.getHandle(trackerGeomToken_);
       trackerGeometry_ = &(*tmpTkGeometry);
 
-      edm::ESHandle<SiPixelFedCablingMap> pixelCabling;
-      iSetup.get<SiPixelFedCablingMapRcd>().get(pixelCabling);
+      edm::ESHandle<SiPixelFedCablingMap> pixelCabling = iSetup.getHandle(cablingMapToken_);
       cablingMap = pixelCabling.product();
 
       firstEvent_ = false;

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1RawData.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1RawData.cc
@@ -11,8 +11,6 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
 namespace {
 

--- a/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1RawData.cc
+++ b/DQM/SiPixelPhase1Common/plugins/SiPixelPhase1RawData.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/SiPixelRawData/interface/SiPixelRawDataError.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 namespace {
 
   class SiPixelPhase1RawData final : public SiPixelPhase1Base {

--- a/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
+++ b/DQM/SiPixelPhase1Common/src/GeometryInterface.cc
@@ -12,11 +12,6 @@
 // general plotting helpers
 #include "DQM/SiPixelPhase1Common/interface/SiPixelCoordinates.h"
 
-// edm stuff
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/ESInputTag.h"
-
 // Tracker Geometry/Topology  stuff
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -9,7 +9,6 @@
 #include <boost/algorithm/string.hpp>
 
 // Geometry stuff
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1RecHits.cc
@@ -11,7 +11,6 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
@@ -35,6 +34,8 @@ namespace {
     edm::EDGetTokenT<reco::TrackCollection> srcToken_;
     edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
 
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+
     bool onlyValid_;
     bool applyVertexCut_;
   };
@@ -43,6 +44,8 @@ namespace {
     srcToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"));
 
     offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(std::string("offlinePrimaryVertices"));
+
+    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 
     onlyValid_ = iConfig.getParameter<bool>("onlyValidHits");
 
@@ -53,8 +56,7 @@ namespace {
     if (!checktrigger(iEvent, iSetup, DCS))
       return;
 
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
 
     edm::Handle<reco::TrackCollection> tracks;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -101,7 +101,8 @@ namespace {
 
     trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
-    clusterShapeHitFilterToken_ = esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
+    clusterShapeHitFilterToken_ =
+        esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
   }
 
   void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -118,7 +119,7 @@ namespace {
     edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
 
-    edm::ESHandle<TrackerTopology> tTopoHandle  = iSetup.getHandle(trackerTopoToken_);
+    edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(trackerTopoToken_);
     auto const& tkTpl = *tTopoHandle;
 
     edm::ESHandle<ClusterShapeHitFilter> shapeFilterH = iSetup.getHandle(clusterShapeHitFilterToken_);

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackClusters.cc
@@ -17,7 +17,6 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelClusterShapeCache.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
@@ -83,6 +82,10 @@ namespace {
     edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
     edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
     edm::EDGetTokenT<SiPixelClusterShapeCache> pixelClusterShapeCacheToken_;
+
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<ClusterShapeHitFilter, CkfComponentsRecord> clusterShapeHitFilterToken_;
   };
 
   SiPixelPhase1TrackClusters::SiPixelPhase1TrackClusters(const edm::ParameterSet& iConfig)
@@ -95,6 +98,10 @@ namespace {
 
     pixelClusterShapeCacheToken_ =
         consumes<SiPixelClusterShapeCache>(iConfig.getParameter<edm::InputTag>("clusterShapeCache"));
+
+    trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+    clusterShapeHitFilterToken_ = esConsumes<ClusterShapeHitFilter, CkfComponentsRecord>(edm::ESInputTag("", "ClusterShapeHitFilter"));
   }
 
   void SiPixelPhase1TrackClusters::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -108,16 +115,13 @@ namespace {
     }
 
     // get geometry
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
 
-    edm::ESHandle<TrackerTopology> tTopoHandle;
-    iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
+    edm::ESHandle<TrackerTopology> tTopoHandle  = iSetup.getHandle(trackerTopoToken_);
     auto const& tkTpl = *tTopoHandle;
 
-    edm::ESHandle<ClusterShapeHitFilter> shapeFilterH;
-    iSetup.get<CkfComponentsRecord>().get("ClusterShapeHitFilter", shapeFilterH);
+    edm::ESHandle<ClusterShapeHitFilter> shapeFilterH = iSetup.getHandle(clusterShapeHitFilterToken_);
     auto const& shapeFilter = *shapeFilterH;
 
     edm::Handle<reco::VertexCollection> vertices;

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
@@ -12,7 +12,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -56,6 +55,13 @@ namespace {
     edm::EDGetTokenT<MeasurementTrackerEvent> tracker_;  //new
     bool applyVertexCut_;
 
+    edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+    edm::ESGetToken<Propagator, TrackingComponentsRecord> propagatorToken_;
+    edm::ESGetToken<Chi2MeasurementEstimatorBase, TrackingComponentsRecord> chi2MeasurementEstimatorBaseToken_;
+    edm::ESGetToken<MeasurementTracker, CkfComponentsRecord> measurementTrackerToken_;
+    edm::ESGetToken<PixelClusterParameterEstimator, TkPixelCPERecord> pixelClusterParameterEstimatorToken_;
+
     const TrackerTopology* trackerTopology_;
     const Propagator* trackerPropagator_;
     const MeasurementEstimator* chi2MeasurementEstimator_;
@@ -71,6 +77,13 @@ namespace {
     trajTrackCollectionToken_ =
         consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryInput"));
     clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));
+
+    trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+    propagatorToken_ = esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", "PropagatorWithMaterial"));
+    chi2MeasurementEstimatorBaseToken_ = esConsumes<Chi2MeasurementEstimatorBase, TrackingComponentsRecord>(edm::ESInputTag("", "Chi2"));
+    measurementTrackerToken_ = esConsumes<MeasurementTracker, CkfComponentsRecord>();
+    pixelClusterParameterEstimatorToken_ = esConsumes<PixelClusterParameterEstimator, TkPixelCPERecord>(edm::ESInputTag("", "PixelCPEGeneric"));
   }
 
   void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -78,8 +91,7 @@ namespace {
       return;
 
     // get geometry
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
 
     // get primary vertex
@@ -87,28 +99,24 @@ namespace {
     iEvent.getByToken(vtxToken_, vertices);
 
     // TrackerTopology for module informations
-    edm::ESHandle<TrackerTopology> trackerTopologyHandle;
-    iSetup.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
+    edm::ESHandle<TrackerTopology> trackerTopologyHandle = iSetup.getHandle(trackerTopoToken_);
     trackerTopology_ = trackerTopologyHandle.product();
 
     // Tracker propagator for propagating tracks to other layers
-    edm::ESHandle<Propagator> propagatorHandle;
-    iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorHandle);
+    edm::ESHandle<Propagator> propagatorHandle = iSetup.getHandle(propagatorToken_);
     std::unique_ptr<Propagator> propagatorUniquePtr(propagatorHandle.product()->clone());
     trackerPropagator_ = propagatorUniquePtr.get();
     const_cast<Propagator*>(trackerPropagator_)->setPropagationDirection(oppositeToMomentum);
 
     // Measurement estimator
-    edm::ESHandle<Chi2MeasurementEstimatorBase> chi2MeasurementEstimatorHandle;
-    iSetup.get<TrackingComponentsRecord>().get("Chi2", chi2MeasurementEstimatorHandle);
+    edm::ESHandle<Chi2MeasurementEstimatorBase> chi2MeasurementEstimatorHandle = iSetup.getHandle(chi2MeasurementEstimatorBaseToken_);
     chi2MeasurementEstimator_ = chi2MeasurementEstimatorHandle.product();
 
     //Tracker
     edm::Handle<MeasurementTrackerEvent> trackerMeas;
     iEvent.getByToken(tracker_, trackerMeas);
 
-    edm::ESHandle<MeasurementTracker> measurementTrackerHandle;
-    iSetup.get<CkfComponentsRecord>().get(measurementTrackerHandle);
+    edm::ESHandle<MeasurementTracker> measurementTrackerHandle = iSetup.getHandle(measurementTrackerToken_);
 
     //vertices
     if (!vertices.isValid())
@@ -139,8 +147,7 @@ namespace {
       return;
     //
 
-    edm::ESHandle<PixelClusterParameterEstimator> cpEstimator;
-    iSetup.get<TkPixelCPERecord>().get("PixelCPEGeneric", cpEstimator);
+    edm::ESHandle<PixelClusterParameterEstimator> cpEstimator = iSetup.getHandle(pixelClusterParameterEstimatorToken_);
     if (!cpEstimator.isValid())
       return;
 

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackEfficiency.cc
@@ -81,9 +81,11 @@ namespace {
     trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
     trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
     propagatorToken_ = esConsumes<Propagator, TrackingComponentsRecord>(edm::ESInputTag("", "PropagatorWithMaterial"));
-    chi2MeasurementEstimatorBaseToken_ = esConsumes<Chi2MeasurementEstimatorBase, TrackingComponentsRecord>(edm::ESInputTag("", "Chi2"));
+    chi2MeasurementEstimatorBaseToken_ =
+        esConsumes<Chi2MeasurementEstimatorBase, TrackingComponentsRecord>(edm::ESInputTag("", "Chi2"));
     measurementTrackerToken_ = esConsumes<MeasurementTracker, CkfComponentsRecord>();
-    pixelClusterParameterEstimatorToken_ = esConsumes<PixelClusterParameterEstimator, TkPixelCPERecord>(edm::ESInputTag("", "PixelCPEGeneric"));
+    pixelClusterParameterEstimatorToken_ =
+        esConsumes<PixelClusterParameterEstimator, TkPixelCPERecord>(edm::ESInputTag("", "PixelCPEGeneric"));
   }
 
   void SiPixelPhase1TrackEfficiency::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -109,7 +111,8 @@ namespace {
     const_cast<Propagator*>(trackerPropagator_)->setPropagationDirection(oppositeToMomentum);
 
     // Measurement estimator
-    edm::ESHandle<Chi2MeasurementEstimatorBase> chi2MeasurementEstimatorHandle = iSetup.getHandle(chi2MeasurementEstimatorBaseToken_);
+    edm::ESHandle<Chi2MeasurementEstimatorBase> chi2MeasurementEstimatorHandle =
+        iSetup.getHandle(chi2MeasurementEstimatorBaseToken_);
     chi2MeasurementEstimator_ = chi2MeasurementEstimatorHandle.product();
 
     //Tracker

--- a/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc
+++ b/DQM/SiPixelPhase1Track/plugins/SiPixelPhase1TrackResiduals.cc
@@ -10,8 +10,6 @@
 #include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
@@ -33,6 +31,8 @@ namespace {
     TrackerValidationVariables validator;
     edm::EDGetTokenT<reco::VertexCollection> offlinePrimaryVerticesToken_;
 
+    edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+
     bool applyVertexCut_;
   };
 
@@ -41,14 +41,15 @@ namespace {
     applyVertexCut_ = iConfig.getUntrackedParameter<bool>("VertexCut", true);
 
     offlinePrimaryVerticesToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"));
+
+    trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   }
 
   void SiPixelPhase1TrackResiduals::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
     if (!checktrigger(iEvent, iSetup, DCS))
       return;
 
-    edm::ESHandle<TrackerGeometry> tracker;
-    iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+    edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
     assert(tracker.isValid());
 
     edm::Handle<reco::VertexCollection> vertices;

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.cc
@@ -16,7 +16,6 @@
 #include "PixelThresholdClusterizer.h"
 
 // Geometry
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
 
 // Data Formats
@@ -54,6 +53,9 @@ SiPixelClusterProducer::SiPixelClusterProducer(edm::ParameterSet const& conf)
     tPixelClusters = consumes<SiPixelClusterCollectionNew>(conf.getParameter<edm::InputTag>("src"));
   else
     tPixelDigi = consumes<edm::DetSetVector<PixelDigi>>(conf.getParameter<edm::InputTag>("src"));
+
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 
   const auto& payloadType = conf.getParameter<std::string>("payloadType");
   if (payloadType == "HLT")
@@ -102,11 +104,9 @@ void SiPixelClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     e.getByToken(tPixelDigi, inputDigi);
 
   // Step A.2: get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = es.getHandle(trackerGeomToken_);
 
-  edm::ESHandle<TrackerTopology> trackerTopologyHandle;
-  es.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
+  edm::ESHandle<TrackerTopology> trackerTopologyHandle = es.getHandle(trackerTopoToken_);
   tTopo_ = trackerTopologyHandle.product();
 
   // Step B: create the final output collection

--- a/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/SiPixelClusterProducer.h
@@ -33,6 +33,7 @@
 //#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -71,6 +72,8 @@ private:
   edm::EDGetTokenT<SiPixelClusterCollectionNew> tPixelClusters;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
   edm::EDPutTokenT<SiPixelClusterCollectionNew> tPutPixelClusters;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   // TO DO: maybe allow a map of pointers?
   std::unique_ptr<SiPixelGainCalibrationServiceBase> theSiPixelGainCalibration_;
   const std::string clusterMode_;                      // user's choice of the clusterizer

--- a/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
@@ -97,6 +97,8 @@ private:
   edm::ParameterSet conf_;
   edm::InputTag src_;
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> tPixelCluster;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   bool printLocal;
   int countEvents, countAllEvents;
   double sumClusters;
@@ -145,6 +147,8 @@ ReadPixClusters::ReadPixClusters(edm::ParameterSet const &conf)
 
   cout << " Construct " << printLocal << endl;
   tPixelCluster = consumes<edmNew::DetSetVector<SiPixelCluster>>(src_);
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 // Virtual destructor needed.
 ReadPixClusters::~ReadPixClusters() {}
@@ -330,14 +334,12 @@ void ReadPixClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   using namespace edm;
 
   // Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = es.getHandle(trackerGeomToken_);
   const TrackerGeometry &theTracker(*geom);
 
 #ifdef NEW_ID
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  es.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = es.getHandle(trackerTopoToken_);
 #endif
 
   countAllEvents++;

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -848,6 +848,8 @@ private:
 
   // Needed for the ByToken method
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > myClus;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 
   //TFile* hFile;
   TH1D *hdetunit;
@@ -996,6 +998,8 @@ TestClusters::TestClusters(edm::ParameterSet const &conf) : conf_(conf), src_(co
 
   // For the ByToken method
   myClus = consumes<edmNew::DetSetVector<SiPixelCluster> >(conf.getParameter<edm::InputTag>("src"));
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 // Virtual destructor needed.
 TestClusters::~TestClusters() {}
@@ -1861,8 +1865,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   //static int nsum = 0, lsold=-999, lumiold=0.;
 
   // Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = es.getHandle(trackerGeomToken_);
   const TrackerGeometry &theTracker(*geom);
 
   countAllEvents++;
@@ -2245,8 +2248,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
 #ifdef NEW_ID
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  es.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = es.getHandle(trackerTopoToken_);
 #endif
 
   //---------------------------------------

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestClusters.cc
@@ -836,8 +836,6 @@ public:
   virtual void endJob() override;
 
 private:
-  edm::ParameterSet conf_;
-  edm::InputTag src_;
   //const static bool PRINT = false;
   bool PRINT;
   int select1, select2;
@@ -848,6 +846,14 @@ private:
 
   // Needed for the ByToken method
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > myClus;
+  edm::EDGetTokenT<LumiSummary> lumiSummaryToken_;
+  edm::EDGetTokenT<LumiDetails> lumiDetailsToken_;
+  edm::EDGetTokenT<edm::ConditionsInLumiBlock> condToken_;
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1gtrrToken_;
+  edm::EDGetTokenT<Level1TriggerScalersCollection> l1tsToken_;
+  edm::EDGetTokenT<edm::TriggerResults> hltToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 
@@ -988,16 +994,22 @@ private:
 
 /////////////////////////////////////////////////////////////////
 // Contructor, empty.
-TestClusters::TestClusters(edm::ParameterSet const &conf) : conf_(conf), src_(conf.getParameter<edm::InputTag>("src")) {
+TestClusters::TestClusters(edm::ParameterSet const &conf) {
   PRINT = conf.getUntrackedParameter<bool>("Verbosity", false);
   select1 = conf.getUntrackedParameter<int>("Select1", 0);
   select2 = conf.getUntrackedParameter<int>("Select2", 0);
-  //src_ =  conf.getParameter<edm::InputTag>( "src" );
   if (PRINT)
     cout << " Construct " << endl;
 
   // For the ByToken method
   myClus = consumes<edmNew::DetSetVector<SiPixelCluster> >(conf.getParameter<edm::InputTag>("src"));
+  lumiSummaryToken_ = consumes<LumiSummary>(edm::InputTag("lumiProducer"));
+  lumiDetailsToken_ = consumes<LumiDetails>(edm::InputTag("lumiProducer"));
+  condToken_ = consumes<edm::ConditionsInLumiBlock>(edm::InputTag("conditionsInEdm"));
+  l1gtrrToken_ = consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag("gtDigis"));
+  l1tsToken_ = consumes<Level1TriggerScalersCollection>(edm::InputTag("scalersRawToDigi"));
+  hltToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
+  vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
@@ -1892,11 +1904,11 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   edm::LuminosityBlock const &iLumi = e.getLuminosityBlock();
   edm::Handle<LumiSummary> lumi;
   edm::Handle<LumiDetails> ld;
-  iLumi.getByLabel("lumiProducer", lumi);
-  iLumi.getByLabel("lumiProducer", ld);
+  iLumi.getByToken(lumiSummaryToken_, lumi);
+  iLumi.getByToken(lumiDetailsToken_, ld);
 
   edm::Handle<edm::ConditionsInLumiBlock> cond;
-  iLumi.getByLabel("conditionsInEdm", cond);
+  iLumi.getByToken(condToken_, cond);
   // This will only work when running on RECO until (if) they fix it in the FW
   // When running on RAW and reconstructing, the LumiSummary will not appear
   // in the event before reaching endLuminosityBlock(). Therefore, it is not
@@ -1944,7 +1956,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   int numPVsGood = 0;
   if (select2 < 11 && run > 165000) {  // skip for earlier runs, crashes
     edm::Handle<reco::VertexCollection> vertices;
-    e.getByLabel("offlinePrimaryVertices", vertices);
+    e.getByToken(vtxToken_, vertices);
 
     //int numPVs = vertices->size(); // unused
     if (!vertices.failedToGet() && vertices.isValid()) {
@@ -2006,7 +2018,6 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
   // Get Cluster Collection from InputTag
   edm::Handle<edmNew::DetSetVector<SiPixelCluster> > clusters;
-  //e.getByLabel( src_ , clusters);
   // New By Token method
   e.getByToken(myClus, clusters);
 
@@ -2032,7 +2043,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
 #ifdef L1
   // Get L1
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  e.getByLabel("gtDigis", L1GTRR);
+  e.getByToken(l1gtrrToken_, L1GTRR);
 
   if (L1GTRR.isValid()) {
     //bool l1a = L1GTRR->decision();  // global decission?  unused
@@ -2105,7 +2116,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
   edm::Handle<edm::TriggerResults> HLTResults;
 
   // Extract the HLT results
-  e.getByLabel(edm::InputTag("TriggerResults", "", "HLT"), HLTResults);
+  e.getByToken(hltToken_, HLTResults);
   if ((HLTResults.isValid() == true) && (HLTResults->size() > 0)) {
     //TrigNames.init(*HLTResults);
     const edm::TriggerNames &TrigNames = e.triggerNames(*HLTResults);
@@ -2145,7 +2156,7 @@ void TestClusters::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
 #ifdef USE_RESYNCS
   Handle<Level1TriggerScalersCollection> l1ts;
-  e.getByLabel("scalersRawToDigi", l1ts);
+  e.getByToken(l1tsToken_, l1ts);
 
   if (l1ts->size() > 0) {
     int r1 = (*l1ts)[0].lastResync();

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
@@ -186,7 +186,8 @@ TestPixTracks::TestPixTracks(edm::ParameterSet const &conf) {
   hltToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
   vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   srcToken_ = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("src"));
-  trackAssocToken_ = consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
+  trackAssocToken_ =
+      consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
@@ -119,6 +119,7 @@ public:
 private:
   edm::ParameterSet conf_;
   edm::InputTag src_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   //const static bool PRINT = false;
   bool PRINT;
   float countTracks, countGoodTracks, countTracksInPix, countPVs, countEvents, countLumi;
@@ -177,6 +178,7 @@ TestPixTracks::TestPixTracks(edm::ParameterSet const &conf)
     : conf_(conf) {
   PRINT = conf.getUntrackedParameter<bool>("Verbosity", false);
   src_ = conf.getParameter<edm::InputTag>("src");
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }
 
@@ -490,14 +492,8 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   }    // if valid
 #endif
 
-  // -- Does this belong into beginJob()?
-  //ESHandle<TrackerGeometry> TG;
-  //iSetup.get<TrackerDigiGeometryRecord>().get(TG);
-  //const TrackerGeometry* theTrackerGeometry = TG.product();
-  //const TrackerGeometry& theTracker(*theTrackerGeometry);
   // Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = es.getHandle(trackerGeomToken_);
   const TrackerGeometry &theTracker(*geom);
 
   // -- Primary vertices

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestPixTracks.cc
@@ -117,8 +117,13 @@ public:
   virtual void endJob() override;
 
 private:
-  edm::ParameterSet conf_;
-  edm::InputTag src_;
+  edm::EDGetTokenT<LumiSummary> lumiToken_;
+  edm::EDGetTokenT<edm::ConditionsInLumiBlock> condToken_;
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1gtrrToken_;
+  edm::EDGetTokenT<edm::TriggerResults> hltToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  edm::EDGetTokenT<reco::TrackCollection> srcToken_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trackAssocToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   //const static bool PRINT = false;
   bool PRINT;
@@ -173,11 +178,15 @@ private:
 };
 /////////////////////////////////////////////////////////////////
 // Contructor,
-TestPixTracks::TestPixTracks(edm::ParameterSet const &conf)
-    //  : conf_(conf), src_(conf.getParameter<edm::InputTag>( "src" )) { }
-    : conf_(conf) {
+TestPixTracks::TestPixTracks(edm::ParameterSet const &conf) {
   PRINT = conf.getUntrackedParameter<bool>("Verbosity", false);
-  src_ = conf.getParameter<edm::InputTag>("src");
+  lumiToken_ = consumes<LumiSummary>(edm::InputTag("lumiProducer"));
+  condToken_ = consumes<edm::ConditionsInLumiBlock>(edm::InputTag("conditionsInEdm"));
+  l1gtrrToken_ = consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag("gtDigis"));
+  hltToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
+  vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+  srcToken_ = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("src"));
+  trackAssocToken_ = consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }
@@ -417,11 +426,11 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
   edm::LuminosityBlock const &iLumi = e.getLuminosityBlock();
   edm::Handle<LumiSummary> lumi;
-  iLumi.getByLabel("lumiProducer", lumi);
+  iLumi.getByToken(lumiToken_, lumi);
   edm::Handle<edm::ConditionsInLumiBlock> cond;
   float intlumi = 0, instlumi = 0;
   int beamint1 = 0, beamint2 = 0;
-  iLumi.getByLabel("conditionsInEdm", cond);
+  iLumi.getByToken(condToken_, cond);
   // This will only work when running on RECO until (if) they fix it in the FW
   // When running on RAW and reconstructing, the LumiSummary will not appear
   // in the event before reaching endLuminosityBlock(). Therefore, it is not
@@ -443,7 +452,7 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
 #ifdef L1
   // Get L1
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  e.getByLabel("gtDigis", L1GTRR);
+  e.getByToken(l1gtrrToken_, L1GTRR);
 
   if (L1GTRR.isValid()) {
     //bool l1a = L1GTRR->decision();  // global decission?
@@ -470,7 +479,7 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   edm::Handle<edm::TriggerResults> HLTResults;
 
   // Extract the HLT results
-  e.getByLabel(edm::InputTag("TriggerResults", "", "HLT"), HLTResults);
+  e.getByToken(hltToken_, HLTResults);
   if ((HLTResults.isValid() == true) && (HLTResults->size() > 0)) {
     //TrigNames.init(*HLTResults);
     const edm::TriggerNames &TrigNames = e.triggerNames(*HLTResults);
@@ -499,7 +508,7 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // -- Primary vertices
   // ----------------------------------------------------------------------
   edm::Handle<reco::VertexCollection> vertices;
-  e.getByLabel("offlinePrimaryVertices", vertices);
+  e.getByToken(vtxToken_, vertices);
 
   if (PRINT)
     cout << " PV list " << vertices->size() << endl;
@@ -551,7 +560,7 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // e.getByLabel("ctfWithMaterialTracksP5", recTracks);
   // e.getByLabel("splittedTracksP5", recTracks);
   //e.getByLabel("cosmictrackfinderP5", recTracks);
-  e.getByLabel(src_, recTracks);
+  e.getByToken(srcToken_, recTracks);
 
   if (PRINT)
     cout << " Tracks " << recTracks->size() << endl;
@@ -861,7 +870,7 @@ void TestPixTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // Use Trajectories
 
   edm::Handle<TrajTrackAssociationCollection> trajTrackCollectionHandle;
-  e.getByLabel(conf_.getParameter<std::string>("trajectoryInput"), trajTrackCollectionHandle);
+  e.getByToken(trackAssocToken_, trajTrackCollectionHandle);
 
   TrajectoryStateCombiner tsoscomb;
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -125,8 +125,14 @@ public:
   virtual void endJob() override;
 
 private:
-  edm::ParameterSet conf_;
-  edm::InputTag src_;
+  edm::EDGetTokenT<LumiSummary> lumiToken_;
+  edm::EDGetTokenT<edm::ConditionsInLumiBlock> condToken_;
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> l1gtrrToken_;
+  edm::EDGetTokenT<edm::TriggerResults> hltToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  edm::EDGetTokenT<reco::TrackCollection> srcToken_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trackAssocToken_;
+
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   //const static bool PRINT = false;
   bool PRINT;
@@ -194,11 +200,15 @@ private:
 };
 /////////////////////////////////////////////////////////////////
 // Contructor,
-TestWithTracks::TestWithTracks(edm::ParameterSet const &conf)
-    //  : conf_(conf), src_(conf.getParameter<edm::InputTag>( "src" )) { }
-    : conf_(conf) {
+TestWithTracks::TestWithTracks(edm::ParameterSet const &conf) {
   PRINT = conf.getUntrackedParameter<bool>("Verbosity", false);
-  src_ = conf.getParameter<edm::InputTag>("src");
+  lumiToken_ = consumes<LumiSummary>(edm::InputTag("lumiProducer"));
+  condToken_ = consumes<edm::ConditionsInLumiBlock>(edm::InputTag("conditionsInEdm"));
+  l1gtrrToken_ = consumes<L1GlobalTriggerReadoutRecord>(edm::InputTag("gtDigis"));
+  hltToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
+  vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+  srcToken_ = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("src"));
+  trackAssocToken_ = consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }
@@ -520,11 +530,11 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
 
   edm::LuminosityBlock const &iLumi = e.getLuminosityBlock();
   edm::Handle<LumiSummary> lumi;
-  iLumi.getByLabel("lumiProducer", lumi);
+  iLumi.getByToken(lumiToken_, lumi);
   edm::Handle<edm::ConditionsInLumiBlock> cond;
   float intlumi = 0, instlumi = 0;
   int beamint1 = 0, beamint2 = 0;
-  iLumi.getByLabel("conditionsInEdm", cond);
+  iLumi.getByToken(condToken_, cond);
   // This will only work when running on RECO until (if) they fix it in the FW
   // When running on RAW and reconstructing, the LumiSummary will not appear
   // in the event before reaching endLuminosityBlock(). Therefore, it is not
@@ -546,7 +556,7 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
 #ifdef L1
   // Get L1
   Handle<L1GlobalTriggerReadoutRecord> L1GTRR;
-  e.getByLabel("gtDigis", L1GTRR);
+  e.getByToken(l1gtrrToken_, L1GTRR);
 
   if (L1GTRR.isValid()) {
     //bool l1a = L1GTRR->decision();  // global decission?
@@ -573,7 +583,7 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   edm::Handle<edm::TriggerResults> HLTResults;
 
   // Extract the HLT results
-  e.getByLabel(edm::InputTag("TriggerResults", "", "HLT"), HLTResults);
+  e.getByToken(hltToken_, HLTResults);
   if ((HLTResults.isValid() == true) && (HLTResults->size() > 0)) {
     //TrigNames.init(*HLTResults);
     const edm::TriggerNames &TrigNames = e.triggerNames(*HLTResults);
@@ -602,7 +612,7 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // -- Primary vertices
   // ----------------------------------------------------------------------
   edm::Handle<reco::VertexCollection> vertices;
-  e.getByLabel("offlinePrimaryVertices", vertices);
+  e.getByToken(vtxToken_, vertices);
 
   if (PRINT)
     cout << " PV list " << vertices->size() << endl;
@@ -656,7 +666,7 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // e.getByLabel("ctfWithMaterialTracksP5", recTracks);
   // e.getByLabel("splittedTracksP5", recTracks);
   //e.getByLabel("cosmictrackfinderP5", recTracks);
-  e.getByLabel(src_, recTracks);
+  e.getByToken(srcToken_, recTracks);
 
   if (PRINT)
     cout << " Tracks " << recTracks->size() << endl;
@@ -1243,7 +1253,7 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   // Use Trajectories
 
   edm::Handle<TrajTrackAssociationCollection> trajTrackCollectionHandle;
-  e.getByLabel(conf_.getParameter<std::string>("trajectoryInput"), trajTrackCollectionHandle);
+  e.getByToken(trackAssocToken_, trajTrackCollectionHandle);
 
   TrajectoryStateCombiner tsoscomb;
 

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -127,6 +127,7 @@ public:
 private:
   edm::ParameterSet conf_;
   edm::InputTag src_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   //const static bool PRINT = false;
   bool PRINT;
   float countTracks, countGoodTracks, countTracksInPix, countPVs, countEvents, countLumi;
@@ -198,6 +199,7 @@ TestWithTracks::TestWithTracks(edm::ParameterSet const &conf)
     : conf_(conf) {
   PRINT = conf.getUntrackedParameter<bool>("Verbosity", false);
   src_ = conf.getParameter<edm::InputTag>("src");
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }
 
@@ -593,14 +595,8 @@ void TestWithTracks::analyze(const edm::Event &e, const edm::EventSetup &es) {
   }    // if valid
 #endif
 
-  // -- Does this belong into beginJob()?
-  //ESHandle<TrackerGeometry> TG;
-  //iSetup.get<TrackerDigiGeometryRecord>().get(TG);
-  //const TrackerGeometry* theTrackerGeometry = TG.product();
-  //const TrackerGeometry& theTracker(*theTrackerGeometry);
   // Get event setup
-  edm::ESHandle<TrackerGeometry> geom;
-  es.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = es.getHandle(trackerGeomToken_);
   const TrackerGeometry &theTracker(*geom);
 
   // -- Primary vertices

--- a/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/TestWithTracks.cc
@@ -208,7 +208,8 @@ TestWithTracks::TestWithTracks(edm::ParameterSet const &conf) {
   hltToken_ = consumes<edm::TriggerResults>(edm::InputTag("TriggerResults", "", "HLT"));
   vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   srcToken_ = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("src"));
-  trackAssocToken_ = consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
+  trackAssocToken_ =
+      consumes<TrajTrackAssociationCollection>(edm::InputTag(conf.getParameter<std::string>("trajectoryInput")));
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   //if(PRINT) cout<<" Construct "<<endl;
 }

--- a/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
@@ -110,6 +110,10 @@ private:
                 double &dz);
 
   // ----------member data:
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
+  edm::ESGetToken<TransientTrackingRecHitBuilder, TransientRecHitRecord> transientTrackingRecHitBuilderToken_;
 
   TH1D *h000, *h001, *h002, *h003, *h004, *h005, *h006, *h007, *h008, *h009;
   TH1D *h010, *h011, *h012, *h013, *h014, *h015, *h016, *h017, *h018, *h019;
@@ -167,7 +171,16 @@ private:
 //
 // constructor:
 //
-Triplet::Triplet(const edm::ParameterSet &iConfig) { std::cout << "Triplet constructed\n"; }
+Triplet::Triplet(const edm::ParameterSet &iConfig) {
+
+  trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+  transientTrackBuilderToken_ =
+      esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"));
+  transientTrackingRecHitBuilderToken_ =
+      esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", "WithTrackAngle"));
+
+  std::cout << "Triplet constructed\n"; }
 //
 // destructor:
 //
@@ -360,8 +373,7 @@ void Triplet::beginJob() {
 //
 void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<IdealGeometryRecord>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(trackerTopoToken_);
 
   using namespace std;
   using namespace edm;
@@ -554,8 +566,7 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //
   // get tracker geometry:
   //
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  edm::ESHandle<TrackerGeometry> pDD = iSetup.getHandle(trackerGeomToken_);
 
   if (!pDD.isValid()) {
     cout << "Unable to find TrackerDigiGeometry. Return\n";
@@ -649,14 +660,13 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //
   // transient track builder, needs B-field from data base (global tag in .py)
   //
-  edm::ESHandle<TransientTrackBuilder> theB;
-
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", theB);
+  edm::ESHandle<TransientTrackBuilder> theB =
+      iSetup.getHandle(transientTrackBuilderToken_);
   //
   // transient rec hits:
   //
-  ESHandle<TransientTrackingRecHitBuilder> hitBuilder;
-  iSetup.get<TransientRecHitRecord>().get("WithTrackAngle", hitBuilder);
+  edm::ESHandle<TransientTrackingRecHitBuilder> hitBuilder =
+      iSetup.getHandle(transientTrackingRecHitBuilderToken_);
   //
   //
   //

--- a/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
@@ -187,7 +187,8 @@ Triplet::Triplet(const edm::ParameterSet &iConfig) {
   transientTrackingRecHitBuilderToken_ =
       esConsumes<TransientTrackingRecHitBuilder, TransientRecHitRecord>(edm::ESInputTag("", "WithTrackAngle"));
 
-  std::cout << "Triplet constructed\n"; }
+  std::cout << "Triplet constructed\n";
+}
 //
 // destructor:
 //
@@ -667,13 +668,11 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //
   // transient track builder, needs B-field from data base (global tag in .py)
   //
-  edm::ESHandle<TransientTrackBuilder> theB =
-      iSetup.getHandle(transientTrackBuilderToken_);
+  edm::ESHandle<TransientTrackBuilder> theB = iSetup.getHandle(transientTrackBuilderToken_);
   //
   // transient rec hits:
   //
-  edm::ESHandle<TransientTrackingRecHitBuilder> hitBuilder =
-      iSetup.getHandle(transientTrackingRecHitBuilderToken_);
+  edm::ESHandle<TransientTrackingRecHitBuilder> hitBuilder = iSetup.getHandle(transientTrackingRecHitBuilderToken_);
   //
   //
   //

--- a/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/Triplet.cc
@@ -110,6 +110,10 @@ private:
                 double &dz);
 
   // ----------member data:
+  edm::EDGetTokenT<reco::BeamSpot> bsToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
+  edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+
   edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken_;
   edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
   edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackBuilderToken_;
@@ -172,6 +176,9 @@ private:
 // constructor:
 //
 Triplet::Triplet(const edm::ParameterSet &iConfig) {
+  bsToken_ = consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+  vtxToken_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+  trackToken_ = consumes<reco::TrackCollection>(edm::InputTag("generalTracks"));
 
   trackerTopoToken_ = esConsumes<TrackerTopology, TrackerTopologyRcd>();
   trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
@@ -407,7 +414,7 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // beam spot:
   //
   edm::Handle<reco::BeamSpot> rbs;
-  iEvent.getByLabel("offlineBeamSpot", rbs);
+  iEvent.getByToken(bsToken_, rbs);
 
   XYZPoint bsP = XYZPoint(0, 0, 0);
   //int ibs = 0;
@@ -439,7 +446,7 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // primary vertices:
   //
   Handle<VertexCollection> vertices;
-  iEvent.getByLabel("offlinePrimaryVertices", vertices);
+  iEvent.getByToken(vtxToken_, vertices);
 
   if (vertices.failedToGet())
     return;
@@ -555,7 +562,7 @@ void Triplet::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //
   Handle<TrackCollection> tracks;
 
-  iEvent.getByLabel("generalTracks", tracks);
+  iEvent.getByToken(trackToken_, tracks);
 
   if (tracks.failedToGet())
     return;

--- a/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelDigisTest.cc
@@ -115,6 +115,10 @@ private:
   // ----------member data ---------------------------
   bool PRINT;
   edm::EDGetTokenT<edm::DetSetVector<PixelDigi>> tPixelDigi;
+
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken;
+
 #ifdef USE_SIM_LINKS
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink>> tPixelDigiSimLink;
 #endif
@@ -172,6 +176,10 @@ PixelDigisTest::PixelDigisTest(const edm::ParameterSet &iConfig) {
   PRINT = iConfig.getUntrackedParameter<bool>("Verbosity", false);
   src_ = iConfig.getParameter<edm::InputTag>("src");
   tPixelDigi = consumes<edm::DetSetVector<PixelDigi>>(src_);
+
+  trackerTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
+
 #ifdef USE_SIM_LINKS
   tPixelDigiSimLink = consumes<edm::DetSetVector<PixelDigiSimLink>>(src_);
 #endif
@@ -322,8 +330,7 @@ void PixelDigisTest::beginJob() {
 // ------------ method called to produce the data  ------------
 void PixelDigisTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(trackerTopoToken);
 
   using namespace edm;
   if (PRINT)
@@ -394,8 +401,7 @@ void PixelDigisTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iS
 #endif
 
   // Get event setup (to get global transformation)
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = iSetup.getHandle(trackerGeomToken);
   const TrackerGeometry &theTracker(*geom);
 
   int numberOfDetUnits = 0;

--- a/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelMixedSimHitsTest.cc
@@ -74,10 +74,11 @@ public:
 private:
   // ----------member data ---------------------------
   edm::ParameterSet conf_;
-  edm::InputTag src_;
   const static bool PRINT = false;
   typedef std::vector<std::string> vstring;
   vstring trackerContainers;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken;
   // Histograms
   TFile *hFile;
   TH1F *hBunchCrossing, *htof1m, *htof0, *htof1p, *htof2p;
@@ -112,6 +113,8 @@ private:
 };
 //
 PixelMixedSimHitsTest::PixelMixedSimHitsTest(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+  trackerTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
   trackerContainers.clear();
   trackerContainers = iConfig.getParameter<std::vector<std::string> >("ROUList");
   cout << " Construct PixelSimHitsTest " << endl;
@@ -253,8 +256,7 @@ void PixelMixedSimHitsTest::beginJob() {
 // ------------ method called to produce the data  ------------
 void PixelMixedSimHitsTest::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(trackerTopoToken);
 
   const double PI = 3.142;
 
@@ -263,8 +265,7 @@ void PixelMixedSimHitsTest::analyze(const edm::Event &iEvent, const edm::EventSe
     cout << " Analyze PixelSimHitsTest " << endl;
 
   // Get event setup (to get global transformation)
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = iSetup.getHandle(trackerGeomToken);
   const TrackerGeometry &theTracker(*geom);
 
   // Get input data

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTest.cc
@@ -84,6 +84,8 @@ private:
   bool PRINT;
   string mode_;  // select bpix/fpix
   edm::EDGetTokenT<PSimHitContainer> tPixelSimHits;
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken;
   int numEvents;
   double numSimHits, numSimHitsGood;
 
@@ -121,6 +123,9 @@ PixelSimHitsTest::PixelSimHitsTest(const edm::ParameterSet &iConfig) : conf_(iCo
 
   edm::InputTag tag(src_, list_);  // for the ByToken
   tPixelSimHits = consumes<PSimHitContainer>(tag);
+
+  trackerTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 
   mode_ = iConfig.getUntrackedParameter<std::string>("mode", "bpix");  // select bpix or fpix
   PRINT = iConfig.getUntrackedParameter<bool>("Verbosity", false);     // printout
@@ -262,13 +267,11 @@ void PixelSimHitsTest::analyze(const edm::Event &iEvent, const edm::EventSetup &
     cout << " Analyze PixelSimHitsTest " << endl;
 
   // Get event setup (to get global transformation)
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = iSetup.getHandle(trackerGeomToken);
   const TrackerGeometry &theTracker(*geom);
 
   //Retrieve tracker topology from geometry (for det id)
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(trackerTopoToken);
 
   // Get input data
   int totalNumOfSimHits = 0;

--- a/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
+++ b/SimTracker/SiPixelDigitizer/test/PixelSimHitsTestForward.cc
@@ -74,6 +74,9 @@ private:
   // ----------member data ---------------------------
   const static bool PRINT = true;
 
+  edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> trackerTopoToken;
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken;
+
   TFile *hFile;
   TH1F *heloss1, *heloss2, *heloss3, *hdetunit, *hpabs, *hpid, *htof, *htid;
   TH1F *hpixid, *hpixsubid, *hlayerid, *hladder1id, *hladder2id, *hladder3id, *hz1id, *hz2id, *hz3id;
@@ -120,6 +123,9 @@ PixelSimHitsTestForward::PixelSimHitsTestForward(const edm::ParameterSet &iConfi
   //daemon.operator->();
 
   cout << " Construct PixelSimHitsTestForward " << endl;
+
+  trackerTopoToken = esConsumes<TrackerTopology, TrackerTopologyRcd>();
+  trackerGeomToken = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 
 PixelSimHitsTestForward::~PixelSimHitsTestForward() {
@@ -252,8 +258,7 @@ void PixelSimHitsTestForward::beginJob() {
 // ------------ method called to produce the data  ------------
 void PixelSimHitsTestForward::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopo);
+  edm::ESHandle<TrackerTopology> tTopo = iSetup.getHandle(trackerTopoToken);
 
   const double PI = 3.142;
 
@@ -262,8 +267,7 @@ void PixelSimHitsTestForward::analyze(const edm::Event &iEvent, const edm::Event
     cout << " Analyze PixelSimHitsTestForward " << endl;
 
   // Get event setup (to get global transformation)
-  edm::ESHandle<TrackerGeometry> geom;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geom);
+  edm::ESHandle<TrackerGeometry> geom = iSetup.getHandle(trackerGeomToken);
   const TrackerGeometry &theTracker(*geom);
 
   // Get input data

--- a/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
+++ b/Validation/SiPixelPhase1HitsV/interface/SiPixelPhase1HitsV.h
@@ -13,6 +13,8 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 namespace reco {
   class TrackToTrackingParticleAssociator;
@@ -46,6 +48,8 @@ private:
   edm::EDGetTokenT<edm::View<reco::Track>> tracksToken_;
   edm::EDGetTokenT<TrackingParticleCollection> tpToken_;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> trackAssociatorByHitsToken_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 };
 
 #endif

--- a/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
+++ b/Validation/SiPixelPhase1HitsV/src/SiPixelPhase1HitsV.cc
@@ -15,8 +15,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
@@ -33,7 +31,9 @@ SiPixelPhase1HitsV::SiPixelPhase1HitsV(const edm::ParameterSet &iConfig)
       tracksToken_(consumes<edm::View<reco::Track>>(iConfig.getParameter<edm::InputTag>("tracksTag"))),
       tpToken_(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("tpTag"))),
       trackAssociatorByHitsToken_(consumes<reco::TrackToTrackingParticleAssociator>(
-          iConfig.getParameter<edm::InputTag>("trackAssociatorByHitsTag"))) {}
+          iConfig.getParameter<edm::InputTag>("trackAssociatorByHitsTag"))),
+
+      trackerGeomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()) {}
 
 void SiPixelPhase1HitsV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   edm::Handle<edm::PSimHitContainer> barrelLowInput;
@@ -60,8 +60,7 @@ void SiPixelPhase1HitsV::analyze(const edm::Event &iEvent, const edm::EventSetup
 
   // Get geometry information
 
-  edm::ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
 
   // get low barrel info
   for (it = barrelLowInput->begin(); it != barrelLowInput->end(); ++it) {

--- a/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
+++ b/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
@@ -12,6 +12,8 @@
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 class SiPixelPhase1TrackClustersV : public SiPixelPhase1Base {
   enum {
@@ -27,6 +29,8 @@ public:
 private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> clustersToken_;
   edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 };
 
 #endif

--- a/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
+++ b/Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h
@@ -11,9 +11,6 @@
 
 #include "DQM/SiPixelPhase1Common/interface/SiPixelPhase1Base.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
 class SiPixelPhase1TrackClustersV : public SiPixelPhase1Base {
   enum {
@@ -28,9 +25,6 @@ public:
 
 private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> clustersToken_;
-  edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
-
-  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> trackerGeomToken_;
 };
 
 #endif

--- a/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
+++ b/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
@@ -10,7 +10,6 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h"
 
-
 SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Base(iConfig) {
   clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));

--- a/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
+++ b/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
@@ -15,23 +15,20 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 
 SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Base(iConfig) {
   clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));
   tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 
 void SiPixelPhase1TrackClustersV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get geometry
-  edm::ESHandle<TrackerGeometry> tracker;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
+  edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
   assert(tracker.isValid());
 
   // get the map

--- a/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
+++ b/Validation/SiPixelPhase1TrackClustersV/src/SiPixelPhase1TrackClustersV.cc
@@ -10,31 +10,13 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "Validation/SiPixelPhase1TrackClustersV/interface/SiPixelPhase1TrackClustersV.h"
 
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
-#include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
 
 SiPixelPhase1TrackClustersV::SiPixelPhase1TrackClustersV(const edm::ParameterSet &iConfig)
     : SiPixelPhase1Base(iConfig) {
   clustersToken_ = consumes<edmNew::DetSetVector<SiPixelCluster>>(iConfig.getParameter<edm::InputTag>("clusters"));
-  tracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
-  trackerGeomToken_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
 }
 
 void SiPixelPhase1TrackClustersV::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
-  // get geometry
-  edm::ESHandle<TrackerGeometry> tracker = iSetup.getHandle(trackerGeomToken_);
-  assert(tracker.isValid());
-
-  // get the map
-  edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByToken(tracksToken_, tracks);
-
   // get clusters
   edm::Handle<edmNew::DetSetVector<SiPixelCluster>> clusterColl;
   iEvent.getByToken(clustersToken_, clusterColl);


### PR DESCRIPTION
#### PR description:

This PR addresses the esConsumes migration (https://github.com/cms-sw/cmssw/issues/31061) for the SiPixel code. This is a purely framework-related update so no changes in the output are expected. In the process some limited cleanup of header file includes was done. As a by-product, the code in `RecoLocalTracker/SiPixelClusterizer/test/` was fully migrated to consumes (there were still a lot of `getByLabel` calls which were migrated to `getByToken`). Code touched in https://github.com/cms-sw/cmssw/pull/31697 intentionally skipped in this PR.

#### PR validation:

Code compiles and explicitly tested by running workflow 4.53.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport needed.
