### PR TITLE
DAQ: fix FedRawData source going out of array boundaries(11_1_X backport)

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -65,7 +65,7 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id,
   if (detectedFRDversion_ == 0) {
     fin_.read((char*)&detectedFRDversion_, sizeof(uint16_t));
     fin_.read((char*)&flags_, sizeof(uint16_t));
-    assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= 6);
+    assert(detectedFRDversion_ > 0 && detectedFRDversion_ <= FRDHeaderMaxVersion);
     if (buffer_.size() < FRDHeaderVersionSize[detectedFRDversion_])
       buffer_.resize(FRDHeaderVersionSize[detectedFRDversion_]);
     *((uint32_t*)(&buffer_[0])) = detectedFRDversion_;

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -95,6 +95,7 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventForOutput const& e) {
   e.getByToken(token_, fedBuffers);
 
   // determine the expected size of the FRDEvent IN BYTES !!!!!
+  assert(frdVersion_ <= FRDHeaderMaxVersion);
   int headerSize = FRDHeaderVersionSize[frdVersion_];
   int expectedSize = headerSize;
   int nFeds = frdVersion_ < 3 ? 1024 : FEDNumbering::lastFEDId() + 1;

--- a/EventFilter/Utilities/src/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/src/FedRawDataInputSource.cc
@@ -484,7 +484,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent() {
 
       if (detectedFRDversion_ == 0) {
         detectedFRDversion_ = *((uint16_t*)dataPosition);
-        if (detectedFRDversion_ > 6)
+        if (detectedFRDversion_ > FRDHeaderMaxVersion)
           throw cms::Exception("FedRawDataInputSource::getNextEvent")
               << "Unknown FRD version -: " << detectedFRDversion_;
         assert(detectedFRDversion_ >= 1);
@@ -1341,7 +1341,7 @@ void FedRawDataInputSource::readWorker(unsigned int tid) {
     if (detectedFRDversion_ == 0 && chunk->offset_ == 0) {
       detectedFRDversion_ = *((uint16_t*)(chunk->buf_ + file->rawHeaderSize_));
     }
-    assert(detectedFRDversion_ <= 6);
+    assert(detectedFRDversion_ <= FRDHeaderMaxVersion);
     chunk->readComplete_ =
         true;  //this is atomic to secure the sequential buffer fill before becoming available for processing)
     file->chunks_[chunk->fileIndex_] = chunk;  //put the completed chunk in the file chunk vector at predetermined index

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -126,13 +126,13 @@ struct FRDEventHeader_V1 {
 const uint16 FRDEVENT_MASK_ISGENDATA = 1;
 
 constexpr size_t FRDHeaderMaxVersion = 6;
-constexpr std::array<uint32, FRDHeaderMaxVersion + 1> FRDHeaderVersionSize = {0,
-                                                                              2 * sizeof(uint32),
-                                                                              (4 + 1024) * sizeof(uint32),
-                                                                              7 * sizeof(uint32),
-                                                                              8 * sizeof(uint32),
-                                                                              6 * sizeof(uint32),
-                                                                              6 * sizeof(uint32)};
+constexpr std::array<uint32, FRDHeaderMaxVersion + 1> FRDHeaderVersionSize {{0,
+                                                                             2 * sizeof(uint32),
+                                                                             (4 + 1024) * sizeof(uint32),
+                                                                             7 * sizeof(uint32),
+                                                                             8 * sizeof(uint32),
+                                                                             6 * sizeof(uint32),
+                                                                             6 * sizeof(uint32)}};
 
 class FRDEventMsgView {
 public:

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -69,6 +69,8 @@
 
 #include "IOPool/Streamer/interface/MsgTools.h"
 
+#include <array>
+
 struct FRDEventHeader_V6 {
   uint16 version_;
   uint16 flags_;
@@ -123,8 +125,9 @@ struct FRDEventHeader_V1 {
 
 const uint16 FRDEVENT_MASK_ISGENDATA = 1;
 
-const uint32 FRDHeaderVersionSize[6] = {
-    0, 2 * sizeof(uint32), (4 + 1024) * sizeof(uint32), 7 * sizeof(uint32), 8 * sizeof(uint32), 6 * sizeof(uint32)};
+const size_t FRDHeaderMaxVersion = 6;
+const std::array<uint32,FRDHeaderMaxVersion+1> FRDHeaderVersionSize = {
+    0, 2 * sizeof(uint32), (4 + 1024) * sizeof(uint32), 7 * sizeof(uint32), 8 * sizeof(uint32), 6 * sizeof(uint32), 6 * sizeof(uint32)};
 
 class FRDEventMsgView {
 public:

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -126,13 +126,13 @@ struct FRDEventHeader_V1 {
 const uint16 FRDEVENT_MASK_ISGENDATA = 1;
 
 constexpr size_t FRDHeaderMaxVersion = 6;
-constexpr std::array<uint32, FRDHeaderMaxVersion + 1> FRDHeaderVersionSize {{0,
-                                                                             2 * sizeof(uint32),
-                                                                             (4 + 1024) * sizeof(uint32),
-                                                                             7 * sizeof(uint32),
-                                                                             8 * sizeof(uint32),
-                                                                             6 * sizeof(uint32),
-                                                                             6 * sizeof(uint32)}};
+constexpr std::array<uint32, FRDHeaderMaxVersion + 1> FRDHeaderVersionSize{{0,
+                                                                            2 * sizeof(uint32),
+                                                                            (4 + 1024) * sizeof(uint32),
+                                                                            7 * sizeof(uint32),
+                                                                            8 * sizeof(uint32),
+                                                                            6 * sizeof(uint32),
+                                                                            6 * sizeof(uint32)}};
 
 class FRDEventMsgView {
 public:

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -125,9 +125,14 @@ struct FRDEventHeader_V1 {
 
 const uint16 FRDEVENT_MASK_ISGENDATA = 1;
 
-const size_t FRDHeaderMaxVersion = 6;
-const std::array<uint32,FRDHeaderMaxVersion+1> FRDHeaderVersionSize = {
-    0, 2 * sizeof(uint32), (4 + 1024) * sizeof(uint32), 7 * sizeof(uint32), 8 * sizeof(uint32), 6 * sizeof(uint32), 6 * sizeof(uint32)};
+constexpr size_t FRDHeaderMaxVersion = 6;
+constexpr std::array<uint32, FRDHeaderMaxVersion + 1> FRDHeaderVersionSize = {0,
+                                                                              2 * sizeof(uint32),
+                                                                              (4 + 1024) * sizeof(uint32),
+                                                                              7 * sizeof(uint32),
+                                                                              8 * sizeof(uint32),
+                                                                              6 * sizeof(uint32),
+                                                                              6 * sizeof(uint32)};
 
 class FRDEventMsgView {
 public:


### PR DESCRIPTION
PR description:
Fix FRD format array version check. Version 6 did not get added to the version size mapping, but was allowed in modules, leading to reading out of boundaries.
This by luck did not cause any problems so far on standard gcc builds on x86_64, but caused assertion in IB tests in for CLANG build, as well as ARM and PPC builds where it was spotted (see #32091)

Fix also removes hardcoded version from around the code. It is now defined only in the same header file where it also defines std::array size.

Bugfix doesn't change any other behavior.
Note: it does NOT affect anything used in production DAQ, only version 5 FRD is used there and that is not affected.

PR validation:
Fixes unit test in EventFilter/Utilities/test for CLANG build.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Backport of #32116 (master)
