### PR TITLE
Add UL18 V5 jet energy corrections + V2 jet resolution [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,11 +26,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v30',
+    'run1_data'         :   '106X_dataRun2_v31',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v30',
+    'run2_data'         :   '106X_dataRun2_v31',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v28',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v29',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -56,15 +56,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v12',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v13',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v12',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v14',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v10',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v11',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v10',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v11',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR add UL18 V5 jet energy corrections + V2 jet resolution to 2018 and 2021 realistic MC as well as to the corresponding IOVs of the data GTs. Validation slides can be found at https://github.com/cms-jet/JECDatabase/blob/master/PDF/Summer19UL18_V5/Validation_Summer19UL18_V5_JEC.pdf.

The Run 3 GTs are not updated in the backport in order to minimize unnecessary changes.

The GT diffs are as follows:

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v30/106X_dataRun2_v31

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v28/106X_dataRun2_relval_v29

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v12/106X_upgrade2018_realistic_v13

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v12/106X_upgrade2018_realistic_HEfail_v14

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v10/106X_upgrade2018cosmics_realistic_deco_v11

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v10/106X_upgrade2018cosmics_realistic_peak_v11

#### PR validation:

See the validation slides at https://github.com/cms-jet/JECDatabase/blob/master/PDF/Summer19UL18_V5/Validation_Summer19UL18_V5_JEC.pdf.

Also, a technical test was performed: `runTheMatrix.py -l limited,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #32169. The JEC updates in this PR is intended for the re-miniAOD.
