### PR TITLE
Add comments describing the ConvertingESProducer[WithDependencies]T class templates

### DIFF
--- a/HeterogeneousCore/CUDACore/interface/ConvertingESProducerT.h
+++ b/HeterogeneousCore/CUDACore/interface/ConvertingESProducerT.h
@@ -9,6 +9,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
+/* class template: ConvertingESProducerT
+ * 
+ * This class template can be used to simplify the implementation of any ESProducer that reads
+ * conditions data from a record and pushes derived conditions data to the same record.
+ * The current use case is to convert and copy the calibrations from the CPU to the GPUs.
+ */
+
 template <typename Record, typename Target, typename Source>
 class ConvertingESProducerT : public edm::ESProducer {
 public:

--- a/HeterogeneousCore/CUDACore/interface/ConvertingESProducerWithDependenciesT.h
+++ b/HeterogeneousCore/CUDACore/interface/ConvertingESProducerWithDependenciesT.h
@@ -12,6 +12,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
+/* class template: ConvertingESProducerWithDependenciesT
+ * 
+ * This class template can be used to simplify the implementation of any ESProducer that reads
+ * multiple conditions data from one or more records record and pushes derived conditions data
+ * to a combined dependent record.
+ * The current use case is to convert and copy the calibrations from the CPU to the GPUs.
+ */
+
 namespace detail {
   // simple implementation of a type zipper over 2 tuples
   // here, the main requirement is the default constructor for Gen template


### PR DESCRIPTION
#### PR description:

Add comments describing the `ConvertingESProducerT` and `ConvertingESProducerWithDependenciesT` class templates.

#### PR validation:

None - add only comments.