### PR TITLE
NanoAOD: pass through for muon and Isotrack above 15 GeV in pt, regardless of ID or dxy/dz

### DIFF
--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -3,7 +3,7 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 finalIsolatedTracks = cms.EDProducer("IsolatedTrackCleaner",
     tracks = cms.InputTag("isolatedTracks"),
-    cut = cms.string("((pt>5 && (abs(pdgId) == 11 || abs(pdgId) == 13)) || pt > 10) && (abs(pdgId) < 15 || abs(eta) < 2.5) && abs(dxy) < 0.2 && abs(dz) < 0.1 && ((pfIsolationDR03().chargedHadronIso < 5 && pt < 25) || pfIsolationDR03().chargedHadronIso/pt < 0.2)"), 
+    cut = cms.string("((pt>5 && (abs(pdgId) == 11 || abs(pdgId) == 13)) || pt > 10) && (abs(pdgId) < 15 || abs(eta) < 2.5) && ((pfIsolationDR03().chargedHadronIso < 5 && pt < 25) || pfIsolationDR03().chargedHadronIso/pt < 0.2)"),
     finalLeptons = cms.VInputTag(
         cms.InputTag("finalElectrons"),
         cms.InputTag("finalLooseMuons"),

--- a/PhysicsTools/NanoAOD/python/isotracks_cff.py
+++ b/PhysicsTools/NanoAOD/python/isotracks_cff.py
@@ -3,7 +3,7 @@ from PhysicsTools.NanoAOD.common_cff import *
 
 finalIsolatedTracks = cms.EDProducer("IsolatedTrackCleaner",
     tracks = cms.InputTag("isolatedTracks"),
-    cut = cms.string("((pt>5 && (abs(pdgId) == 11 || abs(pdgId) == 13)) || pt > 10) && (abs(pdgId) < 15 || abs(eta) < 2.5) && ((pfIsolationDR03().chargedHadronIso < 5 && pt < 25) || pfIsolationDR03().chargedHadronIso/pt < 0.2)"),
+    cut = cms.string("((pt>5 && (abs(pdgId) == 11 || abs(pdgId) == 13)) || pt > 10) && (abs(pdgId) < 15 || abs(eta) < 2.5) && ((abs(dxy) < 0.2 && abs(dz) < 0.1) || pt>15) && ((pfIsolationDR03().chargedHadronIso < 5 && pt < 25) || pfIsolationDR03().chargedHadronIso/pt < 0.2)"),
     finalLeptons = cms.VInputTag(
         cms.InputTag("finalElectrons"),
         cms.InputTag("finalLooseMuons"),

--- a/PhysicsTools/NanoAOD/python/muons_cff.py
+++ b/PhysicsTools/NanoAOD/python/muons_cff.py
@@ -51,7 +51,7 @@ slimmedMuonsWithUserData = cms.EDProducer("PATMuonUserDataEmbedder",
 
 finalMuons = cms.EDFilter("PATMuonRefSelector",
     src = cms.InputTag("slimmedMuonsWithUserData"),
-    cut = cms.string("pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt'))")
+    cut = cms.string("pt > 15 || (pt > 3 && (passed('CutBasedIdLoose') || passed('SoftCutBasedId') || passed('SoftMvaId') || passed('CutBasedIdGlobalHighPt') || passed('CutBasedIdTrkHighPt')))")
 )
 
 finalLooseMuons = cms.EDFilter("PATMuonRefSelector", # for isotrack cleaning


### PR DESCRIPTION
#### PR description:

This PR is to pass through all muons from MiniAOD to NanoAOD above pT > 15 GeV, regardless of the ID. This is needed to make more detailed tag-and-probe efficiency studies for the w-mass measurement.

The total size difference is of the order of 0.25%. We ran tests on 50k events for ttbar and dy and the difference in size is:

ttbar: 105727232 vs. 105437681 bytes with pass-through ON versus OFF, ratio 1.00275
    (41754 versus 37945 muons, 10% more)
dy: 61925228 vs. 61753275 bytes with pass-through ON versus OFF, ratio: 1.00278
    (68772 versus 66746 muons, 3% more)

#### PR validation:

Ran 50k Mini->Nano events for DY and ttbar MC in the SMP-RunIISummer16NanoAODv8 campaign.


