### PR TITLE
Add an infinite-IOV record for GPU modules configuration

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h
+++ b/HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h
@@ -1,0 +1,8 @@
+#ifndef HeterogeneousCore_CUDACore_interface_JobConfigurationGPURecord_h
+#define HeterogeneousCore_CUDACore_interface_JobConfigurationGPURecord_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class JobConfigurationGPURecord : public edm::eventsetup::EventSetupRecordImplementation<JobConfigurationGPURecord> {};
+
+#endif  // HeterogeneousCore_CUDACore_interface_JobConfigurationGPURecord_h

--- a/HeterogeneousCore/CUDACore/src/JobConfigurationGPURecord.cc
+++ b/HeterogeneousCore/CUDACore/src/JobConfigurationGPURecord.cc
@@ -1,0 +1,4 @@
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+#include "HeterogeneousCore/CUDACore/interface/JobConfigurationGPURecord.h"
+
+EVENTSETUP_RECORD_REG(JobConfigurationGPURecord);


### PR DESCRIPTION
#### PR description:

Add an infinite-IOV record for GPU modules configuration: as an interim approach, some modules are using the EventSetup approach to copy complex configurations to the GPUs; the new "JobConfigurationGPURecord" should be used for those, to make it easier both to highlight the intent, and clean up the client code when a better solution is found.

#### PR validation:

Changes in use in the Patatrack releases.

#### If this PR is a backport please specify the original PR and why you need to backport that PR:

Includes changes from:
  - cms-patatrack#566: Reduce code duplication in CPU and GPU modules