### PR TITLE
Implement new MessageLogger configuration

### DIFF
--- a/FWCore/Framework/test/test_deepCall_unscheduled_cfg.py
+++ b/FWCore/Framework/test/test_deepCall_unscheduled_cfg.py
@@ -23,13 +23,11 @@ process.Tracer = cms.Service('Tracer',
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations   = cms.untracked.vstring('cout',
-                                           'cerr'
-    ),
-    categories = cms.untracked.vstring(
-        'Tracer'
+    cerr = cms.untracked.PSet(
+      enableStatistics = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         default = cms.untracked.PSet (
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/src/ELadministrator.h
+++ b/FWCore/MessageService/src/ELadministrator.h
@@ -60,26 +60,12 @@ namespace edm {
   namespace service {
 
     // ----------------------------------------------------------------------
-    // Prerequisite classes:
-    // ----------------------------------------------------------------------
-
-    class ELdestination;
-    class ELcout;
-    class MessageLoggerScribe;
-
-    // ----------------------------------------------------------------------
     // ELadministrator:
     // ----------------------------------------------------------------------
 
-    class ELadministrator {  // *** Destructable Singleton Pattern ***
-
-      friend class MessageLoggerScribe;               // proper ELadministrator cleanup
-      friend class ThreadSafeLogMessageLoggerScribe;  // proper ELadministrator cleanup
-      friend class ELcout;                            // ELcout behavior
-
-      // *** Error Logger Functionality ***
-
+    class ELadministrator {
     public:
+      ELadministrator();
       ~ELadministrator();
 
       //Replaces ErrorLog which is no longer needed
@@ -117,11 +103,6 @@ namespace edm {
       const ELseverityLevel& exitThreshold() const;
       const ELseverityLevel& highSeverity() const;
       int severityCounts(int lev) const;
-
-    protected:
-      // ---  traditional birth/death, but disallowed to users:
-      //
-      ELadministrator();
 
     private:
       // ---  traditional member data:

--- a/FWCore/MessageService/src/MessageLoggerDefaults.cc
+++ b/FWCore/MessageService/src/MessageLoggerDefaults.cc
@@ -21,49 +21,49 @@
 namespace edm {
   namespace service {
 
-    std::string MessageLoggerDefaults::threshold(std::string const& dest) {
+    std::string MessageLoggerDefaults::threshold(std::string const& dest) const {
       std::string thr = "";
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
+        auto const& destin = d->second;
         thr = destin.threshold;
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (thr.empty()) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
+          auto const& def_destin = dd->second;
           thr = def_destin.threshold;
         }
       }
       return thr;
     }  // threshold
 
-    std::string MessageLoggerDefaults::output(std::string const& dest) {
+    std::string MessageLoggerDefaults::output(std::string const& dest) const {
       std::string otpt = "";
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
+        auto const& destin = d->second;
         otpt = destin.output;
       }
       // There is no default output; so if we did not find the dest, then return ""
       return otpt;
     }  // output
 
-    int MessageLoggerDefaults::limit(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::limit(std::string const& dest, std::string const& cat) const {
       int lim = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.category.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.category.find(cat);
         if (c != destin.category.end()) {
           lim = c->second.limit;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (lim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.category.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.category.find(cat);
           if (c != def_destin.category.end()) {
             lim = c->second.limit;
           }
@@ -71,8 +71,8 @@ namespace edm {
       }
       if (lim == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.category.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.category.find("default");
           if (cd != destin.category.end()) {
             lim = cd->second.limit;
           }
@@ -80,8 +80,8 @@ namespace edm {
       }
       if (lim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.category.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.category.find("default");
           if (cdd != def_destin.category.end()) {
             lim = cdd->second.limit;
           }
@@ -90,21 +90,21 @@ namespace edm {
       return lim;
     }  // limit
 
-    int MessageLoggerDefaults::reportEvery(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::reportEvery(std::string const& dest, std::string const& cat) const {
       int re = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.category.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.category.find(cat);
         if (c != destin.category.end()) {
           re = c->second.reportEvery;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (re == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.category.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.category.find(cat);
           if (c != def_destin.category.end()) {
             re = c->second.reportEvery;
           }
@@ -112,8 +112,8 @@ namespace edm {
       }
       if (re == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.category.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.category.find("default");
           if (cd != destin.category.end()) {
             re = cd->second.reportEvery;
           }
@@ -121,8 +121,8 @@ namespace edm {
       }
       if (re == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.category.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.category.find("default");
           if (cdd != def_destin.category.end()) {
             re = cdd->second.reportEvery;
           }
@@ -131,21 +131,21 @@ namespace edm {
       return re;
     }  // reportEvery
 
-    int MessageLoggerDefaults::timespan(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::timespan(std::string const& dest, std::string const& cat) const {
       int tim = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.category.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.category.find(cat);
         if (c != destin.category.end()) {
           tim = c->second.timespan;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (tim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.category.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.category.find(cat);
           if (c != def_destin.category.end()) {
             tim = c->second.timespan;
           }
@@ -153,8 +153,8 @@ namespace edm {
       }
       if (tim == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.category.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.category.find("default");
           if (cd != destin.category.end()) {
             tim = cd->second.timespan;
           }
@@ -162,8 +162,8 @@ namespace edm {
       }
       if (tim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.category.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.category.find("default");
           if (cdd != def_destin.category.end()) {
             tim = cdd->second.timespan;
           }
@@ -172,21 +172,21 @@ namespace edm {
       return tim;
     }  // timespan
 
-    int MessageLoggerDefaults::sev_limit(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::sev_limit(std::string const& dest, std::string const& cat) const {
       int lim = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.sev.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.sev.find(cat);
         if (c != destin.sev.end()) {
           lim = c->second.limit;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (lim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.sev.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.sev.find(cat);
           if (c != def_destin.sev.end()) {
             lim = c->second.limit;
           }
@@ -194,8 +194,8 @@ namespace edm {
       }
       if (lim == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.sev.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.sev.find("default");
           if (cd != destin.sev.end()) {
             lim = cd->second.limit;
           }
@@ -203,8 +203,8 @@ namespace edm {
       }
       if (lim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.sev.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.sev.find("default");
           if (cdd != def_destin.sev.end()) {
             lim = cdd->second.limit;
           }
@@ -213,21 +213,21 @@ namespace edm {
       return lim;
     }  // sev_limit
 
-    int MessageLoggerDefaults::sev_reportEvery(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::sev_reportEvery(std::string const& dest, std::string const& cat) const {
       int re = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.sev.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.sev.find(cat);
         if (c != destin.sev.end()) {
           re = c->second.reportEvery;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (re == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.sev.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.sev.find(cat);
           if (c != def_destin.sev.end()) {
             re = c->second.reportEvery;
           }
@@ -235,8 +235,8 @@ namespace edm {
       }
       if (re == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.sev.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.sev.find("default");
           if (cd != destin.sev.end()) {
             re = cd->second.reportEvery;
           }
@@ -244,8 +244,8 @@ namespace edm {
       }
       if (re == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.sev.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.sev.find("default");
           if (cdd != def_destin.sev.end()) {
             re = cdd->second.reportEvery;
           }
@@ -254,21 +254,21 @@ namespace edm {
       return re;
     }  // sev_reportEvery
 
-    int MessageLoggerDefaults::sev_timespan(std::string const& dest, std::string const& cat) {
+    int MessageLoggerDefaults::sev_timespan(std::string const& dest, std::string const& cat) const {
       int tim = NO_VALUE_SET;
-      std::map<std::string, Destination>::iterator d = destination.find(dest);
+      auto d = destination.find(dest);
       if (d != destination.end()) {
-        Destination& destin = d->second;
-        std::map<std::string, Category>::iterator c = destin.sev.find(cat);
+        auto const& destin = d->second;
+        auto c = destin.sev.find(cat);
         if (c != destin.sev.end()) {
           tim = c->second.timespan;
         }
       }
-      std::map<std::string, Destination>::iterator dd = destination.find("default");
+      auto dd = destination.find("default");
       if (tim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator c = def_destin.sev.find(cat);
+          auto const& def_destin = dd->second;
+          auto c = def_destin.sev.find(cat);
           if (c != def_destin.sev.end()) {
             tim = c->second.timespan;
           }
@@ -276,8 +276,8 @@ namespace edm {
       }
       if (tim == NO_VALUE_SET) {
         if (d != destination.end()) {
-          Destination& destin = d->second;
-          std::map<std::string, Category>::iterator cd = destin.sev.find("default");
+          auto const& destin = d->second;
+          auto cd = destin.sev.find("default");
           if (cd != destin.sev.end()) {
             tim = cd->second.timespan;
           }
@@ -285,8 +285,8 @@ namespace edm {
       }
       if (tim == NO_VALUE_SET) {
         if (dd != destination.end()) {
-          Destination& def_destin = dd->second;
-          std::map<std::string, Category>::iterator cdd = def_destin.sev.find("default");
+          auto const& def_destin = dd->second;
+          auto cdd = def_destin.sev.find("default");
           if (cdd != def_destin.sev.end()) {
             tim = cdd->second.timespan;
           }

--- a/FWCore/MessageService/src/MessageLoggerDefaults.h
+++ b/FWCore/MessageService/src/MessageLoggerDefaults.h
@@ -94,16 +94,16 @@ namespace edm {
 
       // access to values set
 
-      std::string threshold(std::string const& dest);
-      std::string output(std::string const& dest);
+      std::string threshold(std::string const& dest) const;
+      std::string output(std::string const& dest) const;
 
-      int limit(std::string const& dest, std::string const& cat);
-      int reportEvery(std::string const& dest, std::string const& cat);
-      int timespan(std::string const& dest, std::string const& cat);
+      int limit(std::string const& dest, std::string const& cat) const;
+      int reportEvery(std::string const& dest, std::string const& cat) const;
+      int timespan(std::string const& dest, std::string const& cat) const;
 
-      int sev_limit(std::string const& dest, std::string const& sev);
-      int sev_reportEvery(std::string const& dest, std::string const& sev);
-      int sev_timespan(std::string const& dest, std::string const& sev);
+      int sev_limit(std::string const& dest, std::string const& sev) const;
+      int sev_reportEvery(std::string const& dest, std::string const& sev) const;
+      int sev_timespan(std::string const& dest, std::string const& sev) const;
 
       // Modes with hardwired defaults
 

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -31,6 +31,13 @@ namespace edm {
     }  // operator() to validate the PSet passed in
 
     void edm::service::MessageServicePSetValidation::messageLoggerPSet(ParameterSet const& pset) {
+      // See if new config API is being used
+      if (pset.exists("files") or
+          (not(pset.exists("destinations") or pset.existsAs<std::vector<std::string>>("statistics", true) or
+               pset.existsAs<std::vector<std::string>>("statistics", false) or pset.exists("categories")))) {
+        return;
+      }
+
       // Four types of material are allowed at the MessageLogger level:
       //   PSet lists (such as destinations or categories
       //   Suppression lists, such as SuppressInfo or debugModules
@@ -84,9 +91,9 @@ namespace edm {
 
       if (!flaws_.str().empty()) {
         flaws_ << "\nThe above are from MessageLogger configuration validation.\n"
-              << "In most cases, these involve lines that the logger configuration code\n"
-              << "would not process, but which the cfg creator obviously meant to have "
-              << "effect.\n";
+               << "In most cases, these involve lines that the logger configuration code\n"
+               << "would not process, but which the cfg creator obviously meant to have "
+               << "effect.\n";
       }
 
     }  // messageLoggerPSet
@@ -117,47 +124,47 @@ namespace edm {
       bool dmStar = wildcard(debugModules_);
       if (dmStar && debugModules_.size() != 1) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "debugModules contains wildcard character *"
-              << " and also " << debugModules_.size() - 1 << " other entries - * must be alone\n";
+               << " PSet: \n"
+               << "debugModules contains wildcard character *"
+               << " and also " << debugModules_.size() - 1 << " other entries - * must be alone\n";
       }
       suppressDebug_ = check<vString>(pset, "MessageLogger", "suppressDebug");
       if ((!suppressDebug_.empty()) && (!dmStar)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "suppressDebug contains modules, but debugModules is not *\n"
-              << "Unless all the debugModules are enabled,\n"
-              << "suppressing specific modules is meaningless\n";
+               << " PSet: \n"
+               << "suppressDebug contains modules, but debugModules is not *\n"
+               << "Unless all the debugModules are enabled,\n"
+               << "suppressing specific modules is meaningless\n";
       }
       if (wildcard(suppressDebug_)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "Use of wildcard (*) in suppressDebug is not supported\n"
-              << "By default, LogDebug is suppressed for all modules\n";
+               << " PSet: \n"
+               << "Use of wildcard (*) in suppressDebug is not supported\n"
+               << "By default, LogDebug is suppressed for all modules\n";
       }
       suppressInfo_ = check<vString>(pset, "MessageLogger", "suppressInfo");
       if (wildcard(suppressInfo_)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "Use of wildcard (*) in suppressInfo is not supported\n";
+               << " PSet: \n"
+               << "Use of wildcard (*) in suppressInfo is not supported\n";
       }
       suppressFwkInfo_ = check<vString>(pset, "MessageLogger", "suppressFwkInfo");
       if (wildcard(suppressFwkInfo_)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "Use of wildcard (*) in suppressFwkInfo is not supported\n";
+               << " PSet: \n"
+               << "Use of wildcard (*) in suppressFwkInfo is not supported\n";
       }
       suppressWarning_ = check<vString>(pset, "MessageLogger", "suppressWarning");
       if (wildcard(suppressWarning_)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "Use of wildcard (*) in suppressWarning is not supported\n";
+               << " PSet: \n"
+               << "Use of wildcard (*) in suppressWarning is not supported\n";
       }
       suppressError_ = check<vString>(pset, "MessageLogger", "suppressError");
       if (wildcard(suppressError_)) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << "Use of wildcard (*) in suppressError is not supported\n";
+               << " PSet: \n"
+               << "Use of wildcard (*) in suppressError is not supported\n";
       }
 
     }  // suppressionLists
@@ -169,18 +176,18 @@ namespace edm {
       for (vString::const_iterator i = vStrings.begin(); i != end; ++i) {
         if (!allowedVstring(*i)) {
           flaws_ << "MessageLogger"
-                << " PSet: \n"
-                << (*i) << " is used as a vstring, "
-                << "but no such vstring is recognized\n";
+                 << " PSet: \n"
+                 << (*i) << " is used as a vstring, "
+                 << "but no such vstring is recognized\n";
         }
       }
       vStrings = pset.getParameterNamesForType<vString>(true);
       end = vStrings.end();
       for (vString::const_iterator i = vStrings.begin(); i != end; ++i) {
         flaws_ << "MessageLogger"
-              << " PSet: \n"
-              << (*i) << " is used as a tracked vstring: "
-              << "tracked parameters not allowed here\n";
+               << " PSet: \n"
+               << (*i) << " is used as a tracked vstring: "
+               << "tracked parameters not allowed here\n";
       }
     }  // vStringsCheck
 
@@ -213,7 +220,7 @@ namespace edm {
       if (checkThreshold(thresh))
         return true;
       flaws_ << psetName << " PSet: \n"
-            << "threshold has value " << thresh << " which is not among {DEBUG, INFO, FWKINFO, WARNING, ERROR}\n";
+             << "threshold has value " << thresh << " which is not among {DEBUG, INFO, FWKINFO, WARNING, ERROR}\n";
       return false;
     }  // validateThreshold
 
@@ -239,7 +246,7 @@ namespace edm {
         for (vString::const_iterator j = i + 1; j != end; ++j) {
           if (*i == *j) {
             flaws_ << psetName << " PSet: \n"
-                  << "in vString " << parameterLabel << " duplication of the string " << *i << "\n";
+                   << "in vString " << parameterLabel << " duplication of the string " << *i << "\n";
           }
         }
       }
@@ -256,7 +263,7 @@ namespace edm {
         for (vString::const_iterator j = v2.begin(); j != end2; ++j) {
           if (*i == *j) {
             flaws_ << psetName << " PSet: \n"
-                  << "in vStrings " << p1 << " and " << p2 << " duplication of the string " << *i << "\n";
+                   << "in vStrings " << p1 << " and " << p2 << " duplication of the string " << *i << "\n";
           }
         }
       }
@@ -276,7 +283,7 @@ namespace edm {
       }
       if (coutPresent && cerrPresent) {
         flaws_ << psetName << " PSet: \n"
-              << "vString " << parameterLabel << " has both cout and cerr \n";
+               << "vString " << parameterLabel << " has both cout and cerr \n";
       }
     }  // noCoutCerrClash(v)
 
@@ -287,7 +294,7 @@ namespace edm {
       for (vString::const_iterator i = v.begin(); i != end; ++i) {
         if (!keywordCheck(*i)) {
           flaws_ << psetName << " PSet: \n"
-                << "vString " << parameterLabel << " should not contain the keyword " << *i << "\n";
+                 << "vString " << parameterLabel << " should not contain the keyword " << *i << "\n";
         }
       }
     }  // noKeywords(v)
@@ -368,7 +375,7 @@ namespace edm {
       disallowedParam<float>(pset, v, psetName, parameterLabel, "float");
       disallowedParam<double>(pset, v, psetName, parameterLabel, "double");
       disallowedParam<std::string>(pset, v, psetName, parameterLabel, "string");
-      disallowedParam<std::vector<std::string> >(pset, v, psetName, parameterLabel, "vstring");
+      disallowedParam<std::vector<std::string>>(pset, v, psetName, parameterLabel, "vstring");
     }  // noNonPSetUsage
 
     void edm::service::MessageServicePSetValidation::noBadParams(vString const& v,
@@ -382,8 +389,8 @@ namespace edm {
         for (vString::const_iterator j = params.begin(); j != end2; ++j) {
           if (*i == *j) {
             flaws_ << psetName << " PSet: \n"
-                  << *i << " (listed in vstring " << parameterLabel << ")\n"
-                  << "is used as a parameter of type " << type << " instead of as a PSet \n";
+                   << *i << " (listed in vstring " << parameterLabel << ")\n"
+                   << "is used as a parameter of type " << type << " instead of as a PSet \n";
           }
         }
       }
@@ -423,8 +430,8 @@ namespace edm {
         if (ok_optionalPSet)
           continue;
         flaws_ << "MessageLogger "
-              << " PSet: \n"
-              << *i << " is an unrecognized name for a PSet\n";
+               << " PSet: \n"
+               << *i << " is an unrecognized name for a PSet\n";
       }
       psnames.clear();
       unsigned int n = pset.getParameterSetNames(psnames, true);
@@ -432,8 +439,8 @@ namespace edm {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
           flaws_ << "MessageLogger "
-                << " PSet: \n"
-                << "PSet " << *i << " is tracked - not allowed\n";
+                 << " PSet: \n"
+                 << "PSet " << *i << " is tracked - not allowed\n";
         }
       }
     }
@@ -654,7 +661,7 @@ namespace edm {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
           flaws_ << psetName << " PSet: \n"
-                << "PSet " << *i << " is tracked - not allowed\n";
+                 << "PSet " << *i << " is tracked - not allowed\n";
         }
       }
     }  // noNoncategoryPsets
@@ -681,7 +688,7 @@ namespace edm {
                                                                   std::string const& categoryName) {
       if (pset.existsAs<ParameterSet>(categoryName, true)) {
         flaws_ << OuterPsetName << " PSet: \n"
-              << "Category PSet " << categoryName << " is tracked - not allowed\n";
+               << "Category PSet " << categoryName << " is tracked - not allowed\n";
         return;
       }
       ParameterSet empty_PSet;
@@ -710,14 +717,14 @@ namespace edm {
         if (*i == "timespan")
           continue;
         flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-              << (*i) << " is not an allowed parameter within a category PSet \n";
+               << (*i) << " is not an allowed parameter within a category PSet \n";
       }
       x = pset.getParameterNamesForType<int>(true);
       end = x.end();
       for (vString::const_iterator i = x.begin(); i != end; ++i) {
         flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-              << (*i) << " is used as a tracked int \n"
-              << "Tracked parameters not allowed here \n";
+               << (*i) << " is used as a tracked int \n"
+               << "Tracked parameters not allowed here \n";
       }
     }  // catInts()
 
@@ -729,8 +736,8 @@ namespace edm {
       vString::const_iterator end = psnames.end();
       for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
         flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-              << *i << " is used as a  PSet\n"
-              << "PSets not allowed within a category PSet\n";
+               << *i << " is used as a  PSet\n"
+               << "PSets not allowed within a category PSet\n";
       }
       psnames.clear();
       unsigned int n = pset.getParameterSetNames(psnames, true);
@@ -738,9 +745,9 @@ namespace edm {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
           flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-                << *i << " is used as a tracked PSet\n"
-                << "tracked parameters not permitted, and "
-                << "PSets not allowed within a category PSet\n";
+                 << *i << " is used as a tracked PSet\n"
+                 << "tracked parameters not permitted, and "
+                 << "PSets not allowed within a category PSet\n";
         }
       }
     }  // catNoPSets
@@ -755,16 +762,16 @@ namespace edm {
         if (((*i) == "placeholder") || ((*i) == "optionalPSet"))
           continue;
         flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-              << (*i) << " is used as a " << type << "\n"
-              << "Usage of " << type << " is not recognized here\n";
+               << (*i) << " is used as a " << type << "\n"
+               << "Usage of " << type << " is not recognized here\n";
       }
       x = pset.getParameterNamesForType<bool>(true);
       end = x.end();
       for (vString::const_iterator i = x.begin(); i != end; ++i) {
         flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-              << (*i) << " is used as a tracked " << type << "\n"
-              << "Tracked parameters not allowed here, "
-              << " and even untracked it would not be recognized\n";
+               << (*i) << " is used as a tracked " << type << "\n"
+               << "Tracked parameters not allowed here, "
+               << " and even untracked it would not be recognized\n";
       }
     }  // catBoolRestriction()
 

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -27,7 +27,7 @@ namespace edm {
 
     std::string edm::service::MessageServicePSetValidation::operator()(ParameterSet const& pset) {
       messageLoggerPSet(pset);
-      return flaws.str();
+      return flaws_.str();
     }  // operator() to validate the PSet passed in
 
     void edm::service::MessageServicePSetValidation::messageLoggerPSet(ParameterSet const& pset) {
@@ -82,8 +82,8 @@ namespace edm {
 
       // Append explanatory information if flaws were found
 
-      if (!flaws.str().empty()) {
-        flaws << "\nThe above are from MessageLogger configuration validation.\n"
+      if (!flaws_.str().empty()) {
+        flaws_ << "\nThe above are from MessageLogger configuration validation.\n"
               << "In most cases, these involve lines that the logger configuration code\n"
               << "would not process, but which the cfg creator obviously meant to have "
               << "effect.\n";
@@ -92,70 +92,70 @@ namespace edm {
     }  // messageLoggerPSet
 
     void edm::service::MessageServicePSetValidation::psetLists(ParameterSet const& pset) {
-      destinations = check<vString>(pset, "MessageLogger", "destinations");
-      noDuplicates(destinations, "MessageLogger", "destinations");
-      noKeywords(destinations, "MessageLogger", "destinations");
-      noNonPSetUsage(pset, destinations, "MessageLogger", "destinations");
-      // REMOVED: noCoutCerrClash(destinations,"MessageLogger", "destinations");
+      destinations_ = check<vString>(pset, "MessageLogger", "destinations");
+      noDuplicates(destinations_, "MessageLogger", "destinations");
+      noKeywords(destinations_, "MessageLogger", "destinations");
+      noNonPSetUsage(pset, destinations_, "MessageLogger", "destinations");
+      // REMOVED: noCoutCerrClash(destinations_,"MessageLogger", "destinations");
 
-      statistics = check<vString>(pset, "MessageLogger", "statistics");
-      noDuplicates(statistics, "MessageLogger", "statistics");
-      noKeywords(statistics, "MessageLogger", "statistics");
-      noNonPSetUsage(pset, statistics, "MessageLogger", "statistics");
+      statistics_ = check<vString>(pset, "MessageLogger", "statistics");
+      noDuplicates(statistics_, "MessageLogger", "statistics");
+      noKeywords(statistics_, "MessageLogger", "statistics");
+      noNonPSetUsage(pset, statistics_, "MessageLogger", "statistics");
 
-      categories = check<vString>(pset, "MessageLogger", "categories");
-      noDuplicates(categories, "MessageLogger", "categories");
-      noKeywords(categories, "MessageLogger", "categories");
-      noNonPSetUsage(pset, categories, "MessageLogger", "categories");
-      noDuplicates(categories, destinations, "MessageLogger", "categories", "destinations");
-      noDuplicates(categories, statistics, "MessageLogger", "categories", "statistics");
+      categories_ = check<vString>(pset, "MessageLogger", "categories");
+      noDuplicates(categories_, "MessageLogger", "categories");
+      noKeywords(categories_, "MessageLogger", "categories");
+      noNonPSetUsage(pset, categories_, "MessageLogger", "categories");
+      noDuplicates(categories_, destinations_, "MessageLogger", "categories", "destinations");
+      noDuplicates(categories_, statistics_, "MessageLogger", "categories", "statistics");
 
     }  // psetLists
 
     void edm::service::MessageServicePSetValidation::suppressionLists(ParameterSet const& pset) {
-      debugModules = check<vString>(pset, "MessageLogger", "debugModules");
-      bool dmStar = wildcard(debugModules);
-      if (dmStar && debugModules.size() != 1) {
-        flaws << "MessageLogger"
+      debugModules_ = check<vString>(pset, "MessageLogger", "debugModules");
+      bool dmStar = wildcard(debugModules_);
+      if (dmStar && debugModules_.size() != 1) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "debugModules contains wildcard character *"
-              << " and also " << debugModules.size() - 1 << " other entries - * must be alone\n";
+              << " and also " << debugModules_.size() - 1 << " other entries - * must be alone\n";
       }
-      suppressDebug = check<vString>(pset, "MessageLogger", "suppressDebug");
-      if ((!suppressDebug.empty()) && (!dmStar)) {
-        flaws << "MessageLogger"
+      suppressDebug_ = check<vString>(pset, "MessageLogger", "suppressDebug");
+      if ((!suppressDebug_.empty()) && (!dmStar)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "suppressDebug contains modules, but debugModules is not *\n"
               << "Unless all the debugModules are enabled,\n"
               << "suppressing specific modules is meaningless\n";
       }
-      if (wildcard(suppressDebug)) {
-        flaws << "MessageLogger"
+      if (wildcard(suppressDebug_)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "Use of wildcard (*) in suppressDebug is not supported\n"
               << "By default, LogDebug is suppressed for all modules\n";
       }
-      suppressInfo = check<vString>(pset, "MessageLogger", "suppressInfo");
-      if (wildcard(suppressInfo)) {
-        flaws << "MessageLogger"
+      suppressInfo_ = check<vString>(pset, "MessageLogger", "suppressInfo");
+      if (wildcard(suppressInfo_)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "Use of wildcard (*) in suppressInfo is not supported\n";
       }
-      suppressFwkInfo = check<vString>(pset, "MessageLogger", "suppressFwkInfo");
-      if (wildcard(suppressFwkInfo)) {
-        flaws << "MessageLogger"
+      suppressFwkInfo_ = check<vString>(pset, "MessageLogger", "suppressFwkInfo");
+      if (wildcard(suppressFwkInfo_)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "Use of wildcard (*) in suppressFwkInfo is not supported\n";
       }
-      suppressWarning = check<vString>(pset, "MessageLogger", "suppressWarning");
-      if (wildcard(suppressWarning)) {
-        flaws << "MessageLogger"
+      suppressWarning_ = check<vString>(pset, "MessageLogger", "suppressWarning");
+      if (wildcard(suppressWarning_)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "Use of wildcard (*) in suppressWarning is not supported\n";
       }
-      suppressError = check<vString>(pset, "MessageLogger", "suppressError");
-      if (wildcard(suppressError)) {
-        flaws << "MessageLogger"
+      suppressError_ = check<vString>(pset, "MessageLogger", "suppressError");
+      if (wildcard(suppressError_)) {
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << "Use of wildcard (*) in suppressError is not supported\n";
       }
@@ -168,7 +168,7 @@ namespace edm {
       vString::const_iterator end = vStrings.end();
       for (vString::const_iterator i = vStrings.begin(); i != end; ++i) {
         if (!allowedVstring(*i)) {
-          flaws << "MessageLogger"
+          flaws_ << "MessageLogger"
                 << " PSet: \n"
                 << (*i) << " is used as a vstring, "
                 << "but no such vstring is recognized\n";
@@ -177,7 +177,7 @@ namespace edm {
       vStrings = pset.getParameterNamesForType<vString>(true);
       end = vStrings.end();
       for (vString::const_iterator i = vStrings.begin(); i != end; ++i) {
-        flaws << "MessageLogger"
+        flaws_ << "MessageLogger"
               << " PSet: \n"
               << (*i) << " is used as a tracked vstring: "
               << "tracked parameters not allowed here\n";
@@ -212,7 +212,7 @@ namespace edm {
                                                                        std::string const& psetName) {
       if (checkThreshold(thresh))
         return true;
-      flaws << psetName << " PSet: \n"
+      flaws_ << psetName << " PSet: \n"
             << "threshold has value " << thresh << " which is not among {DEBUG, INFO, FWKINFO, WARNING, ERROR}\n";
       return false;
     }  // validateThreshold
@@ -238,7 +238,7 @@ namespace edm {
       for (vString::const_iterator i = v.begin(); i != end; ++i) {
         for (vString::const_iterator j = i + 1; j != end; ++j) {
           if (*i == *j) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << "in vString " << parameterLabel << " duplication of the string " << *i << "\n";
           }
         }
@@ -255,7 +255,7 @@ namespace edm {
       for (vString::const_iterator i = v1.begin(); i != end1; ++i) {
         for (vString::const_iterator j = v2.begin(); j != end2; ++j) {
           if (*i == *j) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << "in vStrings " << p1 << " and " << p2 << " duplication of the string " << *i << "\n";
           }
         }
@@ -275,7 +275,7 @@ namespace edm {
           cerrPresent = true;
       }
       if (coutPresent && cerrPresent) {
-        flaws << psetName << " PSet: \n"
+        flaws_ << psetName << " PSet: \n"
               << "vString " << parameterLabel << " has both cout and cerr \n";
       }
     }  // noCoutCerrClash(v)
@@ -286,7 +286,7 @@ namespace edm {
       vString::const_iterator end = v.end();
       for (vString::const_iterator i = v.begin(); i != end; ++i) {
         if (!keywordCheck(*i)) {
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << "vString " << parameterLabel << " should not contain the keyword " << *i << "\n";
         }
       }
@@ -381,7 +381,7 @@ namespace edm {
       for (vString::const_iterator i = v.begin(); i != end1; ++i) {
         for (vString::const_iterator j = params.begin(); j != end2; ++j) {
           if (*i == *j) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << *i << " (listed in vstring " << parameterLabel << ")\n"
                   << "is used as a parameter of type " << type << " instead of as a PSet \n";
           }
@@ -404,11 +404,11 @@ namespace edm {
       pset.getParameterSetNames(psnames, false);
       vString::const_iterator end = psnames.end();
       for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-        if (lookForMatch(destinations, *i))
+        if (lookForMatch(destinations_, *i))
           continue;
-        if (lookForMatch(statistics, *i))
+        if (lookForMatch(statistics_, *i))
           continue;
-        if (lookForMatch(categories, *i))
+        if (lookForMatch(categories_, *i))
           continue;
         if ((*i) == "default")
           continue;
@@ -422,7 +422,7 @@ namespace edm {
         }
         if (ok_optionalPSet)
           continue;
-        flaws << "MessageLogger "
+        flaws_ << "MessageLogger "
               << " PSet: \n"
               << *i << " is an unrecognized name for a PSet\n";
       }
@@ -431,7 +431,7 @@ namespace edm {
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-          flaws << "MessageLogger "
+          flaws_ << "MessageLogger "
                 << " PSet: \n"
                 << "PSet " << *i << " is tracked - not allowed\n";
         }
@@ -446,8 +446,8 @@ namespace edm {
 
     void edm::service::MessageServicePSetValidation::destinationPSets(ParameterSet const& pset) {
       ParameterSet empty_PSet;
-      std::vector<std::string>::const_iterator end = destinations.end();
-      for (std::vector<std::string>::const_iterator i = destinations.begin(); i != end; ++i) {
+      std::vector<std::string>::const_iterator end = destinations_.end();
+      for (std::vector<std::string>::const_iterator i = destinations_.begin(); i != end; ++i) {
         ParameterSet const& d = pset.getUntrackedParameterSet(*i, empty_PSet);
         destinationPSet(d, *i);
       }
@@ -481,11 +481,11 @@ namespace edm {
       check<bool>(pset, psetName, "resetStatistics");
       std::string s = check<std::string>(pset, "psetName", "filename");
       if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
+        flaws_ << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
       }
       s = check<std::string>(pset, "psetName", "extension");
       if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of extension \n";
+        flaws_ << psetName << " PSet: \n" << s << " is not allowed as a value of extension \n";
       }
       s = check<std::string>(pset, "psetName", "output");
 
@@ -562,9 +562,9 @@ namespace edm {
 
     void edm::service::MessageServicePSetValidation::statisticsPSets(ParameterSet const& pset) {
       ParameterSet empty_PSet;
-      std::vector<std::string>::const_iterator end = statistics.end();
-      for (std::vector<std::string>::const_iterator i = statistics.begin(); i != end; ++i) {
-        if (lookForMatch(destinations, *i))
+      std::vector<std::string>::const_iterator end = statistics_.end();
+      for (std::vector<std::string>::const_iterator i = statistics_.begin(); i != end; ++i) {
+        if (lookForMatch(destinations_, *i))
           continue;
         ParameterSet const& d = pset.getUntrackedParameterSet(*i, empty_PSet);
         statisticsPSet(d, *i);
@@ -590,11 +590,11 @@ namespace edm {
       check<bool>(pset, psetName, "reset");
       std::string s = check<std::string>(pset, "psetName", "filename");
       if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
+        flaws_ << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
       }
       s = check<std::string>(pset, "psetName", "extension");
       if ((s == "cerr") || (s == "cout")) {
-        flaws << psetName << " PSet: \n" << s << " is not allowed as a value of extension \n";
+        flaws_ << psetName << " PSet: \n" << s << " is not allowed as a value of extension \n";
       }
       s = check<std::string>(pset, "psetName", "output");
 
@@ -622,7 +622,7 @@ namespace edm {
       pset.getParameterSetNames(psnames, false);
       vString::const_iterator end = psnames.end();
       for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-        if (lookForMatch(categories, *i))
+        if (lookForMatch(categories_, *i))
           continue;
         if ((*i) == "default")
           continue;
@@ -646,14 +646,14 @@ namespace edm {
         }
         if (ok_optionalPSet)
           continue;
-        flaws << psetName << " PSet: \n" << *i << " is an unrecognized name for a PSet in this context \n";
+        flaws_ << psetName << " PSet: \n" << *i << " is an unrecognized name for a PSet in this context \n";
       }
       psnames.clear();
       unsigned int n = pset.getParameterSetNames(psnames, true);
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << "PSet " << *i << " is tracked - not allowed\n";
         }
       }
@@ -670,8 +670,8 @@ namespace edm {
         categoryPSet(pset, psetName, "default");
       // The above conditional is because default in the main level is treated
       // as a set of defaults differnt from those of a simple category.
-      std::vector<std::string>::const_iterator end = categories.end();
-      for (std::vector<std::string>::const_iterator i = categories.begin(); i != end; ++i) {
+      std::vector<std::string>::const_iterator end = categories_.end();
+      for (std::vector<std::string>::const_iterator i = categories_.begin(); i != end; ++i) {
         categoryPSet(pset, psetName, *i);
       }
     }  // categoryPSets
@@ -680,7 +680,7 @@ namespace edm {
                                                                   std::string const& OuterPsetName,
                                                                   std::string const& categoryName) {
       if (pset.existsAs<ParameterSet>(categoryName, true)) {
-        flaws << OuterPsetName << " PSet: \n"
+        flaws_ << OuterPsetName << " PSet: \n"
               << "Category PSet " << categoryName << " is tracked - not allowed\n";
         return;
       }
@@ -709,13 +709,13 @@ namespace edm {
           continue;
         if (*i == "timespan")
           continue;
-        flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+        flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
               << (*i) << " is not an allowed parameter within a category PSet \n";
       }
       x = pset.getParameterNamesForType<int>(true);
       end = x.end();
       for (vString::const_iterator i = x.begin(); i != end; ++i) {
-        flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+        flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
               << (*i) << " is used as a tracked int \n"
               << "Tracked parameters not allowed here \n";
       }
@@ -728,7 +728,7 @@ namespace edm {
       pset.getParameterSetNames(psnames, false);
       vString::const_iterator end = psnames.end();
       for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-        flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+        flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
               << *i << " is used as a  PSet\n"
               << "PSets not allowed within a category PSet\n";
       }
@@ -737,7 +737,7 @@ namespace edm {
       if (n > 0) {
         end = psnames.end();
         for (vString::const_iterator i = psnames.begin(); i != end; ++i) {
-          flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+          flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
                 << *i << " is used as a tracked PSet\n"
                 << "tracked parameters not permitted, and "
                 << "PSets not allowed within a category PSet\n";
@@ -754,14 +754,14 @@ namespace edm {
       for (vString::const_iterator i = x.begin(); i != end; ++i) {
         if (((*i) == "placeholder") || ((*i) == "optionalPSet"))
           continue;
-        flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+        flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
               << (*i) << " is used as a " << type << "\n"
               << "Usage of " << type << " is not recognized here\n";
       }
       x = pset.getParameterNamesForType<bool>(true);
       end = x.end();
       for (vString::const_iterator i = x.begin(); i != end; ++i) {
-        flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+        flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
               << (*i) << " is used as a tracked " << type << "\n"
               << "Tracked parameters not allowed here, "
               << " and even untracked it would not be recognized\n";

--- a/FWCore/MessageService/src/MessageServicePSetValidation.cc
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.cc
@@ -349,6 +349,12 @@ namespace edm {
         return false;
       if (word == "optionalPSet")
         return false;
+      if (word == "enableStatistics")
+        return false;
+      if (word == "statisticsThreshold")
+        return false;
+      if (word == "resetStatistics")
+        return false;
       return true;
     }  // keywordCheck
 
@@ -460,12 +466,19 @@ namespace edm {
       // General parameters
 
       check<bool>(pset, psetName, "placeholder");
+      {
+        std::string thresh = check<std::string>(pset, "psetName", "statisticsThreshold");
+        if (!thresh.empty())
+          validateThreshold(thresh, psetName);
+      }
       std::string thresh = check<std::string>(pset, "psetName", "threshold");
       if (!thresh.empty())
         validateThreshold(thresh, psetName);
       check<bool>(pset, psetName, "noLineBreaks");
       check<int>(pset, psetName, "lineLength");
       check<bool>(pset, psetName, "noTimeStamps");
+      check<bool>(pset, psetName, "enableStatistics");
+      check<bool>(pset, psetName, "resetStatistics");
       std::string s = check<std::string>(pset, "psetName", "filename");
       if ((s == "cerr") || (s == "cout")) {
         flaws << psetName << " PSet: \n" << s << " is not allowed as a value of filename \n";
@@ -485,8 +498,11 @@ namespace edm {
       okbool.push_back("optionalPSet");
       okbool.push_back("noLineBreaks");
       okbool.push_back("noTimeStamps");
+      okbool.push_back("enableStatistics");
+      okbool.push_back("resetStatistics");
       noneExcept<bool>(pset, psetName, "bool", okbool);
       vString okstring;
+      okstring.push_back("statisticsThreshold");
       okstring.push_back("threshold");
       okstring.push_back("output");
       okstring.push_back("filename");

--- a/FWCore/MessageService/src/MessageServicePSetValidation.h
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.h
@@ -109,8 +109,8 @@ namespace edm {
           return val;
         } catch (cms::Exception& e) {
           flaws_ << psetName << " PSet: \n"
-                << parameterLabel << " is declared but causes an exception when processed: \n"
-                << e.what() << "\n";
+                 << parameterLabel << " is declared but causes an exception when processed: \n"
+                 << e.what() << "\n";
           return val;
         }
       }  // check()
@@ -133,8 +133,8 @@ namespace edm {
         vString::const_iterator end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           flaws_ << psetName << " PSet: \n"
-                << (*i) << " is used as a " << type << "\n"
-                << "Usage of " << type << " is not recognized here\n";
+                 << (*i) << " is used as a " << type << "\n"
+                 << "Usage of " << type << " is not recognized here\n";
         }
         x = pset.template getParameterNamesForType<T>(true);
         end = x.end();
@@ -142,9 +142,9 @@ namespace edm {
           if ((*i) == "@service_type")
             continue;
           flaws_ << psetName << " PSet: \n"
-                << (*i) << " is used as a tracked " << type << "\n"
-                << "Tracked parameters not allowed here, "
-                << " and even untracked it would not be recognized\n";
+                 << (*i) << " is used as a tracked " << type << "\n"
+                 << "Tracked parameters not allowed here, "
+                 << " and even untracked it would not be recognized\n";
         }
       }  // noneExcept()
 
@@ -159,8 +159,8 @@ namespace edm {
           std::string val = (*i);
           if (val != ok) {
             flaws_ << psetName << " PSet: \n"
-                  << val << " is used as a " << type << "\n"
-                  << "This usage is not recognized in this type of PSet\n";
+                   << val << " is used as a " << type << "\n"
+                   << "This usage is not recognized in this type of PSet\n";
           }
         }
         x = pset.template getParameterNamesForType<T>(true);
@@ -169,8 +169,8 @@ namespace edm {
           if ((*i) == "@service_type")
             continue;
           flaws_ << psetName << " PSet: \n"
-                << (*i) << " is used as a tracked " << type << "\n"
-                << "Tracked parameters not allowed here\n";
+                 << (*i) << " is used as a tracked " << type << "\n"
+                 << "Tracked parameters not allowed here\n";
         }
       }  // noneExcept(okValue)
 
@@ -183,8 +183,8 @@ namespace edm {
           std::string val = (*i);
           if ((val != ok1) && (val != ok2)) {
             flaws_ << psetName << " PSet: \n"
-                  << val << " is used as a " << type << "\n"
-                  << "This usage is not recognized in this type of PSet\n";
+                   << val << " is used as a " << type << "\n"
+                   << "This usage is not recognized in this type of PSet\n";
           }
         }
         x = pset.template getParameterNamesForType<T>(true);
@@ -193,8 +193,8 @@ namespace edm {
           if ((*i) == "@service_type")
             continue;
           flaws_ << psetName << " PSet: \n"
-                << (*i) << " is used as a tracked " << type << "\n"
-                << "Tracked parameters not allowed here\n";
+                 << (*i) << " is used as a tracked " << type << "\n"
+                 << "Tracked parameters not allowed here\n";
         }
       }  // noneExcept(okValue1, okValue2)
 
@@ -214,8 +214,8 @@ namespace edm {
           }
           if (!found) {
             flaws_ << psetName << " PSet: \n"
-                  << *i << " is used as a " << type << "\n"
-                  << "This usage is not recognized in this type of PSet\n";
+                   << *i << " is used as a " << type << "\n"
+                   << "This usage is not recognized in this type of PSet\n";
           }
         }
         x = pset.template getParameterNamesForType<T>(true);
@@ -224,8 +224,8 @@ namespace edm {
           if ((*i) == "@service_type")
             continue;
           flaws_ << psetName << " PSet: \n"
-                << (*i) << " is used as a tracked " << type << "\n"
-                << "Tracked parameters not allowed here\n";
+                 << (*i) << " is used as a tracked " << type << "\n"
+                 << "Tracked parameters not allowed here\n";
         }
       }  // noneExcept(vok)
 
@@ -238,16 +238,16 @@ namespace edm {
         vString::const_iterator end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-                << (*i) << " is used as a " << type << "\n"
-                << "Usage of " << type << " is not recognized here\n";
+                 << (*i) << " is used as a " << type << "\n"
+                 << "Usage of " << type << " is not recognized here\n";
         }
         x = pset.template getParameterNamesForType<T>(true);
         end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
-                << (*i) << " is used as a tracked " << type << "\n"
-                << "Tracked parameters not allowed here, "
-                << " and even untracked it would not be recognized\n";
+                 << (*i) << " is used as a tracked " << type << "\n"
+                 << "Tracked parameters not allowed here, "
+                 << " and even untracked it would not be recognized\n";
         }
       }  // catNone()
 

--- a/FWCore/MessageService/src/MessageServicePSetValidation.h
+++ b/FWCore/MessageService/src/MessageServicePSetValidation.h
@@ -101,14 +101,14 @@ namespace edm {
             return val;
           }
           if (pset.existsAs<T>(parameterLabel, true)) {
-            flaws << psetName << " PSet: \n" << parameterLabel << " is declared as tracked - needs to be untracked \n";
+            flaws_ << psetName << " PSet: \n" << parameterLabel << " is declared as tracked - needs to be untracked \n";
             val = pset.getParameter<T>(parameterLabel);
           } else {
-            flaws << psetName << " PSet: \n" << parameterLabel << " is declared with incorrect type \n";
+            flaws_ << psetName << " PSet: \n" << parameterLabel << " is declared with incorrect type \n";
           }
           return val;
         } catch (cms::Exception& e) {
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << parameterLabel << " is declared but causes an exception when processed: \n"
                 << e.what() << "\n";
           return val;
@@ -132,7 +132,7 @@ namespace edm {
         vString x = pset.template getParameterNamesForType<T>(false);
         vString::const_iterator end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << (*i) << " is used as a " << type << "\n"
                 << "Usage of " << type << " is not recognized here\n";
         }
@@ -141,7 +141,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           if ((*i) == "@service_type")
             continue;
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << (*i) << " is used as a tracked " << type << "\n"
                 << "Tracked parameters not allowed here, "
                 << " and even untracked it would not be recognized\n";
@@ -158,7 +158,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           std::string val = (*i);
           if (val != ok) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << val << " is used as a " << type << "\n"
                   << "This usage is not recognized in this type of PSet\n";
           }
@@ -168,7 +168,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           if ((*i) == "@service_type")
             continue;
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << (*i) << " is used as a tracked " << type << "\n"
                 << "Tracked parameters not allowed here\n";
         }
@@ -182,7 +182,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           std::string val = (*i);
           if ((val != ok1) && (val != ok2)) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << val << " is used as a " << type << "\n"
                   << "This usage is not recognized in this type of PSet\n";
           }
@@ -192,7 +192,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           if ((*i) == "@service_type")
             continue;
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << (*i) << " is used as a tracked " << type << "\n"
                 << "Tracked parameters not allowed here\n";
         }
@@ -213,7 +213,7 @@ namespace edm {
               found = true;
           }
           if (!found) {
-            flaws << psetName << " PSet: \n"
+            flaws_ << psetName << " PSet: \n"
                   << *i << " is used as a " << type << "\n"
                   << "This usage is not recognized in this type of PSet\n";
           }
@@ -223,7 +223,7 @@ namespace edm {
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
           if ((*i) == "@service_type")
             continue;
-          flaws << psetName << " PSet: \n"
+          flaws_ << psetName << " PSet: \n"
                 << (*i) << " is used as a tracked " << type << "\n"
                 << "Tracked parameters not allowed here\n";
         }
@@ -237,14 +237,14 @@ namespace edm {
         vString x = pset.template getParameterNamesForType<T>(false);
         vString::const_iterator end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
-          flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+          flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
                 << (*i) << " is used as a " << type << "\n"
                 << "Usage of " << type << " is not recognized here\n";
         }
         x = pset.template getParameterNamesForType<T>(true);
         end = x.end();
         for (vString::const_iterator i = x.begin(); i != end; ++i) {
-          flaws << categoryName << " category PSet nested in " << psetName << " PSet: \n"
+          flaws_ << categoryName << " category PSet nested in " << psetName << " PSet: \n"
                 << (*i) << " is used as a tracked " << type << "\n"
                 << "Tracked parameters not allowed here, "
                 << " and even untracked it would not be recognized\n";
@@ -252,16 +252,16 @@ namespace edm {
       }  // catNone()
 
       // private data
-      std::ostringstream flaws;
-      std::vector<std::string> destinations;
-      std::vector<std::string> statistics;
-      std::vector<std::string> categories;
-      std::vector<std::string> debugModules;
-      std::vector<std::string> suppressInfo;
-      std::vector<std::string> suppressFwkInfo;
-      std::vector<std::string> suppressDebug;
-      std::vector<std::string> suppressWarning;
-      std::vector<std::string> suppressError;
+      std::ostringstream flaws_;
+      std::vector<std::string> destinations_;
+      std::vector<std::string> statistics_;
+      std::vector<std::string> categories_;
+      std::vector<std::string> debugModules_;
+      std::vector<std::string> suppressInfo_;
+      std::vector<std::string> suppressFwkInfo_;
+      std::vector<std::string> suppressDebug_;
+      std::vector<std::string> suppressWarning_;
+      std::vector<std::string> suppressError_;
 
     };  // MessageServicePSetValidation
 

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -653,7 +653,7 @@ namespace edm {
       std::vector<std::string> ordinary_destination_filenames;
       for (vString::const_iterator it = destinations.begin(); it != destinations.end(); ++it) {
         std::string filename = *it;
-        std::string psetname = filename;
+        const std::string& psetname = filename;
 
         // check that this destination is not just a placeholder // change log 11
         edm::ParameterSet dest_pset = getAparameter<edm::ParameterSet>(job_pset, psetname, empty_PSet);

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -325,7 +325,7 @@ namespace edm {
 
       auto const& files = job_pset.getUntrackedParameter<edm::ParameterSet>("files");
       for (auto const& name : files.getParameterNamesForType<edm::ParameterSet>(false)) {
-        auto const& dest_pset = job_pset.getUntrackedParameter<edm::ParameterSet>(name);
+        auto const& dest_pset = files.getUntrackedParameter<edm::ParameterSet>(name);
         auto const actual_filename = destinationFileName(dest_pset, name);
 
         auto dest_ctrl = makeDestinationCtrl(actual_filename);
@@ -589,9 +589,7 @@ namespace edm {
       } else {
         // change log 5
         int lineLen = getAparameter<int>(dest_pset, "lineLength", defaults.lineLength_);
-        if (lineLen != 80) {
-          dest_ctrl->setLineLength(lineLen);
-        }
+        dest_ctrl->setLineLength(lineLen);
       }
 
       // if indicated, suppress time stamps in this destination's output
@@ -883,11 +881,11 @@ namespace edm {
         category.addOptionalUntracked<int>("timespan");
 
         edm::ParameterSetDescription destination_base;
-        destination_base.addUntracked<bool>("noLineBreaks", false);
-        destination_base.addUntracked<bool>("noTimeStamps", false);
-        destination_base.addUntracked<int>("lineLength", -1);
-        destination_base.addUntracked<std::string>("threshold", "INFO");
-        destination_base.addUntracked<std::string>("statisticsThreshold", "INFO");
+        destination_base.addOptionalUntracked<bool>("noLineBreaks");
+        destination_base.addOptionalUntracked<bool>("noTimeStamps");
+        destination_base.addOptionalUntracked<int>("lineLength");
+        destination_base.addOptionalUntracked<std::string>("threshold");
+        destination_base.addOptionalUntracked<std::string>("statisticsThreshold");
 
         /*
     destination_base.addUntracked<edm::ParameterSetDescription>("DEBUG",category);
@@ -912,7 +910,7 @@ namespace edm {
           default_pset.addOptionalUntracked<int>("timespan");
           default_pset.addUntracked<bool>("noLineBreaks", false);
           default_pset.addUntracked<bool>("noTimeStamps", false);
-          default_pset.addUntracked<int>("lineLength", -1);
+          default_pset.addUntracked<int>("lineLength", 80);
           default_pset.addUntracked<std::string>("threshold", "INFO");
           default_pset.addUntracked<std::string>("statisticsThreshold", "INFO");
 

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.cc
@@ -20,6 +20,9 @@
 #include "FWCore/MessageLogger/interface/MessageDrop.h"      // change log 37
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"  // change log 37
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h"
+
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
@@ -103,9 +106,9 @@ namespace edm {
           break;
         }
         case MessageLoggerQ::CONFIGURE: {  // changelog 17
-          auto job_pset_p =
-              std::unique_ptr<PSet>(static_cast<PSet*>(operand));  // propagate_const<T> has no reset() function
-          //validate(*job_pset_p);
+          auto job_pset_p = std::unique_ptr<edm::ParameterSet>(
+              static_cast<edm::ParameterSet*>(operand));  // propagate_const<T> has no reset() function
+          validate(*job_pset_p);
           configure_errorlog(*job_pset_p);
           break;
         }
@@ -189,14 +192,159 @@ namespace edm {
       }
     }
 
-    void ThreadSafeLogMessageLoggerScribe::configure_errorlog(PSet& job_pset) {
-      vString empty_vString;
-      String empty_String;
-      PSet empty_PSet;
+    namespace {
+      bool usingOldConfig(edm::ParameterSet const& pset) {
+        if (not pset.exists("files") and
+            ((pset.exists("destinations") or pset.existsAs<std::vector<std::string>>("statistics", true) or
+              pset.existsAs<std::vector<std::string>>("statistics", false) or pset.exists("categories")))) {
+          return true;
+        }
+        return false;
+      }
+
+      std::set<std::string> findCategoriesInDestination(edm::ParameterSet const& pset) {
+        auto psets = pset.getParameterNamesForType<edm::ParameterSet>(false);
+        auto itFound = std::find(psets.begin(), psets.end(), "default");
+        if (itFound != psets.end()) {
+          psets.erase(itFound);
+        }
+
+        return std::set<std::string>(psets.begin(), psets.end());
+      }
+      std::vector<std::string> findAllCategories(edm::ParameterSet const& pset) {
+        auto psets = pset.getParameterNamesForType<edm::ParameterSet>(false);
+        auto itFound = std::find(psets.begin(), psets.end(), "default");
+        if (itFound != psets.end()) {
+          psets.erase(itFound);
+        }
+
+        std::set<std::string> categories;
+        itFound = std::find(psets.begin(), psets.end(), "cout");
+        if (itFound != psets.end()) {
+          categories = findCategoriesInDestination(pset.getUntrackedParameter<edm::ParameterSet>("cout"));
+          psets.erase(itFound);
+        }
+
+        itFound = std::find(psets.begin(), psets.end(), "cerr");
+        if (itFound != psets.end()) {
+          categories.merge(findCategoriesInDestination(pset.getUntrackedParameter<edm::ParameterSet>("cerr")));
+          psets.erase(itFound);
+        }
+
+        auto const& files = pset.getUntrackedParameter<edm::ParameterSet>("files");
+        for (auto const& name : files.getParameterNamesForType<edm::ParameterSet>(false)) {
+          categories.merge(findCategoriesInDestination(files.getUntrackedParameter<edm::ParameterSet>(name)));
+        }
+        categories.merge(std::set<std::string>(psets.begin(), psets.end()));
+
+        return std::vector<std::string>(categories.begin(), categories.end());
+      }
+
+    }  // namespace
+
+    std::string ThreadSafeLogMessageLoggerScribe::destinationFileName(edm::ParameterSet const& dest_pset,
+                                                                      std::string const& psetname) const {
+      // Determine the destination file name to use if no explicit filename is
+      // supplied in the cfg.
+      std::string const empty_String;
+      std::string filename = psetname;
+      std::string filename_default = getAparameter<std::string>(dest_pset, "output", empty_String);
+      if (filename_default == empty_String) {
+        filename_default = messageLoggerDefaults->output(psetname);  // change log 31
+        if (filename_default == empty_String) {
+          filename_default = filename;
+        }
+      }
+
+      std::string explicit_filename = getAparameter<std::string>(dest_pset, "filename", filename_default);
+      if (explicit_filename != empty_String)
+        filename = explicit_filename;
+      std::string explicit_extension = getAparameter<std::string>(dest_pset, "extension", empty_String);
+      if (explicit_extension != empty_String) {
+        if (explicit_extension[0] == '.') {
+          filename += explicit_extension;
+        } else {
+          filename = filename + "." + explicit_extension;
+        }
+      }
+
+      // Attach a default extension of .log if there is no extension on a file
+      // change log 18 - this had been done in concert with attaching destination
+
+      std::string actual_filename = filename;  // change log 4
+      if ((filename != "cout") && (filename != "cerr")) {
+        const std::string::size_type npos = std::string::npos;
+        if (filename.find('.') == npos) {
+          actual_filename += ".log";
+        }
+      }
+      return actual_filename;
+    }
+
+    void ThreadSafeLogMessageLoggerScribe::configure_errorlog_new(edm::ParameterSet& job_pset) {
+      {
+        auto preconfiguration_message =
+            job_pset.getUntrackedParameter<std::string>("generate_preconfiguration_message");
+        if (not preconfiguration_message.empty()) {
+          // To test a preconfiguration message without first going thru the
+          // configuration we are about to do, we issue the message (so it sits
+          // on the queue), then copy the processing that the LOG_A_MESSAGE case
+          // does.  We suppress the timestamp to allow for automated unit testing.
+          early_dest->suppressTime();
+          LogError("preconfiguration") << preconfiguration_message;
+        }
+      }
+      if (!stream_ps.empty()) {
+        LogWarning("multiLogConfig") << "The message logger has been configured multiple times";
+        clean_slate_configuration = false;  // Change Log 22
+      }
+      m_waitingThreshold = job_pset.getUntrackedParameter<unsigned int>("waiting_threshold");
+
+      auto defaults = parseDefaults(job_pset);
+      auto categories = findAllCategories(job_pset);
+
+      // Initialize unversal suppression variables
+      MessageDrop::debugAlwaysSuppressed = true;
+      MessageDrop::infoAlwaysSuppressed = true;
+      MessageDrop::fwkInfoAlwaysSuppressed = true;
+      MessageDrop::warningAlwaysSuppressed = true;
+
+      early_dest->setThreshold(ELhighestSeverity);
+
+      auto cout_dest = job_pset.getUntrackedParameter<edm::ParameterSet>("cout");
+      if (cout_dest.getUntrackedParameter<bool>("enable")) {
+        auto dest_ctrl = makeDestinationCtrl("cout");
+        configure_dest(job_pset, defaults, categories, dest_ctrl, cout_dest, "cout");
+      }
+
+      auto cerr_dest = job_pset.getUntrackedParameter<edm::ParameterSet>("cerr");
+      if (cerr_dest.getUntrackedParameter<bool>("enable")) {
+        auto dest_ctrl = makeDestinationCtrl("cerr");
+        configure_dest(job_pset, defaults, categories, dest_ctrl, cerr_dest, "cerr");
+      }
+
+      auto const& files = job_pset.getUntrackedParameter<edm::ParameterSet>("files");
+      for (auto const& name : files.getParameterNamesForType<edm::ParameterSet>(false)) {
+        auto const& dest_pset = job_pset.getUntrackedParameter<edm::ParameterSet>(name);
+        auto const actual_filename = destinationFileName(dest_pset, name);
+
+        auto dest_ctrl = makeDestinationCtrl(actual_filename);
+        configure_dest(job_pset, defaults, categories, dest_ctrl, dest_pset, name);
+      }
+    }
+
+    void ThreadSafeLogMessageLoggerScribe::configure_errorlog(edm::ParameterSet& job_pset) {
+      if (not usingOldConfig(job_pset)) {
+        configure_errorlog_new(job_pset);
+        return;
+      }
+      const vString empty_vString;
+      const std::string empty_String;
+      const edm::ParameterSet empty_PSet;
 
       // The following is present to test pre-configuration message handling:
-      String preconfiguration_message =
-          getAparameter<String>(job_pset, "generate_preconfiguration_message", empty_String);
+      std::string preconfiguration_message =
+          getAparameter<std::string>(job_pset, "generate_preconfiguration_message", empty_String);
       if (preconfiguration_message != empty_String) {
         // To test a preconfiguration message without first going thru the
         // configuration we are about to do, we issue the message (so it sits
@@ -211,9 +359,38 @@ namespace edm {
         clean_slate_configuration = false;  // Change Log 22
       }
       m_waitingThreshold = getAparameter<unsigned int>(job_pset, "waiting_threshold", 100);
-      configure_ordinary_destinations(job_pset);  // Change Log 16
-      configure_statistics(job_pset);             // Change Log 16
-    }                                     // ThreadSafeLogMessageLoggerScribe::configure_errorlog()
+      auto defaults = parseDefaults(job_pset);
+      // grab list of categories
+      vString categories = getAparameter<vString>(job_pset, "categories", empty_vString);
+      // grab list of hardwired categories (hardcats) -- these are to be added
+      // to the list of categories -- change log 24
+      {
+        std::vector<std::string> hardcats = messageLoggerDefaults->categories;
+        // combine the lists, not caring about possible duplicates (for now)
+        copy_all(hardcats, std::back_inserter(categories));
+      }  // no longer need hardcats
+
+      auto destination_names = configure_ordinary_destinations(job_pset, defaults, categories);
+      configure_statistics(job_pset, defaults, categories, destination_names);
+    }  // ThreadSafeLogMessageLoggerScribe::configure_errorlog()
+
+    std::shared_ptr<ELdestination> ThreadSafeLogMessageLoggerScribe::makeDestinationCtrl(std::string const& filename) {
+      std::shared_ptr<ELdestination> dest_ctrl;
+      if (filename == "cout") {
+        dest_ctrl = admin_p->attach(std::make_shared<ELoutput>(std::cout));
+        stream_ps["cout"] = &std::cout;
+      } else if (filename == "cerr") {
+        early_dest->setThreshold(ELzeroSeverity);
+        dest_ctrl = early_dest;
+        stream_ps["cerr"] = &std::cerr;
+      } else {
+        auto os_sp = std::make_shared<std::ofstream>(filename.c_str());
+        file_ps.push_back(os_sp);
+        dest_ctrl = admin_p->attach(std::make_shared<ELoutput>(*os_sp));
+        stream_ps[filename] = os_sp.get();
+      }
+      return dest_ctrl;
+    }
 
     namespace {
       void setGlobalThresholds(ELseverityLevel threshold_sev) {
@@ -231,51 +408,50 @@ namespace edm {
         }
       }
     }  // namespace
-    void ThreadSafeLogMessageLoggerScribe::configure_dest(PSet const& job_pset,
+
+    ThreadSafeLogMessageLoggerScribe::ConfigurableDefaults ThreadSafeLogMessageLoggerScribe::parseDefaults(
+        edm::ParameterSet const& job_pset) {
+      const edm::ParameterSet empty_PSet;
+      ThreadSafeLogMessageLoggerScribe::ConfigurableDefaults returnValue;
+      // grab default limit/interval/timespan common to all destinations/categories:
+      edm::ParameterSet default_pset = getAparameter<edm::ParameterSet>(job_pset, "default", empty_PSet);
+      returnValue.limit_ = getAparameter<int>(
+          default_pset, "limit", ThreadSafeLogMessageLoggerScribe::ConfigurableDefaults::COMMON_DEFAULT_LIMIT);
+      returnValue.reportEvery_ = getAparameter<int>(
+          default_pset, "reportEvery", ThreadSafeLogMessageLoggerScribe::ConfigurableDefaults::COMMON_DEFAULT_INTERVAL);
+      returnValue.timespan_ = getAparameter<int>(
+          default_pset, "timespan", ThreadSafeLogMessageLoggerScribe::ConfigurableDefaults::COMMON_DEFAULT_TIMESPAN);
+      std::string default_threshold = getAparameter<std::string>(job_pset, "threshold", std::string());
+      returnValue.threshold_ = getAparameter<std::string>(default_pset, "threshold", default_threshold);
+      returnValue.noLineBreaks_ = getAparameter<bool>(default_pset, "noLineBreaks", false);
+      returnValue.lineLength_ = getAparameter<int>(default_pset, "lineLength", 80);
+      returnValue.noTimeStamps_ = getAparameter<bool>(default_pset, "noTimeStamps", false);
+
+      return returnValue;
+    }
+
+    void ThreadSafeLogMessageLoggerScribe::configure_dest(edm::ParameterSet const& job_pset,
+                                                          ConfigurableDefaults const& defaults,
+                                                          vString const& categories,
                                                           std::shared_ptr<ELdestination> dest_ctrl,
-                                                          String const& filename) {
-      static const int NO_VALUE_SET = -45654;  // change log 2
-      vString empty_vString;
-      PSet empty_PSet;
-      String empty_String;
+                                                          edm::ParameterSet const& dest_pset,
+                                                          std::string const& filename) {
+      vString const empty_vString;
+      edm::ParameterSet const empty_PSet;
+      std::string const empty_String;
 
       // Defaults:							// change log 3a
       const std::string COMMON_DEFAULT_THRESHOLD = "INFO";
-      const int COMMON_DEFAULT_LIMIT = NO_VALUE_SET;
-      const int COMMON_DEFAULT_INTERVAL = NO_VALUE_SET;  // change log 6
-      const int COMMON_DEFAULT_TIMESPAN = NO_VALUE_SET;
 
       vString const severities = {{"WARNING", "INFO", "FWKINFO", "ERROR", "DEBUG"}};
 
-      // grab list of categories
-      vString categories = getAparameter<vString>(job_pset, "categories", empty_vString);
-
-      // grab list of hardwired categories (hardcats) -- these are to be added
-      // to the list of categories -- change log 24
-      {
-        std::vector<std::string> hardcats = messageLoggerDefaults->categories;
-        // combine the lists, not caring about possible duplicates (for now)
-        copy_all(hardcats, std::back_inserter(categories));
-      }  // no longer need hardcats
-
       // grab default threshold common to all destinations
-      String default_threshold = getAparameter<String>(job_pset, "threshold", empty_String);
+      std::string const default_threshold = getAparameter<std::string>(job_pset, "threshold", empty_String);
       // change log 3a
       // change log 24
 
       // grab default limit/interval/timespan common to all destinations/categories:
-      PSet default_pset = getAparameter<PSet>(job_pset, "default", empty_PSet);
-      int default_limit = getAparameter<int>(default_pset, "limit", COMMON_DEFAULT_LIMIT);
-      int default_interval = getAparameter<int>(default_pset, "reportEvery", COMMON_DEFAULT_INTERVAL);
-      // change log 6, 10
-      int default_timespan = getAparameter<int>(default_pset, "timespan", COMMON_DEFAULT_TIMESPAN);
-      // change log 2a
-      // change log 3a
-      String default_pset_threshold = getAparameter<String>(default_pset, "threshold", default_threshold);
-      // change log 34
-
-      // grab all of this destination's parameters:
-      PSet dest_pset = getAparameter<PSet>(job_pset, filename, empty_PSet);
+      edm::ParameterSet const default_pset = getAparameter<edm::ParameterSet>(job_pset, "default", empty_PSet);
 
       // See if this is just a placeholder			// change log 9
       bool is_placeholder = getAparameter<bool>(dest_pset, "placeholder", false);
@@ -283,33 +459,33 @@ namespace edm {
         return;
 
       // grab this destination's default limit/interval/timespan:
-      PSet dest_default_pset = getAparameter<PSet>(dest_pset, "default", empty_PSet);
-      int dest_default_limit = getAparameter<int>(dest_default_pset, "limit", default_limit);
-      int dest_default_interval = getAparameter<int>(dest_default_pset, "reportEvery", default_interval);
+      edm::ParameterSet dest_default_pset = getAparameter<edm::ParameterSet>(dest_pset, "default", empty_PSet);
+      int dest_default_limit = getAparameter<int>(dest_default_pset, "limit", defaults.limit_);
+      int dest_default_interval = getAparameter<int>(dest_default_pset, "reportEvery", defaults.reportEvery_);
       // change log 6
-      int dest_default_timespan = getAparameter<int>(dest_default_pset, "timespan", default_timespan);
+      int dest_default_timespan = getAparameter<int>(dest_default_pset, "timespan", defaults.timespan_);
       // change log 1a
-      if (dest_default_limit != NO_VALUE_SET) {
+      if (dest_default_limit != defaults.NO_VALUE_SET) {
         if (dest_default_limit < 0)
           dest_default_limit = 2000000000;
         dest_ctrl->setLimit("*", dest_default_limit);
-      }                                             // change log 1b, 2a, 2b
-      if (dest_default_interval != NO_VALUE_SET) {  // change log 6
+      }                                                      // change log 1b, 2a, 2b
+      if (dest_default_interval != defaults.NO_VALUE_SET) {  // change log 6
         dest_ctrl->setInterval("*", dest_default_interval);
       }
-      if (dest_default_timespan != NO_VALUE_SET) {
+      if (dest_default_timespan != defaults.NO_VALUE_SET) {
         if (dest_default_timespan < 0)
           dest_default_timespan = 2000000000;
         dest_ctrl->setTimespan("*", dest_default_timespan);
       }  // change log 1b, 2a, 2b
 
       // establish this destination's threshold:
-      String dest_threshold = getAparameter<String>(dest_pset, "threshold", default_threshold);
+      std::string dest_threshold = getAparameter<std::string>(dest_pset, "threshold", default_threshold);
       if (dest_threshold == empty_String) {
         dest_threshold = default_threshold;
       }
       if (dest_threshold == empty_String) {  // change log 34
-        dest_threshold = default_pset_threshold;
+        dest_threshold = defaults.threshold_;
       }
       if (dest_threshold == empty_String) {
         dest_threshold = messageLoggerDefaults->threshold(filename);
@@ -323,46 +499,47 @@ namespace edm {
 
       // establish this destination's limit/interval/timespan for each category:
       for (vString::const_iterator id_it = categories.begin(); id_it != categories.end(); ++id_it) {
-        String msgID = *id_it;
-        PSet default_category_pset = getAparameter<PSet>(default_pset, msgID, empty_PSet);  // change log 5
-        PSet category_pset = getAparameter<PSet>(dest_pset, msgID, default_category_pset);
+        std::string msgID = *id_it;
+        edm::ParameterSet default_category_pset =
+            getAparameter<edm::ParameterSet>(default_pset, msgID, empty_PSet);  // change log 5
+        edm::ParameterSet category_pset = getAparameter<edm::ParameterSet>(dest_pset, msgID, default_category_pset);
 
-        int category_default_limit = getAparameter<int>(default_category_pset, "limit", NO_VALUE_SET);
+        int category_default_limit = getAparameter<int>(default_category_pset, "limit", defaults.NO_VALUE_SET);
         int limit = getAparameter<int>(category_pset, "limit", category_default_limit);
-        if (limit == NO_VALUE_SET)
+        if (limit == defaults.NO_VALUE_SET)
           limit = dest_default_limit;
         // change log 7
-        int category_default_interval = getAparameter<int>(default_category_pset, "reportEvery", NO_VALUE_SET);
+        int category_default_interval = getAparameter<int>(default_category_pset, "reportEvery", defaults.NO_VALUE_SET);
         int interval = getAparameter<int>(category_pset, "reportEvery", category_default_interval);
-        if (interval == NO_VALUE_SET)
+        if (interval == defaults.NO_VALUE_SET)
           interval = dest_default_interval;
         // change log 6  and then 7
-        int category_default_timespan = getAparameter<int>(default_category_pset, "timespan", NO_VALUE_SET);
+        int category_default_timespan = getAparameter<int>(default_category_pset, "timespan", defaults.NO_VALUE_SET);
         int timespan = getAparameter<int>(category_pset, "timespan", category_default_timespan);
-        if (timespan == NO_VALUE_SET)
+        if (timespan == defaults.NO_VALUE_SET)
           timespan = dest_default_timespan;
         // change log 7
 
         const std::string& category = msgID;
-        if (limit == NO_VALUE_SET) {  // change log 24
+        if (limit == defaults.NO_VALUE_SET) {  // change log 24
           limit = messageLoggerDefaults->limit(filename, category);
         }
-        if (interval == NO_VALUE_SET) {  // change log 24
+        if (interval == defaults.NO_VALUE_SET) {  // change log 24
           interval = messageLoggerDefaults->reportEvery(filename, category);
         }
-        if (timespan == NO_VALUE_SET) {  // change log 24
+        if (timespan == defaults.NO_VALUE_SET) {  // change log 24
           timespan = messageLoggerDefaults->timespan(filename, category);
         }
 
-        if (limit != NO_VALUE_SET) {
+        if (limit != defaults.NO_VALUE_SET) {
           if (limit < 0)
             limit = 2000000000;
           dest_ctrl->setLimit(msgID, limit);
         }  // change log 2a, 2b
-        if (interval != NO_VALUE_SET) {
+        if (interval != defaults.NO_VALUE_SET) {
           dest_ctrl->setInterval(msgID, interval);
         }  // change log 6
-        if (timespan != NO_VALUE_SET) {
+        if (timespan != defaults.NO_VALUE_SET) {
           if (timespan < 0)
             timespan = 2000000000;
           dest_ctrl->setTimespan(msgID, timespan);
@@ -372,32 +549,32 @@ namespace edm {
 
       // establish this destination's limit for each severity:
       for (vString::const_iterator sev_it = severities.begin(); sev_it != severities.end(); ++sev_it) {
-        String sevID = *sev_it;
+        std::string sevID = *sev_it;
         ELseverityLevel severity(sevID);
-        PSet default_sev_pset = getAparameter<PSet>(default_pset, sevID, empty_PSet);
-        PSet sev_pset = getAparameter<PSet>(dest_pset, sevID, default_sev_pset);
+        edm::ParameterSet default_sev_pset = getAparameter<edm::ParameterSet>(default_pset, sevID, empty_PSet);
+        edm::ParameterSet sev_pset = getAparameter<edm::ParameterSet>(dest_pset, sevID, default_sev_pset);
         // change log 5
-        int limit = getAparameter<int>(sev_pset, "limit", NO_VALUE_SET);
-        if (limit == NO_VALUE_SET) {  // change log 24
+        int limit = getAparameter<int>(sev_pset, "limit", defaults.NO_VALUE_SET);
+        if (limit == defaults.NO_VALUE_SET) {  // change log 24
           limit = messageLoggerDefaults->sev_limit(filename, sevID);
         }
-        if (limit != NO_VALUE_SET) {
+        if (limit != defaults.NO_VALUE_SET) {
           if (limit < 0)
             limit = 2000000000;  // change log 38
           dest_ctrl->setLimit(severity, limit);
         }
-        int interval = getAparameter<int>(sev_pset, "reportEvery", NO_VALUE_SET);
-        if (interval == NO_VALUE_SET) {  // change log 24
+        int interval = getAparameter<int>(sev_pset, "reportEvery", defaults.NO_VALUE_SET);
+        if (interval == defaults.NO_VALUE_SET) {  // change log 24
           interval = messageLoggerDefaults->sev_reportEvery(filename, sevID);
         }
-        if (interval != NO_VALUE_SET)
+        if (interval != defaults.NO_VALUE_SET)
           dest_ctrl->setInterval(severity, interval);
         // change log 2
-        int timespan = getAparameter<int>(sev_pset, "timespan", NO_VALUE_SET);
-        if (timespan == NO_VALUE_SET) {  // change log 24
+        int timespan = getAparameter<int>(sev_pset, "timespan", defaults.NO_VALUE_SET);
+        if (timespan == defaults.NO_VALUE_SET) {  // change log 24
           timespan = messageLoggerDefaults->sev_timespan(filename, sevID);
         }
-        if (timespan != NO_VALUE_SET) {
+        if (timespan != defaults.NO_VALUE_SET) {
           if (timespan < 0)
             timespan = 2000000000;  // change log 38
           dest_ctrl->setTimespan(severity, timespan);
@@ -405,35 +582,31 @@ namespace edm {
       }  // for
 
       // establish this destination's linebreak policy:
-      bool noLineBreaks_default = getAparameter<bool>(default_pset, "noLineBreaks", false);
       // change log 5
-      bool noLineBreaks = getAparameter<bool>(dest_pset, "noLineBreaks", noLineBreaks_default);
+      bool noLineBreaks = getAparameter<bool>(dest_pset, "noLineBreaks", defaults.noLineBreaks_);
       if (noLineBreaks) {
         dest_ctrl->setLineLength(32000);
       } else {
-        int lenDef = 80;
-        int lineLen_default = getAparameter<int>(default_pset, "lineLength", lenDef);
         // change log 5
-        int lineLen = getAparameter<int>(dest_pset, "lineLength", lineLen_default);
-        if (lineLen != lenDef) {
+        int lineLen = getAparameter<int>(dest_pset, "lineLength", defaults.lineLength_);
+        if (lineLen != 80) {
           dest_ctrl->setLineLength(lineLen);
         }
       }
 
       // if indicated, suppress time stamps in this destination's output
-      bool suppressTime_default = getAparameter<bool>(default_pset, "noTimeStamps", false);
-      bool suppressTime = getAparameter<bool>(dest_pset, "noTimeStamps", suppressTime_default);
+      bool suppressTime = getAparameter<bool>(dest_pset, "noTimeStamps", defaults.noTimeStamps_);
       if (suppressTime) {
         dest_ctrl->suppressTime();
       }
 
     }  // ThreadSafeLogMessageLoggerScribe::configure_dest()
 
-    void ThreadSafeLogMessageLoggerScribe::configure_ordinary_destinations(PSet const& job_pset)  // Changelog 16
-    {
-      vString empty_vString;
-      String empty_String;
-      PSet empty_PSet;
+    std::vector<std::string> ThreadSafeLogMessageLoggerScribe::configure_ordinary_destinations(
+        edm::ParameterSet const& job_pset, ConfigurableDefaults const& defaults, vString const& categories) {
+      vString const empty_vString;
+      std::string const empty_String;
+      edm::ParameterSet const empty_PSet;
 
       // Initialize unversal suppression variables
       MessageDrop::debugAlwaysSuppressed = true;
@@ -455,12 +628,13 @@ namespace edm {
         early_dest->setThreshold(ELhighestSeverity);
 
       // establish each destination:
+      std::vector<std::string> ordinary_destination_filenames;
       for (vString::const_iterator it = destinations.begin(); it != destinations.end(); ++it) {
-        String filename = *it;
-        String psetname = filename;
+        std::string filename = *it;
+        std::string psetname = filename;
 
         // check that this destination is not just a placeholder // change log 11
-        PSet dest_pset = getAparameter<PSet>(job_pset, psetname, empty_PSet);
+        edm::ParameterSet dest_pset = getAparameter<edm::ParameterSet>(job_pset, psetname, empty_PSet);
         bool is_placeholder = getAparameter<bool>(dest_pset, "placeholder", false);
         if (is_placeholder)
           continue;
@@ -475,38 +649,7 @@ namespace edm {
         // an extension() method.  We recognize the potential name confusion here
         // (filename(filename))!
 
-        // Determine the destination file name to use if no explicit filename is
-        // supplied in the cfg.
-        String filename_default = getAparameter<String>(dest_pset, "output", empty_String);
-        if (filename_default == empty_String) {
-          filename_default = messageLoggerDefaults->output(psetname);  // change log 31
-          if (filename_default == empty_String) {
-            filename_default = filename;
-          }
-        }
-
-        String explicit_filename = getAparameter<String>(dest_pset, "filename", filename_default);
-        if (explicit_filename != empty_String)
-          filename = explicit_filename;
-        String explicit_extension = getAparameter<String>(dest_pset, "extension", empty_String);
-        if (explicit_extension != empty_String) {
-          if (explicit_extension[0] == '.') {
-            filename += explicit_extension;
-          } else {
-            filename = filename + "." + explicit_extension;
-          }
-        }
-
-        // Attach a default extension of .log if there is no extension on a file
-        // change log 18 - this had been done in concert with attaching destination
-
-        std::string actual_filename = filename;  // change log 4
-        if ((filename != "cout") && (filename != "cerr")) {
-          const std::string::size_type npos = std::string::npos;
-          if (filename.find('.') == npos) {
-            actual_filename += ".log";
-          }
-        }
+        auto const actual_filename = destinationFileName(dest_pset, psetname);
 
         // Check that this is not a duplicate name			// change log 18
         if (stream_ps.find(actual_filename) != stream_ps.end()) {
@@ -527,32 +670,22 @@ namespace edm {
         ordinary_destination_filenames.push_back(actual_filename);
 
         // attach the current destination, keeping a control handle to it:
-        std::shared_ptr<ELdestination> dest_ctrl;
-        if (actual_filename == "cout") {
-          dest_ctrl = admin_p->attach(std::make_shared<ELoutput>(std::cout));
-          stream_ps["cout"] = &std::cout;
-        } else if (actual_filename == "cerr") {
-          early_dest->setThreshold(ELzeroSeverity);
-          dest_ctrl = early_dest;
-          stream_ps["cerr"] = &std::cerr;
-        } else {
-          auto os_sp = std::make_shared<std::ofstream>(actual_filename.c_str());
-          file_ps.push_back(os_sp);
-          dest_ctrl = admin_p->attach(std::make_shared<ELoutput>(*os_sp));
-          stream_ps[actual_filename] = os_sp.get();
-        }
-
+        std::shared_ptr<ELdestination> dest_ctrl = makeDestinationCtrl(actual_filename);
         // now configure this destination:
-        configure_dest(job_pset, dest_ctrl, psetname);
+        configure_dest(job_pset, defaults, categories, dest_ctrl, dest_pset, psetname);
 
       }  // for [it = destinations.begin() to end()]
 
+      return ordinary_destination_filenames;
     }  // configure_ordinary_destinations
 
-    void ThreadSafeLogMessageLoggerScribe::configure_statistics(PSet const& job_pset) {
-      vString empty_vString;
-      String empty_String;
-      PSet empty_PSet;
+    void ThreadSafeLogMessageLoggerScribe::configure_statistics(edm::ParameterSet const& job_pset,
+                                                                ConfigurableDefaults const& defaults,
+                                                                vString const& categories,
+                                                                vString const& ordinary_destination_filenames) {
+      vString const empty_vString;
+      std::string const empty_String;
+      edm::ParameterSet const empty_PSet;
 
       // grab list of statistics destinations:
       vString statistics = getAparameter<vString>(job_pset, "statistics", empty_vString);
@@ -570,7 +703,7 @@ namespace edm {
           no_statistics_configured = statistics.empty();
         } else {
           for (auto const& dest : destinations) {
-            PSet stat_pset = getAparameter<PSet>(job_pset, dest, empty_PSet);
+            edm::ParameterSet stat_pset = getAparameter<edm::ParameterSet>(job_pset, dest, empty_PSet);
             if (getAparameter<bool>(stat_pset, "enableStatistics", false)) {
               statistics.push_back(dest);
             }
@@ -580,17 +713,17 @@ namespace edm {
 
       // establish each statistics destination:
       for (vString::const_iterator it = statistics.begin(); it != statistics.end(); ++it) {
-        String statname = *it;
-        const String& psetname = statname;
+        std::string statname = *it;
+        const std::string& psetname = statname;
 
         // check that this destination is not just a placeholder // change log 20
-        PSet stat_pset = getAparameter<PSet>(job_pset, psetname, empty_PSet);
+        edm::ParameterSet stat_pset = getAparameter<edm::ParameterSet>(job_pset, psetname, empty_PSet);
         bool is_placeholder = getAparameter<bool>(stat_pset, "placeholder", false);
         if (is_placeholder)
           continue;
 
         // Determine the destination file name
-        String filename = getAparameter<String>(stat_pset, "output", empty_String);
+        std::string filename = getAparameter<std::string>(stat_pset, "output", empty_String);
         if (filename == empty_String) {
           filename = messageLoggerDefaults->output(psetname);  // change log 31
           if (filename == empty_String) {
@@ -602,10 +735,10 @@ namespace edm {
         // change log 14 -- probably suspenders and a belt, because ouput option
         // is present, but uniformity is nice.
 
-        String explicit_filename = getAparameter<String>(stat_pset, "filename", filename);
+        std::string explicit_filename = getAparameter<std::string>(stat_pset, "filename", filename);
         if (explicit_filename != empty_String)
           filename = explicit_filename;
-        String explicit_extension = getAparameter<String>(stat_pset, "extension", empty_String);
+        std::string explicit_extension = getAparameter<std::string>(stat_pset, "extension", empty_String);
         if (explicit_extension != empty_String) {
           if (explicit_extension[0] == '.') {
             filename += explicit_extension;
@@ -670,16 +803,17 @@ namespace edm {
           admin_p->attach(stat);
           statisticsDestControls.push_back(stat);
           bool reset = getAparameter<bool>(stat_pset, "resetStatistics", false);
-          if(not reset) {
+          if (not reset) {
             //check for old syntax
             reset = getAparameter<bool>(stat_pset, "reset", false);
           }
           statisticsResets.push_back(reset);
 
           // now configure this destination:
-          configure_dest(job_pset, stat, psetname);
+          edm::ParameterSet dest_pset = getAparameter<edm::ParameterSet>(job_pset, psetname, empty_PSet);
+          configure_dest(job_pset, defaults, categories, stat, dest_pset, psetname);
 
-          String dest_threshold = getAparameter<String>(stat_pset, "statisticsThreshold", empty_String);
+          std::string dest_threshold = getAparameter<std::string>(stat_pset, "statisticsThreshold", empty_String);
           if (dest_threshold != empty_String) {
             ELseverityLevel threshold_sev(dest_threshold);
             stat->setThreshold(threshold_sev);
@@ -727,6 +861,105 @@ namespace edm {
       } else {
         statisticsDestControls[0]->summaryForJobReport(sm);
       }
+    }
+
+    namespace {
+      void fillDescriptions(edm::ConfigurationDescriptions& config) {
+        edm::ParameterSetDescription topDesc;
+
+        topDesc.addUntracked<bool>("messageSummaryToJobReport", false);
+        topDesc.addUntracked<std::string>("generate_preconfiguration_message", "");
+        topDesc.addUntracked<unsigned int>("waiting_threshold", 100);
+        topDesc.addUntracked<std::vector<std::string>>("suppressDebug", {});
+        topDesc.addUntracked<std::vector<std::string>>("suppressInfo", {});
+        topDesc.addUntracked<std::vector<std::string>>("suppressFwkInfo", {});
+        topDesc.addUntracked<std::vector<std::string>>("suppressWarning", {});
+        topDesc.addUntracked<std::vector<std::string>>("suppressError", {});
+        topDesc.addUntracked<std::vector<std::string>>("debugModules", {});
+
+        edm::ParameterSetDescription category;
+        category.addUntracked<int>("reportEvery", 1);
+        category.addUntracked<int>("limit", -1);
+        category.addOptionalUntracked<int>("timespan");
+
+        edm::ParameterSetDescription destination_base;
+        destination_base.addUntracked<bool>("noLineBreaks", false);
+        destination_base.addUntracked<bool>("noTimeStamps", false);
+        destination_base.addUntracked<int>("lineLength", -1);
+        destination_base.addUntracked<std::string>("threshold", "INFO");
+        destination_base.addUntracked<std::string>("statisticsThreshold", "INFO");
+
+        /*
+    destination_base.addUntracked<edm::ParameterSetDescription>("DEBUG",category);
+    destination_base.addUntracked<edm::ParameterSetDescription>("INFO", category);
+    destination_base.addUntracked<edm::ParameterSetDescription>("FWKINFO",category);
+    destination_base.addUntracked<edm::ParameterSetDescription>("WARNING",category);
+    destination_base.addUntracked<edm::ParameterSetDescription>("ERROR",category);
+    */
+
+        edm::ParameterWildcard<edm::ParameterSetDescription> catnode("*", edm::RequireZeroOrMore, false, category);
+        catnode.setComment("Specialize either a category or any of 'DEBUG', 'INFO', 'FWKINFO', 'WARNING' or 'ERROR'");
+        //destination_base.addWildcardUntracked<edm::ParameterSetDescription>(category);
+        destination_base.addNode(catnode);
+
+        edm::ParameterSetDescription destination_noStats(destination_base);
+        destination_noStats.addUntracked<bool>("enableStatistics", false);
+
+        {
+          edm::ParameterSetDescription default_pset;
+          default_pset.addUntracked<int>("reportEvery", 1);
+          default_pset.addUntracked<int>("limit", -1);
+          default_pset.addOptionalUntracked<int>("timespan");
+          default_pset.addUntracked<bool>("noLineBreaks", false);
+          default_pset.addUntracked<bool>("noTimeStamps", false);
+          default_pset.addUntracked<int>("lineLength", -1);
+          default_pset.addUntracked<std::string>("threshold", "INFO");
+          default_pset.addUntracked<std::string>("statisticsThreshold", "INFO");
+
+          edm::ParameterSetDescription cerr_destination(destination_base);
+          cerr_destination.addUntracked<bool>("enableStatistics", true);
+          cerr_destination.addUntracked<bool>("enable", true);
+          //topDesc.addUntracked<edm::ParameterSetDescription>("cerr",cerr_destination);
+
+          edm::ParameterSetDescription cout_destination(destination_noStats);
+          cout_destination.addUntracked<bool>("enable", false);
+          //topDesc.addUntracked<edm::ParameterSetDescription>("cout",cout_destination);
+
+          edm::ParameterSetDescription fileDestination(destination_noStats);
+
+          fileDestination.addOptionalUntracked<std::string>("output");
+          fileDestination.addOptionalUntracked<std::string>("filename");
+          fileDestination.addOptionalUntracked<std::string>("extension");
+          edm::ParameterSetDescription files;
+          edm::ParameterWildcard<edm::ParameterSetDescription> fileWildcard(
+              "*", edm::RequireZeroOrMore, false, fileDestination);
+          files.addNode(fileWildcard);
+
+          std::map<std::string, edm::ParameterSetDescription> standards = {
+              {"cerr", cerr_destination}, {"cout", cout_destination}, {"default", default_pset}, {"files", files}};
+
+          edm::ParameterWildcardWithSpecifics psets("*", edm::RequireZeroOrMore, false, category, std::move(standards));
+          topDesc.addNode(psets);
+        }
+
+        config.addDefault(topDesc);
+      }
+    }  // namespace
+
+    void ThreadSafeLogMessageLoggerScribe::validate(edm::ParameterSet& pset) const {
+      // See if old config API is being used
+      if (usingOldConfig(pset))
+        return;
+      if (not pset.exists("files") and
+          ((pset.exists("destinations") or pset.existsAs<std::vector<std::string>>("statistics", true) or
+            pset.existsAs<std::vector<std::string>>("statistics", false) or pset.exists("categories")))) {
+        return;
+      }
+
+      ConfigurationDescriptions config{"MessageLogger", "MessageLogger"};
+      fillDescriptions(config);
+
+      config.validate(pset, "MessageLogger");
     }
 
   }  // end of namespace service

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -50,7 +50,6 @@ namespace edm {
       void runCommand(MessageLoggerQ::OpCode opcode, void* operand) override;
       // changeLog 9
 
-    private:
       struct ConfigurableDefaults {
         static constexpr int NO_VALUE_SET = -45654;
         static constexpr int COMMON_DEFAULT_LIMIT = NO_VALUE_SET;
@@ -66,6 +65,7 @@ namespace edm {
         bool noTimeStamps_;
       };
 
+    private:
       static ConfigurableDefaults parseDefaults(edm::ParameterSet const& job_pset);
 
       // --- convenience typedefs
@@ -88,6 +88,12 @@ namespace edm {
                                 ConfigurableDefaults const& defaults,
                                 vString const& categories,
                                 std::vector<std::string> const& destination_names);
+      void configure_statistics_dest(edm::ParameterSet const& job_pset,
+                                     ConfigurableDefaults const& defaults,
+                                     vString const& categories,
+                                     edm::ParameterSet const& stat_pset,
+                                     std::string const& psetname,
+                                     std::string const& filename);
       void configure_dest(edm::ParameterSet const& job_pset,
                           ConfigurableDefaults const&,
                           vString const& categories,

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -119,17 +119,17 @@ namespace edm {
 
       void validate(edm::ParameterSet&) const;
       // --- data:
-      edm::propagate_const<std::shared_ptr<ELadministrator>> admin_p;
-      std::shared_ptr<ELdestination> early_dest;
-      std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> file_ps;
-      std::map<std::string, edm::propagate_const<std::ostream*>> stream_ps;
-      std::vector<std::shared_ptr<ELstatistics>> statisticsDestControls;
-      std::vector<bool> statisticsResets;
-      bool clean_slate_configuration;
-      value_ptr<MessageLoggerDefaults> messageLoggerDefaults;
-      bool active;
-      std::atomic<bool> purge_mode;  // changeLog 9
-      std::atomic<int> count;        // changeLog 9
+      edm::propagate_const<std::shared_ptr<ELadministrator>> m_admin_p;
+      std::shared_ptr<ELdestination> m_early_dest;
+      std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> m_file_ps;
+      std::map<std::string, edm::propagate_const<std::ostream*>> m_stream_ps;
+      std::vector<std::shared_ptr<ELstatistics>> m_statisticsDestControls;
+      std::vector<bool> m_statisticsResets;
+      bool m_clean_slate_configuration;
+      value_ptr<MessageLoggerDefaults> m_messageLoggerDefaults;
+      bool m_active;
+      std::atomic<bool> m_purge_mode;
+      std::atomic<int> m_count;
       std::atomic<bool> m_messageBeingSent;
       tbb::concurrent_queue<ErrorObj*> m_waitingMessages;
       size_t m_waitingThreshold;

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -51,10 +51,25 @@ namespace edm {
       // changeLog 9
 
     private:
+      struct ConfigurableDefaults {
+        static constexpr int NO_VALUE_SET = -45654;
+        static constexpr int COMMON_DEFAULT_LIMIT = NO_VALUE_SET;
+        static constexpr int COMMON_DEFAULT_INTERVAL = NO_VALUE_SET;
+        static constexpr int COMMON_DEFAULT_TIMESPAN = NO_VALUE_SET;
+
+        std::string threshold_;
+        int limit_;
+        int reportEvery_;
+        int timespan_;
+        int lineLength_;
+        bool noLineBreaks_;
+        bool noTimeStamps_;
+      };
+
+      static ConfigurableDefaults parseDefaults(edm::ParameterSet const& job_pset);
+
       // --- convenience typedefs
-      typedef std::string String;
-      typedef std::vector<String> vString;
-      typedef ParameterSet PSet;
+      using vString = std::vector<std::string>;
 
       // --- log one consumed message
       void log(ErrorObj* errorobj_p);
@@ -64,13 +79,24 @@ namespace edm {
       void triggerFJRmessageSummary(std::map<std::string, double>& sm);
 
       // --- handle details of configuring via a ParameterSet:
-      void configure_errorlog(PSet&);
-      void configure_ordinary_destinations(PSet const&);  // Change Log 3
-      void configure_statistics(PSet const&);             // Change Log 3
-      void configure_dest(PSet const&, std::shared_ptr<ELdestination> dest_ctrl, String const& filename);
+      void configure_errorlog(edm::ParameterSet&);
+      void configure_errorlog_new(edm::ParameterSet&);
+      std::vector<std::string> configure_ordinary_destinations(edm::ParameterSet const&,
+                                                               ConfigurableDefaults const& defaults,
+                                                               vString const& categories);
+      void configure_statistics(edm::ParameterSet const&,
+                                ConfigurableDefaults const& defaults,
+                                vString const& categories,
+                                std::vector<std::string> const& destination_names);
+      void configure_dest(edm::ParameterSet const& job_pset,
+                          ConfigurableDefaults const&,
+                          vString const& categories,
+                          std::shared_ptr<ELdestination> dest_ctrl,
+                          edm::ParameterSet const& dest_pset,
+                          std::string const& filename);
 
-      template <class T>  // ChangeLog 11
-      T getAparameter(PSet const& p, std::string const& id, T const& def) {
+      template <class T>
+      static T getAparameter(edm::ParameterSet const& p, std::string const& id, T const& def) {
         T t = def;
         try {
           t = p.template getUntrackedParameter<T>(id, def);
@@ -88,13 +114,15 @@ namespace edm {
 
       // --- other helpers
       void parseCategories(std::string const& s, std::vector<std::string>& cats);
+      std::string destinationFileName(edm::ParameterSet const&, std::string const&) const;
+      std::shared_ptr<ELdestination> makeDestinationCtrl(std::string const& filename);
 
+      void validate(edm::ParameterSet&) const;
       // --- data:
       edm::propagate_const<std::shared_ptr<ELadministrator>> admin_p;
       std::shared_ptr<ELdestination> early_dest;
       std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> file_ps;
-      std::map<String, edm::propagate_const<std::ostream*>> stream_ps;
-      std::vector<String> ordinary_destination_filenames;
+      std::map<std::string, edm::propagate_const<std::ostream*>> stream_ps;
       std::vector<std::shared_ptr<ELstatistics>> statisticsDestControls;
       std::vector<bool> statisticsResets;
       bool clean_slate_configuration;

--- a/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
+++ b/FWCore/MessageService/src/ThreadSafeLogMessageLoggerScribe.h
@@ -64,10 +64,10 @@ namespace edm {
       void triggerFJRmessageSummary(std::map<std::string, double>& sm);
 
       // --- handle details of configuring via a ParameterSet:
-      void configure_errorlog();
-      void configure_ordinary_destinations();  // Change Log 3
-      void configure_statistics();             // Change Log 3
-      void configure_dest(std::shared_ptr<ELdestination> dest_ctrl, String const& filename);
+      void configure_errorlog(PSet&);
+      void configure_ordinary_destinations(PSet const&);  // Change Log 3
+      void configure_statistics(PSet const&);             // Change Log 3
+      void configure_dest(PSet const&, std::shared_ptr<ELdestination> dest_ctrl, String const& filename);
 
       template <class T>  // ChangeLog 11
       T getAparameter(PSet const& p, std::string const& id, T const& def) {
@@ -93,7 +93,6 @@ namespace edm {
       edm::propagate_const<std::shared_ptr<ELadministrator>> admin_p;
       std::shared_ptr<ELdestination> early_dest;
       std::vector<edm::propagate_const<std::shared_ptr<std::ofstream>>> file_ps;
-      edm::propagate_const<std::shared_ptr<PSet>> job_pset_p;
       std::map<String, edm::propagate_const<std::ostream*>> stream_ps;
       std::vector<String> ordinary_destination_filenames;
       std::vector<std::shared_ptr<ELstatistics>> statisticsDestControls;

--- a/FWCore/MessageService/test/PsetValidationSamples/cat_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/cat_cfg.py
@@ -13,8 +13,7 @@ process.load("FWCore.MessageService.test.Services_cff")
 process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
-                   'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y' ), 
+                   'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'),
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B', 'cat_J', 'cat_K'),
 
@@ -75,7 +74,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -89,6 +89,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/categories_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/categories_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
         
 #enable one of the following -- the first should pass, the rest fail
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
@@ -43,7 +42,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -57,6 +57,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/debugModules_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/debugModules_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B'),
         
@@ -42,7 +41,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -56,6 +56,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/dest_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/dest_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y' ), 
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B'),
  
@@ -61,7 +60,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -75,6 +75,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/fwkJRlist_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/fwkJRlist_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
         
    
     u1_infos = cms.untracked.PSet(
@@ -29,7 +28,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -43,6 +43,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/statlist_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/statlist_cfg.py
@@ -1,5 +1,5 @@
 # Test of a feature of PSet validation:
-#   The vstring statistics list
+#   The  statistics
 
 import FWCore.ParameterSet.Config as cms
 
@@ -15,13 +15,6 @@ process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
         
-#enable one of the following -- the first should pass, the rest fail
-     statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
-#    statistics = cms.vstring('cout'),
-#    statistics = cms.untracked.int32(2),
-#    statistics = cms.untracked.vstring('u1_warnings', 'u1_errors', 'u1_warnings'),
-#    statistics = cms.untracked.vstring('cout','limit'),
-
    
     u1_infos = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
@@ -35,7 +28,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -49,6 +43,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/suppress_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/suppress_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B'),
     debugModules = cms.untracked.vstring('*'),
@@ -44,7 +43,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -58,6 +58,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/vstring_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/vstring_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B'),
     debugModules = cms.untracked.vstring('*'),
@@ -36,7 +35,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -50,6 +50,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/PsetValidationSamples/xPSet_cfg.py
+++ b/FWCore/MessageService/test/PsetValidationSamples/xPSet_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
 
     destinations = cms.untracked.vstring( 'u1_warnings',  'u1_errors',
                    'u1_infos',  'u1_debugs', 'u1_default', 'u1_x'), 
-    statistics = cms.untracked.vstring( 'u1_warnings', 'u1_default', 'u1_y'), 
     categories = cms.untracked.vstring('preEventProcessing','FwkTest',
                                        'cat_A','cat_B'),
     debugModules = cms.untracked.vstring('*'),
@@ -36,7 +35,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_warnings = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+        noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u1_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
@@ -50,6 +50,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     ),
     u1_default = cms.untracked.PSet(
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
+
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/filter-timestamps.sed
+++ b/FWCore/MessageService/test/filter-timestamps.sed
@@ -1,1 +1,1 @@
-s/ [0-9]?[0-9]-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-2[0-9][0-9][0-9] [0-9]?[0-9]:[0-9][0-9]:[0-9][0-9](\.[0-9][0-9][0-9])? [A-Z]?[A-Z][A-Z][A-Z]( |\t|$)/ {Timestamp} /
+s/ [0-9]?[0-9]-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-2[0-9][0-9][0-9] [0-9]?[0-9]:[0-9][0-9]:[0-9][0-9](\.[0-9][0-9][0-9])? [A-Z]?[A-Z][A-Z][A-Z]( |\t|-|$)/ {Timestamp} /

--- a/FWCore/MessageService/test/u10_cfg.py
+++ b/FWCore/MessageService/test/u10_cfg.py
@@ -11,11 +11,15 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u10_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u10_warnings'),
+    files = cms.untracked.PSet(
+        u10_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u11_cfg.py
+++ b/FWCore/MessageService/test/u11_cfg.py
@@ -18,24 +18,8 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u11_supercede_specific = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        int4bydefault = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(10),
-            limit = cms.untracked.int32(-1)
-        ),
-        expect_supercede_specific = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(-1)
-        ),
-        int25bydefaults = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        int7bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     default = cms.untracked.PSet(
         expect_specific = cms.untracked.PSet(
@@ -70,87 +54,92 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u11_overall_specific = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        u11_supercede_specific = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            int4bydefault = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(10),
+                limit = cms.untracked.int32(-1)
+            ),
+            expect_supercede_specific = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(1),
+                limit = cms.untracked.int32(-1)
+            ),
+            int25bydefaults = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            int7bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        int4bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u11_overall_specific = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            int4bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_overall_specific = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(1),
+                limit = cms.untracked.int32(-1)
+            ),
+            int25bydefaults = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        expect_overall_specific = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(-1)
+        u11_non_supercede_common = cms.untracked.PSet(
+            int4bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_non_supercede_common_specific = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(1),
+                limit = cms.untracked.int32(-1)
+            ),
+            default = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(18),
+                limit = cms.untracked.int32(3)
+            ),
+            int25bydefaults = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        int25bydefaults = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u11_specific = cms.untracked.PSet(
+            int4bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_specific = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(1),
+                limit = cms.untracked.int32(-1)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(30)
+            ),
+            int25bydefaults = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(12)
+            ),
+            int7bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        ),
+        u11_overall_unnamed = cms.untracked.PSet(
+            int4bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            int25bydefaults = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            int7bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_overall_unnamed = cms.untracked.PSet(
+                reportEvery = cms.untracked.int32(1),
+                limit = cms.untracked.int32(-1)
+            )
         )
-    ),
-    u11_non_supercede_common = cms.untracked.PSet(
-        int4bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        expect_non_supercede_common_specific = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(-1)
-        ),
-        default = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(18),
-            limit = cms.untracked.int32(3)
-        ),
-        int25bydefaults = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u11_specific = cms.untracked.PSet(
-        int4bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        expect_specific = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(-1)
-        ),
-        noTimeStamps = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(30)
-        ),
-        int25bydefaults = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(12)
-        ),
-        int7bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u11_overall_unnamed = cms.untracked.PSet(
-        int4bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        int25bydefaults = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        int7bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        expect_overall_unnamed = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(-1)
-        )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'int4bydefault', 
-        'int7bycommondefault', 
-        'int25bydefaults', 
-        'expect_overall_unnamed', 
-        'expect_overall_specific', 
-        'expect_supercede_specific', 
-        'expect_non_supercede_common_specific', 
-        'expect_specific', 
-        'FwkReport', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u11_overall_unnamed', 
-        'u11_overall_specific', 
-        'u11_supercede_specific', 
-        'u11_non_supercede_common', 
-        'u11_specific')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u12_cfg.py
+++ b/FWCore/MessageService/test/u12_cfg.py
@@ -11,16 +11,15 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u12_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+      enable = cms.untracked.bool(False)
     ),
-    u12_placeholder = cms.untracked.PSet(
-        placeholder = cms.untracked.bool(True)
-    ),
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u12_warnings', 
-        'u12_placeholder')
+    files = cms.untracked.PSet(
+        u12_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u13_cfg.py
+++ b/FWCore/MessageService/test/u13_cfg.py
@@ -11,38 +11,32 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u13_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
     debugModules = cms.untracked.vstring('*'),
-    u13_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkReport', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u13_infos', 
-        'u13_debugs')
+    files = cms.untracked.PSet(
+        u13_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        ),
+        u13_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u13d_cfg.py
+++ b/FWCore/MessageService/test/u13d_cfg.py
@@ -12,21 +12,24 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u13d_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+      enable = cms.untracked.bool(False)
     ),
-    debugModules = cms.untracked.vstring('*'),
-    u13d_debugs = cms.untracked.PSet(
+    files = cms.untracked.PSet(
+      u13d_infos = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO'),
+          noTimeStamps = cms.untracked.bool(True),
+          FwkReport = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      ),
+      u13d_debugs = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG'),
         noTimeStamps = cms.untracked.bool(True),
         FwkReport = cms.untracked.PSet(
@@ -38,12 +41,9 @@ process.MessageLogger = cms.Service("MessageLogger",
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )
+      )
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkReport', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u13d_infos', 
-        'u13d_debugs')
+    debugModules = cms.untracked.vstring('*'),
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u14_cfg.py
+++ b/FWCore/MessageService/test/u14_cfg.py
@@ -13,41 +13,31 @@ process.load("FWCore.MessageService.test.Services_cff")
 process.MessageLogger = cms.Service("MessageLogger",
     suppressInfo = cms.untracked.vstring('sendSomeMessages'),
     suppressFwkInfo = cms.untracked.vstring('source'),
-    u14_default = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u14_default = cms.untracked.PSet(
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        u14_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        u14_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        u14_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        u14_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True)
         )
     ),
-    u14_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    u14_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u14_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    u14_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u14_warnings',
-        'u14_errors', 
-        'u14_infos', 
-        'u14_debugs', 
-        'u14_default')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u15_cfg.py
+++ b/FWCore/MessageService/test/u15_cfg.py
@@ -12,38 +12,32 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u15_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
     debugModules = cms.untracked.vstring('*'),
-    u15_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkReport', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u15_infos', 
-        'u15_debugs')
+    files = cms.untracked.PSet(
+        u15_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        ),
+        u15_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u16-2warnings_cfg.py
+++ b/FWCore/MessageService/test/u16-2warnings_cfg.py
@@ -12,78 +12,69 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    # produce file u16_statistics.mslog
-    u16_statistics = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mslog'),
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        )
-    ),
-    # produce file u16_job_report.mmxml
-    u16_job_report = cms.untracked.PSet(
-        extension = cms.untracked.string('mmxml')
+    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     default = cms.untracked.PSet(
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )
     ),
-    # produce file u16_errors.mmlog
-    u16_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mmlog'),
-        enableStatistics = cms.untracked.bool(True)
-    ),
-    # produce file u16_altWarnings.log
-    u16_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        filename = cms.untracked.string('u16_altWarnings')
-    ),
-    # produce file u16_default.log
-    u16_default = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        # produce file u16_statistics.mslog
+        u16_statistics = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('mslog'),
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
+        ),
+        # produce file u16_job_report.mmxml
+        u16_job_report = cms.untracked.PSet(
+            extension = cms.untracked.string('mmxml')
+        ),
+        # produce file u16_errors.mmlog
+        u16_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('mmlog'),
+            enableStatistics = cms.untracked.bool(True)
+        ),
+        # produce file u16_altWarnings.log
+        u16_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            filename = cms.untracked.string('u16_altWarnings')
+        ),
+        # produce file u16_default.log
+        u16_default = cms.untracked.PSet(
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        # produce file u16_infos.mmlog
+        u16_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('.mmlog')
+        ),
+        # produce file u16_altDebugs.mmlog
+        u16_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            extension = cms.untracked.string('mmlog'),
+            filename = cms.untracked.string('u16_altDebugs')
+        ),
+        # produce another file u16_altWarnings.log - temporary test
+        u16_warnings2 = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            filename = cms.untracked.string('u16_altWarnings')
         )
-    ),
-    # produce file u16_infos.mmlog
-    u16_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        extension = cms.untracked.string('.mmlog')
-    ),
-    # produce file u16_altDebugs.mmlog
-    u16_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        extension = cms.untracked.string('mmlog'),
-        filename = cms.untracked.string('u16_altDebugs')
-    ),
-    destinations = cms.untracked.vstring('u16_warnings', 
-        'u16_warnings2', 
-        'u16_errors', 
-        'u16_infos', 
-        'u16_debugs', 
-        'u16_default'),
-    debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    # produce another file u16_altWarnings.log - temporary test
-    u16_warnings2 = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        filename = cms.untracked.string('u16_altWarnings')
     )
 )
 

--- a/FWCore/MessageService/test/u16-2warnings_cfg.py
+++ b/FWCore/MessageService/test/u16-2warnings_cfg.py
@@ -12,14 +12,15 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    # put stats into u16_errors.mmlog and another file
-    statistics = cms.untracked.vstring('u16_statistics', 
-        'u16_errors'),
     # produce file u16_statistics.mslog
     u16_statistics = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
         noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mslog')
+        extension = cms.untracked.string('mslog'),
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
     ),
     # produce file u16_job_report.mmxml
     u16_job_report = cms.untracked.PSet(
@@ -34,7 +35,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     u16_errors = cms.untracked.PSet(
         threshold = cms.untracked.string('ERROR'),
         noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mmlog')
+        extension = cms.untracked.string('mmlog'),
+        enableStatistics = cms.untracked.bool(True)
     ),
     # produce file u16_altWarnings.log
     u16_warnings = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u16_cfg.py
+++ b/FWCore/MessageService/test/u16_cfg.py
@@ -12,68 +12,56 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    # produce file u16_statistics.mslog
-    u16_statistics = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        extension = cms.untracked.string('mslog'),
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        )
-    ),
     default = cms.untracked.PSet(
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         )
     ),
-    # produce file u16_errors.mmlog
-    u16_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mmlog'),
-        enableStatistics = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    # produce file u16_altWarnings.log
-    u16_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        filename = cms.untracked.string('u16_altWarnings')
-    ),
-    # produce file u16_default.log
-    u16_default = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        # produce file u16_statistics.mslog
+        u16_statistics = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            extension = cms.untracked.string('mslog'),
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
+        ),
+        # produce file u16_errors.mmlog
+        u16_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('mmlog'),
+            enableStatistics = cms.untracked.bool(True)
+        ),
+        # produce file u16_altWarnings.log
+        u16_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            filename = cms.untracked.string('u16_altWarnings')
+        ),
+        # produce file u16_default.log
+        u16_default = cms.untracked.PSet(
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        # produce file u16_infos.mmlog
+        u16_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('.mmlog')
+        ),
+        # produce file u16_altDebugs.mmlog
+        u16_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('mmlog'),
+            filename = cms.untracked.string('u16_altDebugs')
         )
     ),
-    # produce file u16_infos.mmlog
-    u16_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        extension = cms.untracked.string('.mmlog')
-    ),
-    # produce file u16_altDebugs.mmlog
-    u16_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        extension = cms.untracked.string('mmlog'),
-        filename = cms.untracked.string('u16_altDebugs')
-    ),
-    debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u16_warnings', 
-        'u16_errors', 
-        'u16_infos', 
-        'u16_debugs', 
-        'u16_default',
-        'u16_statistics')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u16_cfg.py
+++ b/FWCore/MessageService/test/u16_cfg.py
@@ -12,13 +12,14 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    # put stats into u16_errors.mmlog and another file
-    statistics = cms.untracked.vstring('u16_statistics', 
-        'u16_errors'),
     # produce file u16_statistics.mslog
     u16_statistics = cms.untracked.PSet(
         threshold = cms.untracked.string('WARNING'),
-        extension = cms.untracked.string('mslog')
+        extension = cms.untracked.string('mslog'),
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
     ),
     default = cms.untracked.PSet(
         FwkTest = cms.untracked.PSet(
@@ -29,7 +30,8 @@ process.MessageLogger = cms.Service("MessageLogger",
     u16_errors = cms.untracked.PSet(
         threshold = cms.untracked.string('ERROR'),
         noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('mmlog')
+        extension = cms.untracked.string('mmlog'),
+        enableStatistics = cms.untracked.bool(True)
     ),
     # produce file u16_altWarnings.log
     u16_warnings = cms.untracked.PSet(
@@ -70,7 +72,8 @@ process.MessageLogger = cms.Service("MessageLogger",
         'u16_errors', 
         'u16_infos', 
         'u16_debugs', 
-        'u16_default')
+        'u16_default',
+        'u16_statistics')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u17_cfg.py
+++ b/FWCore/MessageService/test/u17_cfg.py
@@ -15,14 +15,14 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    statistics = cms.untracked.vstring('u17_all'),
     categories = cms.untracked.vstring('cat_P', 
         'cat_S', 
         'FwkTest',
 	'FwkReport'),
     u17_all = cms.untracked.PSet(
-	threshold = cms.untracked.string('INFO'),
+        threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/u17_cfg.py
+++ b/FWCore/MessageService/test/u17_cfg.py
@@ -15,28 +15,28 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    categories = cms.untracked.vstring('cat_P', 
-        'cat_S', 
-        'FwkTest',
-	'FwkReport'),
-    u17_all = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        enableStatistics = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkReport = cms.untracked.PSet(
-            limit = cms.untracked.int32(110)
-        ),
-        cat_P = cms.untracked.PSet(
-            limit = cms.untracked.int32(2)
-        ),
-        cat_S = cms.untracked.PSet(
-            limit = cms.untracked.int32(2)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u17_all')
+    files = cms.untracked.PSet(
+        u17_all = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            enableStatistics = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(110)
+            ),
+            cat_P = cms.untracked.PSet(
+                limit = cms.untracked.int32(2)
+            ),
+            cat_S = cms.untracked.PSet(
+                limit = cms.untracked.int32(2)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u18_cfg.py
+++ b/FWCore/MessageService/test/u18_cfg.py
@@ -11,23 +11,22 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u18_system = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u18_system = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            noTimeStamps = cms.untracked.bool(True)
         ),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    u18_everything = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u18_everything = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
         )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u18_system', 
-        'u18_everything')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u19_cfg.py
+++ b/FWCore/MessageService/test/u19_cfg.py
@@ -11,32 +11,26 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u19_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
     debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('u19_infos', 
-        'u19_debugs'),
-    u19_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'ridiculously_long_category_name')
+    files = cms.untracked.PSet(
+        u19_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        ),
+        u19_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u19d_cfg.py
+++ b/FWCore/MessageService/test/u19d_cfg.py
@@ -12,32 +12,30 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u19d_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(enable = cms.untracked.bool(False)),
+    files = cms.untracked.PSet(
+      u19d_infos = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO'),
+          noTimeStamps = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      ),
+      u19d_debugs = cms.untracked.PSet(
+          threshold = cms.untracked.string('DEBUG'),
+          noTimeStamps = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      )
     ),
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('u19d_infos', 
-        'u19d_debugs'),
-    u19d_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'ridiculously_long_category_name')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u1_cfg.py
+++ b/FWCore/MessageService/test/u1_cfg.py
@@ -14,51 +14,49 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u1_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u1_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u1_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    u1_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u1_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
         ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u1_default = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u1_debugs = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u1_default = cms.untracked.PSet(
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        ),
+        u1_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True)
         )
-    ),
-    u1_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True)
     ),
     debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u1_warnings', 
-        'u1_errors', 
-        'u1_infos', 
-        'u1_debugs', 
-        'u1_default')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u1d_cfg.py
+++ b/FWCore/MessageService/test/u1d_cfg.py
@@ -15,51 +15,49 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u1d_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+      enable = cms.untracked.bool(False)
     ),
-    u1d_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    files = cms.untracked.PSet(
+      u1d_infos = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO'),
+          noTimeStamps = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      ),
+      u1d_warnings = cms.untracked.PSet(
+          threshold = cms.untracked.string('WARNING'),
+          noTimeStamps = cms.untracked.bool(True)
+      ),
+      u1d_debugs = cms.untracked.PSet(
+          threshold = cms.untracked.string('DEBUG'),
+          noTimeStamps = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      ),
+      u1d_default = cms.untracked.PSet(
+          noTimeStamps = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          ),
+          preEventProcessing = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      ),
+      u1d_errors = cms.untracked.PSet(
+          threshold = cms.untracked.string('ERROR'),
+          noTimeStamps = cms.untracked.bool(True)
+      )
     ),
-    u1d_debugs = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u1d_default = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    u1d_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    debugModules = cms.untracked.vstring('*'),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u1d_warnings', 
-        'u1d_errors', 
-        'u1d_infos', 
-        'u1d_debugs', 
-        'u1d_default')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u21_cfg.py
+++ b/FWCore/MessageService/test/u21_cfg.py
@@ -15,41 +15,40 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u21_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u21_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u21_warnings = cms.untracked.PSet(
+            INFO = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FWKINFO = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            importantInfo = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            threshold = cms.untracked.string('INFO')
         )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'importantInfo', 
-        'routineInfo'),
-    u21_warnings = cms.untracked.PSet(
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FWKINFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        noTimeStamps = cms.untracked.bool(True),
-        importantInfo = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        threshold = cms.untracked.string('INFO')
-    ),
-    destinations = cms.untracked.vstring('u21_warnings', 
-        'u21_infos')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u22_cfg.py
+++ b/FWCore/MessageService/test/u22_cfg.py
@@ -17,19 +17,18 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u22_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u22_warnings')
+    files = cms.untracked.PSet(
+        u22_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u23_cfg.py
+++ b/FWCore/MessageService/test/u23_cfg.py
@@ -16,10 +16,10 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    statistics = cms.untracked.vstring('u23_infos'),
     u23_infos = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/u23_cfg.py
+++ b/FWCore/MessageService/test/u23_cfg.py
@@ -16,22 +16,19 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u23_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        enableStatistics = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'timer', 
-        'trace'),
-    destinations = cms.untracked.vstring('u23_infos')
+    files = cms.untracked.PSet(
+      u23_infos = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO'),
+          noTimeStamps = cms.untracked.bool(True),
+          enableStatistics = cms.untracked.bool(True),
+          FwkTest = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+          )
+      )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u24.sh
+++ b/FWCore/MessageService/test/u24.sh
@@ -9,7 +9,7 @@ status=0
   
 rm -f u24.log  
 
-cmsRun -p $LOCAL_TEST_DIR/u24_cfg.py || exit $?
+cmsRun -p $LOCAL_TEST_DIR/u24_cfg.py && exit $?
  
 for file in u24.log
 do

--- a/FWCore/MessageService/test/u24_cfg.py
+++ b/FWCore/MessageService/test/u24_cfg.py
@@ -16,25 +16,26 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    # produce SAME file u24.log via warnings config - should be ignored!
-    u24_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('log'),
-        filename = cms.untracked.string('u24')
-    ),
     debugModules = cms.untracked.vstring('*'),
-    # produce file u24.log
-    u24_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True),
-        extension = cms.untracked.string('log'),
-        filename = cms.untracked.string('u24')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u24_warnings', 
-        'u24_errors')
+    files = cms.untracked.PSet(
+        # produce SAME file u24.log via warnings config - should cause exception!
+        u24_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('log'),
+            filename = cms.untracked.string('u24')
+        ),
+        # produce file u24.log
+        u24_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True),
+            extension = cms.untracked.string('log'),
+            filename = cms.untracked.string('u24')
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u25_cfg.py
+++ b/FWCore/MessageService/test/u25_cfg.py
@@ -12,21 +12,20 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('u25_only'),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    u25_only = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        enableStatistics = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        ERROR = cms.untracked.PSet(
-            limit = cms.untracked.int32(3)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u25_only = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            enableStatistics = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            ERROR = cms.untracked.PSet(
+                limit = cms.untracked.int32(3)
+            )
         )
     )
 )

--- a/FWCore/MessageService/test/u25_cfg.py
+++ b/FWCore/MessageService/test/u25_cfg.py
@@ -13,12 +13,12 @@ process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
     destinations = cms.untracked.vstring('u25_only'),
-    statistics = cms.untracked.vstring('u25_only'),
     categories = cms.untracked.vstring('preEventProcessing', 
         'FwkTest'),
     u25_only = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/u26_cfg.py
+++ b/FWCore/MessageService/test/u26_cfg.py
@@ -14,11 +14,15 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u26_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u26_warnings')
+    files = cms.untracked.PSet(
+        u26_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u27_cfg.py
+++ b/FWCore/MessageService/test/u27_cfg.py
@@ -20,22 +20,19 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u27_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        enableStatistics = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'timer', 
-        'trace'),
-    destinations = cms.untracked.vstring('u27_infos')
+    files = cms.untracked.PSet(
+        u27_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            enableStatistics = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u27_cfg.py
+++ b/FWCore/MessageService/test/u27_cfg.py
@@ -14,7 +14,6 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    statistics = cms.untracked.vstring('u27_infos'),
     messageSummaryToJobReport = cms.untracked.bool(True),
     default = cms.untracked.PSet(
         FwkTest = cms.untracked.PSet(
@@ -24,6 +23,7 @@ process.MessageLogger = cms.Service("MessageLogger",
     u27_infos = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
         FwkTest = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
         ),

--- a/FWCore/MessageService/test/u28_cerr_cfg.py
+++ b/FWCore/MessageService/test/u28_cerr_cfg.py
@@ -14,18 +14,9 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('cerr'),
     cerr = cms.untracked.PSet(
         statisticsThreshold = cms.untracked.string('WARNING'),
         enableStatistics = cms.untracked.bool(True)
-    ),
-    u28_output = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
     )
 )
 

--- a/FWCore/MessageService/test/u28_cerr_cfg.py
+++ b/FWCore/MessageService/test/u28_cerr_cfg.py
@@ -16,10 +16,9 @@ process.load("FWCore.MessageService.test.Services_cff")
 process.MessageLogger = cms.Service("MessageLogger",
     categories = cms.untracked.vstring('preEventProcessing'),
     destinations = cms.untracked.vstring('cerr'),
-    statistics = cms.untracked.vstring('cerr_stats'),
-    cerr_stats = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        output = cms.untracked.string('cerr')
+    cerr = cms.untracked.PSet(
+        statisticsThreshold = cms.untracked.string('WARNING'),
+        enableStatistics = cms.untracked.bool(True)
     ),
     u28_output = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),

--- a/FWCore/MessageService/test/u28_cfg.py
+++ b/FWCore/MessageService/test/u28_cfg.py
@@ -16,17 +16,14 @@ process.load("FWCore.MessageService.test.Services_cff")
 process.MessageLogger = cms.Service("MessageLogger",
     categories = cms.untracked.vstring('preEventProcessing'),
     destinations = cms.untracked.vstring('u28_output'),
-    statistics = cms.untracked.vstring('u28_statistics'),
-    u28_statistics = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        output = cms.untracked.string('u28_output')
-    ),
     u28_output = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
         preEventProcessing = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
+        ),
+        enableStatistics = cms.untracked.bool(True),
+        statisticsThreshold = cms.untracked.string('WARNING')
     )
 )
 

--- a/FWCore/MessageService/test/u28_cfg.py
+++ b/FWCore/MessageService/test/u28_cfg.py
@@ -14,16 +14,16 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u28_output'),
-    u28_output = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        enableStatistics = cms.untracked.bool(True),
-        statisticsThreshold = cms.untracked.string('WARNING')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+      u28_output = cms.untracked.PSet(
+          threshold = cms.untracked.string('INFO'),
+          noTimeStamps = cms.untracked.bool(True),
+          enableStatistics = cms.untracked.bool(True),
+          statisticsThreshold = cms.untracked.string('WARNING')
+      )
     )
 )
 

--- a/FWCore/MessageService/test/u2_cfg.py
+++ b/FWCore/MessageService/test/u2_cfg.py
@@ -11,12 +11,16 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u2_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u2_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
     ),
     generate_preconfiguration_message = cms.untracked.string('This tests a message generated before configuration'),
-    destinations = cms.untracked.vstring('u2_warnings')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u30Lumi_cfg.py
+++ b/FWCore/MessageService/test/u30Lumi_cfg.py
@@ -13,19 +13,18 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(1000)
         )
     ),
-    u30_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(1000)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u30_infos')
+    files = cms.untracked.PSet(
+        u30_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(1000)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u30_cfg.py
+++ b/FWCore/MessageService/test/u30_cfg.py
@@ -16,19 +16,18 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(1000)
         )
     ),
-    u30_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u30_infos')
+    files = cms.untracked.PSet(
+        u30_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u31_cfg.py
+++ b/FWCore/MessageService/test/u31_cfg.py
@@ -14,22 +14,22 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u31_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        enableStatistics = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'FwkTest', 
-        'timer', 
-        'trace'),
-    destinations = cms.untracked.vstring('u31_infos')
+    files = cms.untracked.PSet(
+        u31_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            preEventProcessing = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            enableStatistics = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u31_cfg.py
+++ b/FWCore/MessageService/test/u31_cfg.py
@@ -14,7 +14,6 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    statistics = cms.untracked.vstring('u31_infos'),
     u31_infos = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO'),
         noTimeStamps = cms.untracked.bool(True),
@@ -23,7 +22,8 @@ process.MessageLogger = cms.Service("MessageLogger",
         ),
         preEventProcessing = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
+        ),
+        enableStatistics = cms.untracked.bool(True)
     ),
     categories = cms.untracked.vstring('preEventProcessing', 
         'FwkTest', 

--- a/FWCore/MessageService/test/u33_cfg.py
+++ b/FWCore/MessageService/test/u33_cfg.py
@@ -10,18 +10,21 @@ import FWCore.Framework.test.cmsExceptionsFatal_cff
 process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 
 process.MessageLogger = cms.Service("MessageLogger",
-   destinations = cms.untracked.vstring('u33_all'),
-    categories = cms.untracked.vstring('cat_A'), 
     suppressInfo = cms.untracked.vstring('ssm_2a'), 
-    debugModules = cms.untracked.vstring('ssm_1b'), 
-    u33_all = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-                    limit = cms.untracked.int32(-1)
-        ),
-        enableStatistics = cms.untracked.bool(True)
+    debugModules = cms.untracked.vstring('ssm_1b'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
+    files = cms.untracked.PSet(
+        u33_all = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+                        limit = cms.untracked.int32(-1)
+            ),
+            enableStatistics = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u33_cfg.py
+++ b/FWCore/MessageService/test/u33_cfg.py
@@ -11,7 +11,6 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 
 process.MessageLogger = cms.Service("MessageLogger",
    destinations = cms.untracked.vstring('u33_all'),
-    statistics = cms.untracked.vstring('u33_all'),
     categories = cms.untracked.vstring('cat_A'), 
     suppressInfo = cms.untracked.vstring('ssm_2a'), 
     debugModules = cms.untracked.vstring('ssm_1b'), 
@@ -21,6 +20,7 @@ process.MessageLogger = cms.Service("MessageLogger",
         default = cms.untracked.PSet(
                     limit = cms.untracked.int32(-1)
         ),
+        enableStatistics = cms.untracked.bool(True)
     ),
 )
 

--- a/FWCore/MessageService/test/u33d_cfg.py
+++ b/FWCore/MessageService/test/u33d_cfg.py
@@ -11,7 +11,6 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 
 process.MessageLogger = cms.Service("MessageLogger",
    destinations = cms.untracked.vstring('u33d_all'),
-    statistics = cms.untracked.vstring('u33d_all'),
     categories = cms.untracked.vstring('cat_A'), 
     suppressInfo = cms.untracked.vstring('ssm_2a'), 
     debugModules = cms.untracked.vstring('ssm_1b'), 
@@ -21,6 +20,7 @@ process.MessageLogger = cms.Service("MessageLogger",
         default = cms.untracked.PSet(
                     limit = cms.untracked.int32(-1)
         ),
+        enableStatistics = cms.untracked.bool(True)
     ),
 )
 

--- a/FWCore/MessageService/test/u33d_cfg.py
+++ b/FWCore/MessageService/test/u33d_cfg.py
@@ -10,18 +10,21 @@ import FWCore.Framework.test.cmsExceptionsFatal_cff
 process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 
 process.MessageLogger = cms.Service("MessageLogger",
-   destinations = cms.untracked.vstring('u33d_all'),
-    categories = cms.untracked.vstring('cat_A'), 
-    suppressInfo = cms.untracked.vstring('ssm_2a'), 
-    debugModules = cms.untracked.vstring('ssm_1b'), 
-    u33d_all = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        noTimeStamps = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-                    limit = cms.untracked.int32(-1)
-        ),
-        enableStatistics = cms.untracked.bool(True)
+    suppressInfo = cms.untracked.vstring('ssm_2a'),
+    debugModules = cms.untracked.vstring('ssm_1b'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
     ),
+    files = cms.untracked.PSet(
+        u33d_all = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG'),
+            noTimeStamps = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+                        limit = cms.untracked.int32(-1)
+            ),
+            enableStatistics = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u34_cfg.py
+++ b/FWCore/MessageService/test/u34_cfg.py
@@ -15,11 +15,14 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u34_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u34_warnings',
+    files = cms.untracked.PSet(
+        u34_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
     )
 )
 

--- a/FWCore/MessageService/test/u35_cfg.py
+++ b/FWCore/MessageService/test/u35_cfg.py
@@ -14,16 +14,18 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u35_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    u35_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    destinations = cms.untracked.vstring('u35_warnings',
-    					 'u35_infos'
+    files = cms.untracked.PSet(
+        u35_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        ),
+        u35_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
     )
 )
 

--- a/FWCore/MessageService/test/u36_cfg.py
+++ b/FWCore/MessageService/test/u36_cfg.py
@@ -14,16 +14,20 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u36_only = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        INFO = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        WARNING = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u36_only')
+    files = cms.untracked.PSet(
+        u36_only = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            INFO = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            WARNING = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            )
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u3_cfg.py
+++ b/FWCore/MessageService/test/u3_cfg.py
@@ -12,25 +12,24 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u3_infos = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u3_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO'),
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         ),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u3_statistics = cms.untracked.PSet(
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
         )
-    ),
-    u3_statistics = cms.untracked.PSet(
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing',
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u3_infos', 'u3_statistics')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u3_cfg.py
+++ b/FWCore/MessageService/test/u3_cfg.py
@@ -22,10 +22,15 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    statistics = cms.untracked.vstring('u3_statistics'),
-    categories = cms.untracked.vstring('preEventProcessing', 
+    u3_statistics = cms.untracked.PSet(
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
+    ),
+    categories = cms.untracked.vstring('preEventProcessing',
         'FwkTest'),
-    destinations = cms.untracked.vstring('u3_infos')
+    destinations = cms.untracked.vstring('u3_infos', 'u3_statistics')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u4_cfg.py
+++ b/FWCore/MessageService/test/u4_cfg.py
@@ -12,30 +12,30 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u4_statistics = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        ),
-        enableStatistics = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    u4_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        u4_statistics = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            ),
+            enableStatistics = cms.untracked.bool(True)
         ),
-        enableStatistics = cms.untracked.bool(True)
-    ),
-    anotherStats = cms.untracked.PSet(
-        output = cms.untracked.string('u4_another'),
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
+        u4_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True),
+            enableStatistics = cms.untracked.bool(True)
+        ),
+        anotherStats = cms.untracked.PSet(
+            output = cms.untracked.string('u4_another'),
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
         )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u4_errors', 'u4_statistics', 'anotherStats')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u4_cfg.py
+++ b/FWCore/MessageService/test/u4_cfg.py
@@ -13,23 +13,29 @@ process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
     u4_statistics = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING')
+        threshold = cms.untracked.string('WARNING'),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        ),
+        enableStatistics = cms.untracked.bool(True)
     ),
-    statistics = cms.untracked.vstring('u4_statistics', 
-        'anotherStats', 
-        'u4_errors'),
     u4_errors = cms.untracked.PSet(
         threshold = cms.untracked.string('ERROR'),
         noTimeStamps = cms.untracked.bool(True),
         preEventProcessing = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
+        ),
+        enableStatistics = cms.untracked.bool(True)
     ),
     anotherStats = cms.untracked.PSet(
-        output = cms.untracked.string('u4_another')
+        output = cms.untracked.string('u4_another'),
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
     ),
     categories = cms.untracked.vstring('preEventProcessing'),
-    destinations = cms.untracked.vstring('u4_errors')
+    destinations = cms.untracked.vstring('u4_errors', 'u4_statistics', 'anotherStats')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u5_cfg.py
+++ b/FWCore/MessageService/test/u5_cfg.py
@@ -12,35 +12,35 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u5_errors = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        noTimeStamps = cms.untracked.bool(True),
-        preEventProcessing = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    categories = cms.untracked.vstring('preEventProcessing'),
-    u5_default = cms.untracked.PSet(
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        u5_errors = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR'),
+            noTimeStamps = cms.untracked.bool(True),
+        ),
+        u5_default = cms.untracked.PSet(
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
+        ),
+        u5_noreset = cms.untracked.PSet(
+            resetStatistics = cms.untracked.bool(False),
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
+        ),
+        u5_reset = cms.untracked.PSet(
+            resetStatistics = cms.untracked.bool(True),
+            enableStatistics = cms.untracked.bool(True),
+            default = cms.untracked.PSet(
+              limit = cms.untracked.int32(0)
+            )
         )
-    ),
-    u5_noreset = cms.untracked.PSet(
-        resetStatistics = cms.untracked.bool(False),
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        )
-    ),
-    u5_reset = cms.untracked.PSet(
-        resetStatistics = cms.untracked.bool(True),
-        enableStatistics = cms.untracked.bool(True),
-        default = cms.untracked.PSet(
-          limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('u5_errors', 'u5_reset', 'u5_noreset', 'u5_default')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u5_cfg.py
+++ b/FWCore/MessageService/test/u5_cfg.py
@@ -12,9 +12,6 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    statistics = cms.untracked.vstring('u5_default', 
-        'u5_reset', 
-        'u5_noreset'),
     u5_errors = cms.untracked.PSet(
         threshold = cms.untracked.string('ERROR'),
         noTimeStamps = cms.untracked.bool(True),
@@ -23,13 +20,27 @@ process.MessageLogger = cms.Service("MessageLogger",
         )
     ),
     categories = cms.untracked.vstring('preEventProcessing'),
+    u5_default = cms.untracked.PSet(
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
+    ),
     u5_noreset = cms.untracked.PSet(
-        reset = cms.untracked.bool(False)
+        resetStatistics = cms.untracked.bool(False),
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
     ),
     u5_reset = cms.untracked.PSet(
-        reset = cms.untracked.bool(True)
+        resetStatistics = cms.untracked.bool(True),
+        enableStatistics = cms.untracked.bool(True),
+        default = cms.untracked.PSet(
+          limit = cms.untracked.int32(0)
+        )
     ),
-    destinations = cms.untracked.vstring('u5_errors')
+    destinations = cms.untracked.vstring('u5_errors', 'u5_reset', 'u5_noreset', 'u5_default')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u6_cfg.py
+++ b/FWCore/MessageService/test/u6_cfg.py
@@ -11,11 +11,15 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u6_warnings = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        noTimeStamps = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('u6_warnings')
+    files = cms.untracked.PSet(
+        u6_warnings = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING'),
+            noTimeStamps = cms.untracked.bool(True)
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u7_cfg.py
+++ b/FWCore/MessageService/test/u7_cfg.py
@@ -11,25 +11,26 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    u7_restrict = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        u7_restrict = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            special = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            )
         ),
-        noTimeStamps = cms.untracked.bool(True),
-        special = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+        u7_log = cms.untracked.PSet(
+            noTimeStamps = cms.untracked.bool(True),
+            FwkTest = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         )
-    ),
-    u7_log = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(True),
-        FwkTest = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('u7_log', 
-        'u7_restrict'),
-    categories = cms.untracked.vstring('FwkTest', 
-        'special')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u8_cfg.py
+++ b/FWCore/MessageService/test/u8_cfg.py
@@ -18,6 +18,9 @@ process.options = FWCore.Framework.test.cmsExceptionsFatal_cff.options
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     default = cms.untracked.PSet(
         expect_specific = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
@@ -46,84 +49,71 @@ process.MessageLogger = cms.Service("MessageLogger",
             limit = cms.untracked.int32(0)
         )
     ),
-    u8_non_supercede_common = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+    files = cms.untracked.PSet(
+        u8_non_supercede_common = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_non_supercede_common_specific = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            noTimeStamps = cms.untracked.bool(True)
         ),
-        expect_non_supercede_common_specific = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+        u8_supercede_specific = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            lim2bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(8)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            expect_supercede_specific = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            )
         ),
-        noTimeStamps = cms.untracked.bool(True)
-    ),
-    u8_supercede_specific = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
+        u8_overall_unnamed = cms.untracked.PSet(
+            lim3bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            lim2bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_overall_unnamed = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            )
         ),
-        lim2bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(8)
+        u8_specific = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            expect_specific = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            lim2bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            lim0bydefaults = cms.untracked.PSet(
+                limit = cms.untracked.int32(6)
+            )
         ),
-        noTimeStamps = cms.untracked.bool(True),
-        expect_supercede_specific = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
+        u8_overall_specific = cms.untracked.PSet(
+            lim3bydefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(3)
+            ),
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            noTimeStamps = cms.untracked.bool(True),
+            expect_overall_specific = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            lim2bycommondefault = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            )
         )
-    ),
-    u8_overall_unnamed = cms.untracked.PSet(
-        lim3bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        noTimeStamps = cms.untracked.bool(True),
-        lim2bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        expect_overall_unnamed = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
-    ),
-    u8_specific = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        expect_specific = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        ),
-        noTimeStamps = cms.untracked.bool(True),
-        lim2bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        lim0bydefaults = cms.untracked.PSet(
-            limit = cms.untracked.int32(6)
-        )
-    ),
-    u8_overall_specific = cms.untracked.PSet(
-        lim3bydefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(3)
-        ),
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        noTimeStamps = cms.untracked.bool(True),
-        expect_overall_specific = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        ),
-        lim2bycommondefault = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        )
-    ),
-    categories = cms.untracked.vstring('preEventProcessing', 
-        'lim3bydefault', 
-        'lim2bycommondefault', 
-        'lim0bydefaults', 
-        'expect_overall_unnamed', 
-        'expect_overall_specific', 
-        'expect_supercede_specific', 
-        'expect_non_supercede_common_specific', 
-        'expect_specific', 
-        'FwkTest'),
-    destinations = cms.untracked.vstring('u8_overall_unnamed', 
-        'u8_overall_specific', 
-        'u8_supercede_specific', 
-        'u8_non_supercede_common', 
-        'u8_specific')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/FWCore/MessageService/test/u9_cfg.py
+++ b/FWCore/MessageService/test/u9_cfg.py
@@ -13,7 +13,7 @@ process.load("FWCore.MessageService.test.Services_cff")
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
 process.MessageLogger.destinations = ['warnings', 'infos']
-process.MessageLogger.statistics = ['warnings', 'infos']
+del process.MessageLogger.statistics
 process.MessageLogger.categories.append('FwkTest')
 process.MessageLogger.default = cms.untracked.PSet(
     noTimeStamps = cms.untracked.bool(False),
@@ -24,6 +24,7 @@ process.MessageLogger.default = cms.untracked.PSet(
 )
 process.MessageLogger.warnings = cms.untracked.PSet(
     threshold = cms.untracked.string('WARNING'),
+    enableStatistics = cms.untracked.bool(True),
     default = cms.untracked.PSet(
         limit = cms.untracked.int32(3)
     ),
@@ -34,6 +35,7 @@ process.MessageLogger.infos = cms.untracked.PSet(
         limit = cms.untracked.int32(2)
     ),
     noTimeStamps = cms.untracked.bool(True),
+    enableStatistics = cms.untracked.bool(True),
     FwkTest = cms.untracked.PSet(
         limit = cms.untracked.int32(0)
     )

--- a/FWCore/MessageService/test/unit_test_outputs/u24.log
+++ b/FWCore/MessageService/test/unit_test_outputs/u24.log
@@ -1,28 +1,8 @@
-%MSG-e duplicateDestination:  (NoModuleName) pre-events
+----- Begin Fatal Exception {Timestamp} ----------------------
+An exception of category 'DuplicateDestination' occurred while
+   [0] Constructing the EventProcessor
+   [1] Constructing service of type MessageLogger
+Exception Message:
 Duplicate name for a MessageLogger Destination: u24.log
-Only the first configuration instructions are used
-%MSG
-%MSG-e cat_A:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 1
-LogError was used to send this message-which is long enough to span lines but-will not be broken up by the logger any more
-%MSG
-%MSG-e cat_B:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 1
-LogError was used to send this other message
-%MSG
-%MSG-w cat_A:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 1
-LogWarning was used to send this message
-%MSG
-%MSG-w cat_B:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 1
-LogWarning was used to send this other message
-%MSG
-%MSG-e cat_A:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 2
-LogError was used to send this message-which is long enough to span lines but-will not be broken up by the logger any more
-%MSG
-%MSG-e cat_B:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 2
-LogError was used to send this other message
-%MSG
-%MSG-w cat_A:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 2
-LogWarning was used to send this message
-%MSG
-%MSG-w cat_B:  UnitTestClient_A:sendSomeMessages Run: 1 Event: 2
-LogWarning was used to send this other message
-%MSG
+Please modify the configuration to use unique file names.
+----- End Fatal Exception -------------------------------------------------

--- a/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
@@ -1,0 +1,43 @@
+
+#ifndef FWCore_ParameterSet_ParameterWildcardWithSpecifics_h
+#define FWCore_ParameterSet_ParameterWildcardWithSpecifics_h
+
+#include <string>
+#include <map>
+#include "FWCore/ParameterSet/interface/ParameterWildcardBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+namespace edm {
+
+  class ParameterSet;
+  class DocFormatHelper;
+
+  class ParameterWildcardWithSpecifics : public ParameterWildcardBase {
+  public:
+    ParameterWildcardWithSpecifics(std::string_view,
+                                    WildcardValidationCriteria criteria,
+                                    bool isTracked,
+                                    ParameterSetDescription const& desc,
+                                    std::map<std::string,ParameterSetDescription> exceptions);
+
+
+    ParameterDescriptionNode* clone() const override;
+
+  private:
+    void validate_(ParameterSet& pset, std::set<std::string>& validatedLabels, bool optional) const override;
+
+    bool hasNestedContent_() const override;
+
+    void printNestedContent_(std::ostream& os, bool optional, DocFormatHelper& dfh) const override;
+
+    bool exists_(ParameterSet const& pset) const override;
+
+    void validatePSetVector(std::string const& parameterName, ParameterSet& pset) const;
+    
+    void validateDescription(std::string const& parameterName, ParameterSet& pset) const;
+    
+    ParameterSetDescription wildcardDesc_;
+    std::map<std::string, ParameterSetDescription> exceptions_;
+  };
+}  // namespace edm
+#endif

--- a/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
+++ b/FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h
@@ -15,11 +15,10 @@ namespace edm {
   class ParameterWildcardWithSpecifics : public ParameterWildcardBase {
   public:
     ParameterWildcardWithSpecifics(std::string_view,
-                                    WildcardValidationCriteria criteria,
-                                    bool isTracked,
-                                    ParameterSetDescription const& desc,
-                                    std::map<std::string,ParameterSetDescription> exceptions);
-
+                                   WildcardValidationCriteria criteria,
+                                   bool isTracked,
+                                   ParameterSetDescription const& desc,
+                                   std::map<std::string, ParameterSetDescription> exceptions);
 
     ParameterDescriptionNode* clone() const override;
 
@@ -33,9 +32,9 @@ namespace edm {
     bool exists_(ParameterSet const& pset) const override;
 
     void validatePSetVector(std::string const& parameterName, ParameterSet& pset) const;
-    
+
     void validateDescription(std::string const& parameterName, ParameterSet& pset) const;
-    
+
     ParameterSetDescription wildcardDesc_;
     std::map<std::string, ParameterSetDescription> exceptions_;
   };

--- a/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
@@ -11,11 +11,12 @@
 
 namespace edm {
 
-  ParameterWildcardWithSpecifics::ParameterWildcardWithSpecifics(std::string_view pattern,
-                                                     WildcardValidationCriteria criteria,
-                                                     bool isTracked,
-                                                     ParameterSetDescription const& desc,
-                                                     std::map<std::string, ParameterSetDescription> exceptions )
+  ParameterWildcardWithSpecifics::ParameterWildcardWithSpecifics(
+      std::string_view pattern,
+      WildcardValidationCriteria criteria,
+      bool isTracked,
+      ParameterSetDescription const& desc,
+      std::map<std::string, ParameterSetDescription> exceptions)
       : ParameterWildcardBase(k_PSet, isTracked, criteria), wildcardDesc_(desc), exceptions_(std::move(exceptions)) {
     throwIfInvalidPattern(std::string(pattern));
   }
@@ -25,18 +26,18 @@ namespace edm {
   }
 
   void ParameterWildcardWithSpecifics::validate_(ParameterSet& pset,
-                                                  std::set<std::string>& validatedLabels,
-                                                  bool optional) const {
+                                                 std::set<std::string>& validatedLabels,
+                                                 bool optional) const {
     std::vector<std::string> parameterNames = pset.getParameterNamesForType<ParameterSet>(isTracked());
     validateMatchingNames(parameterNames, validatedLabels, optional);
 
-    for(auto const& name: parameterNames) {
+    for (auto const& name : parameterNames) {
       validateDescription(name, pset);
     }
     //inject exceptions if not already in the pset
-    for(auto const& v: exceptions_) {
-      if(std::find(parameterNames.begin(), parameterNames.end(), v.first) == parameterNames.end()) {
-        if(isTracked()){
+    for (auto const& v : exceptions_) {
+      if (std::find(parameterNames.begin(), parameterNames.end(), v.first) == parameterNames.end()) {
+        if (isTracked()) {
           pset.addParameter<edm::ParameterSet>(v.first, edm::ParameterSet());
         } else {
           pset.addUntrackedParameter<edm::ParameterSet>(v.first, edm::ParameterSet());
@@ -45,27 +46,23 @@ namespace edm {
         validateDescription(v.first, pset);
       }
     }
-    
   }
 
-  void ParameterWildcardWithSpecifics::validateDescription(std::string const& parameterName,
-                                                           ParameterSet& pset) const {
+  void ParameterWildcardWithSpecifics::validateDescription(std::string const& parameterName, ParameterSet& pset) const {
     ParameterSet* containedPSet = pset.getPSetForUpdate(parameterName);
     auto itFound = exceptions_.find(parameterName);
-    if(itFound != exceptions_.end()) {
+    if (itFound != exceptions_.end()) {
       itFound->second.validate(*containedPSet);
     } else {
       wildcardDesc_.validate(*containedPSet);
     }
   }
 
-  bool ParameterWildcardWithSpecifics::hasNestedContent_() const {
-    return true;
-  }
+  bool ParameterWildcardWithSpecifics::hasNestedContent_() const { return true; }
 
   void ParameterWildcardWithSpecifics::printNestedContent_(std::ostream& os,
-                                                                       bool /*optional*/,
-                                                                       DocFormatHelper& dfh) const {
+                                                           bool /*optional*/,
+                                                           DocFormatHelper& dfh) const {
     int indentation = dfh.indentation();
     if (dfh.parent() != DocFormatHelper::TOP) {
       indentation -= DocFormatHelper::offsetSectionContent();

--- a/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcardWithSpecifics.cc
@@ -1,0 +1,104 @@
+#include "FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h"
+
+#include "FWCore/ParameterSet/interface/DocFormatHelper.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/VParameterSetEntry.h"
+#include "FWCore/Utilities/interface/Algorithms.h"
+
+#include <cassert>
+#include <iomanip>
+#include <ostream>
+
+namespace edm {
+
+  ParameterWildcardWithSpecifics::ParameterWildcardWithSpecifics(std::string_view pattern,
+                                                     WildcardValidationCriteria criteria,
+                                                     bool isTracked,
+                                                     ParameterSetDescription const& desc,
+                                                     std::map<std::string, ParameterSetDescription> exceptions )
+      : ParameterWildcardBase(k_PSet, isTracked, criteria), wildcardDesc_(desc), exceptions_(std::move(exceptions)) {
+    throwIfInvalidPattern(std::string(pattern));
+  }
+
+  ParameterDescriptionNode* ParameterWildcardWithSpecifics::clone() const {
+    return new ParameterWildcardWithSpecifics(*this);
+  }
+
+  void ParameterWildcardWithSpecifics::validate_(ParameterSet& pset,
+                                                  std::set<std::string>& validatedLabels,
+                                                  bool optional) const {
+    std::vector<std::string> parameterNames = pset.getParameterNamesForType<ParameterSet>(isTracked());
+    validateMatchingNames(parameterNames, validatedLabels, optional);
+
+    for(auto const& name: parameterNames) {
+      validateDescription(name, pset);
+    }
+    //inject exceptions if not already in the pset
+    for(auto const& v: exceptions_) {
+      if(std::find(parameterNames.begin(), parameterNames.end(), v.first) == parameterNames.end()) {
+        if(isTracked()){
+          pset.addParameter<edm::ParameterSet>(v.first, edm::ParameterSet());
+        } else {
+          pset.addUntrackedParameter<edm::ParameterSet>(v.first, edm::ParameterSet());
+        }
+        validatedLabels.insert(v.first);
+        validateDescription(v.first, pset);
+      }
+    }
+    
+  }
+
+  void ParameterWildcardWithSpecifics::validateDescription(std::string const& parameterName,
+                                                           ParameterSet& pset) const {
+    ParameterSet* containedPSet = pset.getPSetForUpdate(parameterName);
+    auto itFound = exceptions_.find(parameterName);
+    if(itFound != exceptions_.end()) {
+      itFound->second.validate(*containedPSet);
+    } else {
+      wildcardDesc_.validate(*containedPSet);
+    }
+  }
+
+  bool ParameterWildcardWithSpecifics::hasNestedContent_() const {
+    return true;
+  }
+
+  void ParameterWildcardWithSpecifics::printNestedContent_(std::ostream& os,
+                                                                       bool /*optional*/,
+                                                                       DocFormatHelper& dfh) const {
+    int indentation = dfh.indentation();
+    if (dfh.parent() != DocFormatHelper::TOP) {
+      indentation -= DocFormatHelper::offsetSectionContent();
+    }
+
+    printSpaces(os, indentation);
+    os << "Section " << dfh.section() << "." << dfh.counter() << " description of PSet matching wildcard:";
+    os << "\n";
+    if (!dfh.brief())
+      os << "\n";
+
+    std::stringstream ss;
+    ss << dfh.section() << "." << dfh.counter();
+    std::string newSection = ss.str();
+
+    DocFormatHelper new_dfh(dfh);
+    new_dfh.setSection(newSection);
+    new_dfh.setIndentation(indentation + DocFormatHelper::offsetSectionContent());
+    new_dfh.setParent(DocFormatHelper::OTHER);
+
+    wildcardDesc_.print(os, new_dfh);
+    //NOTE: need to extend to also include the specific cases.
+  }
+
+  bool ParameterWildcardWithSpecifics::exists_(ParameterSet const& pset) const {
+    if (criteria() == RequireZeroOrMore)
+      return true;
+
+    std::vector<std::string> parameterNames = pset.getParameterNamesForType<ParameterSet>(isTracked());
+
+    if (criteria() == RequireAtLeastOne)
+      return !parameterNames.empty();
+    return parameterNames.size() == 1U;
+  }
+
+}  // namespace edm

--- a/FWCore/ParameterSet/test/parameterSetDescription_t.cc
+++ b/FWCore/ParameterSet/test/parameterSetDescription_t.cc
@@ -10,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterDescriptionBase.h"
 #include "FWCore/ParameterSet/interface/ParameterDescriptionNode.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterWildcardWithSpecifics.h"
 #include "FWCore/ParameterSet/interface/allowedValues.h"
 #include "FWCore/ParameterSet/interface/PluginDescription.h"
 #include "FWCore/ParameterSet/interface/ValidatedPluginMacros.h"
@@ -294,6 +295,54 @@ namespace testParameterSetDescription {
     }
 
     return;
+  }
+
+  void testWildcardWithExceptions() {
+    {
+      edm::ParameterSetDescription set;
+
+      edm::ParameterSetDescription wild;
+      wild.addUntracked<unsigned>("n11", 1);
+
+      edm::ParameterSetDescription except_;
+      except_.addUntracked<double>("f", 3.14);
+      std::map<std::string, edm::ParameterSetDescription> excptions = {{"special", except_}};
+      edm::ParameterWildcardWithSpecifics w("*", edm::RequireZeroOrMore, true, wild, std::move(excptions));
+      set.addNode(w);
+      edm::ParameterSet pset;
+      testDesc(w, set, pset, true, true);
+      edm::ParameterSet nested1;
+      nested1.addUntrackedParameter<unsigned>("n11", 3);
+      pset.addParameter<edm::ParameterSet>("nested1", nested1);
+      testDesc(w, set, pset, true, true);
+      edm::ParameterSet special;
+      special.addUntrackedParameter<double>("f", 5);
+      pset.addParameter<edm::ParameterSet>("special", special);
+      testDesc(w, set, pset, true, true);
+    }
+
+    {
+      edm::ParameterSetDescription set;
+
+      edm::ParameterSetDescription wild;
+      wild.add<unsigned>("n11", 1);
+
+      edm::ParameterSetDescription except_;
+      except_.add<double>("f", 3.14);
+      std::map<std::string, edm::ParameterSetDescription> excptions = {{"special", except_}};
+      edm::ParameterWildcardWithSpecifics w("*", edm::RequireZeroOrMore, true, wild, std::move(excptions));
+      set.addNode(w);
+      edm::ParameterSet pset;
+      testDesc(w, set, pset, true, true);
+      edm::ParameterSet nested1;
+      nested1.addParameter<unsigned>("n11", 3);
+      pset.addParameter<edm::ParameterSet>("nested1", nested1);
+      testDesc(w, set, pset, true, true);
+      edm::ParameterSet special;
+      special.addParameter<double>("f", 5);
+      pset.addParameter<edm::ParameterSet>("special", special);
+      testDesc(w, set, pset, true, true);
+    }
   }
 
   // ---------------------------------------------------------------------------------
@@ -1723,6 +1772,7 @@ int main(int, char**) try {
   psetDesc.validate(pset);
 
   testParameterSetDescription::testWildcards();
+  testParameterSetDescription::testWildcardWithExceptions();
   testParameterSetDescription::testSwitch();
   testParameterSetDescription::testAllowedValues();
   testParameterSetDescription::testXor();


### PR DESCRIPTION
#### PR description:

This adds support for using the new MessageLogger configuration syntax. The old syntax is also supported. The decision on which format to apply is based on the presence or absence of key parameters for each implementation.

The discussion about the new format can be found here: #31910

The new code makes use of the ParameterSet validation system to enforce correctness.

The standard MessageLogger_cfi.py configuration has not been updated to use the new configuration at this point since it would cause too many non framework configurations to break. That migration will happen at a later stage.

#### PR validation:

All framework unit tests have been updated to use the new syntax and they all pass.