### PR TITLE
Updated configurations in CondFormats to new MessageLogger syntax

### DIFF
--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DBuilder_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("SiStripDeDxMipBuilder")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     cablingBuilder = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('dedxmipBuilder.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        dedxmipBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DReader_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx2DReader_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DeDxMipReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    fedcablingReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('dedxReader.log')
+    debugModules = cms.untracked.vstring(''),
+    fedcablingReader = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    files = cms.untracked.PSet(
+        dedxReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DBuilder_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("SiStripDeDxMipBuilder")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     cablingBuilder = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('SiStripDeDx3DBuilder.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        SiStripDeDx3DBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DReader_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDx3DReader_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DeDxMipReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    fedcablingReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('SiStripDeDx3DReader.log')
+    debugModules = cms.untracked.vstring(''),
+    fedcablingReader = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    files = cms.untracked.PSet(
+        SiStripDeDx3DReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDxBuilder_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDxBuilder_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("SiStripDeDxMipBuilder")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     cablingBuilder = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('dedxmipBuilder.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        dedxmipBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/PhysicsToolsObjects/test/SiStripDeDxReader_cfg.py
+++ b/CondFormats/PhysicsToolsObjects/test/SiStripDeDxReader_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DeDxMipReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    fedcablingReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('dedxReader.log')
+    debugModules = cms.untracked.vstring(''),
+    fedcablingReader = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    files = cms.untracked.PSet(
+        dedxReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondFormats/SiPixelObjects/test/read_cfg.py
+++ b/CondFormats/SiPixelObjects/test/read_cfg.py
@@ -12,9 +12,15 @@ process.siPixelCabling.toGet = cms.VPSet(cms.PSet(
 ))
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('read'),
-    read = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    files = cms.untracked.PSet(
+        read = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.readstruct =  cms.EDAnalyzer("SiPixelFedCablingMapAnalyzer")


### PR DESCRIPTION
#### PR description:

All configurations in CondFormats subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.