### PR TITLE
Improving HGCal validation 

### DIFF
--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -159,27 +159,27 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 _totclusternum_layer_EE_zminus = PlotGroup("totclusternum_layer_EE", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _totclusternum_layer_FH_zminus = PlotGroup("totclusternum_layer_FH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _totclusternum_layer_BH_zminus = PlotGroup("totclusternum_layer_BH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 _energyclustered_perlayer_EE_zminus = PlotGroup("energyclustered_perlayer_EE", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
-_energyclustered_perlayer_FH_zminus = PlotGroup("energyclustered_perlayer", [
+_energyclustered_perlayer_FH_zminus = PlotGroup("energyclustered_perlayer_FH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _energyclustered_perlayer_BH_zminus = PlotGroup("energyclustered_perlayer_BH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
@@ -192,54 +192,54 @@ _common_cells["ymax"] = 10000
 _common_cells["ylog"] = True
 _cellsnum_perthick_perlayer_120_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_120_EE", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_120_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_FH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_120_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_BH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _cellsnum_perthick_perlayer_200_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_200_EE", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_200_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_FH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_200_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_BH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _cellsnum_perthick_perlayer_300_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_300_EE", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_300_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_FH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_300_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_BH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _cellsnum_perthick_perlayer_scint_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_EE", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_scint_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_FH", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_scint_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_BH", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
@@ -254,213 +254,213 @@ _common_distance["ylog"] = True
 
 _distancetomaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetomaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetomaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetomaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancebetseedandmaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancebetseedandmaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancebetseedandmaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancebetseedandmaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_EE_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_FH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_BH_zminus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_EE_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_FH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_BH_zminus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancetoseedcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetoseedcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetoseedcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetoseedcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #=====================================================================================================================
 #----------------------------------------------------------------------------------------------------------------
@@ -469,107 +469,107 @@ _common = {"stat": True, "drawStyle": "EP", "staty": 0.65 }
 #120 um
 _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 #scint um
 _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_EE_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_FH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_BH_zminus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_EE_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_FH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_BH_zminus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #Coming back to the usual definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
@@ -579,77 +579,77 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 _totclusternum_layer_EE_zplus = PlotGroup("totclusternum_layer_EE", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _totclusternum_layer_FH_zplus = PlotGroup("totclusternum_layer_FH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _totclusternum_layer_BH_zplus = PlotGroup("totclusternum_layer_BH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 _energyclustered_perlayer_EE_zplus = PlotGroup("energyclustered_perlayer_EE", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _energyclustered_perlayer_FH_zplus = PlotGroup("energyclustered_perlayer_FH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _energyclustered_perlayer_BH_zplus = PlotGroup("energyclustered_perlayer_BH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _cellsnum_perthick_perlayer_120_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_120_EE", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_120_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_FH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 _cellsnum_perthick_perlayer_120_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_BH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _cellsnum_perthick_perlayer_200_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_200_EE", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_200_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_FH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_200_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_BH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 #300 um
 _cellsnum_perthick_perlayer_300_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_300_EE", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _cellsnum_perthick_perlayer_300_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_FH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 _cellsnum_perthick_perlayer_300_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_BH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
-_cellsnum_perthick_perlayer_scint_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_EE", [
-  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+_cellsnum_perthick_perlayer_scint_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_Sci_EE", [
+  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
+], ncols=7)
 
-_cellsnum_perthick_perlayer_scint_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_FH", [
-  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+_cellsnum_perthick_perlayer_scint_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_Sci_FH", [
+  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
+], ncols=7)
 
-_cellsnum_perthick_perlayer_scint_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_BH", [
-  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+_cellsnum_perthick_perlayer_scint_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_Sci_BH", [
+  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
@@ -664,214 +664,214 @@ _common_distance["ylog"] = True
 
 _distancetomaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetomaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetomaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetomaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancebetseedandmaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancebetseedandmaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancebetseedandmaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancebetseedandmaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_EE_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_FH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_BH_zplus", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_EE_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_FH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_BH_zplus", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancetoseedcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetoseedcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetoseedcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetoseedcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #=====================================================================================================================
 #----------------------------------------------------------------------------------------------------------------
@@ -881,106 +881,106 @@ _common = {"stat": True, "drawStyle": "EP", "staty": 0.65 }
 #120 um
 _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_EE_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_FH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_BH_zplus", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
 _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #200 um
 _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #300 um
 _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #scint um
 _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_EE_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_FH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_BH_zplus", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 #Just in case we add some plots below to be on the safe side.
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
@@ -1117,17 +1117,22 @@ _common_energy_score = dict(removeEmptyBins=False, xbinlabelsize=10,
     xmax=1.,
     ymin=0.01,
     ymax=1.)
-_energyscore_cp2lc_zminus = []
-for i in range(0, maxlayerzm):
-  _energyscore_cp2lc_zminus.append(PlotOnSideGroup("Energy_vs_Score_Layer{:02d}".format(i), Plot("Energy_vs_Score_caloparticle2layer_perlayer{:02d}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1))
+_energyscore_cp2lc_zminus = PlotGroup("Energy_vs_Score_CP2LC", [Plot("Energy_vs_Score_caloparticle2layer_perlayer{:02d}".format(i), title="Energy_vs_Score_CP2LC", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score) for i in range(0, maxlayerzm)
+                                                     ], ncols=10)
 
-_energyscore_lc2cp_zminus = []
+_energyscore_cp2lc_zplus = PlotGroup("Energy_vs_Score_CP2LC", [Plot("Energy_vs_Score_caloparticle2layer_perlayer{:02d}".format(i), title="Energy_vs_Score_CP2LC", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score) for i in range(maxlayerzm,maxlayerzp)
+                                                     ], ncols=10)
 _common_energy_score["xlog"]=False
 _common_energy_score["ylog"]=False
 _common_energy_score["xmin"]=-0.1
-for i in range(0, maxlayerzm):
-  _energyscore_lc2cp_zminus.append(PlotOnSideGroup("Energy_vs_Score_Layer{:02d}".format(i), Plot("Energy_vs_Score_layer2caloparticle_perlayer{:02d}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1))
-#_energyclustered =
+_energyscore_lc2cp_zminus = PlotGroup("Energy_vs_Score_LC2CP", [Plot("Energy_vs_Score_layer2caloparticle_perlayer{:02d}".format(i), title="Energy_vs_Score_LC2CP", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score) for i in range(0, maxlayerzm)
+                                                     ], ncols=10)
+_energyscore_lc2cp_zplus = PlotGroup("Energy_vs_Score_LC2CP", [Plot("Energy_vs_Score_layer2caloparticle_perlayer{:02d}".format(i), title="Energy_vs_Score_LC2CP", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score) for i in range(maxlayerzm,maxlayerzp)
+                                                     ], ncols=10)
 
 #--------------------------------------------------------------------------------------------
 # z+
@@ -1247,28 +1252,6 @@ _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _mergeplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global merge Rate in z+", **_common_merge)])
 _merges_zplus = PlotGroup("MergeRate", _mergeplots_zplus, ncols=8)
 
-
-_common_energy_score = dict(removeEmptyBins=False, xbinlabelsize=10,
-    stat=True,
-    xbinlabeloption="d",
-    ncols=1,
-    ylog=True,
-    xlog=True,
-    xmin=0.001,
-    xmax=1.,
-    ymin=0.01,
-    ymax=1.)
-_energyscore_cp2lc_zplus = []
-for i in range(maxlayerzm,maxlayerzp):
-  _energyscore_cp2lc_zplus.append(PlotOnSideGroup("Energy_vs_Score_Layer{:02d}".format(i), Plot("Energy_vs_Score_caloparticle2layer_perlayer{:02d}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1))
-
-_common_energy_score["xlog"]=False
-_common_energy_score["ylog"]=False
-_common_energy_score["xmin"]=-0.1
-_energyscore_lc2cp_zplus = []
-for i in range(maxlayerzm,maxlayerzp):
-  _energyscore_lc2cp_zplus.append(PlotOnSideGroup("Energy_vs_Score_Layer{:02d}".format(i), Plot("Energy_vs_Score_layer2caloparticle_perlayer{:02d}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1))
-#_energyclustered =
 
 #--------------------------------------------------------------------------------------------
 # MULTICLUSTERS
@@ -1425,30 +1408,30 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 #--------------------------------------------------------------------------------------------
 _clusternum_in_multicluster_perlayer_zminus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_EE", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
-], ncols=4)
+], ncols=7)
 
 _clusternum_in_multicluster_perlayer_zminus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_FH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
-], ncols=4)
+], ncols=7)
 
 _clusternum_in_multicluster_perlayer_zminus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_BH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
-], ncols=4)
+], ncols=7)
 
 #--------------------------------------------------------------------------------------------
 # z+
 #--------------------------------------------------------------------------------------------
 _clusternum_in_multicluster_perlayer_zplus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_EE", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
-], ncols=4)
+], ncols=7)
 
 _clusternum_in_multicluster_perlayer_zplus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_FH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
-], ncols=4)
+], ncols=7)
 
 _clusternum_in_multicluster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_BH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
-], ncols=4)
+], ncols=7)
 
 #Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
@@ -1481,205 +1464,169 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 
 _Occupancy_EE_zplus = PlotGroup("Occupancy_EE_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_EE_zplus", 
                                                         xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                        ], ncols=4)
+                                                        ], ncols=7)
 
 _Occupancy_HE_Silicon_zplus = PlotGroup("Occupancy_HE_Silicon_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_zplus", 
                                                                        xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                       ], ncols=4)
+                                                                       ], ncols=7)
 
 _Occupancy_HE_Scintillator_zplus = PlotGroup("Occupancy_HE_Scintillator_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Scintillator_zplus", 
                                                                                          xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                         ], ncols=4)
+                                                                                         ], ncols=7)
 
-_Occupancy_EE_zminus = PlotGroup("Occupancy_EE_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_EE_zminus", 
+_Occupancy_EE_zminus = PlotGroup("Occupancy_EE_zminus", [Plot("HitOccupancy_Minus_layer_{:02d}".format(i), title="Occupancy_EE_zminus", 
                                                          xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                         ], ncols=4)
+                                                         ], ncols=7)
 
-_Occupancy_HE_Silicon_zminus = PlotGroup("Occupancy_HE_Silicon_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Silicon_zminus", 
+_Occupancy_HE_Silicon_zminus = PlotGroup("Occupancy_HE_Silicon_zminus", [Plot("HitOccupancy_Minus_layer_{:02d}".format(i), title="Occupancy_HE_Silicon_zminus", 
                                                                          xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                         ], ncols=4)
+                                                                         ], ncols=7)
 
-_Occupancy_HE_Scintillator_zminus = PlotGroup("Occupancy_HE_Scintillator_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Scintillator_zminus", 
+_Occupancy_HE_Scintillator_zminus = PlotGroup("Occupancy_HE_Scintillator_zminus", [Plot("HitOccupancy_Minus_layer_{:02d}".format(i), title="Occupancy_HE_Scintillator_zminus", 
                                                                                    xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                   ], ncols=4)
+                                                                                   ], ncols=7)
 
 _common_etaphi = dict(removeEmptyBins=False, xbinlabelsize=10, xbinlabeloption="d", ymin=None)
 
-_SimHits_EtaPhi_EE_zplus=[]
-for i in range(EE_min,EE_max+1):
-    _SimHits_EtaPhi_EE_zplus.append(PlotOnSideGroup("EE_EtaPhi_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="SimHits_EtaPhi_EE_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_EE_zplus = PlotGroup("EtaPhi_EE_zplus", [Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="EtaPhi_EE_zplus", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(EE_min,EE_max+1)
+                                                     ], ncols=7)
 
-_SimHits_EtaPhi_HE_Silicon_zplus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _SimHits_EtaPhi_HE_Silicon_zplus.append(PlotOnSideGroup("HE_Silicon_EtaPhi_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="SimHits_EtaPhi_HE_Silicon_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_HE_Silicon_zplus = PlotGroup("EtaPhi_HE_Silicon_zplus", [Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="EtaPhi_HE_Silicon_zplus", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(HESilicon_min,HESilicon_max+1)
+                                                     ], ncols=7)
 
-_SimHits_EtaPhi_HE_Scintillator_zplus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _SimHits_EtaPhi_HE_Scintillator_zplus.append(PlotOnSideGroup("HE_Scintillator_EtaPhi_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="SimHits_EtaPhi_HE_Scintillator_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_HE_Scintillator_zplus = PlotGroup("EtaPhi_HE_Scintillator_zplus", [Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="EtaPhi_HE_Scintillator_zplus", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                     ], ncols=7)
 
-_SimHits_EtaPhi_EE_zminus=[]
-for i in range(EE_min,EE_max+1):
-    _SimHits_EtaPhi_EE_zminus.append(PlotOnSideGroup("EE_EtaPhi_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="SimHits_EtaPhi_EE_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_EE_zminus = PlotGroup("EtaPhi_EE_zminus", [Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="EtaPhi_EE_zminus", 
+                                                      xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(EE_min,EE_max+1)
+                                                      ], ncols=7)
 
-_SimHits_EtaPhi_HE_Silicon_zminus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _SimHits_EtaPhi_HE_Silicon_zminus.append(PlotOnSideGroup("HE_Silicon_EtaPhi_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="SimHits_EtaPhi_HE_Silicon_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_HE_Silicon_zminus = PlotGroup("EtaPhi_HE_Silicon_zminus", [Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="EtaPhi_HE_Silicon_zminus", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(HESilicon_min,HESilicon_max+1)
+                                                     ], ncols=7)
 
-_SimHits_EtaPhi_HE_Scintillator_zminus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _SimHits_EtaPhi_HE_Scintillator_zminus.append(PlotOnSideGroup("HE_Scintillator_EtaPhi_zminuslayer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="SimHits_EtaPhi_HE_Scintillator_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+_EtaPhi_HE_Scintillator_zminus = PlotGroup("EtaPhi_HE_Scintillator_zminus", [Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="EtaPhi_HE_Scintillator_zminus", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                     ], ncols=7)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "ymin": 0.1, "ylog": True}
 
 _Energy_EE_0 = PlotGroup("Energy_Time_0_EE", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_EE", 
                                               xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                              ], ncols=4)
+                                              ], ncols=7)
 
 _Energy_HE_Silicon_0 = PlotGroup("Energy_Time_0_HE_Silicon", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_HE_Silicon", 
                                                               xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                              ], ncols=4)
+                                                              ], ncols=7)
 
 _Energy_HE_Scintillator_0 = PlotGroup("Energy_Time_0_HE_Scintillator", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_HE_Scintillator", 
                                                                         xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                        ], ncols=4)
+                                                                        ], ncols=7)
 
 _Energy_EE_1 = PlotGroup("Energy_Time_1_EE", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_EE", 
                                               xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                              ], ncols=4)
+                                              ], ncols=7)
 
 _Energy_HE_Silicon_1 = PlotGroup("Energy_Time_1_HE_Silicon", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_HE_Silicon", 
                                                               xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                              ], ncols=4)
+                                                              ], ncols=7)
 
 _Energy_HE_Scintillator_1 = PlotGroup("Energy_Time_1_HE_Scintillator", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_HE_Scintillator", 
                                                                         xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                        ], ncols=4)
+                                                                        ], ncols=7)
 
 _Energy_EE = PlotGroup("Energy_EE", [Plot("energy_layer_{:02d}".format(i), title="Energy_EE", 
                                              xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                             ], ncols=4)
+                                             ], ncols=7)
 
 _Energy_HE_Silicon = PlotGroup("Energy_HE_Silicon", [Plot("energy_layer_{:02d}".format(i), title="Energy_HE_Silicon", 
                                                              xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                             ], ncols=4)
+                                                             ], ncols=7)
 
 _Energy_HE_Scintillator = PlotGroup("Energy_HE_Scintillator", [Plot("energy_layer_{:02d}".format(i), title="Energy_HE_Scintillator", 
                                                                                xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                               ], ncols=4)
-
-_RecHits_EtaPhi_EE_zplus=[]
-for i in range(EE_min,EE_max+1):
-    _RecHits_EtaPhi_EE_zplus.append(PlotOnSideGroup("RecHits_EtaPhi_EE_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="RecHits_EtaPhi_EE_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
-
-_RecHits_EtaPhi_HE_Silicon_zplus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _RecHits_EtaPhi_HE_Silicon_zplus.append(PlotOnSideGroup("RecHits_EtaPhi_HE_Silicon_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="RecHits_EtaPhi_HE_Silicon_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
-
-_RecHits_EtaPhi_HE_Scintillator_zplus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _RecHits_EtaPhi_HE_Scintillator_zplus.append(PlotOnSideGroup("RecHits_EtaPhi_HE_Scintillator_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="RecHits_EtaPhi_HE_Scintillator_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
-
-_RecHits_EtaPhi_EE_zminus=[]
-for i in range(EE_min,EE_max+1):
-    _RecHits_EtaPhi_EE_zminus.append(PlotOnSideGroup("RecHits_EtaPhi_EE_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="RecHits_EtaPhi_EE_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
-
-_RecHits_EtaPhi_HE_Silicon_zminus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _RecHits_EtaPhi_HE_Silicon_zminus.append(PlotOnSideGroup("RecHits_EtaPhi_HE_Silicon_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="RecHits_EtaPhi_HE_Silicon_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
-
-_RecHits_EtaPhi_HE_Scintillator_zminus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _RecHits_EtaPhi_HE_Scintillator_zminus.append(PlotOnSideGroup("RecHits_EtaPhi_HE_Scintillator_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="RecHits_EtaPhi_HE_Scintillator_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
+                                                                               ], ncols=7)
 
 _DigiHits_ADC_EE = PlotGroup("ADC_EE", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_EE", 
                                         xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                        ], ncols=4)
+                                        ], ncols=7)
 
 _DigiHits_ADC_HE_Silicon = PlotGroup("ADC_HE_Silicon", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Silicon", 
                                                        xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                       ], ncols=4)
+                                                       ], ncols=7)
 
 _DigiHits_ADC_HE_Scintillator = PlotGroup("ADC_HE_Scintillator", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Scintillator", 
                                                                   xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                  ], ncols=4)
+                                                                  ], ncols=7)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 
 _DigiHits_Occupancy_EE_zplus = PlotGroup("Occupancy_EE_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zplus", 
                                                                 xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                ], ncols=4)
+                                                                ], ncols=7)
 
 _DigiHits_Occupancy_HE_Silicon_zplus = PlotGroup("Occupancy_HE_Silicon_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zplus", 
                                                                                  xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                 ], ncols=4)
+                                                                                 ], ncols=7)
 
 _DigiHits_Occupancy_HE_Scintillator_zplus = PlotGroup("Occupancy_HE_Scintillator_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zplus", 
                                                                                           xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                           ], ncols=4)
+                                                                                           ], ncols=7)
 
 _DigiHits_Occupancy_EE_zminus = PlotGroup("Occupancy_EE_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zminus", 
                                                                   xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                  ], ncols=4)
+                                                                  ], ncols=7)
 
 _DigiHits_Occupancy_HE_Silicon_zminus = PlotGroup("Occupancy_HE_Silicon_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zminus", 
                                                                                   xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                  ], ncols=4)
+                                                                                  ], ncols=7)
 
 _DigiHits_Occupancy_HE_Scintillator_zminus = PlotGroup("Occupancy_HE_Scintillator_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zminus", 
                                                                                             xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                            ], ncols=4)
+                                                                                            ], ncols=7)
 
 _common_XY = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d", ymin=None)
 
-_DigiHits_Occupancy_XY_EE_zplus=[]
-for i in range(EE_min,EE_max+1):
-    _DigiHits_Occupancy_XY_EE_zplus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_EE_zplus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_EE_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
+_DigiHits_Occupancy_XY_EE = PlotGroup("Occupancy_XY_EE", [Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_EE", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY) for i in range(EE_min,EE_max+1)
+                                                     ], ncols=7)
 
-_DigiHits_Occupancy_XY_HE_Silicon_zplus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _DigiHits_Occupancy_XY_HE_Silicon_zplus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_HE_Silicon_zplus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Silicon_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
+_DigiHits_Occupancy_XY_HE_Silicon = PlotGroup("Occupancy_XY_HE_Silicon", [Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Silicon", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY) for i in range(HESilicon_min,HESilicon_max+1)
+                                                     ], ncols=7)
 
-_DigiHits_Occupancy_XY_HE_Scintillator_zplus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _DigiHits_Occupancy_XY_HE_Scintillator_zplus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_HE_Scintillator_zplus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Scintillator_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
-
-_DigiHits_Occupancy_XY_EE_zminus=[]
-for i in range(EE_min,EE_max+1):
-    _DigiHits_Occupancy_XY_EE_zminus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_EE_zminus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_EE_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
-
-_DigiHits_Occupancy_XY_HE_Silicon_zminus=[]
-for i in range(HESilicon_min,HESilicon_max+1):
-    _DigiHits_Occupancy_XY_HE_Silicon_zminus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_HE_Silicon_zminus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Silicon_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
-
-_DigiHits_Occupancy_XY_HE_Scintillator_zminus=[]
-for i in range(HEScintillator_min,HEScintillator_max+1):
-    _DigiHits_Occupancy_XY_HE_Scintillator_zminus.append(PlotOnSideGroup("DigiHits_Occupancy_XY_HE_Scintillator_zminus_layer_{:02d}".format(i), Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Scintillator_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY), ncols=1))
+_DigiHits_Occupancy_XY_HE_Scintillator = PlotGroup("Occupancy_XY_HE_Scintillator", [Plot("DigiOccupancy_XY_layer_{:02d}".format(i), title="DigiHits_Occupancy_XY_HE_Scintillator", 
+                                                     xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_XY) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                     ], ncols=7)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "ymin": 0.1, "ylog": True}
 
 _DigiHits_TOA_EE = PlotGroup("TOA_EE", [
                                                  Plot("TOA_layer_{:02d}".format(i), title="TOA_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                 ], ncols=4)
+                                                 ], ncols=7)
 
 _DigiHits_TOA_HE_Silicon = PlotGroup("TOA_HE_Silicon", [
                                                                  Plot("TOA_layer_{:02d}".format(i), title="TOA_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                 ], ncols=4)
+                                                                 ], ncols=7)
 
 _DigiHits_TOA_HE_Scintillator = PlotGroup("TOA_HE_Scintillator", [
                                                                            Plot("TOA_layer_{:02d}".format(i), title="TOA_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                           ], ncols=4)
+                                                                           ], ncols=7)
 
 _DigiHits_TOT_EE = PlotGroup("TOT_EE", [
                                                  Plot("TOT_layer_{:02d}".format(i), title="TOT_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                 ], ncols=4)
+                                                 ], ncols=7)
 
 _DigiHits_TOT_HE_Silicon = PlotGroup("TOT_HE_Silicon", [
                                                                  Plot("TOT_layer_{:02d}".format(i), title="TOT_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                 ], ncols=4)
+                                                                 ], ncols=7)
 
 _DigiHits_TOT_HE_Scintillator = PlotGroup("TOT_HE_Scintillator", [
                                                                            Plot("TOT_layer_{:02d}".format(i), title="TOT_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                           ], ncols=4)
+                                                                           ], ncols=7)
 
 #===================================================================================================================
 #Plot definition for HitCalibration
@@ -1975,6 +1922,10 @@ lc_zminus = [
   _fakes_zminus,
   # [N] Merge Rate Plots
   _merges_zminus,
+  # [O] Energy vs Score 2D plots CP to LC
+  _energyscore_cp2lc_zminus,
+  # [P] Energy vs Score 2D plots LC to CP
+  _energyscore_lc2cp_zminus
 ]
 lc_zplus = [
   _totclusternum_layer_EE_zplus,
@@ -2004,10 +1955,12 @@ lc_zplus = [
   _duplicates_zplus,
   _fakes_zplus,
   _merges_zplus,
+  _energyscore_cp2lc_zplus,
+  _energyscore_lc2cp_zplus
 ]
 
 def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel):
-  regions = ["Z-", "Z+"]
+  regions = ["zminus", "zplus"]
   setPlots = [lc_zminus, lc_zplus]
   for reg, setPlot in zip(regions, setPlots):
     print(_hgcalFolders(collection))
@@ -2017,45 +1970,6 @@ def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_colle
                 *setPlot,
                 loopSubFolders=False,
                 purpose=PlotPurpose.Timing, page=layerClustersLabel, section=reg))
-
-
-# [O] Energy vs Score 2D plots CP to LC
-# z-
-for i,item in enumerate(_energyscore_cp2lc_zminus, start=1):
-  hgcalLayerClustersPlotter.append("Energy_vs_Score_CP2LC_zminus", [
-              "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-              ], PlotFolder(
-              item,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_CP2LC_zminus"))
-
-# z+
-for i,item in enumerate(_energyscore_cp2lc_zplus, start=1):
-  hgcalLayerClustersPlotter.append("Energy_vs_Score_CP2LC_zplus", [
-              "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-              ], PlotFolder(
-              item,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_CP2LC_zplus"))
-
-# [P] Energy vs Score 2D plots LC to CP
-# z-
-for i,item in enumerate(_energyscore_lc2cp_zminus, start=1):
-  hgcalLayerClustersPlotter.append("Energy_vs_Score_LC2CP_zminus", [
-              "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-              ], PlotFolder(
-              item,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_LC2CP_zminus"))
-
-# z+
-for i,item in enumerate(_energyscore_lc2cp_zplus, start=1):
-  hgcalLayerClustersPlotter.append("Energy_vs_Score_LC2CP_zplus", [
-              "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-              ], PlotFolder(
-              item,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_LC2CP_zplus"))
 
 #=================================================================================================
 def _hgcalFolders(lastDirName="hgcalLayerClusters"):
@@ -2140,14 +2054,20 @@ def append_hgcalHitsPlots(collection = "HGCalSimHitsV", name_collection = "Simul
   _hitsCommonPlots_EE = [
     _Occupancy_EE_zplus,
     _Occupancy_EE_zminus, 
+    _EtaPhi_EE_zminus,
+    _EtaPhi_EE_zplus
   ]
   _hitsCommonPlots_HE_Sil = [
     _Occupancy_HE_Silicon_zplus,
     _Occupancy_HE_Silicon_zminus,
+    _EtaPhi_HE_Silicon_zminus,
+    _EtaPhi_HE_Silicon_zplus
   ]
   _hitsCommonPlots_HE_Sci = [
     _Occupancy_HE_Scintillator_zplus,
     _Occupancy_HE_Scintillator_zminus,
+    _EtaPhi_HE_Scintillator_zminus,
+    _EtaPhi_HE_Scintillator_zplus
   ]
 
   regions = ["HGCalEESensitive", "HGCalHESiliconSensitive", "HGCalHEScintillatorSensitive"]
@@ -2174,115 +2094,10 @@ def append_hgcalHitsPlots(collection = "HGCalSimHitsV", name_collection = "Simul
                 loopSubFolders=False,
                 purpose=PlotPurpose.Timing, page=hitsLabel, section=name_collection))
 
-for i,item in enumerate(_SimHits_EtaPhi_EE_zplus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zplus"
-                                                                  ))
-
-for i,item in enumerate(_SimHits_EtaPhi_HE_Silicon_zplus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zplus"
-                                                                  ))
-
-for i,item in enumerate(_SimHits_EtaPhi_HE_Scintillator_zplus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive",
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zplus"))
-
-for i,item in enumerate(_SimHits_EtaPhi_EE_zminus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zminus"
-                                                                   ))
-
-for i,item in enumerate(_SimHits_EtaPhi_HE_Silicon_zminus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zminus"
-                                                                   ))
-
-for i,item in enumerate(_SimHits_EtaPhi_HE_Scintillator_zminus, start=1):
-    hgcalHitPlotter.append("SimHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zminus"
-                                                                   ))
-
-for i,item in enumerate(_RecHits_EtaPhi_EE_zplus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zplus"
-                                                                  ))
-
-for i,item in enumerate(_RecHits_EtaPhi_HE_Silicon_zplus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHESiliconSensitive"
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zplus"
-                                                                  ))
-
-for i,item in enumerate(_RecHits_EtaPhi_HE_Scintillator_zplus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHEScintillatorSensitive",
-                                                    ], PlotFolder(
-                                                                  item,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zplus"))
-
-for i,item in enumerate(_RecHits_EtaPhi_EE_zminus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zminus"
-                                                                   ))
-
-for i,item in enumerate(_RecHits_EtaPhi_HE_Silicon_zminus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHESiliconSensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zminus"
-                                                                   ))
-
-for i,item in enumerate(_RecHits_EtaPhi_HE_Scintillator_zminus, start=1):
-    hgcalHitPlotter.append("RecHits_EtaPhi_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHEScintillatorSensitive"
-                                                     ], PlotFolder(
-                                                                   item,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zminus"
-                                                                   ))
-
 _digisCommonPlots_EE = [
   _DigiHits_Occupancy_EE_zplus,
   _DigiHits_Occupancy_EE_zminus,
+  _DigiHits_Occupancy_XY_EE,
   _DigiHits_ADC_EE,
   _DigiHits_TOA_EE,
   _DigiHits_TOT_EE,
@@ -2290,6 +2105,7 @@ _digisCommonPlots_EE = [
 _digisCommonPlots_HE_Sil = [
   _DigiHits_Occupancy_HE_Silicon_zplus,
   _DigiHits_Occupancy_HE_Silicon_zminus,
+  _DigiHits_Occupancy_XY_HE_Silicon,
   _DigiHits_ADC_HE_Silicon,
   _DigiHits_TOA_HE_Silicon,
   _DigiHits_TOT_HE_Silicon,
@@ -2297,6 +2113,7 @@ _digisCommonPlots_HE_Sil = [
 _digisCommonPlots_HE_Sci = [
   _DigiHits_Occupancy_HE_Scintillator_zplus,
   _DigiHits_Occupancy_HE_Scintillator_zminus,
+  _DigiHits_Occupancy_XY_HE_Scintillator,
   _DigiHits_ADC_HE_Scintillator,
   _DigiHits_TOA_HE_Scintillator,
   _DigiHits_TOT_HE_Scintillator,
@@ -2315,57 +2132,6 @@ def append_hgcalDigisPlots(collection = "HGCalDigisV", name_collection = "Digis"
                 loopSubFolders=False,
                 purpose=PlotPurpose.Timing, page=hitsLabel, section=name_collection))
 
-for i,item in enumerate(_DigiHits_Occupancy_XY_EE_zplus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zplus", [
-                                                           "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                                           ], PlotFolder(
-                                                                         item,
-                                                                         loopSubFolders=False,
-                                                                         purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zplus"
-                                                                         ))
-
-for i,item in enumerate(_DigiHits_Occupancy_XY_HE_Silicon_zplus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zplus", [
-                                                           "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                                           ], PlotFolder(
-                                                                         item,
-                                                                         loopSubFolders=False,
-                                                                         purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zplus"
-                                                                         ))
-
-for i,item in enumerate(_DigiHits_Occupancy_XY_HE_Scintillator_zplus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zplus", [
-                                                           "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive",
-                                                           ], PlotFolder(
-                                                                         item,
-                                                                         loopSubFolders=False,
-                                                                         purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zplus"))
-
-for i,item in enumerate(_DigiHits_Occupancy_XY_EE_zminus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zminus", [
-                                                            "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                                            ], PlotFolder(
-                                                                          item,
-                                                                          loopSubFolders=False,
-                                                                          purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zminus"
-                                                                          ))
-
-for i,item in enumerate(_DigiHits_Occupancy_XY_HE_Silicon_zminus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zminus", [
-                                                            "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                                            ], PlotFolder(
-                                                                          item,
-                                                                          loopSubFolders=False,
-                                                                          purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zminus"
-                                                                          ))
-
-for i,item in enumerate(_DigiHits_Occupancy_XY_HE_Scintillator_zminus, start=1):
-    hgcalHitPlotter.append("DigiHits_Occupancy_XY_zminus", [
-                                                            "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive",
-                                                            ], PlotFolder(
-                                                                          item,
-                                                                          loopSubFolders=False,
-                                                                          purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zminus"))
 #=================================================================================================
 # hitCalibration
 hgcalHitCalibPlotter = Plotter()

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -157,27 +157,27 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 # z-
 #--------------------------------------------------------------------------------------------
-_totclusternum_layer_EE_zminus = PlotGroup("totclusternum_layer_EE_zminus", [
+_totclusternum_layer_EE_zminus = PlotGroup("totclusternum_layer_EE", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_totclusternum_layer_FH_zminus = PlotGroup("totclusternum_layer_FH_zminus", [
+_totclusternum_layer_FH_zminus = PlotGroup("totclusternum_layer_FH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_totclusternum_layer_BH_zminus = PlotGroup("totclusternum_layer_BH_zminus", [
+_totclusternum_layer_BH_zminus = PlotGroup("totclusternum_layer_BH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
-_energyclustered_perlayer_EE_zminus = PlotGroup("energyclustered_perlayer_EE_zminus", [
+_energyclustered_perlayer_EE_zminus = PlotGroup("energyclustered_perlayer_EE", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_energyclustered_perlayer_FH_zminus = PlotGroup("energyclustered_perlayer_FH_zminus", [
+_energyclustered_perlayer_FH_zminus = PlotGroup("energyclustered_perlayer", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_energyclustered_perlayer_BH_zminus = PlotGroup("energyclustered_perlayer_BH_zminus", [
+_energyclustered_perlayer_BH_zminus = PlotGroup("energyclustered_perlayer_BH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
@@ -190,54 +190,54 @@ _common_cells["xmax"] = 50
 _common_cells["ymin"] = 0.1
 _common_cells["ymax"] = 10000
 _common_cells["ylog"] = True
-_cellsnum_perthick_perlayer_120_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_120_EE_zminus", [
+_cellsnum_perthick_perlayer_120_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_120_EE", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_120_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_FH_zminus", [
+_cellsnum_perthick_perlayer_120_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_FH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_120_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_BH_zminus", [
+_cellsnum_perthick_perlayer_120_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_120_BH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
 #200 um
-_cellsnum_perthick_perlayer_200_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_200_EE_zminus", [
+_cellsnum_perthick_perlayer_200_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_200_EE", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_200_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_FH_zminus", [
+_cellsnum_perthick_perlayer_200_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_FH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_200_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_BH_zminus", [
+_cellsnum_perthick_perlayer_200_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_200_BH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
 #300 um
-_cellsnum_perthick_perlayer_300_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_300_EE_zminus", [
+_cellsnum_perthick_perlayer_300_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_300_EE", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_300_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_FH_zminus", [
+_cellsnum_perthick_perlayer_300_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_FH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_300_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_BH_zminus", [
+_cellsnum_perthick_perlayer_300_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_300_BH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
 #scint um
-_cellsnum_perthick_perlayer_scint_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_-1_EE_zminus", [
+_cellsnum_perthick_perlayer_scint_EE_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_EE", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_scint_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_-1_FH_zminus", [
+_cellsnum_perthick_perlayer_scint_FH_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_FH", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_scint_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_-1_BH_zminus", [
+_cellsnum_perthick_perlayer_scint_BH_zminus = PlotGroup("cellsnum_perthick_perlayer_Sci_BH", [
   Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
@@ -577,78 +577,78 @@ _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 #--------------------------------------------------------------------------------------------
 # z+
 #--------------------------------------------------------------------------------------------
-_totclusternum_layer_EE_zplus = PlotGroup("totclusternum_layer_EE_zplus", [
+_totclusternum_layer_EE_zplus = PlotGroup("totclusternum_layer_EE", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_totclusternum_layer_FH_zplus = PlotGroup("totclusternum_layer_FH_zplus", [
+_totclusternum_layer_FH_zplus = PlotGroup("totclusternum_layer_FH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
 
-_totclusternum_layer_BH_zplus = PlotGroup("totclusternum_layer_BH_zplus", [
+_totclusternum_layer_BH_zplus = PlotGroup("totclusternum_layer_BH", [
   Plot("totclusternum_layer_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
-_energyclustered_perlayer_EE_zplus = PlotGroup("energyclustered_perlayer_EE_zplus", [
+_energyclustered_perlayer_EE_zplus = PlotGroup("energyclustered_perlayer_EE", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_energyclustered_perlayer_FH_zplus = PlotGroup("energyclustered_perlayer_FH_zplus", [
+_energyclustered_perlayer_FH_zplus = PlotGroup("energyclustered_perlayer_FH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
 
-_energyclustered_perlayer_BH_zplus = PlotGroup("energyclustered_perlayer_BH_zplus", [
+_energyclustered_perlayer_BH_zplus = PlotGroup("energyclustered_perlayer_BH", [
   Plot("energyclustered_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_cellsnum_perthick_perlayer_120_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_120_EE_zplus", [
+_cellsnum_perthick_perlayer_120_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_120_EE", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_120_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_FH_zplus", [
+_cellsnum_perthick_perlayer_120_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_FH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
-_cellsnum_perthick_perlayer_120_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_BH_zplus", [
+_cellsnum_perthick_perlayer_120_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_120_BH", [
   Plot("cellsnum_perthick_perlayer_120_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
 #200 um
-_cellsnum_perthick_perlayer_200_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_200_EE_zplus", [
+_cellsnum_perthick_perlayer_200_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_200_EE", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_200_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_FH_zplus", [
+_cellsnum_perthick_perlayer_200_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_FH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_200_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_BH_zplus", [
+_cellsnum_perthick_perlayer_200_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_200_BH", [
   Plot("cellsnum_perthick_perlayer_200_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 #300 um
-_cellsnum_perthick_perlayer_300_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_300_EE_zplus", [
+_cellsnum_perthick_perlayer_300_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_300_EE", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_300_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_FH_zplus", [
+_cellsnum_perthick_perlayer_300_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_FH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
-_cellsnum_perthick_perlayer_300_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_BH_zplus", [
+_cellsnum_perthick_perlayer_300_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_300_BH", [
   Plot("cellsnum_perthick_perlayer_300_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
 #scint um
-_cellsnum_perthick_perlayer_scint_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_EE_zplus", [
-  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
+_cellsnum_perthick_perlayer_scint_EE_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_EE", [
+  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_scint_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_FH_zplus", [
-  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
+_cellsnum_perthick_perlayer_scint_FH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_FH", [
+  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
 
-_cellsnum_perthick_perlayer_scint_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_BH_zplus", [
-  Plot("cellsnum_perthick_perlayer_-1_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
+_cellsnum_perthick_perlayer_scint_BH_zplus = PlotGroup("cellsnum_perthick_perlayer_-1_BH", [
+  Plot("cellsnum_perthick_perlayer_Sci_{:02d}".format(i), xtitle="", **_common_cells) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
 #----------------------------------------------------------------------------------------------------------------
@@ -999,7 +999,7 @@ _common_score = {"title": "Score CaloParticle to LayerClusters in z-",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_caloparticle_to_layerclusters_zminus = PlotGroup("score_caloparticle_to_layercluster_zminus", [
+_score_caloparticle_to_layerclusters_zminus = PlotGroup("score_caloparticle_to_layercluster", [
         Plot("Score_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(0,maxlayerzm)
         ], ncols=8 )
 
@@ -1014,7 +1014,7 @@ _common_score = {"title": "Score LayerCluster to CaloParticles in z-",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_layercluster_to_caloparticles_zminus = PlotGroup("score_layercluster_to_caloparticle_zminus", [
+_score_layercluster_to_caloparticles_zminus = PlotGroup("score_layercluster_to_caloparticle", [
         Plot("Score_layercl2caloparticle_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(0,maxlayerzm)
         ], ncols=8 )
 
@@ -1026,7 +1026,7 @@ _common_shared.update(_legend_common)
 _shared_plots_zminus = [Plot("SharedEnergy_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(0,maxlayerzm)]
 _shared_plots_zminus.extend([Plot("SharedEnergy_caloparticle2layercl_vs_eta_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(0,maxlayerzm)])
 _shared_plots_zminus.extend([Plot("SharedEnergy_caloparticle2layercl_vs_phi_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(0,maxlayerzm)])
-_sharedEnergy_caloparticle_to_layercluster_zminus = PlotGroup("sharedEnergy_caloparticle_to_layercluster_zminus", _shared_plots_zminus, ncols=8)
+_sharedEnergy_caloparticle_to_layercluster_zminus = PlotGroup("sharedEnergy_caloparticle_to_layercluster", _shared_plots_zminus, ncols=8)
 
 _common_shared= {"title": "Shared Energy Layer Cluster To CaloParticle in z-",
                  "stat": False,
@@ -1043,7 +1043,7 @@ _common_shared= {"title": "Shared Energy Layer Cluster To Best CaloParticle in z
 _common_shared.update(_legend_common)
 _shared_plots2_zminus.extend([Plot("SharedEnergy_layercl2caloparticle_vs_eta_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(0,maxlayerzm)])
 _shared_plots2_zminus.extend([Plot("SharedEnergy_layercl2caloparticle_vs_phi_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(0,maxlayerzm)])
-_sharedEnergy_layercluster_to_caloparticle_zminus = PlotGroup("sharedEnergy_layercluster_to_caloparticle_zminus", _shared_plots2_zminus, ncols=8)
+_sharedEnergy_layercluster_to_caloparticle_zminus = PlotGroup("sharedEnergy_layercluster_to_caloparticle", _shared_plots2_zminus, ncols=8)
 
 
 _common_assoc = {#"title": "Cell Association Table in z-",
@@ -1056,7 +1056,7 @@ _common_assoc = {#"title": "Cell Association Table in z-",
                  "ymax": 10000,
                  "ylog": True}
 _common_assoc.update(_legend_common)
-_cell_association_table_zminus = PlotGroup("cellAssociation_table_zminus", [
+_cell_association_table_zminus = PlotGroup("cellAssociation_table", [
         Plot("cellAssociation_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_assoc) for i in range(0,maxlayerzm)
         ], ncols=8 )
 
@@ -1070,7 +1070,7 @@ _common_eff["xmin"] = _bin_count
 _common_eff["xmax"] = maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _effplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Efficiencies in z-", **_common_eff)])
-_efficiencies_zminus = PlotGroup("Efficiencies_zminus", _effplots_zminus, ncols=8)
+_efficiencies_zminus = PlotGroup("Efficiencies", _effplots_zminus, ncols=8)
 
 _common_dup = {"stat": False, "legend": False}
 _dupplots_zminus = [Plot("duplicate_eta_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(0,maxlayerzm)]
@@ -1080,7 +1080,7 @@ _common_dup["xmin"] = _bin_count
 _common_dup["xmax"] = _common_dup["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _dupplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Duplicates in z-", **_common_dup)])
-_duplicates_zminus = PlotGroup("Duplicates_zminus", _dupplots_zminus, ncols=8)
+_duplicates_zminus = PlotGroup("Duplicates", _dupplots_zminus, ncols=8)
 
 _common_fake = {"stat": False, "legend": False}
 _fakeplots_zminus = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(0,maxlayerzm)]
@@ -1092,7 +1092,7 @@ _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _common_fake["xbinlabels"] = [ "L{:02d}".format(i+1) for i in range(0,maxlayerzm) ]
 _common_fake["xbinlabelsize"] = 10.
 _fakeplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Fake Rate in z-", **_common_fake)])
-_fakes_zminus = PlotGroup("FakeRate_zminus", _fakeplots_zminus, ncols=8)
+_fakes_zminus = PlotGroup("FakeRate", _fakeplots_zminus, ncols=8)
 
 _common_merge = {"stat": False, "legend": False}
 _mergeplots_zminus = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(0,maxlayerzm)]
@@ -1104,7 +1104,7 @@ _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _common_merge["xbinlabels"] = [ "L{:02d}".format(i+1) for i in range(0,maxlayerzm) ]
 _common_merge["xbinlabelsize"] = 10.
 _mergeplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global merge Rate in z-", **_common_merge)])
-_merges_zminus = PlotGroup("MergeRate_zminus", _mergeplots_zminus, ncols=8)
+_merges_zminus = PlotGroup("MergeRate", _mergeplots_zminus, ncols=8)
 
 
 _common_energy_score = dict(removeEmptyBins=False, xbinlabelsize=10,
@@ -1143,7 +1143,7 @@ _common_score = {"title": "Score CaloParticle to LayerClusters in z+",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_caloparticle_to_layerclusters_zplus = PlotGroup("score_caloparticle_to_layercluster_zplus", [
+_score_caloparticle_to_layerclusters_zplus = PlotGroup("score_caloparticle_to_layercluster", [
         Plot("Score_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(maxlayerzm,maxlayerzp)
         ], ncols=8 )
 
@@ -1158,7 +1158,7 @@ _common_score = {"title": "Score LayerCluster to CaloParticles in z+",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_layercluster_to_caloparticles_zplus = PlotGroup("score_layercluster_to_caloparticle_zplus", [
+_score_layercluster_to_caloparticles_zplus = PlotGroup("score_layercluster_to_caloparticle", [
         Plot("Score_layercl2caloparticle_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(maxlayerzm,maxlayerzp)
         ], ncols=8 )
 
@@ -1170,7 +1170,7 @@ _common_shared.update(_legend_common)
 _shared_plots_zplus = [Plot("SharedEnergy_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(maxlayerzm,maxlayerzp)]
 _shared_plots_zplus.extend([Plot("SharedEnergy_caloparticle2layercl_vs_eta_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(maxlayerzm,maxlayerzp)])
 _shared_plots_zplus.extend([Plot("SharedEnergy_caloparticle2layercl_vs_phi_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(maxlayerzm,maxlayerzp)])
-_sharedEnergy_caloparticle_to_layercluster_zplus = PlotGroup("sharedEnergy_caloparticle_to_layercluster_zplus", _shared_plots_zplus, ncols=8)
+_sharedEnergy_caloparticle_to_layercluster_zplus = PlotGroup("sharedEnergy_caloparticle_to_layercluster", _shared_plots_zplus, ncols=8)
 
 _common_shared= {"title": "Shared Energy Layer Cluster To CaloParticle in z+",
                  "stat": False,
@@ -1187,7 +1187,7 @@ _common_shared= {"title": "Shared Energy Layer Cluster To Best CaloParticle in z
 _common_shared.update(_legend_common)
 _shared_plots2_zplus.extend([Plot("SharedEnergy_layercl2caloparticle_vs_eta_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(maxlayerzm,maxlayerzp)])
 _shared_plots2_zplus.extend([Plot("SharedEnergy_layercl2caloparticle_vs_phi_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_shared) for i in range(maxlayerzm,maxlayerzp)])
-_sharedEnergy_layercluster_to_caloparticle_zplus = PlotGroup("sharedEnergy_layercluster_to_caloparticle_zplus", _shared_plots2_zplus, ncols=8)
+_sharedEnergy_layercluster_to_caloparticle_zplus = PlotGroup("sharedEnergy_layercluster_to_caloparticle", _shared_plots2_zplus, ncols=8)
 
 
 _common_assoc = {#"title": "Cell Association Table in z+",
@@ -1200,7 +1200,7 @@ _common_assoc = {#"title": "Cell Association Table in z+",
                  "ymax": 10000,
                  "ylog": True}
 _common_assoc.update(_legend_common)
-_cell_association_table_zplus = PlotGroup("cellAssociation_table_zplus", [
+_cell_association_table_zplus = PlotGroup("cellAssociation_table", [
         Plot("cellAssociation_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_assoc) for i in range(maxlayerzm,maxlayerzp)
         ], ncols=8 )
 
@@ -1214,7 +1214,7 @@ _common_eff["xmin"] = _bin_count
 _common_eff["xmax"] = _common_eff["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _effplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Efficiencies in z+", **_common_eff)])
-_efficiencies_zplus = PlotGroup("Efficiencies_zplus", _effplots_zplus, ncols=8)
+_efficiencies_zplus = PlotGroup("Efficiencies", _effplots_zplus, ncols=8)
 
 
 _common_dup = {"stat": False, "legend": False}
@@ -1225,7 +1225,7 @@ _common_dup["xmin"] = _bin_count
 _common_dup["xmax"] = _common_dup["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _dupplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Duplicates in z+", **_common_dup)])
-_duplicates_zplus = PlotGroup("Duplicates_zplus", _dupplots_zplus, ncols=8)
+_duplicates_zplus = PlotGroup("Duplicates", _dupplots_zplus, ncols=8)
 
 _common_fake = {"stat": False, "legend": False}
 _fakeplots_zplus = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(maxlayerzm,maxlayerzp)]
@@ -1235,7 +1235,7 @@ _common_fake["xmin"] = _bin_count
 _common_fake["xmax"] = _common_fake["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _fakeplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Fake Rate in z+", **_common_fake)])
-_fakes_zplus = PlotGroup("FakeRate_zplus", _fakeplots_zplus, ncols=8)
+_fakes_zplus = PlotGroup("FakeRate", _fakeplots_zplus, ncols=8)
 
 _common_merge = {"stat": False, "legend": False}
 _mergeplots_zplus = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(maxlayerzm,maxlayerzp)]
@@ -1245,7 +1245,7 @@ _common_merge["xmin"] = _bin_count
 _common_merge["xmax"] = _common_merge["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _mergeplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global merge Rate in z+", **_common_merge)])
-_merges_zplus = PlotGroup("MergeRate_zplus", _mergeplots_zplus, ncols=8)
+_merges_zplus = PlotGroup("MergeRate", _mergeplots_zplus, ncols=8)
 
 
 _common_energy_score = dict(removeEmptyBins=False, xbinlabelsize=10,
@@ -1718,6 +1718,8 @@ _PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
 
 #=================================================================================================
 hgcalLayerClustersPlotter = Plotter()
+layerClustersLabel = 'Layer Clusters'
+
 #We follow Chris categories in folders
 # [A] calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
 # (one entry per rechit, in the appropriate histo)
@@ -1726,7 +1728,7 @@ hgcalLayerClustersPlotter.append("CellsEnergyDensityPerThickness", [
         ], PlotFolder(
         _cellsenedens_thick,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="CellsEnergyDensityPerThickness"
+        purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
         ))
 
 # [B] number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
@@ -1736,75 +1738,9 @@ hgcalLayerClustersPlotter.append("TotalNumberofLayerClustersPerThickness", [
         ], PlotFolder(
         _totclusternum_thick,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="TotalNumberofLayerClustersPerThickness"
+        purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
         ))
 
-# [C] number of layer clusters per layer (one entry per event in each histo)
-# z-
-hgcalLayerClustersPlotter.append("NumberofLayerClustersPerLayer_zminus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _totclusternum_layer_EE_zminus,
-        _totclusternum_layer_FH_zminus,
-        _totclusternum_layer_BH_zminus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="NumberofLayerClustersPerLayer_zminus"
-        ))
-
-# z+
-hgcalLayerClustersPlotter.append("NumberofLayerClustersPerLayer_zplus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _totclusternum_layer_EE_zplus,
-        _totclusternum_layer_FH_zplus,
-        _totclusternum_layer_BH_zplus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="NumberofLayerClustersPerLayer_zplus"
-        ))
-
-# [D] For each layer cluster:
-# number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
-# NB: not all combinations exist; e.g. no 120um Si in layers with scint.
-# (One entry in the appropriate histo per layer cluster).
-# z-
-hgcalLayerClustersPlotter.append("CellsNumberPerLayerPerThickness_zminus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _cellsnum_perthick_perlayer_120_EE_zminus,
-        _cellsnum_perthick_perlayer_120_FH_zminus,
-        _cellsnum_perthick_perlayer_120_BH_zminus,
-        _cellsnum_perthick_perlayer_200_EE_zminus,
-        _cellsnum_perthick_perlayer_200_FH_zminus,
-        _cellsnum_perthick_perlayer_200_BH_zminus,
-        _cellsnum_perthick_perlayer_300_EE_zminus,
-        _cellsnum_perthick_perlayer_300_FH_zminus,
-        _cellsnum_perthick_perlayer_300_BH_zminus,
-        _cellsnum_perthick_perlayer_scint_EE_zminus,
-        _cellsnum_perthick_perlayer_scint_FH_zminus,
-        _cellsnum_perthick_perlayer_scint_BH_zminus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="CellsNumberPerLayerPerThickness_zminus"
-        ))
-
-# z+
-hgcalLayerClustersPlotter.append("CellsNumberPerLayerPerThickness_zplus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _cellsnum_perthick_perlayer_120_EE_zplus,
-        _cellsnum_perthick_perlayer_120_FH_zplus,
-        _cellsnum_perthick_perlayer_120_BH_zplus,
-        _cellsnum_perthick_perlayer_200_EE_zplus,
-        _cellsnum_perthick_perlayer_200_FH_zplus,
-        _cellsnum_perthick_perlayer_200_BH_zplus,
-        _cellsnum_perthick_perlayer_300_EE_zplus,
-        _cellsnum_perthick_perlayer_300_FH_zplus,
-        _cellsnum_perthick_perlayer_300_BH_zplus,
-        _cellsnum_perthick_perlayer_scint_EE_zplus,
-        _cellsnum_perthick_perlayer_scint_FH_zplus,
-        _cellsnum_perthick_perlayer_scint_BH_zplus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="CellsNumberPerLayerPerThickness_zplus"
-        ))
 
 # [E] For each layer cluster:
 # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
@@ -1971,28 +1907,6 @@ hgcalLayerClustersPlotter.append("CellsDistanceToSeedAndMaxCellPerLayerPerThickn
         purpose=PlotPurpose.Timing, page="CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zplus"
         ))
 
-# [F] Looking at the fraction of true energy that has been clustered; by layer and overall
-# z-
-hgcalLayerClustersPlotter.append("EnergyClusteredByLayerAndOverall_zminus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _energyclustered_perlayer_EE_zminus,
-        _energyclustered_perlayer_FH_zminus,
-        _energyclustered_perlayer_BH_zminus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="EnergyClusteredByLayerAndOverall_zminus"
-        ))
-# z+
-hgcalLayerClustersPlotter.append("EnergyClusteredByLayerAndOverall_zplus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _energyclustered_perlayer_EE_zplus,
-        _energyclustered_perlayer_FH_zplus,
-        _energyclustered_perlayer_BH_zplus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="EnergyClusteredByLayerAndOverall_zplus"
-        ))
-
 # [G] Miscellaneous plots:
 # longdepthbarycentre: The longitudinal depth barycentre. One entry per event.
 # mixedhitscluster: Number of clusters per event with hits in different thicknesses.
@@ -2006,7 +1920,7 @@ hgcalLayerClustersPlotter.append("Miscellaneous", [
             _mixedhitsclusters,
             _longdepthbarycentre,
             loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Miscellaneous"
+            purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
             ))
 
 # [H] SelectedCaloParticles plots
@@ -2015,161 +1929,95 @@ hgcalLayerClustersPlotter.append("SelectedCaloParticles_Photons", [
             ], PlotFolder(
             _SelectedCaloParticles,
             loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SelectedCaloParticles_Photons"
+            purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
             ))
 
-# [I] Score of CaloParticles wrt Layer Clusters
-# z-
-hgcalLayerClustersPlotter.append("ScoreCaloParticlesToLayerClusters_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _score_caloparticle_to_layerclusters_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="ScoreCaloParticlesToLayerClusters_zminus"))
+lc_zminus = [
+  # [C] number of layer clusters per layer (one entry per event in each histo)
+  _totclusternum_layer_EE_zminus,
+  _totclusternum_layer_FH_zminus,
+  _totclusternum_layer_BH_zminus,
+  # [D] For each layer cluster:
+  # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
+  # NB: not all combinations exist; e.g. no 120um Si in layers with scint.
+  # (One entry in the appropriate histo per layer cluster).
+  _cellsnum_perthick_perlayer_120_EE_zminus,
+  _cellsnum_perthick_perlayer_120_FH_zminus,
+  _cellsnum_perthick_perlayer_120_BH_zminus,
+  _cellsnum_perthick_perlayer_200_EE_zminus,
+  _cellsnum_perthick_perlayer_200_FH_zminus,
+  _cellsnum_perthick_perlayer_200_BH_zminus,
+  _cellsnum_perthick_perlayer_300_EE_zminus,
+  _cellsnum_perthick_perlayer_300_FH_zminus,
+  _cellsnum_perthick_perlayer_300_BH_zminus,
+  _cellsnum_perthick_perlayer_scint_EE_zminus,
+  _cellsnum_perthick_perlayer_scint_FH_zminus,
+  _cellsnum_perthick_perlayer_scint_BH_zminus,
+  # [F] Looking at the fraction of true energy that has been clustered; by layer and overall
+  _energyclustered_perlayer_EE_zminus,
+  _energyclustered_perlayer_FH_zminus,
+  _energyclustered_perlayer_BH_zminus,
+  # [I] Score of CaloParticles wrt Layer Clusters
+  _score_caloparticle_to_layerclusters_zminus,
+  # [J] Score of LayerClusters wrt CaloParticles
+  _score_layercluster_to_caloparticles_zminus,
+  # [K] Shared Energy between CaloParticle and LayerClusters
+  _sharedEnergy_caloparticle_to_layercluster_zminus,
+  # [K2] Shared Energy between LayerClusters and CaloParticle
+  _sharedEnergy_layercluster_to_caloparticle_zminus,
+  # [L] Cell Association per Layer
+  _cell_association_table_zminus,
+  # [M] Efficiency Plots
+  _efficiencies_zminus,
+  # [L] Duplicate Plots
+  _duplicates_zminus,
+  # [M] Fake Rate Plots
+  _fakes_zminus,
+  # [N] Merge Rate Plots
+  _merges_zminus,
+]
+lc_zplus = [
+  _totclusternum_layer_EE_zplus,
+  _totclusternum_layer_FH_zplus,
+  _totclusternum_layer_BH_zplus,
+  _cellsnum_perthick_perlayer_120_EE_zplus,
+  _cellsnum_perthick_perlayer_120_FH_zplus,
+  _cellsnum_perthick_perlayer_120_BH_zplus,
+  _cellsnum_perthick_perlayer_200_EE_zplus,
+  _cellsnum_perthick_perlayer_200_FH_zplus,
+  _cellsnum_perthick_perlayer_200_BH_zplus,
+  _cellsnum_perthick_perlayer_300_EE_zplus,
+  _cellsnum_perthick_perlayer_300_FH_zplus,
+  _cellsnum_perthick_perlayer_300_BH_zplus,
+  _cellsnum_perthick_perlayer_scint_EE_zplus,
+  _cellsnum_perthick_perlayer_scint_FH_zplus,
+  _cellsnum_perthick_perlayer_scint_BH_zplus,
+  _energyclustered_perlayer_EE_zplus,
+  _energyclustered_perlayer_FH_zplus,
+  _energyclustered_perlayer_BH_zplus,
+  _score_caloparticle_to_layerclusters_zplus,
+  _score_layercluster_to_caloparticles_zplus,
+  _sharedEnergy_caloparticle_to_layercluster_zplus,
+  _sharedEnergy_layercluster_to_caloparticle_zplus,
+  _cell_association_table_zplus,
+  _efficiencies_zplus,
+  _duplicates_zplus,
+  _fakes_zplus,
+  _merges_zplus,
+]
 
-# z+
-hgcalLayerClustersPlotter.append("ScoreCaloParticlesToLayerClusters_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _score_caloparticle_to_layerclusters_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="ScoreCaloParticlesToLayerClusters_zplus"))
+def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel):
+  regions = ["Z-", "Z+"]
+  setPlots = [lc_zminus, lc_zplus]
+  for reg, setPlot in zip(regions, setPlots):
+    print(_hgcalFolders(collection))
+    hgcalLayerClustersPlotter.append(collection+"_"+reg, [
+                _hgcalFolders(collection)
+                ], PlotFolder(
+                *setPlot,
+                loopSubFolders=False,
+                purpose=PlotPurpose.Timing, page=layerClustersLabel, section=reg))
 
-# [J] Score of LayerClusters wrt CaloParticles
-# z-
-hgcalLayerClustersPlotter.append("ScoreLayerClustersToCaloParticles_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _score_layercluster_to_caloparticles_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="ScoreLayerClustersToCaloParticles_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("ScoreLayerClustersToCaloParticles_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _score_layercluster_to_caloparticles_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="ScoreLayerClustersToCaloParticles_zplus"))
-
-# [K] Shared Energy between CaloParticle and LayerClusters
-# z-
-hgcalLayerClustersPlotter.append("SharedEnergy_C2L_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _sharedEnergy_caloparticle_to_layercluster_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergy_CaloParticleToLayerCluster_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("SharedEnergy_C2L_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _sharedEnergy_caloparticle_to_layercluster_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergy_CaloParticleToLayerCluster_zplus"))
-
-# [K2] Shared Energy between LayerClusters and CaloParticle
-# z-
-hgcalLayerClustersPlotter.append("SharedEnergyL2C_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _sharedEnergy_layercluster_to_caloparticle_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergyLayerClusterToCaloParticle_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("SharedEnergyL2C_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _sharedEnergy_layercluster_to_caloparticle_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergyLayerClusterToCaloParticle_zplus"))
-
-# [L] Cell Association per Layer
-# z-
-hgcalLayerClustersPlotter.append("CellAssociation_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _cell_association_table_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="CellAssociation_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("CellAssociation_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _cell_association_table_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="CellAssociation_zplus"))
-
-# [M] Efficiency Plots
-# z-
-hgcalLayerClustersPlotter.append("Efficiencies_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _efficiencies_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Efficiencies_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("Efficiencies_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _efficiencies_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Efficiencies_zplus"))
-
-# [L] Duplicate Plots
-# z-
-hgcalLayerClustersPlotter.append("Duplicates_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _duplicates_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Duplicates_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("Duplicates_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _duplicates_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Duplicates_zplus"))
-
-# [M] Fake Rate Plots
-# z-
-hgcalLayerClustersPlotter.append("FakeRate_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _fakes_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Fakes_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("FakeRate_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _fakes_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Fakes_zplus"))
-
-# [N] Merge Rate Plots
-# z-
-hgcalLayerClustersPlotter.append("MergeRate_zminus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _merges_zminus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Merges_zminus"))
-
-# z+
-hgcalLayerClustersPlotter.append("MergeRate_zplus", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _merges_zplus,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="Merges_zplus"))
 
 # [O] Energy vs Score 2D plots CP to LC
 # z-
@@ -2243,7 +2091,7 @@ _multiclustersAllPlots = [
 hgcalMultiClustersPlotter = Plotter()
 def append_hgcalMultiClustersPlots(collection = 'ticlMultiClustersFromTrackstersMerge', name_collection = "MultiClustersMerge"):
   # Appending all plots for MCs
-  hgcalMultiClustersPlotter.append(name_collection, [
+  hgcalMultiClustersPlotter.append(collection, [
               _hgcalFolders(collection)
               ], PlotFolder(
               *_multiclustersAllPlots,
@@ -2319,7 +2167,7 @@ def append_hgcalHitsPlots(collection = "HGCalSimHitsV", name_collection = "Simul
   for reg, setPlot in zip(regions, setPlots):
     dirName = collection+"/"+reg
     print(dirName)
-    hgcalHitPlotter.append(name_collection, [
+    hgcalHitPlotter.append(collection, [
                 _hgcalHitFolders(dirName)
                 ], PlotFolder(
                 *setPlot,

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1555,6 +1555,18 @@ _Energy_HE_Scintillator_1 = PlotGroup("Energy_Time_1_HE_Scintillator", [Plot("en
                                                                         xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
                                                                         ], ncols=4)
 
+_Energy_EE = PlotGroup("Energy_EE", [Plot("energy_layer_{:02d}".format(i), title="Energy_EE", 
+                                             xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                             ], ncols=4)
+
+_Energy_HE_Silicon = PlotGroup("Energy_HE_Silicon", [Plot("energy_layer_{:02d}".format(i), title="Energy_HE_Silicon", 
+                                                             xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+                                                             ], ncols=4)
+
+_Energy_HE_Scintillator = PlotGroup("Energy_HE_Scintillator", [Plot("energy_layer_{:02d}".format(i), title="Energy_HE_Scintillator", 
+                                                                               xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                               ], ncols=4)
+
 _RecHits_EtaPhi_EE_zplus=[]
 for i in range(EE_min,EE_max+1):
     _RecHits_EtaPhi_EE_zplus.append(PlotOnSideGroup("RecHits_EtaPhi_EE_zplus_layer_{:02d}".format(i), Plot("EtaPhi_Plus_layer_{:02d}".format(i), title="RecHits_EtaPhi_EE_zplus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
@@ -1645,28 +1657,28 @@ for i in range(HEScintillator_min,HEScintillator_max+1):
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "ymin": 0.1, "ylog": True}
 
-_DigiHits_TOA_EE = PlotGroup("DigiHits_TOA_EE", [
-                                                 Plot("TOA_layer_{:02d}".format(i), title="DigiHits_TOA_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+_DigiHits_TOA_EE = PlotGroup("TOA_EE", [
+                                                 Plot("TOA_layer_{:02d}".format(i), title="TOA_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
                                                  ], ncols=4)
 
-_DigiHits_TOA_HE_Silicon = PlotGroup("DigiHits_TOA_HE_Silicon", [
-                                                                 Plot("TOA_layer_{:02d}".format(i), title="DigiHits_TOA_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+_DigiHits_TOA_HE_Silicon = PlotGroup("TOA_HE_Silicon", [
+                                                                 Plot("TOA_layer_{:02d}".format(i), title="TOA_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
                                                                  ], ncols=4)
 
-_DigiHits_TOA_HE_Scintillator = PlotGroup("DigiHits_TOA_HE_Scintillator", [
-                                                                           Plot("TOA_layer_{:02d}".format(i), title="DigiHits_TOA_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+_DigiHits_TOA_HE_Scintillator = PlotGroup("TOA_HE_Scintillator", [
+                                                                           Plot("TOA_layer_{:02d}".format(i), title="TOA_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
                                                                            ], ncols=4)
 
-_DigiHits_TOT_EE = PlotGroup("DigiHits_TOT_EE", [
-                                                 Plot("TOT_layer_{:02d}".format(i), title="DigiHits_TOT_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+_DigiHits_TOT_EE = PlotGroup("TOT_EE", [
+                                                 Plot("TOT_layer_{:02d}".format(i), title="TOT_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
                                                  ], ncols=4)
 
-_DigiHits_TOT_HE_Silicon = PlotGroup("DigiHits_TOT_HE_Silicon", [
-                                                                 Plot("TOT_layer_{:02d}".format(i), title="DigiHits_TOT_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+_DigiHits_TOT_HE_Silicon = PlotGroup("TOT_HE_Silicon", [
+                                                                 Plot("TOT_layer_{:02d}".format(i), title="TOT_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
                                                                  ], ncols=4)
 
-_DigiHits_TOT_HE_Scintillator = PlotGroup("DigiHits_TOT_HE_Scintillator", [
-                                                                           Plot("TOT_layer_{:02d}".format(i), title="DigiHits_TOT_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+_DigiHits_TOT_HE_Scintillator = PlotGroup("TOT_HE_Scintillator", [
+                                                                           Plot("TOT_layer_{:02d}".format(i), title="TOT_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
                                                                            ], ncols=4)
 
 #===================================================================================================================
@@ -2264,19 +2276,6 @@ def append_hgcalMultiClustersPlots(collection = 'ticlMultiClustersFromTracksters
 def _hgcalHitFolders(dirName="HGCalSimHitsV/HGCalEESensitive"):
     return "DQMData/Run 1/HGCAL/Run summary/"+dirName
 
-_hitsCommonPlots_EE = [
-  _Occupancy_EE_zplus,
-  _Occupancy_EE_zminus, 
-]
-_hitsCommonPlots_HE_Sil = [
-  _Occupancy_HE_Silicon_zplus,
-  _Occupancy_HE_Silicon_zminus,
-]
-_hitsCommonPlots_HE_Sci = [
-  _Occupancy_HE_Scintillator_zplus,
-  _Occupancy_HE_Scintillator_zminus  
-]
-
 hgcalHitPlotter = Plotter()
 hitsLabel = 'Hits'
 simHitsLabel = 'Simulated Hits'
@@ -2290,8 +2289,33 @@ hgcalHitPlotter.append("SimHits_Validation", [
                                                             ))
 
 def append_hgcalHitsPlots(collection = "HGCalSimHitsV", name_collection = "Simulated Hits"):
+  _hitsCommonPlots_EE = [
+    _Occupancy_EE_zplus,
+    _Occupancy_EE_zminus, 
+  ]
+  _hitsCommonPlots_HE_Sil = [
+    _Occupancy_HE_Silicon_zplus,
+    _Occupancy_HE_Silicon_zminus,
+  ]
+  _hitsCommonPlots_HE_Sci = [
+    _Occupancy_HE_Scintillator_zplus,
+    _Occupancy_HE_Scintillator_zminus,
+  ]
+
   regions = ["HGCalEESensitive", "HGCalHESiliconSensitive", "HGCalHEScintillatorSensitive"]
   setPlots = [_hitsCommonPlots_EE, _hitsCommonPlots_HE_Sil, _hitsCommonPlots_HE_Sci]
+  if "SimHits" in collection :
+    _hitsCommonPlots_EE.append(_Energy_EE_0)
+    _hitsCommonPlots_EE.append(_Energy_EE_1)
+    _hitsCommonPlots_HE_Sil.append(_Energy_HE_Silicon_0)
+    _hitsCommonPlots_HE_Sil.append( _Energy_HE_Silicon_1)
+    _hitsCommonPlots_HE_Sil.append(_Energy_HE_Scintillator_0)
+    _hitsCommonPlots_HE_Sil.append(_Energy_HE_Scintillator_1)
+  if "RecHits" in collection :
+    _hitsCommonPlots_EE.append(_Energy_EE)
+    _hitsCommonPlots_HE_Sil.append(_Energy_HE_Silicon)
+    _hitsCommonPlots_HE_Sil.append(_Energy_HE_Scintillator)
+
   for reg, setPlot in zip(regions, setPlots):
     dirName = collection+"/"+reg
     print(dirName)

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -252,213 +252,213 @@ _common_distance["ymin"] = 1e-3
 _common_distance["ymax"] = 10000
 _common_distance["ylog"] = True
 
-_distancetomaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE_zminus", [
+_distancetomaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH_zminus", [
+_distancetomaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH_zminus", [
+_distancetomaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancetomaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE_zminus", [
+_distancetomaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH_zminus", [
+_distancetomaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH_zminus", [
+_distancetomaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancetomaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE_zminus", [
+_distancetomaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH_zminus", [
+_distancetomaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH_zminus", [
+_distancetomaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #scint um
-_distancetomaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_EE_zminus", [
+_distancetomaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_EE", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_FH_zminus", [
+_distancetomaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_FH", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_-1_BH_zminus", [
+_distancetomaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_BH", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancebetseedandmaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancebetseedandmaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancebetseedandmaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #scint um
-_distancebetseedandmaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_EE_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_FH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_BH_zminus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #scint um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_EE_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_FH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_BH_zminus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancetoseedcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE_zminus", [
+_distancetoseedcell_perthickperlayer_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH_zminus", [
+_distancetoseedcell_perthickperlayer_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH_zminus", [
+_distancetoseedcell_perthickperlayer_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancetoseedcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE_zminus", [
+_distancetoseedcell_perthickperlayer_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH_zminus", [
+_distancetoseedcell_perthickperlayer_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH_zminus", [
+_distancetoseedcell_perthickperlayer_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancetoseedcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE_zminus", [
+_distancetoseedcell_perthickperlayer_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH_zminus", [
+_distancetoseedcell_perthickperlayer_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH_zminus", [
+_distancetoseedcell_perthickperlayer_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #scint um
-_distancetoseedcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_EE_zminus", [
+_distancetoseedcell_perthickperlayer_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_EE", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_FH_zminus", [
+_distancetoseedcell_perthickperlayer_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_FH", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_-1_BH_zminus", [
+_distancetoseedcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_BH", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
@@ -467,107 +467,107 @@ _distancetoseedcell_perthickperlayer_scint_BH_zminus = PlotGroup("distancetoseed
 #We need points for the weighted plots
 _common = {"stat": True, "drawStyle": "EP", "staty": 0.65 }
 #120 um
-_distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 #scint um
-_distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_EE_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_FH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_BH_zminus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #200 um
-_distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #300 um
-_distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
 #scint um
-_distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_EE_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_FH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_BH_zminus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zminus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=7)
 
@@ -662,214 +662,214 @@ _common_distance["ymin"] = 1e-3
 _common_distance["ymax"] = 10000
 _common_distance["ylog"] = True
 
-_distancetomaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE_zplus", [
+_distancetomaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_EE", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH_zplus", [
+_distancetomaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_FH", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH_zplus", [
+_distancetomaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_120_BH", [
   Plot("distancetomaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancetomaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE_zplus", [
+_distancetomaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_EE", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH_zplus", [
+_distancetomaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_FH", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH_zplus", [
+_distancetomaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_200_BH", [
   Plot("distancetomaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancetomaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE_zplus", [
+_distancetomaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_EE", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH_zplus", [
+_distancetomaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_FH", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH_zplus", [
+_distancetomaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_300_BH", [
   Plot("distancetomaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancetomaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_EE_zplus", [
+_distancetomaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_EE", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_FH_zplus", [
+_distancetomaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_FH", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_-1_BH_zplus", [
+_distancetomaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_Sci_BH", [
   Plot("distancetomaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancebetseedandmaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_120_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancebetseedandmaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_200_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancebetseedandmaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_300_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancebetseedandmaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_EE_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_EE", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_FH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_FH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_-1_BH_zplus", [
+_distancebetseedandmaxcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcell_perthickperlayer_Sci_BH", [
   Plot("distancebetseedandmaxcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_EE_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_EE", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_FH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_FH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_BH_zplus", [
+_distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus = PlotGroup("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_Sci_BH", [
   Plot("distancebetseedandmaxcellvsclusterenergy_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancetoseedcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE_zplus", [
+_distancetoseedcell_perthickperlayer_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_EE", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH_zplus", [
+_distancetoseedcell_perthickperlayer_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_FH", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH_zplus", [
+_distancetoseedcell_perthickperlayer_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_120_BH", [
   Plot("distancetoseedcell_perthickperlayer_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancetoseedcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE_zplus", [
+_distancetoseedcell_perthickperlayer_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_EE", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH_zplus", [
+_distancetoseedcell_perthickperlayer_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_FH", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH_zplus", [
+_distancetoseedcell_perthickperlayer_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_200_BH", [
   Plot("distancetoseedcell_perthickperlayer_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancetoseedcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE_zplus", [
+_distancetoseedcell_perthickperlayer_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_EE", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH_zplus", [
+_distancetoseedcell_perthickperlayer_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_FH", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH_zplus", [
+_distancetoseedcell_perthickperlayer_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_300_BH", [
   Plot("distancetoseedcell_perthickperlayer_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancetoseedcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_EE_zplus", [
+_distancetoseedcell_perthickperlayer_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_EE", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_FH_zplus", [
+_distancetoseedcell_perthickperlayer_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_FH", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_-1_BH_zplus", [
+_distancetoseedcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_Sci_BH", [
   Plot("distancetoseedcell_perthickperlayer_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
@@ -879,106 +879,106 @@ _distancetoseedcell_perthickperlayer_scint_BH_zplus = PlotGroup("distancetoseedc
 _common = {"stat": True, "drawStyle": "EP", "staty": 0.65 }
 
 #120 um
-_distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_120_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
-_distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_200_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_300_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_EE_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_EE", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_FH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_FH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_-1_BH_zplus", [
+_distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetomaxcell_perthickperlayer_eneweighted_Sci_BH", [
   Plot("distancetomaxcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #----------------------------------------------------------------------------------------------------------------
 #120 um
-_distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_120_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_120_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #200 um
-_distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_200_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_200_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #300 um
-_distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_300_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_300_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 
 #scint um
-_distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_EE_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_EE", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_FH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_FH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=7)
 
-_distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_-1_BH_zplus", [
+_distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zplus = PlotGroup("distancetoseedcell_perthickperlayer_eneweighted_Sci_BH", [
   Plot("distancetoseedcell_perthickperlayer_eneweighted_-1_{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=7)
 #Just in case we add some plots below to be on the safe side.
@@ -1001,7 +1001,7 @@ _common_score = {"title": "Score CaloParticle to LayerClusters in z-",
 _common_score.update(_legend_common)
 _score_caloparticle_to_layerclusters_zminus = PlotGroup("score_caloparticle_to_layercluster", [
         Plot("Score_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(0,maxlayerzm)
-        ], ncols=8 )
+        ], ncols=10 )
 
 _common_score = {"title": "Score LayerCluster to CaloParticles in z-",
                  "stat": False,
@@ -1062,49 +1062,57 @@ _cell_association_table_zminus = PlotGroup("cellAssociation_table", [
 
 _bin_count = 0
 _xbinlabels = [ "L{:02d}".format(i+1) for i in range(0,maxlayerzm) ]
-_common_eff = {"stat": False, "legend": False}
-_effplots_zminus = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(0,maxlayerzm)]
-_effplots_zminus.extend([Plot("effic_phi_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(0,maxlayerzm)])
-_common_eff = {"stat": False, "legend": False, "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_eff = {"stat": False, "legend": False, "ymin": 0.0, "ymax": 1.1}
+_effplots_zminus_eta = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(0,maxlayerzm)]
+_effplots_zminus_phi = [Plot("effic_phi_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(0,maxlayerzm)]
+_common_eff = {"stat": False, "legend": False, "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v", "ymin": 0.0, "ymax": 1.1}
 _common_eff["xmin"] = _bin_count
 _common_eff["xmax"] = maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_effplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Efficiencies in z-", **_common_eff)])
-_efficiencies_zminus = PlotGroup("Efficiencies", _effplots_zminus, ncols=8)
+_effplots_zminus = [Plot("globalEfficiencies", xtitle="Global Efficiencies in z-", **_common_eff)]
+_efficiencies_zminus_eta = PlotGroup("Efficiencies_vs_eta", _effplots_zminus_eta, ncols=10)
+_efficiencies_zminus_phi = PlotGroup("Efficiencies_vs_phi", _effplots_zminus_phi, ncols=10)
+_efficiencies_zminus     = PlotGroup("Efficiencies_global", _effplots_zminus, ncols=1)
 
-_common_dup = {"stat": False, "legend": False}
-_dupplots_zminus = [Plot("duplicate_eta_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(0,maxlayerzm)]
-_dupplots_zminus.extend([Plot("duplicate_phi_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(0,maxlayerzm)])
-_common_dup = {"stat": False, "legend": False, "title": "Global Duplicates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_dup = {"stat": False, "legend": False, "ymin":0.0, "ymax":1.1}
+_dupplots_zminus_eta = [Plot("duplicate_eta_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(0,maxlayerzm)]
+_dupplots_zminus_phi = [Plot("duplicate_phi_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(0,maxlayerzm)]
+_common_dup = {"stat": False, "legend": False, "title": "Global Duplicates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v", "ymin": 0.0, "ymax": 1.1}
 _common_dup["xmin"] = _bin_count
 _common_dup["xmax"] = _common_dup["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_dupplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Duplicates in z-", **_common_dup)])
-_duplicates_zminus = PlotGroup("Duplicates", _dupplots_zminus, ncols=8)
+_dupplots_zminus = [Plot("globalEfficiencies", xtitle="Global Duplicates in z-", **_common_dup)]
+_duplicates_zminus_eta = PlotGroup("Duplicates_vs_eta", _dupplots_zminus_eta, ncols=10)
+_duplicates_zminus_phi = PlotGroup("Duplicates_vs_phi", _dupplots_zminus_phi, ncols=10)
+_duplicates_zminus     = PlotGroup("Duplicates_global", _dupplots_zminus, ncols=1)
 
-_common_fake = {"stat": False, "legend": False}
-_fakeplots_zminus = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(0,maxlayerzm)]
-_fakeplots_zminus.extend([Plot("fake_phi_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(0,maxlayerzm)])
-_common_fake = {"stat": False, "legend": False, "title": "Global Fake Rates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_fake = {"stat": False, "legend": False, "ymin":0.0, "ymax":1.1}
+_fakeplots_zminus_eta = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(0,maxlayerzm)]
+_fakeplots_zminus_phi = [Plot("fake_phi_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(0,maxlayerzm)]
+_common_fake = {"stat": False, "legend": False, "title": "Global Fake Rates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v", "ymin": 0.0, "ymax": 1.1}
 _common_fake["xmin"] = _bin_count
 _common_fake["xmax"] = _common_fake["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _common_fake["xbinlabels"] = [ "L{:02d}".format(i+1) for i in range(0,maxlayerzm) ]
 _common_fake["xbinlabelsize"] = 10.
-_fakeplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global Fake Rate in z-", **_common_fake)])
-_fakes_zminus = PlotGroup("FakeRate", _fakeplots_zminus, ncols=8)
+_fakeplots_zminus = [Plot("globalEfficiencies", xtitle="Global Fake Rate in z-", **_common_fake)]
+_fakes_zminus_eta = PlotGroup("FakeRate_vs_eta", _fakeplots_zminus_eta, ncols=10)
+_fakes_zminus_phi = PlotGroup("FakeRate_vs_phi", _fakeplots_zminus_phi, ncols=10)
+_fakes_zminus     = PlotGroup("FakeRate_global", _fakeplots_zminus, ncols=1)
 
-_common_merge = {"stat": False, "legend": False}
-_mergeplots_zminus = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(0,maxlayerzm)]
-_mergeplots_zminus.extend([Plot("merge_phi_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(0,maxlayerzm)])
-_common_merge = {"stat": False, "legend": False, "title": "Global Merge Rates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_merge = {"stat": False, "legend": False, "ymin":0.0, "ymax":1.1}
+_mergeplots_zminus_eta = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(0,maxlayerzm)]
+_mergeplots_zminus_phi = [Plot("merge_phi_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(0,maxlayerzm)]
+_common_merge = {"stat": False, "legend": False, "title": "Global Merge Rates in z-", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v", "ymin": 0.0, "ymax": 1.1}
 _common_merge["xmin"] = _bin_count
 _common_merge["xmax"] = _common_merge["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
 _common_merge["xbinlabels"] = [ "L{:02d}".format(i+1) for i in range(0,maxlayerzm) ]
 _common_merge["xbinlabelsize"] = 10.
-_mergeplots_zminus.extend([Plot("globalEfficiencies", xtitle="Global merge Rate in z-", **_common_merge)])
-_merges_zminus = PlotGroup("MergeRate", _mergeplots_zminus, ncols=8)
+_mergeplots_zminus = [Plot("globalEfficiencies", xtitle="Global merge Rate in z-", **_common_merge)]
+_merges_zminus_eta = PlotGroup("MergeRate_vs_eta", _mergeplots_zminus_eta, ncols=10)
+_merges_zminus_phi = PlotGroup("MergeRate_vs_phi", _mergeplots_zminus_phi, ncols=10)
+_merges_zminus     = PlotGroup("MergeRate_global", _mergeplots_zminus, ncols=1)
 
 
 _common_energy_score = dict(removeEmptyBins=False, xbinlabelsize=10,
@@ -1150,7 +1158,7 @@ _common_score = {"title": "Score CaloParticle to LayerClusters in z+",
 _common_score.update(_legend_common)
 _score_caloparticle_to_layerclusters_zplus = PlotGroup("score_caloparticle_to_layercluster", [
         Plot("Score_caloparticle2layercl_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_score) for i in range(maxlayerzm,maxlayerzp)
-        ], ncols=8 )
+        ], ncols=10 )
 
 _common_score = {"title": "Score LayerCluster to CaloParticles in z+",
                  "stat": False,
@@ -1211,46 +1219,53 @@ _cell_association_table_zplus = PlotGroup("cellAssociation_table", [
 
 
 _bin_count = 50
-_common_eff = {"stat": False, "legend": False}
-_effplots_zplus = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]
-_effplots_zplus.extend([Plot("effic_phi_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)])
-_common_eff = {"stat": False, "legend": False, "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_eff = {"stat": False, "legend": False, "ymin":0.0, "ymax":1.1}
+_effplots_zplus_eta = [Plot("effic_eta_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]
+_effplots_zplus_phi = [Plot("effic_phi_layer{:02d}".format(i), xtitle="", **_common_eff) for i in range(maxlayerzm,maxlayerzp)]
+_common_eff = {"stat": False, "legend": False, "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "d", "ymin": 0.0, "ymax": 1.1}
 _common_eff["xmin"] = _bin_count
 _common_eff["xmax"] = _common_eff["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_effplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Efficiencies in z+", **_common_eff)])
-_efficiencies_zplus = PlotGroup("Efficiencies", _effplots_zplus, ncols=8)
+_effplots_zplus = [Plot("globalEfficiencies", xtitle="Global Efficiencies in z+", **_common_eff)]
+_efficiencies_zplus_eta = PlotGroup("Efficiencies_vs_eta", _effplots_zplus_eta, ncols=10)
+_efficiencies_zplus_phi = PlotGroup("Efficiencies_vs_phi", _effplots_zplus_phi, ncols=10)
+_efficiencies_zplus = PlotGroup("Efficiencies_global", _effplots_zplus, ncols=1)
 
-
-_common_dup = {"stat": False, "legend": False}
-_dupplots_zplus = [Plot("duplicate_eta_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(maxlayerzm,maxlayerzp)]
-_dupplots_zplus.extend([Plot("duplicate_phi_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(maxlayerzm,maxlayerzp)])
-_common_dup = {"stat": False, "legend": False, "title": "Global Duplicates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_dup = {"stat": False, "legend": False, "ymin": 0.0, "ymax": 1.1}
+_dupplots_zplus_eta = [Plot("duplicate_eta_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(maxlayerzm,maxlayerzp)]
+_dupplots_zplus_phi = [Plot("duplicate_phi_layer{:02d}".format(i), xtitle="", **_common_dup) for i in range(maxlayerzm,maxlayerzp)]
+_common_dup = {"stat": False, "legend": False, "title": "Global Duplicates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "d", "ymin": 0.0, "ymax": 1.1}
 _common_dup["xmin"] = _bin_count
 _common_dup["xmax"] = _common_dup["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_dupplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Duplicates in z+", **_common_dup)])
-_duplicates_zplus = PlotGroup("Duplicates", _dupplots_zplus, ncols=8)
+_dupplots_zplus = [Plot("globalEfficiencies", xtitle="Global Duplicates in z+", **_common_dup)]
+_duplicates_zplus_eta = PlotGroup("Duplicates_vs_eta", _dupplots_zplus_eta, ncols=10)
+_duplicates_zplus_phi = PlotGroup("Duplicates_vs_phi", _dupplots_zplus_phi, ncols=10)
+_duplicates_zplus = PlotGroup("Duplicates_global", _dupplots_zplus, ncols=1)
 
-_common_fake = {"stat": False, "legend": False}
-_fakeplots_zplus = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(maxlayerzm,maxlayerzp)]
-_fakeplots_zplus.extend([Plot("fake_phi_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(maxlayerzm,maxlayerzp)])
-_common_fake = {"stat": False, "legend": False, "title": "Global Fake Rates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_fake = {"stat": False, "legend": False, "ymin": 0.0, "ymax": 1.1}
+_fakeplots_zplus_eta = [Plot("fake_eta_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(maxlayerzm,maxlayerzp)]
+_fakeplots_zplus_phi = [Plot("fake_phi_layer{:02d}".format(i), xtitle="", **_common_fake) for i in range(maxlayerzm,maxlayerzp)]
+_common_fake = {"stat": False, "legend": False, "title": "Global Fake Rates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "d", "ymin": 0.0, "ymax": 1.1}
 _common_fake["xmin"] = _bin_count
 _common_fake["xmax"] = _common_fake["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_fakeplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global Fake Rate in z+", **_common_fake)])
-_fakes_zplus = PlotGroup("FakeRate", _fakeplots_zplus, ncols=8)
+_fakeplots_zplus = [Plot("globalEfficiencies", xtitle="Global Fake Rate in z+", **_common_fake)]
+_fakes_zplus_eta = PlotGroup("FakeRate_vs_eta", _fakeplots_zplus_eta, ncols=10)
+_fakes_zplus_phi = PlotGroup("FakeRate_vs_phi", _fakeplots_zplus_phi, ncols=10)
+_fakes_zplus = PlotGroup("FakeRate_global", _fakeplots_zplus, ncols=1)
 
-_common_merge = {"stat": False, "legend": False}
-_mergeplots_zplus = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(maxlayerzm,maxlayerzp)]
-_mergeplots_zplus.extend([Plot("merge_phi_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(maxlayerzm,maxlayerzp)])
-_common_merge = {"stat": False, "legend": False, "title": "Global Merge Rates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "v"}
+_common_merge = {"stat": False, "legend": False, "ymin": 0.0, "ymax": 1.1}
+_mergeplots_zplus_eta = [Plot("merge_eta_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(maxlayerzm,maxlayerzp)]
+_mergeplots_zplus_phi = [Plot("merge_phi_layer{:02d}".format(i), xtitle="", **_common_merge) for i in range(maxlayerzm,maxlayerzp)]
+_common_merge = {"stat": False, "legend": False, "title": "Global Merge Rates in z+", "xbinlabels": _xbinlabels, "xbinlabelsize": 12, "xbinlabeloptions": "d", "ymin": 0.0, "ymax": 1.1}
 _common_merge["xmin"] = _bin_count
 _common_merge["xmax"] = _common_merge["xmin"] + maxlayerzm
 _bin_count += 4*maxlayerzm # 2 for the eta{-,+} and 2 for phi{+,-}
-_mergeplots_zplus.extend([Plot("globalEfficiencies", xtitle="Global merge Rate in z+", **_common_merge)])
-_merges_zplus = PlotGroup("MergeRate", _mergeplots_zplus, ncols=8)
+_mergeplots_zplus = [Plot("globalEfficiencies", xtitle="Global merge Rate in z+", **_common_merge)]
+_merges_zplus_eta = PlotGroup("MergeRate_vs_eta", _mergeplots_zplus_eta, ncols=10)
+_merges_zplus_phi = PlotGroup("MergeRate_vs_phi", _mergeplots_zplus_phi, ncols=10)
+_merges_zplus = PlotGroup("MergeRate_global", _mergeplots_zplus, ncols=1)
 
 
 #--------------------------------------------------------------------------------------------
@@ -1329,26 +1344,26 @@ _cell_association_table = PlotGroup("cellAssociation_table", [
         Plot("cellAssociation_perlayer{:02d}".format(i), xtitle="Layer {:02d} in z-".format(i%maxlayerzm+1) if (i<maxlayerzm) else "Layer {:02d} in z+".format(i%maxlayerzm+1), **_common_assoc) for i in range(0,maxlayerzm)
         ], ncols=8 )
 
-_common_eff = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d"}
+_common_eff = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
 _effplots = [Plot("effic_eta", xtitle="", **_common_eff)]
 _effplots.extend([Plot("effic_phi", xtitle="", **_common_eff)])
 _effplots.extend([Plot("globalEfficiencies", xtitle="", **_common_eff)])
 _efficiencies = PlotGroup("Efficiencies", _effplots, ncols=3)
 
 
-_common_dup = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d"}
+_common_dup = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
 _dupplots = [Plot("duplicate_eta", xtitle="", **_common_dup)]
 _dupplots.extend([Plot("duplicate_phi", xtitle="", **_common_dup)])
 _dupplots.extend([Plot("globalEfficiencies", xtitle="", **_common_dup)])
 _duplicates = PlotGroup("Duplicates", _dupplots, ncols=3)
 
-_common_fake = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d"}
+_common_fake = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
 _fakeplots = [Plot("fake_eta", xtitle="", **_common_fake)]
 _fakeplots.extend([Plot("fake_phi", xtitle="", **_common_fake)])
 _fakeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_fake)])
 _fakes = PlotGroup("FakeRate", _fakeplots, ncols=3)
 
-_common_merge = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d"}
+_common_merge = {"stat": False, "legend": False, "xbinlabelsize": 14, "xbinlabeloption": "d", "ymin": 0.0, "ymax": 1.1}
 _mergeplots = [Plot("merge_eta", xtitle="", **_common_merge)]
 _mergeplots.extend([Plot("merge_phi", xtitle="", **_common_merge)])
 _mergeplots.extend([Plot("globalEfficiencies", xtitle="", **_common_merge)])
@@ -1667,173 +1682,6 @@ _PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
 hgcalLayerClustersPlotter = Plotter()
 layerClustersLabel = 'Layer Clusters'
 
-
-
-# [E] For each layer cluster:
-# distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
-# separate histos in each layer for 120um Si, 200/300um Si, Scint
-# NB: not all combinations exist; e.g. no 120um Si in layers with scint.
-# (One entry in each of the four appropriate histos per cell in a layer cluster)
-# z-
-hgcalLayerClustersPlotter.append("CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zminus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _distancetomaxcell_perthickperlayer_120_EE_zminus,
-        _distancetomaxcell_perthickperlayer_120_FH_zminus,
-        _distancetomaxcell_perthickperlayer_120_BH_zminus,
-        _distancetomaxcell_perthickperlayer_200_EE_zminus,
-        _distancetomaxcell_perthickperlayer_200_FH_zminus,
-        _distancetomaxcell_perthickperlayer_200_BH_zminus,
-        _distancetomaxcell_perthickperlayer_300_EE_zminus,
-        _distancetomaxcell_perthickperlayer_300_FH_zminus,
-        _distancetomaxcell_perthickperlayer_300_BH_zminus,
-        _distancetomaxcell_perthickperlayer_scint_EE_zminus,
-        _distancetomaxcell_perthickperlayer_scint_FH_zminus,
-        _distancetomaxcell_perthickperlayer_scint_BH_zminus,
-        _distancetoseedcell_perthickperlayer_120_EE_zminus,
-        _distancetoseedcell_perthickperlayer_120_FH_zminus,
-        _distancetoseedcell_perthickperlayer_120_BH_zminus,
-        _distancetoseedcell_perthickperlayer_200_EE_zminus,
-        _distancetoseedcell_perthickperlayer_200_FH_zminus,
-        _distancetoseedcell_perthickperlayer_200_BH_zminus,
-        _distancetoseedcell_perthickperlayer_300_EE_zminus,
-        _distancetoseedcell_perthickperlayer_300_FH_zminus,
-        _distancetoseedcell_perthickperlayer_300_BH_zminus,
-        _distancetoseedcell_perthickperlayer_scint_EE_zminus,
-        _distancetoseedcell_perthickperlayer_scint_FH_zminus,
-        _distancetoseedcell_perthickperlayer_scint_BH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zminus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zminus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_120_EE_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_120_FH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_120_BH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_200_EE_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_200_FH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_200_BH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_300_EE_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_300_FH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_300_BH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_EE_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_FH_zminus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_BH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zminus"
-        ))
-
-# z+
-hgcalLayerClustersPlotter.append("CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zplus", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _distancetomaxcell_perthickperlayer_120_EE_zplus,
-        _distancetomaxcell_perthickperlayer_120_FH_zplus,
-        _distancetomaxcell_perthickperlayer_120_BH_zplus,
-        _distancetomaxcell_perthickperlayer_200_EE_zplus,
-        _distancetomaxcell_perthickperlayer_200_FH_zplus,
-        _distancetomaxcell_perthickperlayer_200_BH_zplus,
-        _distancetomaxcell_perthickperlayer_300_EE_zplus,
-        _distancetomaxcell_perthickperlayer_300_FH_zplus,
-        _distancetomaxcell_perthickperlayer_300_BH_zplus,
-        _distancetomaxcell_perthickperlayer_scint_EE_zplus,
-        _distancetomaxcell_perthickperlayer_scint_FH_zplus,
-        _distancetomaxcell_perthickperlayer_scint_BH_zplus,
-        _distancetoseedcell_perthickperlayer_120_EE_zplus,
-        _distancetoseedcell_perthickperlayer_120_FH_zplus,
-        _distancetoseedcell_perthickperlayer_120_BH_zplus,
-        _distancetoseedcell_perthickperlayer_200_EE_zplus,
-        _distancetoseedcell_perthickperlayer_200_FH_zplus,
-        _distancetoseedcell_perthickperlayer_200_BH_zplus,
-        _distancetoseedcell_perthickperlayer_300_EE_zplus,
-        _distancetoseedcell_perthickperlayer_300_FH_zplus,
-        _distancetoseedcell_perthickperlayer_300_BH_zplus,
-        _distancetoseedcell_perthickperlayer_scint_EE_zplus,
-        _distancetoseedcell_perthickperlayer_scint_FH_zplus,
-        _distancetoseedcell_perthickperlayer_scint_BH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zplus,
-        _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zplus,
-        _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_120_EE_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_120_FH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_120_BH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_200_EE_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_200_FH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_200_BH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_300_EE_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_300_FH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_300_BH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_EE_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_FH_zplus,
-        _distancebetseedandmaxcell_perthickperlayer_scint_BH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus,
-        _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zplus"
-        ))
-
 lc_general = [
   # [A] calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
   # (one entry per rechit, in the appropriate histo)
@@ -1873,6 +1721,83 @@ lc_zminus = [
   _cellsnum_perthick_perlayer_scint_EE_zminus,
   _cellsnum_perthick_perlayer_scint_FH_zminus,
   _cellsnum_perthick_perlayer_scint_BH_zminus,
+  # [E] For each layer cluster:
+  # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
+  # separate histos in each layer for 120um Si, 200/300um Si, Scint
+  # NB: not all combinations exist; e.g. no 120um Si in layers with scint.
+  # (One entry in each of the four appropriate histos per cell in a layer cluster)
+  _distancetomaxcell_perthickperlayer_120_EE_zminus,
+  _distancetomaxcell_perthickperlayer_120_FH_zminus,
+  _distancetomaxcell_perthickperlayer_120_BH_zminus,
+  _distancetomaxcell_perthickperlayer_200_EE_zminus,
+  _distancetomaxcell_perthickperlayer_200_FH_zminus,
+  _distancetomaxcell_perthickperlayer_200_BH_zminus,
+  _distancetomaxcell_perthickperlayer_300_EE_zminus,
+  _distancetomaxcell_perthickperlayer_300_FH_zminus,
+  _distancetomaxcell_perthickperlayer_300_BH_zminus,
+  _distancetomaxcell_perthickperlayer_scint_EE_zminus,
+  _distancetomaxcell_perthickperlayer_scint_FH_zminus,
+  _distancetomaxcell_perthickperlayer_scint_BH_zminus,
+  _distancetoseedcell_perthickperlayer_120_EE_zminus,
+  _distancetoseedcell_perthickperlayer_120_FH_zminus,
+  _distancetoseedcell_perthickperlayer_120_BH_zminus,
+  _distancetoseedcell_perthickperlayer_200_EE_zminus,
+  _distancetoseedcell_perthickperlayer_200_FH_zminus,
+  _distancetoseedcell_perthickperlayer_200_BH_zminus,
+  _distancetoseedcell_perthickperlayer_300_EE_zminus,
+  _distancetoseedcell_perthickperlayer_300_FH_zminus,
+  _distancetoseedcell_perthickperlayer_300_BH_zminus,
+  _distancetoseedcell_perthickperlayer_scint_EE_zminus,
+  _distancetoseedcell_perthickperlayer_scint_FH_zminus,
+  _distancetoseedcell_perthickperlayer_scint_BH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zminus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zminus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_120_EE_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_120_FH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_120_BH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_200_EE_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_200_FH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_200_BH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_300_EE_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_300_FH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_300_BH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_EE_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_FH_zminus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_BH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus,
   # [F] Looking at the fraction of true energy that has been clustered; by layer and overall
   _energyclustered_perlayer_EE_zminus,
   _energyclustered_perlayer_FH_zminus,
@@ -1889,12 +1814,20 @@ lc_zminus = [
   _cell_association_table_zminus,
   # [M] Efficiency Plots
   _efficiencies_zminus,
+  _efficiencies_zminus_eta,
+  _efficiencies_zminus_phi,
   # [L] Duplicate Plots
   _duplicates_zminus,
+  _duplicates_zminus_eta,
+  _duplicates_zminus_phi,
   # [M] Fake Rate Plots
   _fakes_zminus,
+  _fakes_zminus_eta,
+  _fakes_zminus_phi,
   # [N] Merge Rate Plots
   _merges_zminus,
+  _merges_zminus_eta,
+  _merges_zminus_phi,
   # [O] Energy vs Score 2D plots CP to LC
   _energyscore_cp2lc_zminus,
   # [P] Energy vs Score 2D plots LC to CP
@@ -1916,6 +1849,78 @@ lc_zplus = [
   _cellsnum_perthick_perlayer_scint_EE_zplus,
   _cellsnum_perthick_perlayer_scint_FH_zplus,
   _cellsnum_perthick_perlayer_scint_BH_zplus,
+  _distancetomaxcell_perthickperlayer_120_EE_zplus,
+  _distancetomaxcell_perthickperlayer_120_FH_zplus,
+  _distancetomaxcell_perthickperlayer_120_BH_zplus,
+  _distancetomaxcell_perthickperlayer_200_EE_zplus,
+  _distancetomaxcell_perthickperlayer_200_FH_zplus,
+  _distancetomaxcell_perthickperlayer_200_BH_zplus,
+  _distancetomaxcell_perthickperlayer_300_EE_zplus,
+  _distancetomaxcell_perthickperlayer_300_FH_zplus,
+  _distancetomaxcell_perthickperlayer_300_BH_zplus,
+  _distancetomaxcell_perthickperlayer_scint_EE_zplus,
+  _distancetomaxcell_perthickperlayer_scint_FH_zplus,
+  _distancetomaxcell_perthickperlayer_scint_BH_zplus,
+  _distancetoseedcell_perthickperlayer_120_EE_zplus,
+  _distancetoseedcell_perthickperlayer_120_FH_zplus,
+  _distancetoseedcell_perthickperlayer_120_BH_zplus,
+  _distancetoseedcell_perthickperlayer_200_EE_zplus,
+  _distancetoseedcell_perthickperlayer_200_FH_zplus,
+  _distancetoseedcell_perthickperlayer_200_BH_zplus,
+  _distancetoseedcell_perthickperlayer_300_EE_zplus,
+  _distancetoseedcell_perthickperlayer_300_FH_zplus,
+  _distancetoseedcell_perthickperlayer_300_BH_zplus,
+  _distancetoseedcell_perthickperlayer_scint_EE_zplus,
+  _distancetoseedcell_perthickperlayer_scint_FH_zplus,
+  _distancetoseedcell_perthickperlayer_scint_BH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_EE_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_FH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_120_BH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_EE_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_FH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_200_BH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_EE_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_FH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_300_BH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_EE_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_FH_zplus,
+  _distancetomaxcell_perthickperlayer_eneweighted_scint_BH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_EE_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_FH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_120_BH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_EE_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_FH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_200_BH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_EE_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_FH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_300_BH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_EE_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_FH_zplus,
+  _distancetoseedcell_perthickperlayer_eneweighted_scint_BH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_120_EE_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_120_FH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_120_BH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_200_EE_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_200_FH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_200_BH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_300_EE_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_300_FH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_300_BH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_EE_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_FH_zplus,
+  _distancebetseedandmaxcell_perthickperlayer_scint_BH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_EE_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_FH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_120_BH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_EE_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_FH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_200_BH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_EE_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_FH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_300_BH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus,
+  _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus,
   _energyclustered_perlayer_EE_zplus,
   _energyclustered_perlayer_FH_zplus,
   _energyclustered_perlayer_BH_zplus,
@@ -1924,10 +1929,22 @@ lc_zplus = [
   _sharedEnergy_caloparticle_to_layercluster_zplus,
   _sharedEnergy_layercluster_to_caloparticle_zplus,
   _cell_association_table_zplus,
+  # Efficiency Plots
   _efficiencies_zplus,
+  _efficiencies_zplus_eta,
+  _efficiencies_zplus_phi,
+  # Duplicate Plots
   _duplicates_zplus,
+  _duplicates_zplus_eta,
+  _duplicates_zplus_phi,
+  # Fake Rate Plots
   _fakes_zplus,
+  _fakes_zplus_eta,
+  _fakes_zplus_phi,
+  # Merge Rate Plots
   _merges_zplus,
+  _merges_zplus_eta,
+  _merges_zplus_phi,
   _energyscore_cp2lc_zplus,
   _energyscore_lc2cp_zplus
 ]

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1834,9 +1834,11 @@ lc_zminus = [
   _energyscore_lc2cp_zminus
 ]
 lc_zplus = [
+  # number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zplus,
   _totclusternum_layer_FH_zplus,
   _totclusternum_layer_BH_zplus,
+  # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
   _cellsnum_perthick_perlayer_120_EE_zplus,
   _cellsnum_perthick_perlayer_120_FH_zplus,
   _cellsnum_perthick_perlayer_120_BH_zplus,
@@ -1849,6 +1851,7 @@ lc_zplus = [
   _cellsnum_perthick_perlayer_scint_EE_zplus,
   _cellsnum_perthick_perlayer_scint_FH_zplus,
   _cellsnum_perthick_perlayer_scint_BH_zplus,
+  # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
   _distancetomaxcell_perthickperlayer_120_EE_zplus,
   _distancetomaxcell_perthickperlayer_120_FH_zplus,
   _distancetomaxcell_perthickperlayer_120_BH_zplus,
@@ -1921,13 +1924,19 @@ lc_zplus = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus,
+  # Looking at the fraction of true energy that has been clustered; by layer and overall
   _energyclustered_perlayer_EE_zplus,
   _energyclustered_perlayer_FH_zplus,
   _energyclustered_perlayer_BH_zplus,
+  # Score of CaloParticles wrt Layer Clusters
   _score_caloparticle_to_layerclusters_zplus,
+  # Score of LayerClusters wrt CaloParticles
   _score_layercluster_to_caloparticles_zplus,
+  # Shared Energy between CaloParticle and LayerClusters
   _sharedEnergy_caloparticle_to_layercluster_zplus,
+  # Shared Energy between LayerClusters and CaloParticle
   _sharedEnergy_layercluster_to_caloparticle_zplus,
+  # Cell Association per Layer
   _cell_association_table_zplus,
   # Efficiency Plots
   _efficiencies_zplus,

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1667,26 +1667,6 @@ _PhotonsFromMultiCl_Closest_EoverCPenergy = PlotGroup("PhotonsFromMultiCl", [
 hgcalLayerClustersPlotter = Plotter()
 layerClustersLabel = 'Layer Clusters'
 
-#We follow Chris categories in folders
-# [A] calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
-# (one entry per rechit, in the appropriate histo)
-hgcalLayerClustersPlotter.append("CellsEnergyDensityPerThickness", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _cellsenedens_thick,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
-        ))
-
-# [B] number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
-# (one entry per event in each of the four histos)
-hgcalLayerClustersPlotter.append("TotalNumberofLayerClustersPerThickness", [
-        "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-        ], PlotFolder(
-        _totclusternum_thick,
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
-        ))
 
 
 # [E] For each layer cluster:
@@ -1854,31 +1834,24 @@ hgcalLayerClustersPlotter.append("CellsDistanceToSeedAndMaxCellPerLayerPerThickn
         purpose=PlotPurpose.Timing, page="CellsDistanceToSeedAndMaxCellPerLayerPerThickness_zplus"
         ))
 
-# [G] Miscellaneous plots:
-# longdepthbarycentre: The longitudinal depth barycentre. One entry per event.
-# mixedhitscluster: Number of clusters per event with hits in different thicknesses.
-# num_reco_cluster_eta: Number of reco clusters vs eta
-
-hgcalLayerClustersPlotter.append("Miscellaneous", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
-            ], PlotFolder(
-            _num_reco_cluster_eta,
-            _energyclustered,
-            _mixedhitsclusters,
-            _longdepthbarycentre,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
-            ))
-
-# [H] SelectedCaloParticles plots
-hgcalLayerClustersPlotter.append("SelectedCaloParticles_Photons", [
-            "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/SelectedCaloParticles/22",
-            ], PlotFolder(
-            _SelectedCaloParticles,
-            loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page=layerClustersLabel, section="General"
-            ))
-
+lc_general = [
+  # [A] calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
+  # (one entry per rechit, in the appropriate histo)
+  _cellsenedens_thick,
+  # [B] number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
+  # (one entry per event in each of the four histos)
+  _totclusternum_thick,
+  # [G] Miscellaneous plots:
+  # longdepthbarycentre: The longitudinal depth barycentre. One entry per event.
+  # mixedhitscluster: Number of clusters per event with hits in different thicknesses.
+  # num_reco_cluster_eta: Number of reco clusters vs eta
+  _num_reco_cluster_eta,
+  _energyclustered,
+  _mixedhitsclusters,
+  _longdepthbarycentre,
+  # [H] SelectedCaloParticles plots
+  _SelectedCaloParticles,
+]
 lc_zminus = [
   # [C] number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zminus,
@@ -1960,8 +1933,8 @@ lc_zplus = [
 ]
 
 def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel):
-  regions = ["zminus", "zplus"]
-  setPlots = [lc_zminus, lc_zplus]
+  regions = ["General", "zminus", "zplus"]
+  setPlots = [lc_general, lc_zminus, lc_zplus]
   for reg, setPlot in zip(regions, setPlots):
     print(_hgcalFolders(collection))
     hgcalLayerClustersPlotter.append(collection+"_"+reg, [

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1479,29 +1479,29 @@ _HitValidation = PlotGroup("HitValidation", [
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 
-_SimHits_Occupancy_EE_zplus = PlotGroup("SimHits_Occupancy_EE_zplus", [
-                                                                       Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_Occupancy_EE_zplus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+_Occupancy_EE_zplus = PlotGroup("Occupancy_EE_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_EE_zplus", 
+                                                        xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                                        ], ncols=4)
+
+_Occupancy_HE_Silicon_zplus = PlotGroup("Occupancy_HE_Silicon_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_zplus", 
+                                                                       xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
                                                                        ], ncols=4)
 
-_SimHits_Occupancy_HE_Silicon_zplus = PlotGroup("SimHits_Occupancy_HE_Silicon_zplus", [
-                                                                                       Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_HE_Occupancy_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                       ], ncols=4)
-
-_SimHits_Occupancy_HE_Scintillator_zplus = PlotGroup("SimHits_Occupancy_HE_Scintillator_zplus", [
-                                                                                                 Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_Occupancy_HE_Scintillator_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                 ], ncols=4)
-
-_SimHits_Occupancy_EE_zminus = PlotGroup("SimHits_Occupancy_EE_zminus", [
-                                                                         Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_Occupancy_EE_zminus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                         ], ncols=4)
-
-_SimHits_Occupancy_HE_Silicon_zminus = PlotGroup("SimHits_Occupancy_HE_Silicon_zminus", [
-                                                                                         Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_Occupancy_HE_Silicon_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+_Occupancy_HE_Scintillator_zplus = PlotGroup("Occupancy_HE_Scintillator_zplus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Scintillator_zplus", 
+                                                                                         xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
                                                                                          ], ncols=4)
 
-_SimHits_Occupancy_HE_Scintillator_zminus = PlotGroup("SimHits_Occupancy_HE_Scintillator_zminus", [
-                                                                                                   Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="SimHits_Occupancy_HE_Scintillator_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                   ], ncols=4)
+_Occupancy_EE_zminus = PlotGroup("Occupancy_EE_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_EE_zminus", 
+                                                         xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                                         ], ncols=4)
+
+_Occupancy_HE_Silicon_zminus = PlotGroup("Occupancy_HE_Silicon_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Silicon_zminus", 
+                                                                         xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+                                                                         ], ncols=4)
+
+_Occupancy_HE_Scintillator_zminus = PlotGroup("Occupancy_HE_Scintillator_zminus", [Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="Occupancy_HE_Scintillator_zminus", 
+                                                                                   xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                                   ], ncols=4)
 
 _common_etaphi = dict(removeEmptyBins=False, xbinlabelsize=10, xbinlabeloption="d", ymin=None)
 
@@ -1531,69 +1531,29 @@ for i in range(HEScintillator_min,HEScintillator_max+1):
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "ymin": 0.1, "ylog": True}
 
-_SimHits_Energy_EE_0 = PlotGroup("SimHits_Energy_Time_0_EE", [
-                                                              Plot("energy_time_0_layer_{:02d}".format(i), title="SimHits_Energy_Time_0_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+_Energy_EE_0 = PlotGroup("Energy_Time_0_EE", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_EE", 
+                                              xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                              ], ncols=4)
+
+_Energy_HE_Silicon_0 = PlotGroup("Energy_Time_0_HE_Silicon", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_HE_Silicon", 
+                                                              xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
                                                               ], ncols=4)
 
-_SimHits_Energy_HE_Silicon_0 = PlotGroup("SimHits_Energy_Time_0_HE_Silicon", [
-                                                                              Plot("energy_time_0_layer_{:02d}".format(i), title="SimHits_Energy_Time_0_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                              ], ncols=4)
+_Energy_HE_Scintillator_0 = PlotGroup("Energy_Time_0_HE_Scintillator", [Plot("energy_time_0_layer_{:02d}".format(i), title="Energy_Time_0_HE_Scintillator", 
+                                                                        xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                        ], ncols=4)
 
-_SimHits_Energy_HE_Scintillator_0 = PlotGroup("SimHits_Energy_Time_0_HE_Scintillator", [
-                                                                                        Plot("energy_time_0_layer_{:02d}".format(i), title="SimHits_Energy_Time_0_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                        ], ncols=4)
+_Energy_EE_1 = PlotGroup("Energy_Time_1_EE", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_EE", 
+                                              xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                              ], ncols=4)
 
-_SimHits_Energy_EE_1 = PlotGroup("SimHits_Energy_Time_1_EE", [
-                                                              Plot("energy_time_1_layer_{:02d}".format(i), title="SimHits_Energy_Time_1_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+_Energy_HE_Silicon_1 = PlotGroup("Energy_Time_1_HE_Silicon", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_HE_Silicon", 
+                                                              xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
                                                               ], ncols=4)
 
-_SimHits_Energy_HE_Silicon_1 = PlotGroup("SimHits_Energy_Time_1_HE_Silicon", [
-                                                                              Plot("energy_time_1_layer_{:02d}".format(i), title="SimHits_Energy_Time_1_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                              ], ncols=4)
-
-_SimHits_Energy_HE_Scintillator_1 = PlotGroup("SimHits_Energy_Time_1_HE_Scintillator", [
-                                                                                        Plot("energy_time_1_layer_{:02d}".format(i), title="SimHits_Energy_Time_1_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                        ], ncols=4)
-
-_common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
-
-_RecHits_Occupancy_EE_zplus = PlotGroup("RecHits_Occupancy_EE_zplus", [
-                                                                       Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="RecHits_Occupancy_EE_zplus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                       ], ncols=4)
-
-_RecHits_Occupancy_HE_Silicon_zplus = PlotGroup("RecHits_Occupancy_HE_Silicon_zplus", [
-                                                                                       Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="RecHits_Occupancy_HE_Silicon_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                       ], ncols=4)
-
-_RecHits_Occupancy_HE_Scintillator_zplus = PlotGroup("RecHits_Occupancy_HE_Scintillator_zplus", [
-                                                                                                 Plot("HitOccupancy_Plus_layer_{:02d}".format(i), title="RecHits_Occupancy_HE_Scintillator_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                 ], ncols=4)
-
-_RecHits_Occupancy_EE_zminus = PlotGroup("RecHits_Occupancy_EE_zminus", [
-                                                                         Plot("HitOccupancy_Minus_layer_{:02d}".format(i), title="RecHits_Occupancy_EE_zminus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                         ], ncols=4)
-
-_RecHits_Occupancy_HE_Silicon_zminus = PlotGroup("RecHits_Occupancy_HE_Silicon_zminus", [
-                                                                                         Plot("HitOccupancy_Minus_layer_{:02d}".format(i), title="RecHits_Occupancy_HE_Silicon_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                         ], ncols=4)
-
-_RecHits_Occupancy_HE_Scintillator_zminus = PlotGroup("RecHits_Occupancy_HE_Scintillator_zminus", [
-                                                                                                   Plot("HitOccupancy_Minus_layer_{:02d}".format(i),  title="RecHits_Occupancy_HE_Scintillator_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                   ], ncols=4)
-
-_common = {"stat": True, "drawStyle": "hist", "staty": 0.65, "ymin": 0.1, "ylog": True}
-
-_RecHits_Energy_EE = PlotGroup("RecHits_Energy_EE", [
-                                                     Plot("energy_layer_{:02d}".format(i), title="RecHits_Energy_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                     ], ncols=4)
-
-_RecHits_Energy_HE_Silicon = PlotGroup("RecHits_Energy_HE_Silicon", [
-                                                                     Plot("energy_layer_{:02d}".format(i), title="RecHits_Energy_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                     ], ncols=4)
-
-_RecHits_Energy_HE_Scintillator = PlotGroup("RecHits_Energy_HE_Scintillator", [
-                                                                               Plot("energy_layer_{:02d}".format(i), title="RecHits_Energy_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                               ], ncols=4)
+_Energy_HE_Scintillator_1 = PlotGroup("Energy_Time_1_HE_Scintillator", [Plot("energy_time_1_layer_{:02d}".format(i), title="Energy_Time_1_HE_Scintillator", 
+                                                                        xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                        ], ncols=4)
 
 _RecHits_EtaPhi_EE_zplus=[]
 for i in range(EE_min,EE_max+1):
@@ -1619,43 +1579,43 @@ _RecHits_EtaPhi_HE_Scintillator_zminus=[]
 for i in range(HEScintillator_min,HEScintillator_max+1):
     _RecHits_EtaPhi_HE_Scintillator_zminus.append(PlotOnSideGroup("RecHits_EtaPhi_HE_Scintillator_zminus_layer_{:02d}".format(i), Plot("EtaPhi_Minus_layer_{:02d}".format(i), title="RecHits_EtaPhi_HE_Scintillator_zminus", xtitle="Layer {}".format(i), drawStyle="COLZ", adjustMarginRight=0.1, **_common_etaphi), ncols=1))
 
-_DigiHits_ADC_EE = PlotGroup("DigiHits_ADC_EE", [
-                                                 Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_EE", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                 ], ncols=4)
+_DigiHits_ADC_EE = PlotGroup("ADC_EE", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_EE", 
+                                        xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                        ], ncols=4)
 
-_DigiHits_ADC_HE_Silicon = PlotGroup("DigiHits_ADC_HE_Silicon", [
-                                                                 Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Silicon", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                 ], ncols=4)
+_DigiHits_ADC_HE_Silicon = PlotGroup("ADC_HE_Silicon", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Silicon", 
+                                                       xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+                                                       ], ncols=4)
 
-_DigiHits_ADC_HE_Scintillator = PlotGroup("DigiHits_ADC_HE_Scintillator", [
-                                                                           Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Scintillator", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                           ], ncols=4)
+_DigiHits_ADC_HE_Scintillator = PlotGroup("ADC_HE_Scintillator", [Plot("ADC_layer_{:02d}".format(i), title="DigiHits_ADC_HE_Scintillator", 
+                                                                  xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                  ], ncols=4)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 
-_DigiHits_Occupancy_EE_zplus = PlotGroup("DigiHits_Occupancy_EE_zplus", [
-                                                                         Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zplus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                         ], ncols=4)
+_DigiHits_Occupancy_EE_zplus = PlotGroup("Occupancy_EE_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zplus", 
+                                                                xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                                                ], ncols=4)
 
-_DigiHits_Occupancy_HE_Silicon_zplus = PlotGroup("DigiHits_Occupancy_HE_Silicon_zplus", [
-                                                                                         Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
-                                                                                         ], ncols=4)
+_DigiHits_Occupancy_HE_Silicon_zplus = PlotGroup("Occupancy_HE_Silicon_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zplus", 
+                                                                                 xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+                                                                                 ], ncols=4)
 
-_DigiHits_Occupancy_HE_Scintillator_zplus = PlotGroup("DigiHits_Occupancy_HE_Scintillator_zplus", [
-                                                                                                   Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zplus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                   ], ncols=4)
-
-_DigiHits_Occupancy_EE_zminus = PlotGroup("DigiHits_Occupancy_EE_zminus", [
-                                                                           Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zminus", xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
-                                                                           ], ncols=4)
-
-_DigiHits_Occupancy_HE_Silicon_zminus = PlotGroup("DigiHits_Occupancy_HE_Silicon_zminus", [
-                                                                                           Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+_DigiHits_Occupancy_HE_Scintillator_zplus = PlotGroup("Occupancy_HE_Scintillator_zplus", [Plot("DigiOccupancy_Plus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zplus", 
+                                                                                          xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
                                                                                            ], ncols=4)
 
-_DigiHits_Occupancy_HE_Scintillator_zminus = PlotGroup("DigiHits_Occupancy_HE_Scintillator_zminus", [
-                                                                                                     Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zminus", xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
-                                                                                                     ], ncols=4)
+_DigiHits_Occupancy_EE_zminus = PlotGroup("Occupancy_EE_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_EE_zminus", 
+                                                                  xtitle="Layer {}".format(i), **_common) for i in range(EE_min,EE_max+1)
+                                                                  ], ncols=4)
+
+_DigiHits_Occupancy_HE_Silicon_zminus = PlotGroup("Occupancy_HE_Silicon_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Silicon_zminus", 
+                                                                                  xtitle="Layer {}".format(i), **_common) for i in range(HESilicon_min,HESilicon_max+1)
+                                                                                  ], ncols=4)
+
+_DigiHits_Occupancy_HE_Scintillator_zminus = PlotGroup("Occupancy_HE_Scintillator_zminus", [Plot("DigiOccupancy_Minus_layer_{:02d}".format(i), title="DigiHits_Occupancy_HE_Scintillator_zminus", 
+                                                                                            xtitle="Layer {}".format(i), **_common) for i in range(HEScintillator_min,HEScintillator_max+1)
+                                                                                            ], ncols=4)
 
 _common_XY = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d", ymin=None)
 
@@ -2301,63 +2261,46 @@ def append_hgcalMultiClustersPlots(collection = 'ticlMultiClustersFromTracksters
 
 #=================================================================================================
 # hitValidation
+def _hgcalHitFolders(dirName="HGCalSimHitsV/HGCalEESensitive"):
+    return "DQMData/Run 1/HGCAL/Run summary/"+dirName
+
+_hitsCommonPlots_EE = [
+  _Occupancy_EE_zplus,
+  _Occupancy_EE_zminus, 
+]
+_hitsCommonPlots_HE_Sil = [
+  _Occupancy_HE_Silicon_zplus,
+  _Occupancy_HE_Silicon_zminus,
+]
+_hitsCommonPlots_HE_Sci = [
+  _Occupancy_HE_Scintillator_zplus,
+  _Occupancy_HE_Scintillator_zminus  
+]
+
 hgcalHitPlotter = Plotter()
+hitsLabel = 'Hits'
+simHitsLabel = 'Simulated Hits'
 
 hgcalHitPlotter.append("SimHits_Validation", [
                                               "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HitValidation",
                                               ], PlotFolder(
                                                             _HitValidation,
                                                             loopSubFolders=False,
-                                                            purpose=PlotPurpose.Timing, page="SimHits_Validation"
+                                                            purpose=PlotPurpose.Timing, page=hitsLabel, section=simHitsLabel
                                                             ))
 
-hgcalHitPlotter.append("SimHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                                   ], PlotFolder(
-                                                                 _SimHits_Occupancy_EE_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("SimHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                                   ], PlotFolder(
-                                                                 _SimHits_Occupancy_HE_Silicon_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("SimHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive"
-                                                   ], PlotFolder(
-                                                                 _SimHits_Occupancy_HE_Scintillator_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("SimHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                                    ], PlotFolder(
-                                                                  _SimHits_Occupancy_EE_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zminus"
-                                                                  ))
-
-hgcalHitPlotter.append("SimHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                                    ], PlotFolder(
-                                                                  _SimHits_Occupancy_HE_Silicon_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zminus"
-                                                                  ))
-
-hgcalHitPlotter.append("SimHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive"
-                                                    ], PlotFolder(
-                                                                  _SimHits_Occupancy_HE_Scintillator_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="SimHits_Occupancy_zminus"
-                                                                  ))
+def append_hgcalHitsPlots(collection = "HGCalSimHitsV", name_collection = "Simulated Hits"):
+  regions = ["HGCalEESensitive", "HGCalHESiliconSensitive", "HGCalHEScintillatorSensitive"]
+  setPlots = [_hitsCommonPlots_EE, _hitsCommonPlots_HE_Sil, _hitsCommonPlots_HE_Sci]
+  for reg, setPlot in zip(regions, setPlots):
+    dirName = collection+"/"+reg
+    print(dirName)
+    hgcalHitPlotter.append(name_collection, [
+                _hgcalHitFolders(dirName)
+                ], PlotFolder(
+                *setPlot,
+                loopSubFolders=False,
+                purpose=PlotPurpose.Timing, page=hitsLabel, section=name_collection))
 
 for i,item in enumerate(_SimHits_EtaPhi_EE_zplus, start=1):
     hgcalHitPlotter.append("SimHits_EtaPhi_zplus", [
@@ -2412,126 +2355,6 @@ for i,item in enumerate(_SimHits_EtaPhi_HE_Scintillator_zminus, start=1):
                                                                    purpose=PlotPurpose.Timing, page="SimHits_EtaPhi_zminus"
                                                                    ))
 
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_EE_0,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_HE_Silicon_0,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_HE_Scintillator_0,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalEESensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_EE_1,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHESiliconSensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_HE_Silicon_1,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("SimHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalSimHitsV/HGCalHEScintillatorSensitive"
-                                          ], PlotFolder(
-                                                        _SimHits_Energy_HE_Scintillator_1,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="SimHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
-                                                   ], PlotFolder(
-                                                                 _RecHits_Occupancy_EE_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHESiliconSensitive"
-                                                   ], PlotFolder(
-                                                                 _RecHits_Occupancy_HE_Silicon_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zplus", [
-                                                   "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHEScintillatorSensitive"
-                                                   ], PlotFolder(
-                                                                 _RecHits_Occupancy_HE_Scintillator_zplus,
-                                                                 loopSubFolders=False,
-                                                                 purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zplus"
-                                                                 ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
-                                                    ], PlotFolder(
-                                                                  _RecHits_Occupancy_EE_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zminus"
-                                                                  ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHESiliconSensitive"
-                                                    ], PlotFolder(
-                                                                  _RecHits_Occupancy_HE_Silicon_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zminus"
-                                                                  ))
-
-hgcalHitPlotter.append("RecHits_Occupancy_zminus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHEScintillatorSensitive"
-                                                    ], PlotFolder(
-                                                                  _RecHits_Occupancy_HE_Scintillator_zminus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="RecHits_Occupancy_zminus"
-                                                                  ))
-
-hgcalHitPlotter.append("RecHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
-                                          ], PlotFolder(
-                                                        _RecHits_Energy_EE,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="RecHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("RecHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHESiliconSensitive"
-                                          ], PlotFolder(
-                                                        _RecHits_Energy_HE_Silicon,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="RecHits_Energy"
-                                                        ))
-
-hgcalHitPlotter.append("RecHits_Energy", [
-                                          "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalHEScintillatorSensitive"
-                                          ], PlotFolder(
-                                                        _RecHits_Energy_HE_Scintillator,
-                                                        loopSubFolders=False,
-                                                        purpose=PlotPurpose.Timing, page="RecHits_Energy"
-                                                        ))
-
 for i,item in enumerate(_RecHits_EtaPhi_EE_zplus, start=1):
     hgcalHitPlotter.append("RecHits_EtaPhi_zplus", [
                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalRecHitsV/HGCalEESensitive"
@@ -2585,77 +2408,40 @@ for i,item in enumerate(_RecHits_EtaPhi_HE_Scintillator_zminus, start=1):
                                                                    purpose=PlotPurpose.Timing, page="RecHits_EtaPhi_zminus"
                                                                    ))
 
-hgcalHitPlotter.append("DigiHits_ADC", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_ADC_EE,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_ADC"
-                                                      ))
+_digisCommonPlots_EE = [
+  _DigiHits_Occupancy_EE_zplus,
+  _DigiHits_Occupancy_EE_zminus,
+  _DigiHits_ADC_EE,
+  _DigiHits_TOA_EE,
+  _DigiHits_TOT_EE,
+]
+_digisCommonPlots_HE_Sil = [
+  _DigiHits_Occupancy_HE_Silicon_zplus,
+  _DigiHits_Occupancy_HE_Silicon_zminus,
+  _DigiHits_ADC_HE_Silicon,
+  _DigiHits_TOA_HE_Silicon,
+  _DigiHits_TOT_HE_Silicon,
+]
+_digisCommonPlots_HE_Sci = [
+  _DigiHits_Occupancy_HE_Scintillator_zplus,
+  _DigiHits_Occupancy_HE_Scintillator_zminus,
+  _DigiHits_ADC_HE_Scintillator,
+  _DigiHits_TOA_HE_Scintillator,
+  _DigiHits_TOT_HE_Scintillator,
+]
 
-hgcalHitPlotter.append("DigiHits_ADC", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_ADC_HE_Silicon,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_ADC"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_ADC", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_ADC_HE_Scintillator,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_ADC"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                                    ], PlotFolder(
-                                                                  _DigiHits_Occupancy_EE_zplus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zplus"
-                                                                  ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                                    ], PlotFolder(
-                                                                  _DigiHits_Occupancy_HE_Silicon_zplus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zplus"
-                                                                  ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zplus", [
-                                                    "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive"
-                                                    ], PlotFolder(
-                                                                  _DigiHits_Occupancy_HE_Scintillator_zplus,
-                                                                  loopSubFolders=False,
-                                                                  purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zplus"
-                                                                  ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                                     ], PlotFolder(
-                                                                   _DigiHits_Occupancy_EE_zminus,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zminus"
-                                                                   ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                                     ], PlotFolder(
-                                                                   _DigiHits_Occupancy_HE_Silicon_zminus,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zminus"
-                                                                   ))
-
-hgcalHitPlotter.append("DigiHits_Occupancy_zminus", [
-                                                     "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive"
-                                                     ], PlotFolder(
-                                                                   _DigiHits_Occupancy_HE_Scintillator_zminus,
-                                                                   loopSubFolders=False,
-                                                                   purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_zminus"
-                                                                   ))
+def append_hgcalDigisPlots(collection = "HGCalDigisV", name_collection = "Digis"):
+  regions = ["HGCalEESensitive", "HGCalHESiliconSensitive", "HGCalHEScintillatorSensitive"]
+  setPlots = [_digisCommonPlots_EE, _digisCommonPlots_HE_Sil, _digisCommonPlots_HE_Sci]
+  for reg, setPlot in zip(regions, setPlots):
+    dirName = collection+"/"+reg
+    print(dirName)
+    hgcalHitPlotter.append(name_collection, [
+                _hgcalHitFolders(dirName)
+                ], PlotFolder(
+                *setPlot,
+                loopSubFolders=False,
+                purpose=PlotPurpose.Timing, page=hitsLabel, section=name_collection))
 
 for i,item in enumerate(_DigiHits_Occupancy_XY_EE_zplus, start=1):
     hgcalHitPlotter.append("DigiHits_Occupancy_XY_zplus", [
@@ -2708,71 +2494,24 @@ for i,item in enumerate(_DigiHits_Occupancy_XY_HE_Scintillator_zminus, start=1):
                                                                           item,
                                                                           loopSubFolders=False,
                                                                           purpose=PlotPurpose.Timing, page="DigiHits_Occupancy_XY_zminus"))
-
-hgcalHitPlotter.append("DigiHits_TOA", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOA_EE,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOA"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_TOA", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOA_HE_Silicon,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOA"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_TOA", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOA_HE_Scintillator,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOA"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_TOT", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalEESensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOT_EE,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOT"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_TOT", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHESiliconSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOT_HE_Silicon,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOT"
-                                                      ))
-
-hgcalHitPlotter.append("DigiHits_TOT", [
-                                        "DQMData/Run 1/HGCAL/Run summary/HGCalDigisV/HGCalHEScintillatorSensitive"
-                                        ], PlotFolder(
-                                                      _DigiHits_TOT_HE_Scintillator,
-                                                      loopSubFolders=False,
-                                                      purpose=PlotPurpose.Timing, page="DigiHits_TOT"
-                                                      ))
 #=================================================================================================
 # hitCalibration
 hgcalHitCalibPlotter = Plotter()
+hitCalibrationLabel = 'Calibrated RecHits'
 
 hgcalHitCalibPlotter.append("Layer_Occupancy", [
                                                 "DQMData/Run 1/HGCalHitCalibration/Run summary",
                                                 ], PlotFolder(
                                                               _LayerOccupancy,
                                                               loopSubFolders=False,
-                                                              purpose=PlotPurpose.Timing, page="Layer_Occupancy"
+                                                              purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
                                                               ))
 hgcalHitCalibPlotter.append("ReconstructableEnergyOverCPenergy", [
         "DQMData/Run 1/HGCalHitCalibration/Run summary",
         ], PlotFolder(
         _ReconstructableEnergyOverCPenergy,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="ReconstructableEnergyOverCPenergy"
+        purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
 hgcalHitCalibPlotter.append("ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy", [
@@ -2780,7 +2519,7 @@ hgcalHitCalibPlotter.append("ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCP
         ], PlotFolder(
         _ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="ParticleFlowClusterHGCalFromMultiCl_Closest_EoverCPenergy"
+        purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
 hgcalHitCalibPlotter.append("PhotonsFromMultiCl_Closest_EoverCPenergy", [
@@ -2788,7 +2527,7 @@ hgcalHitCalibPlotter.append("PhotonsFromMultiCl_Closest_EoverCPenergy", [
         ], PlotFolder(
         _PhotonsFromMultiCl_Closest_EoverCPenergy,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="PhotonsFromMultiCl_Closest_EoverCPenergy"
+        purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
 hgcalHitCalibPlotter.append("EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy", [
@@ -2796,5 +2535,5 @@ hgcalHitCalibPlotter.append("EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPen
         ], PlotFolder(
         _EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy,
         loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page="EcalDrivenGsfElectronsFromMultiCl_Closest_EoverCPenergy"
+        purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))

--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1284,7 +1284,7 @@ _common_score = {#"title": "Score CaloParticle to MultiClusters",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_caloparticle_to_multiclusters = PlotGroup("score_caloparticle_to_multicluster", [
+_score_caloparticle_to_multiclusters = PlotGroup("ScoreCaloParticlesToMultiClusters", [
         Plot("Score_caloparticle2multicl", **_common_score)
         ], ncols=1)
 
@@ -1299,9 +1299,9 @@ _common_score = {#"title": "Score MultiCluster to CaloParticles",
                  "ylog": True
                 }
 _common_score.update(_legend_common)
-_score_multicluster_to_caloparticles = PlotGroup("score_multicluster_to_caloparticle", [
+_score_multicluster_to_caloparticles = PlotGroup("ScoreMultiClustersToCaloParticles", [
         Plot("Score_multicl2caloparticle", **_common_score)
-        ])
+        ], ncols=1)
 
 _common_shared= {"title": "Shared Energy CaloParticle To Multi Cluster ",
                  "stat": False,
@@ -1315,7 +1315,7 @@ _common_shared["xmin"] = -4.0
 _common_shared["xmax"] = 4.0
 _shared_plots.extend([Plot("SharedEnergy_caloparticle2multicl_vs_eta", **_common_shared)])
 _shared_plots.extend([Plot("SharedEnergy_caloparticle2multicl_vs_phi", **_common_shared)])
-_sharedEnergy_caloparticle_to_multicluster = PlotGroup("sharedEnergy_caloparticle_to_multicluster", _shared_plots, ncols=3)
+_sharedEnergy_caloparticle_to_multicluster = PlotGroup("SharedEnergy_CaloParticleToMultiCluster", _shared_plots, ncols=3)
 
 _common_shared= {"title": "Shared Energy Multi Cluster To CaloParticle ",
                  "stat": False,
@@ -1329,7 +1329,7 @@ _common_shared["xmin"] = -4.0
 _common_shared["xmax"] = 4.0
 _shared_plots2.extend([Plot("SharedEnergy_multicl2caloparticle_vs_eta", **_common_shared)])
 _shared_plots2.extend([Plot("SharedEnergy_multicl2caloparticle_vs_phi", **_common_shared)])
-_sharedEnergy_multicluster_to_caloparticle = PlotGroup("sharedEnergy_multicluster_to_caloparticle", _shared_plots2, ncols=3)
+_sharedEnergy_multicluster_to_caloparticle = PlotGroup("SharedEnergy_MultiClusterToCaloParticle", _shared_plots2, ncols=3)
 
 
 _common_assoc = {#"title": "Cell Association Table",
@@ -1374,39 +1374,32 @@ _merges = PlotGroup("MergeRate", _mergeplots, ncols=3)
 _common_energy_score = dict(removeEmptyBins=True, xbinlabelsize=10, xbinlabeloption="d")
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
-_energyscore_cp2mcl = PlotOnSideGroup("_energyscore_cp2mcl", Plot("Energy_vs_Score_caloparticle2multi", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_cp2mcl = PlotOnSideGroup("Energy_vs_Score_CaloParticlesToMultiClusters", Plot("Energy_vs_Score_caloparticle2multi", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 _common_energy_score["ymax"] = 1.
 _common_energy_score["xmax"] = 1.0
-_energyscore_mcl2cp = PlotOnSideGroup("_energyscore_mcl2cp", Plot("Energy_vs_Score_multi2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
+_energyscore_mcl2cp = PlotOnSideGroup("Energy_vs_Score_MultiClustersToCaloParticles", Plot("Energy_vs_Score_multi2caloparticle", drawStyle="COLZ", adjustMarginRight=0.1, **_common_energy_score), ncols=1)
 
 #Coming back to the usual box definition
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
-_totmulticlusternum = PlotGroup("totmulticlusternum", [
+_totmulticlusternum = PlotGroup("TotalNumberofMultiClusters", [
   Plot("totmulticlusternum", xtitle="", **_common)
 ],ncols=1)
 
-_multicluster_firstlayer = PlotGroup("multicluster_firstlayer", [
-  Plot("multicluster_firstlayer", xtitle="Layer number", **_common)
-],ncols=1)
-
-_multicluster_lastlayer = PlotGroup("multicluster_lastlayer", [
-  Plot("multicluster_lastlayer", xtitle="Layer number", **_common)
-],ncols=1)
-
-_multicluster_layersnum = PlotGroup("multicluster_layersnum", [
-  Plot("multicluster_layersnum", xtitle="", **_common)
-],ncols=1)
+_multicluster_layernum_plots = [Plot("multicluster_firstlayer", xtitle="MultiCluster First Layer", **_common)]
+_multicluster_layernum_plots.extend([Plot("multicluster_lastlayer", xtitle="MultiCluster Last Layer", **_common)])
+_multicluster_layernum_plots.extend([Plot("multicluster_layersnum", xtitle="MultiCluster Number of Layers", **_common)])
+_multicluster_layernum = PlotGroup("LayerNumbersOfMultiCluster", _multicluster_layernum_plots, ncols=3)
 
 _common["xmax"] = 50
-_clusternum_in_multicluster = PlotGroup("clusternum_in_multicluster",[
+_clusternum_in_multicluster = PlotGroup("NumberofLayerClustersinMultiCluster",[
   Plot("clusternum_in_multicluster", xtitle="", **_common)
 ],ncols=1)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 _common = {"stat": True, "drawStyle": "pcolz", "staty": 0.65}
 
-_clusternum_in_multicluster_vs_layer = PlotGroup("clusternum_in_multicluster_vs_layer",[
+_clusternum_in_multicluster_vs_layer = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer",[
   Plot("clusternum_in_multicluster_vs_layer", xtitle="Layer number", ytitle = "<2d Layer Clusters in Multicluster>",  **_common)
 ],ncols=1)
 
@@ -1415,50 +1408,45 @@ _common["scale"] = 100.
 _multiplicity_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_numberOfEventsHistogram"
 _multiplicity_zminus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zminus_numberOfEventsHistogram"
 _multiplicity_zplus_numberOfEventsHistogram = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/ticlMultiClustersFromTrackstersEM/multiplicity_zplus_numberOfEventsHistogram"
-_multiplicityOfLCinMCL = PlotGroup("multiplicityOfLCinMCL",[
-  Plot("multiplicityOfLCinMCL", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster size (n_{hit})         ", drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)
-],ncols=1)
 
-_multiplicityOfLCinMCL_vs_layercluster_zminus = PlotGroup("multiplicityOfLCinMCL_vs_layercluster_zminus",[
-  Plot("multiplicityOfLCinMCL_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number         ", drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)
-],ncols=1)
-
-_multiplicityOfLCinMCL_vs_layercluster_zplus = PlotGroup("multiplicityOfLCinMCL_vs_layercluster_zplus",[
-  Plot("multiplicityOfLCinMCL_vs_layercluster_zplus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number         ", drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)
-],ncols=1)
-
-_multiplicityOfLCinMCL_vs_layerclusterenergy = PlotGroup("multiplicityOfLCinMCL_vs_layerclusterenergy",[
-  Plot("multiplicityOfLCinMCL_vs_layerclusterenergy", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster Energy (GeV)         ", drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)
-],ncols=1)
+_multiplicityOfLCinMCL_plots = [Plot("multiplicityOfLCinMCL", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster size (n_{hit})", 
+                                drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]
+_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layerclusterenergy", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Cluster Energy (GeV)", 
+                                drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)]) 
+_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layercluster_zplus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number", 
+                                drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
+_multiplicityOfLCinMCL_plots.extend([Plot("multiplicityOfLCinMCL_vs_layercluster_zminus", xtitle="Layer Cluster multiplicity in Multiclusters", ytitle = "Layer Number", 
+                                drawCommand = "colz text45", normalizeToNumberOfEvents = True, **_common)])
+_multiplicityOfLCinMCL = PlotGroup("MultiplcityofLCinMLC", _multiplicityOfLCinMCL_plots, ncols=2)
 
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65}
 #--------------------------------------------------------------------------------------------
 # z-
 #--------------------------------------------------------------------------------------------
-_clusternum_in_multicluster_perlayer_zminus_EE = PlotGroup("clusternum_in_multicluster_perlayer_zminus_EE", [
+_clusternum_in_multicluster_perlayer_zminus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_EE", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm)
 ], ncols=4)
 
-_clusternum_in_multicluster_perlayer_zminus_FH = PlotGroup("clusternum_in_multicluster_perlayer_zminus_FH", [
+_clusternum_in_multicluster_perlayer_zminus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_FH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzm,lastLayerFHzm)
 ], ncols=4)
 
-_clusternum_in_multicluster_perlayer_zminus_BH = PlotGroup("clusternum_in_multicluster_perlayer_zminus_BH", [
+_clusternum_in_multicluster_perlayer_zminus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zminus_BH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzm,maxlayerzm)
 ], ncols=4)
 
 #--------------------------------------------------------------------------------------------
 # z+
 #--------------------------------------------------------------------------------------------
-_clusternum_in_multicluster_perlayer_zplus_EE = PlotGroup("clusternum_in_multicluster_perlayer_zplus_EE", [
+_clusternum_in_multicluster_perlayer_zplus_EE = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_EE", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(maxlayerzm,lastLayerEEzp)
 ], ncols=4)
 
-_clusternum_in_multicluster_perlayer_zplus_FH = PlotGroup("clusternum_in_multicluster_perlayer_zplus_FH", [
+_clusternum_in_multicluster_perlayer_zplus_FH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_FH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerEEzp,lastLayerFHzp)
 ], ncols=4)
 
-_clusternum_in_multicluster_perlayer_zplus_BH = PlotGroup("clusternum_in_multicluster_perlayer_zplus_BH", [
+_clusternum_in_multicluster_perlayer_zplus_BH = PlotGroup("NumberofLayerClustersinMultiClusterPerLayer_zplus_BH", [
   Plot("clusternum_in_multicluster_perlayer{:02d}".format(i), xtitle="", **_common) for i in range(lastLayerFHzp,maxlayerzp)
 ], ncols=4)
 
@@ -1466,33 +1454,16 @@ _clusternum_in_multicluster_perlayer_zplus_BH = PlotGroup("clusternum_in_multicl
 _common = {"stat": True, "drawStyle": "hist", "staty": 0.65 }
 
 #Some multiclusters quantities
-_multicluster_pt = PlotGroup("multicluster_pt", [
-  Plot("multicluster_pt", xtitle="", **_common)
-],ncols=1)
+_multicluster_eppe_plots = [Plot("multicluster_eta", xtitle="MultiCluster #eta", **_common)]
+_multicluster_eppe_plots.extend([Plot("multicluster_phi", xtitle="MultiCluster #phi", **_common)])
+_multicluster_eppe_plots.extend([Plot("multicluster_pt", xtitle="MultiCluster p_{T}", **_common)])
+_multicluster_eppe_plots.extend([Plot("multicluster_energy", xtitle="MultiCluster Energy", **_common)])
+_multicluster_eppe = PlotGroup("EtaPhiPtEnergy", _multicluster_eppe_plots, ncols=2)
 
-_multicluster_eta = PlotGroup("multicluster_eta", [
-  Plot("multicluster_eta", xtitle="", **_common)
-],ncols=1)
-
-_multicluster_phi = PlotGroup("multicluster_phi", [
-  Plot("multicluster_phi", xtitle="", **_common)
-],ncols=1)
-
-_multicluster_energy = PlotGroup("multicluster_energy", [
-  Plot("multicluster_energy", xtitle="", **_common)
-],ncols=1)
-
-_multicluster_x = PlotGroup("multicluster_x", [
-  Plot("multicluster_x", xtitle="", **_common)
-],ncols=1)
-
-_multicluster_y = PlotGroup("multicluster_y", [
-  Plot("multicluster_y", xtitle="", **_common)
-],ncols=1)
-
-_multicluster_z = PlotGroup("multicluster_z", [
-  Plot("multicluster_z", xtitle="", **_common)
-],ncols=1)
+_multicluster_xyz_plots = [Plot("multicluster_x", xtitle="MultiCluster x", **_common)]
+_multicluster_xyz_plots.extend([Plot("multicluster_y", xtitle="MultiCluster y", **_common)])
+_multicluster_xyz_plots.extend([Plot("multicluster_z", xtitle="MultiCluster z", **_common)])
+_multicluster_xyz = PlotGroup("XYZ", _multicluster_xyz_plots, ncols=3)
 
 #--------------------------------------------------------------------------------------------
 # SIMHITS, DIGIS, RECHITS
@@ -2111,20 +2082,20 @@ hgcalLayerClustersPlotter.append("ScoreLayerClustersToCaloParticles_zplus", [
 
 # [K] Shared Energy between CaloParticle and LayerClusters
 # z-
-hgcalLayerClustersPlotter.append("SharedEnergyC2L_zminus", [
+hgcalLayerClustersPlotter.append("SharedEnergy_C2L_zminus", [
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
             ], PlotFolder(
             _sharedEnergy_caloparticle_to_layercluster_zminus,
             loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergyCaloParticleToLayerCluster_zminus"))
+            purpose=PlotPurpose.Timing, page="SharedEnergy_CaloParticleToLayerCluster_zminus"))
 
 # z+
-hgcalLayerClustersPlotter.append("SharedEnergyC2L_zplus", [
+hgcalLayerClustersPlotter.append("SharedEnergy_C2L_zplus", [
             "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/hgcalLayerClusters",
             ], PlotFolder(
             _sharedEnergy_caloparticle_to_layercluster_zplus,
             loopSubFolders=False,
-            purpose=PlotPurpose.Timing, page="SharedEnergyCaloParticleToLayerCluster_zplus"))
+            purpose=PlotPurpose.Timing, page="SharedEnergy_CaloParticleToLayerCluster_zplus"))
 
 # [K2] Shared Energy between LayerClusters and CaloParticle
 # z-
@@ -2267,175 +2238,65 @@ for i,item in enumerate(_energyscore_lc2cp_zplus, start=1):
               purpose=PlotPurpose.Timing, page="Energy_vs_Score_LC2CP_zplus"))
 
 #=================================================================================================
-def create_hgcalMultiClustersPlotter(collection = 'ticlMultiClustersFromTrackstersMerge'):
+def _hgcalFolders(lastDirName="hgcalLayerClusters"):
+    return "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/"+lastDirName
 
-  hgcalMultiClustersPlotter = Plotter()
-  dqmfolder = "DQMData/Run 1/HGCAL/Run summary/HGCalValidator/" + collection
+_multiclustersAllPlots = [
+  _efficiencies,
+  _duplicates,
+  _fakes,
+  _merges,
+  _multicluster_eppe,
+  _multicluster_xyz,
+  _totmulticlusternum,
+  _score_caloparticle_to_multiclusters,
+  _score_multicluster_to_caloparticles,
+  _sharedEnergy_caloparticle_to_multicluster,
+  _sharedEnergy_multicluster_to_caloparticle,
+  #_energyscore_cp2mcl_mcl2cp,
+  _energyscore_cp2mcl,
+  _energyscore_mcl2cp,
+  _clusternum_in_multicluster,
+  _clusternum_in_multicluster_vs_layer,
+  _clusternum_in_multicluster_perlayer_zminus_EE,
+  _clusternum_in_multicluster_perlayer_zminus_FH,
+  _clusternum_in_multicluster_perlayer_zminus_BH,
+  _clusternum_in_multicluster_perlayer_zplus_EE,
+  _clusternum_in_multicluster_perlayer_zplus_FH,
+  _clusternum_in_multicluster_perlayer_zplus_BH,
+  _multicluster_layernum,
+  _multiplicityOfLCinMCL,
+]
 
-  # [A] Score of CaloParticles wrt Multi Clusters
-  hgcalMultiClustersPlotter.append("ScoreCaloParticlesToMultiClusters", [
-              dqmfolder
+hgcalMultiClustersPlotter = Plotter()
+def append_hgcalMultiClustersPlots(collection = 'ticlMultiClustersFromTrackstersMerge', name_collection = "MultiClustersMerge"):
+  # Appending all plots for MCs
+  hgcalMultiClustersPlotter.append(name_collection, [
+              _hgcalFolders(collection)
               ], PlotFolder(
-              _score_caloparticle_to_multiclusters,
+              *_multiclustersAllPlots,
               loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="ScoreCaloParticlesToMultiClusters"))
+              purpose=PlotPurpose.Timing, page="MultiClusters", section=name_collection))
 
-  # [B] Score of MultiClusters wrt CaloParticles
-  hgcalMultiClustersPlotter.append("ScoreMultiClustersToCaloParticles", [
-              dqmfolder
-              ], PlotFolder(
-              _score_multicluster_to_caloparticles,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="ScoreMultiClustersToCaloParticles"))
-  
-  # [C] Shared Energy between CaloParticle and MultiClusters
-  hgcalMultiClustersPlotter.append("SharedEnergy_CP2MCL", [
-              dqmfolder
-              ], PlotFolder(
-              _sharedEnergy_caloparticle_to_multicluster,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="SharedEnergyCaloParticleToMultiCluster"))
-  
-  # [C2] Shared Energy between MultiClusters and CaloParticle
-  hgcalMultiClustersPlotter.append("SharedEnergy_MCL2CP", [
-              dqmfolder
-              ], PlotFolder(
-              _sharedEnergy_multicluster_to_caloparticle,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="SharedEnergyMultiClusterToCaloParticle"))
-  
-  # [E] Efficiency Plots
-  hgcalMultiClustersPlotter.append("Efficiencies", [
-              dqmfolder
-              ], PlotFolder(
-              _efficiencies,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Efficiencies"))
-  
-  # [F] Duplicate Plots
-  hgcalMultiClustersPlotter.append("Duplicates", [
-              dqmfolder
-              ], PlotFolder(
-              _duplicates,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Duplicates"))
-  
-  # [G] Fake Rate Plots
-  hgcalMultiClustersPlotter.append("FakeRate", [
-              dqmfolder
-              ], PlotFolder(
-              _fakes,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Fakes"))
-  
-  # [H] Merge Rate Plots
-  hgcalMultiClustersPlotter.append("MergeRate", [
-              dqmfolder
-              ], PlotFolder(
-              _merges,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Merges"))
-  
-  # [I] Energy vs Score 2D plots CP to MCL and MCL to CP
-  hgcalMultiClustersPlotter.append("Energy_vs_Score_CP2MCL_MCL2CP", [
-              dqmfolder
-              ], PlotFolder(
-              #_energyscore_cp2mcl_mcl2cp,
-              _energyscore_cp2mcl,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_CP2MCL"))
-  
-  # [J] Energy vs Score 2D plots MCL to CP
-  hgcalMultiClustersPlotter.append("Energy_vs_Score_MCL2CP", [
-              dqmfolder
-              ], PlotFolder(
-              _energyscore_mcl2cp,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Energy_vs_Score_MCL2CP"))
-  
-  #[K] Number of multiclusters per event.
-  hgcalMultiClustersPlotter.append("NumberofMultiClusters", [
-              dqmfolder
-              ], PlotFolder(
-              _totmulticlusternum,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="NumberofMultiClusters"
-              ))
-  
-  #[L] total number of layer clusters in multicluster per event and per layer
-  hgcalMultiClustersPlotter.append("NumberofLayerClustersinMultiClusterPerEventAndPerLayer", [
-              dqmfolder
-              ], PlotFolder(
-              _clusternum_in_multicluster,
-              _clusternum_in_multicluster_vs_layer,
-              _clusternum_in_multicluster_perlayer_zminus_EE,
-              _clusternum_in_multicluster_perlayer_zminus_FH,
-              _clusternum_in_multicluster_perlayer_zminus_BH,
-              _clusternum_in_multicluster_perlayer_zplus_EE,
-              _clusternum_in_multicluster_perlayer_zplus_FH,
-              _clusternum_in_multicluster_perlayer_zplus_BH,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="NumberofLayerClustersinMultiClusterPerEventAndPerLayer"
-              ))
-  
-  #[M] For each multicluster: pt, eta, phi, energy, x, y, z.
-  hgcalMultiClustersPlotter.append("MultiClustersPtEtaPhiEneXYZ", [
-              dqmfolder
-              ], PlotFolder(
-              _multicluster_pt,
-              _multicluster_eta,
-              _multicluster_phi,
-              _multicluster_energy,
-              _multicluster_x,
-              _multicluster_y,
-              _multicluster_z,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="MultiClustersPtEtaPhiEneXYZ"
-              ))
-  
-  #[N] Multicluster first, last, total number of layers
-  hgcalMultiClustersPlotter.append("NumberofMultiClusters_First_Last_NLayers", [
-              dqmfolder
-              ], PlotFolder(
-              _multicluster_firstlayer,
-              _multicluster_lastlayer,
-              _multicluster_layersnum,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="NumberofMultiClusters_First_Last_NLayers"
-              ))
-  
-  #[O] Multiplicity of layer clusters in multicluster
-  hgcalMultiClustersPlotter.append("Multiplicity", [
-              dqmfolder
-              ], PlotFolder(
-              _multiplicityOfLCinMCL,
-              _multiplicityOfLCinMCL_vs_layerclusterenergy,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Multiplicity",
-              numberOfEventsHistogram=_multiplicity_numberOfEventsHistogram
-              ))
-  
   #We append here two PlotFolder because we want the text to be in percent
   #and the number of events are different in zplus and zminus
-  hgcalMultiClustersPlotter.append("Multiplicity", [
-              dqmfolder
-              ], PlotFolder(
-              _multiplicityOfLCinMCL_vs_layercluster_zminus,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Multiplicity",
-              numberOfEventsHistogram=_multiplicity_zminus_numberOfEventsHistogram
-              ))
-  
-  hgcalMultiClustersPlotter.append("Multiplicity", [
-              dqmfolder
-              ], PlotFolder(
-              _multiplicityOfLCinMCL_vs_layercluster_zplus,
-              loopSubFolders=False,
-              purpose=PlotPurpose.Timing, page="Multiplicity",
-              numberOfEventsHistogram=_multiplicity_zplus_numberOfEventsHistogram
-              ))
-
-  return hgcalMultiClustersPlotter
+  #hgcalMultiClustersPlotter.append("Multiplicity", [
+  #            dqmfolder
+  #            ], PlotFolder(
+  #            _multiplicityOfLCinMCL_vs_layercluster_zminus,
+  #            loopSubFolders=False,
+  #            purpose=PlotPurpose.Timing, page=collection,
+  #            numberOfEventsHistogram=_multiplicity_zminus_numberOfEventsHistogram
+  #            ))
+  #
+  #hgcalMultiClustersPlotter.append("Multiplicity", [
+  #            dqmfolder
+  #            ], PlotFolder(
+  #            _multiplicityOfLCinMCL_vs_layercluster_zplus,
+  #            loopSubFolders=False,
+  #            purpose=PlotPurpose.Timing, page=collection,
+  #            numberOfEventsHistogram=_multiplicity_zplus_numberOfEventsHistogram
+  #            ))
 
 
 #=================================================================================================

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -8,6 +8,20 @@ from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSam
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
+layerClustersGeneralLabel = 'hgcalLayerClusters'
+trackstersIters = ["ticlMultiClustersFromTrackstersMerge", "ticlMultiClustersFromTrackstersMIP",
+                   "ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersTrkEM",
+                   "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD",
+                   "ticlMultiClustersFromTrackstersDummy"]
+multiclustersGeneralLabel = 'hgcalMultiClusters'
+hitValidationLabel = 'hitValidation'
+hitCalibrationLabel = 'hitCalibration'
+allLabel = 'all'
+
+collection_choices = [layerClustersGeneralLabel]
+collection_choices.extend(trackstersIters)
+collection_choices.extend([multiclustersGeneralLabel]+[hitValidationLabel]+[hitCalibrationLabel]+[allLabel])
+
 def main(opts):
 
     drawArgs={}
@@ -26,25 +40,27 @@ def main(opts):
     val = SimpleValidation([sample], opts.outputDir[0])
     htmlReport = val.createHtmlReport(validationName=opts.html_validation_name[0])   
 
-    if opts.collection=="hgcalLayerClusters":
+    if opts.collection==layerClustersGeneralLabel:
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
 	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
-    elif opts.collection in ["hgcalMultiClusters","ticlMultiClustersFromTrackstersMerge","ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersEM","ticlMultiClustersFromTrackstersHAD"]:
+    elif (opts.collection in trackstersIters) or (opts.collection == multiclustersGeneralLabel):
+        tracksterCollection = opts.collection.replace("ticlMultiClustersFromTracksters","ticlTracksters")
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        hgcalPlots.append_hgcalMultiClustersPlots(opts.collection, opts.collection)
+        hgcalPlots.append_hgcalMultiClustersPlots(opts.collection, tracksterCollection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
-    elif opts.collection=="hitValidation":
+    elif opts.collection==hitValidationLabel:
     	hgchit = [hgcalPlots.hgcalHitPlotter]
     	val.doPlots(hgchit, plotterDrawArgs=drawArgs)   
-    elif opts.collection=="hitCalibration":
+    elif opts.collection==hitCalibrationLabel:
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
     else :
+        #multiclusters
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersTrk", "MultiClustersTrk")
-        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersEM", "MultiClustersEM")
-        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersHAD", "MultiClustersHAD")
-        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersMerge", "MultiClustersMerge")
+        for i_iter in trackstersIters :
+            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
+            print(i_iter)
+            hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
 
 	#hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
@@ -108,8 +124,8 @@ if __name__ == "__main__":
                         help="Validation name for HTML page generation (enters to <title> element) (default '')")
     parser.add_argument("--verbose", action="store_true", default = False,
                         help="Be verbose")
-    parser.add_argument("--collection", choices=["hgcalLayerClusters", "hgcalMultiClusters", "ticlMultiClustersFromTrackstersMerge", "ticlMultiClustersFromTrackstersTrk", "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD", "hitValidation", "hitCalibration", "all"], default="hgcalLayerClusters",
-                        help="Choose output plots collections: hgcalLayerCluster, hgcalMultiClusters, ticlMultiClustersFromTrackstersMerge, ticlMultiClustersFromTrackstersTrk, ticlMultiClustersFromTrackstersEM, ticlMultiClustersFromTrackstersHAD, hitValidation, hitCalibration, all")    
+    parser.add_argument("--collection", choices=collection_choices, default=layerClustersGeneralLabel,
+                        help="Choose output plots collections among possible choices")    
 
     opts = parser.parse_args()
 

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -125,9 +125,6 @@ if __name__ == "__main__":
 
     opts = parser.parse_args()
 
-#    if opts.collection == "all" and len(opts.outputDir)==1:
-#	raise RuntimeError("need to assign names for all directories")
-
     for f in opts.files:
         if not os.path.exists(f):
             parser.error("DQM file %s does not exist" % f)

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 import os
 import argparse
+from time import time
 
 from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSample
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
@@ -55,49 +56,38 @@ def main(opts):
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
     else :
+        #hits
+    	hgchit = [hgcalPlots.hgcalHitPlotter]
+        hgcalPlots.append_hgcalHitsPlots('HGCalSimHitsV', "Simulated Hits")
+        hgcalPlots.append_hgcalHitsPlots('HGCalRecHitsV', "Reconstruced Hits")
+        hgcalPlots.append_hgcalDigisPlots('HGCalDigisV', "Digis")
+    	val.doPlots(hgchit, plotterDrawArgs=drawArgs)   
+
+        #calib
+        hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
+        val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
+
         #multiclusters
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
         for i_iter in trackstersIters :
             tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
-            print(i_iter)
             hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
 
 	#hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
 	#val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
+
 #        #In case of all you have to keep a specific order in one to one 
 #        #correspondance between subdirprefix and collections and validation names
 #	#layer clusters 
 #	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
 #	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
-#        #multiclusters
-#        sample = SimpleSample(opts.subdirprefix[1], opts.html_sample, filenames)
-#        val = SimpleValidation([sample], opts.outputDir[1])
-#        htmlReport_2 = val.createHtmlReport(validationName=opts.html_validation_name[1])
-#        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-#        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
-#        #hits
-#	sample = SimpleSample(opts.subdirprefix[2], opts.html_sample, filenames)
-#	val = SimpleValidation([sample], opts.outputDir[2])
-#	htmlReport_3 = val.createHtmlReport(validationName=opts.html_validation_name[2])
-#	hgchit = [hgcalPlots.hgcalHitPlotter]
-#        val.doPlots(hgchit, plotterDrawArgs=drawArgs)
-#        #calib
-#        sample = SimpleSample(opts.subdirprefix[3], opts.html_sample, filenames)
-#        val = SimpleValidation([sample], opts.outputDir[3])
-#        htmlReport_4 = val.createHtmlReport(validationName=opts.html_validation_name[3])
-#        hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
-#        val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
     if opts.no_html:
         print("Plots created into directory '%s'." % opts.outputDir)
     else:
         htmlReport.write()
-#	if(opts.collection=="all"):
-#		htmlReport_2.write()
-#                htmlReport_3.write()
-#		htmlReport_4.write()
 
         print("Plots and HTML report created into directory '%s'. You can just move it to some www area and access the pages via web browser" % (','.join(opts.outputDir)))
 

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -43,7 +43,8 @@ def main(opts):
 
     if opts.collection==layerClustersGeneralLabel:
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
+	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters")
+        val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
     elif (opts.collection in trackstersIters) or (opts.collection == multiclustersGeneralLabel):
         tracksterCollection = opts.collection.replace("ticlMultiClustersFromTracksters","ticlTracksters")
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
@@ -51,11 +52,15 @@ def main(opts):
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
     elif opts.collection==hitValidationLabel:
     	hgchit = [hgcalPlots.hgcalHitPlotter]
+        hgcalPlots.append_hgcalHitsPlots('HGCalSimHitsV', "Simulated Hits")
+        hgcalPlots.append_hgcalHitsPlots('HGCalRecHitsV', "Reconstruced Hits")
+        hgcalPlots.append_hgcalDigisPlots('HGCalDigisV', "Digis")
     	val.doPlots(hgchit, plotterDrawArgs=drawArgs)   
     elif opts.collection==hitCalibrationLabel:
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
     else :
+
         #hits
     	hgchit = [hgcalPlots.hgcalHitPlotter]
         hgcalPlots.append_hgcalHitsPlots('HGCalSimHitsV', "Simulated Hits")
@@ -67,22 +72,17 @@ def main(opts):
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
+ 	#layer clusters 
+	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
+	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters")
+	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
+
         #multiclusters
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
         for i_iter in trackstersIters :
             tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
             hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
-
-	#hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	#val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
-
-
-#        #In case of all you have to keep a specific order in one to one 
-#        #correspondance between subdirprefix and collections and validation names
-#	#layer clusters 
-#	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-#	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
     if opts.no_html:
         print("Plots created into directory '%s'." % opts.outputDir)

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -5,7 +5,7 @@ import os
 import argparse
 from time import time
 
-from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSample
+from Validation.RecoTrack.plotting.validation import SeparateValidation, SimpleValidation, SimpleSample
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
@@ -40,6 +40,8 @@ def main(opts):
     sample = SimpleSample(opts.subdirprefix[0], opts.html_sample, filenames)
   
     val = SimpleValidation([sample], opts.outputDir[0])
+    if opts.separate:
+        val = SeparateValidation([sample], opts.outputDir[0])
     htmlReport = val.createHtmlReport(validationName=opts.html_validation_name[0])   
 
     if opts.collection==layerClustersGeneralLabel:

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -9,19 +9,20 @@ from Validation.RecoTrack.plotting.validation import SimpleValidation, SimpleSam
 import Validation.HGCalValidation.hgcalPlots as hgcalPlots
 import Validation.RecoTrack.plotting.plotting as plotting
 
-layerClustersGeneralLabel = 'hgcalLayerClusters'
 trackstersIters = ["ticlMultiClustersFromTrackstersMerge", "ticlMultiClustersFromTrackstersMIP",
                    "ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersTrkEM",
                    "ticlMultiClustersFromTrackstersEM", "ticlMultiClustersFromTrackstersHAD",
                    "ticlMultiClustersFromTrackstersDummy"]
+
+layerClustersGeneralLabel = 'hgcalLayerClusters'
 multiclustersGeneralLabel = 'hgcalMultiClusters'
+trackstersGeneralLabel = 'allTiclMultiClusters'
 hitValidationLabel = 'hitValidation'
 hitCalibrationLabel = 'hitCalibration'
 allLabel = 'all'
 
 collection_choices = [layerClustersGeneralLabel]
-collection_choices.extend(trackstersIters)
-collection_choices.extend([multiclustersGeneralLabel]+[hitValidationLabel]+[hitCalibrationLabel]+[allLabel])
+collection_choices.extend([multiclustersGeneralLabel]+[trackstersGeneralLabel]+[hitValidationLabel]+[hitCalibrationLabel]+[allLabel])
 
 def main(opts):
 
@@ -45,10 +46,15 @@ def main(opts):
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
 	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters")
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
-    elif (opts.collection in trackstersIters) or (opts.collection == multiclustersGeneralLabel):
-        tracksterCollection = opts.collection.replace("ticlMultiClustersFromTracksters","ticlTracksters")
+    elif opts.collection == multiclustersGeneralLabel:
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
-        hgcalPlots.append_hgcalMultiClustersPlots(opts.collection, tracksterCollection)
+        hgcalPlots.append_hgcalMultiClustersPlots(multiclustersGeneralLabel, "MultiClusters")
+        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
+    elif (opts.collection == trackstersGeneralLabel) :
+        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
+        for i_iter in trackstersIters :
+            tracksterCollection = i_iter.replace("ticlMultiClustersFromTracksters","ticlTracksters")
+            hgcalPlots.append_hgcalMultiClustersPlots(i_iter, tracksterCollection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
     elif opts.collection==hitValidationLabel:
     	hgchit = [hgcalPlots.hgcalHitPlotter]

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -30,7 +30,8 @@ def main(opts):
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
 	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
     elif opts.collection in ["hgcalMultiClusters","ticlMultiClustersFromTrackstersMerge","ticlMultiClustersFromTrackstersTrk","ticlMultiClustersFromTrackstersEM","ticlMultiClustersFromTrackstersHAD"]:
-        hgcmulticlus = [hgcalPlots.create_hgcalMultiClustersPlotter(opts.collection)]
+        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
+        hgcalPlots.append_hgcalMultiClustersPlots(opts.collection, opts.collection)
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
     elif opts.collection=="hitValidation":
     	hgchit = [hgcalPlots.hgcalHitPlotter]
@@ -39,38 +40,48 @@ def main(opts):
         hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
         val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
     else :
-        #In case of all you have to keep a specific order in one to one 
-        #correspondance between subdirprefix and collections and validation names
-	#layer clusters 
-	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
-        #multiclusters
-        sample = SimpleSample(opts.subdirprefix[1], opts.html_sample, filenames)
-        val = SimpleValidation([sample], opts.outputDir[1])
-        htmlReport_2 = val.createHtmlReport(validationName=opts.html_validation_name[1])
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
+        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersTrk", "MultiClustersTrk")
+        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersEM", "MultiClustersEM")
+        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersHAD", "MultiClustersHAD")
+        hgcalPlots.append_hgcalMultiClustersPlots("ticlMultiClustersFromTrackstersMerge", "MultiClustersMerge")
         val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
-        #hits
-	sample = SimpleSample(opts.subdirprefix[2], opts.html_sample, filenames)
-	val = SimpleValidation([sample], opts.outputDir[2])
-	htmlReport_3 = val.createHtmlReport(validationName=opts.html_validation_name[2])
-	hgchit = [hgcalPlots.hgcalHitPlotter]
-        val.doPlots(hgchit, plotterDrawArgs=drawArgs)
-        #calib
-        sample = SimpleSample(opts.subdirprefix[3], opts.html_sample, filenames)
-        val = SimpleValidation([sample], opts.outputDir[3])
-        htmlReport_4 = val.createHtmlReport(validationName=opts.html_validation_name[3])
-        hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
-        val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
+
+	#hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
+	#val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
+
+#        #In case of all you have to keep a specific order in one to one 
+#        #correspondance between subdirprefix and collections and validation names
+#	#layer clusters 
+#	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
+#	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
+#        #multiclusters
+#        sample = SimpleSample(opts.subdirprefix[1], opts.html_sample, filenames)
+#        val = SimpleValidation([sample], opts.outputDir[1])
+#        htmlReport_2 = val.createHtmlReport(validationName=opts.html_validation_name[1])
+#        hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
+#        val.doPlots(hgcmulticlus, plotterDrawArgs=drawArgs)
+#        #hits
+#	sample = SimpleSample(opts.subdirprefix[2], opts.html_sample, filenames)
+#	val = SimpleValidation([sample], opts.outputDir[2])
+#	htmlReport_3 = val.createHtmlReport(validationName=opts.html_validation_name[2])
+#	hgchit = [hgcalPlots.hgcalHitPlotter]
+#        val.doPlots(hgchit, plotterDrawArgs=drawArgs)
+#        #calib
+#        sample = SimpleSample(opts.subdirprefix[3], opts.html_sample, filenames)
+#        val = SimpleValidation([sample], opts.outputDir[3])
+#        htmlReport_4 = val.createHtmlReport(validationName=opts.html_validation_name[3])
+#        hgchitcalib = [hgcalPlots.hgcalHitCalibPlotter]
+#        val.doPlots(hgchitcalib, plotterDrawArgs=drawArgs)
 
     if opts.no_html:
         print("Plots created into directory '%s'." % opts.outputDir)
     else:
         htmlReport.write()
-	if(opts.collection=="all"):
-		htmlReport_2.write()
-                htmlReport_3.write()
-		htmlReport_4.write()
+#	if(opts.collection=="all"):
+#		htmlReport_2.write()
+#                htmlReport_3.write()
+#		htmlReport_4.write()
 
         print("Plots and HTML report created into directory '%s'. You can just move it to some www area and access the pages via web browser" % (','.join(opts.outputDir)))
 
@@ -102,8 +113,8 @@ if __name__ == "__main__":
 
     opts = parser.parse_args()
 
-    if opts.collection == "all" and len(opts.outputDir)==1:
-	raise RuntimeError("need to assign names for all directories")
+#    if opts.collection == "all" and len(opts.outputDir)==1:
+#	raise RuntimeError("need to assign names for all directories")
 
     for f in opts.files:
         if not os.path.exists(f):

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2491,7 +2491,6 @@ class PlotGroup(object):
     def _save(self, canvas, saveFormat, prefix=None, postfix=None, single=False, directory=""):
         # Save the canvas to file and clear
         name = self._name
-        print('in _save, the directory+name is: ', directory+'/'+name)
         if not os.path.exists(directory+'/'+name):
             os.makedirs(directory+'/'+name)
         if prefix is not None:

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -2465,7 +2465,7 @@ class PlotGroup(object):
                 legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.03,
                                             denomUncertainty=(ratioForThisPlot and plot.drawRatioUncertainty))
 
-            ret.extend(self._save(c, saveFormat, prefix=prefix, postfix="_"+plot.getName(), single=True, directory=directory))
+            ret.extend(self._save(c, saveFormat, prefix=prefix, postfix="/"+plot.getName(), single=True, directory=directory))
         return ret
 
     def _modifyPadForRatio(self, pad):
@@ -2491,6 +2491,9 @@ class PlotGroup(object):
     def _save(self, canvas, saveFormat, prefix=None, postfix=None, single=False, directory=""):
         # Save the canvas to file and clear
         name = self._name
+        print('in _save, the directory+name is: ', directory+'/'+name)
+        if not os.path.exists(directory+'/'+name):
+            os.makedirs(directory+'/'+name)
         if prefix is not None:
             name = prefix+name
         if postfix is not None:

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1304,3 +1304,90 @@ class SimpleValidation:
 
         print("Created plots in %s" % newdir)
         return map(lambda n: n.replace(newdir, newsubdir), fileList)
+
+class SeparateValidation:
+    def __init__(self, samples, newdir):
+        self._samples = samples
+        self._newdir = newdir
+        if not os.path.exists(newdir):
+            os.makedirs(newdir)
+
+        self._htmlReport = html.HtmlReportDummy()
+
+    def createHtmlReport(self, validationName=""):
+        if hasattr(self._htmlReport, "write"):
+            raise Exception("HTML report object already created. There is probably some logic error in the calling code.")
+        self._htmlReport = html.HtmlReport(validationName, self._newdir)
+        return self._htmlReport
+
+    def doPlots(self, plotters, plotterDrawArgs={}, **kwargs):
+        self._plotterDrawArgs = plotterDrawArgs
+
+        for sample in self._samples:
+            self._subdirprefix = sample.label()
+            self._labels = sample.legendLabels()
+            self._htmlReport.beginSample(sample)
+
+            self._openFiles = []
+            for f in sample.files():
+                if os.path.exists(f):
+                    self._openFiles.append(ROOT.TFile.Open(f))
+                else:
+                    print("File %s not found (from sample %s), ignoring it" % (f, sample.name()))
+                    self._openFiles.append(None)
+
+            for plotter in plotters:
+                self._doPlotsForPlotter(plotter, sample, **kwargs)
+
+            for tf in self._openFiles:
+                if tf is not None:
+                    tf.Close()
+            self._openFiles = []
+
+    def _doPlotsForPlotter(self, plotter, sample, limitSubFoldersOnlyTo=None):
+        print('... in _doPlotsForPlotter')
+        plotterInstance = plotter.readDirs(*self._openFiles)
+        for plotterFolder, dqmSubFolder in plotterInstance.iterFolders(limitSubFoldersOnlyTo=limitSubFoldersOnlyTo):
+            if sample is not None and not _processPlotsForSample(plotterFolder, sample):
+                continue
+            plotFiles = self._doPlots(plotterFolder, dqmSubFolder)
+            print('    plotFiles:', plotFiles)
+            if len(plotFiles) > 0:
+                self._htmlReport.addPlots(plotterFolder, dqmSubFolder, plotFiles)
+
+    def _doPlots(self, plotterFolder, dqmSubFolder):
+        print('..... in _doPlots')
+        plotterFolder.create(self._openFiles, self._labels, dqmSubFolder)
+        newsubdir = self._subdirprefix+plotterFolder.getSelectionName(dqmSubFolder)
+        newdir = os.path.join(self._newdir, newsubdir)
+        print('      ', newsubdir)
+        print('      ', newdir)
+        if not os.path.exists(newdir):
+            os.makedirs(newdir)
+        fileList = plotterFolder.draw(directory=newdir, separate=True, **self._plotterDrawArgs)
+        print('      ', fileList)
+#        for pg in plotterFolder.getPlotGroups():
+        print('     PlotterFolder name ', plotterFolder.getName())
+
+        for tableCreator in plotterFolder.getTableCreators():
+            self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
+
+        if len(fileList) == 0:
+            return fileList
+
+        dups = _findDuplicates(fileList)
+        if len(dups) > 0:
+            print("Plotter produced multiple files with names", ", ".join(dups))
+            print("Typically this is a naming problem in the plotter configuration")
+            sys.exit(1)
+
+        if self._plotterDrawArgs.get("separate", False):
+            if not os.path.exists("%s/res"%newdir):
+              os.makedirs("%s/res"%newdir)
+            downloadables = ["index.php", "res/jquery-ui.js", "res/jquery.js", "res/style.css", "res/style.js", "res/theme.css"]
+            for d in downloadables:
+                if not os.path.exists("%s/%s" % (newdir,d)):
+                    urllib.urlretrieve("https://raw.githubusercontent.com/musella/php-plots/master/%s"%d, "%s/%s"%(newdir,d))
+
+        print("Created separated plots in %s" % newdir)
+        return map(lambda n: n.replace(newdir, newsubdir), fileList)

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -1379,11 +1379,9 @@ class SeparateValidation:
             if f[:f.rfind("/")] not in linkList :
                 if str(f[:f.rfind("/")]) != str(newdir) :
                     linkList.append(f[:f.rfind("/")])
-        sorted(linkList)
 
         for tableCreator in plotterFolder.getTableCreators():
             self._htmlReport.addTable(tableCreator.create(self._openFiles, self._labels, dqmSubFolder))
-
 
         for link in linkList :
             if not os.path.exists("%s/res"%link):


### PR DESCRIPTION
#### PR description:

* Enable the option `--collection all` to produce a list of collection with respective plots, while keeping the single collection option also available
* Improve the visualisation of the validation for each collection with the creation of tables of plots  
* If `--separate` option is enable, each entry in the table will be converted to a link to a webpage which will displayed all plots separately. In order to do this, I have created `SeparateValidation` which is enable in the `makeHGCalValidationPlots.py` script. 

#### PR validation:

* I have verified that the code is still working in case the `SimpleValidation` is used with the `--separate` option.
* Two examples of my development can be found in [this folder](http://ebrondol.web.cern.ch/ebrondol/HGCal/fixValidation_all/20201111_all_no_separate/) using only the flag `--collection all` and in [this other folder](http://ebrondol.web.cern.ch/ebrondol/HGCal/fixValidation_all/20201111_allTiclMultiClusters_separate/) using `--separate --collection allTiclMultiClusters`
