### PR TITLE
HcalDQM: Enabling hcalcalib to work under #31206

### DIFF
--- a/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/clients/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -44,7 +44,7 @@ process.load('DQM.Integration.config.environment_cfi')
 #	Central DQM Customization
 #-------------------------------------
 process.source.streamLabel = cms.untracked.string("streamDQMCalibration")
-process.source.SelectEvents = cms.untracked.vstring("*HcalCalibration*")
+#process.source.SelectEvents = cms.untracked.vstring("*HcalCalibration*")
 process.dqmEnv.subSystemFolder = subsystem
 process.dqmSaver.tag = subsystem
 process.dqmSaver.runNumber = options.runNumber
@@ -238,7 +238,8 @@ process.p = cms.Path(
 					*process.tasksSequence
 					*process.harvestingSequence
                     *process.dqmEnv
-                    *process.dqmSaver)
+                    *process.dqmSaver
+		    *process.dqmSaverPB)
 
 #-------------------------------------
 #	Scheduling


### PR DESCRIPTION
Putting hcalcalib client into the list of modified clients in #31206 in preparation for the MWGR

#### PR validation:
local test shows hcalcalib client correctly saves the output DQM root using run338628.


