### PR TITLE
Fix esConsumes() for an EDModule that consumes EDProduct with @currentProcess

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -69,7 +69,7 @@ namespace edm {
 
   class EDConsumerBase {
   public:
-    EDConsumerBase() : m_tokenLabels{'\0'}, frozen_(false), containsCurrentProcessAlias_(false) {}
+    EDConsumerBase();
     virtual ~EDConsumerBase() noexcept(false);
 
     // disallow copying

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -31,39 +31,14 @@
 
 using namespace edm;
 
-//
-// constants, enums and typedefs
-//
+namespace {
+  std::vector<char> makeEmptyTokenLabels() { return std::vector<char>{'\0'}; }
+}  // namespace
 
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-//EDConsumerBase::EDConsumerBase()
-//{
-//}
-
-// EDConsumerBase::EDConsumerBase(const EDConsumerBase& rhs)
-// {
-//    // do actual copying here;
-// }
+EDConsumerBase::EDConsumerBase()
+    : m_tokenLabels{makeEmptyTokenLabels()}, frozen_(false), containsCurrentProcessAlias_(false) {}
 
 EDConsumerBase::~EDConsumerBase() noexcept(false) {}
-
-//
-// assignment operators
-//
-// const EDConsumerBase& EDConsumerBase::operator=(const EDConsumerBase& rhs)
-// {
-//   //An exception safe implementation is
-//   EDConsumerBase temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
 
 //
 // member functions
@@ -549,10 +524,10 @@ void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) 
   if (containsCurrentProcessAlias_) {
     containsCurrentProcessAlias_ = false;
 
-    std::vector<char> newTokenLabels;
+    auto newTokenLabels = makeEmptyTokenLabels();
 
     // first calculate the size of the new vector and reserve memory for it
-    std::vector<char>::size_type newSize = 0;
+    std::vector<char>::size_type newSize = newTokenLabels.size();
     std::string newProcessName;
     for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       newProcessName = &m_tokenLabels[iter->m_startOfModuleLabel + iter->m_deltaToProcessName];
@@ -563,7 +538,7 @@ void EDConsumerBase::convertCurrentProcessAlias(std::string const& processName) 
     }
     newTokenLabels.reserve(newSize);
 
-    unsigned int newStartOfModuleLabel = 0;
+    unsigned int newStartOfModuleLabel = newTokenLabels.size();
     for (auto iter = m_tokenInfo.begin<kLabels>(), itEnd = m_tokenInfo.end<kLabels>(); iter != itEnd; ++iter) {
       unsigned int startOfModuleLabel = iter->m_startOfModuleLabel;
       unsigned short deltaToProcessName = iter->m_deltaToProcessName;

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -1,6 +1,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -213,6 +214,24 @@ namespace edmtest {
                                         << ": Data values = " << dataJ->value();
   }
 
+  class ESTestAnalyzerL : public edm::stream::EDAnalyzer<> {
+  public:
+    explicit ESTestAnalyzerL(edm::ParameterSet const& iConfig)
+        : edToken_(consumes(iConfig.getParameter<edm::InputTag>("src"))), esToken_(esConsumes()) {}
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  private:
+    edm::EDGetTokenT<IntProduct> edToken_;
+    edm::ESGetToken<ESTestDataJ, ESTestRecordJ> esToken_;
+  };
+
+  void ESTestAnalyzerL::analyze(edm::Event const& ev, edm::EventSetup const& es) {
+    auto const& intData = ev.get(edToken_);
+    auto const& dataJ = es.getData(esToken_);
+    edm::LogAbsolute("ESTestAnalyzerJ") << "ESTestAnalyzerL: process = " << moduleDescription().processName()
+                                        << ": ED value " << intData.value << ": ES value = " << dataJ.value();
+  }
+
 }  // namespace edmtest
 using namespace edmtest;
 DEFINE_FWK_MODULE(ESTestAnalyzerA);
@@ -220,3 +239,4 @@ DEFINE_FWK_MODULE(ESTestAnalyzerB);
 DEFINE_FWK_MODULE(ESTestAnalyzerK);
 DEFINE_FWK_MODULE(ESTestAnalyzerAZ);
 DEFINE_FWK_MODULE(ESTestAnalyzerJ);
+DEFINE_FWK_MODULE(ESTestAnalyzerL);

--- a/FWCore/Integration/test/EventSetupTestCurrentProcess_cfg.py
+++ b/FWCore/Integration/test/EventSetupTestCurrentProcess_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(3)
+)
+
+process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
+
+process.DoodadESSource = cms.ESSource("DoodadESSource")
+
+process.emptyESSourceK = cms.ESSource("EmptyESSource",
+    recordName = cms.string("ESTestRecordK"),
+    firstValid = cms.vuint32(1,2,3),
+    iovIsRunNotTime = cms.bool(True)
+)
+
+process.testDataProxyProviderJ = cms.ESProducer("ESTestDataProxyProviderJ",
+    expectedCacheIds = cms.untracked.vuint32(2, 3, 4)
+)
+
+process.intProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+
+process.esAnalyzerL1 = cms.EDAnalyzer("ESTestAnalyzerL",
+    src = cms.InputTag("intProducer")
+)
+process.esAnalyzerL2 = cms.EDAnalyzer("ESTestAnalyzerL",
+    src = cms.InputTag("intProducer", "", cms.InputTag.currentProcess())
+)
+
+process.p = cms.Path(
+    process.intProducer+
+    process.esAnalyzerL1+
+    process.esAnalyzerL2
+)

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -30,4 +30,7 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/testEventSetupRunLumi_cfg.py || die 'Fa
 echo testConcurrentIOVsESSource_cfg.py
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsESSource_cfg.py || die 'Failed in testConcurrentIOVsESSource_cfg.py' $?
 
+echo EventSetupTestCurrentProcess_cfg.py
+cmsRun ${LOCAL_TEST_DIR}/EventSetupTestCurrentProcess_cfg.py || die 'Failed in EventSetupTestCurrentProcess_cfg.py' $?
+
 popd


### PR DESCRIPTION
#### PR description:

ES tokens use an "empty string optimization", i.e. re-using the `\0` as the first element of `EDConsumerBase::m_tokenLabels` for empty strings. However, when an EDProduct is consumed with `@currentProcess` process name, `EDConsumerBase::convertCurrentProcessAlias()` overwrites `m_tokenLabels` to have something else as the first element, leading to `NoProxyException` being thrown when an `ESHandle` obtained with `ESGetToken` is dereferenced.

This PR fixed `convertCurrentProcessAlias()` to leave `\0` as the first element of `m_tokenLabels`.

This problem was observed in #31962.

#### PR validation:

Framework unit tests run. In addition, with #31962 `11634.0` step2 runs (that fails without this PR).