### PR TITLE
Fix use of LOCAL_TMP_DIR in unit tests

### DIFF
--- a/FWCore/TFWLiteSelector/test/run_all_t.sh
+++ b/FWCore/TFWLiteSelector/test/run_all_t.sh
@@ -5,7 +5,7 @@ function die { echo $1: status $2 ;  exit $2; }
 
 pushd ${LOCAL_TMP_DIR}
 
-export tmpdir=${LOCAL_TMP_DIR:-/tmp}
+export TMPDIR=${LOCAL_TMP_DIR:-/tmp}
 cmsRun ${LOCAL_TEST_DIR}/gen_things_cfg.py || die 'Failed generating test root file' $?
 
 rm -f a.jpg refA.jpg


### PR DESCRIPTION
#### PR description:

The TFWLiteSelector unit tests use `TMPDIR` for communication between PROOF processes on the same system.  TMPDIR should be set to the (hopefully unique) `LOCAL_TMP_DIR` so that different processes don't step on each other; however, the shell script sets `tmpdir` instead of `TMPDIR`.  This PR corrects the error.  This might fix #32162

#### PR validation:

Unit tests still run.  Only affects TFWLiteSelector  unit tests, nothing else in CMSSW should be affected.
