### PR TITLE
Force the last IOVs to end earlier

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -86,10 +86,20 @@ namespace {
     void on() { callEndJob_ = true; }
     void off() { callEndJob_ = false; }
     edm::EventProcessor* operator->() { return ep_.get(); }
+    edm::EventProcessor* get() { return ep_.get(); }
 
   private:
     std::unique_ptr<edm::EventProcessor> ep_;
     bool callEndJob_;
+  };
+
+  class TaskCleanupSentry {
+  public:
+    TaskCleanupSentry(edm::EventProcessor* ep) : ep_(ep) {}
+    ~TaskCleanupSentry() { ep_->taskCleanup(); }
+
+  private:
+    edm::EventProcessor* ep_;
   };
 
 }  // namespace
@@ -287,6 +297,7 @@ int main(int argc, char* argv[]) {
         EventProcessorWithSentry procTmp(
             std::make_unique<edm::EventProcessor>(processDesc, jobReportToken, edm::serviceregistry::kTokenOverrides));
         proc = std::move(procTmp);
+        TaskCleanupSentry sentry{proc.get()};
 
         alwaysAddContext = false;
         context = "Calling beginJob";

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -107,6 +107,8 @@ namespace edm {
     EventProcessor(EventProcessor const&) = delete;             // Disallow copying and moving
     EventProcessor& operator=(EventProcessor const&) = delete;  // Disallow copying and moving
 
+    void taskCleanup();
+
     /**This should be called before the first call to 'run'
        If this is not called in time, it will automatically be called
        the first time 'run' is called

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -530,6 +530,8 @@ namespace edm {
     ParentageRegistry::instance()->clear();
   }
 
+  void EventProcessor::taskCleanup() { espController_->endIOVs(); }
+
   void EventProcessor::beginJob() {
     if (beginJobCalled_)
       return;

--- a/FWCore/Framework/src/EventSetupRecordIOVQueue.h
+++ b/FWCore/Framework/src/EventSetupRecordIOVQueue.h
@@ -47,6 +47,8 @@ namespace edm {
       EventSetupRecordIOVQueue(unsigned int nConcurrentIOVs);
       ~EventSetupRecordIOVQueue();
 
+      void endIOV();
+
       void setNewIntervalForAnySubProcess();
 
       void checkForNewIOVs(WaitingTaskHolder const& taskToStartAfterIOVInit,
@@ -73,6 +75,7 @@ namespace edm {
       unsigned long long cacheIdentifier_;
       WaitingTaskHolder endIOVTaskHolder_;
       WaitingTask* endIOVWaitingTask_ = nullptr;
+      bool endIOVCalled_ = false;
     };
 
   }  // namespace eventsetup

--- a/FWCore/Framework/src/EventSetupsController.cc
+++ b/FWCore/Framework/src/EventSetupsController.cc
@@ -33,6 +33,12 @@ namespace edm {
 
     EventSetupsController::EventSetupsController() {}
 
+    void EventSetupsController::endIOVs() {
+      for (auto& eventSetupRecordIOVQueue : eventSetupRecordIOVQueues_) {
+        eventSetupRecordIOVQueue->endIOV();
+      }
+    }
+
     std::shared_ptr<EventSetupProvider> EventSetupsController::makeProvider(ParameterSet& iPSet,
                                                                             ActivityRegistry* activityRegistry,
                                                                             ParameterSet const* eventSetupPset) {

--- a/FWCore/Framework/src/EventSetupsController.h
+++ b/FWCore/Framework/src/EventSetupsController.h
@@ -83,6 +83,8 @@ namespace edm {
       EventSetupsController(EventSetupsController const&) = delete;
       EventSetupsController const& operator=(EventSetupsController const&) = delete;
 
+      void endIOVs();
+
       std::shared_ptr<EventSetupProvider> makeProvider(ParameterSet&,
                                                        ActivityRegistry*,
                                                        ParameterSet const* eventSetupPset = nullptr);

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -381,6 +381,7 @@ namespace edm {
         if (beginJobCalled_) {
           endJob();
         }
+        espController_->endIOVs();
       });
     }
 


### PR DESCRIPTION
#### PR description:

This is a bug fix related to changes introduced into CMSSW in September. The symptom of the problem was a seg fault which occurred very rarely (#32065). The problem occurred very late in a cmsRun process as the EventProcessor was being destroyed and should not have had any other effect.

The most recently opened IOV for each EventSetup record type is held open. This change forces those IOVs to close earlier and within the recently added tbb arena::execute calls instead of executing the tasks that close them as the EventProcessor destructor runs.

#### PR validation:

Relies on existing unit tests.
