### PR TITLE
Updated configurations in CondTools/Hcal to new MessageLogger syntax

### DIFF
--- a/CondTools/Hcal/test/dbwriteCastorChannelQuality_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorChannelQuality_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorElectronicsMap_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorElectronicsMap_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorGainWidths_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorGainWidths_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorGains_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorGains_cfg.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
@@ -69,11 +72,14 @@ process.p = cms.Path(process.mytest)
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorPedestalWidths_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorPedestalWidths_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorPedestals_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorPedestals_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorQIEData_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorQIEData_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorRecoParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorRecoParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteCastorSaturationCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteCastorSaturationCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalChannelQuality_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalChannelQuality_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalDcsMap_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalDcsMap_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalDcsValues_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalDcsValues_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalElectronicsMap_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalElectronicsMap_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalFlagHFDigiTimeParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalFlagHFDigiTimeParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalGains_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalGains_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalL1TriggerObjects_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalL1TriggerObjects_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalLUTCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalLUTCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalLongRecoParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalLongRecoParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalLutMetadata_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalLutMetadata_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalMCParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalMCParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalPFCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalPFCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalPedestalWidths_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalPedestalWidths_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalPedestals_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalPedestals_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalQIEData_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalQIEData_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalQIETypes.py
+++ b/CondTools/Hcal/test/dbwriteHcalQIETypes.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalRecoParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalRecoParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalRespCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalRespCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalTimeCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalTimeCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalTimingParams_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalTimingParams_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Hcal/test/dbwriteHcalValidationCorrs_cfg.py
+++ b/CondTools/Hcal/test/dbwriteHcalValidationCorrs_cfg.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")


### PR DESCRIPTION
#### PR description:

All configurations in CondTools/Hcal package which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.