### PR TITLE
CSJetProducer bug fix for flow modulation

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -89,7 +89,7 @@ akCs4PFJets = cms.EDProducer(
     csRParam  = cms.double(-1.),
     csAlpha   = cms.double(2.),
     writeJetsWithConst = cms.bool(True),
-    useModulatedRho = cms.bool(True),
+    useModulatedRho = cms.bool(False),
     rhoFlowFitParams = cms.InputTag('hiFJRhoFlowModulation', 'rhoFlowFitParams'),
     jetCollInstanceName = cms.string("pfParticlesCs"),
 )

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -176,8 +176,8 @@ void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescripti
   desc.add<double>("csRParam", -1.);
   desc.add<double>("csAlpha", 2.);
   desc.add<bool>("useModulatedRho", false);
-  desc.add<double>("minFlowChi2Prob", false);
-  desc.add<double>("maxFlowChi2Prob", false);
+  desc.add<double>("minFlowChi2Prob", 0.05);
+  desc.add<double>("maxFlowChi2Prob", 0.95);
   desc.add<edm::InputTag>("etaMap", {"hiFJRhoProducer", "mapEtaEdges"});
   desc.add<edm::InputTag>("rho", {"hiFJRhoProducer", "mapToRho"});
   desc.add<edm::InputTag>("rhom", {"hiFJRhoProducer", "mapToRhoM"});


### PR DESCRIPTION
#### PR description:

This is a bug fix for flow modulation in `CSJetProducer`. `minFlowChi2Prob` and `maxFlowChi2Prob` are never set and there are no specified defaults. This leads to `minProb` and `maxProb` to be always False and this way the whole flow modulation part is skipped. I'm setting appropriate default values in `fillDescriptions`, so that it works fine as long as `useModulatedRho = True`

Hopefully this can be added to 11_2_0.

@mandrenguyen @FHead 
