### PR TITLE
Phase2-hgx268 Extending scintillator DetId to contain tile type c/m and SiPM type

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h
@@ -11,10 +11,12 @@
    [9:16]  |radius| index (starting from a minimum radius depending on type)
    [17:21] Layer #
    [22]    Trigger(1)/Detector(0) cell
-   [23:24] Reserved for future extension
+   [23]    SiPM type (0 for 2mm: 1 for 4mm)
+   [24]    Free
    [25:25] z-side (0 for +z; 1 for -z)
-   [26:27] Type (0 fine divisions of scintillators;
-                 1 coarse divisions of scintillators)
+   [26:27] Tile granularity and type (0 fine divisions of scintillators;
+                                      1 coarse divisions of type "c";
+                                      2 coarse divisions of type "m")
    [28:31] Detector type (HGCalHSc)
 */
 
@@ -25,7 +27,7 @@ public:
   /** Create cellid from raw id (0=invalid tower id) */
   HGCScintillatorDetId(uint32_t rawid);
   /** Constructor from subdetector, zplus, layer, module, cell numbers */
-  HGCScintillatorDetId(int type, int layer, int iradius, int iphi, bool trigger = false);
+  HGCScintillatorDetId(int type, int layer, int iradius, int iphi, bool trigger = false, int sipm = 0);
   /** Constructor from a generic cell id */
   HGCScintillatorDetId(const DetId& id);
   /** Assignment from a generic cell id */
@@ -37,8 +39,9 @@ public:
   /// get the subdetector
   DetId::Detector subdet() const { return det(); }
 
-  /// get the type
+  /// get/set the type
   int type() const { return (id_ >> kHGCalTypeOffset) & kHGCalTypeMask; }
+  void setType(int type);
 
   /// get the z-side of the cell (1/-1)
   int zside() const { return (((id_ >> kHGCalZsideOffset) & kHGCalZsideMask) ? -1 : 1); }
@@ -56,6 +59,10 @@ public:
   int iphi() const;
   std::pair<int, int> ietaphi() const { return std::pair<int, int>(ieta(), iphi()); }
   std::pair<int, int> iradiusphi() const { return std::pair<int, int>(iradius(), iphi()); }
+
+  /// get/set the sipm size
+  int sipm() const { return (id_ >> kHGCalSiPMOffset) & kHGCalSiPMMask; }
+  void setSiPM(int sipm);
 
   /// trigger or detector cell
   std::vector<HGCScintillatorDetId> detectorCells() const;
@@ -78,10 +85,14 @@ public:
   static const int kHGCalLayerMask = 0x1F;
   static const int kHGCalTriggerOffset = 22;
   static const int kHGCalTriggerMask = 0x1;
+  static const int kHGCalSiPMOffset = 23;
+  static const int kHGCalSiPMMask = 0x1;
+  static const int kHGCalSiPMMask0 = 0xFF7FFFFF;
   static const int kHGCalZsideOffset = 25;
   static const int kHGCalZsideMask = 0x1;
   static const int kHGCalTypeOffset = 26;
   static const int kHGCalTypeMask = 0x3;
+  static const int kHGCalTypeMask0 = 0xF3FFFFFF;
 
   int iradiusTriggerAbs() const;
   int iradiusTrigger() const { return zside() * iradiusTriggerAbs(); }

--- a/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
@@ -9,12 +9,13 @@ HGCScintillatorDetId::HGCScintillatorDetId() : DetId() {}
 
 HGCScintillatorDetId::HGCScintillatorDetId(uint32_t rawid) : DetId(rawid) {}
 
-HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int radius, int phi, bool trigger)
+HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int radius, int phi, bool trigger, int sipm)
     : DetId(HGCalHSc, ForwardEmpty) {
   int zside = (radius < 0) ? 1 : 0;
   int itrig = trigger ? 1 : 0;
   int radiusAbs = std::abs(radius);
   id_ |= (((type & kHGCalTypeMask) << kHGCalTypeOffset) | ((zside & kHGCalZsideMask) << kHGCalZsideOffset) |
+	  ((sipm & kHGCalSiPMMask) << kHGCalSiPMOffset) |
           ((itrig & kHGCalTriggerMask) << kHGCalTriggerOffset) | ((layer & kHGCalLayerMask) << kHGCalLayerOffset) |
           ((radiusAbs & kHGCalRadiusMask) << kHGCalRadiusOffset) | ((phi & kHGCalPhiMask) << kHGCalPhiOffset));
 }
@@ -68,6 +69,16 @@ int HGCScintillatorDetId::iphiTrigger() const {
     return iphi();
 }
 
+void HGCScintillatorDetId::setType(int type) {
+  id_ &= kHGCalTypeMask0;
+  id_ |= ((type & kHGCalTypeMask) << kHGCalTypeOffset);
+}
+
+void HGCScintillatorDetId::setSiPM(int sipm) {
+  id_ &= kHGCalSiPMMask0;
+  id_ |= ((sipm & kHGCalSiPMMask) << kHGCalSiPMOffset);
+}
+
 std::vector<HGCScintillatorDetId> HGCScintillatorDetId::detectorCells() const {
   std::vector<HGCScintillatorDetId> cells;
   int irad = iradiusAbs();
@@ -101,6 +112,6 @@ HGCScintillatorDetId HGCScintillatorDetId::triggerCell() const {
 
 std::ostream& operator<<(std::ostream& s, const HGCScintillatorDetId& id) {
   return s << " HGCScintillatorDetId::EE:HE= " << id.isEE() << ":" << id.isHE() << " trigger= " << id.trigger()
-           << " type= " << id.type() << " layer= " << id.layer() << " radius= " << id.iradius() << ":"
+           << " type= " << id.type() << " SiPM= " << id.sipm() << " layer= " << id.layer() << " radius= " << id.iradius() << ":"
            << id.iradiusTrigger() << " phi= " << id.iphi() << ":" << id.iphiTrigger();
 }

--- a/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
+++ b/DataFormats/ForwardDetId/src/HGCScintillatorDetId.cc
@@ -15,9 +15,9 @@ HGCScintillatorDetId::HGCScintillatorDetId(int type, int layer, int radius, int 
   int itrig = trigger ? 1 : 0;
   int radiusAbs = std::abs(radius);
   id_ |= (((type & kHGCalTypeMask) << kHGCalTypeOffset) | ((zside & kHGCalZsideMask) << kHGCalZsideOffset) |
-	  ((sipm & kHGCalSiPMMask) << kHGCalSiPMOffset) |
-          ((itrig & kHGCalTriggerMask) << kHGCalTriggerOffset) | ((layer & kHGCalLayerMask) << kHGCalLayerOffset) |
-          ((radiusAbs & kHGCalRadiusMask) << kHGCalRadiusOffset) | ((phi & kHGCalPhiMask) << kHGCalPhiOffset));
+          ((sipm & kHGCalSiPMMask) << kHGCalSiPMOffset) | ((itrig & kHGCalTriggerMask) << kHGCalTriggerOffset) |
+          ((layer & kHGCalLayerMask) << kHGCalLayerOffset) | ((radiusAbs & kHGCalRadiusMask) << kHGCalRadiusOffset) |
+          ((phi & kHGCalPhiMask) << kHGCalPhiOffset));
 }
 
 HGCScintillatorDetId::HGCScintillatorDetId(const DetId& gen) {
@@ -112,6 +112,7 @@ HGCScintillatorDetId HGCScintillatorDetId::triggerCell() const {
 
 std::ostream& operator<<(std::ostream& s, const HGCScintillatorDetId& id) {
   return s << " HGCScintillatorDetId::EE:HE= " << id.isEE() << ":" << id.isHE() << " trigger= " << id.trigger()
-           << " type= " << id.type() << " SiPM= " << id.sipm() << " layer= " << id.layer() << " radius= " << id.iradius() << ":"
-           << id.iradiusTrigger() << " phi= " << id.iphi() << ":" << id.iphiTrigger();
+           << " type= " << id.type() << " SiPM= " << id.sipm() << " layer= " << id.layer()
+           << " radius= " << id.iradius() << ":" << id.iradiusTrigger() << " phi= " << id.iphi() << ":"
+           << id.iphiTrigger();
 }

--- a/DataFormats/ForwardDetId/test/testHGCDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHGCDetId.cc
@@ -110,8 +110,10 @@ void testScint(int layer) {
       for (int zp = 0; zp < 2; ++zp) {
         int radius = (2 * zp - 1) * ring;
         HGCScintillatorDetId id(type, layer, radius, phi, false, sipm);
-        std::cout << "Input " << type << ":" << layer << ":" << radius << ":" << phi << ":" << sipm << " ID " << std::hex << id << std::dec;
-        if ((id.iradius() != radius) || (id.iphi() != phi) || (id.layer() != layer) || (id.type() != type) || (id.sipm() != sipm))
+        std::cout << "Input " << type << ":" << layer << ":" << radius << ":" << phi << ":" << sipm << " ID "
+                  << std::hex << id << std::dec;
+        if ((id.iradius() != radius) || (id.iphi() != phi) || (id.layer() != layer) || (id.type() != type) ||
+            (id.sipm() != sipm))
           std::cout << " ***** ERROR *****" << std::endl;
         else
           std::cout << std::endl;

--- a/DataFormats/ForwardDetId/test/testHGCDetId.cc
+++ b/DataFormats/ForwardDetId/test/testHGCDetId.cc
@@ -100,22 +100,25 @@ void testWafer(int layer, double rin, double rout) {
 }
 
 void testScint(int layer) {
-  int type = (layer <= 12) ? 0 : 1;
-  int phimax = (type == 0) ? 360 : 240;
-  for (int ieta = 1; ieta < 128; ++ieta) {
+  int type = ((layer <= 8) ? 0 : ((layer <= 17) ? 1 : 2));
+  int phimax = (type == 0) ? 360 : 288;
+  int irmin = ((layer <= 12) ? 10 : ((layer <= 14) ? 14 : ((layer <= 18) ? 7 : 1)));
+  int irmax = ((layer <= 12) ? 33 : ((layer <= 14) ? 37 : 42));
+  int sipm = (layer <= 17) ? 0 : 1;
+  for (int ring = irmin; ring <= irmax; ++ring) {
     for (int phi = 1; phi <= phimax; ++phi) {
       for (int zp = 0; zp < 2; ++zp) {
-        int eta = (2 * zp - 1) * ieta;
-        HGCScintillatorDetId id(type, layer, eta, phi, false);
-        std::cout << "Input " << type << ":" << layer << ":" << eta << ":" << phi << " ID " << id;
-        if ((id.ieta() != eta) || (id.iphi() != phi) || (id.layer() != layer) || (id.type() != type))
+        int radius = (2 * zp - 1) * ring;
+        HGCScintillatorDetId id(type, layer, radius, phi, false, sipm);
+        std::cout << "Input " << type << ":" << layer << ":" << radius << ":" << phi << ":" << sipm << " ID " << std::hex << id << std::dec;
+        if ((id.iradius() != radius) || (id.iphi() != phi) || (id.layer() != layer) || (id.type() != type) || (id.sipm() != sipm))
           std::cout << " ***** ERROR *****" << std::endl;
         else
           std::cout << std::endl;
       }
-      phi += 4;
+      phi += 9;
     }
-    ieta += 3;
+    ring += 3;
   }
 }
 


### PR DESCRIPTION
#### PR description:

Extending scintillator DetId to contain tile type c/m and SiPM type

#### PR validation:

Tested using runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special
