### PR TITLE
Updated configurations in CalibMuon to new MessageLogger syntax

### DIFF
--- a/CalibMuon/CSCCalibration/test/CSCBadChamberPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCBadChamberPopCon_cfg.py
@@ -16,12 +16,15 @@ process.CondDBCommon.connect = 'sqlite_file:CSCBadChambers_15April2011.db'
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 #process.CondDBCommon.DBParameters.messageLevel = cms.untracked.int32(3)
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCBadStripsPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCBadStripsPopCon_cfg.py
@@ -13,12 +13,15 @@ process = cms.Process("ProcessOne")
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCBadWiresPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCBadWiresPopCon_cfg.py
@@ -13,12 +13,15 @@ process = cms.Process("ProcessOne")
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBChipSpeedCorrectionPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBChipSpeedCorrectionPopCon_cfg.py
@@ -13,12 +13,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBChipSpeedCorrection_dat
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBCrosstalkPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBCrosstalkPopCon_cfg.py
@@ -14,12 +14,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBCrossTalk.db")
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBGainsPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBGainsPopCon_cfg.py
@@ -12,12 +12,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBGains.db")
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBGasGainCorrectionPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBGasGainCorrectionPopCon_cfg.py
@@ -12,12 +12,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBGasGainCorrection_test.
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBL1TPParametersPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBL1TPParametersPopCon_cfg.py
@@ -16,12 +16,15 @@ process.CondDBCommon.connect = "oracle://cms_orcoff_prep/CMS_COND_CSC"
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBNoiseMatrixPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBNoiseMatrixPopCon_cfg.py
@@ -14,12 +14,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBNoiseMatrix.db")
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCDBPedestalsPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCDBPedestalsPopCon_cfg.py
@@ -14,12 +14,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:DBPedestals.db")
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CalibMuon/CSCCalibration/test/CSCL1TPParametersPopCon_cfg.py
+++ b/CalibMuon/CSCCalibration/test/CSCL1TPParametersPopCon_cfg.py
@@ -14,12 +14,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:DBL1TPParameters.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",


### PR DESCRIPTION
#### PR description:

All configurations in CalibMuon subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.