### PR TITLE
Updated configurations in CondTools/Ecal to new MessageLogger syntax

### DIFF
--- a/CondTools/Ecal/interface/testEcalTimeCalib.py
+++ b/CondTools/Ecal/interface/testEcalTimeCalib.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 process.load("CondCore.CondDB.CondDB_cfi")
 

--- a/CondTools/Ecal/interface/testEcalTimeOffset.py
+++ b/CondTools/Ecal/interface/testEcalTimeOffset.py
@@ -14,10 +14,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-  destinations=cms.untracked.vstring("cout"),
-  cout=cms.untracked.PSet(
-  )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EcalTimeOffsetConstant.db'

--- a/CondTools/Ecal/python/EcalO2O_DAQ_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_DAQ_cfg.py
@@ -10,8 +10,13 @@ process.CondDBCommon.connect = 'sqlite_file:EcalDAQTowerStatus.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalO2O_DAQ_v2_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_DAQ_v2_cfg.py
@@ -10,8 +10,13 @@ process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalO2O_DCS_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_DCS_cfg.py
@@ -7,9 +7,14 @@ process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/cond
 process.CondDBCommon.connect = 'sqlite_file:EcalDCSTowerStatus.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1000000),

--- a/CondTools/Ecal/python/EcalO2O_channelStatus_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_channelStatus_cfg.py
@@ -10,9 +10,14 @@ process.load("Geometry.CaloEventSetup.EcalTrigTowerConstituents_cfi")
 process.load("CalibCalorimetry.EcalTrivialCondModules.EcalTrivialCondRetriever_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalO2O_laser_online_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_laser_online_cfg.py
@@ -10,9 +10,14 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_42X_ECAL_LASP'
 #process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalO2O_laser_online_cfg_last_express.py
+++ b/CondTools/Ecal/python/EcalO2O_laser_online_cfg_last_express.py
@@ -17,9 +17,14 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_42X_ECAL_LASP'
 #process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalO2O_laser_online_cfg_prompt_40hoursdelay.py
+++ b/CondTools/Ecal/python/EcalO2O_laser_online_cfg_prompt_40hoursdelay.py
@@ -17,9 +17,14 @@ process.CondDBCommon.connect = 'oracle://cms_orcon_prod/CMS_COND_42X_ECAL_LAS'
 #process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalO2O_pedestals_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_pedestals_cfg.py
@@ -9,9 +9,14 @@ process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalO2O_pedestals_v5_online_cfg.py
+++ b/CondTools/Ecal/python/EcalO2O_pedestals_v5_online_cfg.py
@@ -9,9 +9,14 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/EcalTPGFineGrainStripfromFile_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGFineGrainStripfromFile_cfg.py
@@ -10,8 +10,13 @@ process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/'
 process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainStrip.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalTPGFineGrainTowerfromFile_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGFineGrainTowerfromFile_cfg.py
@@ -10,8 +10,13 @@ process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/'
 process.CondDB.connect = 'sqlite_file:EcalTPGFineGrainTower.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalTPGLinPed_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGLinPed_cfg.py
@@ -11,8 +11,13 @@ process.CondDB.connect = 'sqlite_file:EcalLinPed.db'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalTPGPedfromFile_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGPedfromFile_cfg.py
@@ -11,8 +11,13 @@ process.CondDBCommon.connect = 'sqlite_file:EcalLinPed.db'
 #process.CondDBCommon.connect = 'oracle://cms_orcoff_prep/CMS_COND_ECAL'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalTPGPhysicsConstfromFile_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGPhysicsConstfromFile_cfg.py
@@ -10,8 +10,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EcalTPGPhysicsConst.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/EcalTPGSpikeThresholdfromFile_cfg.py
+++ b/CondTools/Ecal/python/EcalTPGSpikeThresholdfromFile_cfg.py
@@ -10,8 +10,13 @@ process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/'
 process.CondDB.connect = 'sqlite_file:EcalTPGSpike.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/Ecal_Laser_weekly_Linearization_Check_cfg.py
+++ b/CondTools/Ecal/python/Ecal_Laser_weekly_Linearization_Check_cfg.py
@@ -11,8 +11,13 @@ process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/'
 process.CondDB.connect = 'sqlite_file:EcalLin.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/Ecal_Laser_weekly_Linearization_cfg.py
+++ b/CondTools/Ecal/python/Ecal_Laser_weekly_Linearization_cfg.py
@@ -10,8 +10,13 @@ process.CondDB.connect = 'sqlite_file:EcalLin.db'
 #process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_CONDITIONS'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/Ecal_Laser_weekly_cfg.py
+++ b/CondTools/Ecal/python/Ecal_Laser_weekly_cfg.py
@@ -10,8 +10,13 @@ process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/'
 process.CondDB.connect = 'sqlite_file:DBLaser.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/Ecal_PulseShapes_cfg.py
+++ b/CondTools/Ecal/python/Ecal_PulseShapes_cfg.py
@@ -13,9 +13,14 @@ process.CondDBCommon.DBParameters.authenticationPath = '.'
 process.CondDBCommon.DBParameters.messageLevel=cms.untracked.int32(1)
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/Ecal_PulseSymmCovariances_cfg.py
+++ b/CondTools/Ecal/python/Ecal_PulseSymmCovariances_cfg.py
@@ -13,9 +13,14 @@ process.CondDBCommon.DBParameters.authenticationPath = '.'
 process.CondDBCommon.DBParameters.messageLevel=cms.untracked.int32(1)
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/copyEcalPFRecHitThresholdsFromFile_cfg.py
+++ b/CondTools/Ecal/python/copyEcalPFRecHitThresholdsFromFile_cfg.py
@@ -15,8 +15,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyEcalPFRecHitThresholds_cfg.py
+++ b/CondTools/Ecal/python/copyEcalPFRecHitThresholds_cfg.py
@@ -13,8 +13,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyFileAlignEB_cfg.py
+++ b/CondTools/Ecal/python/copyFileAlignEB_cfg.py
@@ -17,8 +17,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EBAlignment_test.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyFileAlignEE_cfg.py
+++ b/CondTools/Ecal/python/copyFileAlignEE_cfg.py
@@ -17,8 +17,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EEAlignment_test.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyFileAlignES_cfg.py
+++ b/CondTools/Ecal/python/copyFileAlignES_cfg.py
@@ -17,8 +17,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESAlignment_test.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copySimPulseShapeFromFile_cfg.py
+++ b/CondTools/Ecal/python/copySimPulseShapeFromFile_cfg.py
@@ -31,8 +31,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialAlignEB_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialAlignEB_cfg.py
@@ -10,8 +10,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EBAlign.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialAlignEE_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialAlignEE_cfg.py
@@ -10,8 +10,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:EEAlign.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialAlignES_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialAlignES_cfg.py
@@ -10,8 +10,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESAlign.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialChannelsStatus_sqlit_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialChannelsStatus_sqlit_cfg.py
@@ -8,8 +8,13 @@ process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialDAQ_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialDAQ_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialDCS_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialDCS_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialDQM_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialDQM_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialES_DataHG_sqlite_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialES_DataHG_sqlite_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB_DataHG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialES_sqlite_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialES_sqlite_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialEcalSampleMask.py
+++ b/CondTools/Ecal/python/copyTrivialEcalSampleMask.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 #process.CondDBCommon.connect = 'sqlite_file:DBSMask.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialEcalSamplesCorrelation_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialEcalSamplesCorrelation_cfg.py
@@ -7,8 +7,13 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'sqlite_file:EcalSamplesCorrelation.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialEcalTimeBiasCorrections_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialEcalTimeBiasCorrections_cfg.py
@@ -9,8 +9,13 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'sqlite_file:DBEcalTimeBiasCorrections.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialEnergyCorrectionObjectSpecific_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialEnergyCorrectionObjectSpecific_cfg.py
@@ -9,8 +9,13 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialEnergyCorrection_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialEnergyCorrection_cfg.py
@@ -9,8 +9,13 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-  debugModules = cms.untracked.vstring('*'),
-  destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialLin.py
+++ b/CondTools/Ecal/python/copyTrivialLin.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialPedestals_orcon_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialPedestals_orcon_cfg.py
@@ -10,8 +10,13 @@ process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivialTPGChannelsStatus_sqlit_cfg.py
+++ b/CondTools/Ecal/python/copyTrivialTPGChannelsStatus_sqlit_cfg.py
@@ -11,8 +11,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/nfshome0/popcondev/cond
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_TimeOffsetConstant_cfg.py
+++ b/CondTools/Ecal/python/copyTrivial_TimeOffsetConstant_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:TimeOffsetConstant.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_aging_cfg.py
+++ b/CondTools/Ecal/python/copyTrivial_aging_cfg.py
@@ -15,8 +15,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_aging_cfgIC.py
+++ b/CondTools/Ecal/python/copyTrivial_aging_cfgIC.py
@@ -15,8 +15,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 #process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_orcoff_LaserOnly.py
+++ b/CondTools/Ecal/python/copyTrivial_orcoff_LaserOnly.py
@@ -12,8 +12,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_orcoff_cfg.py
+++ b/CondTools/Ecal/python/copyTrivial_orcoff_cfg.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_orcoff_noLaser.py
+++ b/CondTools/Ecal/python/copyTrivial_orcoff_noLaser.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/copyTrivial_sqlite_LinCor.py
+++ b/CondTools/Ecal/python/copyTrivial_sqlite_LinCor.py
@@ -9,8 +9,13 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 #process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/fill_test_db_cfg.py
+++ b/CondTools/Ecal/python/fill_test_db_cfg.py
@@ -8,9 +8,14 @@ process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/cond
 process.CondDBCommon.connect = 'sqlite_file:DB.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/runPedHist.py
+++ b/CondTools/Ecal/python/runPedHist.py
@@ -5,7 +5,14 @@ process = cms.Process("Noise")
 process.load("FWCore.MessageService.test.Services_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-  destinations = cms.untracked.vstring('messages.txt'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        messages = cms.untracked.PSet(
+            extension = cms.untracked.string('txt')
+        )
+    )
 )
 
 #######################################################################################

--- a/CondTools/Ecal/python/srCondWrite_cfg.py
+++ b/CondTools/Ecal/python/srCondWrite_cfg.py
@@ -8,9 +8,14 @@ process.CondDB.connect = 'sqlite_file:EcalSRSettings_beam2016_option1_v1_mc.db'
 #process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                        debugModules = cms.untracked.vstring('*'),
-                                        destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                                 firstValue = cms.uint64(1),

--- a/CondTools/Ecal/python/updateADCToGeV.py
+++ b/CondTools/Ecal/python/updateADCToGeV.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ProcessOne")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/updateIntercali.py
+++ b/CondTools/Ecal/python/updateIntercali.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ProcessOne")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/updatePFRecHitThresholds.py
+++ b/CondTools/Ecal/python/updatePFRecHitThresholds.py
@@ -4,11 +4,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ProcessOne")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/updateTPGWeightGroup.py
+++ b/CondTools/Ecal/python/updateTPGWeightGroup.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ProcessOne")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/python/updateTPGWeightIdMap.py
+++ b/CondTools/Ecal/python/updateTPGWeightIdMap.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ProcessOne")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights.py
+++ b/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights_BeamCommi09_1.py
+++ b/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights_BeamCommi09_1.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights_hlt.py
+++ b/CondTools/Ecal/test/WEIGHTS/testEcalTBWeights_hlt.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              threshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/alpha/create_alpha_trivial_byLaser_v6.py
+++ b/CondTools/Ecal/test/alpha/create_alpha_trivial_byLaser_v6.py
@@ -30,8 +30,13 @@ process.CondDB.connect = 'sqlite_file:EcalLaserAlphas_EB152-150_EE116_107_SICopt
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/test/alpha/create_alpha_trivial_byTYPE.py
+++ b/CondTools/Ecal/test/alpha/create_alpha_trivial_byTYPE.py
@@ -28,8 +28,13 @@ process.CondDB.connect = 'sqlite_file:EcalLaserAlphas_byTYPE.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/test/alpha/create_alpha_trivial_fromFILE.py
+++ b/CondTools/Ecal/test/alpha/create_alpha_trivial_fromFILE.py
@@ -28,8 +28,13 @@ process.CondDB.connect = 'sqlite_file:EcalLaserAlphas_fromFILE.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/test/alpha/create_alpha_trivial_mixed.py
+++ b/CondTools/Ecal/test/alpha/create_alpha_trivial_mixed.py
@@ -27,8 +27,13 @@ process.CondDB.connect = 'sqlite_file:EcalLaserAlphas_mixed.db'
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/Ecal/test/channelstatus/testEcalChannelStatus.py
+++ b/CondTools/Ecal/test/channelstatus/testEcalChannelStatus.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/energycalib/testEcalADCToGeVConstant.py
+++ b/CondTools/Ecal/test/energycalib/testEcalADCToGeVConstant.py
@@ -26,11 +26,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/energycalib/testEcalIntercalibConstants.py
+++ b/CondTools/Ecal/test/energycalib/testEcalIntercalibConstants.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/energycalib/testEcalIntercalibConstantsMC.py
+++ b/CondTools/Ecal/test/energycalib/testEcalIntercalibConstantsMC.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/energycalib/testEcalIntercalibErrors.py
+++ b/CondTools/Ecal/test/energycalib/testEcalIntercalibErrors.py
@@ -15,11 +15,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/energycalib/testPopConIntercalibConstants.py
+++ b/CondTools/Ecal/test/energycalib/testPopConIntercalibConstants.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/gainratio/testEcalGainRatios.py
+++ b/CondTools/Ecal/test/gainratio/testEcalGainRatios.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/groups/testEcalWeightXtalGroup.py
+++ b/CondTools/Ecal/test/groups/testEcalWeightXtalGroup.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/groups/testEcalWeightXtalGroupMC.py
+++ b/CondTools/Ecal/test/groups/testEcalWeightXtalGroupMC.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/mappingelectronics/testEcalMappingElectronics.py
+++ b/CondTools/Ecal/test/mappingelectronics/testEcalMappingElectronics.py
@@ -2,11 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/preshower/writeESChannelStatus.py
+++ b/CondTools/Ecal/test/preshower/writeESChannelStatus.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESChannelStatus.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESEEIntercalibConstants_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESEEIntercalibConstants_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESEEIntercalibConstants_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESEEIntercalibConstants_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESEEIntercalibConstants_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESEEIntercalibConstants_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESGain_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESGain_HG.py
@@ -6,9 +6,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESGain_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESGain_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESGain_LG.py
@@ -6,9 +6,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESGain_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESIntercalibConstants_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESIntercalibConstants_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESIntercalibConstants_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESIntercalibConstants_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESIntercalibConstants_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESIntercalibConstants_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESMissingEnergyCalibration_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESMissingEnergyCalibration_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESMissingEnergyCalibration_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESMissingEnergyCalibration_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESMissingEnergyCalibration_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESMissingEnergyCalibration_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESPedestals_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESPedestals_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESPedestals_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESPedestals_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESPedestals_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESPedestals_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESRecHitRatioCuts_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESRecHitRatioCuts_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESRecHitRatioCuts_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESRecHitRatioCuts_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESRecHitRatioCuts_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESRecHitRatioCuts_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESThresholds_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESThresholds_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESThresholds_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESThresholds_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESThresholds_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESThresholds_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESTimeSampleWeights_HG.py
+++ b/CondTools/Ecal/test/preshower/writeESTimeSampleWeights_HG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESTimeSampleWeights_HG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/preshower/writeESTimeSampleWeights_LG.py
+++ b/CondTools/Ecal/test/preshower/writeESTimeSampleWeights_LG.py
@@ -8,9 +8,14 @@ process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'sqlite_file:ESTimeSampleWeights_LG.db'
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/Ecal/test/timecalib/testEcalTimeCalib_2009runs_0.py
+++ b/CondTools/Ecal/test/timecalib/testEcalTimeCalib_2009runs_0.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/timecalib/testEcalTimeCalib_v2_hlt.py
+++ b/CondTools/Ecal/test/timecalib/testEcalTimeCalib_v2_hlt.py
@@ -15,10 +15,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/CondTools/Ecal/test/tools/testReaddbWriteXML.py
+++ b/CondTools/Ecal/test/tools/testReaddbWriteXML.py
@@ -7,11 +7,14 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 ##process.load("CondCore.DBCommon.CondDBSetup_cfi")

--- a/CondTools/Ecal/test/tools/testReaddbWriteXMLManyTags.py
+++ b/CondTools/Ecal/test/tools/testReaddbWriteXMLManyTags.py
@@ -7,11 +7,14 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 ##process.load("CondCore.DBCommon.CondDBSetup_cfi")

--- a/CondTools/Ecal/test/tools/testTemplate.py
+++ b/CondTools/Ecal/test/tools/testTemplate.py
@@ -26,11 +26,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.MessageLogger=cms.Service("MessageLogger",
-                              destinations=cms.untracked.vstring("cout"),
-                              cout=cms.untracked.PSet(
-                              treshold=cms.untracked.string("INFO")
-                              )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        treshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load("CondCore.DBCommon.CondDBCommon_cfi")


### PR DESCRIPTION
#### PR description:

All configurations in CondTools/Ecal package which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.