### PR TITLE
Throw an exception in cms::cuda::chooseDevice() if CUDAService is disabled

### DIFF
--- a/HeterogeneousCore/CUDACore/src/chooseDevice.cc
+++ b/HeterogeneousCore/CUDACore/src/chooseDevice.cc
@@ -1,4 +1,5 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
 
 #include "chooseDevice.h"
@@ -6,6 +7,14 @@
 namespace cms::cuda {
   int chooseDevice(edm::StreamID id) {
     edm::Service<CUDAService> cudaService;
+    if (not cudaService->enabled()) {
+      cms::Exception ex("CUDAError");
+      ex << "Unable to choose current device because CUDAService is disabled. If CUDAService was not explicitly\n"
+            "disabled in the configuration, the probable cause is that there is no GPU or there is some problem\n"
+            "in the CUDA runtime or drivers.";
+      ex.addContext("Calling cms::cuda::chooseDevice()");
+      throw ex;
+    }
 
     // For startes we "statically" assign the device based on
     // edm::Stream number. This is suboptimal if the number of


### PR DESCRIPTION
#### PR description:

It was noticed in https://github.com/cms-sw/cmssw/pull/31719#issuecomment-727072323 that there is a viable call path in modules using CUDA that leads to a crash instead of an exception when run on a machine without a GPU. This PR changes `cms::cuda::chooseDevice()` to require that `CUDAService` is enabled, and throw an explanatory exception if it is disabled.

#### PR validation:

Edited `HeterogeneousCore/CUDATest/test/testCUDASwitch_cfg.py` to force CUDA being enabled to see the exception is being thrown on a machine without GPU.