### PR TITLE
remove hgcal local reco from reconstruction_trackingOnlyTask for trackingPhase2PU140 (11_1_X backport)

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_cff.py
@@ -208,6 +208,9 @@ reconstructionTask.visit(cms.ModuleNamesFromGlobalsVisitor(globals(),_modulesInR
 logErrorHarvester.includeModules = cms.untracked.vstring(set(_modulesInReconstruction))
 
 reconstruction_trackingOnlyTask = cms.Task(localrecoTask,globalreco_trackingTask)
+#calo parts removed as long as tracking is not running jetCore in phase2
+trackingPhase2PU140.toReplaceWith(reconstruction_trackingOnlyTask,
+                                  reconstruction_trackingOnlyTask.copyAndExclude([hgcalLocalRecoTask,castorreco]))
 reconstruction_trackingOnly = cms.Sequence(reconstruction_trackingOnlyTask)
 reconstruction_pixelTrackingOnlyTask = cms.Task(
     pixeltrackerlocalrecoTask,


### PR DESCRIPTION
Backport of #31844 
--------------------------------
This backport fixes the crash in `20434.1`
https://cmssdt.cern.ch/SDT/html/cmssdt-ib/#/relVal/CMSSW_11_1/2020-11-10-2300?selectedArchs=slc7_amd64_gcc820&selectedFlavors=X&selectedStatus=failed

Tested in `20434.1`.

From @slava77's PR:

This is in response to #31743 : reconstruction_trackingOnlyTask by default includes localrecoTask, which includes calolocalrecoTask, which in turn includes hgcalLocalRecoTask.
There are no actual dependencies on products made in hgcalLocalRecoTask.

This also removed castorreco from reconstruction_trackingOnlyTask, which is not needed/used either.

A recent update in #31527 introduced an explicit dependency of hgcalLocalRecoTask on tracking and broke reconstruction_trackingOnlyTask.
I propose to simply remove dependence on hgcalLocalRecoTask at this point (rather than picking individual unwanted modules).

tested on 23234.1 (phase-2 D49 trackingOnly wf)

@JanFSchulte @felicepantaleo @rovere