### PR TITLE
Run3-sim75 Remove namespace for comparison in SD classes

### DIFF
--- a/Geometry/EcalSimData/data/ecalsens.xml
+++ b/Geometry/EcalSimData/data/ecalsens.xml
@@ -19,7 +19,7 @@
    <Parameter name="Depth2Name" value="EATJ" eval="false"/>
   </SpecPar>
   <SpecPar name="ecal_ee">
-   <PartSelector path="//EFRY"/>
+   <PartSelector path="//EFRY.*"/>
    <Parameter name="SensitiveDetector" value="EcalSensitiveDetector" eval="false"/>
    <Parameter name="ReadOutName" value="EcalHitsEE" eval="false"/>
    <Parameter name="ncrys" value="25.0"/>

--- a/SimG4CMS/Calo/plugins/EcalSimHitStudy.cc
+++ b/SimG4CMS/Calo/plugins/EcalSimHitStudy.cc
@@ -32,6 +32,7 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include <TH1F.h>
+#include <TH2F.h>
 #include <cmath>
 #include <iostream>
 #include <fstream>
@@ -40,7 +41,7 @@
 #include <string>
 #include <vector>
 
-//#define EDM_ML_DEBUG
+#define EDM_ML_DEBUG
 
 class EcalSimHitStudy : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
@@ -74,6 +75,7 @@ private:
   TH1F *etot_[ndets_], *etotg_[ndets_], *edepAll_[ndets_];
   TH1F *r1by9_[ndets_], *r1by25_[ndets_], *r9by25_[ndets_];
   TH1F *sEtaEta_[ndets_], *sEtaPhi_[ndets_], *sPhiPhi_[ndets_];
+  TH2F *poszp_[ndets_], *poszn_[ndets_];
 };
 
 EcalSimHitStudy::EcalSimHitStudy(const edm::ParameterSet& ps) {
@@ -134,96 +136,119 @@ void EcalSimHitStudy::beginJob() {
   for (int i = 0; i < ndets_; i++) {
     sprintf(name, "Hit%d", i);
     sprintf(title, "Number of hits in %s", dets[i].c_str());
-    hit_[i] = tfile->make<TH1F>(name, title, 1000, 0., 20000.);
+    hit_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0., 20000.);
     hit_[i]->GetXaxis()->SetTitle(title);
     hit_[i]->GetYaxis()->SetTitle("Events");
     hit_[i]->Sumw2();
     sprintf(name, "Time%d", i);
     sprintf(title, "Time of the hit (ns) in %s", dets[i].c_str());
-    time_[i] = tfile->make<TH1F>(name, title, 1000, 0., 1000.);
+    time_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0., 1000.);
     time_[i]->GetXaxis()->SetTitle(title);
     time_[i]->GetYaxis()->SetTitle("Hits");
     time_[i]->Sumw2();
     sprintf(name, "TimeAll%d", i);
     sprintf(title, "Hit time (ns) in %s (for first hit in the cell)", dets[i].c_str());
-    timeAll_[i] = tfile->make<TH1F>(name, title, 1000, 0., 1000.);
+    timeAll_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0., 1000.);
     timeAll_[i]->GetXaxis()->SetTitle(title);
     timeAll_[i]->GetYaxis()->SetTitle("Hits");
     timeAll_[i]->Sumw2();
     sprintf(name, "Edep%d", i);
     sprintf(title, "Energy deposit (GeV) in %s", dets[i].c_str());
-    edep_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    edep_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     edep_[i]->GetXaxis()->SetTitle(title);
     edep_[i]->GetYaxis()->SetTitle("Hits");
     edep_[i]->Sumw2();
     sprintf(name, "EdepAll%d", i);
     sprintf(title, "Total Energy deposit in the cell (GeV) in %s", dets[i].c_str());
-    edepAll_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    edepAll_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     edepAll_[i]->GetXaxis()->SetTitle(title);
     edepAll_[i]->GetYaxis()->SetTitle("Hits");
     edepAll_[i]->Sumw2();
     sprintf(name, "EdepEM%d", i);
     sprintf(title, "Energy deposit (GeV) by EM particles in %s", dets[i].c_str());
-    edepEM_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    edepEM_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     edepEM_[i]->GetXaxis()->SetTitle(title);
     edepEM_[i]->GetYaxis()->SetTitle("Hits");
     edepEM_[i]->Sumw2();
     sprintf(name, "EdepHad%d", i);
     sprintf(title, "Energy deposit (GeV) by hadrons in %s", dets[i].c_str());
-    edepHad_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    edepHad_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     edepHad_[i]->GetXaxis()->SetTitle(title);
     edepHad_[i]->GetYaxis()->SetTitle("Hits");
     edepHad_[i]->Sumw2();
     sprintf(name, "Etot%d", i);
     sprintf(title, "Total energy deposit (GeV) in %s", dets[i].c_str());
-    etot_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    etot_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     etot_[i]->GetXaxis()->SetTitle(title);
     etot_[i]->GetYaxis()->SetTitle("Events");
     etot_[i]->Sumw2();
     sprintf(name, "EtotG%d", i);
     sprintf(title, "Total energy deposit (GeV) in %s (t < 100 ns)", dets[i].c_str());
-    etotg_[i] = tfile->make<TH1F>(name, title, 5000, 0., maxEnergy_);
+    etotg_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 5000, 0., maxEnergy_);
     etotg_[i]->GetXaxis()->SetTitle(title);
     etotg_[i]->GetYaxis()->SetTitle("Events");
     etotg_[i]->Sumw2();
     sprintf(name, "r1by9%d", i);
     sprintf(title, "E1/E9 in %s", dets[i].c_str());
-    r1by9_[i] = tfile->make<TH1F>(name, title, 100, 0.0, 1.0);
+    r1by9_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 100, 0.0, 1.0);
     r1by9_[i]->GetXaxis()->SetTitle(title);
     r1by9_[i]->GetYaxis()->SetTitle("Events");
     r1by9_[i]->Sumw2();
     sprintf(name, "r1by25%d", i);
     sprintf(title, "E1/E25 in %s", dets[i].c_str());
-    r1by25_[i] = tfile->make<TH1F>(name, title, 100, 0.0, 1.0);
+    r1by25_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 100, 0.0, 1.0);
     r1by25_[i]->GetXaxis()->SetTitle(title);
     r1by25_[i]->GetYaxis()->SetTitle("Events");
     r1by25_[i]->Sumw2();
     sprintf(name, "r9by25%d", i);
     sprintf(title, "E9/E25 in %s", dets[i].c_str());
-    r9by25_[i] = tfile->make<TH1F>(name, title, 100, 0.0, 1.0);
+    r9by25_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 100, 0.0, 1.0);
     r9by25_[i]->GetXaxis()->SetTitle(title);
     r9by25_[i]->GetYaxis()->SetTitle("Events");
     r9by25_[i]->Sumw2();
     double ymax = (i == 0) ? 0.0005 : 0.005;
     sprintf(name, "sEtaEta%d", i);
     sprintf(title, "Cov(#eta,#eta) in %s", dets[i].c_str());
-    sEtaEta_[i] = tfile->make<TH1F>(name, title, 1000, 0.0, ymax);
+    sEtaEta_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0.0, ymax);
     sEtaEta_[i]->GetXaxis()->SetTitle(title);
     sEtaEta_[i]->GetYaxis()->SetTitle("Events");
     sEtaEta_[i]->Sumw2();
     sprintf(name, "sEtaPhi%d", i);
     sprintf(title, "Cov(#eta,#phi) in %s", dets[i].c_str());
-    sEtaPhi_[i] = tfile->make<TH1F>(name, title, 1000, 0.0, ymax);
+    sEtaPhi_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0.0, ymax);
     sEtaPhi_[i]->GetXaxis()->SetTitle(title);
     sEtaPhi_[i]->GetYaxis()->SetTitle("Events");
     sEtaPhi_[i]->Sumw2();
     ymax = (i == 0) ? 0.001 : 0.01;
     sprintf(name, "sPhiPhi%d", i);
     sprintf(title, "Cov(#phi,#phi) in %s", dets[i].c_str());
-    sPhiPhi_[i] = tfile->make<TH1F>(name, title, 1000, 0.0, ymax);
+    sPhiPhi_[i] = tfile->make<TH1F>(name, dets[i].c_str(), 1000, 0.0, ymax);
     sPhiPhi_[i]->GetXaxis()->SetTitle(title);
     sPhiPhi_[i]->GetYaxis()->SetTitle("Events");
     sPhiPhi_[i]->Sumw2();
+    if (i == 0) {
+      sprintf (title, "%s+", dets[i].c_str());
+      poszp_[i] = tfile->make<TH2F>("poszp0", title, 100, 0, 100, 360, 0, 360);
+      poszp_[i]->GetXaxis()->SetTitle("i#eta");
+      poszp_[i]->GetYaxis()->SetTitle("i#phi");
+      sprintf (title, "%s-", dets[i].c_str());
+      poszn_[i] = tfile->make<TH2F>("poszn0", title, 100, 0, 100, 360, 0, 360);
+      poszn_[i]->GetXaxis()->SetTitle("i#eta");
+      poszn_[i]->GetYaxis()->SetTitle("i#phi");
+    } else {
+      sprintf (title, "%s+", dets[i].c_str());
+      poszp_[i] = tfile->make<TH2F>("poszp1", title, 100, -200, 200, 100, -200, 200);
+      poszp_[i]->GetXaxis()->SetTitle("x (cm)");
+      poszp_[i]->GetYaxis()->SetTitle("y (cm)");
+      sprintf (title, "%s-", dets[i].c_str());
+      poszn_[i] = tfile->make<TH2F>("poszn1", title, 100, -200, 200, 100, -200, 200);
+      poszn_[i]->GetXaxis()->SetTitle("x (cm)");
+      poszn_[i]->GetYaxis()->SetTitle("y (cm)");
+    }
+    poszp_[i]->GetYaxis()->SetTitleOffset(1.2);
+    poszp_[i]->Sumw2();
+    poszn_[i]->GetYaxis()->SetTitleOffset(1.2);
+    poszn_[i]->Sumw2();
   }
 }
 
@@ -236,34 +261,37 @@ void EcalSimHitStudy::analyze(const edm::Event& e, const edm::EventSetup& iS) {
   iS.get<CaloGeometryRecord>().get(pG);
   geometry_ = pG.product();
 
+  double eInc = 0, etaInc = 0, phiInc = 0;
+  int type(-1);
   edm::Handle<edm::HepMCProduct> EvtHandle;
   e.getByToken(tok_evt_, EvtHandle);
-  const HepMC::GenEvent* myGenEvent = EvtHandle->GetEvent();
+  if (EvtHandle.isValid()) {
+    const HepMC::GenEvent* myGenEvent = EvtHandle->GetEvent();
 
-  double eInc = 0, etaInc = 0, phiInc = 0;
-  HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
-  if (p != myGenEvent->particles_end()) {
-    eInc = (*p)->momentum().e();
-    etaInc = (*p)->momentum().eta();
-    phiInc = (*p)->momentum().phi();
+    HepMC::GenEvent::particle_const_iterator p = myGenEvent->particles_begin();
+    if (p != myGenEvent->particles_end()) {
+      eInc = (*p)->momentum().e();
+      etaInc = (*p)->momentum().eta();
+      phiInc = (*p)->momentum().phi();
+    }
+    double ptInc = eInc / std::cosh(etaInc);
+    ptInc_->Fill(ptInc);
+    eneInc_->Fill(eInc);
+    etaInc_->Fill(etaInc);
+    phiInc_->Fill(phiInc);
+    
+    if (std::abs(etaInc) < 1.46)
+      type = 0;
+    else if (std::abs(etaInc) > 1.49 && std::abs(etaInc) < 3.0)
+      type = 1;
   }
-  double ptInc = eInc / std::cosh(etaInc);
-  ptInc_->Fill(ptInc);
-  eneInc_->Fill(eInc);
-  etaInc_->Fill(etaInc);
-  phiInc_->Fill(phiInc);
 
-  int type(-1);
-  if (std::abs(etaInc) < 1.46)
-    type = 0;
-  else if (std::abs(etaInc) > 1.49 && std::abs(etaInc) < 3.0)
-    type = 1;
-  if (type >= 0) {
-    bool getHits(false);
+  int typeMin = (type < 0) ? 0 : type;
+  int typeMax = (type < 0) ? 1 : type;
+  for (int type = typeMin; type <= typeMax; ++type) {
     edm::Handle<edm::PCaloHitContainer> hitsCalo;
     e.getByToken(toks_calo_[type], hitsCalo);
-    if (hitsCalo.isValid())
-      getHits = true;
+    bool getHits = (hitsCalo.isValid());
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HitStudy") << "EcalSimHitStudy: Input flags Hits " << getHits << " with " << hitsCalo->size()
                                  << " hits";
@@ -340,6 +368,19 @@ void EcalSimHitStudy::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
     for (auto it : hitMap) {
       timeAll_[indx]->Fill((it.second).time);
       edepAll_[indx]->Fill((it.second).energy);
+      DetId id(it.first);
+      if (indx == 0) {
+	if (EBDetId(id).zside() >= 0) 
+	  poszp_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
+	else
+	  poszn_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
+      } else {
+        GlobalPoint gpos = geometry_->getGeometry(id)->getPosition();
+	if (EEDetId(id).zside() >= 0) 
+	  poszp_[indx]->Fill(gpos.x(), gpos.y());
+	else
+	  poszn_[indx]->Fill(gpos.x(), gpos.y());
+      }
     }
 
     math::XYZVector meanPosition(0.0, 0.0, 0.0);

--- a/SimG4CMS/Calo/plugins/EcalSimHitStudy.cc
+++ b/SimG4CMS/Calo/plugins/EcalSimHitStudy.cc
@@ -227,20 +227,20 @@ void EcalSimHitStudy::beginJob() {
     sPhiPhi_[i]->GetYaxis()->SetTitle("Events");
     sPhiPhi_[i]->Sumw2();
     if (i == 0) {
-      sprintf (title, "%s+", dets[i].c_str());
+      sprintf(title, "%s+", dets[i].c_str());
       poszp_[i] = tfile->make<TH2F>("poszp0", title, 100, 0, 100, 360, 0, 360);
       poszp_[i]->GetXaxis()->SetTitle("i#eta");
       poszp_[i]->GetYaxis()->SetTitle("i#phi");
-      sprintf (title, "%s-", dets[i].c_str());
+      sprintf(title, "%s-", dets[i].c_str());
       poszn_[i] = tfile->make<TH2F>("poszn0", title, 100, 0, 100, 360, 0, 360);
       poszn_[i]->GetXaxis()->SetTitle("i#eta");
       poszn_[i]->GetYaxis()->SetTitle("i#phi");
     } else {
-      sprintf (title, "%s+", dets[i].c_str());
+      sprintf(title, "%s+", dets[i].c_str());
       poszp_[i] = tfile->make<TH2F>("poszp1", title, 100, -200, 200, 100, -200, 200);
       poszp_[i]->GetXaxis()->SetTitle("x (cm)");
       poszp_[i]->GetYaxis()->SetTitle("y (cm)");
-      sprintf (title, "%s-", dets[i].c_str());
+      sprintf(title, "%s-", dets[i].c_str());
       poszn_[i] = tfile->make<TH2F>("poszn1", title, 100, -200, 200, 100, -200, 200);
       poszn_[i]->GetXaxis()->SetTitle("x (cm)");
       poszn_[i]->GetYaxis()->SetTitle("y (cm)");
@@ -279,7 +279,7 @@ void EcalSimHitStudy::analyze(const edm::Event& e, const edm::EventSetup& iS) {
     eneInc_->Fill(eInc);
     etaInc_->Fill(etaInc);
     phiInc_->Fill(phiInc);
-    
+
     if (std::abs(etaInc) < 1.46)
       type = 0;
     else if (std::abs(etaInc) > 1.49 && std::abs(etaInc) < 3.0)
@@ -370,16 +370,16 @@ void EcalSimHitStudy::analyzeHits(std::vector<PCaloHit>& hits, int indx) {
       edepAll_[indx]->Fill((it.second).energy);
       DetId id(it.first);
       if (indx == 0) {
-	if (EBDetId(id).zside() >= 0) 
-	  poszp_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
-	else
-	  poszn_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
+        if (EBDetId(id).zside() >= 0)
+          poszp_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
+        else
+          poszn_[indx]->Fill(EBDetId(id).ietaAbs(), EBDetId(id).iphi());
       } else {
         GlobalPoint gpos = geometry_->getGeometry(id)->getPosition();
-	if (EEDetId(id).zside() >= 0) 
-	  poszp_[indx]->Fill(gpos.x(), gpos.y());
-	else
-	  poszn_[indx]->Fill(gpos.x(), gpos.y());
+        if (EEDetId(id).zside() >= 0)
+          poszp_[indx]->Fill(gpos.x(), gpos.y());
+        else
+          poszn_[indx]->Fill(gpos.x(), gpos.y());
       }
     }
 

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -224,7 +224,7 @@ double ECalSD::getEnergyDeposit(const G4Step* aStep) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalSim") << lv->GetName() << " " << dd4hep::dd::noNamespace(lv->GetName())
                               << " Light Collection Efficiency " << weight << ":" << wt1 << " wt2= " << wt2
-                              << " Weighted Energy Deposit " << edep / CLHEP::MeV << " MeV";
+                              << " Weighted Energy Deposit " << edep / CLHEP::MeV << " MeV at " << preStepPoint->GetPosition();
 #endif
   return edep;
 }
@@ -293,7 +293,7 @@ uint16_t ECalSD::getRadiationLength(const G4StepPoint* hitPoint, const G4Logical
     double radl = hitPoint->GetMaterial()->GetRadlen();
     thisX0 = (uint16_t)floor(scaleRL * crystalDepth / radl);
 #ifdef plotDebug
-    const std::string& lvname = lv->GetName();
+    const std::string& lvname = dd4hep::dd::noNamespace(lv->GetName());
     int k1 = (lvname.find("EFRY") != std::string::npos) ? 2 : 0;
     int k2 = (lvname.find("refl") != std::string::npos) ? 1 : 0;
     int kk = k1 + k2;
@@ -354,17 +354,17 @@ void ECalSD::initMap() {
       if (strncmp(lvname.c_str(), depth1Name.c_str(), 4) == 0) {
         if (!any(useDepth1, lv)) {
           useDepth1.push_back(lv);
-          //#ifdef EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
           edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " << lvname << " in Depth 1 volume list";
-          //#endif
+#endif
         }
         const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
         if (lvr != nullptr && !any(useDepth1, lvr)) {
           useDepth1.push_back(lvr);
-          //#ifdef EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
           edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " << lvname << "_refl"
                                       << " in Depth 1 volume list";
-          //#endif
+#endif
         }
       }
     }
@@ -372,9 +372,9 @@ void ECalSD::initMap() {
       if (strncmp(lvname.c_str(), depth2Name.c_str(), 4) == 0) {
         if (!any(useDepth2, lv)) {
           useDepth2.push_back(lv);
-          //#ifdef EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
           edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " << lvname << " in Depth 2 volume list";
-          //#endif
+#endif
         }
         const G4LogicalVolume* lvr = nameMap[lvname + "_refl"];
         if (lvr != nullptr && !any(useDepth2, lvr)) {
@@ -400,18 +400,18 @@ void ECalSD::initMap() {
       } else {
         if (!any(noWeight, lv)) {
           noWeight.push_back(lv);
-          //#ifdef EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
           edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " << lvname << " Material " << matname
                                       << " in noWeight list";
-          //#endif
+#endif
         }
         lv = nameMap[lvname];
         if (lv != nullptr && !any(noWeight, lv)) {
           noWeight.push_back(lv);
-          //#ifdef EDM_ML_DEBUG
+#ifdef EDM_ML_DEBUG
           edm::LogVerbatim("EcalSim") << "ECalSD::initMap Logical Volume " << lvname << " Material " << matname
                                       << " in noWeight list";
-          //#endif
+#endif
         }
       }
     }
@@ -420,9 +420,9 @@ void ECalSD::initMap() {
   edm::LogVerbatim("EcalSim") << "ECalSD: Length Table:";
   int i = 0;
   for (auto ite : xtalLMap) {
-    G4String name("Unknown");
+    std::string name("Unknown");
     if (ite.first != nullptr)
-      name = (ite.first)->GetName();
+      name = dd4hep::dd::noNamespace((ite.first)->GetName());
     edm::LogVerbatim("EcalSim") << " " << i << " " << ite.first << " " << name << " L = " << ite.second;
     ++i;
   }

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -224,7 +224,8 @@ double ECalSD::getEnergyDeposit(const G4Step* aStep) {
 #ifdef EDM_ML_DEBUG
   edm::LogVerbatim("EcalSim") << lv->GetName() << " " << dd4hep::dd::noNamespace(lv->GetName())
                               << " Light Collection Efficiency " << weight << ":" << wt1 << " wt2= " << wt2
-                              << " Weighted Energy Deposit " << edep / CLHEP::MeV << " MeV at " << preStepPoint->GetPosition();
+                              << " Weighted Energy Deposit " << edep / CLHEP::MeV << " MeV at "
+                              << preStepPoint->GetPosition();
 #endif
   return edep;
 }

--- a/SimG4CMS/Calo/src/EcalDumpGeometry.cc
+++ b/SimG4CMS/Calo/src/EcalDumpGeometry.cc
@@ -99,7 +99,6 @@ void EcalDumpGeometry::dumpTouch(G4VPhysicalVolume* pv, unsigned int leafDepth) 
           double a2 = (std::abs(solid->GetTanAlpha2()) > 1.e-5) ? solid->GetTanAlpha2() : 0.0;
           pars.emplace_back(a2);
         }
-        //      infoVec_.emplace_back(CaloDetInfo(id, lvname, globalpoint, pars));
         infoVec_.emplace_back(CaloDetInfo(id, noRefl(lvname), globalpoint, pars));
       }
       break;

--- a/SimG4CMS/Calo/src/EcalDumpGeometry.cc
+++ b/SimG4CMS/Calo/src/EcalDumpGeometry.cc
@@ -99,8 +99,8 @@ void EcalDumpGeometry::dumpTouch(G4VPhysicalVolume* pv, unsigned int leafDepth) 
           double a2 = (std::abs(solid->GetTanAlpha2()) > 1.e-5) ? solid->GetTanAlpha2() : 0.0;
           pars.emplace_back(a2);
         }
-//      infoVec_.emplace_back(CaloDetInfo(id, lvname, globalpoint, pars));
-	infoVec_.emplace_back(CaloDetInfo(id, noRefl(lvname), globalpoint, pars));
+        //      infoVec_.emplace_back(CaloDetInfo(id, lvname, globalpoint, pars));
+        infoVec_.emplace_back(CaloDetInfo(id, noRefl(lvname), globalpoint, pars));
       }
       break;
     }

--- a/SimG4CMS/Calo/src/EcalDumpGeometry.cc
+++ b/SimG4CMS/Calo/src/EcalDumpGeometry.cc
@@ -99,7 +99,8 @@ void EcalDumpGeometry::dumpTouch(G4VPhysicalVolume* pv, unsigned int leafDepth) 
           double a2 = (std::abs(solid->GetTanAlpha2()) > 1.e-5) ? solid->GetTanAlpha2() : 0.0;
           pars.emplace_back(a2);
         }
-        infoVec_.emplace_back(CaloDetInfo(id, noRefl(lvname), globalpoint, pars));
+//      infoVec_.emplace_back(CaloDetInfo(id, lvname, globalpoint, pars));
+	infoVec_.emplace_back(CaloDetInfo(id, noRefl(lvname), globalpoint, pars));
       }
       break;
     }

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -30,6 +30,8 @@
 #include "G4PhysicalConstants.hh"
 #include "Randomize.hh"
 
+#include "DD4hep/Filter.h"
+
 #include <iostream>
 #include <fstream>
 #include <iomanip>
@@ -191,10 +193,10 @@ HCalSD::HCalSD(const std::string& name,
     ss0 << "HCalSD: Names to be tested for Volume = HF has " << hfNames.size() << " elements";
 #endif
     for (unsigned int i = 0; i < hfNames.size(); ++i) {
-      G4String namv = static_cast<G4String>(hfNames[i]);
+      G4String namv(static_cast<std::string>(dd4hep::dd::noNamespace(hfNames[i])));
       lv = nullptr;
       for (auto lvol : *lvs) {
-        if (lvol->GetName() == namv) {
+        if (dd4hep::dd::noNamespace(lvol->GetName()) == namv) {
           lv = lvol;
           break;
         }
@@ -225,7 +227,7 @@ HCalSD::HCalSD(const std::string& name,
   for (auto const& namx : matNames) {
     const G4Material* mat = nullptr;
     for (matite = matTab->begin(); matite != matTab->end(); ++matite) {
-      if ((*matite)->GetName() == static_cast<G4String>(namx)) {
+      if (static_cast<std::string>(dd4hep::dd::noNamespace((*matite)->GetName())) == namx) {
         mat = (*matite);
         break;
       }
@@ -341,10 +343,10 @@ void HCalSD::fillLogVolumeVector(const std::string& value,
   std::stringstream ss3;
   ss3 << "HCalSD: " << lvnames.size() << " names to be tested for Volume <" << value << ">:";
   for (unsigned int i = 0; i < lvnames.size(); ++i) {
-    G4String namv = static_cast<G4String>(lvnames[i]);
+    G4String namv(static_cast<std::string>(dd4hep::dd::noNamespace(lvnames[i])));
     lv = nullptr;
     for (auto lvol : *lvs) {
-      if (lvol->GetName() == namv) {
+      if (dd4hep::dd::noNamespace(lvol->GetName()) == namv) {
         lv = lvol;
         break;
       }
@@ -989,7 +991,7 @@ void HCalSD::plotProfile(const G4Step* aStep, const G4ThreeVector& global, doubl
   double depth = -2000;
   int idx = 4;
   for (int n = 0; n < touch->GetHistoryDepth(); ++n) {
-    G4String name = touch->GetVolume(n)->GetName();
+    G4String name(static_cast<std::string>(dd4hep::dd::noNamespace(touch->GetVolume(n)->GetName())));
 #ifdef EDM_ML_DEBUG
     edm::LogVerbatim("HcalSim") << "plotProfile Depth " << n << " Name " << name;
 #endif


### PR DESCRIPTION
#### PR description:

Remove namespace for comparison in SD classes. DDD removes namespace while passing on the name to Geant4 while DD4Hep does not. So comparison of names  is better done after removing namespace.

#### PR validation:

Tested using workflows in the test areas of SimG4Core/Configuration/test

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special