### PR TITLE
Adopt ChargedHadronPFTrackIsolationProducer for PFTICL candidates

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
@@ -59,14 +59,17 @@ void ChargedHadronPFTrackIsolationProducer::produce(edm::StreamID, edm::Event& e
         ((c.rawEcalEnergy() + c.rawHcalEnergy()) > minRawCaloEnergy_)) {
       const reco::PFCandidate::ElementsInBlocks& theElements = c.elementsInBlocks();
       if (theElements.empty())
-        continue;
-      const reco::PFBlockRef blockRef = theElements[0].first;
-      const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
-      // Find the tracks in the block
-      for (auto const& ele : elements) {
-        reco::PFBlockElement::Type type = ele.type();
-        if (type == reco::PFBlockElement::TRACK)
-          nTracks++;
+        nTracks = 1;  // the PFBlockElements is empty for pfTICL charged candidates
+      // because they don't go through PFBlocks machanism. We consider each charged candidate to be well isolated for now.
+      else {
+        const reco::PFBlockRef blockRef = theElements[0].first;
+        const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
+        // Find the tracks in the block
+        for (auto const& ele : elements) {
+          reco::PFBlockElement::Type type = ele.type();
+          if (type == reco::PFBlockElement::TRACK)
+            nTracks++;
+        }
       }
     }
     values.push_back((nTracks == 1));


### PR DESCRIPTION
#### PR description:

[address issues reported by HGCAL folks]
Update ChargedHadronPFTrackIsolationProducer so that we won’t get a crash even when --customise RecoHGCal/TICL/iterativeTICL_cff.injectTICLintoPF is specified. PF candidates from TICL don’t go through PFBlocks. This is generally fine, but when `rawECALEnergy` and `rawHCALEnergy` are set to TICL PF candidates for JetMET to perform PF hadron calibration, it leads to a logic error. More in detail, after setting these quantities [2.1], the `ChargedHadronPFTrackIsolationProducer` [2.2] crashes because it checks the PFElement of type `TRACK` to identify isolated charged hadrons. (It was not crashing before as the `rawECALEnergy` and `rawECALEnergy` are 0, effectively bypassing this check.)

This isolation check is relevant for PF candidates coming from PFAlgo, where multiple tracks can associate to the same calorimeter clusters, but this is not relevant for PF candidates from TICL. In this PR, we consider PF charged candidates from TICL isolated, avoid the crash, and allow `rawCaloEnergy` & `rawHcalEnergy` to be properly stored for packed candidates.

[2.1] https://github.com/cms-sw/cmssw/commit/1e3e2ecab2d05d3aa3df04262866bdf7bf472602#diff-49ac77e92d14b3c79dfe08879ad1b7f4054eb34bf175e844010e4a77c0d242f1
[2.2] https://github.com/cms-sw/cmssw/blob/master/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc#L53-L77

#### PR validation:

Check in a manual workflow with --customise RecoHGCal/TICL/iterativeTICL_cff.injectTICLintoPF
that rawCaloEnergy & rawHcalEnergy are stored in packed charged candidates. Example:
```
                                             (rawCaloFraction(), rawHcalFraction(), caloFraction(), hcalFraction(), ptTrk())
pfcands 2091: pt   3.2 eta -2.44 pdgId  -211 1.000 0.020 1.000 0.020 1.201 
pfcands 2092: pt   3.3 eta -2.52 pdgId   211 0.990 0.210 0.990 0.210 1.467 
pfcands 2093: pt   3.5 eta -2.84 pdgId  -211 0.990 0.380 0.990 0.380 1.616 
pfcands 2094: pt   3.8 eta -2.90 pdgId  -211 1.000 0.380 1.000 0.380 2.922 
```
(raw)CaloFraction() is ~1 by definition now, because PFTICL candidates don’t really use the track pt information yet, and it comes from hgcal measurements.
ptTrk is stored, so I think we have necessary information stored.

Also, make sure ttbar 2021 and 2026D49 (without injectTICLintoPF, 11634.0 & 23234.0) run without a crash.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport.

@hqucms @rovere @felicepantaleo @bendavid 