### PR TITLE
resolve fortran warnings in GeneratorInterface under gcc10

### DIFF
--- a/GeneratorInterface/AMPTInterface/src/hipyset1.35.f
+++ b/GeneratorInterface/AMPTInterface/src/hipyset1.35.f
@@ -10346,9 +10346,12 @@ C...(Phys. Rev. D33, 665, plus errata from the authors).
     
 C...Define initial two objects, initialize loop.    
       ISUB=MINT(1)  
-      SH=VINT(44)   
-      IREF(1,5)=0   
-      IREF(1,6)=0   
+      SH=VINT(44)
+C...Initialize variable with default value
+      DO I=1,6
+         IREF(1,I)=0.0
+      ENDDO
+
       IF(ISET(ISUB).EQ.1.OR.ISET(ISUB).EQ.3) THEN   
         IREF(1,1)=MINT(84)+2+ISET(ISUB) 
         IREF(1,2)=0 
@@ -10373,7 +10376,7 @@ cms.. pre-intialize
       DO 140 JT=1,JTMAX 
       KDCY(JT)=0    
       KFL1(JT)=0    
-      KFL2(JT)=0    
+      KFL2(JT)=0
       NSD(JT)=IREF(IP,JT)   
       ID=IREF(IP,JT)    
       IF(ID.EQ.0) GOTO 140  

--- a/GeneratorInterface/ExhumeInterface/src/HDecay.f
+++ b/GeneratorInterface/ExhumeInterface/src/HDecay.f
@@ -1049,7 +1049,10 @@ C--------------------------------------------
       XLB1(2)=0D0
       XLB2(1)=0D0
       XLB2(2)=0D0
-
+C...  Initialize with zero
+      DO I=1,6
+         XLB(I) = 0.0
+      ENDDO
       IF(N0.EQ.3)THEN
        XLB(3)=XLAMBDA
        XLB(4)=XLB(3)*(XLB(3)/AMC)**(2.D0/25.D0)

--- a/GeneratorInterface/MCatNLOInterface/plugins/mcatnlo_upinit.f
+++ b/GeneratorInterface/MCatNLOInterface/plugins/mcatnlo_upinit.f
@@ -73,7 +73,9 @@ CC SET 'TOUCHED' FLAGS TO ZERO (CMSSW)
       GAMMAXS=0
       GAMWS=0
       GAMZS=0
-
+c... initialize
+      NDNS1=0
+      NDNS2=0
       DO I=1,1000
          RMASSS(I)=0
       ENDDO

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-ems.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-ems.f
@@ -3446,6 +3446,9 @@ c initial definitions
       ntry=0
       iremo1=0
       jremo=0
+c... initialize
+      jrem=0.0
+      amremn=0.0
       if(ir.eq.1)then
         cremn='targ'
         jrem=1
@@ -9557,7 +9560,7 @@ c        xorptl(3,nptl)=xorptl(3,ii)
 c        xorptl(4,nptl)=t
 c        tivptl(1,nptl)=t
 c        tivptl(2,nptl)=t
-c        mm=nptl
+        mm=nptl
 c        kolp(i)=1
       else
         mm=npproj(i)
@@ -9628,7 +9631,8 @@ c        xorptl(3,nptl)=xorptl(3,jj)
 c        xorptl(4,nptl)=t
 c        tivptl(1,nptl)=t
 c        tivptl(2,nptl)=t
-c        mm=nptl
+c... initialize
+        mm=nptl
 c        kolt(j)=1
       else
         mm=nptarg(j)

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-hnb.f
@@ -6274,7 +6274,9 @@ c log of f3 * f4 * f5
       if(ish.ge.7)write(ifch,*)'log(f3*f4*f5):',f35log
 
 c log of phase space integral --> psilog
-           if(iocova.eq.1)then
+c ... initialization
+      psilog=0.0
+      if(iocova.eq.1)then
       psilog=alog(2.*np*np*(np-1)/tecm**4/pi)
       do i=1,np
       psilog=psilog+alog(tecm**2*pi/2./i/i)
@@ -6767,9 +6769,15 @@ c-----------------------------------------------------------------------
       parameter(mxclu=10000)
       integer ku(mxclu),kd(mxclu),ks(mxclu)
       character cfl*3,cen*6,cvol*6
+c... initialize
+      do i=1,nrclu
+         ku(i)=0.0
+         kd(i)=0.0
+         ks(i)=0.0
+      enddo
 
       if(iii.eq.0)then
-
+      
       ku(nrclu)=u
       kd(nrclu)=d
       ks(nrclu)=s
@@ -8441,6 +8449,8 @@ c     -----------------------------------------
       tau=taui
       taux=taui
       taum=0.0
+c...  initialize
+      mcut=0
       if(ish.ge.9)write(ifch,*)'initial tau:',tau,'   c_M:',mpar
 
         if(corzer.gt.1.e-30)then

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-ids.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/epos-ids.f
@@ -897,6 +897,8 @@ c-----------------------------------------------------------------------
       endif
 
       s=puv+pdv+psv+pcv+pus+pds+pss+pcs
+c... initialize
+      i=0.0
       if(s.gt.0.)then
        r=rangen()*s
        if(r.gt.(pdv+pus+pds+pss+psv+pcv+pcs).and.puv.gt.0.)then

--- a/GeneratorInterface/ReggeGribovPartonMCInterface/src/qgsjet-II-04.f
+++ b/GeneratorInterface/ReggeGribovPartonMCInterface/src/qgsjet-II-04.f
@@ -4335,6 +4335,8 @@ c-----------------------------------------------------------------------
       common /qgarr43/ moniou
       common /qgdebug/  debug
 
+c... initialize
+      qgppdi=0.d0
       if(debug.ge.3)write (moniou,201)xp,iqq
       if(xp.ge..9999999d0)then
        qgppdi=0.d0
@@ -13095,6 +13097,8 @@ c---------------------------------------------------------------------------
       if(debug.ge.2)write (moniou,201)s,t,iq1,iq2
 
       u=s-t
+c... initialize
+      qgfbor=0.0
       if(n.eq.1)then
        if(iq1.eq.0.and.iq2.eq.0)then        !gluon-gluon
         qgfbor=(3.d0-t*u/s**2+s*u/t**2+s*t/u**2)*4.5d0


### PR DESCRIPTION
#### PR description:
Initializes variable with default values to suppress warning message.
 
- changes made on subpackage:
   - AMPTInterface
   - ExhumeInterface
   - MCatNLOInterface
   - ReggeGribovPartonMCInterface

- what changes are expected in the output
warning "Variable used uninitialized" no more

- what other PRs or externals it depends upon if any
None

- link to any additional material useful to provide a documentation for this PR
Issue #32058 

#### PR validation:

scram b runtests , no more warning under gcc10 compilation.