### PR TITLE
Updated configurations in CondTools/Si* to new MessageLogger syntax

### DIFF
--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapProducer_dump.py
@@ -4,16 +4,13 @@ process = cms.Process("DTCCablingMapPayloadDumpTest")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-	destinations = cms.untracked.vstring(
-		'cerr',
-		'cout'
-	),
-	cerr = cms.untracked.PSet(
-		threshold  = cms.untracked.string('INFO')
-	),
-	cout = cms.untracked.PSet(
-		threshold  = cms.untracked.string('INFO')
-	),
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 # Load CondDB service

--- a/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_dump.py
+++ b/CondTools/SiPhase2Tracker/test/DTCCablingMapTestProducer_dump.py
@@ -4,16 +4,13 @@ process = cms.Process("DTCCablingMapPayloadDumpTest")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-	destinations = cms.untracked.vstring(
-		'cerr',
-		'cout'
-	),
-	cerr = cms.untracked.PSet(
-		threshold  = cms.untracked.string('INFO') 
-	),
-	cout = cms.untracked.PSet(
-		threshold  = cms.untracked.string('INFO') 
-	),
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('INFO')
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 # Load CondDB service

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilderFromROCList_cfg.py
@@ -6,10 +6,13 @@ process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelBadModuleByHandBuilder_cfg.py
@@ -7,10 +7,13 @@ process.load("Geometry.TrackerGeometryBuilder.trackerParameters_cfi")
 process.TrackerTopologyEP = cms.ESProducer("TrackerTopologyEP")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiPixel/test/SiPixelCalibConfigurationObjectMaker_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelCalibConfigurationObjectMaker_cfg.py
@@ -18,7 +18,12 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",

--- a/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelDynamicInefficiencyReader_cfg.py
@@ -19,10 +19,13 @@ process.source = cms.Source("EmptySource",
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 process.Timing = cms.Service("Timing")

--- a/CondTools/SiPixel/test/SiPixelInclusiveReader_sqlite_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelInclusiveReader_sqlite_cfg.py
@@ -9,10 +9,13 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.GlobalTag.globaltag = 'MC_31X_V3::All'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 

--- a/CondTools/SiPixel/test/SiPixelLorentzAngleReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelLorentzAngleReader_cfg.py
@@ -19,10 +19,13 @@ process.TFileService = cms.Service("TFileService",
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('WARNING')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 process.Timing = cms.Service("Timing")

--- a/CondTools/SiPixel/test/SiPixelVCalReader_cfg.py
+++ b/CondTools/SiPixel/test/SiPixelVCalReader_cfg.py
@@ -55,8 +55,13 @@ process.TFileService = cms.Service("TFileService",
     fileName = cms.string(outfile)
 )
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout = cms.untracked.PSet(threshold = cms.untracked.string(threshold))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 process.Timing = cms.Service("Timing")
 

--- a/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripBadModuleByHandBuilder_cfg.py
@@ -2,10 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    destinations = cms.untracked.vstring('cout')
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiStrip/test/SiStripCablingTrackerMap_cfg.py
+++ b/CondTools/SiStrip/test/SiStripCablingTrackerMap_cfg.py
@@ -4,11 +4,18 @@ process = cms.Process("TrackerMapProd")
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     cablingReader = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('cablingMap.log')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        cablingMap = cms.untracked.PSet(
+
+        )
+    )
 )
 
 import CalibTracker.Configuration.Common.PoolDBESSource_cfi

--- a/CondTools/SiStrip/test/SiStripDetVOffReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripDetVOffReader_cfg.py
@@ -2,11 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DetVOffReader")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring(''),
-    threshold = cms.untracked.string('INFO'),
-    destinations = cms.untracked.vstring('SiStripDetVOffReader.log')
+    files = cms.untracked.PSet(
+        SiStripDetVOffReader = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripNoiseBuilder_cfg.py
@@ -2,9 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
 process.MessageLogger = cms.Service("MessageLogger",
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO')),
-                                    destinations = cms.untracked.vstring('cout')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
 
 process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),

--- a/CondTools/SiStrip/test/SiStripSummaryBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryBuilder_cfg.py
@@ -2,10 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("ICALIB")
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('SiStripSummaryBuilder.log')
+    files = cms.untracked.PSet(
+        SiStripSummaryBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 # different !!

--- a/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripSummaryReader_cfg.py
@@ -3,10 +3,17 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("SiStripSummaryReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('SiStripSummaryReader.log')
+    files = cms.untracked.PSet(
+        SiStripSummaryReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 

--- a/CondTools/SiStrip/test/SiStripThresholdBuilder_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdBuilder_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Builder")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     ThresholdBuilder = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('ThresholdBuilder.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        ThresholdBuilder = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
+++ b/CondTools/SiStrip/test/SiStripThresholdReader_cfg.py
@@ -9,14 +9,21 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("Reader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring(''),
     ThresholdReader = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
+    ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
     cout = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')
     ),
-    destinations = cms.untracked.vstring('ThresholdReader.log')
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        ThresholdReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

All configurations in CondTools/Si* packages which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.