### PR TITLE
Switch l1tstage2 DQM client to run3

### DIFF
--- a/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process("L1TStage2DQM", Run2_2018)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("L1TStage2DQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:

--- a/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/l1tstage2emulator_dqm_sourceclient-live_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import sys
-from Configuration.Eras.Era_Run2_2018_cff import Run2_2018
-process = cms.Process("L1TStage2EmulatorDQM", Run2_2018)
+from Configuration.Eras.Era_Run3_cff import Run3
+process = cms.Process("L1TStage2EmulatorDQM", Run3)
 
 unitTest = False
 if 'unitTest=True' in sys.argv:


### PR DESCRIPTION
#### PR description:
This PR is to migrate the stage2 L1Trigger DQM code to use the Run3 era modifiers.  Changes should be minimal at this point and from my tests this seems correct.

Relates to this PR from @dinyar https://github.com/cms-sw/cmssw/pull/31951 

#### PR validation:
I have tested this PR running the clients on a specific run and compared the outputs - things seem as expected to me.