### PR TITLE
Backport fixes for gen weights in NanoAOD (#31680, #31982, #31946, #31939, #32071)

### DIFF
--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -589,7 +589,7 @@ public:
 
       //<weight MUF="1.0" MUR="2.0" PDF="306000" id="1006"> MUR=2.0  </weight>
       std::regex scalew(
-          "<weight\\s+(?:.*\\s+)?id=\"(\\d+)\">\\s*(?:lhapdf=\\d+|dyn=\\s*-?\\d+)?\\s*((?:mu[rR]|renscfact)=(\\S+)\\s+("
+          "<weight\\s+(?:.*\\s+)?id=\"(\\d+|\\d+-NNLOPS)\">\\s*(?:lhapdf=\\d+|dyn=\\s*-?\\d+)?\\s*((?:mu[rR]|renscfact)=(\\S+)\\s+("
           "?:mu[Ff]|facscfact)=(\\S+)(\\s+.*)?)</weight>");
       std::regex pdfw(
           "<weight\\s+id=\"(\\d+)\">\\s*(?:PDF set|lhapdf|PDF|pdfset)\\s*=\\s*(\\d+)\\s*(?:\\s.*)?</weight>");

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -802,6 +802,7 @@ public:
             // I aplogize to contributing the rampant copy paste of code
             } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
               if (lheDebug)
+                std::cout << ">>> Looks like an EW parameter weight" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {
                 if (lheDebug)
                   std::cout << "    " << lines[iLine];

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -589,8 +589,8 @@ public:
 
       //<weight MUF="1.0" MUR="2.0" PDF="306000" id="1006"> MUR=2.0  </weight>
       std::regex scalew(
-          "<weight\\s+(?:.*\\s+)?id=\"(\\d+|\\d+-NNLOPS)\">\\s*(?:lhapdf=\\d+|dyn=\\s*-?\\d+)?\\s*((?:mu[rR]|renscfact)=(\\S+)\\s+("
-          "?:mu[Ff]|facscfact)=(\\S+)(\\s+.*)?)</weight>");
+          "<weight\\s+(?:.*\\s+)?id=\"(\\d+|\\d+-NNLOPS)\">\\s*(?:lhapdf=\\d+|dyn=\\s*-?\\d+)?\\s*((?:mu[rR]|renscfact)"
+          "=(\\S+)\\s+(?:mu[Ff]|facscfact)=(\\S+)(\\s+.*)?)</weight>");
       std::regex pdfw(
           "<weight\\s+id=\"(\\d+)\">\\s*(?:PDF set|lhapdf|PDF|pdfset)\\s*=\\s*(\\d+)\\s*(?:\\s.*)?</weight>");
       std::regex pdfwOld("<weight\\s+(?:.*\\s+)?id=\"(\\d+)\">\\s*Member \\s*(\\d+)\\s*(?:.*)</weight>");

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -182,7 +182,16 @@ namespace {
     std::vector<unsigned int> pdfWeightIDs;
     std::string pdfWeightsDoc;
     // ---- ps ----
+    std::vector<unsigned int> defPSWeightIDs = {6, 7, 8, 9};
+    std::vector<unsigned int> defPSWeightIDs_alt = {27, 5, 26, 4};
+    bool matchPS_alt = false;
     std::vector<unsigned int> psWeightIDs;
+    unsigned int psBaselineID = 1;
+    std::string psWeightsDoc;
+
+    void setMissingWeight(int idx) { psWeightIDs[idx] = (matchPS_alt) ? defPSWeightIDs_alt[idx] : defPSWeightIDs[idx]; }
+
+    bool empty() const { return scaleWeightIDs.empty() && pdfWeightIDs.empty() && psWeightIDs.empty(); }
   };
 
   struct LumiCacheInfoHolder {
@@ -256,7 +265,8 @@ public:
         keepAllPSWeights_(params.getParameter<bool>("keepAllPSWeights")),
         debug_(params.getUntrackedParameter<bool>("debug", false)),
         debugRun_(debug_.load()),
-        hasIssuedWarning_(false) {
+        hasIssuedWarning_(false),
+        psWeightWarning_(false) {
     produces<nanoaod::FlatTable>();
     produces<std::string>("genModel");
     produces<nanoaod::FlatTable>("LHEScale");
@@ -310,25 +320,35 @@ public:
         break;
       }
     }
+
+    const auto genWeightChoice = &(streamCache(id)->weightChoice);
     if (lheInfo.isValid()) {
-      if (getLHEweightsFromGenInfo)
+      if (getLHEweightsFromGenInfo && !hasIssuedWarning_.exchange(true))
         edm::LogWarning("LHETablesProducer")
             << "Found both a LHEEventProduct and a GenLumiInfoHeader: will only save weights from LHEEventProduct.\n";
       // get the dynamic choice of weights
       const DynamicWeightChoice* weightChoice = runCache(iEvent.getRun().index());
       // go fill tables
-      fillLHEWeightTables(
-          counter, weightChoice, weight, *lheInfo, *genInfo, lheScaleTab, lhePdfTab, lheRwgtTab, lheNamedTab, genPSTab);
+      fillLHEWeightTables(counter,
+                          weightChoice,
+                          genWeightChoice,
+                          weight,
+                          *lheInfo,
+                          *genInfo,
+                          lheScaleTab,
+                          lhePdfTab,
+                          lheRwgtTab,
+                          lheNamedTab,
+                          genPSTab);
     } else if (getLHEweightsFromGenInfo) {
-      const DynamicWeightChoiceGenInfo* weightChoice = &(streamCache(id)->weightChoice);
       fillLHEPdfWeightTablesFromGenInfo(
-          counter, weightChoice, weight, *genInfo, lheScaleTab, lhePdfTab, lheNamedTab, genPSTab);
+          counter, genWeightChoice, weight, *genInfo, lheScaleTab, lhePdfTab, lheNamedTab, genPSTab);
       lheRwgtTab = std::make_unique<nanoaod::FlatTable>(1, "LHEReweightingWeights", true);
       //lheNamedTab = std::make_unique<nanoaod::FlatTable>(1, "LHENamedWeights", true);
       //genPSTab = std::make_unique<nanoaod::FlatTable>(1, "PSWeight", true);
     } else {
       // Still try to add the PS weights
-      fillOnlyPSWeightTable(counter, weight, *genInfo, genPSTab);
+      fillOnlyPSWeightTable(counter, genWeightChoice, weight, *genInfo, genPSTab);
       // make dummy values
       lheScaleTab = std::make_unique<nanoaod::FlatTable>(1, "LHEScaleWeights", true);
       lhePdfTab = std::make_unique<nanoaod::FlatTable>(1, "LHEPdfWeights", true);
@@ -348,6 +368,7 @@ public:
 
   void fillLHEWeightTables(Counter* counter,
                            const DynamicWeightChoice* weightChoice,
+                           const DynamicWeightChoiceGenInfo* genWeightChoice,
                            double genWeight,
                            const LHEEventProduct& lheProd,
                            const GenEventInfoProduct& genProd,
@@ -388,31 +409,10 @@ public:
         wNamed[mNamed - namedWeightIDs_.begin()] = weight.wgt / w0;
     }
 
-    std::size_t vectorSize =
-        (genProd.weights().size() > 2)
-            ? (keepAllPSWeights_ ? (genProd.weights().size() - 2)
-                                 : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1))
-            : 1;
-    std::vector<double> wPS(vectorSize, 1);
+    std::vector<double> wPS;
     std::string psWeightDocStr;
-    if (vectorSize > 1) {
-      double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
-      if (keepAllPSWeights_) {
-        for (std::size_t i = 0; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i + 2]) / nominal;
-        }
-        psWeightDocStr = "All PS weights (w_var / w_nominal)";
-      } else {
-        for (std::size_t i = 6; i < 10; i++) {
-          wPS[i - 6] = (genProd.weights()[i]) / nominal;
-        }
-        psWeightDocStr =
-            "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-            "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
-      }
-    } else {
-      psWeightDocStr = "dummy PS weight (1.0) ";
-    }
+    setPSWeightInfo(genProd.weights(), genWeightChoice, wPS, psWeightDocStr);
+
     outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
     outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
@@ -454,7 +454,6 @@ public:
                                          std::unique_ptr<nanoaod::FlatTable>& outPS) const {
     const std::vector<unsigned int>& scaleWeightIDs = weightChoice->scaleWeightIDs;
     const std::vector<unsigned int>& pdfWeightIDs = weightChoice->pdfWeightIDs;
-    const std::vector<unsigned int>& psWeightIDs = weightChoice->psWeightIDs;
 
     auto weights = genProd.weights();
     double w0 = (weights.size() > 1) ? weights.at(1) : 1.;
@@ -466,21 +465,9 @@ public:
     for (auto id : pdfWeightIDs) {
       wPDF.push_back(weights.at(id) / w0);
     }
-    if (!psWeightIDs.empty()) {
-      double psNom =
-          weights.at(psWeightIDs.at(0));  // normalise PS weights by "Baseline", which should be the first entry
-      for (std::size_t i = 1; i < psWeightIDs.size(); i++)
-        wPS.push_back(weights.at(psWeightIDs.at(i)) / psNom);
-    } else
-      wPS.push_back(1.0);
-    std::string psWeightDocStr;
-    if (keepAllPSWeights_) {
-      psWeightDocStr = "All PS weights (w_var / w_nominal)";
-    } else {
-      psWeightDocStr =
-          "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-          "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
-    }
+
+    std::string psWeightsDocStr;
+    setPSWeightInfo(genProd.weights(), weightChoice, wPS, psWeightsDocStr);
 
     outScale = std::make_unique<nanoaod::FlatTable>(wScale.size(), "LHEScaleWeight", false);
     outScale->addColumn<float>(
@@ -508,39 +495,63 @@ public:
   }
 
   void fillOnlyPSWeightTable(Counter* counter,
+                             const DynamicWeightChoiceGenInfo* genWeightChoice,
                              double genWeight,
                              const GenEventInfoProduct& genProd,
                              std::unique_ptr<nanoaod::FlatTable>& outPS) const {
-    std::size_t vectorSize =
-        (genProd.weights().size() > 2)
-            ? (keepAllPSWeights_ ? (genProd.weights().size() - 2)
-                                 : ((genProd.weights().size() == 14 || genProd.weights().size() == 46) ? 4 : 1))
-            : 1;
-    std::vector<double> wPS(vectorSize, 1);
+    std::vector<double> wPS;
     std::string psWeightDocStr;
-    if (vectorSize > 1) {
-      double nominal = genProd.weights()[1];  // Called 'Baseline' in GenLumiInfoHeader
-      if (keepAllPSWeights_) {
-        for (std::size_t i = 0; i < vectorSize; i++) {
-          wPS[i] = (genProd.weights()[i + 2]) / nominal;
-        }
-        psWeightDocStr = "All PS weights (w_var / w_nominal)";
-      } else {
-        for (std::size_t i = 6; i < 10; i++) {
-          wPS[i - 6] = (genProd.weights()[i]) / nominal;
-        }
-        psWeightDocStr =
-            "PS weights (w_var / w_nominal); [0] is ISR=0.5 FSR=1; [1] is ISR=1 "
-            "FSR=0.5; [2] is ISR=2 FSR=1; [3] is ISR=1 FSR=2 ";
-      }
-    } else {
-      psWeightDocStr = "dummy PS weight (1.0) ";
-    }
+    setPSWeightInfo(genProd.weights(), genWeightChoice, wPS, psWeightDocStr);
     outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
     outPS->addColumn<float>("", wPS, psWeightDocStr, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
     counter->incGenOnly(genWeight);
     counter->incPSOnly(genWeight, wPS);
+  }
+
+  void setPSWeightInfo(const std::vector<double>& genWeights,
+                       const DynamicWeightChoiceGenInfo* genWeightChoice,
+                       std::vector<double>& wPS,
+                       std::string& psWeightDocStr) const {
+    wPS.clear();
+    // isRegularPSSet = keeping all weights and the weights are a usual size, ie
+    //                  all weights are PS weights (don't use header incase missing names)
+    bool isRegularPSSet = keepAllPSWeights_ && (genWeights.size() == 14 || genWeights.size() == 46);
+    if (!genWeightChoice->psWeightIDs.empty() && !isRegularPSSet) {
+      psWeightDocStr = genWeightChoice->psWeightsDoc;
+      double psNom = genWeights.at(genWeightChoice->psBaselineID);
+      for (auto wgtidx : genWeightChoice->psWeightIDs) {
+        wPS.push_back(genWeights.at(wgtidx) / psNom);
+      }
+    } else {
+      int vectorSize =
+          keepAllPSWeights_ ? (genWeights.size() - 2) : ((genWeights.size() == 14 || genWeights.size() == 46) ? 4 : 1);
+
+      if (vectorSize > 1) {
+        double nominal = genWeights.at(1);  // Called 'Baseline' in GenLumiInfoHeader
+        if (keepAllPSWeights_) {
+          for (int i = 0; i < vectorSize; i++) {
+            wPS.push_back(genWeights.at(i + 2) / nominal);
+          }
+          psWeightDocStr = "All PS weights (w_var / w_nominal)";
+        } else {
+          if (!psWeightWarning_.exchange(true))
+            edm::LogWarning("LHETablesProducer")
+                << "GenLumiInfoHeader not found: Central PartonShower weights will fill with the 6-10th entries \n"
+                << "    This may incorrect for some mcs (madgraph 2.6.1 with its `isr:murfact=0.5` have a differnt "
+                   "order )";
+          for (std::size_t i = 6; i < 10; i++) {
+            wPS.push_back(genWeights.at(i) / nominal);
+          }
+          psWeightDocStr =
+              "PS weights (w_var / w_nominal);   [0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2"
+              "[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;";
+        }
+      } else {
+        wPS.push_back(1.0);
+        psWeightDocStr = "dummy PS weight (1.0) ";
+      }
+    }
   }
 
   // create an empty counter
@@ -933,6 +944,7 @@ public:
     if (!genLumiInfoHead.isValid())
       edm::LogWarning("LHETablesProducer")
           << "No GenLumiInfoHeader product found, will not fill generator model string.\n";
+
     std::string label;
     if (genLumiInfoHead.isValid()) {
       label = genLumiInfoHead->configDescription();
@@ -950,6 +962,7 @@ public:
 
       std::regex scalew("LHE,\\s+id\\s+=\\s+(\\d+),\\s+(.+)\\,\\s+mur=(\\S+)\\smuf=(\\S+)");
       std::regex pdfw("LHE,\\s+id\\s+=\\s+(\\d+),\\s+(.+),\\s+Member\\s+(\\d+)\\s+of\\ssets\\s+(\\w+\\b)");
+      std::regex mainPSw("sr(Def|:murfac=)(Hi|Lo|_dn|_up|0.5|2.0)");
       std::smatch groups;
       auto weightNames = genLumiInfoHead->weightNames();
       std::unordered_map<std::string, uint32_t> knownPDFSetsFromGenInfo_;
@@ -974,14 +987,34 @@ public:
             } else
               pdfSetWeightIDs.back().add(id, std::atoi(id.c_str()));
           }
-        } else if (line.find("Baseline") != std::string::npos || line.find("isr") != std::string::npos ||
-                   line.find("fsr") != std::string::npos) {
-          if (keepAllPSWeights_ || line.find("Baseline") != std::string::npos ||
-              line.find("Def") != std::string::npos) {
+        } else if (line == "Baseline") {
+          weightChoice->psBaselineID = weightIter;
+        } else if (line.find("isr") != std::string::npos || line.find("fsr") != std::string::npos) {
+          weightChoice->matchPS_alt = line.find("sr:") != std::string::npos;  // (f/i)sr: for new weights
+          if (keepAllPSWeights_) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
+          } else if (std::regex_search(line, groups, mainPSw)) {
+            if (weightChoice->psWeightIDs.size() == 0)
+              weightChoice->psWeightIDs = std::vector<unsigned int>(4, -1);
+            int psIdx = (line.find("fsr") != std::string::npos) ? 1 : 0;
+            psIdx += (groups.str(2) == "Hi" || groups.str(2) == "_up" || groups.str(2) == "2.0") ? 0 : 2;
+            weightChoice->psWeightIDs[psIdx] = weightIter;
           }
         }
         weightIter++;
+      }
+      if (keepAllPSWeights_) {
+        weightChoice->psWeightsDoc = "All PS weights (w_var / w_nominal)";
+      } else if (weightChoice->psWeightIDs.size() == 4) {
+        weightChoice->psWeightsDoc =
+            "PS weights (w_var / w_nominal);   [0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2"
+            "[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;";
+        for (int i = 0; i < 4; i++) {
+          if (static_cast<int>(weightChoice->psWeightIDs[i]) == -1)
+            weightChoice->setMissingWeight(i);
+        }
+      } else {
+        weightChoice->psWeightsDoc = "dummy PS weight (1.0) ";
       }
 
       weightChoice->scaleWeightIDs.clear();
@@ -1133,7 +1166,7 @@ protected:
   unsigned int maxPdfWeights_;
   bool keepAllPSWeights_;
 
-  mutable std::atomic<bool> debug_, debugRun_, hasIssuedWarning_;
+  mutable std::atomic<bool> debug_, debugRun_, hasIssuedWarning_, psWeightWarning_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -903,8 +903,8 @@ public:
         std::stringstream pdfDoc;
         pdfDoc << "LHE pdf variation weights (w_var / w_nominal) for LHA IDs ";
         bool found = false;
-        for (uint32_t lhaid : preferredPDFLHAIDs_) {
-          for (const auto& pw : pdfSetWeightIDs) {
+        for (const auto& pw : pdfSetWeightIDs) {
+          for (uint32_t lhaid : preferredPDFLHAIDs_) {
             if (pw.lhaIDs.first != lhaid && pw.lhaIDs.first != (lhaid + 1))
               continue;  // sometimes the first weight is not saved if that PDF is the nominal one for the sample
             if (pw.wids.size() == 1)

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -478,11 +478,8 @@ public:
         "", wPDF, weightChoice->pdfWeightsDoc, nanoaod::FlatTable::FloatColumn, lheWeightPrecision_);
 
     outPS = std::make_unique<nanoaod::FlatTable>(wPS.size(), "PSWeight", false);
-    outPS->addColumn<float>("",
-                            wPS,
-                            wPS.size() > 1 ? psWeightDocStr : "dummy PS weight (1.0) ",
-                            nanoaod::FlatTable::FloatColumn,
-                            lheWeightPrecision_);
+    outPS->addColumn<float>("", wPS, psWeightsDocStr, nanoaod::FlatTable::FloatColumn,
+                                    lheWeightPrecision_);
 
     outNamed = std::make_unique<nanoaod::FlatTable>(1, "LHEWeight", true);
     outNamed->addColumnValue<float>(
@@ -1014,7 +1011,7 @@ public:
           if (keepAllPSWeights_) {
             weightChoice->psWeightIDs.push_back(weightIter);  // PS variations
           } else if (std::regex_search(line, groups, mainPSw)) {
-            if (weightChoice->psWeightIDs.size() == 0)
+            if (weightChoice->psWeightIDs.empty())
               weightChoice->psWeightIDs = std::vector<unsigned int>(4, -1);
             int psIdx = (line.find("fsr") != std::string::npos) ? 1 : 0;
             psIdx += (groups.str(2) == "Hi" || groups.str(2) == "_up" || groups.str(2) == "2.0") ? 0 : 2;

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -799,6 +799,25 @@ public:
                   break;
                 }
               }
+            // I aplogize to contributing the rampant copy paste of code
+            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
+              if (lheDebug)
+              for (++iLine; iLine < nLines; ++iLine) {
+                if (lheDebug)
+                  std::cout << "    " << lines[iLine];
+                if (std::regex_search(lines[iLine], groups, rwgt)) {
+                  std::string rwgtID = groups.str(1);
+                  if (lheDebug)
+                    std::cout << "    >>> LHE reweighting weight: " << rwgtID << std::endl;
+                  if (std::find(lheReweighingIDs.begin(), lheReweighingIDs.end(), rwgtID) == lheReweighingIDs.end()) {
+                    // we're only interested in the beggining of the block
+                    lheReweighingIDs.emplace_back(rwgtID);
+                  }
+                } else if (std::regex_search(lines[iLine], endweightgroup)) {
+                  if (lheDebug)
+                    std::cout << ">>> Looks like the end of a weight group" << std::endl;
+                } 
+              }
             } else {
               for (++iLine; iLine < nLines; ++iLine) {
                 if (lheDebug)

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -563,9 +563,9 @@ public:
       std::vector<ScaleVarWeight> scaleVariationIDs;
       std::vector<PDFSetWeights> pdfSetWeightIDs;
       std::vector<std::string> lheReweighingIDs;
+      bool isFirstGroup = true;
 
       std::regex weightgroupmg26x("<weightgroup\\s+(?:name|type)=\"(.*)\"\\s+combine=\"(.*)\"\\s*>");
-      std::regex weightgroupmg26xNew("<weightgroup\\s+combine=\"(.*)\"\\s+(?:name|type)=\"(.*)\"\\s*>");
       std::regex weightgroup("<weightgroup\\s+combine=\"(.*)\"\\s+(?:name|type)=\"(.*)\"\\s*>");
       std::regex weightgroupRwgt("<weightgroup\\s+(?:name|type)=\"(.*)\"\\s*>");
       std::regex endweightgroup("</weightgroup>");
@@ -616,26 +616,26 @@ public:
           boost::replace_all(lines[iLine], "&gt;", ">");
           if (std::regex_search(lines[iLine], groups, weightgroupmg26x)) {
             ismg26x = true;
-          } else if (std::regex_search(lines[iLine], groups, weightgroupmg26xNew)) {
+          } else if (std::regex_search(lines[iLine], groups, scalewmg26xNew) ||
+                     std::regex_search(lines[iLine], groups, pdfwmg26xNew)) {
             ismg26xNew = true;
           }
         }
         for (unsigned int iLine = 0, nLines = lines.size(); iLine < nLines; ++iLine) {
           if (lheDebug)
             std::cout << lines[iLine];
-          if (std::regex_search(lines[iLine],
-                                groups,
-                                ismg26x ? weightgroupmg26x : (ismg26xNew ? weightgroupmg26xNew : weightgroup))) {
+          if (std::regex_search(lines[iLine], groups, ismg26x ? weightgroupmg26x : weightgroup)) {
             std::string groupname = groups.str(2);
             if (ismg26x)
               groupname = groups.str(1);
-            else if (ismg26xNew)
-              groupname = groups.str(2);
             if (lheDebug)
               std::cout << ">>> Looks like the beginning of a weight group for '" << groupname << "'" << std::endl;
-            if (groupname.find("scale_variation") == 0 || groupname == "Central scale variation") {
-              if (lheDebug)
+            if (groupname.find("scale_variation") == 0 || groupname == "Central scale variation" || isFirstGroup) {
+              if (lheDebug && groupname.find("scale_variation") != 0 && groupname != "Central scale variation")
+                std::cout << ">>> First weight is not scale variation, but assuming is the Central Weight" << std::endl;
+              else if (lheDebug)
                 std::cout << ">>> Looks like scale variation for theory uncertainties" << std::endl;
+              isFirstGroup = false;
               for (++iLine; iLine < nLines; ++iLine) {
                 if (lheDebug) {
                   std::cout << "    " << lines[iLine];
@@ -657,9 +657,7 @@ public:
                     break;
                   } else
                     missed_weightgroup = false;
-                } else if (std::regex_search(
-                               lines[iLine],
-                               ismg26x ? weightgroupmg26x : (ismg26xNew ? weightgroupmg26xNew : weightgroup))) {
+                } else if (std::regex_search(lines[iLine], ismg26x ? weightgroupmg26x : weightgroup)) {
                   if (lheDebug)
                     std::cout << ">>> Looks like the beginning of a new weight group, I will assume I missed the end "
                                  "of the group."
@@ -691,9 +689,7 @@ public:
                     break;
                   } else
                     missed_weightgroup = false;
-                } else if (std::regex_search(
-                               lines[iLine],
-                               ismg26x ? weightgroupmg26x : (ismg26xNew ? weightgroupmg26xNew : weightgroup))) {
+                } else if (std::regex_search(lines[iLine], ismg26x ? weightgroupmg26x : weightgroup)) {
                   if (lheDebug)
                     std::cout << ">>> Looks like the beginning of a new weight group, I will assume I missed the end "
                                  "of the group."

--- a/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
+++ b/PhysicsTools/NanoAOD/plugins/GenWeightsTableProducer.cc
@@ -799,8 +799,8 @@ public:
                   break;
                 }
               }
-            // I aplogize to contributing the rampant copy paste of code
-            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" || groupname == "width_variation") {
+            } else if (groupname == "mass_variation" || groupname == "sthw2_variation" ||
+                       groupname == "width_variation") {
               if (lheDebug)
                 std::cout << ">>> Looks like an EW parameter weight" << std::endl;
               for (++iLine; iLine < nLines; ++iLine) {
@@ -817,7 +817,7 @@ public:
                 } else if (std::regex_search(lines[iLine], endweightgroup)) {
                   if (lheDebug)
                     std::cout << ">>> Looks like the end of a weight group" << std::endl;
-                } 
+                }
               }
             } else {
               for (++iLine; iLine < nLines; ++iLine) {

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -5,12 +5,17 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
     genLumiInfoHeader = cms.InputTag("generator"),
     lheInfo = cms.VInputTag(cms.InputTag("externalLHEProducer"), cms.InputTag("source")),
     preferredPDFs = cms.VPSet( # see https://lhapdf.hepforge.org/pdfsets.html
-        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
         cms.PSet( name = cms.string("NNPDF31_nnlo_hessian_pdfas"), lhaid = cms.uint32(306000) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_hessian"), lhaid = cms.uint32(304400) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_mc_hessian_pdfas"), lhaid = cms.uint32(325300) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_mc"), lhaid = cms.uint32(316200) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_nf_4_mc_hessian"), lhaid = cms.uint32(325500) ),
+        cms.PSet( name = cms.string("NNPDF31_nnlo_as_0118_nf_4"), lhaid = cms.uint32(320900) ),
         cms.PSet( name = cms.string("NNPDF30_nlo_as_0118"), lhaid = cms.uint32(260000) ), # for some 92X samples. Note that the nominal weight, 260000, is not included in the LHE ...
         cms.PSet( name = cms.string("NNPDF30_lo_as_0130"), lhaid = cms.uint32(262000) ), # some MLM 80X samples have only this (e.g. /store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v2/120000/02A210D6-F5C3-E611-B570-008CFA197BD4.root )
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
+        cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
     ),
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),

--- a/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
+++ b/PhysicsTools/NanoAOD/python/genWeightsTable_cfi.py
@@ -16,6 +16,8 @@ genWeightsTable = cms.EDProducer("GenWeightsTableProducer",
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_4_pdfas"), lhaid = cms.uint32(292000) ), # some FXFX 80X samples have only this (e.g. WWTo1L1Nu2Q, WWTo4Q)
         cms.PSet( name = cms.string("NNPDF30_nlo_nf_5_pdfas"), lhaid = cms.uint32(292200) ), # some FXFX 80X samples have only this (e.g. DYJetsToLL_Pt, WJetsToLNu_Pt, DYJetsToNuNu_Pt)
         cms.PSet( name = cms.string("PDF4LHC15_nnlo_30_pdfas"), lhaid = cms.uint32(91400) ),
+        cms.PSet( name = cms.string("PDF4LHC15_nlo_30_pdfas"), lhaid = cms.uint32(90400) ),
+        cms.PSet( name = cms.string("PDF4LHC15_nlo_30"), lhaid = cms.uint32(90900) ),
     ),
     namedWeightIDs = cms.vstring(),
     namedWeightLabels = cms.vstring(),


### PR DESCRIPTION
#### PR description:
Backport of #31680, #31982, #31946, #31939, #32071. Fixes to Gen weight storage in NanoAOD

#### PR validation:

Tests in progress

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

#31680, #31982, #31946, #31939, #32071

Needed for Nano v8 production in 106X