### PR TITLE
Add DQMGlobalRunSummaryEDAnalyzer to support use of edm::RunSummaryCache

### DIFF
--- a/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
+++ b/DQMServices/Demo/test/TestDQMEDAnalyzer.cc
@@ -276,6 +276,58 @@ private:
 };
 DEFINE_FWK_MODULE(TestDQMGlobalEDAnalyzer);
 
+class TestDQMGlobalRunSummaryEDAnalyzer : public DQMGlobalRunSummaryEDAnalyzer<TestHistograms, int> {
+public:
+  explicit TestDQMGlobalRunSummaryEDAnalyzer(const edm::ParameterSet& iConfig)
+      : folder_(iConfig.getParameter<std::string>("folder")),
+        howmany_(iConfig.getParameter<int>("howmany")),
+        myvalue_(iConfig.getParameter<double>("value")) {}
+  ~TestDQMGlobalRunSummaryEDAnalyzer() override{};
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<std::string>("folder", "Global/testglobal")->setComment("Where to put all the histograms");
+    desc.add<int>("howmany", 1)->setComment("How many copies of each ME to put");
+    desc.add<double>("value", 1)->setComment("Which value to use on the third axis (first two are lumi and run)");
+    descriptions.add("testglobalrunsummary", desc);
+  }
+
+private:
+  std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+    return std::make_shared<int>(0);
+  }
+
+  void bookHistograms(DQMStore::IBooker& ibooker,
+                      edm::Run const&,
+                      edm::EventSetup const&,
+                      TestHistograms& h) const override {
+    h.folder = this->folder_;
+    h.howmany = this->howmany_;
+    h.bookall(ibooker);
+  }
+
+  void dqmAnalyze(edm::Event const& iEvent, edm::EventSetup const&, TestHistograms const& h) const override {
+    h.fillall(iEvent.luminosityBlock(), iEvent.run(), myvalue_);
+  }
+
+  void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int* runSummaryCache) const override {
+    (*runSummaryCache) += 1;
+  }
+
+  void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int* runSummaryCache) const override {}
+
+  void dqmEndRun(edm::Run const& run,
+                 edm::EventSetup const& setup,
+                 TestHistograms const& h,
+                 int const& runSummaryCache) const override {}
+
+private:
+  std::string folder_;
+  int howmany_;
+  double myvalue_;
+};
+DEFINE_FWK_MODULE(TestDQMGlobalRunSummaryEDAnalyzer);
+
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 class TestLegacyEDAnalyzer : public edm::EDAnalyzer {
 public:

--- a/DQMServices/Demo/test/run_analyzers_cfg.py
+++ b/DQMServices/Demo/test/run_analyzers_cfg.py
@@ -10,11 +10,13 @@ process.load("DQMServices.Demo.testonefillrun_cfi")
 process.load("DQMServices.Demo.testonelumi_cfi")
 process.load("DQMServices.Demo.testonelumifilllumi_cfi")
 process.load("DQMServices.Demo.testglobal_cfi")
+process.load("DQMServices.Demo.testglobalrunsummary_cfi")
 process.load("DQMServices.Demo.testlegacy_cfi")
 process.load("DQMServices.Demo.testlegacyfillrun_cfi")
 process.load("DQMServices.Demo.testlegacyfilllumi_cfi")
 process.test_general = cms.Sequence(process.test 
-                                  + process.testglobal)
+                                  + process.testglobal
+                                  + process.testglobalrunsummary)
 process.test_one     = cms.Sequence(process.testone
                                   + process.testonefillrun)
 process.test_legacy  = cms.Sequence(process.testonelumi + process.testonelumifilllumi
@@ -71,7 +73,7 @@ process.options = cms.untracked.PSet(
 if args.nConcurrent > 1:
   process.DQMStore.assertLegacySafe = cms.untracked.bool(False)
 
-for mod in [process.test, process.testglobal, process.testone, process.testonefillrun, process.testonelumi, process.testonelumifilllumi, process.testlegacy, process.testlegacyfillrun, process.testlegacyfilllumi]:
+for mod in [process.test, process.testglobal, process.testglobalrunsummary, process.testone, process.testonefillrun, process.testonelumi, process.testonelumifilllumi, process.testlegacy, process.testlegacyfillrun, process.testlegacyfilllumi]:
   mod.howmany = args.howmany
 
 if args.noone:

--- a/DQMServices/Demo/test/runtests.sh
+++ b/DQMServices/Demo/test/runtests.sh
@@ -19,7 +19,7 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=alltypes.root numberEventsIn
 # the scalar MEs should have the last lumi number (5) (5 float + 5 int)
 # testonefilllumi also should have 5 entries in the histograms (9 more)
 # the "fillrun" module should have one entry in the histograms (9 total) and 0 in the scalars (2 total)
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 27, 200: 9, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 --summary)" ]
 # per lumi we see 20 in most histograms (4*9), and the current lumi number in the scalars (6 modules * 2).
 # the two fillumi modules should have one entry in each of the lumi histograms, (2*9 total)
 [ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py alltypes.root -r 1 -l 1 --summary)" ]
@@ -42,7 +42,7 @@ cmsRun $LOCAL_TEST_DIR/run_analyzers_cfg.py outfile=nolegacy-cl.root numberEvent
 # same math as above, just a few less modules, and more events.
 for f in nolegacy.root nolegacy-mt.root nolegacy-cl.root
 do
-  [ "0: 1, 0.0: 1, 1: 9, 1000: 27, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
+  [ "0: 1, 0.0: 1, 1: 9, 1000: 18, 2000: 9, 5: 3, 5.0: 3" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 --summary)" ]
   [ "1: 2, 1.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 1 --summary)" ]
   [ "2: 2, 2.0: 2, 200: 18" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 2 --summary)" ]
   [ "200: 18, 3: 2, 3.0: 2" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py $f -r 1 -l 3 --summary)" ]
@@ -135,7 +135,7 @@ cmsRun $LOCAL_TEST_DIR/run_harvesters_cfg.py outfile=edmtome.root inputFiles=met
 [ 66 = $(dqmiolistmes.py edmtome.root -r 1 | wc -l) ]
 [ 66 = $(dqmiolistmes.py edmtome.root -r 1 -l 1 | wc -l) ]
 # again, no legacy module (run) output here due to JOB scope for legacy modules
-[ "0: 1, 0.0: 1, 1: 9, 100: 36, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
+[ "0: 1, 0.0: 1, 1: 9, 100: 27, 200: 9, 5: 14, 5.0: 5" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 --summary)" ]
 [ "1: 24, 1.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 1 --summary)" ]
 [ "1: 18, 2: 6, 2.0: 6, 20: 36" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 2 --summary)" ]
 [ "1: 18, 20: 36, 3: 6, 3.0: 6" = "$($LOCAL_TEST_DIR/dqmiodumpentries.py edmtome.root -r 1 -l 3 --summary)" ]


### PR DESCRIPTION
#### PR description:

Following https://github.com/cms-sw/cmssw/pull/32004#issuecomment-724014288, this PR suggests to add `DQMGlobalRunSummaryEDAnalyzer` to cover the case where `edm::RunSummaryCache` is used with `DQMGlobalEDAnalyzer`. Special treatment is needed because `RunSummaryCache` changes the signature of `globalEndRunProduce()` function.

#### PR validation:

Unit tests in `DQMServices/Demo` pass.