### PR TITLE
Updated configurations in CaloOnlineTools to new MessageLogger syntax

### DIFF
--- a/CaloOnlineTools/EcalTools/python/ecalHexDisplay_cfg.py
+++ b/CaloOnlineTools/EcalTools/python/ecalHexDisplay_cfg.py
@@ -18,13 +18,16 @@ process.maxEvents = cms.untracked.PSet(
 process.counter = cms.OutputModule("AsciiOutputModule")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 process.p = cms.Path(process.hexDump)

--- a/CaloOnlineTools/EcalTools/python/ecalURecHitHists_cfg.py
+++ b/CaloOnlineTools/EcalTools/python/ecalURecHitHists_cfg.py
@@ -32,12 +32,14 @@ process.src1 = cms.ESSource("EcalTrivialConditionRetriever",
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    suppressInfo = cms.untracked.vstring('ecalEBunpacker'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    categories = cms.untracked.vstring('EcalURecHitHists'),
-    destinations = cms.untracked.vstring('cout')
+    suppressInfo = cms.untracked.vstring('ecalEBunpacker')
 )
 
 process.p = cms.Path(process.ecalEBunpacker*process.ecalUncalibHit*process.ecalURecHitHists)


### PR DESCRIPTION
#### PR description:

All configurations in CaloOnlineTools subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.