### PR TITLE
Phase2 improved conditions and ntuple maker update

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
@@ -40,7 +40,7 @@
 #define T2HY 10          // = T2YSIZE/2
 #define T2HYP1 T2HY + 1  // = T2YSIZE/2+1
 #define T2HX 3           // = T2XSIZE/2
-#define TEMP_ENTRY_SIZEX_A 60
-#define TEMP_ENTRY_SIZEX_B 60
-#define TEMP_ENTRY_SIZEY 60
+#define TEMP_ENTRY_SIZEX_A 80
+#define TEMP_ENTRY_SIZEX_B 80
+#define TEMP_ENTRY_SIZEY 100
 #endif

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -52,15 +52,15 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 ##

--- a/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
+++ b/SLHCUpgradeSimulations/Geometry/test/BuildFile.xml
@@ -31,6 +31,13 @@
     <use name="SimTracker/TrackerHitAssociation"/>
     <use name="Geometry/Records"/>
     <use name="Geometry/TrackerGeometryBuilder"/>
+    <use name="TrackingTools/TransientTrack"/>
+    <use name="TrackingTools/TransientTrackingRecHit"/>
+    <use name="TrackingTools/TrajectoryState"/>
+    <use name="TrackingTools/TrackAssociator"/>
+    <use name="TrackingTools/Records"/>
+    <use name="TrackingTools/TrackFitters"/>
+    <use name="RecoTracker/TransientTrackingRecHit"/>
   </library>
 
   <bin name="testPhase2PixelNtuple" file="testPhase2PixelNtuple.cpp">

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 
-from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
-process = cms.Process('USER',Phase2C11)
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('USER',Phase2C9)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')

--- a/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/phase2_digi_reco_pixelntuple_cfg.py
@@ -1,13 +1,8 @@
-# Auto generated configuration file
-# using: 
-# Revision: 1.19 
-# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: step2 --conditions auto:phase2_realistic -s DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW,HLT:@fake2,RAW2DIGI,L1Reco,RECO --datatier GEN-SIM-RECO -n 10 --geometry Extended2023D41 --era Phase2 --eventcontent FEVTDEBUGHLT --filein file:SingleMuPt1000_pythia8_cfi_GEN_SIM.root --runUnscheduled --no_exec
 import FWCore.ParameterSet.Config as cms
 
 
-from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
-process = cms.Process('Phase2PixelNtuple',Phase2C9)
+from Configuration.Eras.Era_Phase2C11_cff import Phase2C11
+process = cms.Process('USER',Phase2C11)
 
 # import of standard configurations
 process.load('Configuration.StandardSequences.Services_cff')
@@ -35,7 +30,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-		'/store/relval/CMSSW_11_2_0_pre1/RelValSingleMuPt10/GEN-SIM/110X_mcRun4_realistic_v3_2026D49noPU-v1/10000/743B02CC-F5B9-5642-A7EF-EE222E18C54F.root'
+        '/store/relval/CMSSW_11_2_0_pre8/RelValSingleMuPt10/GEN-SIM-RECO/112X_mcRun4_realistic_v3_2026D49noPU-v1/00000/007d817e-9c59-4dec-959b-0f227942cdf0.root'
     )
 )
 
@@ -66,22 +61,30 @@ process.mcverticesanalyzer.pileupSummaryCollection = cms.InputTag("addPileupInfo
 #    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
 #    splitLevel = cms.untracked.int32(0)
 #)
+
+# # # -- Trajectory producer
+process.load("RecoTracker.TrackProducer.TrackRefitters_cff")
+process.TrackRefitter.src = 'generalTracks'
+process.TrackRefitter.NavigationSchool = ""
+
 process.ReadLocalMeasurement = cms.EDAnalyzer("Phase2PixelNtuple",
-   trackProducer = cms.InputTag("generalTracks"),
-   #verbose = cms.untracked.bool(True),
-   #picky = cms.untracked.bool(False),                                             
-   ### for using track hit association
-   associatePixel = cms.bool(True),
-   associateStrip = cms.bool(False),
-   associateRecoTracks = cms.bool(False),
-   ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
-                         'TrackerHitsPixelBarrelHighTof',
-                         'TrackerHitsPixelEndcapLowTof',
-                         'TrackerHitsPixelEndcapHighTof'),
-   usePhase2Tracker = cms.bool(True),
-   pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
-   phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker")
-)
+                                              trackProducer = cms.InputTag("generalTracks"),
+                                              trajectoryInput = cms.InputTag('TrackRefitter::USER'),
+                                              #verbose = cms.untracked.bool(True),
+                                              #picky = cms.untracked.bool(False),                                             
+                                              ### for using track hit association
+                                              associatePixel = cms.bool(True),
+                                              associateStrip = cms.bool(False),
+                                              associateRecoTracks = cms.bool(False),
+                                              ROUList = cms.vstring('TrackerHitsPixelBarrelLowTof',
+                                                                    'TrackerHitsPixelBarrelHighTof',
+                                                                    'TrackerHitsPixelEndcapLowTof',
+                                                                    'TrackerHitsPixelEndcapHighTof'),
+                                              ttrhBuilder = cms.string("WithTrackAngle"),
+                                              usePhase2Tracker = cms.bool(True),
+                                              pixelSimLinkSrc = cms.InputTag("simSiPixelDigis", "Pixel"),
+                                              phase2TrackerSimLinkSrc = cms.InputTag("simSiPixelDigis", "Tracker")
+                                          )
 
 
 # Additional output definition
@@ -91,15 +94,6 @@ process.mix.digitizers = cms.PSet(process.theDigitizersValid)
 
 # This pset is specific for producing simulated events for the designers of the PROC (InnerTracker)
 # They need pixel RecHits where the charge is stored with high-granularity and large dinamic range
-
-# digitizer
-process.mix.digitizers.pixel.PixelDigitizerAlgorithm.AdcFullScale   = cms.int32(255)
-process.mix.digitizers.pixel.PixelDigitizerAlgorithm.ElectronPerAdc = cms.double(135.)
-process.mix.digitizers.pixel.PixelDigitizerAlgorithm.AddXTalk = cms.bool(False)
-
-# clusterizer
-process.siPixelClusters.ElectronPerADCGain  = cms.double(135.)
-process.siPixelClustersPreSplitting.ElectronPerADCGain  = cms.double(135.)
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
@@ -112,7 +106,7 @@ process.digi2raw_step = cms.Path(process.DigiToRaw)
 process.raw2digi_step = cms.Path(process.RawToDigi)
 process.L1Reco_step = cms.Path(process.L1Reco)
 process.reconstruction_step = cms.Path(process.reconstruction)
-process.user_step = cms.Path(process.ReadLocalMeasurement + process.mcverticesanalyzer)
+process.user_step = cms.Path(process.TrackRefitter * process.ReadLocalMeasurement * process.mcverticesanalyzer)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 #process.FEVTDEBUGHLToutput_step = cms.EndPath(process.FEVTDEBUGHLToutput)
 


### PR DESCRIPTION
This PR updates the phase2 template and genError objects to have extended angle coverage. This was needed in order to correct a previous issue where there were a good number of hits outside their angle space and lead to poor resolution.
Results validating these condition changes were shown at the phase 2 simulation meeting [here](https://indico.cern.ch/event/949829/contributions/4116024/attachments/2147562/3620113/2020_11_20_Test_new_CPE.pdf)

It also has an update to the Phase 2 ntuple maker used in validation studies. This update saves more information about the track the hits belong to and the local angles used in the hit reconstruction. Because the ntuple maker now requires the trajectory as an input configuration files that use it must be changed, the example configuration file in the same directory has been updated to reflect this. 

@mmusich @tsusa @emiglior @mtosi @tvami @pmaksim1  @jalimena @perrotta @slava77

