### PR TITLE
DataFormats for Phase-2 L1T-HLT

### DIFF
--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/HcalIsolatedTrack"/>
 <use name="DataFormats/TauReco"/>
+<use name="DataFormats/L1TParticleFlow"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -50,12 +50,15 @@ namespace trigger {
       size_type pftaus_;
       size_type pfmets_;
       size_type l1tmuon_;
-      size_type l1tkmuon_;
       size_type l1tegamma_;
-      size_type l1tkele_;
-      size_type l1tkem_;
       size_type l1tjet_;
+      size_type l1ttkmuon_;
+      size_type l1ttkele_;
+      size_type l1ttkem_;
       size_type l1tpfjet_;
+      size_type l1tpftau_;
+      size_type l1thpspftau_;
+      size_type l1tpftrack_;
       size_type l1ttau_;
       size_type l1tetsum_;
 
@@ -79,12 +82,15 @@ namespace trigger {
             pftaus_(0),
             pfmets_(0),
             l1tmuon_(0),
-            l1tkmuon_(0),
             l1tegamma_(0),
-            l1tkele_(0),
-            l1tkem_(0),
             l1tjet_(0),
+            l1ttkmuon_(0),
+            l1ttkele_(0),
+            l1ttkem_(0),
             l1tpfjet_(0),
+            l1tpftau_(0),
+            l1thpspftau_(0),
+            l1tpftrack_(0),
             l1ttau_(0),
             l1tetsum_(0) {
         filterTag_ = edm::InputTag().encode();
@@ -107,12 +113,15 @@ namespace trigger {
                           size_type pftaus,
                           size_type pfmets,
                           size_type l1tmuon,
-                          size_type l1tkmuon,
                           size_type l1tegamma,
-                          size_type l1tkele,
-                          size_type l1tkem,
                           size_type l1tjet,
+                          size_type l1ttkmuon,
+                          size_type l1ttkele,
+                          size_type l1ttkem,
                           size_type l1tpfjet,
+                          size_type l1tpftau,
+                          size_type l1thpspftau,
+                          size_type l1tpftrack,
                           size_type l1ttau,
                           size_type l1tetsum)
           : filterTag_(filterTag.encode()),
@@ -133,12 +142,15 @@ namespace trigger {
             pftaus_(pftaus),
             pfmets_(pfmets),
             l1tmuon_(l1tmuon),
-            l1tkmuon_(l1tkmuon),
             l1tegamma_(l1tegamma),
-            l1tkele_(l1tkele),
-            l1tkem_(l1tkem),
             l1tjet_(l1tjet),
+            l1ttkmuon_(l1ttkmuon),
+            l1ttkele_(l1ttkele),
+            l1ttkem_(l1ttkem),
             l1tpfjet_(l1tpfjet),
+            l1tpftau_(l1tpftau),
+            l1thpspftau_(l1thpspftau),
+            l1tpftrack_(l1tpftrack),
             l1ttau_(l1ttau),
             l1tetsum_(l1tetsum) {}
     };
@@ -181,12 +193,15 @@ namespace trigger {
                               addObjects(tfowr.pftauIds(), tfowr.pftauRefs()),
                               addObjects(tfowr.pfmetIds(), tfowr.pfmetRefs()),
                               addObjects(tfowr.l1tmuonIds(), tfowr.l1tmuonRefs()),
-                              addObjects(tfowr.l1tkmuonIds(), tfowr.l1tkmuonRefs()),
                               addObjects(tfowr.l1tegammaIds(), tfowr.l1tegammaRefs()),
-                              addObjects(tfowr.l1tkeleIds(), tfowr.l1tkeleRefs()),
-                              addObjects(tfowr.l1tkemIds(), tfowr.l1tkemRefs()),
                               addObjects(tfowr.l1tjetIds(), tfowr.l1tjetRefs()),
+                              addObjects(tfowr.l1ttkmuonIds(), tfowr.l1ttkmuonRefs()),
+                              addObjects(tfowr.l1ttkeleIds(), tfowr.l1ttkeleRefs()),
+                              addObjects(tfowr.l1ttkemIds(), tfowr.l1ttkemRefs()),
                               addObjects(tfowr.l1tpfjetIds(), tfowr.l1tpfjetRefs()),
+                              addObjects(tfowr.l1tpftauIds(), tfowr.l1tpftauRefs()),
+                              addObjects(tfowr.l1thpspftauIds(), tfowr.l1thpspftauRefs()),
+                              addObjects(tfowr.l1tpftrackIds(), tfowr.l1tpftrackRefs()),
                               addObjects(tfowr.l1ttauIds(), tfowr.l1ttauRefs()),
                               addObjects(tfowr.l1tetsumIds(), tfowr.l1tetsumRefs()))
 
@@ -319,40 +334,51 @@ namespace trigger {
       const size_type end(filterObjects_.at(filter).l1tmuon_);
       return std::pair<size_type, size_type>(begin, end);
     }
-
-    std::pair<size_type, size_type> l1tkmuonSlice(size_type filter) const {
-      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkmuon_);
-      const size_type end(filterObjects_.at(filter).l1tkmuon_);
-      return std::pair<size_type, size_type>(begin, end);
-    }
-
     std::pair<size_type, size_type> l1tegammaSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tegamma_);
       const size_type end(filterObjects_.at(filter).l1tegamma_);
       return std::pair<size_type, size_type>(begin, end);
     }
-
-    std::pair<size_type, size_type> l1tkeleSlice(size_type filter) const {
-      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkele_);
-      const size_type end(filterObjects_.at(filter).l1tkele_);
-      return std::pair<size_type, size_type>(begin, end);
-    }
-
-    std::pair<size_type, size_type> l1tkemSlice(size_type filter) const {
-      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkem_);
-      const size_type end(filterObjects_.at(filter).l1tkem_);
-      return std::pair<size_type, size_type>(begin, end);
-    }
-
     std::pair<size_type, size_type> l1tjetSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tjet_);
       const size_type end(filterObjects_.at(filter).l1tjet_);
       return std::pair<size_type, size_type>(begin, end);
     }
 
+    /* Phase-2 */
+    std::pair<size_type, size_type> l1ttkmuonSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1ttkmuon_);
+      const size_type end(filterObjects_.at(filter).l1ttkmuon_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1ttkeleSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1ttkele_);
+      const size_type end(filterObjects_.at(filter).l1ttkele_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1ttkemSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1ttkem_);
+      const size_type end(filterObjects_.at(filter).l1ttkem_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
     std::pair<size_type, size_type> l1tpfjetSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tpfjet_);
       const size_type end(filterObjects_.at(filter).l1tpfjet_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1tpftauSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tpftau_);
+      const size_type end(filterObjects_.at(filter).l1tpftau_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1thpspftauSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1thpspftau_);
+      const size_type end(filterObjects_.at(filter).l1thpspftau_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+    std::pair<size_type, size_type> l1tpftrackSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tpftrack_);
+      const size_type end(filterObjects_.at(filter).l1tpftrack_);
       return std::pair<size_type, size_type>(begin, end);
     }
 
@@ -557,17 +583,6 @@ namespace trigger {
       TriggerRefsCollections::getObjects(id, l1tmuon, begin, end);
     }
 
-    void getObjects(size_type filter, Vids& ids, VRl1tkmuon& l1tkmuon) const {
-      const size_type begin(l1tkmuonSlice(filter).first);
-      const size_type end(l1tkmuonSlice(filter).second);
-      TriggerRefsCollections::getObjects(ids, l1tkmuon, begin, end);
-    }
-    void getObjects(size_type filter, int id, VRl1tkmuon& l1tkmuon) const {
-      const size_type begin(l1tkmuonSlice(filter).first);
-      const size_type end(l1tkmuonSlice(filter).second);
-      TriggerRefsCollections::getObjects(id, l1tkmuon, begin, end);
-    }
-
     void getObjects(size_type filter, Vids& ids, VRl1tegamma& l1tegamma) const {
       const size_type begin(l1tegammaSlice(filter).first);
       const size_type end(l1tegammaSlice(filter).second);
@@ -577,27 +592,6 @@ namespace trigger {
       const size_type begin(l1tegammaSlice(filter).first);
       const size_type end(l1tegammaSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tegamma, begin, end);
-    }
-
-    void getObjects(size_type filter, Vids& ids, VRl1tkele& l1tkele) const {
-      const size_type begin(l1tkeleSlice(filter).first);
-      const size_type end(l1tkeleSlice(filter).second);
-      TriggerRefsCollections::getObjects(ids, l1tkele, begin, end);
-    }
-    void getObjects(size_type filter, int id, VRl1tkele& l1tkele) const {
-      const size_type begin(l1tkeleSlice(filter).first);
-      const size_type end(l1tkeleSlice(filter).second);
-      TriggerRefsCollections::getObjects(id, l1tkele, begin, end);
-    }
-    void getObjects(size_type filter, Vids& ids, VRl1tkem& l1tkem) const {
-      const size_type begin(l1tkemSlice(filter).first);
-      const size_type end(l1tkemSlice(filter).second);
-      TriggerRefsCollections::getObjects(ids, l1tkem, begin, end);
-    }
-    void getObjects(size_type filter, int id, VRl1tkem& l1tkem) const {
-      const size_type begin(l1tkemSlice(filter).first);
-      const size_type end(l1tkemSlice(filter).second);
-      TriggerRefsCollections::getObjects(id, l1tkem, begin, end);
     }
 
     void getObjects(size_type filter, Vids& ids, VRl1tjet& l1tjet) const {
@@ -611,6 +605,40 @@ namespace trigger {
       TriggerRefsCollections::getObjects(id, l1tjet, begin, end);
     }
 
+    /* Phase-2 */
+    void getObjects(size_type filter, Vids& ids, VRl1ttkmuon& l1ttkmuon) const {
+      const size_type begin(l1ttkmuonSlice(filter).first);
+      const size_type end(l1ttkmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1ttkmuon, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1ttkmuon& l1ttkmuon) const {
+      const size_type begin(l1ttkmuonSlice(filter).first);
+      const size_type end(l1ttkmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1ttkmuon, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1ttkele& l1ttkele) const {
+      const size_type begin(l1ttkeleSlice(filter).first);
+      const size_type end(l1ttkeleSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1ttkele, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1ttkele& l1ttkele) const {
+      const size_type begin(l1ttkeleSlice(filter).first);
+      const size_type end(l1ttkeleSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1ttkele, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1ttkem& l1ttkem) const {
+      const size_type begin(l1ttkemSlice(filter).first);
+      const size_type end(l1ttkemSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1ttkem, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1ttkem& l1ttkem) const {
+      const size_type begin(l1ttkemSlice(filter).first);
+      const size_type end(l1ttkemSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1ttkem, begin, end);
+    }
+
     void getObjects(size_type filter, Vids& ids, VRl1tpfjet& l1tpfjet) const {
       const size_type begin(l1tpfjetSlice(filter).first);
       const size_type end(l1tpfjetSlice(filter).second);
@@ -620,6 +648,39 @@ namespace trigger {
       const size_type begin(l1tpfjetSlice(filter).first);
       const size_type end(l1tpfjetSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tpfjet, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tpftau& l1tpftau) const {
+      const size_type begin(l1tpftauSlice(filter).first);
+      const size_type end(l1tpftauSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tpftau, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tpftau& l1tpftau) const {
+      const size_type begin(l1tpftauSlice(filter).first);
+      const size_type end(l1tpftauSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tpftau, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1thpspftau& l1thpspftau) const {
+      const size_type begin(l1thpspftauSlice(filter).first);
+      const size_type end(l1thpspftauSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1thpspftau, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1thpspftau& l1thpspftau) const {
+      const size_type begin(l1thpspftauSlice(filter).first);
+      const size_type end(l1thpspftauSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1thpspftau, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tpftrack& l1tpftrack) const {
+      const size_type begin(l1tpftrackSlice(filter).first);
+      const size_type end(l1tpftrackSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tpftrack, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tpftrack& l1tpftrack) const {
+      const size_type begin(l1tpftrackSlice(filter).first);
+      const size_type end(l1tpftrackSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tpftrack, begin, end);
     }
 
     void getObjects(size_type filter, Vids& ids, VRl1ttau& l1ttau) const {

--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -50,8 +50,12 @@ namespace trigger {
       size_type pftaus_;
       size_type pfmets_;
       size_type l1tmuon_;
+      size_type l1tkmuon_;
       size_type l1tegamma_;
+      size_type l1tkele_;
+      size_type l1tkem_;
       size_type l1tjet_;
+      size_type l1tpfjet_;
       size_type l1ttau_;
       size_type l1tetsum_;
 
@@ -75,8 +79,12 @@ namespace trigger {
             pftaus_(0),
             pfmets_(0),
             l1tmuon_(0),
+            l1tkmuon_(0),
             l1tegamma_(0),
+            l1tkele_(0),
+            l1tkem_(0),
             l1tjet_(0),
+            l1tpfjet_(0),
             l1ttau_(0),
             l1tetsum_(0) {
         filterTag_ = edm::InputTag().encode();
@@ -99,8 +107,12 @@ namespace trigger {
                           size_type pftaus,
                           size_type pfmets,
                           size_type l1tmuon,
+                          size_type l1tkmuon,
                           size_type l1tegamma,
+                          size_type l1tkele,
+                          size_type l1tkem,
                           size_type l1tjet,
+                          size_type l1tpfjet,
                           size_type l1ttau,
                           size_type l1tetsum)
           : filterTag_(filterTag.encode()),
@@ -121,8 +133,12 @@ namespace trigger {
             pftaus_(pftaus),
             pfmets_(pfmets),
             l1tmuon_(l1tmuon),
+            l1tkmuon_(l1tkmuon),
             l1tegamma_(l1tegamma),
+            l1tkele_(l1tkele),
+            l1tkem_(l1tkem),
             l1tjet_(l1tjet),
+            l1tpfjet_(l1tpfjet),
             l1ttau_(l1ttau),
             l1tetsum_(l1tetsum) {}
     };
@@ -165,8 +181,12 @@ namespace trigger {
                               addObjects(tfowr.pftauIds(), tfowr.pftauRefs()),
                               addObjects(tfowr.pfmetIds(), tfowr.pfmetRefs()),
                               addObjects(tfowr.l1tmuonIds(), tfowr.l1tmuonRefs()),
+                              addObjects(tfowr.l1tkmuonIds(), tfowr.l1tkmuonRefs()),
                               addObjects(tfowr.l1tegammaIds(), tfowr.l1tegammaRefs()),
+                              addObjects(tfowr.l1tkeleIds(), tfowr.l1tkeleRefs()),
+                              addObjects(tfowr.l1tkemIds(), tfowr.l1tkemRefs()),
                               addObjects(tfowr.l1tjetIds(), tfowr.l1tjetRefs()),
+                              addObjects(tfowr.l1tpfjetIds(), tfowr.l1tpfjetRefs()),
                               addObjects(tfowr.l1ttauIds(), tfowr.l1ttauRefs()),
                               addObjects(tfowr.l1tetsumIds(), tfowr.l1tetsumRefs()))
 
@@ -300,15 +320,39 @@ namespace trigger {
       return std::pair<size_type, size_type>(begin, end);
     }
 
+    std::pair<size_type, size_type> l1tkmuonSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkmuon_);
+      const size_type end(filterObjects_.at(filter).l1tkmuon_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+
     std::pair<size_type, size_type> l1tegammaSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tegamma_);
       const size_type end(filterObjects_.at(filter).l1tegamma_);
       return std::pair<size_type, size_type>(begin, end);
     }
 
+    std::pair<size_type, size_type> l1tkeleSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkele_);
+      const size_type end(filterObjects_.at(filter).l1tkele_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+
+    std::pair<size_type, size_type> l1tkemSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tkem_);
+      const size_type end(filterObjects_.at(filter).l1tkem_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+
     std::pair<size_type, size_type> l1tjetSlice(size_type filter) const {
       const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tjet_);
       const size_type end(filterObjects_.at(filter).l1tjet_);
+      return std::pair<size_type, size_type>(begin, end);
+    }
+
+    std::pair<size_type, size_type> l1tpfjetSlice(size_type filter) const {
+      const size_type begin(filter == 0 ? 0 : filterObjects_.at(filter - 1).l1tpfjet_);
+      const size_type end(filterObjects_.at(filter).l1tpfjet_);
       return std::pair<size_type, size_type>(begin, end);
     }
 
@@ -513,6 +557,17 @@ namespace trigger {
       TriggerRefsCollections::getObjects(id, l1tmuon, begin, end);
     }
 
+    void getObjects(size_type filter, Vids& ids, VRl1tkmuon& l1tkmuon) const {
+      const size_type begin(l1tkmuonSlice(filter).first);
+      const size_type end(l1tkmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tkmuon, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tkmuon& l1tkmuon) const {
+      const size_type begin(l1tkmuonSlice(filter).first);
+      const size_type end(l1tkmuonSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tkmuon, begin, end);
+    }
+
     void getObjects(size_type filter, Vids& ids, VRl1tegamma& l1tegamma) const {
       const size_type begin(l1tegammaSlice(filter).first);
       const size_type end(l1tegammaSlice(filter).second);
@@ -524,6 +579,28 @@ namespace trigger {
       TriggerRefsCollections::getObjects(id, l1tegamma, begin, end);
     }
 
+    void getObjects(size_type filter, Vids& ids, VRl1tkele& l1tkele) const {
+      const size_type begin(l1tkeleSlice(filter).first);
+      const size_type end(l1tkeleSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tkele, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tkele& l1tkele) const {
+      const size_type begin(l1tkeleSlice(filter).first);
+      const size_type end(l1tkeleSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tkele, begin, end);
+    }
+    void getObjects(size_type filter, Vids& ids, VRl1tkem& l1tkem) const {
+      const size_type begin(l1tkemSlice(filter).first);
+      const size_type end(l1tkemSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tkem, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tkem& l1tkem) const {
+      const size_type begin(l1tkemSlice(filter).first);
+      const size_type end(l1tkemSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tkem, begin, end);
+    }
+
+
     void getObjects(size_type filter, Vids& ids, VRl1tjet& l1tjet) const {
       const size_type begin(l1tjetSlice(filter).first);
       const size_type end(l1tjetSlice(filter).second);
@@ -533,6 +610,17 @@ namespace trigger {
       const size_type begin(l1tjetSlice(filter).first);
       const size_type end(l1tjetSlice(filter).second);
       TriggerRefsCollections::getObjects(id, l1tjet, begin, end);
+    }
+
+    void getObjects(size_type filter, Vids& ids, VRl1tpfjet& l1tpfjet) const {
+      const size_type begin(l1tpfjetSlice(filter).first);
+      const size_type end(l1tpfjetSlice(filter).second);
+      TriggerRefsCollections::getObjects(ids, l1tpfjet, begin, end);
+    }
+    void getObjects(size_type filter, int id, VRl1tpfjet& l1tpfjet) const {
+      const size_type begin(l1tpfjetSlice(filter).first);
+      const size_type end(l1tpfjetSlice(filter).second);
+      TriggerRefsCollections::getObjects(id, l1tpfjet, begin, end);
     }
 
     void getObjects(size_type filter, Vids& ids, VRl1ttau& l1ttau) const {

--- a/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
+++ b/DataFormats/HLTReco/interface/TriggerEventWithRefs.h
@@ -600,7 +600,6 @@ namespace trigger {
       TriggerRefsCollections::getObjects(id, l1tkem, begin, end);
     }
 
-
     void getObjects(size_type filter, Vids& ids, VRl1tjet& l1tjet) const {
       const size_type begin(l1tjetSlice(filter).first);
       const size_type end(l1tjetSlice(filter).second);

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -43,6 +43,13 @@
 #include "DataFormats/L1Trigger/interface/Jet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
@@ -73,8 +80,12 @@ namespace trigger {
   typedef std::vector<l1extra::L1HFRingsRef> VRl1hfrings;        //deprecate
 
   typedef l1t::MuonVectorRef VRl1tmuon;
+  typedef l1t::TkMuonVectorRef VRl1tkmuon;
   typedef l1t::EGammaVectorRef VRl1tegamma;
+  typedef l1t::TkElectronVectorRef VRl1tkele;
+  typedef l1t::TkEmVectorRef VRl1tkem;
   typedef l1t::JetVectorRef VRl1tjet;
+  typedef l1t::PFJetVectorRef VRl1tpfjet;
   typedef l1t::TauVectorRef VRl1ttau;
   typedef l1t::EtSumVectorRef VRl1tetsum;
 
@@ -116,10 +127,18 @@ namespace trigger {
 
     Vids l1tmuonIds_;
     VRl1tmuon l1tmuonRefs_;
+    Vids l1tkmuonIds_;
+    VRl1tkmuon l1tkmuonRefs_;
     Vids l1tegammaIds_;
     VRl1tegamma l1tegammaRefs_;
+    Vids l1tkeleIds_;
+    VRl1tkele l1tkeleRefs_;
+    Vids l1tkemIds_;
+    VRl1tkem l1tkemRefs_;
     Vids l1tjetIds_;
     VRl1tjet l1tjetRefs_;
+    Vids l1tpfjetIds_;
+    VRl1tpfjet l1tpfjetRefs_;
     Vids l1ttauIds_;
     VRl1ttau l1ttauRefs_;
     Vids l1tetsumIds_;
@@ -166,10 +185,18 @@ namespace trigger {
 
           l1tmuonIds_(),
           l1tmuonRefs_(),
+          l1tkmuonIds_(),
+          l1tkmuonRefs_(),
           l1tegammaIds_(),
           l1tegammaRefs_(),
+          l1tkeleIds_(),
+          l1tkeleRefs_(),
+          l1tkemIds_(),
+          l1tkemRefs_(),
           l1tjetIds_(),
           l1tjetRefs_(),
+          l1tpfjetIds_(),
+          l1tpfjetRefs_(),
           l1ttauIds_(),
           l1ttauRefs_(),
           l1tetsumIds_(),
@@ -214,10 +241,18 @@ namespace trigger {
 
       std::swap(l1tmuonIds_, other.l1tmuonIds_);
       std::swap(l1tmuonRefs_, other.l1tmuonRefs_);
+      std::swap(l1tkmuonIds_, other.l1tkmuonIds_);
+      std::swap(l1tkmuonRefs_, other.l1tkmuonRefs_);
       std::swap(l1tegammaIds_, other.l1tegammaIds_);
       std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
+      std::swap(l1tkeleIds_, other.l1tkeleIds_);
+      std::swap(l1tkeleRefs_, other.l1tkeleRefs_);
+      std::swap(l1tkemIds_, other.l1tkemIds_);
+      std::swap(l1tkemRefs_, other.l1tkemRefs_);
       std::swap(l1tjetIds_, other.l1tjetIds_);
       std::swap(l1tjetRefs_, other.l1tjetRefs_);
+      std::swap(l1tpfjetIds_, other.l1tpfjetIds_);
+      std::swap(l1tpfjetRefs_, other.l1tpfjetRefs_);
       std::swap(l1ttauIds_, other.l1ttauIds_);
       std::swap(l1ttauRefs_, other.l1ttauRefs_);
       std::swap(l1tetsumIds_, other.l1tetsumIds_);
@@ -289,13 +324,29 @@ namespace trigger {
       l1tmuonIds_.push_back(id);
       l1tmuonRefs_.push_back(ref);
     }
+     void addObject(int id, const l1t::TkMuonRef& ref) {
+      l1tkmuonIds_.push_back(id);
+      l1tkmuonRefs_.push_back(ref);
+    }
     void addObject(int id, const l1t::EGammaRef& ref) {
       l1tegammaIds_.push_back(id);
       l1tegammaRefs_.push_back(ref);
     }
+    void addObject(int id, const l1t::TkElectronRef& ref) {
+      l1tkeleIds_.push_back(id);
+      l1tkeleRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::TkEmRef& ref) {
+      l1tkemIds_.push_back(id);
+      l1tkemRefs_.push_back(ref);
+    }
     void addObject(int id, const l1t::JetRef& ref) {
       l1tjetIds_.push_back(id);
       l1tjetRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::PFJetRef& ref) {
+      l1tpfjetIds_.push_back(id);
+      l1tpfjetRefs_.push_back(ref);
     }
     void addObject(int id, const l1t::TauRef& ref) {
       l1ttauIds_.push_back(id);
@@ -398,17 +449,41 @@ namespace trigger {
       l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
       return l1tmuonIds_.size();
     }
+     size_type addObjects(const Vids& ids, const VRl1tkmuon& refs) {
+      assert(ids.size() == refs.size());
+      l1tkmuonIds_.insert(l1tkmuonIds_.end(), ids.begin(), ids.end());
+      l1tkmuonRefs_.insert(l1tkmuonRefs_.end(), refs.begin(), refs.end());
+      return l1tkmuonIds_.size();
+    }
     size_type addObjects(const Vids& ids, const VRl1tegamma& refs) {
       assert(ids.size() == refs.size());
       l1tegammaIds_.insert(l1tegammaIds_.end(), ids.begin(), ids.end());
       l1tegammaRefs_.insert(l1tegammaRefs_.end(), refs.begin(), refs.end());
       return l1tegammaIds_.size();
     }
+    size_type addObjects(const Vids& ids, const VRl1tkele& refs) {
+      assert(ids.size() == refs.size());
+      l1tkeleIds_.insert(l1tkeleIds_.end(), ids.begin(), ids.end());
+      l1tkeleRefs_.insert(l1tkeleRefs_.end(), refs.begin(), refs.end());
+      return l1tkeleIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tkem& refs) {
+      assert(ids.size() == refs.size());
+      l1tkemIds_.insert(l1tkemIds_.end(), ids.begin(), ids.end());
+      l1tkemRefs_.insert(l1tkemRefs_.end(), refs.begin(), refs.end());
+      return l1tkemIds_.size();
+    }
     size_type addObjects(const Vids& ids, const VRl1tjet& refs) {
       assert(ids.size() == refs.size());
       l1tjetIds_.insert(l1tjetIds_.end(), ids.begin(), ids.end());
       l1tjetRefs_.insert(l1tjetRefs_.end(), refs.begin(), refs.end());
       return l1tjetIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tpfjet& refs) {
+      assert(ids.size() == refs.size());
+      l1tpfjetIds_.insert(l1tpfjetIds_.end(), ids.begin(), ids.end());
+      l1tpfjetRefs_.insert(l1tpfjetRefs_.end(), refs.begin(), refs.end());
+      return l1tpfjetIds_.size();
     }
     size_type addObjects(const Vids& ids, const VRl1ttau& refs) {
       assert(ids.size() == refs.size());
@@ -939,6 +1014,41 @@ namespace trigger {
       return;
     }
 
+    void getObjects(Vids& ids, VRl1tkmuon& refs) const { getObjects(ids, refs, 0, l1tkmuonIds_.size()); }
+    void getObjects(Vids& ids, VRl1tkmuon& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkmuonIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tkmuonIds_[i];
+        refs[j] = l1tkmuonRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tkmuon& refs) const { getObjects(id, refs, 0, l1tkmuonIds_.size()); }
+    void getObjects(int id, VRl1tkmuon& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkmuonIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkmuonIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkmuonIds_[i]) {
+          refs[j] = l1tkmuonRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
     void getObjects(Vids& ids, VRl1tegamma& refs) const { getObjects(ids, refs, 0, l1tegammaIds_.size()); }
     void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
       assert(begin <= end);
@@ -973,6 +1083,75 @@ namespace trigger {
       }
       return;
     }
+    void getObjects(Vids& ids, VRl1tkele& refs) const { getObjects(ids, refs, 0, l1tkeleIds_.size()); }
+    void getObjects(Vids& ids, VRl1tkele& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkeleIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tkeleIds_[i];
+        refs[j] = l1tkeleRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tkele& refs) const { getObjects(id, refs, 0, l1tkeleIds_.size()); }
+    void getObjects(int id, VRl1tkele& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkeleIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkeleIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkeleIds_[i]) {
+          refs[j] = l1tkeleRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+    void getObjects(Vids& ids, VRl1tkem& refs) const { getObjects(ids, refs, 0, l1tkemIds_.size()); }
+    void getObjects(Vids& ids, VRl1tkem& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkemIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tkemIds_[i];
+        refs[j] = l1tkemRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tkem& refs) const { getObjects(id, refs, 0, l1tkemIds_.size()); }
+    void getObjects(int id, VRl1tkem& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tkemIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkemIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tkemIds_[i]) {
+          refs[j] = l1tkemRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
 
     void getObjects(Vids& ids, VRl1tjet& refs) const { getObjects(ids, refs, 0, l1tjetIds_.size()); }
     void getObjects(Vids& ids, VRl1tjet& refs, size_type begin, size_type end) const {
@@ -1008,6 +1187,42 @@ namespace trigger {
       }
       return;
     }
+
+    void getObjects(Vids& ids, VRl1tpfjet& refs) const { getObjects(ids, refs, 0, l1tpfjetIds_.size()); }
+    void getObjects(Vids& ids, VRl1tpfjet& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpfjetIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tpfjetIds_[i];
+        refs[j] = l1tpfjetRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tpfjet& refs) const { getObjects(id, refs, 0, l1tpfjetIds_.size()); }
+    void getObjects(int id, VRl1tpfjet& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpfjetIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpfjetIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpfjetIds_[i]) {
+          refs[j] = l1tpfjetRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
 
     void getObjects(Vids& ids, VRl1ttau& refs) const { getObjects(ids, refs, 0, l1ttauIds_.size()); }
     void getObjects(Vids& ids, VRl1ttau& refs, size_type begin, size_type end) const {
@@ -1253,13 +1468,29 @@ namespace trigger {
     const Vids& l1tmuonIds() const { return l1tmuonIds_; }
     const VRl1tmuon& l1tmuonRefs() const { return l1tmuonRefs_; }
 
+    size_type l1tkmuonSize() const { return l1tkmuonIds_.size(); }
+    const Vids& l1tkmuonIds() const { return l1tkmuonIds_; }
+    const VRl1tkmuon& l1tkmuonRefs() const { return l1tkmuonRefs_; }
+
     size_type l1tegammaSize() const { return l1tegammaIds_.size(); }
     const Vids& l1tegammaIds() const { return l1tegammaIds_; }
     const VRl1tegamma& l1tegammaRefs() const { return l1tegammaRefs_; }
 
+    size_type l1tkeleSize() const { return l1tkeleIds_.size(); }
+    const Vids& l1tkeleIds() const { return l1tkeleIds_; }
+    const VRl1tkele& l1tkeleRefs() const { return l1tkeleRefs_; }
+
+    size_type l1tkemSize() const { return l1tkemIds_.size(); }
+    const Vids& l1tkemIds() const { return l1tkemIds_; }
+    const VRl1tkem& l1tkemRefs() const { return l1tkemRefs_; }
+
     size_type l1tjetSize() const { return l1tjetIds_.size(); }
     const Vids& l1tjetIds() const { return l1tjetIds_; }
     const VRl1tjet& l1tjetRefs() const { return l1tjetRefs_; }
+
+    size_type l1tpfjetSize() const { return l1tpfjetIds_.size(); }
+    const Vids& l1tpfjetIds() const { return l1tpfjetIds_; }
+    const VRl1tpfjet& l1tpfjetRefs() const { return l1tpfjetRefs_; }
 
     size_type l1ttauSize() const { return l1ttauIds_.size(); }
     const Vids& l1ttauIds() const { return l1ttauIds_; }

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -50,6 +50,9 @@
 #include "DataFormats/L1TCorrelator/interface/TkEm.h"
 #include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
 #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
 
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
@@ -80,14 +83,19 @@ namespace trigger {
   typedef std::vector<l1extra::L1HFRingsRef> VRl1hfrings;        //deprecate
 
   typedef l1t::MuonVectorRef VRl1tmuon;
-  typedef l1t::TkMuonVectorRef VRl1tkmuon;
   typedef l1t::EGammaVectorRef VRl1tegamma;
-  typedef l1t::TkElectronVectorRef VRl1tkele;
-  typedef l1t::TkEmVectorRef VRl1tkem;
   typedef l1t::JetVectorRef VRl1tjet;
-  typedef l1t::PFJetVectorRef VRl1tpfjet;
   typedef l1t::TauVectorRef VRl1ttau;
   typedef l1t::EtSumVectorRef VRl1tetsum;
+
+  /* Phase-2 */
+  typedef l1t::TkMuonVectorRef VRl1ttkmuon;
+  typedef l1t::TkElectronVectorRef VRl1ttkele;
+  typedef l1t::TkEmVectorRef VRl1ttkem;
+  typedef l1t::PFJetVectorRef VRl1tpfjet;
+  typedef l1t::HPSPFTauVectorRef VRl1thpspftau;
+  typedef l1t::PFTauVectorRef VRl1tpftau;
+  typedef l1t::PFTrackVectorRef VRl1tpftrack;
 
   typedef std::vector<reco::PFJetRef> VRpfjet;
   typedef std::vector<reco::PFTauRef> VRpftau;
@@ -127,22 +135,30 @@ namespace trigger {
 
     Vids l1tmuonIds_;
     VRl1tmuon l1tmuonRefs_;
-    Vids l1tkmuonIds_;
-    VRl1tkmuon l1tkmuonRefs_;
     Vids l1tegammaIds_;
     VRl1tegamma l1tegammaRefs_;
-    Vids l1tkeleIds_;
-    VRl1tkele l1tkeleRefs_;
-    Vids l1tkemIds_;
-    VRl1tkem l1tkemRefs_;
     Vids l1tjetIds_;
     VRl1tjet l1tjetRefs_;
-    Vids l1tpfjetIds_;
-    VRl1tpfjet l1tpfjetRefs_;
     Vids l1ttauIds_;
     VRl1ttau l1ttauRefs_;
     Vids l1tetsumIds_;
     VRl1tetsum l1tetsumRefs_;
+
+    /* Phase-2 */
+    Vids l1ttkmuonIds_;
+    VRl1ttkmuon l1ttkmuonRefs_;
+    Vids l1ttkeleIds_;
+    VRl1ttkele l1ttkeleRefs_;
+    Vids l1ttkemIds_;
+    VRl1ttkem l1ttkemRefs_;
+    Vids l1tpfjetIds_;
+    VRl1tpfjet l1tpfjetRefs_;
+    Vids l1tpftauIds_;
+    VRl1tpftau l1tpftauRefs_;
+    Vids l1thpspftauIds_;
+    VRl1thpspftau l1thpspftauRefs_;
+    Vids l1tpftrackIds_;
+    VRl1tpftrack l1tpftrackRefs_;
 
     Vids pfjetIds_;
     VRpfjet pfjetRefs_;
@@ -185,22 +201,30 @@ namespace trigger {
 
           l1tmuonIds_(),
           l1tmuonRefs_(),
-          l1tkmuonIds_(),
-          l1tkmuonRefs_(),
           l1tegammaIds_(),
           l1tegammaRefs_(),
-          l1tkeleIds_(),
-          l1tkeleRefs_(),
-          l1tkemIds_(),
-          l1tkemRefs_(),
           l1tjetIds_(),
           l1tjetRefs_(),
-          l1tpfjetIds_(),
-          l1tpfjetRefs_(),
           l1ttauIds_(),
           l1ttauRefs_(),
           l1tetsumIds_(),
           l1tetsumRefs_(),
+
+          /* Phase-2 */
+          l1ttkmuonIds_(),
+          l1ttkmuonRefs_(),
+          l1ttkeleIds_(),
+          l1ttkeleRefs_(),
+          l1ttkemIds_(),
+          l1ttkemRefs_(),
+          l1tpfjetIds_(),
+          l1tpfjetRefs_(),
+          l1tpftauIds_(),
+          l1tpftauRefs_(),
+          l1thpspftauIds_(),
+          l1thpspftauRefs_(),
+          l1tpftrackIds_(),
+          l1tpftrackRefs_(),
 
           pfjetIds_(),
           pfjetRefs_(),
@@ -241,22 +265,30 @@ namespace trigger {
 
       std::swap(l1tmuonIds_, other.l1tmuonIds_);
       std::swap(l1tmuonRefs_, other.l1tmuonRefs_);
-      std::swap(l1tkmuonIds_, other.l1tkmuonIds_);
-      std::swap(l1tkmuonRefs_, other.l1tkmuonRefs_);
       std::swap(l1tegammaIds_, other.l1tegammaIds_);
       std::swap(l1tegammaRefs_, other.l1tegammaRefs_);
-      std::swap(l1tkeleIds_, other.l1tkeleIds_);
-      std::swap(l1tkeleRefs_, other.l1tkeleRefs_);
-      std::swap(l1tkemIds_, other.l1tkemIds_);
-      std::swap(l1tkemRefs_, other.l1tkemRefs_);
       std::swap(l1tjetIds_, other.l1tjetIds_);
       std::swap(l1tjetRefs_, other.l1tjetRefs_);
-      std::swap(l1tpfjetIds_, other.l1tpfjetIds_);
-      std::swap(l1tpfjetRefs_, other.l1tpfjetRefs_);
       std::swap(l1ttauIds_, other.l1ttauIds_);
       std::swap(l1ttauRefs_, other.l1ttauRefs_);
       std::swap(l1tetsumIds_, other.l1tetsumIds_);
       std::swap(l1tetsumRefs_, other.l1tetsumRefs_);
+
+      /* Phase-2 */
+      std::swap(l1ttkmuonIds_, other.l1ttkmuonIds_);
+      std::swap(l1ttkmuonRefs_, other.l1ttkmuonRefs_);
+      std::swap(l1ttkeleIds_, other.l1ttkeleIds_);
+      std::swap(l1ttkeleRefs_, other.l1ttkeleRefs_);
+      std::swap(l1ttkemIds_, other.l1ttkemIds_);
+      std::swap(l1ttkemRefs_, other.l1ttkemRefs_);
+      std::swap(l1tpfjetIds_, other.l1tpfjetIds_);
+      std::swap(l1tpfjetRefs_, other.l1tpfjetRefs_);
+      std::swap(l1tpftauIds_, other.l1tpftauIds_);
+      std::swap(l1tpftauRefs_, other.l1tpftauRefs_);
+      std::swap(l1thpspftauIds_, other.l1thpspftauIds_);
+      std::swap(l1thpspftauRefs_, other.l1thpspftauRefs_);
+      std::swap(l1tpftrackIds_, other.l1tpftrackIds_);
+      std::swap(l1tpftrackRefs_, other.l1tpftrackRefs_);
 
       std::swap(pfjetIds_, other.pfjetIds_);
       std::swap(pfjetRefs_, other.pfjetRefs_);
@@ -324,29 +356,13 @@ namespace trigger {
       l1tmuonIds_.push_back(id);
       l1tmuonRefs_.push_back(ref);
     }
-    void addObject(int id, const l1t::TkMuonRef& ref) {
-      l1tkmuonIds_.push_back(id);
-      l1tkmuonRefs_.push_back(ref);
-    }
     void addObject(int id, const l1t::EGammaRef& ref) {
       l1tegammaIds_.push_back(id);
       l1tegammaRefs_.push_back(ref);
     }
-    void addObject(int id, const l1t::TkElectronRef& ref) {
-      l1tkeleIds_.push_back(id);
-      l1tkeleRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::TkEmRef& ref) {
-      l1tkemIds_.push_back(id);
-      l1tkemRefs_.push_back(ref);
-    }
     void addObject(int id, const l1t::JetRef& ref) {
       l1tjetIds_.push_back(id);
       l1tjetRefs_.push_back(ref);
-    }
-    void addObject(int id, const l1t::PFJetRef& ref) {
-      l1tpfjetIds_.push_back(id);
-      l1tpfjetRefs_.push_back(ref);
     }
     void addObject(int id, const l1t::TauRef& ref) {
       l1ttauIds_.push_back(id);
@@ -355,6 +371,36 @@ namespace trigger {
     void addObject(int id, const l1t::EtSumRef& ref) {
       l1tetsumIds_.push_back(id);
       l1tetsumRefs_.push_back(ref);
+    }
+
+    /* Phase-2 */
+    void addObject(int id, const l1t::TkMuonRef& ref) {
+      l1ttkmuonIds_.push_back(id);
+      l1ttkmuonRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::TkElectronRef& ref) {
+      l1ttkeleIds_.push_back(id);
+      l1ttkeleRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::TkEmRef& ref) {
+      l1ttkemIds_.push_back(id);
+      l1ttkemRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::PFJetRef& ref) {
+      l1tpfjetIds_.push_back(id);
+      l1tpfjetRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::PFTauRef& ref) {
+      l1tpftauIds_.push_back(id);
+      l1tpftauRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::HPSPFTauRef& ref) {
+      l1thpspftauIds_.push_back(id);
+      l1thpspftauRefs_.push_back(ref);
+    }
+    void addObject(int id, const l1t::PFTrackRef& ref) {
+      l1tpftrackIds_.push_back(id);
+      l1tpftrackRefs_.push_back(ref);
     }
     void addObject(int id, const reco::PFJetRef& ref) {
       pfjetIds_.push_back(id);
@@ -449,41 +495,17 @@ namespace trigger {
       l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
       return l1tmuonIds_.size();
     }
-    size_type addObjects(const Vids& ids, const VRl1tkmuon& refs) {
-      assert(ids.size() == refs.size());
-      l1tkmuonIds_.insert(l1tkmuonIds_.end(), ids.begin(), ids.end());
-      l1tkmuonRefs_.insert(l1tkmuonRefs_.end(), refs.begin(), refs.end());
-      return l1tkmuonIds_.size();
-    }
     size_type addObjects(const Vids& ids, const VRl1tegamma& refs) {
       assert(ids.size() == refs.size());
       l1tegammaIds_.insert(l1tegammaIds_.end(), ids.begin(), ids.end());
       l1tegammaRefs_.insert(l1tegammaRefs_.end(), refs.begin(), refs.end());
       return l1tegammaIds_.size();
     }
-    size_type addObjects(const Vids& ids, const VRl1tkele& refs) {
-      assert(ids.size() == refs.size());
-      l1tkeleIds_.insert(l1tkeleIds_.end(), ids.begin(), ids.end());
-      l1tkeleRefs_.insert(l1tkeleRefs_.end(), refs.begin(), refs.end());
-      return l1tkeleIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tkem& refs) {
-      assert(ids.size() == refs.size());
-      l1tkemIds_.insert(l1tkemIds_.end(), ids.begin(), ids.end());
-      l1tkemRefs_.insert(l1tkemRefs_.end(), refs.begin(), refs.end());
-      return l1tkemIds_.size();
-    }
     size_type addObjects(const Vids& ids, const VRl1tjet& refs) {
       assert(ids.size() == refs.size());
       l1tjetIds_.insert(l1tjetIds_.end(), ids.begin(), ids.end());
       l1tjetRefs_.insert(l1tjetRefs_.end(), refs.begin(), refs.end());
       return l1tjetIds_.size();
-    }
-    size_type addObjects(const Vids& ids, const VRl1tpfjet& refs) {
-      assert(ids.size() == refs.size());
-      l1tpfjetIds_.insert(l1tpfjetIds_.end(), ids.begin(), ids.end());
-      l1tpfjetRefs_.insert(l1tpfjetRefs_.end(), refs.begin(), refs.end());
-      return l1tpfjetIds_.size();
     }
     size_type addObjects(const Vids& ids, const VRl1ttau& refs) {
       assert(ids.size() == refs.size());
@@ -502,6 +524,50 @@ namespace trigger {
       l1hfringsIds_.insert(l1hfringsIds_.end(), ids.begin(), ids.end());
       l1hfringsRefs_.insert(l1hfringsRefs_.end(), refs.begin(), refs.end());
       return l1hfringsIds_.size();
+    }
+
+    /* Phase-2 */
+    size_type addObjects(const Vids& ids, const VRl1ttkmuon& refs) {
+      assert(ids.size() == refs.size());
+      l1ttkmuonIds_.insert(l1ttkmuonIds_.end(), ids.begin(), ids.end());
+      l1ttkmuonRefs_.insert(l1ttkmuonRefs_.end(), refs.begin(), refs.end());
+      return l1ttkmuonIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1ttkele& refs) {
+      assert(ids.size() == refs.size());
+      l1ttkeleIds_.insert(l1ttkeleIds_.end(), ids.begin(), ids.end());
+      l1ttkeleRefs_.insert(l1ttkeleRefs_.end(), refs.begin(), refs.end());
+      return l1ttkeleIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1ttkem& refs) {
+      assert(ids.size() == refs.size());
+      l1ttkemIds_.insert(l1ttkemIds_.end(), ids.begin(), ids.end());
+      l1ttkemRefs_.insert(l1ttkemRefs_.end(), refs.begin(), refs.end());
+      return l1ttkemIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tpfjet& refs) {
+      assert(ids.size() == refs.size());
+      l1tpfjetIds_.insert(l1tpfjetIds_.end(), ids.begin(), ids.end());
+      l1tpfjetRefs_.insert(l1tpfjetRefs_.end(), refs.begin(), refs.end());
+      return l1tpfjetIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tpftau& refs) {
+      assert(ids.size() == refs.size());
+      l1tpftauIds_.insert(l1tpftauIds_.end(), ids.begin(), ids.end());
+      l1tpftauRefs_.insert(l1tpftauRefs_.end(), refs.begin(), refs.end());
+      return l1tpftauIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1thpspftau& refs) {
+      assert(ids.size() == refs.size());
+      l1thpspftauIds_.insert(l1thpspftauIds_.end(), ids.begin(), ids.end());
+      l1thpspftauRefs_.insert(l1thpspftauRefs_.end(), refs.begin(), refs.end());
+      return l1thpspftauIds_.size();
+    }
+    size_type addObjects(const Vids& ids, const VRl1tpftrack& refs) {
+      assert(ids.size() == refs.size());
+      l1tpftrackIds_.insert(l1tpftrackIds_.end(), ids.begin(), ids.end());
+      l1tpftrackRefs_.insert(l1tpftrackRefs_.end(), refs.begin(), refs.end());
+      return l1tpftrackIds_.size();
     }
 
     size_type addObjects(const Vids& ids, const VRpfjet& refs) {
@@ -1014,41 +1080,6 @@ namespace trigger {
       return;
     }
 
-    void getObjects(Vids& ids, VRl1tkmuon& refs) const { getObjects(ids, refs, 0, l1tkmuonIds_.size()); }
-    void getObjects(Vids& ids, VRl1tkmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkmuonIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tkmuonIds_[i];
-        refs[j] = l1tkmuonRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tkmuon& refs) const { getObjects(id, refs, 0, l1tkmuonIds_.size()); }
-    void getObjects(int id, VRl1tkmuon& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkmuonIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkmuonIds_[i]) {
-          ++n;
-        }
-      }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkmuonIds_[i]) {
-          refs[j] = l1tkmuonRefs_[i];
-          ++j;
-        }
-      }
-      return;
-    }
-
     void getObjects(Vids& ids, VRl1tegamma& refs) const { getObjects(ids, refs, 0, l1tegammaIds_.size()); }
     void getObjects(Vids& ids, VRl1tegamma& refs, size_type begin, size_type end) const {
       assert(begin <= end);
@@ -1078,74 +1109,6 @@ namespace trigger {
       for (size_type i = begin; i != end; ++i) {
         if (id == l1tegammaIds_[i]) {
           refs[j] = l1tegammaRefs_[i];
-          ++j;
-        }
-      }
-      return;
-    }
-    void getObjects(Vids& ids, VRl1tkele& refs) const { getObjects(ids, refs, 0, l1tkeleIds_.size()); }
-    void getObjects(Vids& ids, VRl1tkele& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkeleIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tkeleIds_[i];
-        refs[j] = l1tkeleRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tkele& refs) const { getObjects(id, refs, 0, l1tkeleIds_.size()); }
-    void getObjects(int id, VRl1tkele& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkeleIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkeleIds_[i]) {
-          ++n;
-        }
-      }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkeleIds_[i]) {
-          refs[j] = l1tkeleRefs_[i];
-          ++j;
-        }
-      }
-      return;
-    }
-    void getObjects(Vids& ids, VRl1tkem& refs) const { getObjects(ids, refs, 0, l1tkemIds_.size()); }
-    void getObjects(Vids& ids, VRl1tkem& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkemIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tkemIds_[i];
-        refs[j] = l1tkemRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tkem& refs) const { getObjects(id, refs, 0, l1tkemIds_.size()); }
-    void getObjects(int id, VRl1tkem& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tkemIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkemIds_[i]) {
-          ++n;
-        }
-      }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tkemIds_[i]) {
-          refs[j] = l1tkemRefs_[i];
           ++j;
         }
       }
@@ -1181,41 +1144,6 @@ namespace trigger {
       for (size_type i = begin; i != end; ++i) {
         if (id == l1tjetIds_[i]) {
           refs[j] = l1tjetRefs_[i];
-          ++j;
-        }
-      }
-      return;
-    }
-
-    void getObjects(Vids& ids, VRl1tpfjet& refs) const { getObjects(ids, refs, 0, l1tpfjetIds_.size()); }
-    void getObjects(Vids& ids, VRl1tpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpfjetIds_.size());
-      const size_type n(end - begin);
-      ids.resize(n);
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        ids[j] = l1tpfjetIds_[i];
-        refs[j] = l1tpfjetRefs_[i];
-        ++j;
-      }
-    }
-    void getObjects(int id, VRl1tpfjet& refs) const { getObjects(id, refs, 0, l1tpfjetIds_.size()); }
-    void getObjects(int id, VRl1tpfjet& refs, size_type begin, size_type end) const {
-      assert(begin <= end);
-      assert(end <= l1tpfjetIds_.size());
-      size_type n(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpfjetIds_[i]) {
-          ++n;
-        }
-      }
-      refs.resize(n);
-      size_type j(0);
-      for (size_type i = begin; i != end; ++i) {
-        if (id == l1tpfjetIds_[i]) {
-          refs[j] = l1tpfjetRefs_[i];
           ++j;
         }
       }
@@ -1286,6 +1214,252 @@ namespace trigger {
       for (size_type i = begin; i != end; ++i) {
         if (id == l1tetsumIds_[i]) {
           refs[j] = l1tetsumRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    /* Phase-2 */
+    void getObjects(Vids& ids, VRl1ttkmuon& refs) const { getObjects(ids, refs, 0, l1ttkmuonIds_.size()); }
+    void getObjects(Vids& ids, VRl1ttkmuon& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkmuonIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1ttkmuonIds_[i];
+        refs[j] = l1ttkmuonRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1ttkmuon& refs) const { getObjects(id, refs, 0, l1ttkmuonIds_.size()); }
+    void getObjects(int id, VRl1ttkmuon& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkmuonIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkmuonIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkmuonIds_[i]) {
+          refs[j] = l1ttkmuonRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1ttkele& refs) const { getObjects(ids, refs, 0, l1ttkeleIds_.size()); }
+    void getObjects(Vids& ids, VRl1ttkele& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkeleIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1ttkeleIds_[i];
+        refs[j] = l1ttkeleRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1ttkele& refs) const { getObjects(id, refs, 0, l1ttkeleIds_.size()); }
+    void getObjects(int id, VRl1ttkele& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkeleIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkeleIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkeleIds_[i]) {
+          refs[j] = l1ttkeleRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1ttkem& refs) const { getObjects(ids, refs, 0, l1ttkemIds_.size()); }
+    void getObjects(Vids& ids, VRl1ttkem& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkemIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1ttkemIds_[i];
+        refs[j] = l1ttkemRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1ttkem& refs) const { getObjects(id, refs, 0, l1ttkemIds_.size()); }
+    void getObjects(int id, VRl1ttkem& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1ttkemIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkemIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1ttkemIds_[i]) {
+          refs[j] = l1ttkemRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1tpfjet& refs) const { getObjects(ids, refs, 0, l1tpfjetIds_.size()); }
+    void getObjects(Vids& ids, VRl1tpfjet& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpfjetIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tpfjetIds_[i];
+        refs[j] = l1tpfjetRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tpfjet& refs) const { getObjects(id, refs, 0, l1tpfjetIds_.size()); }
+    void getObjects(int id, VRl1tpfjet& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpfjetIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpfjetIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpfjetIds_[i]) {
+          refs[j] = l1tpfjetRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1tpftau& refs) const { getObjects(ids, refs, 0, l1tpftauIds_.size()); }
+    void getObjects(Vids& ids, VRl1tpftau& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpftauIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tpftauIds_[i];
+        refs[j] = l1tpftauRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tpftau& refs) const { getObjects(id, refs, 0, l1tpftauIds_.size()); }
+    void getObjects(int id, VRl1tpftau& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpftauIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpftauIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpftauIds_[i]) {
+          refs[j] = l1tpftauRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1thpspftau& refs) const { getObjects(ids, refs, 0, l1thpspftauIds_.size()); }
+    void getObjects(Vids& ids, VRl1thpspftau& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1thpspftauIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1thpspftauIds_[i];
+        refs[j] = l1thpspftauRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1thpspftau& refs) const { getObjects(id, refs, 0, l1thpspftauIds_.size()); }
+    void getObjects(int id, VRl1thpspftau& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1thpspftauIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1thpspftauIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1thpspftauIds_[i]) {
+          refs[j] = l1thpspftauRefs_[i];
+          ++j;
+        }
+      }
+      return;
+    }
+
+    void getObjects(Vids& ids, VRl1tpftrack& refs) const { getObjects(ids, refs, 0, l1tpftrackIds_.size()); }
+    void getObjects(Vids& ids, VRl1tpftrack& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpftrackIds_.size());
+      const size_type n(end - begin);
+      ids.resize(n);
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        ids[j] = l1tpftrackIds_[i];
+        refs[j] = l1tpftrackRefs_[i];
+        ++j;
+      }
+    }
+    void getObjects(int id, VRl1tpftrack& refs) const { getObjects(id, refs, 0, l1tpftrackIds_.size()); }
+    void getObjects(int id, VRl1tpftrack& refs, size_type begin, size_type end) const {
+      assert(begin <= end);
+      assert(end <= l1tpftrackIds_.size());
+      size_type n(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpftrackIds_[i]) {
+          ++n;
+        }
+      }
+      refs.resize(n);
+      size_type j(0);
+      for (size_type i = begin; i != end; ++i) {
+        if (id == l1tpftrackIds_[i]) {
+          refs[j] = l1tpftrackRefs_[i];
           ++j;
         }
       }
@@ -1466,29 +1640,43 @@ namespace trigger {
     const Vids& l1tmuonIds() const { return l1tmuonIds_; }
     const VRl1tmuon& l1tmuonRefs() const { return l1tmuonRefs_; }
 
-    size_type l1tkmuonSize() const { return l1tkmuonIds_.size(); }
-    const Vids& l1tkmuonIds() const { return l1tkmuonIds_; }
-    const VRl1tkmuon& l1tkmuonRefs() const { return l1tkmuonRefs_; }
-
     size_type l1tegammaSize() const { return l1tegammaIds_.size(); }
     const Vids& l1tegammaIds() const { return l1tegammaIds_; }
     const VRl1tegamma& l1tegammaRefs() const { return l1tegammaRefs_; }
-
-    size_type l1tkeleSize() const { return l1tkeleIds_.size(); }
-    const Vids& l1tkeleIds() const { return l1tkeleIds_; }
-    const VRl1tkele& l1tkeleRefs() const { return l1tkeleRefs_; }
-
-    size_type l1tkemSize() const { return l1tkemIds_.size(); }
-    const Vids& l1tkemIds() const { return l1tkemIds_; }
-    const VRl1tkem& l1tkemRefs() const { return l1tkemRefs_; }
 
     size_type l1tjetSize() const { return l1tjetIds_.size(); }
     const Vids& l1tjetIds() const { return l1tjetIds_; }
     const VRl1tjet& l1tjetRefs() const { return l1tjetRefs_; }
 
+    /* Phase-2 */
+
+    size_type l1ttkmuonSize() const { return l1ttkmuonIds_.size(); }
+    const Vids& l1ttkmuonIds() const { return l1ttkmuonIds_; }
+    const VRl1ttkmuon& l1ttkmuonRefs() const { return l1ttkmuonRefs_; }
+
+    size_type l1ttkeleSize() const { return l1ttkeleIds_.size(); }
+    const Vids& l1ttkeleIds() const { return l1ttkeleIds_; }
+    const VRl1ttkele& l1ttkeleRefs() const { return l1ttkeleRefs_; }
+
+    size_type l1ttkemSize() const { return l1ttkemIds_.size(); }
+    const Vids& l1ttkemIds() const { return l1ttkemIds_; }
+    const VRl1ttkem& l1ttkemRefs() const { return l1ttkemRefs_; }
+
     size_type l1tpfjetSize() const { return l1tpfjetIds_.size(); }
     const Vids& l1tpfjetIds() const { return l1tpfjetIds_; }
     const VRl1tpfjet& l1tpfjetRefs() const { return l1tpfjetRefs_; }
+
+    size_type l1tpftauSize() const { return l1tpftauIds_.size(); }
+    const Vids& l1tpftauIds() const { return l1tpftauIds_; }
+    const VRl1tpftau& l1tpftauRefs() const { return l1tpftauRefs_; }
+
+    size_type l1thpspftauSize() const { return l1thpspftauIds_.size(); }
+    const Vids& l1thpspftauIds() const { return l1thpspftauIds_; }
+    const VRl1thpspftau& l1thpspftauRefs() const { return l1thpspftauRefs_; }
+
+    size_type l1tpftrackSize() const { return l1tpftrackIds_.size(); }
+    const Vids& l1tpftrackIds() const { return l1tpftrackIds_; }
+    const VRl1tpftrack& l1tpftrackRefs() const { return l1tpftrackRefs_; }
 
     size_type l1ttauSize() const { return l1ttauIds_.size(); }
     const Vids& l1ttauIds() const { return l1ttauIds_; }

--- a/DataFormats/HLTReco/interface/TriggerRefsCollections.h
+++ b/DataFormats/HLTReco/interface/TriggerRefsCollections.h
@@ -324,7 +324,7 @@ namespace trigger {
       l1tmuonIds_.push_back(id);
       l1tmuonRefs_.push_back(ref);
     }
-     void addObject(int id, const l1t::TkMuonRef& ref) {
+    void addObject(int id, const l1t::TkMuonRef& ref) {
       l1tkmuonIds_.push_back(id);
       l1tkmuonRefs_.push_back(ref);
     }
@@ -449,7 +449,7 @@ namespace trigger {
       l1tmuonRefs_.insert(l1tmuonRefs_.end(), refs.begin(), refs.end());
       return l1tmuonIds_.size();
     }
-     size_type addObjects(const Vids& ids, const VRl1tkmuon& refs) {
+    size_type addObjects(const Vids& ids, const VRl1tkmuon& refs) {
       assert(ids.size() == refs.size());
       l1tkmuonIds_.insert(l1tkmuonIds_.end(), ids.begin(), ids.end());
       l1tkmuonRefs_.insert(l1tkmuonRefs_.end(), refs.begin(), refs.end());
@@ -1152,7 +1152,6 @@ namespace trigger {
       return;
     }
 
-
     void getObjects(Vids& ids, VRl1tjet& refs) const { getObjects(ids, refs, 0, l1tjetIds_.size()); }
     void getObjects(Vids& ids, VRl1tjet& refs, size_type begin, size_type end) const {
       assert(begin <= end);
@@ -1222,7 +1221,6 @@ namespace trigger {
       }
       return;
     }
-
 
     void getObjects(Vids& ids, VRl1ttau& refs) const { getObjects(ids, refs, 0, l1ttauIds_.size()); }
     void getObjects(Vids& ids, VRl1ttau& refs, size_type begin, size_type end) const {

--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -64,13 +64,14 @@ namespace trigger {
     TriggerL1TkMu = -114,
     TriggerL1TkEle = -115,
     TriggerL1PFJet = -116,
-    TriggerL1TkEm = -117,  // used for photons
-    TriggerL1PFMET = -118,
-    TriggerL1PFETT = -119,
-    TriggerL1PFHT = -120,
-    TriggerL1PFMHT = -121,
-    TriggerL1PFTrack = -122,
-    TriggerL1Vertex = -123,
+    TriggerL1PFTau = -117,
+    TriggerL1TkEm = -118,  // used for photons
+    TriggerL1PFMET = -119,
+    TriggerL1PFETT = -120,
+    TriggerL1PFHT = -121,
+    TriggerL1PFMHT = -122,
+    TriggerL1PFTrack = -123,
+    TriggerL1Vertex = -124,
 
     /// HLT
     TriggerPhoton = +81,

--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -27,6 +27,7 @@ namespace trigger {
     /// L1 - using cases as defined in enum L1GtObject, file:
     /// DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 
+
     TriggerL1Mu = -81,
     TriggerL1NoIsoEG = -82,  // legacy and stage1
     TriggerL1IsoEG = -83,    // legacy and stage1
@@ -60,9 +61,19 @@ namespace trigger {
     TriggerL1AsymHt = -111,
     TriggerL1AsymEtHF = -112,
     TriggerL1AsymHtHF = -113,
+    /// This has all to be decided for Phase-2. Here is Thiago's proposal.
+    TriggerL1TkMu = -114,
+    TriggerL1TkEle = -115,
+    TriggerL1PFJet = -116,
+    TriggerL1TkEm = -117, // used for photons
+    TriggerL1PFMET = -118,
+    TriggerL1PFETT = -119,
+    TriggerL1PFHT  = -120,
+    TriggerL1PFMHT = -121,
+    TriggerL1PFTrack = -122,
+    TriggerL1Vertex = -123, 
 
     /// HLT
-
     TriggerPhoton = +81,
     TriggerElectron = +82,
     TriggerMuon = +83,

--- a/DataFormats/HLTReco/interface/TriggerTypeDefs.h
+++ b/DataFormats/HLTReco/interface/TriggerTypeDefs.h
@@ -27,7 +27,6 @@ namespace trigger {
     /// L1 - using cases as defined in enum L1GtObject, file:
     /// DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetupFwd.h"
 
-
     TriggerL1Mu = -81,
     TriggerL1NoIsoEG = -82,  // legacy and stage1
     TriggerL1IsoEG = -83,    // legacy and stage1
@@ -65,13 +64,13 @@ namespace trigger {
     TriggerL1TkMu = -114,
     TriggerL1TkEle = -115,
     TriggerL1PFJet = -116,
-    TriggerL1TkEm = -117, // used for photons
+    TriggerL1TkEm = -117,  // used for photons
     TriggerL1PFMET = -118,
     TriggerL1PFETT = -119,
-    TriggerL1PFHT  = -120,
+    TriggerL1PFHT = -120,
     TriggerL1PFMHT = -121,
     TriggerL1PFTrack = -122,
-    TriggerL1Vertex = -123, 
+    TriggerL1Vertex = -123,
 
     /// HLT
     TriggerPhoton = +81,

--- a/DataFormats/HLTReco/src/classes.h
+++ b/DataFormats/HLTReco/src/classes.h
@@ -15,5 +15,12 @@
 #include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
 #include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
 
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/HLTReco/src/classes.h
+++ b/DataFormats/HLTReco/src/classes.h
@@ -11,4 +11,9 @@
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"
 #include "DataFormats/Candidate/interface/CompositeCandidateFwd.h"
 
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+
 #include "DataFormats/Common/interface/Ref.h"

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -42,13 +42,13 @@
    <version ClassVersion="10" checksum="2923979599"/>
   </class>
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="16">
+  <class name="trigger::TriggerRefsCollections" ClassVersion="15">
    <version ClassVersion="15" checksum="1920377523"/>
    <version ClassVersion="14" checksum="874193725"/>
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="15">
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="14">
    <version ClassVersion="14" checksum="4087045168"/>
    <version ClassVersion="13" checksum="2951644382"/>
    <version ClassVersion="12" checksum="2645314434"/>
@@ -64,14 +64,14 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="16">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="15">
    <version ClassVersion="15" checksum="450435068"/>
    <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="15">
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="14">
    <version ClassVersion="14" checksum="2001321210"/>
    <version ClassVersion="13" checksum="1258968436"/>
    <version ClassVersion="12" checksum="3347721344"/>

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -43,15 +43,13 @@
   </class>
   <class name="trigger::TriggerObjectCollection"/>
   <class name="trigger::TriggerRefsCollections" ClassVersion="16">
-   <version ClassVersion="16" checksum="1920377523"/>
-   <version ClassVersion="15" checksum="450679879"/>
+   <version ClassVersion="15" checksum="1920377523"/>
    <version ClassVersion="14" checksum="874193725"/>
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
   <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="15">
-   <version ClassVersion="15" checksum="4087045168"/>
-   <version ClassVersion="14" checksum="4165317388"/>
+   <version ClassVersion="14" checksum="4087045168"/>
    <version ClassVersion="13" checksum="2951644382"/>
    <version ClassVersion="12" checksum="2645314434"/>
    <version ClassVersion="11" checksum="1437602318"/>
@@ -67,16 +65,14 @@
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
   <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="16">
-   <version ClassVersion="16" checksum="450435068"/>
-   <version ClassVersion="15" checksum="2824205283"/>
+   <version ClassVersion="15" checksum="450435068"/>
    <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
   <class name="trigger::TriggerEventWithRefs" ClassVersion="15">
-   <version ClassVersion="15" checksum="2001321210"/>
-   <version ClassVersion="14" checksum="948988526"/>
+   <version ClassVersion="14" checksum="2001321210"/>
    <version ClassVersion="13" checksum="1258968436"/>
    <version ClassVersion="12" checksum="3347721344"/>
    <version ClassVersion="11" checksum="2025606788"/>

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -42,13 +42,15 @@
    <version ClassVersion="10" checksum="2923979599"/>
   </class>
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="15">
+  <class name="trigger::TriggerRefsCollections" ClassVersion="16">
+   <version ClassVersion="16" checksum="1920377523"/>
    <version ClassVersion="15" checksum="450679879"/>
    <version ClassVersion="14" checksum="874193725"/>
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="14">
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="15">
+   <version ClassVersion="15" checksum="4087045168"/>
    <version ClassVersion="14" checksum="4165317388"/>
    <version ClassVersion="13" checksum="2951644382"/>
    <version ClassVersion="12" checksum="2645314434"/>
@@ -64,14 +66,16 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="15">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="16">
+   <version ClassVersion="16" checksum="450435068"/>
    <version ClassVersion="15" checksum="2824205283"/>
    <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="14">
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="15">
+   <version ClassVersion="15" checksum="2001321210"/>
    <version ClassVersion="14" checksum="948988526"/>
    <version ClassVersion="13" checksum="1258968436"/>
    <version ClassVersion="12" checksum="3347721344"/>

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -42,12 +42,14 @@
    <version ClassVersion="10" checksum="2923979599"/>
   </class>
   <class name="trigger::TriggerObjectCollection"/>
-  <class name="trigger::TriggerRefsCollections" ClassVersion="14">
+  <class name="trigger::TriggerRefsCollections" ClassVersion="15">
+   <version ClassVersion="15" checksum="450679879"/>
    <version ClassVersion="14" checksum="874193725"/>
    <version ClassVersion="13" checksum="3831523881"/>
    <version ClassVersion="12" checksum="4231679693"/>
   </class>
-  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="13">
+  <class name="trigger::TriggerFilterObjectWithRefs" ClassVersion="14">
+   <version ClassVersion="14" checksum="4165317388"/>
    <version ClassVersion="13" checksum="2951644382"/>
    <version ClassVersion="12" checksum="2645314434"/>
    <version ClassVersion="11" checksum="1437602318"/>
@@ -62,13 +64,15 @@
    <version ClassVersion="11" checksum="3351458717"/>
    <version ClassVersion="10" checksum="1112210423"/>
   </class>
-  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="14">
+  <class name="trigger::TriggerEventWithRefs::TriggerFilterObject" ClassVersion="15">
+   <version ClassVersion="15" checksum="2824205283"/>
    <version ClassVersion="14" checksum="1673531968"/>
    <version ClassVersion="13" checksum="1672519577"/>
    <version ClassVersion="12" checksum="2301242282"/>
   </class>
   <class name="std::vector<trigger::TriggerEventWithRefs::TriggerFilterObject>"/>
-  <class name="trigger::TriggerEventWithRefs" ClassVersion="13">
+  <class name="trigger::TriggerEventWithRefs" ClassVersion="14">
+   <version ClassVersion="14" checksum="948988526"/>
    <version ClassVersion="13" checksum="1258968436"/>
    <version ClassVersion="12" checksum="3347721344"/>
    <version ClassVersion="11" checksum="2025606788"/>

--- a/DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h
+++ b/DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h
@@ -6,6 +6,8 @@
 
 // First version of a class for L1-zvertex
 #include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
 
 namespace l1t {
 
@@ -26,6 +28,9 @@ namespace l1t {
   };
 
   typedef std::vector<TkPrimaryVertex> TkPrimaryVertexCollection;
+  typedef edm::Ref<TkPrimaryVertexCollection> TkPrimaryVertexRef;
+  typedef edm::RefVector<TkPrimaryVertexCollection> TkPrimaryVertexRefVector;
+  typedef std::vector<TkPrimaryVertexRef> TkPrimaryVertexVectorRef;
 
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -21,6 +21,8 @@
   <class name="std::vector<l1t::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEm> >"/>
   <class name="edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> > >"/>
+
 
   <class name="l1t::TkEGTau" ClassVersion="3">
    <version ClassVersion="3" checksum="3759113668"/>
@@ -49,6 +51,7 @@
   <class name="std::vector<l1t::TkElectron>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkElectron> >"/>
   <class name="edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> > >"/>
 
   <class name="l1t::TkJet" ClassVersion="3">
    <version ClassVersion="3" checksum="3336007399"/>
@@ -72,6 +75,7 @@
   <class name="std::vector<l1t::TkMuon>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkMuon> >"/>
   <class name="edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> > >"/>
 
   <class name="l1t::TkGlbMuon" ClassVersion="3">
    <version ClassVersion="3"  checksum="2811548892"/>

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -6,7 +6,9 @@
  </class>
  <class name="std::vector<l1t::TkPrimaryVertex>"/>
  <class name="edm::Wrapper<std::vector<l1t::TkPrimaryVertex> >"/>
-  <class name="edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> >"/>
+ <class name="edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> >"/>
+ <class name="std::vector<edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> > >"/>
+
 
   <class name="l1t::TkEtMiss" ClassVersion="3">
    <version ClassVersion="3" checksum="77762919"/>

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -20,7 +20,7 @@ namespace l1t {
     HPSPFTau();
 
     /// destructor
-    ~HPSPFTau();
+    ~HPSPFTau() override;
 
     /// accessor functions for reco level quantities
     bool isChargedPFCandSeeded() const { return seedChargedPFCand_.isNonnull(); }

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -79,8 +79,6 @@ namespace l1t {
     bool passLooseRelIso() const { return passLooseRelIso_; }
     bool passVLooseRelIso() const { return passVLooseRelIso_; }
 
-    friend class ::HPSPFTauBuilder;
-
   private:
     l1t::PFCandidateRef seedChargedPFCand_;
     l1t::PFJetRef seedPFJet_;
@@ -143,6 +141,5 @@ namespace l1t {
 
 /// print to stream
 std::ostream& operator<<(std::ostream& os, const l1t::HPSPFTau& l1PFTau);
-
 
 #endif

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -9,9 +9,6 @@
 
 #include <ostream>
 
-// forward declation needed in order to declare HPSPFTauBuilder class as friend (that has access to private data-members)
-class HPSPFTauBuilder;
-
 namespace l1t {
 
   class HPSPFTau : public reco::LeafCandidate {

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -52,7 +52,6 @@ namespace l1t {
     const l1t::PFCandidateRefVector& sumPhotons() const { return sumPhotons_; }
     const l1t::PFCandidateRefVector& sumMuons() const { return sumMuons_; }
 
-    //const l1t::VertexRef&            primaryVertex()           const { return primaryVertex_;           }
     const l1t::TkPrimaryVertexRef& primaryVertex() const { return primaryVertex_; }
 
     enum Kind { kUndefined, kOneProng0Pi0, kOneProng1Pi0, kThreeProng0Pi0, kThreeProng1Pi0 };
@@ -112,7 +111,6 @@ namespace l1t {
     l1t::PFCandidateRefVector sumPhotons_;
     l1t::PFCandidateRefVector sumMuons_;
 
-    //l1t::VertexRef primaryVertex_;
     l1t::TkPrimaryVertexRef primaryVertex_;
     Kind tauType_;
 
@@ -139,13 +137,12 @@ namespace l1t {
     bool passVLooseRelIso_;
   };
 
+  void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex);
+  void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z);
 }  // namespace l1t
 
 /// print to stream
 std::ostream& operator<<(std::ostream& os, const l1t::HPSPFTau& l1PFTau);
 
-//void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex);
-void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex);
-void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z);
 
 #endif

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTau.h
@@ -1,0 +1,154 @@
+#ifndef DataFormats_L1TParticleFlow_HPSPFTau_H
+#define DataFormats_L1TParticleFlow_HPSPFTau_H
+
+#include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"  // l1t::PFCandidate, l1t::PFCandidateRef, l1t::PFCandidateRefVector
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"    // l1t::PFJet, l1t::PFJetCollection, l1t::PFJetRef
+#include "DataFormats/Candidate/interface/LeafCandidate.h"  // reco::LeafCandidate
+#include "DataFormats/Candidate/interface/Particle.h"       // reco::Particle::LorentzVector
+#include "DataFormats/L1TCorrelator/interface/TkPrimaryVertex.h"
+
+#include <ostream>
+
+// forward declation needed in order to declare HPSPFTauBuilder class as friend (that has access to private data-members)
+class HPSPFTauBuilder;
+
+namespace l1t {
+
+  class HPSPFTau : public reco::LeafCandidate {
+  public:
+    /// default constructor
+    HPSPFTau();
+
+    /// destructor
+    ~HPSPFTau();
+
+    /// accessor functions for reco level quantities
+    bool isChargedPFCandSeeded() const { return seedChargedPFCand_.isNonnull(); }
+    bool isPFJetSeeded() const { return seedPFJet_.isNonnull(); }
+
+    const l1t::PFCandidateRef& seedChargedPFCand() const { return seedChargedPFCand_; }
+    const l1t::PFJetRef& seedPFJet() const { return seedPFJet_; }
+    const l1t::PFCandidateRef& leadChargedPFCand() const { return leadChargedPFCand_; }
+
+    const l1t::PFCandidateRefVector& signalAllL1PFCandidates() const { return signalAllL1PFCandidates_; }
+    const l1t::PFCandidateRefVector& signalChargedHadrons() const { return signalChargedHadrons_; }
+    const l1t::PFCandidateRefVector& signalElectrons() const { return signalElectrons_; }
+    const l1t::PFCandidateRefVector& signalNeutralHadrons() const { return signalNeutralHadrons_; }
+    const l1t::PFCandidateRefVector& signalPhotons() const { return signalPhotons_; }
+    const l1t::PFCandidateRefVector& signalMuons() const { return signalMuons_; }
+
+    const l1t::PFCandidateRefVector& stripAllL1PFCandidates() const { return stripAllL1PFCandidates_; }
+    const l1t::PFCandidateRefVector& stripElectrons() const { return stripElectrons_; }
+    const l1t::PFCandidateRefVector& stripPhotons() const { return stripPhotons_; }
+
+    const l1t::PFCandidateRefVector& isoAllL1PFCandidates() const { return isoAllL1PFCandidates_; }
+    const l1t::PFCandidateRefVector& isoChargedHadrons() const { return isoChargedHadrons_; }
+    const l1t::PFCandidateRefVector& isoElectrons() const { return isoElectrons_; }
+    const l1t::PFCandidateRefVector& isoNeutralHadrons() const { return isoNeutralHadrons_; }
+    const l1t::PFCandidateRefVector& isoPhotons() const { return isoPhotons_; }
+    const l1t::PFCandidateRefVector& isoMuons() const { return isoMuons_; }
+
+    const l1t::PFCandidateRefVector& sumAllL1PFCandidates() const { return sumAllL1PFCandidates_; }
+    const l1t::PFCandidateRefVector& sumChargedHadrons() const { return sumChargedHadrons_; }
+    const l1t::PFCandidateRefVector& sumElectrons() const { return sumElectrons_; }
+    const l1t::PFCandidateRefVector& sumNeutralHadrons() const { return sumNeutralHadrons_; }
+    const l1t::PFCandidateRefVector& sumPhotons() const { return sumPhotons_; }
+    const l1t::PFCandidateRefVector& sumMuons() const { return sumMuons_; }
+
+    //const l1t::VertexRef&            primaryVertex()           const { return primaryVertex_;           }
+    const l1t::TkPrimaryVertexRef& primaryVertex() const { return primaryVertex_; }
+
+    enum Kind { kUndefined, kOneProng0Pi0, kOneProng1Pi0, kThreeProng0Pi0, kThreeProng1Pi0 };
+    Kind tauType() const { return tauType_; }
+
+    const reco::Particle::LorentzVector& strip_p4() const { return strip_p4_; }
+
+    float sumAllL1PFCandidates_pt() const { return sumAllL1PFCandidates_pt_; }
+    float signalConeSize() const { return signalConeSize_; }
+    float isolationConeSize() const { return signalConeSize_; }
+
+    float sumChargedIso() const { return sumChargedIso_; }
+    float sumNeutralIso() const { return sumNeutralIso_; }
+    float sumCombinedIso() const { return sumCombinedIso_; }
+    float sumChargedIsoPileup() const { return sumChargedIsoPileup_; }
+    float rhoCorr() const { return rhoCorr_; }
+
+    bool passTightIso() const { return passTightIso_; }
+    bool passMediumIso() const { return passMediumIso_; }
+    bool passLooseIso() const { return passLooseIso_; }
+    bool passVLooseIso() const { return passVLooseIso_; }
+
+    bool passTightRelIso() const { return passTightRelIso_; }
+    bool passMediumRelIso() const { return passMediumRelIso_; }
+    bool passLooseRelIso() const { return passLooseRelIso_; }
+    bool passVLooseRelIso() const { return passVLooseRelIso_; }
+
+    friend class ::HPSPFTauBuilder;
+
+  private:
+    l1t::PFCandidateRef seedChargedPFCand_;
+    l1t::PFJetRef seedPFJet_;
+    l1t::PFCandidateRef leadChargedPFCand_;
+
+    l1t::PFCandidateRefVector signalAllL1PFCandidates_;
+    l1t::PFCandidateRefVector signalChargedHadrons_;
+    l1t::PFCandidateRefVector signalElectrons_;
+    l1t::PFCandidateRefVector signalNeutralHadrons_;
+    l1t::PFCandidateRefVector signalPhotons_;
+    l1t::PFCandidateRefVector signalMuons_;
+
+    l1t::PFCandidateRefVector stripAllL1PFCandidates_;
+    l1t::PFCandidateRefVector stripElectrons_;
+    l1t::PFCandidateRefVector stripPhotons_;
+
+    l1t::PFCandidateRefVector isoAllL1PFCandidates_;
+    l1t::PFCandidateRefVector isoChargedHadrons_;
+    l1t::PFCandidateRefVector isoElectrons_;
+    l1t::PFCandidateRefVector isoNeutralHadrons_;
+    l1t::PFCandidateRefVector isoPhotons_;
+    l1t::PFCandidateRefVector isoMuons_;
+
+    l1t::PFCandidateRefVector sumAllL1PFCandidates_;
+    l1t::PFCandidateRefVector sumChargedHadrons_;
+    l1t::PFCandidateRefVector sumElectrons_;
+    l1t::PFCandidateRefVector sumNeutralHadrons_;
+    l1t::PFCandidateRefVector sumPhotons_;
+    l1t::PFCandidateRefVector sumMuons_;
+
+    //l1t::VertexRef primaryVertex_;
+    l1t::TkPrimaryVertexRef primaryVertex_;
+    Kind tauType_;
+
+    reco::Particle::LorentzVector strip_p4_;
+
+    float sumAllL1PFCandidates_pt_;
+    float signalConeSize_;
+    float isolationConeSize_;
+
+    float sumChargedIso_;
+    float sumNeutralIso_;
+    float sumCombinedIso_;
+    float sumChargedIsoPileup_;  // charged PFCands failing dz cut (maybe useful to correct neutral isolation for pile-up contributions by applying delta-beta corrections)
+    float rhoCorr_;              // rho correction (maybe useful for applying pile-up corrections to neutral isolation)
+
+    bool passTightIso_;
+    bool passMediumIso_;
+    bool passLooseIso_;
+    bool passVLooseIso_;
+
+    bool passTightRelIso_;
+    bool passMediumRelIso_;
+    bool passLooseRelIso_;
+    bool passVLooseRelIso_;
+  };
+
+}  // namespace l1t
+
+/// print to stream
+std::ostream& operator<<(std::ostream& os, const l1t::HPSPFTau& l1PFTau);
+
+//void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex);
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex);
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z);
+
+#endif

--- a/DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h
+++ b/DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_L1TParticleFlow_HPSPFTauFwd_H
+#define DataFormats_L1TParticleFlow_HPSPFTauFwd_H
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+namespace l1t {
+
+  class HPSPFTau;
+
+  typedef std::vector<HPSPFTau> HPSPFTauCollection;
+
+  typedef edm::Ref<HPSPFTauCollection> HPSPFTauRef;
+  typedef edm::RefVector<HPSPFTauCollection> HPSPFTauRefVector;
+  typedef std::vector<HPSPFTauRef> HPSPFTauVectorRef;
+}  // namespace l1t
+
+#endif

--- a/DataFormats/L1TParticleFlow/interface/PFJet.h
+++ b/DataFormats/L1TParticleFlow/interface/PFJet.h
@@ -43,5 +43,6 @@ namespace l1t {
 
   typedef std::vector<l1t::PFJet> PFJetCollection;
   typedef edm::Ref<l1t::PFJetCollection> PFJetRef;
+  typedef std::vector<l1t::PFJetRef> PFJetVectorRef;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/PFTau.h
+++ b/DataFormats/L1TParticleFlow/interface/PFTau.h
@@ -59,5 +59,9 @@ namespace l1t {
   };
 
   typedef std::vector<l1t::PFTau> PFTauCollection;
+
+  typedef edm::Ref<l1t::PFTauCollection> PFTauRef;
+  typedef edm::RefVector<l1t::PFTauCollection> PFTauRefVector;
+  typedef std::vector<l1t::PFTauRef> PFTauVectorRef;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/interface/PFTrack.h
+++ b/DataFormats/L1TParticleFlow/interface/PFTrack.h
@@ -83,5 +83,7 @@ namespace l1t {
 
   typedef std::vector<l1t::PFTrack> PFTrackCollection;
   typedef edm::Ref<l1t::PFTrackCollection> PFTrackRef;
+  typedef edm::RefVector<l1t::PFTrackCollection> PFTrackRefVector;
+  typedef std::vector<l1t::PFTrackRef> PFTrackVectorRef;
 }  // namespace l1t
 #endif

--- a/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
+++ b/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
@@ -1,0 +1,87 @@
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+
+// default constructor
+l1t::HPSPFTau::HPSPFTau()
+    : tauType_(kUndefined),
+      sumChargedIso_(0.),
+      sumNeutralIso_(0.),
+      sumCombinedIso_(0.),
+      sumChargedIsoPileup_(0.),
+      rhoCorr_(0.),
+      passTightIso_(false),
+      passMediumIso_(false),
+      passLooseIso_(false),
+      passVLooseIso_(false),
+      passTightRelIso_(false),
+      passMediumRelIso_(false),
+      passLooseRelIso_(false),
+      passVLooseRelIso_(false) {}
+
+// destructor
+l1t::HPSPFTau::~HPSPFTau() {}
+
+// print to stream
+ostream& operator<<(ostream& os, const l1t::HPSPFTau& l1PFTau) {
+  os << "pT = " << l1PFTau.pt() << ", eta = " << l1PFTau.eta() << ", phi = " << l1PFTau.phi()
+     << " (type = " << l1PFTau.tauType() << ")" << std::endl;
+  os << "lead. ChargedPFCand:" << std::endl;
+  if (l1PFTau.leadChargedPFCand().isNonnull()) {
+    printPFCand(os, *l1PFTau.leadChargedPFCand(), l1PFTau.primaryVertex());
+  } else {
+    os << " N/A" << std::endl;
+  }
+  os << "seed:";
+  if (l1PFTau.isChargedPFCandSeeded()) {
+    os << " chargedPFCand";
+  } else if (l1PFTau.isPFJetSeeded()) {
+    os << " PFJet";
+  } else
+    assert(0);
+  os << std::endl;
+  os << "signalPFCands:" << std::endl;
+  for (auto l1PFCand : l1PFTau.signalAllL1PFCandidates()) {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "stripPFCands:" << std::endl;
+  for (auto l1PFCand : l1PFTau.stripAllL1PFCandidates()) {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "strip pT = " << l1PFTau.strip_p4().pt() << std::endl;
+  os << "isolationPFCands:" << std::endl;
+  for (auto l1PFCand : l1PFTau.isoAllL1PFCandidates()) {
+    printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
+  }
+  os << "isolation pT-sum: charged = " << l1PFTau.sumChargedIso() << ", neutral = " << l1PFTau.sumNeutralIso()
+     << " (charged from pileup = " << l1PFTau.sumChargedIsoPileup() << ")" << std::endl;
+  return os;
+}
+
+//void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex)
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex) {
+  //float primaryVertex_z = ( primaryVertex.isNonnull() ) ? primaryVertex->z0() : 0.;
+  float primaryVertex_z = (primaryVertex.isNonnull()) ? primaryVertex->zvertex() : 0.;
+  printPFCand(os, l1PFCand, primaryVertex_z);
+}
+
+void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z) {
+  std::string type_string;
+  if (l1PFCand.id() == l1t::PFCandidate::ChargedHadron)
+    type_string = "PFChargedHadron";
+  else if (l1PFCand.id() == l1t::PFCandidate::Electron)
+    type_string = "PFElectron";
+  else if (l1PFCand.id() == l1t::PFCandidate::NeutralHadron)
+    type_string = "PFNeutralHadron";
+  else if (l1PFCand.id() == l1t::PFCandidate::Photon)
+    type_string = "PFPhoton";
+  else if (l1PFCand.id() == l1t::PFCandidate::Muon)
+    type_string = "PFMuon";
+  else
+    type_string = "N/A";
+  os << " " << type_string << " with pT = " << l1PFCand.pt() << ", eta = " << l1PFCand.eta()
+     << ", phi = " << l1PFCand.phi() << ","
+     << " mass = " << l1PFCand.mass() << ", charge = " << l1PFCand.charge();
+  if (l1PFCand.charge() != 0 && primaryVertex_z != 0.) {
+    os << " (dz = " << std::fabs(l1PFCand.pfTrack()->vertex().z() - primaryVertex_z) << ")";
+  }
+  os << std::endl;
+}

--- a/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
+++ b/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
@@ -56,9 +56,7 @@ ostream& operator<<(ostream& os, const l1t::HPSPFTau& l1PFTau) {
   return os;
 }
 
-//void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::VertexRef& primaryVertex)
 void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex) {
-  //float primaryVertex_z = ( primaryVertex.isNonnull() ) ? primaryVertex->z0() : 0.;
   float primaryVertex_z = (primaryVertex.isNonnull()) ? primaryVertex->zvertex() : 0.;
   printPFCand(os, l1PFCand, primaryVertex_z);
 }

--- a/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
+++ b/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
@@ -39,16 +39,16 @@ ostream& operator<<(ostream& os, const l1t::HPSPFTau& l1PFTau) {
     assert(0);
   os << std::endl;
   os << "signalPFCands:" << std::endl;
-  for (auto l1PFCand : l1PFTau.signalAllL1PFCandidates()) {
+  for (const auto& l1PFCand : l1PFTau.signalAllL1PFCandidates()) {
     printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
   }
   os << "stripPFCands:" << std::endl;
-  for (auto l1PFCand : l1PFTau.stripAllL1PFCandidates()) {
+  for (const auto& l1PFCand : l1PFTau.stripAllL1PFCandidates()) {
     printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
   }
   os << "strip pT = " << l1PFTau.strip_p4().pt() << std::endl;
   os << "isolationPFCands:" << std::endl;
-  for (auto l1PFCand : l1PFTau.isoAllL1PFCandidates()) {
+  for (const auto& l1PFCand : l1PFTau.isoAllL1PFCandidates()) {
     printPFCand(os, *l1PFCand, l1PFTau.primaryVertex());
   }
   os << "isolation pT-sum: charged = " << l1PFTau.sumChargedIso() << ", neutral = " << l1PFTau.sumNeutralIso()

--- a/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
+++ b/DataFormats/L1TParticleFlow/src/HPSPFTau.cc
@@ -1,4 +1,5 @@
 #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 // default constructor
 l1t::HPSPFTau::HPSPFTau()
@@ -35,8 +36,12 @@ ostream& operator<<(ostream& os, const l1t::HPSPFTau& l1PFTau) {
     os << " chargedPFCand";
   } else if (l1PFTau.isPFJetSeeded()) {
     os << " PFJet";
-  } else
-    assert(0);
+  } else {
+    cms::Exception ex("InconsistentTau");
+    ex.addContext("Calling HPSPFTau::operator <<");
+    ex.addAdditionalInfo("This tau is not seed by either a chargedPFCand or a PFJet!");
+    throw ex;
+  }
   os << std::endl;
   os << "signalPFCands:" << std::endl;
   for (const auto& l1PFCand : l1PFTau.signalAllL1PFCandidates()) {
@@ -56,12 +61,12 @@ ostream& operator<<(ostream& os, const l1t::HPSPFTau& l1PFTau) {
   return os;
 }
 
-void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex) {
+void l1t::printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, const l1t::TkPrimaryVertexRef& primaryVertex) {
   float primaryVertex_z = (primaryVertex.isNonnull()) ? primaryVertex->zvertex() : 0.;
-  printPFCand(os, l1PFCand, primaryVertex_z);
+  l1t::printPFCand(os, l1PFCand, primaryVertex_z);
 }
 
-void printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z) {
+void l1t::printPFCand(ostream& os, const l1t::PFCandidate& l1PFCand, float primaryVertex_z) {
   std::string type_string;
   if (l1PFCand.id() == l1t::PFCandidate::ChargedHadron)
     type_string = "PFChargedHadron";

--- a/DataFormats/L1TParticleFlow/src/classes.h
+++ b/DataFormats/L1TParticleFlow/src/classes.h
@@ -6,3 +6,15 @@
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
 #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 #include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
+
+namespace DataFormats_L1TParticleFlow {
+  struct dictionary {
+    l1t::HPSPFTau hpspftau;
+    l1t::HPSPFTauCollection hpspftauCollection;
+    edm::Wrapper<l1t::HPSPFTauCollection> hpspftauCWrapper;
+    l1t::HPSPFTauRefVector hpspftaureRefVector;
+    l1t::HPSPFTauVectorRef hpspftauVectorRef;
+  };
+}  // namespace DataFormats_L1TParticleFlow

--- a/DataFormats/L1TParticleFlow/src/classes.h
+++ b/DataFormats/L1TParticleFlow/src/classes.h
@@ -8,13 +8,3 @@
 #include "DataFormats/L1TParticleFlow/interface/PFTau.h"
 #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
 #include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
-
-namespace DataFormats_L1TParticleFlow {
-  struct dictionary {
-    l1t::HPSPFTau hpspftau;
-    l1t::HPSPFTauCollection hpspftauCollection;
-    edm::Wrapper<l1t::HPSPFTauCollection> hpspftauCWrapper;
-    l1t::HPSPFTauRefVector hpspftaureRefVector;
-    l1t::HPSPFTauVectorRef hpspftauVectorRef;
-  };
-}  // namespace DataFormats_L1TParticleFlow

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -16,6 +16,7 @@
   <class name="edm::Wrapper<l1t::PFTrackCollection>" />
   <class name="edm::Ref<l1t::PFTrackCollection>" />
   <class name="edm::RefVector<l1t::PFTrackCollection>" /> 
+  <class name="std::vector<edm::Ref<l1t::PFTrackCollection> >" />
 
   <class name="l1t::PFCandidate"  ClassVersion="3">
         <version ClassVersion="3" checksum="4253860178"/>
@@ -41,14 +42,15 @@
   <class name="edm::Wrapper<l1t::PFTauCollection>" />
   <class name="edm::Ref<l1t::PFTauCollection>" /> 
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
+  <class name="std::vector<edm::Ref<l1t::PFTauCollection> >" /> 
 
-  <class name="l1t::HPSPFTau" ClassVersion="12">
-   <version ClassVersion="12" checksum="98678086"/>
-   <version ClassVersion="11" checksum="3703824282"/>
+  <class name="l1t::HPSPFTau" ClassVersion="11">
+   <version ClassVersion="11" checksum="98678086"/>
   </class>
   <class name="l1t::HPSPFTauCollection"/>
   <class name="edm::Wrapper<l1t::HPSPFTauCollection>"/>
   <class name="edm::Ref<l1t::HPSPFTauCollection>" />
   <class name="edm::RefVector<l1t::HPSPFTauCollection>" />
+  <class name="std::vector<edm::Ref<l1t::HPSPFTauCollection> >" />
 </lcgdict>
 

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -32,6 +32,7 @@
   <class name="edm::Wrapper<l1t::PFJetCollection>" />
   <class name="edm::Ref<l1t::PFJetCollection>" />
   <class name="edm::RefVector<l1t::PFJetCollection>" />
+  <class name="std::vector<edm::Ref<std::vector<l1t::PFJet>,l1t::PFJet,edm::refhelper::FindUsingAdvance<std::vector<l1t::PFJet>,l1t::PFJet> > >" />
 
   <class name="l1t::PFTau"  ClassVersion="3">
         <version ClassVersion="3" checksum="1410157160"/>

--- a/DataFormats/L1TParticleFlow/src/classes_def.xml
+++ b/DataFormats/L1TParticleFlow/src/classes_def.xml
@@ -42,5 +42,13 @@
   <class name="edm::Ref<l1t::PFTauCollection>" /> 
   <class name="edm::RefVector<l1t::PFTauCollection>" /> 
 
+  <class name="l1t::HPSPFTau" ClassVersion="12">
+   <version ClassVersion="12" checksum="98678086"/>
+   <version ClassVersion="11" checksum="3703824282"/>
+  </class>
+  <class name="l1t::HPSPFTauCollection"/>
+  <class name="edm::Wrapper<l1t::HPSPFTauCollection>"/>
+  <class name="edm::Ref<l1t::HPSPFTauCollection>" />
+  <class name="edm::RefVector<l1t::HPSPFTauCollection>" />
 </lcgdict>
 

--- a/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
+++ b/HLTrigger/HLTcore/interface/HLTEventAnalyzerRAW.h
@@ -3,7 +3,7 @@
 
 /** \class HLTEventAnalyzerRAW
  *
- *  
+ *
  *  This class is an EDAnalyzer analyzing the combined HLT information for RAW
  *
  *
@@ -78,6 +78,22 @@ private:
   trigger::VRl1etmiss l1etmissRefs_;
   trigger::Vids l1hfringsIds_;
   trigger::VRl1hfrings l1hfringsRefs_;
+
+  /* Phase-2 */
+  trigger::Vids l1ttkmuIds_;
+  trigger::VRl1ttkmuon l1ttkmuRefs_;
+  trigger::Vids l1ttkeleIds_;
+  trigger::VRl1ttkele l1ttkeleRefs_;
+  trigger::Vids l1ttkemIds_;
+  trigger::VRl1ttkem l1ttkemRefs_;
+  trigger::Vids l1tpfjetIds_;
+  trigger::VRl1tpfjet l1tpfjetRefs_;
+  trigger::Vids l1tpftauIds_;
+  trigger::VRl1tpftau l1tpftauRefs_;
+  trigger::Vids l1thpspftauIds_;
+  trigger::VRl1thpspftau l1thpspftauRefs_;
+  trigger::Vids l1tpftrackIds_;
+  trigger::VRl1tpftrack l1tpftrackRefs_;
 
   trigger::Vids pfjetIds_;
   trigger::VRpfjet pfjetRefs_;

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -3,7 +3,7 @@
 
 /** \class TriggerSummaryProducerAOD
  *
- *  
+ *
  *  This class is an EDProducer making the HLT summary object for AOD
  *
  *
@@ -45,6 +45,8 @@
 #include "DataFormats/L1Trigger/interface/L1HFRingsFwd.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
+
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 
 #include <map>
 #include <set>
@@ -198,6 +200,7 @@ private:
   edm::GetterOfProducts<l1t::MuonBxCollection> getL1TMuonParticleCollection_;
   edm::GetterOfProducts<l1t::EGammaBxCollection> getL1TEGammaParticleCollection_;
   edm::GetterOfProducts<l1t::JetBxCollection> getL1TJetParticleCollection_;
+  edm::GetterOfProducts<l1t::PFJetCollection> getL1TPFJetParticleCollection_;
   edm::GetterOfProducts<l1t::TauBxCollection> getL1TTauParticleCollection_;
   edm::GetterOfProducts<l1t::EtSumBxCollection> getL1TEtSumParticleCollection_;
 };

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -46,7 +46,14 @@
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
 #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
 
 #include <map>
 #include <set>
@@ -200,8 +207,15 @@ private:
   edm::GetterOfProducts<l1t::MuonBxCollection> getL1TMuonParticleCollection_;
   edm::GetterOfProducts<l1t::EGammaBxCollection> getL1TEGammaParticleCollection_;
   edm::GetterOfProducts<l1t::JetBxCollection> getL1TJetParticleCollection_;
-  edm::GetterOfProducts<l1t::PFJetCollection> getL1TPFJetParticleCollection_;
   edm::GetterOfProducts<l1t::TauBxCollection> getL1TTauParticleCollection_;
   edm::GetterOfProducts<l1t::EtSumBxCollection> getL1TEtSumParticleCollection_;
+  edm::GetterOfProducts<l1t::TkMuonCollection> getL1TTkMuonCollection_;
+  edm::GetterOfProducts<l1t::TkElectronCollection> getL1TTkElectronCollection_;
+  edm::GetterOfProducts<l1t::TkEmCollection> getL1TTkEmCollection_;
+  edm::GetterOfProducts<l1t::PFJetCollection> getL1TPFJetCollection_;
+  edm::GetterOfProducts<l1t::PFTauCollection> getL1TPFTauCollection_;
+  edm::GetterOfProducts<l1t::HPSPFTauCollection> getL1THPSPFTauCollection_;
+  edm::GetterOfProducts<l1t::PFTrackCollection> getL1TPFTrackCollection_;
+
 };
 #endif

--- a/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
+++ b/HLTrigger/HLTcore/interface/TriggerSummaryProducerAOD.h
@@ -216,6 +216,5 @@ private:
   edm::GetterOfProducts<l1t::PFTauCollection> getL1TPFTauCollection_;
   edm::GetterOfProducts<l1t::HPSPFTauCollection> getL1THPSPFTauCollection_;
   edm::GetterOfProducts<l1t::PFTrackCollection> getL1TPFTrackCollection_;
-
 };
 #endif

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -426,7 +426,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       triggerEventWithRefsHandle_->getObjects(filterIndex, l1thpspftauIds_, l1thpspftauRefs_);
       const unsigned int nL1THPSPFTaus(l1thpspftauIds_.size());
       if (nL1THPSPFTaus > 0) {
-        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1THPSPFTaus << "  - the objects: # id pt" << endl;
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1THPSPFTaus: " << nL1THPSPFTaus << "  - the objects: # id pt" << endl;
         for (unsigned int i = 0; i != nL1THPSPFTaus; ++i) {
           LogVerbatim("HLTEventAnalyzerRAW")
               << "   " << i << " " << l1thpspftauIds_[i] << " " << l1thpspftauRefs_[i]->pt() << endl;

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -436,7 +436,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       triggerEventWithRefsHandle_->getObjects(filterIndex, l1tpftrackIds_, l1tpftrackRefs_);
       const unsigned int nL1TPFTracks(l1tpftrackIds_.size());
       if (nL1TPFTracks > 0) {
-        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1TPFTracks << "  - the objects: # id pt" << endl;
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TPFTracks: " << nL1TPFTracks << "  - the objects: # id pt" << endl;
         for (unsigned int i = 0; i != nL1TPFTracks; ++i) {
           LogVerbatim("HLTEventAnalyzerRAW")
               << "   " << i << " " << l1tpftrackIds_[i] << " " << l1tpftrackRefs_[i]->pt() << endl;

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -398,7 +398,8 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       if (nL1TTkEMs > 0) {
         LogVerbatim("HLTEventAnalyzerRAW") << "   L1TTkEMs: " << nL1TTkEMs << "  - the objects: # id pt" << endl;
         for (unsigned int i = 0; i != nL1TTkEMs; ++i) {
-          LogVerbatim("HLTEventAnalyzerRAW") << "   " << i << " " << l1ttkemIds_[i] << " " << l1ttkemRefs_[i]->pt() << endl;
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1ttkemIds_[i] << " " << l1ttkemRefs_[i]->pt() << endl;
         }
       }
 

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -426,7 +426,8 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       triggerEventWithRefsHandle_->getObjects(filterIndex, l1thpspftauIds_, l1thpspftauRefs_);
       const unsigned int nL1THPSPFTaus(l1thpspftauIds_.size());
       if (nL1THPSPFTaus > 0) {
-        LogVerbatim("HLTEventAnalyzerRAW") << "   L1THPSPFTaus: " << nL1THPSPFTaus << "  - the objects: # id pt" << endl;
+        LogVerbatim("HLTEventAnalyzerRAW")
+            << "   L1THPSPFTaus: " << nL1THPSPFTaus << "  - the objects: # id pt" << endl;
         for (unsigned int i = 0; i != nL1THPSPFTaus; ++i) {
           LogVerbatim("HLTEventAnalyzerRAW")
               << "   " << i << " " << l1thpspftauIds_[i] << " " << l1thpspftauRefs_[i]->pt() << endl;

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -416,7 +416,7 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
       triggerEventWithRefsHandle_->getObjects(filterIndex, l1tpftauIds_, l1tpftauRefs_);
       const unsigned int nL1TPFTaus(l1tpftauIds_.size());
       if (nL1TPFTaus > 0) {
-        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1TPFTaus << "  - the objects: # id pt" << endl;
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TPFTaus: " << nL1TPFTaus << "  - the objects: # id pt" << endl;
         for (unsigned int i = 0; i != nL1TPFTaus; ++i) {
           LogVerbatim("HLTEventAnalyzerRAW")
               << "   " << i << " " << l1tpftauIds_[i] << " " << l1tpftauRefs_[i]->pt() << endl;

--- a/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/HLTEventAnalyzerRAW.cc
@@ -28,6 +28,13 @@
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
 #include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 
@@ -196,6 +203,20 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
   l1etmissRefs_.clear();
   l1hfringsIds_.clear();
   l1hfringsRefs_.clear();
+  l1ttkmuIds_.clear();
+  l1ttkmuRefs_.clear();
+  l1ttkeleIds_.clear();
+  l1ttkeleRefs_.clear();
+  l1ttkemIds_.clear();
+  l1ttkemRefs_.clear();
+  l1tpfjetIds_.clear();
+  l1tpfjetRefs_.clear();
+  l1tpftauIds_.clear();
+  l1tpftauRefs_.clear();
+  l1thpspftauIds_.clear();
+  l1thpspftauRefs_.clear();
+  l1tpftrackIds_.clear();
+  l1tpftrackRefs_.clear();
   pfjetIds_.clear();
   pfjetRefs_.clear();
   pftauIds_.clear();
@@ -346,6 +367,78 @@ void HLTEventAnalyzerRAW::analyzeTrigger(const edm::Event& iEvent,
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing1NegEta) << " "
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing2PosEta) << " "
                                              << l1hfringsRefs_[i]->hfBitCount(l1extra::L1HFRings::kRing2NegEta) << endl;
+        }
+      }
+
+      /* Phase-2 */
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1ttkmuIds_, l1ttkmuRefs_);
+      const unsigned int nL1TTkMuons(l1ttkmuIds_.size());
+      if (nL1TTkMuons > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TTkMuons: " << nL1TTkMuons << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TTkMuons; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1ttkmuIds_[i] << " " << l1ttkmuRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1ttkeleIds_, l1ttkeleRefs_);
+      const unsigned int nL1TTkElectrons(l1ttkeleIds_.size());
+      if (nL1TTkElectrons > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW")
+            << "   L1TTkElectrons: " << nL1TTkElectrons << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TTkElectrons; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1ttkeleIds_[i] << " " << l1ttkeleRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1ttkemIds_, l1ttkemRefs_);
+      const unsigned int nL1TTkEMs(l1ttkemIds_.size());
+      if (nL1TTkEMs > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TTkEMs: " << nL1TTkEMs << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TTkEMs; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW") << "   " << i << " " << l1ttkemIds_[i] << " " << l1ttkemRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tpfjetIds_, l1tpfjetRefs_);
+      const unsigned int nL1TPFJets(l1tpfjetIds_.size());
+      if (nL1TPFJets > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   L1TPFJets: " << nL1TPFJets << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TPFJets; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tpfjetIds_[i] << " " << l1tpfjetRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tpftauIds_, l1tpftauRefs_);
+      const unsigned int nL1TPFTaus(l1tpftauIds_.size());
+      if (nL1TPFTaus > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1TPFTaus << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TPFTaus; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tpftauIds_[i] << " " << l1tpftauRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1thpspftauIds_, l1thpspftauRefs_);
+      const unsigned int nL1THPSPFTaus(l1thpspftauIds_.size());
+      if (nL1THPSPFTaus > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1THPSPFTaus << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1THPSPFTaus; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1thpspftauIds_[i] << " " << l1thpspftauRefs_[i]->pt() << endl;
+        }
+      }
+
+      triggerEventWithRefsHandle_->getObjects(filterIndex, l1tpftrackIds_, l1tpftrackRefs_);
+      const unsigned int nL1TPFTracks(l1tpftrackIds_.size());
+      if (nL1TPFTracks > 0) {
+        LogVerbatim("HLTEventAnalyzerRAW") << "   PFJets: " << nL1TPFTracks << "  - the objects: # id pt" << endl;
+        for (unsigned int i = 0; i != nL1TPFTracks; ++i) {
+          LogVerbatim("HLTEventAnalyzerRAW")
+              << "   " << i << " " << l1tpftrackIds_[i] << " " << l1tpftrackRefs_[i]->pt() << endl;
         }
       }
 

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
@@ -178,11 +178,11 @@ void TriggerSummaryAnalyzerRAW::analyze(edm::StreamID, const edm::Event& iEvent,
       if (nL1TPFTau > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TPFTau: " << nL1TPFTau;
 
-      const unsigned int nL1THPSPFTau(handle->l1tetsumSlice(iFO).second - handle->l1tetsumSlice(iFO).first);
+      const unsigned int nL1THPSPFTau(handle->l1thpspftauSlice(iFO).second - handle->l1thpspftauSlice(iFO).first);
       if (nL1THPSPFTau > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1THPSPFTau: " << nL1THPSPFTau;
 
-      const unsigned int nL1TPFTrack(handle->l1tetsumSlice(iFO).second - handle->l1tetsumSlice(iFO).first);
+      const unsigned int nL1TPFTrack(handle->l1tpftrackSlice(iFO).second - handle->l1tpftrackSlice(iFO).first);
       if (nL1TPFTrack > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TPFTrack: " << nL1TPFTrack;
 

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryAnalyzerRAW.cc
@@ -157,6 +157,35 @@ void TriggerSummaryAnalyzerRAW::analyze(edm::StreamID, const edm::Event& iEvent,
       if (nL1TEtSum > 0)
         LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TEtSum: " << nL1TEtSum;
 
+      /* Phase-2 */
+      const unsigned int nL1TTkMuon(handle->l1ttkmuonSlice(iFO).second - handle->l1ttkmuonSlice(iFO).first);
+      if (nL1TTkMuon > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TTkMuon: " << nL1TTkMuon;
+
+      const unsigned int nL1TTkEle(handle->l1ttkeleSlice(iFO).second - handle->l1ttkeleSlice(iFO).first);
+      if (nL1TTkEle > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TTkEle: " << nL1TTkEle;
+
+      const unsigned int nL1TTkEm(handle->l1ttkemSlice(iFO).second - handle->l1ttkemSlice(iFO).first);
+      if (nL1TTkEm > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TTkEm: " << nL1TTkEm;
+
+      const unsigned int nL1TPFJet(handle->l1tpfjetSlice(iFO).second - handle->l1tpfjetSlice(iFO).first);
+      if (nL1TPFJet > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TPFJet: " << nL1TPFJet;
+
+      const unsigned int nL1TPFTau(handle->l1tpftauSlice(iFO).second - handle->l1tpftauSlice(iFO).first);
+      if (nL1TPFTau > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TPFTau: " << nL1TPFTau;
+
+      const unsigned int nL1THPSPFTau(handle->l1tetsumSlice(iFO).second - handle->l1tetsumSlice(iFO).first);
+      if (nL1THPSPFTau > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1THPSPFTau: " << nL1THPSPFTau;
+
+      const unsigned int nL1TPFTrack(handle->l1tetsumSlice(iFO).second - handle->l1tetsumSlice(iFO).first);
+      if (nL1TPFTrack > 0)
+        LogVerbatim("TriggerSummaryAnalyzerRAW") << " L1TPFTrack: " << nL1TPFTrack;
+
       LogVerbatim("TriggerSummaryAnalyzerRAW") << endl;
     }
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "Elements in linearised collections of Refs: " << endl;
@@ -181,6 +210,15 @@ void TriggerSummaryAnalyzerRAW::analyze(edm::StreamID, const edm::Event& iEvent,
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TJet:     " << handle->l1tjetSize() << endl;
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTau:     " << handle->l1ttauSize() << endl;
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TEtSum:   " << handle->l1tetsumSize() << endl;
+    /* Phase-2 */
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTkMuon:    " << handle->l1ttkmuonSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTkEle:     " << handle->l1ttkeleSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TTkEm:      " << handle->l1ttkemSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TPFJet:     " << handle->l1tpfjetSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TPFTau:     " << handle->l1tpftauSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1THPSPFTau:  " << handle->l1thpspftauSize() << endl;
+    LogVerbatim("TriggerSummaryAnalyzerRAW") << "  L1TPFTrack:   " << handle->l1tpftrackSize() << endl;
+
   } else {
     LogVerbatim("TriggerSummaryAnalyzerRAW") << "Handle invalid! Check InputTag provided." << endl;
   }

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -44,6 +44,7 @@
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
 
@@ -133,6 +134,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(productMatch, this);
   getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(productMatch, this);
   getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(productMatch, this);
+  getL1TPFJetParticleCollection_ = edm::GetterOfProducts<l1t::PFJetCollection>(productMatch, this);
   getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(productMatch, this);
   getL1TEtSumParticleCollection_ = edm::GetterOfProducts<l1t::EtSumBxCollection>(productMatch, this);
   getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(productMatch, this);
@@ -157,6 +159,7 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
     getL1TMuonParticleCollection_(bd);
     getL1TEGammaParticleCollection_(bd);
     getL1TJetParticleCollection_(bd);
+    getL1TPFJetParticleCollection_(bd);
     getL1TTauParticleCollection_(bd);
     getL1TEtSumParticleCollection_(bd);
     getPFJetCollection_(bd);
@@ -328,12 +331,14 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       toc, offset, tags, keys, iEvent, getL1TEGammaParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<JetBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TJetParticleCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::PFJetCollection>(
+      toc, offset, tags, keys, iEvent, getL1TPFJetParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<TauBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TTauParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<EtSumBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TEtSumParticleCollection_, collectionTagsEvent);
   ///
-  fillTriggerObjectCollections<PFJetCollection>(
+  fillTriggerObjectCollections<reco::PFJetCollection>(
       toc, offset, tags, keys, iEvent, getPFJetCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<PFTauCollection>(
       toc, offset, tags, keys, iEvent, getPFTauCollection_, collectionTagsEvent);
@@ -388,6 +393,8 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tegammaIds(), fobs[ifob]->l1tegammaRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->l1tjetIds(), fobs[ifob]->l1tjetRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tpfjetIds(), fobs[ifob]->l1tpfjetRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->l1ttauIds(), fobs[ifob]->l1ttauRefs(), offset, keys, ids);
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tetsumIds(), fobs[ifob]->l1tetsumRefs(), offset, keys, ids);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -44,9 +44,17 @@
 #include "DataFormats/L1Trigger/interface/Muon.h"
 #include "DataFormats/L1Trigger/interface/EGamma.h"
 #include "DataFormats/L1Trigger/interface/Jet.h"
-#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
 #include "DataFormats/L1Trigger/interface/Tau.h"
 #include "DataFormats/L1Trigger/interface/EtSum.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTrack.h"
 
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
@@ -134,9 +142,17 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
   getL1TMuonParticleCollection_ = edm::GetterOfProducts<l1t::MuonBxCollection>(productMatch, this);
   getL1TEGammaParticleCollection_ = edm::GetterOfProducts<l1t::EGammaBxCollection>(productMatch, this);
   getL1TJetParticleCollection_ = edm::GetterOfProducts<l1t::JetBxCollection>(productMatch, this);
-  getL1TPFJetParticleCollection_ = edm::GetterOfProducts<l1t::PFJetCollection>(productMatch, this);
   getL1TTauParticleCollection_ = edm::GetterOfProducts<l1t::TauBxCollection>(productMatch, this);
   getL1TEtSumParticleCollection_ = edm::GetterOfProducts<l1t::EtSumBxCollection>(productMatch, this);
+
+  getL1TTkMuonCollection_ = edm::GetterOfProducts<l1t::TkMuonCollection>(productMatch, this);
+  getL1TTkElectronCollection_ = edm::GetterOfProducts<l1t::TkElectronCollection>(productMatch, this);
+  getL1TTkEmCollection_ = edm::GetterOfProducts<l1t::TkEmCollection>(productMatch, this);
+  getL1TPFJetCollection_ = edm::GetterOfProducts<l1t::PFJetCollection>(productMatch, this);
+  getL1TPFTauCollection_ = edm::GetterOfProducts<l1t::PFTauCollection>(productMatch, this);
+  getL1THPSPFTauCollection_ = edm::GetterOfProducts<l1t::HPSPFTauCollection>(productMatch, this);
+  getL1TPFTrackCollection_ = edm::GetterOfProducts<l1t::PFTrackCollection>(productMatch, this);
+
   getPFJetCollection_ = edm::GetterOfProducts<reco::PFJetCollection>(productMatch, this);
   getPFTauCollection_ = edm::GetterOfProducts<reco::PFTauCollection>(productMatch, this);
   getPFMETCollection_ = edm::GetterOfProducts<reco::PFMETCollection>(productMatch, this);
@@ -159,9 +175,15 @@ TriggerSummaryProducerAOD::TriggerSummaryProducerAOD(const edm::ParameterSet& ps
     getL1TMuonParticleCollection_(bd);
     getL1TEGammaParticleCollection_(bd);
     getL1TJetParticleCollection_(bd);
-    getL1TPFJetParticleCollection_(bd);
     getL1TTauParticleCollection_(bd);
     getL1TEtSumParticleCollection_(bd);
+    getL1TTkMuonCollection_(bd);
+    getL1TTkElectronCollection_(bd);
+    getL1TTkEmCollection_(bd);
+    getL1TPFJetCollection_(bd);
+    getL1TPFTauCollection_(bd);
+    getL1THPSPFTauCollection_(bd);
+    getL1TPFTrackCollection_(bd);
     getPFJetCollection_(bd);
     getPFTauCollection_(bd);
     getPFMETCollection_(bd);
@@ -331,18 +353,31 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       toc, offset, tags, keys, iEvent, getL1TEGammaParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<JetBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TJetParticleCollection_, collectionTagsEvent);
-  fillTriggerObjectCollections<l1t::PFJetCollection>(
-      toc, offset, tags, keys, iEvent, getL1TPFJetParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<TauBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TTauParticleCollection_, collectionTagsEvent);
   fillTriggerObjectCollections<EtSumBxCollection>(
       toc, offset, tags, keys, iEvent, getL1TEtSumParticleCollection_, collectionTagsEvent);
   ///
+  fillTriggerObjectCollections<l1t::TkMuonCollection>(
+      toc, offset, tags, keys, iEvent, getL1TTkMuonCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::TkElectronCollection>(
+      toc, offset, tags, keys, iEvent, getL1TTkElectronCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::TkEmCollection>(
+      toc, offset, tags, keys, iEvent, getL1TTkEmCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::PFJetCollection>(
+      toc, offset, tags, keys, iEvent, getL1TPFJetCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::PFTauCollection>(
+      toc, offset, tags, keys, iEvent, getL1TPFTauCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::HPSPFTauCollection>(
+      toc, offset, tags, keys, iEvent, getL1THPSPFTauCollection_, collectionTagsEvent);
+  fillTriggerObjectCollections<l1t::PFTrackCollection>(
+      toc, offset, tags, keys, iEvent, getL1TPFTrackCollection_, collectionTagsEvent);
+  ///
   fillTriggerObjectCollections<reco::PFJetCollection>(
       toc, offset, tags, keys, iEvent, getPFJetCollection_, collectionTagsEvent);
-  fillTriggerObjectCollections<PFTauCollection>(
+  fillTriggerObjectCollections<reco::PFTauCollection>(
       toc, offset, tags, keys, iEvent, getPFTauCollection_, collectionTagsEvent);
-  fillTriggerObjectCollections<PFMETCollection>(
+  fillTriggerObjectCollections<reco::PFMETCollection>(
       toc, offset, tags, keys, iEvent, getPFMETCollection_, collectionTagsEvent);
   ///
   const unsigned int nk(tags.size());
@@ -393,11 +428,25 @@ void TriggerSummaryProducerAOD::produce(edm::StreamID, edm::Event& iEvent, const
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tegammaIds(), fobs[ifob]->l1tegammaRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->l1tjetIds(), fobs[ifob]->l1tjetRefs(), offset, keys, ids);
-      fillFilterObjectMembers(
-          iEvent, filterTag, fobs[ifob]->l1tpfjetIds(), fobs[ifob]->l1tpfjetRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->l1ttauIds(), fobs[ifob]->l1ttauRefs(), offset, keys, ids);
       fillFilterObjectMembers(
           iEvent, filterTag, fobs[ifob]->l1tetsumIds(), fobs[ifob]->l1tetsumRefs(), offset, keys, ids);
+      /**/
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1ttkmuonIds(), fobs[ifob]->l1ttkmuonRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1ttkeleIds(), fobs[ifob]->l1ttkeleRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1ttkemIds(), fobs[ifob]->l1ttkemRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tpfjetIds(), fobs[ifob]->l1tpfjetRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tpftauIds(), fobs[ifob]->l1tpftauRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1thpspftauIds(), fobs[ifob]->l1thpspftauRefs(), offset, keys, ids);
+      fillFilterObjectMembers(
+          iEvent, filterTag, fobs[ifob]->l1tpftrackIds(), fobs[ifob]->l1tpftrackRefs(), offset, keys, ids);
+      /**/
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pfjetIds(), fobs[ifob]->pfjetRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pftauIds(), fobs[ifob]->pftauRefs(), offset, keys, ids);
       fillFilterObjectMembers(iEvent, filterTag, fobs[ifob]->pfmetIds(), fobs[ifob]->pfmetRefs(), offset, keys, ids);

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -89,7 +89,9 @@ void TriggerSummaryProducerRAW::produce(edm::StreamID, edm::Event& iEvent, const
         << fobs[ifob]->l1hfringsSize() << " E/" << fobs[ifob]->pfjetSize() << " F/" << fobs[ifob]->pftauSize() << " G/"
         << fobs[ifob]->pfmetSize() << " I/" << fobs[ifob]->l1tmuonSize() << " J/" << fobs[ifob]->l1tegammaSize()
         << " K/" << fobs[ifob]->l1tjetSize() << " L/" << fobs[ifob]->l1ttauSize() << " M/" << fobs[ifob]->l1tetsumSize()
-        << " N/" << fobs[ifob]->l1tpfjetSize() << endl;
+        << " N/" << fobs[ifob]->l1ttkmuonSize() << " O/" << fobs[ifob]->l1ttkeleSize() << " P/"
+        << fobs[ifob]->l1ttkemSize() << " Q/" << fobs[ifob]->l1tpfjetSize() << " R/" << fobs[ifob]->l1tpftauSize()
+        << " S/" << fobs[ifob]->l1thpspftauSize() << " T/" << fobs[ifob]->l1tpftrackSize() << endl;
     LogTrace("TriggerSummaryProducerRaw")
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tmuonIds().size() = " << fobs[ifob]->l1tmuonIds().size()

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerRAW.cc
@@ -89,7 +89,7 @@ void TriggerSummaryProducerRAW::produce(edm::StreamID, edm::Event& iEvent, const
         << fobs[ifob]->l1hfringsSize() << " E/" << fobs[ifob]->pfjetSize() << " F/" << fobs[ifob]->pftauSize() << " G/"
         << fobs[ifob]->pfmetSize() << " I/" << fobs[ifob]->l1tmuonSize() << " J/" << fobs[ifob]->l1tegammaSize()
         << " K/" << fobs[ifob]->l1tjetSize() << " L/" << fobs[ifob]->l1ttauSize() << " M/" << fobs[ifob]->l1tetsumSize()
-        << endl;
+        << " N/" << fobs[ifob]->l1tpfjetSize() << endl;
     LogTrace("TriggerSummaryProducerRaw")
         << "TriggerSummaryProducerRaw::addFilterObjects(   )"
         << "\n fobs[ifob]->l1tmuonIds().size() = " << fobs[ifob]->l1tmuonIds().size()


### PR DESCRIPTION
This PR adds additional infrastructure for the L1T-HLT interface for Phase2.
It is a sister PR to #32137 
We add a couple new DataFormats to allow selections on the new PF-based L1T objects.

We ran `scram b runtests` with success.

We ran `runTheMatrix.py -l limited -i all --ibeos` with success.
