### PR TITLE
Update global tags to use V5 JEC for 2017 data/MC and add V7b JR for 2018 data/MC [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v29',
+    'run1_data'         :   '106X_dataRun2_v30',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v29',
+    'run2_data'         :   '106X_dataRun2_v30',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v27',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v28',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -48,23 +48,23 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v7',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v8',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v11',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v12',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v11',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v12',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v9',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v10',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v9',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v10',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

First of all, please note that this PR does not contain the recently produced updated 2018 JEC. The tags with the 2018 JEC exist and should be uploaded very soon (tomorrow?).

This PR is a backport of #30478, which should have been prepared in July along with the original PR. This backport PR does not update the JEC for Run 3 scenarios to avoid unnecessary changes.

In addition, there is a correction to the tags for 2018 GTs that will be propagated to master in the next few days with the updated 2018 JEC. For example, in `112X_upgrade2018_realistic_v4`, the `JetResolutionRcd` with label `AK8PFchs_phi` currently uses the tag `JR_Autumn18_V7b_MC_PtResolution_AK8PFchs` (a Pt resolution tag) rather than `JR_Autumn18_V7b_MC_PhiResolution_AK8PFchs`.

The change of HLT JEC in the 2017 cosmics GTs is a purely technical change associated with an incorrectly assigned synchronization; the payload hashes for the two tags are identical. Of course, the HLT JEC are not relevant for the cosmic GT in any case.

The GT diffs for this PR are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v29/106X_dataRun2_v30

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v27/106X_dataRun2_relval_v28

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v7/106X_mc2017_realistic_v8

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_deco_v2/106X_mc2017cosmics_realistic_deco_v3

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_peak_v2/106X_mc2017cosmics_realistic_peak_v3

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v11/106X_upgrade2018_realistic_v12

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v11/106X_upgrade2018_realistic_HEfail_v12

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v9/106X_upgrade2018cosmics_realistic_deco_v10

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v9/106X_upgrade2018cosmics_realistic_peak_v10

#### PR validation:

Please see PR #30478 for details of the validation. In addition, a technical test was performed: `runTheMatrix.py -l limited,7.21,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #30478. The global tags contained in this PR are needed for the Run 2 re-miniAOD.