### PR TITLE
Updated configurations in DQM* to new MessageLogger syntax

### DIFF
--- a/DQM/CSCMonitorModule/python/test/csc_unpacker_dump.py
+++ b/DQM/CSCMonitorModule/python/test/csc_unpacker_dump.py
@@ -29,32 +29,48 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 # initialize MessageLogger and output report
 process.MessageLogger = cms.Service("MessageLogger",
-  destinations = cms.untracked.vstring('detailedInfo'),
-  #destinations = cms.untracked.vstring('detailedInfo_754'),
-  debugModules = cms.untracked.vstring('muonCSCDigis'),
-  categories = cms.untracked.vstring(
-    #'CSCDCCUnpacker|CSCRawToDigi', 'StatusDigis', 'StatusDigi', 'CSCRawToDigi', 'CSCDCCUnpacker', 'EventInfo',
-    'badData'),
-  detailedInfo = cms.untracked.PSet(
-    INFO = cms.untracked.PSet(
-      limit = cms.untracked.int32(0)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    TRACE = cms.untracked.PSet(limit = cms.untracked.int32(0) ),
-    noTimeStamps = cms.untracked.bool(False),
-    FwkReport = cms.untracked.PSet(
-      reportEvery = cms.untracked.int32(1),
-      limit = cms.untracked.int32(10000000)
-    ),
-    CSCRawToDigi = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
-    StatusDigi = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
-    EventInfo = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
-
-    default = cms.untracked.PSet(limit = cms.untracked.int32(10000000)),
-    Root_NoDictionary = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-    DEBUG = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-    FwkSummary = cms.untracked.PSet(reportEvery = cms.untracked.int32(1), limit = cms.untracked.int32(10000000) ),
-    threshold = cms.untracked.string('DEBUG')
-  )
+    debugModules = cms.untracked.vstring('muonCSCDigis'),
+    files = cms.untracked.PSet(
+        detailedInfo = cms.untracked.PSet(
+            CSCRawToDigi = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000)
+            ),
+            DEBUG = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            EventInfo = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000)
+            ),
+            FwkReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000),
+                reportEvery = cms.untracked.int32(1)
+            ),
+            FwkSummary = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000),
+                reportEvery = cms.untracked.int32(1)
+            ),
+            INFO = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            Root_NoDictionary = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            StatusDigi = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000)
+            ),
+            TRACE = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000)
+            ),
+            noTimeStamps = cms.untracked.bool(False),
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 #   include

--- a/DQM/CTPPS/test/elastic_dqm_test_cfg.py
+++ b/DQM/CTPPS/test/elastic_dqm_test_cfg.py
@@ -4,11 +4,13 @@ process = cms.Process('RECODQM')
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
-  statistics = cms.untracked.vstring(),
-  destinations = cms.untracked.vstring('cout'),
-  cout = cms.untracked.PSet(
-      threshold = cms.untracked.string('WARNING')
-  )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # load DQM framework

--- a/DQM/DTMonitorModule/test/dt_dqm_offlineclients_Cosmics_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlineclients_Cosmics_cfg.py
@@ -62,19 +62,25 @@ process.p1 = cms.Path(process.EDMtoMEConverter*
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('DTBlockedROChannelsTest'), 
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'),
-                                                              noLineBreaks = cms.untracked.bool(False),
-                                                              DEBUG = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              INFO = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              DTBlockedROChannelsTest = cms.untracked.PSet(
-                                                                                 limit = cms.untracked.int32(-1))
-                                                              )
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        DTBlockedROChannelsTest = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        enable = cms.untracked.bool(True),
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 
 

--- a/DQM/DTMonitorModule/test/dt_dqm_offlineclients_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlineclients_cfg.py
@@ -82,19 +82,25 @@ process.p1 = cms.Path(process.EDMtoMEConverter*
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('DTBlockedROChannelsTest'), 
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'),
-                                                              noLineBreaks = cms.untracked.bool(False),
-                                                              DEBUG = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              INFO = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              DTBlockedROChannelsTest = cms.untracked.PSet(
-                                                                                 limit = cms.untracked.int32(-1))
-                                                              )
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        DTBlockedROChannelsTest = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        enable = cms.untracked.bool(True),
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 
 

--- a/DQM/DTMonitorModule/test/dt_dqm_offlinesourcesRECO_cfg.py
+++ b/DQM/DTMonitorModule/test/dt_dqm_offlinesourcesRECO_cfg.py
@@ -69,18 +69,25 @@ process.out = cms.OutputModule("PoolOutputModule",
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('DTTimeEvolutionHisto'), 
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'),
-                                                              noLineBreaks = cms.untracked.bool(False),
-                                                              DEBUG = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              INFO = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              DTTimeEvolutionHisto = cms.untracked.PSet(limit = cms.untracked.int32(-1))
-                                                              )
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        DTTimeEvolutionHisto = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        enable = cms.untracked.bool(True),
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('WARNING')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 
 # raw to digi

--- a/DQM/DTMonitorModule/test/dumpRawData_cfg.py
+++ b/DQM/DTMonitorModule/test/dumpRawData_cfg.py
@@ -21,9 +21,14 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
 
 process.dump = cms.EDAnalyzer("DumpFEDRawDataProduct",
                               feds = cms.untracked.vint32(770, 771, 772, 773, 774, 775),

--- a/DQM/MuonMonitor/test/mutracking_dqm_sourceclient-live_cfg.py
+++ b/DQM/MuonMonitor/test/mutracking_dqm_sourceclient-live_cfg.py
@@ -101,10 +101,14 @@ process.GlobalTag = gtCustomise(process.GlobalTag, 'auto:run2_data', '')
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    )
 )
-                                                          )
 
 process.dqmmodules = cms.Sequence(process.dqmEnv + process.dqmSaver)
 

--- a/DQM/RPCMonitorClient/test/rpcBXStudies.py
+++ b/DQM/RPCMonitorClient/test/rpcBXStudies.py
@@ -39,9 +39,14 @@ process.dqmEnv.subSystemFolder = 'RPC'
 process.dqmSaver.convention = 'Online'
 
 process.MessageLogger = cms.Service("MessageLogger",
-     debugModules = cms.untracked.vstring('rpcbxtest'),
-     destinations = cms.untracked.vstring('cout'),
-     cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring('rpcbxtest')
 )
 
 process.p = cms.Path(process.readMeFromFile*process.rpcdqmclient*process.dqmEnv*process.dqmSaver)

--- a/DQM/RPCMonitorClient/test/rpcClient_cfg.py
+++ b/DQM/RPCMonitorClient/test/rpcClient_cfg.py
@@ -65,9 +65,14 @@ process.load("DQM.RPCMonitorClient.RPCChamberQuality_cfi")
 
 ############# Message Logger ####################
 process.MessageLogger = cms.Service("MessageLogger",
-     debugModules = cms.untracked.vstring('rpcdqmclient'),
-     destinations = cms.untracked.vstring('cout'),
-     cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    debugModules = cms.untracked.vstring('rpcdqmclient')
 )
 
 

--- a/DQM/RPCMonitorClient/test/rpcTier0Source_cfg.py
+++ b/DQM/RPCMonitorClient/test/rpcTier0Source_cfg.py
@@ -305,9 +305,14 @@ process.dqmEnv.subSystemFolder = 'RPC'
 process.dqmSaver.convention = 'Online'
 ############# Message Logger ####################
 process.MessageLogger = cms.Service("MessageLogger",
-     debugModules = cms.untracked.vstring('*'),
-     destinations = cms.untracked.vstring('cout'),
-     cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    debugModules = cms.untracked.vstring('*')
 )
 
 

--- a/DQM/SiStripCommissioningAnalysis/test/finedelayAnalysis_cfg.template
+++ b/DQM/SiStripCommissioningAnalysis/test/finedelayAnalysis_cfg.template
@@ -5,9 +5,14 @@ process = cms.Process("SiStrpDQMLive")
 #process.load("DQM.SiStripCommon.MessageLogger_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('SiStripFineDelayHit'),
-    cout = cms.untracked.PSet(threshold = cms.untracked.string('ERROR')),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring('SiStripFineDelayHit')
 )
 
 #----------------------------

--- a/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
+++ b/DQM/SiStripCommon/test/testTkHistoMap_cfg.py
@@ -11,11 +11,14 @@ process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Alignment.CommonAlignmentProducer.FakeAlignmentSource_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_RealData_Offline_cfg.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_RealData_Offline_cfg.py
@@ -3,15 +3,20 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("DQMOfflineRealData")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('SiStripZeroSuppression', 
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring(
+        'SiStripZeroSuppression', 
         'SiStripMonitorDigi', 
         'SiStripMonitorCluster', 
         'SiStripMonitorTrackSim', 
-        'MonitorTrackResidualsSim'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
-    ),
-    destinations = cms.untracked.vstring('cout')
+        'MonitorTrackResidualsSim'
+    )
 )
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_SimData_Offline_cfg.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_SimData_Offline_cfg.py
@@ -5,15 +5,20 @@ process = cms.Process("DQMOnlineSimData")
 # Message Logger
 #-------------------------------------------------
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('SiStripZeroSuppression', 
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring(
+        'SiStripZeroSuppression', 
         'SiStripMonitorDigi', 
         'SiStripMonitorCluster', 
         'SiStripMonitorTrackSim', 
-        'MonitorTrackResidualsSim'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
-    ),
-    destinations = cms.untracked.vstring('cout')
+        'MonitorTrackResidualsSim'
+    )
 )
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_SimData_Online_cfg.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_SimData_Online_cfg.py
@@ -5,15 +5,20 @@ process = cms.Process("DQMOnlineSimData")
 # Message Logger
 #-------------------------------------------------
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('SiStripZeroSuppression', 
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring(
+        'SiStripZeroSuppression', 
         'SiStripMonitorDigi', 
         'SiStripMonitorCluster', 
         'SiStripMonitorTrackSim', 
-        'MonitorTrackResidualsSim'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
-    ),
-    destinations = cms.untracked.vstring('cout')
+        'MonitorTrackResidualsSim'
+    )
 )
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorCluster/test/MonitorCluster_SimData_cfg.py
+++ b/DQM/SiStripMonitorCluster/test/MonitorCluster_SimData_cfg.py
@@ -24,12 +24,18 @@ process.maxEvents = cms.untracked.PSet(
 # Message Logger
 #-------------------------------------------------
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siStripDigis',
-                                         'siStripZeroSuppression',
-                                         'siStripClusters'
-                                         'SiStripMonitorCluster'),
-    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    debugModules = cms.untracked.vstring(
+        'siStripDigis', 
+        'siStripZeroSuppression', 
+        'siStripClustersSiStripMonitorCluster'
+    )
 )
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_RealData_cfg.py
+++ b/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_RealData_cfg.py
@@ -23,11 +23,14 @@ process.maxEvents = cms.untracked.PSet(
 # Message Logger
 #-------------------------------------------------
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siStripDigis'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('siStripDigis')
 )
 
 #-------------------------------------------------

--- a/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_SimData_cfg.py
+++ b/DQM/SiStripMonitorDigi/test/SiStripMonitorDigi_SimData_cfg.py
@@ -34,12 +34,17 @@ process.load("RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_Sim
 process.load("DQM.SiStripMonitorDigi.SiStripMonitorDigi_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siStripDigis', 
-        'SiStripMonitorDigi'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring(
+        'siStripDigis', 
+        'SiStripMonitorDigi'
+    )
 )
 
 process.DQMStore = cms.Service("DQMStore",

--- a/DQM/SiStripMonitorHardware/python/test/dumpFED_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/dumpFED_cfg.py
@@ -14,44 +14,32 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.load('FWCore/MessageService/MessageLogger_cfi')
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    info = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    suppressInfo = cms.untracked.vstring(),
-    # allows to suppress output from specific modules 
-    suppressDebug = cms.untracked.vstring(),
-    debug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    warning = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
+process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('DEBUG')
         ),
-    error = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        error = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('ERROR')
         ),
-    suppressWarning = cms.untracked.vstring(),
-    #debugModules = cms.untracked.vstring('*'),#'siStripFEDMonitor'),
-    destinations = cms.untracked.vstring('cerr', 
-                                         'debug', 
-                                         'info', 
-                                         'warning', 
-                                         'error')
-
+        info = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('INFO')
+        ),
+        warning = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('WARNING')
+        )
+    ),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring()
 )
 
 process.load('DQM.SiStripMonitorHardware.siStripFEDDump_cfi')

--- a/DQM/SiStripMonitorHardware/python/test/testBuildTrackerMap_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testBuildTrackerMap_cfg.py
@@ -8,45 +8,33 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 process.load('FWCore/MessageService/MessageLogger_cfi')
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    info = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    suppressInfo = cms.untracked.vstring(),
-    # allows to suppress output from specific modules 
-    suppressDebug = cms.untracked.vstring(),
-    debug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    warning = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
+process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('DEBUG')
         ),
-    error = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        error = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('ERROR')
         ),
-    suppressWarning = cms.untracked.vstring(),
-    #debugModules = cms.untracked.vstring('*'),#'siStripFEDMonitor'),
-    destinations = cms.untracked.vstring('cerr', 
-                                         'debug', 
-                                         'info', 
-                                         'warning', 
-                                         'error')
-
-    )
+        info = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('INFO')
+        ),
+        warning = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('WARNING')
+        )
+    ),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring()
+)
 
 
 #process.load("CondCore.DBCommon.CondDBSetup_cfi")

--- a/DQM/SiStripMonitorHardware/python/test/testSiStripCMMonitor_cfg.py
+++ b/DQM/SiStripMonitorHardware/python/test/testSiStripCMMonitor_cfg.py
@@ -4,7 +4,6 @@ process = cms.Process('DQMCMMonitor')
 
 process.load('Configuration/StandardSequences/Services_cff')
 process.load('FWCore/MessageService/MessageLogger_cfi')
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 process.source = cms.Source(
   "PoolSource",
@@ -35,45 +34,33 @@ process.maxEvents = cms.untracked.PSet(
 
 #process.load('DQM.SiStripCommon.MessageLogger_cfi')
 process.load('FWCore/MessageService/MessageLogger_cfi')
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    info = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    suppressInfo = cms.untracked.vstring(),
-    # allows to suppress output from specific modules 
-    suppressDebug = cms.untracked.vstring(),
-    debug = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
-    warning = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
-        ),
+process.MessageLogger = cms.Service("MessageLogger",
     cerr = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('DEBUG')
         ),
-    error = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR'),
-        #limit = cms.untracked.int32(100000),
-        noLineBreaks = cms.untracked.bool(False)
+        error = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('ERROR')
         ),
-    suppressWarning = cms.untracked.vstring(),
-    #debugModules = cms.untracked.vstring('*'),#'siStripFEDMonitor'),
-    destinations = cms.untracked.vstring('cerr', 
-                                         'debug', 
-                                         'info', 
-                                         'warning', 
-                                         'error')
-
-    )
+        info = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('INFO')
+        ),
+        warning = cms.untracked.PSet(
+            noLineBreaks = cms.untracked.bool(False),
+            threshold = cms.untracked.string('WARNING')
+        )
+    ),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring()
+)
 
 
 #needed to produce tkHistoMap

--- a/DQM/SiStripMonitorPedestals/test/PedsMonWithDB_cfg.py
+++ b/DQM/SiStripMonitorPedestals/test/PedsMonWithDB_cfg.py
@@ -4,11 +4,14 @@ process = cms.Process("PEDESTALS")
 
 # MessageLogger ########
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('PedsMon'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('PedsMon')
 )
 
 # geometry

--- a/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_Quality_cfg.py
@@ -83,12 +83,15 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring(''),
-                                    cout = cms.untracked.PSet(
-    threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    debugModules = cms.untracked.vstring('')
+)
 
 from DQMServices.Core.DQMQualityTester import DQMQualityTester
 process.qTester = DQMQualityTester(

--- a/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/DBReader_cfg.py
@@ -5,14 +5,19 @@ process = cms.Process("Reader")
 process.load("DQM.SiStripCommon.TkHistoMap_cff")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
-    Reader = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout','Reader') #Reader.log
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        Reader = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateBadStripAndNoise_cfg.py
@@ -3,9 +3,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(108597),

--- a/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripCorrelateNoise_cfg.py
@@ -2,9 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-                                    out = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-                                    destinations = cms.untracked.vstring('out')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        out = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(100355),

--- a/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
+++ b/DQM/SiStripMonitorSummary/test/SiStripPlotGain_cfg.py
@@ -2,9 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-                                    out = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-                                    destinations = cms.untracked.vstring('out')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        out = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(109574),

--- a/DQM/TrackerCommon/test/DQMXMLFile_SiPixelDQM_create_cfg.py
+++ b/DQM/TrackerCommon/test/DQMXMLFile_SiPixelDQM_create_cfg.py
@@ -5,13 +5,14 @@ import os
 
 process = cms.Process( "CREATE" )
 
-process.MessageLogger=cms.Service( "MessageLogger"
-, cout = cms.untracked.PSet(
-    threshold = cms.untracked.string( 'INFO' )
-  )
-, destinations = cms.untracked.vstring(
-    'cout'
-  )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source( "EmptyIOVSource"

--- a/DQM/TrackerCommon/test/DQMXMLFile_SiStripDQM_create_cfg.py
+++ b/DQM/TrackerCommon/test/DQMXMLFile_SiStripDQM_create_cfg.py
@@ -5,13 +5,14 @@ import os
 
 process = cms.Process( "CREATE" )
 
-process.MessageLogger=cms.Service( "MessageLogger"
-, cout = cms.untracked.PSet(
-    threshold = cms.untracked.string( 'INFO' )
-  )
-, destinations = cms.untracked.vstring(
-    'cout'
-  )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source( "EmptyIOVSource"

--- a/DQM/TrackingMonitor/test/TrackEfficiencyMonitor_RealData_cfg.py
+++ b/DQM/TrackingMonitor/test/TrackEfficiencyMonitor_RealData_cfg.py
@@ -36,11 +36,14 @@ process.load("DQM.TrackingMonitor.TrackEfficiencyMonitor_cfi")
 process.load("DQM.TrackingMonitor.TrackEfficiencyClient_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('TrackEffMon'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('TrackEffMon')
 )
 
 process.DQMStore = cms.Service("DQMStore",

--- a/DQMOffline/Trigger/test/egHLTOffDQMTest_cfg.py
+++ b/DQMOffline/Trigger/test/egHLTOffDQMTest_cfg.py
@@ -42,28 +42,33 @@ process.source.fileNames = [
     ]
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING'),
         WARNING = cms.untracked.PSet(
             limit = cms.untracked.int32(10)
         ),
-        noLineBreaks = cms.untracked.bool(True)
+        enable = cms.untracked.bool(True),
+        noLineBreaks = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
     ),
-    debugInfo = cms.untracked.PSet(
-        threshold = cms.untracked.string('DEBUG')
+    debugModules = cms.untracked.vstring(
+        'EgammaHLTOffline', 
+        'EgHLTOfflineClient'
     ),
-    detailedInfo = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    critical = cms.untracked.PSet(
-        threshold = cms.untracked.string('ERROR')
-    ),
-    debugModules = cms.untracked.vstring('EgammaHLTOffline','EgHLTOfflineClient'),
-    destinations = cms.untracked.vstring('debugInfo', 
-        'detailedInfo', 
-        'critical', 
-        'cout')
- )
+    files = cms.untracked.PSet(
+        critical = cms.untracked.PSet(
+            threshold = cms.untracked.string('ERROR')
+        ),
+        debugInfo = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        detailedInfo = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
+)
 
 process.DQMStore.verbose = 1
 #process.DQM.collectorHost = ''

--- a/DQMOffline/Trigger/test/muonPostProcessor_cfg.py
+++ b/DQMOffline/Trigger/test/muonPostProcessor_cfg.py
@@ -13,14 +13,17 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    categories = cms.untracked.vstring('HLTMuonVal'),
-    debugModules = cms.untracked.vstring('*'),
-    threshold = cms.untracked.string('INFO'),
     HLTMuonVal = cms.untracked.PSet(
-        #threshold = cms.untracked.string('DEBUG'),
-        limit = cms.untracked.int32(100000),
+        limit = cms.untracked.int32(100000)
     ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.source = cms.Source("PoolSource",


### PR DESCRIPTION
#### PR description:

All configurations in DQM and DQMOffline subsystems which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.