### PR TITLE
Updated configurations in CalibTracker to new MessageLogger syntax

### DIFF
--- a/CalibTracker/Configuration/test/testConditionAccess_sqlite_cfg.py
+++ b/CalibTracker/Configuration/test/testConditionAccess_sqlite_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Test")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    testConditionAccess = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('testConditionAccess.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        testConditionAccess = cms.untracked.PSet(
+
+        )
+    ),
+    testConditionAccess = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_cfg.py
@@ -34,9 +34,15 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 #process.CondDBCommon.connect = cms.string("sqlite_file:cabling.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('out'),
-    out = cms.untracked.PSet( threshold = cms.untracked.string('DEBUG'))
+    files = cms.untracked.PSet(
+        out = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 process.load("CalibTracker.SiPixelConnectivity.PixelToLNKAssociateFromAsciiESProducer_cfi")

--- a/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_phase1.py
+++ b/CalibTracker/SiPixelConnectivity/test/SiPixelFedCablingMapWriter_phase1.py
@@ -35,10 +35,15 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('log'),
-    #log = cms.untracked.PSet( threshold = cms.untracked.string('DEBUG'))
-    log = cms.untracked.PSet( threshold = cms.untracked.string('WARNING'))
+    files = cms.untracked.PSet(
+        log = cms.untracked.PSet(
+            threshold = cms.untracked.string('WARNING')
+        )
+    )
 )
 
 #process.load("CalibTracker.SiPixelConnectivity.PixelToLNKAssociateFromAsciiESProducer_cfi")

--- a/CalibTracker/SiPixelConnectivity/test/read_cfg.py
+++ b/CalibTracker/SiPixelConnectivity/test/read_cfg.py
@@ -10,10 +10,13 @@ from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['run2_design']
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    )
 )
 
 

--- a/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngle_cfg.py
+++ b/CalibTracker/SiPixelLorentzAngle/test/SiPixelLorentzAngle_cfg.py
@@ -33,11 +33,17 @@ process.load("RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('simul', 
-        'cout'),
-    simul = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    files = cms.untracked.PSet(
+        simul = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR')
+        )
+    )
 )
 
 process.lorentzAngle = cms.EDAnalyzer("SiPixelLorentzAngle",

--- a/CalibTracker/SiPixelTools/test/prodfedfillerwords_cfg.py
+++ b/CalibTracker/SiPixelTools/test/prodfedfillerwords_cfg.py
@@ -6,23 +6,44 @@ process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring ('file:/afs/cern.ch/user/f/florez/CMSSW_2_0_4/src/FedFillerWords/Data/mysimple.root') 
                             )
 			    
-process.MessageLogger = cms.Service("MessageLogger", 
-                                    destinations = cms.untracked.vstring('output'),
-                                    threshold = cms.untracked.string('INFO'),                              
-                                    noLineBreaks = cms.untracked.bool(True)
-                                    )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        output = cms.untracked.PSet(
+
+        )
+    ),
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string('WARNING')
+)
 				    
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('output'),
-				    threshold = cms.untracked.string('ERROR'),
-				    noLineBreaks = cms.untracked.bool(True)
-				    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        output = cms.untracked.PSet(
+
+        )
+    ),
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string('WARNING')
+)
 				    
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('output'),
-				    threshold = cms.untracked.string('WARNING'),
-				    noLineBreaks = cms.untracked.bool(True)
-				    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        output = cms.untracked.PSet(
+
+        )
+    ),
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string('WARNING')
+)
 				    				    
 process.filler = cms.EDProducer("SiPixelFedFillerWordEventNumber",
                                 InputLabel = cms.untracked.string('source'),

--- a/CalibTracker/SiStripChannelGain/test/CodeExample/computeGain_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/CodeExample/computeGain_cfg.py
@@ -25,8 +25,13 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR')  ),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    )
 )
 
 # Conditions (Global Tag is used here):

--- a/CalibTracker/SiStripChannelGain/test/Cosmic_B38/MergeJob_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/Cosmic_B38/MergeJob_cfg.py
@@ -25,13 +25,16 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    suppressWarning = cms.untracked.vstring('TrackRefitter'),
-    suppressInfo = cms.untracked.vstring('TrackRefitter'),
-    suppressDebug = cms.untracked.vstring('TrackRefitter'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
     ),
-    destinations = cms.untracked.vstring('cout')
+    suppressDebug = cms.untracked.vstring('TrackRefitter'),
+    suppressInfo = cms.untracked.vstring('TrackRefitter'),
+    suppressWarning = cms.untracked.vstring('TrackRefitter')
 )
 
 # Conditions (Global Tag is used here):

--- a/CalibTracker/SiStripChannelGain/test/UsefullCode/MakeMap/MakeMap_Merge_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/UsefullCode/MakeMap/MakeMap_Merge_cfg.py
@@ -3,8 +3,13 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DEDX")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(     threshold = cms.untracked.string('ERROR')    ),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    )
 )
 
 

--- a/CalibTracker/SiStripChannelGain/test/UsefullCode/PayloadFromASCIIfile/ProducePayloadFromASCII_cfg.py
+++ b/CalibTracker/SiStripChannelGain/test/UsefullCode/PayloadFromASCIIfile/ProducePayloadFromASCII_cfg.py
@@ -3,8 +3,13 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("APVGAIN")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO')  ), #use ERROR for less printouts
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 

--- a/CalibTracker/SiStripDCS/python/dcs_print_summary_cfg.py
+++ b/CalibTracker/SiStripDCS/python/dcs_print_summary_cfg.py
@@ -3,11 +3,16 @@ import os
 
 process = cms.Process("summary")
 
-process.MessageLogger = cms.Service( "MessageLogger",
-                                     debugModules = cms.untracked.vstring( "*" ),
-                                     cout = cms.untracked.PSet( threshold = cms.untracked.string( "DEBUG" ) ),
-                                     destinations = cms.untracked.vstring( "cout" )
-                                     )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/CalibTracker/SiStripDCS/python/dcs_trend_monitor_cfg.py
+++ b/CalibTracker/SiStripDCS/python/dcs_trend_monitor_cfg.py
@@ -3,11 +3,16 @@ import os
 
 process = cms.Process("plot")
 
-process.MessageLogger = cms.Service( "MessageLogger",
-                                     debugModules = cms.untracked.vstring( "*" ),
-                                     cout = cms.untracked.PSet( threshold = cms.untracked.string( "DEBUG" ) ),
-                                     destinations = cms.untracked.vstring( "cout" )
-                                     )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/CalibTracker/SiStripDCS/test/dcs_tkMap_cfg.py
+++ b/CalibTracker/SiStripDCS/test/dcs_tkMap_cfg.py
@@ -3,11 +3,16 @@ import os
 
 process = cms.Process("plot")
 
-process.MessageLogger = cms.Service( "MessageLogger",
-                                     debugModules = cms.untracked.vstring( "*" ),
-                                     cout = cms.untracked.PSet( threshold = cms.untracked.string( "DEBUG" ) ),
-                                     destinations = cms.untracked.vstring( "cout" )
-                                     )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/fedBadChannelFromNoiseRun_cfg.py
@@ -2,10 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("fedBadChannelFromNoiseRun")
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 

--- a/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/mergeBadChannel_cfg.py
@@ -2,10 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("BadChannelMerge")
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBReaderTemplate_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBReaderTemplate_cfg.py
@@ -6,16 +6,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('reader'),
-    threshold = cms.untracked.string('INFO'),
-    # Warning: debug output can be of ~ 250Mb for Noise and Pedestals
-    # Use this to see only the additional information
-    # threshold = cms.untracked.string('WARNING'),
-    # Use this to see both info and additional info
-    # threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('TAGNAMEReader_Ideal.log')
+    files = cms.untracked.PSet(
+        TAGNAMEReader_Ideal = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripApvGain_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripApvGain_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripApvGainDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('ApvGainBuilder.log')
+    files = cms.untracked.PSet(
+        ApvGainBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBackPlaneCorrection_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBackPlaneCorrection_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripBackPlaneCorrectionDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BackPlaneCorrectionBuilder.log')
+    files = cms.untracked.PSet(
+        BackPlaneCorrectionBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadChannel_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadChannel_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripBadChannelDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BadChannelBuilder.log')
+    files = cms.untracked.PSet(
+        BadChannelBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadFiber_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadFiber_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripBadFiberDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BadFiberBuilder.log')
+    files = cms.untracked.PSet(
+        BadFiberBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadModule_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBadModule_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripBadModuleDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BadModuleBuilder.log')
+    files = cms.untracked.PSet(
+        BadModuleBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBaseDelay_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripBaseDelay_cfg.py
@@ -9,11 +9,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripBaseDelayDummyDBWriter'),
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('BaseDelayBuilder.log')
+    files = cms.untracked.PSet(
+        BaseDelayBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripClusterThreshold_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripClusterThreshold_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripThresholdDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('ClusterThresholdBuilder.log')
+    files = cms.untracked.PSet(
+        ClusterThresholdBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripConfObject_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripConfObject_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripConfObjectDummyDBWriter'),
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('ConfObjectBuilder.log')
+    files = cms.untracked.PSet(
+        ConfObjectBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripDetVOff_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripDetVOff_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripDetVOffDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('DetVOffBuilder.log')
+    files = cms.untracked.PSet(
+        DetVOffBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripFedCabling_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripFedCabling_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripFedCablingDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('CablingBuilder.log')
+    files = cms.untracked.PSet(
+        CablingBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLatency_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLatency_cfg.py
@@ -9,11 +9,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripLatencyDummyDBWriter'),
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('LatencyBuilder.log')
+    files = cms.untracked.PSet(
+        LatencyBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLorentzAngle_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripLorentzAngle_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripLorentzAngleDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('LorentzAngleBuilder.log')
+    files = cms.untracked.PSet(
+        LorentzAngleBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_DecMode_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_DecMode_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripNoisesDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('NoisesBuilder.log')
+    files = cms.untracked.PSet(
+        NoisesBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripNoises_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripNoisesDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('NoisesBuilder.log')
+    files = cms.untracked.PSet(
+        NoisesBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripPedestals_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripPedestals_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripPedestalsDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('PedestalsBuilder.log')
+    files = cms.untracked.PSet(
+        PedestalsBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripThreshold_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/DummyCondDBWriter_SiStripThreshold_cfg.py
@@ -8,11 +8,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripThresholdDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('ThresholdBuilder.log')
+    files = cms.untracked.PSet(
+        ThresholdBuilder = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/SiStripApvGainBuilderFromTag_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripApvGainBuilderFromTag_cfg.py
@@ -2,8 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("APVGAINBUILDER")
 process.MessageLogger = cms.Service("MessageLogger",
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.source = cms.Source("EmptySource",

--- a/CalibTracker/SiStripESProducers/test/python/SiStripBadAPVListBuilder_byHand_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripBadAPVListBuilder_byHand_cfg.py
@@ -11,11 +11,14 @@ def getFileInPath(rfile):
    return None
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripBadComponentBuilder_byHand_cfg.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/SiStripFedCablingManipulator_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/SiStripFedCablingManipulator_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Builder")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     CablingBuilder = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('CablingBuilder.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        CablingBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/checkphase2cabling_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/checkphase2cabling_cfg.py
@@ -4,11 +4,14 @@ process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 # How to use the EmptyIOVSource:

--- a/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDepDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDepDummyPrinter_cfg.py
@@ -9,9 +9,16 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('BackPlaneCorrectionReaderSummary'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BackPlaneCorrectionReader.log')
+    files = cms.untracked.PSet(
+        BackPlaneCorrectionReader = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripBackPlaneCorrectionDummyPrinter_cfg.py
@@ -9,9 +9,16 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('BackPlaneCorrectionReaderSummary'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('BackPlaneCorrectionReader.log')
+    files = cms.untracked.PSet(
+        BackPlaneCorrectionReader = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripClusterThresholdDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripClusterThresholdDummyPrinter_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
     ThresholdReader = cms.untracked.PSet(
         threshold = cms.untracked.string('DEBUG')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('ClusterThresholdReader.log')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        ClusterThresholdReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/siStripDelayDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripDelayDummyPrinter_cfg.py
@@ -11,14 +11,18 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    DelayReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    DelayReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
-    ),
-    destinations = cms.untracked.vstring('DelayReaderSummary', 'DelayReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        DelayReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        DelayReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 # How to use the EmptyIOVSource:

--- a/CalibTracker/SiStripESProducers/test/python/siStripDetVOffDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripDetVOffDummyPrinter_cfg.py
@@ -9,17 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    DetVOffReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    DetVOffReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('DetVOffReaderSummary', 'DetVOffReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        DetVOffReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        DetVOffReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 # Use this instead to see only the summary

--- a/CalibTracker/SiStripESProducers/test/python/siStripGainDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripGainDummyPrinter_cfg.py
@@ -10,14 +10,18 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    GainReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    GainReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
-    ),
-    destinations = cms.untracked.vstring('GainReaderSummary', 'GainReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        GainReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        GainReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 # How to use the EmptyIOVSource:

--- a/CalibTracker/SiStripESProducers/test/python/siStripGainSimDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripGainSimDummyPrinter_cfg.py
@@ -10,17 +10,21 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    GainReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    GainReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('GainReaderSummary', 'GainReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        GainReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        GainReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleDepDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleDepDummyPrinter_cfg.py
@@ -11,14 +11,18 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    LorentzAngleDepReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    LorentzAngleDepReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
-    ),
-    destinations = cms.untracked.vstring('LorentzAngleDepReaderSummary', 'LorentzAngleDepReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        LorentzAngleDepReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        LorentzAngleDepReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 # How to use the EmptyIOVSource:

--- a/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleDummyPrinter_cfg.py
@@ -9,17 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    LorentzAngleReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    LorentzAngleReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('LorentzAngleReaderSummary', 'LorentzAngleReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        LorentzAngleReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        LorentzAngleReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleSimDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripLorentzAngleSimDummyPrinter_cfg.py
@@ -9,17 +9,27 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
+    LorentzAngleReaderDebug = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG')
+    ),
     LorentzAngleReaderSummary = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    LorentzAngleReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('LorentzAngleSimReaderSummary', 'LorentzAngleSimReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        LorentzAngleSimReaderDebug = cms.untracked.PSet(
+
+        ),
+        LorentzAngleSimReaderSummary = cms.untracked.PSet(
+
+        )
+    )
 )
 
 

--- a/CalibTracker/SiStripESProducers/test/python/siStripNoisesDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripNoisesDummyPrinter_cfg.py
@@ -10,17 +10,27 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
+    PedestalsReaderDebug = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG')
+    ),
     PedestalsReaderSummary = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    PedestalsReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('NoisesReaderSummary', 'NoisesReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        NoisesReaderDebug = cms.untracked.PSet(
+
+        ),
+        NoisesReaderSummary = cms.untracked.PSet(
+
+        )
+    )
 )
 
 #process.MessageLogger = cms.Service("MessageLogger",

--- a/CalibTracker/SiStripESProducers/test/python/siStripPedestalsDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripPedestalsDummyPrinter_cfg.py
@@ -10,17 +10,21 @@ process = cms.Process("Reader")
 
 # Use this to have also debug info (WARNING: the resulting file is > 200MB.
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring("*"),
-    PedestalsReaderSummary = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    PedestalsReaderDebug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('PedestalsReaderSummary', 'PedestalsReaderDebug')
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        PedestalsReaderDebug = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        PedestalsReaderSummary = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 # Use this instead to see only the summary

--- a/CalibTracker/SiStripESProducers/test/python/siStripThresholdDummyPrinter_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/siStripThresholdDummyPrinter_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     ThresholdReader = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('ThresholdReader.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        ThresholdReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_firstIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_firstIOV_cfg.py
@@ -3,11 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_secondIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTIB_secondIOV_cfg.py
@@ -3,11 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_firstIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_firstIOV_cfg.py
@@ -3,11 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_secondIOV_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_createTID_secondIOV_cfg.py
@@ -3,11 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_merge_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/DummyCondDBWriter_SiStripBadModule_fromMultipleDBSources_merge_cfg.py
@@ -9,11 +9,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/read_DummyCondDBWriter_SiStripQuality_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripBadStripfromMultipleDBSources/read_DummyCondDBWriter_SiStripQuality_cfg.py
@@ -9,11 +9,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('QualityReader')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadModuleConfigurableFakeESSource_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadModuleConfigurableFakeESSource_cfg.py
@@ -3,14 +3,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     QualityReader = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('QualityReader.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadStripFakeESSource_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromBadStripFakeESSource_cfg.py
@@ -3,11 +3,15 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    destinations = cms.untracked.vstring('QualityReader'),
-    QualityReader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromQualityFakeESSource_cfg.py
+++ b/CalibTracker/SiStripESProducers/test/python/testSiStripQualityESProducer_fromQualityFakeESSource_cfg.py
@@ -3,14 +3,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("CALIB")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     QualityReader = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('QualityReader.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        QualityReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibTracker/SiStripLorentzAngle/python/SQLiteCheck_cfg.py
+++ b/CalibTracker/SiStripLorentzAngle/python/SQLiteCheck_cfg.py
@@ -4,11 +4,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring(''),
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('SQLiteCheck.log')
+    files = cms.untracked.PSet(
+        SQLiteCheck = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CalibTracker/SiStripLorentzAngle/python/SQLiteEnsembleGenerator_cfg.py
+++ b/CalibTracker/SiStripLorentzAngle/python/SQLiteEnsembleGenerator_cfg.py
@@ -4,11 +4,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Builder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('siStripLorentzAngleDummyDBWriter'),
-    threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('SQLiteGenerator.log')
+    files = cms.untracked.PSet(
+        SQLiteGenerator = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('DEBUG')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/DQMOffline/CalibTracker/test/SiStripBadComponentsDQMService_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripBadComponentsDQMService_cfg.py
@@ -7,10 +7,18 @@ process = cms.Process("PWRITE")
 ######################### 
 
 process.MessageLogger = cms.Service("MessageLogger",
-destinations = cms.untracked.vstring('cout', 'readFromFile_57620'),
-readFromFile_57620 = cms.untracked.PSet(
-    threshold = cms.untracked.string('DEBUG')),
-debugModules = cms.untracked.vstring('*')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        readFromFile_57620 = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 

--- a/DQMOffline/CalibTracker/test/SiStripFEDErrorsDQMRead_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripFEDErrorsDQMRead_cfg.py
@@ -11,9 +11,15 @@ process.source = cms.Source("EmptySource",
     interval = cms.uint32(1)
 )
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    destinations = cms.untracked.vstring("SiStripFEDErrorsDQMReader.log"),
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        SiStripFEDErrorsDQMReader = cms.untracked.PSet(
+
+        )
+    ),
     threshold = cms.untracked.string('INFO')
 )
 

--- a/DQMOffline/CalibTracker/test/SiStripFEDErrorsDQM_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripFEDErrorsDQM_cfg.py
@@ -6,45 +6,31 @@ process = cms.Process("TEST")
 # message logger
 ######################### 
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    info = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    #suppressInfo = cms.untracked.vstring(),
-    # allows to suppress output from specific modules 
-    #suppressDebug = cms.untracked.vstring(),
-    debug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    warning = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
+process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('DEBUG')
         ),
-    error = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        error = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('ERROR')
         ),
-    #suppressWarning = cms.untracked.vstring(),
-    debugModules = cms.untracked.vstring('*'),#'siStripFEDMonitor'),
-    destinations = cms.untracked.vstring('cerr', 
-                                         'debug', 
-                                         'info', 
-                                         'warning', 
-                                         'error')
-
+        info = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('INFO')
+        ),
+        warning = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('WARNING')
+        )
     )
+)
 
 #process.MessageLogger = cms.Service("MessageLogger"
 #destinations = cms.untracked.vstring('cout', 'readFromFile'),

--- a/DQMOffline/CalibTracker/test/SiStripNoises_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripNoises_cfg.py
@@ -7,10 +7,18 @@ process = cms.Process("PWRITE")
 ######################### 
 
 process.MessageLogger = cms.Service("MessageLogger",
-destinations = cms.untracked.vstring('cout', 'readFromFile_57620'),
-readFromFile_57620 = cms.untracked.PSet(
-    threshold = cms.untracked.string('DEBUG')),
-debugModules = cms.untracked.vstring('*')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        readFromFile_57620 = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 

--- a/DQMOffline/CalibTracker/test/SiStripPedestals_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripPedestals_cfg.py
@@ -7,10 +7,18 @@ process = cms.Process("PWRITE")
 ######################### 
 
 process.MessageLogger = cms.Service("MessageLogger",
-destinations = cms.untracked.vstring('cout', 'readFromFile_57620'),
-readFromFile_57620 = cms.untracked.PSet(
-    threshold = cms.untracked.string('DEBUG')),
-debugModules = cms.untracked.vstring('*')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        readFromFile_57620 = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 

--- a/DQMOffline/CalibTracker/test/SiStripQualityBadAPVandHotStripIdentifierRoot_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripQualityBadAPVandHotStripIdentifierRoot_cfg.py
@@ -4,11 +4,14 @@ process = cms.Process("ICALIB")
 process.load("DQMServices.Core.DQMStore_cfg")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/DQMOffline/CalibTracker/test/SiStripQualityStatistics_full_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripQualityStatistics_full_cfg.py
@@ -2,10 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/DQMOffline/CalibTracker/test/SiStripQualityStatistics_offline_cfg.py
+++ b/DQMOffline/CalibTracker/test/SiStripQualityStatistics_offline_cfg.py
@@ -2,10 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/DQMOffline/CalibTracker/test/example_QualityCalibration_cfg.py
+++ b/DQMOffline/CalibTracker/test/example_QualityCalibration_cfg.py
@@ -3,11 +3,24 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("SiStripHotStripCalibration")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('orbitFilter','OrbitFilter','SiStripQualityHotStripIdentifierRoot','siStripQualityHotStripIdentifierRoot','SiStripHotStripAlgorithmFromClusterOccupancy'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring(
+        'orbitFilter', 
+        'OrbitFilter', 
+        'SiStripQualityHotStripIdentifierRoot', 
+        'siStripQualityHotStripIdentifierRoot', 
+        'SiStripHotStripAlgorithmFromClusterOccupancy'
+    ),
+    files = cms.untracked.PSet(
+        log = cms.untracked.PSet(
+            extension = cms.untracked.string('txt')
+        )
+    ),
     log = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
-    ),
-    destinations = cms.untracked.vstring('log.txt')
+    )
 )
 
 #-------------------------------------------------

--- a/DQMOffline/CalibTracker/test/template_SiStripQualityBadAPVandHotStripIdentifierRoot_cfg.py
+++ b/DQMOffline/CalibTracker/test/template_SiStripQualityBadAPVandHotStripIdentifierRoot_cfg.py
@@ -4,11 +4,14 @@ process = cms.Process("ICALIB")
 process.load("DQMServices.Core.DQM_cfg")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/DQMOffline/CalibTracker/test/testSuite/SiStripBadStripReader_cfg.py
+++ b/DQMOffline/CalibTracker/test/testSuite/SiStripBadStripReader_cfg.py
@@ -12,10 +12,13 @@ process.source = cms.Source("EmptySource",
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.Timing = cms.Service("Timing")


### PR DESCRIPTION
#### PR description:

All configurations in CalibTracker subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.