### PR TITLE
compress outputs of Alignment/OfflineValidation tools

### DIFF
--- a/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
+++ b/Alignment/OfflineValidation/plugins/CosmicSplitterValidation.cc
@@ -70,6 +70,7 @@ private:
 
   bool is_gold_muon(const edm::Event& e);
 
+  const int compressionSettings_;
   edm::InputTag splitTracks_;
   edm::InputTag splitGlobalMuons_;
   edm::InputTag originalTracks_;
@@ -198,7 +199,8 @@ private:
 // constructors and destructor
 //
 CosmicSplitterValidation::CosmicSplitterValidation(const edm::ParameterSet& iConfig)
-    : splitTracks_(iConfig.getParameter<edm::InputTag>("splitTracks")),
+    : compressionSettings_(iConfig.getUntrackedParameter<int>("compressionSettings", -1)),
+      splitTracks_(iConfig.getParameter<edm::InputTag>("splitTracks")),
       splitGlobalMuons_(iConfig.getParameter<edm::InputTag>("splitGlobalMuons")),
       originalTracks_(iConfig.getParameter<edm::InputTag>("originalTracks")),
       originalGlobalMuons_(iConfig.getParameter<edm::InputTag>("originalGlobalMuons")),
@@ -830,6 +832,10 @@ void CosmicSplitterValidation::analyze(const edm::Event& iEvent, const edm::Even
 // ------------ method called once each job just before starting event loop  ------------
 void CosmicSplitterValidation::beginJob() {
   edm::LogInfo("beginJob") << "Begin Job" << std::endl;
+
+  if (compressionSettings_ > 0) {
+    tfile->file().SetCompressionSettings(compressionSettings_);
+  }
 
   splitterTree_ = tfile->make<TTree>("splitterTree", "splitterTree");
 

--- a/Alignment/OfflineValidation/plugins/OverlapValidation.cc
+++ b/Alignment/OfflineValidation/plugins/OverlapValidation.cc
@@ -113,6 +113,7 @@ private:
 
   TTree* rootTree_;
   edm::FileInPath FileInPath_;
+  const int compressionSettings_;
   const bool addExtraBranches_;
   const int minHitsCut_;
   const float chi2ProbCut_;
@@ -183,6 +184,7 @@ OverlapValidation::OverlapValidation(const edm::ParameterSet& iConfig)
     : config_(iConfig),
       rootTree_(nullptr),
       FileInPath_("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat"),
+      compressionSettings_(iConfig.getUntrackedParameter<int>("compressionSettings", -1)),
       addExtraBranches_(false),
       minHitsCut_(6),
       chi2ProbCut_(0.001) {
@@ -209,6 +211,10 @@ OverlapValidation::OverlapValidation(const edm::ParameterSet& iConfig)
   //
   // root output
   //
+  if (compressionSettings_ > 0) {
+    fs->file().SetCompressionSettings(compressionSettings_);
+  }
+
   rootTree_ = fs->make<TTree>("Overlaps", "Overlaps");
   if (addExtraBranches_) {
     rootTree_->Branch("hitCounts", hitCounts_, "found/s:lost/s");

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -70,6 +70,7 @@ PrimaryVertexValidation::PrimaryVertexValidation(const edm::ParameterSet& iConfi
       ttkToken_(esConsumes<TransientTrackBuilder, TransientTrackRecord>(edm::ESInputTag("", "TransientTrackBuilder"))),
       topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd>()),
       runInfoToken_(esConsumes<RunInfo, RunInfoRcd>()),
+      compressionSettings_(iConfig.getUntrackedParameter<int>("compressionSettings", -1)),
       storeNtuple_(iConfig.getParameter<bool>("storeNtuple")),
       lightNtupleSwitch_(iConfig.getParameter<bool>("isLightNtuple")),
       useTracksFromRecoVtx_(iConfig.getParameter<bool>("useTracksFromRecoVtx")),
@@ -1168,6 +1169,9 @@ void PrimaryVertexValidation::beginJob() {
 
   // Define TTree for output
   Nevt_ = 0;
+  if (compressionSettings_ > 0) {
+    fs->file().SetCompressionSettings(compressionSettings_);
+  }
 
   //  rootFile_ = new TFile(filename_.c_str(),"recreate");
   rootTree_ = fs->make<TTree>("tree", "PV Validation tree");
@@ -3596,6 +3600,7 @@ void PrimaryVertexValidation::fillDescriptions(edm::ConfigurationDescriptions& d
 
   // PV Validation specific
 
+  desc.addUntracked<int>("compressionSettings", -1);
   desc.add<bool>("storeNtuple", false);
   desc.add<bool>("isLightNtuple", true);
   desc.add<bool>("useTracksFromRecoVtx", false);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -136,7 +136,6 @@ private:
   inline double square(double x) { return x * x; }
 
   // ----------member data ---------------------------
-  edm::ParameterSet theConfig;
   int Nevt_;
 
   std::unique_ptr<TrackFilterForPVFindingBase> theTrackFilter_;
@@ -155,6 +154,7 @@ private:
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   const edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
 
+  const int compressionSettings_;  // determines the ROOT compression settings in TFileService
   bool storeNtuple_;
   bool lightNtupleSwitch_;  // switch to keep only info for daily validation
   bool useTracksFromRecoVtx_;

--- a/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
+++ b/Alignment/OfflineValidation/plugins/SplitVertexResolution.cc
@@ -104,6 +104,9 @@ private:
   int ievt;
   int itrks;
 
+  // compression settings
+  const int compressionSettings_;
+
   // switch to keep the ntuple
   bool storeNtuple_;
 
@@ -257,7 +260,8 @@ private:
 };
 
 SplitVertexResolution::SplitVertexResolution(const edm::ParameterSet& iConfig)
-    : storeNtuple_(iConfig.getParameter<bool>("storeNtuple")),
+    : compressionSettings_(iConfig.getUntrackedParameter<int>("compressionSettings", -1)),
+      storeNtuple_(iConfig.getParameter<bool>("storeNtuple")),
       intLumi_(iConfig.getUntrackedParameter<double>("intLumi", 0.)),
       debug_(iConfig.getUntrackedParameter<bool>("Debug", false)),
       pvsTag_(iConfig.getParameter<edm::InputTag>("vtxCollection")),
@@ -641,6 +645,10 @@ void SplitVertexResolution::beginRun(edm::Run const& run, edm::EventSetup const&
 void SplitVertexResolution::beginJob() {
   ievt = 0;
   itrks = 0;
+
+  if (compressionSettings_ > 0) {
+    outfile_->file().SetCompressionSettings(compressionSettings_);
+  }
 
   // luminosity histo
   TFileDirectory EventFeatures = outfile_->mkdir("EventFeatures");

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -326,6 +326,7 @@ private:
   std::unique_ptr<AlignableTracker> alignableTracker_;
 
   // parameters from cfg to steer
+  const int compressionSettings_;
   const bool lCoorHistOn_;
   const bool moduleLevelHistsTransient_;
   const bool moduleLevelProfiles_;
@@ -470,6 +471,7 @@ TH1* TrackerOfflineValidation::DirectoryWrapper::make<TH2F>(const char* name,
 TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iConfig)
     : parSet_(iConfig),
       bareTkGeomPtr_(nullptr),
+      compressionSettings_(parSet_.getUntrackedParameter<int>("compressionSettings", -1)),
       lCoorHistOn_(parSet_.getParameter<bool>("localCoorHistosOn")),
       moduleLevelHistsTransient_(parSet_.getParameter<bool>("moduleLevelHistsTransient")),
       moduleLevelProfiles_(parSet_.getParameter<bool>("moduleLevelProfiles")),
@@ -1368,6 +1370,10 @@ void TrackerOfflineValidation::endJob() {
   // In dqmMode tree operations are are sourced out to the additional module TrackerOfflineValidationSummary
 
   edm::Service<TFileService> fs;
+  if (compressionSettings_ > 0) {
+    fs->file().SetCompressionSettings(compressionSettings_);
+  }
+
   TTree* tree = fs->make<TTree>("TkOffVal", "TkOffVal");
 
   TkOffTreeVariables* treeMemPtr = new TkOffTreeVariables;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -21,11 +21,19 @@ process.noScraping= cms.EDFilter("FilterOutScraping",
                                  )
 ####################################
 
+# Use compressions settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 207
 
  ##
  ## Load and Configure OfflineValidation and Output File
  ##
 process.load("Alignment.OfflineValidation.TrackerOfflineValidation_.oO[offlineValidationMode]Oo._cff")
+process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..compressionSettings = compressionSettings,
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..Tracks = 'FinalTrackRefitter'
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..trajectoryInput = 'FinalTrackRefitter'
 process.TrackerOfflineValidation.oO[offlineValidationMode]Oo..moduleLevelHistsTransient = .oO[offlineModuleLevelHistsTransient]Oo.

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/overlapValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/overlapValidationTemplates.py
@@ -1,4 +1,11 @@
 overlapTemplate = """
+# Use compressions settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 207
 process.analysis = cms.EDAnalyzer("OverlapValidation",
     usePXB = cms.bool(True),
     usePXF = cms.bool(True),
@@ -6,6 +13,7 @@ process.analysis = cms.EDAnalyzer("OverlapValidation",
     useTOB = cms.bool(True),
     useTID = cms.bool(True),
     useTEC = cms.bool(True),
+    compressionSettings = cms.untracked.int32(compressionSettings),
     ROUList = cms.vstring('TrackerHitsTIBLowTof',
         'TrackerHitsTIBHighTof',
         'TrackerHitsTOBLowTof',

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexResolutionTemplates.py
@@ -45,10 +45,19 @@ process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxD0Error    
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.maxDzError                    = 1.0
 process.offlinePrimaryVerticesFromRefittedTrks.TkFilterParameters.minPixelLayersWithHits        = 2   
 
+# Use compressions settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 207
+
 ###################################################################
 # The PV resolution module
 ###################################################################
 process.PrimaryVertexResolution = cms.EDAnalyzer('SplitVertexResolution',
+                                                 compressionSettings = cms.untracked.int32(compressionSettings),
                                                  storeNtuple         = cms.bool(False),
                                                  vtxCollection       = cms.InputTag("offlinePrimaryVerticesFromRefittedTrks"),
                                                  trackCollection     = cms.InputTag("TrackRefitter"),		

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/primaryVertexValidationTemplates.py
@@ -97,10 +97,19 @@ def switchClusterizerParameters(da):
           print(">>>>>>>>>> testPVValidation_cfg.py: msg%-i: Running GAP Algorithm!")
           return GapClusterizationParams
 
+# Use compressions settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 207
+
 ####################################################################
 # Configure the PVValidation Analyzer module
 ####################################################################
 process.PVValidation = cms.EDAnalyzer("PrimaryVertexValidation",
+                                      compressionSettings = cms.untracked.int32(compressionSettings),
                                       TrackCollectionTag = cms.InputTag("FinalTrackRefitter"),
                                       VertexCollectionTag = cms.InputTag(".oO[VertexCollection]Oo."),
                                       Debug = cms.bool(False),

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -7,7 +7,15 @@ process.FittingSmootherRKP5.EstimateCut = -1
 
 .oO[subdetselection]Oo.
 
+# Use compressions settings of TFile
+# see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+# settings = 100 * algorithm + level
+# level is from 1 (small) to 9 (large compression)
+# algo: 1 (ZLIB), 2 (LMZA)
+# see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+compressionSettings = 207
 process.cosmicValidation = cms.EDAnalyzer("CosmicSplitterValidation",
+    compressionSettings = cms.untracked.int32(compressionSettings),
     ifSplitMuons = cms.bool(False),
     ifTrackMCTruth = cms.bool(False),	
     checkIfGolden = cms.bool(False),	

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -69,7 +69,15 @@ process.looper = cms.Looper(
 
     # Output settings
     # ---------------
+    # Use compressions settings of TFile
+    # see https://root.cern.ch/root/html534/TFile.html#TFile:SetCompressionSettings
+    # settings = 100 * algorithm + level
+    # level is from 1 (small) to 9 (large compression)
+    # algo: 1 (ZLIB), 2 (LMZA)
+    # see more about compression & performance: https://root.cern.ch/root/html534/guides/users-guide/InputOutput.html#compression-and-performance
+
     OutputFileName = cms.untracked.string("zmumuHisto.root"),
+    compressionSettings = cms.untracked.int32(compressionSettings), 
 
     # BiasType=0 means no bias to muon momenta
     # ----------------------------------------

--- a/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
+++ b/Alignment/OfflineValidation/python/TrackerOfflineValidation_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 TrackerOfflineValidation = cms.EDAnalyzer("TrackerOfflineValidation",
+    compressionSettings       = cms.untracked.int32(-1),
     useInDqmMode              = cms.bool(False),  # Switch between Standalone tool (using TFileService) and DQM-based version (using DQMStore)
     moduleDirectoryInOutput   = cms.string(""),   # at present adopted only in DQM mode (TFileService attaches the ModuleName as directory automatically)
     Tracks                    = cms.InputTag("TrackRefitter"),

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
@@ -656,7 +656,11 @@ void MuScleFit::beginOfJobInConstructor()
     std::stringstream ss;
     ss << i;
     std::string rootFileName = ss.str() + "_" + theRootFileName_;
-    theFiles_.push_back(new TFile(rootFileName.c_str(), "RECREATE"));
+    if (theCompressionSettings_ > -1) {
+      theFiles_.push_back(new TFile(rootFileName.c_str(), "RECREATE", "", theCompressionSettings_));
+    } else {
+      theFiles_.push_back(new TFile(rootFileName.c_str(), "RECREATE"));
+    }
   }
   if (debug_ > 0)
     std::cout << "[MuScleFit]: Root file created" << std::endl;

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitBase.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitBase.h
@@ -23,6 +23,7 @@ public:
         probabilitiesFile_(iConfig.getUntrackedParameter<std::string>("ProbabilitiesFile", "")),
         theMuonType_(iConfig.getParameter<int>("MuonType")),
         theMuonLabel_(iConfig.getParameter<edm::InputTag>("MuonLabel")),
+        theCompressionSettings_(iConfig.getUntrackedParameter<int>("compressionSettings", -1)),
         theRootFileName_(iConfig.getUntrackedParameter<std::string>("OutputFileName")),
         theGenInfoRootFileName_(
             iConfig.getUntrackedParameter<std::string>("OutputGenInfoFileName", "genSimRecoPlots.root")),
@@ -45,6 +46,7 @@ protected:
 
   int theMuonType_;
   edm::InputTag theMuonLabel_;
+  int theCompressionSettings_;
   std::string theRootFileName_;
   std::string theGenInfoRootFileName_;
 


### PR DESCRIPTION
#### PR description:

The goal of this PR is to introduce the possibility to compress the output `ROOT` files produced by the Alignment OfflineValidation tools, using the LMZA compression. This should allow to reduce the load in terms of space of the `alca_trackeralign` eos group space.

#### PR validation:

Compiles.
Followed recommendations of [this talk, slide n. 20](https://indico.cern.ch/event/973548/contributions/4099353/attachments/2140135/3607129/20-11-11_News_PPDCoord.pdf)
![image](https://user-images.githubusercontent.com/5082376/98806855-18dfc580-241a-11eb-97d3-a1511892eee3.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.