### PR TITLE
Remove use of TGeo to convert reflections

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -2245,8 +2245,6 @@ static long load_dddefinition(Detector& det, xml_h element) {
 
       // Can not deal with reflections without closed geometry
       det.manager().CloseGeometry();
-      // Convert reflections via TGeo reflection factory
-      det.manager().ConvertReflections();
 
       det.endDocument();
     }


### PR DESCRIPTION
Now that the reflections conversion is handled in DD4hep, remove use of TGeo reflection factory to convert reflections.

This PR (together with https://github.com/cms-sw/cmssw/pull/32000) reverts https://github.com/cms-sw/cmssw/pull/31970 .

@ianna @bsunanda 
