### PR TITLE
[TF] Fix needed for tensorflow 2.3.1

### DIFF
--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -140,7 +140,7 @@ namespace tensorflow {
 
     // create a tensor to store the variable file
     Tensor varFileTensor(DT_STRING, TensorShape({}));
-    varFileTensor.scalar<std::string>()() = varFile;
+    varFileTensor.scalar<tensorflow::tstring>()() = varFile;
 
     // run the restore op
     status = session->Run({{varFileTensorName, varFileTensor}}, {}, {restoreOpName}, nullptr);


### PR DESCRIPTION
This change is needed to build cmssw with Tensorflow 2.3.1

[a] https://github.com/cms-sw/cmsdist/pull/6410
```
>> Compiling  src/PhysicsTools/TensorFlow/src/TensorFlow.cc
In file included from src/PhysicsTools/TensorFlow/interface/TensorFlow.h:12,
                 from src/PhysicsTools/TensorFlow/src/TensorFlow.cc:9:
tensorflowe3b366e33aa8ec3622/include/tensorflow/core/framework/tensor.h: In instantiation of 'typename tensorflow::TTypes::Scalar tensorflow::Tensor::scalar() [with T = std::__cxx11::basic_string; typename tensorflow::TTypes::Scalar = Eigen::TensorMap, Eigen::Sizes<>, 1, long int>, 16, Eigen::MakePointer>]':
src/PhysicsTools/TensorFlow/src/TensorFlow.cc:143:39:   required from here
tensorflowe3b366e33aa8ec3622/include/tensorflow/core/framework/tensor.h:879:7: error: static assertion failed: std::string is no longer a scalar type, use tensorflow::tstring
       !std::is_same::value,
       ^~~~
``` 