### PR TITLE
Migration to DD4Hep for RPC db Loader

### DIFF
--- a/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
+++ b/CondTools/Geometry/plugins/RPCRecoIdealDBLoader.cc
@@ -14,15 +14,25 @@
 #include "Geometry/Records/interface/MuonNumberingRecord.h"
 #include "Geometry/MuonNumbering/interface/MuonGeometryConstants.h"
 #include "Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "DetectorDescription/DDCMS/interface/DDCompactView.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 class RPCRecoIdealDBLoader : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
 public:
-  RPCRecoIdealDBLoader(const edm::ParameterSet&) {}
+  RPCRecoIdealDBLoader(const edm::ParameterSet&);
 
   void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   void analyze(edm::Event const& iEvent, edm::EventSetup const&) override {}
   void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {}
+
+private:
+  bool fromDD4Hep_;
 };
+
+RPCRecoIdealDBLoader::RPCRecoIdealDBLoader(const edm::ParameterSet& iC) {
+  fromDD4Hep_ = iC.getUntrackedParameter<bool>("fromDD4Hep", false);
+}
 
 void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) {
   RecoIdealGeometry* rig = new RecoIdealGeometry;
@@ -32,16 +42,22 @@ void RPCRecoIdealDBLoader::beginRun(const edm::Run&, edm::EventSetup const& es) 
     return;
   }
 
-  edm::ESTransientHandle<DDCompactView> pDD;
   edm::ESHandle<MuonGeometryConstants> pMNDC;
-  es.get<IdealGeometryRecord>().get(pDD);
-  es.get<IdealGeometryRecord>().get(pMNDC);
-
-  const DDCompactView& cpv = *pDD;
   RPCGeometryParsFromDD rpcpd;
 
-  rpcpd.build(&cpv, *pMNDC, *rig);
-
+  if (fromDD4Hep_) {
+    edm::ESTransientHandle<cms::DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    es.get<IdealGeometryRecord>().get(pMNDC);
+    const cms::DDCompactView& cpv = *pDD;
+    rpcpd.build(&cpv, *pMNDC, *rig);
+  } else {
+    edm::ESTransientHandle<DDCompactView> pDD;
+    es.get<IdealGeometryRecord>().get(pDD);
+    es.get<IdealGeometryRecord>().get(pMNDC);
+    const DDCompactView& cpv = *pDD;
+    rpcpd.build(&cpv, *pMNDC, *rig);
+  }
   if (mydbservice->isNewTagRequest("RPCRecoGeometryRcd")) {
     mydbservice->createNewIOV<RecoIdealGeometry>(
         rig, mydbservice->beginOfTime(), mydbservice->endOfTime(), "RPCRecoGeometryRcd");

--- a/CondTools/Geometry/test/rpcgeometrywriter.py
+++ b/CondTools/Geometry/test/rpcgeometrywriter.py
@@ -4,6 +4,8 @@ process = cms.Process("RPCGeometryWriter")
 process.load('CondCore.CondDB.CondDB_cfi')
 process.load('Configuration.StandardSequences.GeometryExtended_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -12,7 +14,8 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader")
+process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",
+                                           fromDD4Hep = cms.untracked.bool(True))
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')

--- a/CondTools/Geometry/test/rpcgeometrywriter.py
+++ b/CondTools/Geometry/test/rpcgeometrywriter.py
@@ -6,6 +6,14 @@ process.load('Configuration.StandardSequences.GeometryExtended_cff')
 process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations = cms.untracked.vstring('myLog'),
+    myLog = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO'),
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),

--- a/CondTools/Geometry/test/rpcgeometrywriter.py
+++ b/CondTools/Geometry/test/rpcgeometrywriter.py
@@ -15,7 +15,7 @@ process.source = cms.Source("EmptyIOVSource",
                             )
 
 process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader",
-                                           fromDD4Hep = cms.untracked.bool(True))
+                                           fromDD4Hep = cms.untracked.bool(False))
 
 process.CondDB.timetype = cms.untracked.string('runnumber')
 process.CondDB.connect = cms.string('sqlite_file:myfile.db')

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -22,11 +22,8 @@
 #include <DetectorDescription/DDCMS/interface/DDFilteredView.h>
 #include <DetectorDescription/DDCMS/interface/DDCompactView.h>
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
-#include "DataFormats/Math/interface/CMSUnits.h"
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-using namespace cms_units::operators;
 
 RPCGeometryParsFromDD::RPCGeometryParsFromDD() {}
 
@@ -116,12 +113,15 @@ void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
       edm::LogVerbatim("RPCGeometryParsFromDD")
           << " (3), else, dpar[4]: " << dpar4 << " dpar[8]: " << dpar8 << " dpar[0]: " << dpar0;
     }
+   
     const std::vector<double> vtra = {geant_units::operators::convertMmToCm(tran.x()),
                                       geant_units::operators::convertMmToCm(tran.y()),
                                       geant_units::operators::convertMmToCm(tran.z())};
+    
     edm::LogVerbatim("RPCGeometryParsFromDD") << " (4), tran.x() " << geant_units::operators::convertMmToCm(tran.x())
                                               << " tran.y(): " << geant_units::operators::convertMmToCm(tran.y())
                                               << " tran.z(): " << geant_units::operators::convertMmToCm(tran.z());
+   
     const std::vector<double> vrot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
     edm::LogVerbatim("RPCGeometryParsFromDD")
         << " (5), x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z() " << x.X() << ", " << x.Y() << ", "

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -22,7 +22,7 @@
 #include <DetectorDescription/DDCMS/interface/DDFilteredView.h>
 #include <DetectorDescription/DDCMS/interface/DDCompactView.h>
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
-#include "DataFormats/Math/interface/GeantUnits.h"
+//#include "DataFormats/Math/interface/GeantUnits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 RPCGeometryParsFromDD::RPCGeometryParsFromDD() {}
@@ -99,28 +99,28 @@ void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
     rota.GetComponents(x, y, z);
     std::vector<double> pars;
     if (dpar.size() == 3) {
-      const double width = geant_units::operators::convertMmToCm(dpar[0]);
-      const double length = geant_units::operators::convertMmToCm(dpar[1]);
-      const double thickness = geant_units::operators::convertMmToCm(dpar[2]);
+      const double width = dpar[0];
+      const double length = dpar[1];
+      const double thickness = dpar[2];
       edm::LogVerbatim("RPCGeometryParsFromDD")
           << " (2) dpar.size() == 3, width: " << width << " length: " << length << " thickness: " << thickness;
       pars = {width, length, thickness, numbOfStrips.doubles()[0]};
     } else {
-      const double dpar4 = geant_units::operators::convertMmToCm(dpar[4]);
-      const double dpar8 = geant_units::operators::convertMmToCm(dpar[8]);
-      const double dpar0 = geant_units::operators::convertMmToCm(dpar[0]);
+      const double dpar4 = dpar[4];
+      const double dpar8 = dpar[8];
+      const double dpar0 = dpar[0];
       pars = {dpar4, dpar8, dpar0, 0.4, numbOfStrips.doubles()[0]};
       edm::LogVerbatim("RPCGeometryParsFromDD")
           << " (3), else, dpar[4]: " << dpar4 << " dpar[8]: " << dpar8 << " dpar[0]: " << dpar0;
     }
 
-    const std::vector<double> vtra = {geant_units::operators::convertMmToCm(tran.x()),
-                                      geant_units::operators::convertMmToCm(tran.y()),
-                                      geant_units::operators::convertMmToCm(tran.z())};
+    const std::vector<double> vtra = {tran.x(),
+                                      tran.y(),
+                                      tran.z()};
 
-    edm::LogVerbatim("RPCGeometryParsFromDD") << " (4), tran.x() " << geant_units::operators::convertMmToCm(tran.x())
-                                              << " tran.y(): " << geant_units::operators::convertMmToCm(tran.y())
-                                              << " tran.z(): " << geant_units::operators::convertMmToCm(tran.z());
+    edm::LogVerbatim("RPCGeometryParsFromDD") << " (4), tran.x() " << tran.x()
+                                              << " tran.y(): " << tran.y()
+                                              << " tran.z(): " << tran.z();
 
     const std::vector<double> vrot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
     edm::LogVerbatim("RPCGeometryParsFromDD")
@@ -153,9 +153,9 @@ void RPCGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fview,
     const std::vector<std::string> strpars = {std::string(name)};
 
     std::vector<double> tran(3);
-    tran[0] = static_cast<double>(fview.translation().X());
-    tran[1] = static_cast<double>(fview.translation().Y());
-    tran[2] = static_cast<double>(fview.translation().Z());
+    tran[0] = static_cast<double>(fview.translation().X()) / dd4hep::mm;
+    tran[1] = static_cast<double>(fview.translation().Y()) / dd4hep::mm;
+    tran[2] = static_cast<double>(fview.translation().Z()) / dd4hep::mm;
 
     DDRotationMatrix rota;
     fview.rot(rota);
@@ -164,16 +164,16 @@ void RPCGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fview,
     const std::vector<double> rot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 
     if (dd4hep::isA<dd4hep::Box>(fview.solid())) {
-      const std::vector<double> pars = {dpar[0], dpar[1], dpar[2], double(nStrips)};
+      const std::vector<double> pars = {dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[2] / dd4hep::mm, double(nStrips)};
       edm::LogVerbatim("RPCGeometryParsFromDD")
-          << " (2), dd4hep::Box, width: " << dpar[0] << " length: " << dpar[1] << " thickness: " << dpar[2];
+	<< " (2), dd4hep::Box, width: " << dpar[0] / dd4hep::mm<< " length: " << dpar[1] / dd4hep::mm<< " thickness: " << dpar[2] / dd4hep::mm;
       rgeo.insert(rpcid, tran, rot, pars, strpars);
     } else {
       const double ti = 0.4;
-      const std::vector<double> pars = {dpar[0], dpar[1], dpar[3], ti, double(nStrips)};
+      const std::vector<double> pars = {dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[3] / dd4hep::mm, ti, double(nStrips)};
       edm::LogVerbatim("RPCGeometryParsFromDD")
-          << " (3), else, dpar[0] (i.e. dpar[4] for DD): " << dpar[0] << " dpar[1] (i.e. dpar[8] for DD): " << dpar[1]
-          << " dpar[3] (i.e. dpar[0] for DD): " << dpar[3];
+	<< " (3), else, dpar[0] (i.e. dpar[4] for DD): " << dpar[0] / dd4hep::mm<< " dpar[1] (i.e. dpar[8] for DD): " << dpar[1] / dd4hep::mm
+	<< " dpar[3] (i.e. dpar[0] for DD): " << dpar[3] / dd4hep::mm;
       rgeo.insert(rpcid, tran, rot, pars, strpars);
     }
     edm::LogVerbatim("RPCGeometryParsFromDD")

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -1,31 +1,37 @@
-/** Implementation of the RPC Geometry Builder from DDD
+/* Implementation of the  RPCGeometryParsFromDD Class
+ *  Build the RPCGeometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Mon, 09 Nov 2020 
  *
- *  \author Port of: MuDDDRPCBuilder (ORCA)
- *  \author M. Maggi - INFN Bari
  */
 #include "Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
-
 #include <CondFormats/GeometryObjects/interface/RecoIdealGeometry.h>
 #include <DetectorDescription/Core/interface/DDFilter.h>
 #include <DetectorDescription/Core/interface/DDFilteredView.h>
 #include <DetectorDescription/Core/interface/DDSolid.h>
-
 #include "Geometry/MuonNumbering/interface/MuonGeometryNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/RPCNumberingScheme.h"
-
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
-
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
-
 #include <iostream>
 #include <algorithm>
+#include <DetectorDescription/DDCMS/interface/DDFilteredView.h>
+#include <DetectorDescription/DDCMS/interface/DDCompactView.h>
+#include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
+#include "DataFormats/Math/interface/CMSUnits.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
+
+using namespace cms_units::operators;
 
 RPCGeometryParsFromDD::RPCGeometryParsFromDD() {}
 
 RPCGeometryParsFromDD::~RPCGeometryParsFromDD() {}
 
+// DD
 void RPCGeometryParsFromDD::build(const DDCompactView* cview,
                                   const MuonGeometryConstants& muonConstants,
                                   RecoIdealGeometry& rgeo) {
@@ -38,6 +44,20 @@ void RPCGeometryParsFromDD::build(const DDCompactView* cview,
 
   this->buildGeometry(fview, muonConstants, rgeo);
 }
+
+// DD4Hep
+
+void RPCGeometryParsFromDD::build(const cms::DDCompactView* cview,
+                                  const MuonGeometryConstants& muonConstants,
+                                  RecoIdealGeometry& rgeo) {
+  const std::string attribute = "ReadOutName";
+  const std::string value = "MuonRPCHits";
+  const cms::DDFilter filter(attribute, value);
+  cms::DDFilteredView fview(*cview, filter);
+  this->buildGeometry(fview, muonConstants, rgeo);
+}
+
+// DD
 
 void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
                                           const MuonGeometryConstants& muonConstants,
@@ -88,5 +108,54 @@ void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
     const std::vector<double> vtra = {tran.x(), tran.y(), tran.z()};
     const std::vector<double> vrot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
     rgeo.insert(rpcid.rawId(), vtra, vrot, pars, strpars);
+  }
+}
+
+// DD4Hep
+
+void RPCGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fview,
+                                          const MuonGeometryConstants& muonConstants,
+                                          RecoIdealGeometry& rgeo) {
+  
+  while (fview.firstChild()) {
+    MuonGeometryNumbering mdddnum(muonConstants);
+    RPCNumberingScheme rpcnum(muonConstants);
+    int rawidCh = rpcnum.baseNumberToUnitNumber(mdddnum.geoHistoryToBaseNumber(fview.history()));
+    RPCDetId rpcid = RPCDetId(rawidCh);
+    
+    auto nStrips = fview.get<double>("nStrips");
+    
+    std::vector<double> dpar = fview.parameters();
+    
+    std::string_view name = fview.name();
+    const std::vector<std::string> strpars = {std::string(name)};
+       
+    std::vector<double> tran(3);
+    tran[0] = static_cast<double>(fview.translation().X());
+    tran[1] = static_cast<double>(fview.translation().Y());
+    tran[2] = static_cast<double>(fview.translation().Z());
+
+    DDRotationMatrix rota;
+    fview.rot(rota);
+    DD3Vector x, y, z;
+    rota.GetComponents(x, y, z);
+    const std::vector<double>  rot = {x.X(),
+				      x.Y(),
+				      x.Z(),
+				      y.X(),
+				      y.Y(),
+				      y.Z(),
+				      z.X(),
+				      z.Y(),
+				      z.Z()};
+    
+    if (dd4hep::isA<dd4hep::Box>(fview.solid())) {
+      const std::vector<double> pars = {dpar[0], dpar[1], dpar[2], double(nStrips)};
+      rgeo.insert(rpcid, tran, rot, pars, strpars);   
+    } else {
+      const double ti = 0.4;
+      const std::vector<double> pars = {dpar[0], dpar[1], dpar[3], ti, double(nStrips)};
+      rgeo.insert(rpcid, tran, rot, pars, strpars);   
+    }
   }
 }

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -22,7 +22,6 @@
 #include <DetectorDescription/DDCMS/interface/DDFilteredView.h>
 #include <DetectorDescription/DDCMS/interface/DDCompactView.h>
 #include "DetectorDescription/DDCMS/interface/DDSpecParRegistry.h"
-//#include "DataFormats/Math/interface/GeantUnits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 RPCGeometryParsFromDD::RPCGeometryParsFromDD() {}
@@ -114,13 +113,10 @@ void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
           << " (3), else, dpar[4]: " << dpar4 << " dpar[8]: " << dpar8 << " dpar[0]: " << dpar0;
     }
 
-    const std::vector<double> vtra = {tran.x(),
-                                      tran.y(),
-                                      tran.z()};
+    const std::vector<double> vtra = {tran.x(), tran.y(), tran.z()};
 
-    edm::LogVerbatim("RPCGeometryParsFromDD") << " (4), tran.x() " << tran.x()
-                                              << " tran.y(): " << tran.y()
-                                              << " tran.z(): " << tran.z();
+    edm::LogVerbatim("RPCGeometryParsFromDD")
+        << " (4), tran.x() " << tran.x() << " tran.y(): " << tran.y() << " tran.z(): " << tran.z();
 
     const std::vector<double> vrot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
     edm::LogVerbatim("RPCGeometryParsFromDD")
@@ -164,16 +160,19 @@ void RPCGeometryParsFromDD::buildGeometry(cms::DDFilteredView& fview,
     const std::vector<double> rot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
 
     if (dd4hep::isA<dd4hep::Box>(fview.solid())) {
-      const std::vector<double> pars = {dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[2] / dd4hep::mm, double(nStrips)};
+      const std::vector<double> pars = {
+          dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[2] / dd4hep::mm, double(nStrips)};
       edm::LogVerbatim("RPCGeometryParsFromDD")
-	<< " (2), dd4hep::Box, width: " << dpar[0] / dd4hep::mm<< " length: " << dpar[1] / dd4hep::mm<< " thickness: " << dpar[2] / dd4hep::mm;
+          << " (2), dd4hep::Box, width: " << dpar[0] / dd4hep::mm << " length: " << dpar[1] / dd4hep::mm
+          << " thickness: " << dpar[2] / dd4hep::mm;
       rgeo.insert(rpcid, tran, rot, pars, strpars);
     } else {
       const double ti = 0.4;
-      const std::vector<double> pars = {dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[3] / dd4hep::mm, ti, double(nStrips)};
-      edm::LogVerbatim("RPCGeometryParsFromDD")
-	<< " (3), else, dpar[0] (i.e. dpar[4] for DD): " << dpar[0] / dd4hep::mm<< " dpar[1] (i.e. dpar[8] for DD): " << dpar[1] / dd4hep::mm
-	<< " dpar[3] (i.e. dpar[0] for DD): " << dpar[3] / dd4hep::mm;
+      const std::vector<double> pars = {
+          dpar[0] / dd4hep::mm, dpar[1] / dd4hep::mm, dpar[3] / dd4hep::mm, ti, double(nStrips)};
+      edm::LogVerbatim("RPCGeometryParsFromDD") << " (3), else, dpar[0] (i.e. dpar[4] for DD): " << dpar[0] / dd4hep::mm
+                                                << " dpar[1] (i.e. dpar[8] for DD): " << dpar[1] / dd4hep::mm
+                                                << " dpar[3] (i.e. dpar[0] for DD): " << dpar[3] / dd4hep::mm;
       rgeo.insert(rpcid, tran, rot, pars, strpars);
     }
     edm::LogVerbatim("RPCGeometryParsFromDD")

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -113,15 +113,15 @@ void RPCGeometryParsFromDD::buildGeometry(DDFilteredView& fview,
       edm::LogVerbatim("RPCGeometryParsFromDD")
           << " (3), else, dpar[4]: " << dpar4 << " dpar[8]: " << dpar8 << " dpar[0]: " << dpar0;
     }
-   
+
     const std::vector<double> vtra = {geant_units::operators::convertMmToCm(tran.x()),
                                       geant_units::operators::convertMmToCm(tran.y()),
                                       geant_units::operators::convertMmToCm(tran.z())};
-    
+
     edm::LogVerbatim("RPCGeometryParsFromDD") << " (4), tran.x() " << geant_units::operators::convertMmToCm(tran.x())
                                               << " tran.y(): " << geant_units::operators::convertMmToCm(tran.y())
                                               << " tran.z(): " << geant_units::operators::convertMmToCm(tran.z());
-   
+
     const std::vector<double> vrot = {x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z()};
     edm::LogVerbatim("RPCGeometryParsFromDD")
         << " (5), x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z() " << x.X() << ", " << x.Y() << ", "

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h
@@ -16,10 +16,10 @@
 
 class DDCompactView;
 class DDFilteredView;
-namespace cms { // DD4Hep
-   class DDFilteredView;
-   class DDCompactView;
-}
+namespace cms {  // DD4Hep
+  class DDFilteredView;
+  class DDCompactView;
+}  // namespace cms
 class RPCDetId;
 class RPCRoll;
 class MuonGeometryConstants;
@@ -34,6 +34,7 @@ public:
   void build(const DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
   // DD4Hep
   void build(const cms::DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
+
 private:
   // DD
   void buildGeometry(DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.h
@@ -1,11 +1,12 @@
 #ifndef RPCGeometry_RPCGeometryParsFromDD_H
 #define RPCGeometry_RPCGeometryParsFromDD_H
 
-/** \class  RPCGeometryParsFromDD
- *  Build the RPCGeometry ftom the DDD description
- *
- *  \author Port of: MuDDDRPCBuilder, MuonRPCGeometryBuilder (ORCA)
- *  \author M. Maggi - INFN Bari
+/* \class  RPCGeometryParsFromDD
+ *  Build the RPCGeometry from the DDD and DD4Hep description
+ *  
+ *  DD4hep part added to the original old file (DD version) made by M. Maggi (INFN Bari)
+ *  Author:  Sergio Lo Meo (sergio.lo.meo@cern.ch) 
+ *  Created:  Mon, 09 Nov 2020 
  *
  */
 
@@ -15,6 +16,10 @@
 
 class DDCompactView;
 class DDFilteredView;
+namespace cms { // DD4Hep
+   class DDFilteredView;
+   class DDCompactView;
+}
 class RPCDetId;
 class RPCRoll;
 class MuonGeometryConstants;
@@ -25,10 +30,15 @@ public:
 
   ~RPCGeometryParsFromDD();
 
+  // DD
   void build(const DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
-
+  // DD4Hep
+  void build(const cms::DDCompactView* cview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
 private:
+  // DD
   void buildGeometry(DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
+  // DD4Hep
+  void buildGeometry(cms::DDFilteredView& fview, const MuonGeometryConstants& muonConstants, RecoIdealGeometry& rgeo);
 };
 
 #endif


### PR DESCRIPTION
**PR description:**

This PR (only for RPC) followed what I did for CSC in #32001  . 

**PR validation:**

1) validation by "cmsRun CondTools/Geometry/test/rpcgeometrywriter.py" (with DD4hep flag set False or True):

Begin processing the 1st record. Run 1, Event 1, LumiSection 1 on stream 0 at 11-Nov-2020 13:26:09.163 CET

MessageLogger Summary

Severity    # Occurrences   Total Occurrences
--------    -------------   ---------------

dropped waiting message count 0

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

 2) validation by printouts for both DD & DD4Hep build methods within the RPCGeometryParsFromDD Class in order to compare some DetId parameters (for example the 637566989 detid):

//DD
1, RPCGeometryParsFromDD, detid: 637566989 name: MB1RPC_IGasLeft number of Strips: 90
2, RPCGeometryParsFromDD, dpar.size() == 3, width: 103 length: 58.45 thickness: 0.2
4, RPCGeometryParsFromDD, tran.x(): 413.675 tran.y(): 37.6 tran.z(): -470.45
5, RPCGeometryParsFromDD, x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z():
5, RPCGeometryParsFromDD 3.06162e-16, -1, 3.12322e-16, -4.78895e-16, -8.5632e-16, 1, -1, 6.40079e-16, 1.15045e-17

//DD4Hep
1, RPCGeometryParsFromDD, detid: 637566989 name: MB1RPC_IGasLeft number of Strips: 90
2, RPCGeometryParsFromDD, dd4hep::Box, width: 103 length: 58.45 thickness: 0.2
4, RPCGeometryParsFromDD, tran.x(): 413.675 tran.y(): 37.6 tran.z(): -470.45
5, RPCGeometryParsFromDD, x.X(), x.Y(), x.Z(), y.X(), y.Y(), y.Z(), z.X(), z.Y(), z.Z():
5, RPCGeometryParsFromDD 2.13888e-16, -1, 2.00422e-16, -9.9934e-17, -4.99491e-16, 1, -1, 3.02876e-16, -1.22527e-16

++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

3) validation by "runTheMatrix.py -l 25202.1" (because I edited the RPCGeometryParsFromDD class and not only the DB Class):

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Wed Nov 11 13:59:46 2020-date Wed Nov 11 13:32:32 2020; exit: 0 0 0 0
1 1 1 1 tests passed, 0 0 0 0 failed


**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special
