### PR TITLE
Fix ECAL Endcap quadrants issue with DD4hep reflected volumes + Also fix ECAL Barrel and CSCs reflected active detectors

### DIFF
--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -33,6 +33,8 @@ G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog)
   const Detector &detector = *det->description();
   Geant4Converter g4Geo(detector);
   g4Geo.debugMaterials = false;
+  g4Geo.debugReflections = true;
+  g4Geo.debugPlacements = true;
   Geant4GeometryInfo *geometry = g4Geo.create(world).detach();
   map_ = geometry->g4Volumes;
 
@@ -59,6 +61,25 @@ G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog)
     edm::LogVerbatim("SimG4CoreApplication")
         << " DDG4SensitiveConverter: Sensitive " << fff << " Class Name " << sClassName << " ROU Name " << sROUName;
   }
+
+
+
+ for (auto const &it : map_) {
+   std::cout << "DDG4Builder::DDG4Builder found " << it.first.name() << std::endl;
+
+ }
+
+
+
+
+
+
+
+
+
+
+
+
 
   return geometry->world();
 }

--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -60,7 +60,7 @@ G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog)
     auto reflectedG4LogicalVolumeName = fff + "_refl";
     bool hasReflectedVolumeInStore = false;
     G4LogicalVolumeStore *theStore = G4LogicalVolumeStore::GetInstance();
-    for (auto &lv : *theStore) {
+    for (const auto &lv : *theStore) {
       if (lv->GetName().find(reflectedG4LogicalVolumeName) != std::string::npos) {
         hasReflectedVolumeInStore = true;
       }


### PR DESCRIPTION
**This PR fixes the handling of reflected volumes in CMSSW in DD4hep workflows.**

The key idea is that the handling of reflected volumes is different in old DD and DD4hep, as there are 2 different files in CMSSW:
- old DD: https://github.com/cms-sw/cmssw/blob/master/SimG4Core/Geometry/src/DDG4Builder.cc 
- DD4hep: https://github.com/cms-sw/cmssw/blob/master/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc 

In old DD, **there is a special treatment for reflected volumes, so that the volumes with _refl are added to the sensitive detector catalogue.**
In DD4hep, the G4 reflected volumes were properly created, **but their names with _refl were not added to the active detectors catalogue list.**
**This resulted, further downstream in https://github.com/cms-sw/cmssw/blob/master/SimG4Core/SensitiveDetector/src/SensitiveDetector.cc#L53, to have the reflected volumes not set as active detectors.**
This issue did not appear with the TGeo trick, because the reflected volumes with TGeo, did not have the _refl names.
The reflected active volumes being not considered as sensitive detectors by G4, there were obviously no SimHit on them.

The proper list of active volumes is now fixed, and includes the active reflected volumes.


NB: The affected active volumes, which are now present on a DD4hep workflow, and which were NOT considered as active volumes until now, without the TGeo trick, are:

**In ECAL Endcap:**
reflectedG4LogicalVolumeName = EFRY_refl
-> This solves the ECAL Endcap quadrants issue.

**In ECAL Barrel:**
reflectedG4LogicalVolumeName = ebalgo:EBRY_01_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_01_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_01_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_02_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_02_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_02_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_03_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_03_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_03_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_07_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_04_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_04_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_04_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_05_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_05_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_05_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_06_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_06_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_06_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_07_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_07_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_08_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_08_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_08_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_09_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_09_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_09_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_10_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_10_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_10_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_11_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_11_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_11_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_12_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_12_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_12_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_13_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_13_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_13_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_14_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_14_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_14_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_15_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_15_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_15_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_16_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_16_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_16_refl
reflectedG4LogicalVolumeName = ebalgo:EBRY_17_refl
reflectedG4LogicalVolumeName = ebalgo:EATJ_17_refl
reflectedG4LogicalVolumeName = ebalgo:EAPD_17_refl

**In CSC:**
reflectedG4LogicalVolumeName = csc:ME1A_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME11_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME12_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME13_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME21_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME22_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME31_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME32_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME41_ActiveGasVol_refl
reflectedG4LogicalVolumeName = csc:ME42_ActiveGasVol_refl


NB 2: PR quickly done here, might push a few commits to clean it.

@ianna @civanch @bsunanda @cvuosalo 