### PR TITLE
Update QGL tag for 2016 and 2018 MC and Run 2 data

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -8,7 +8,7 @@ autoCond = {
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
     'run1_mc_hi'        :   '112X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '112X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '112X_mcRun1_pA_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '112X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
@@ -16,23 +16,23 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '112X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '112X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'   :   '112X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '112X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '112X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_asymptotic_deco_v1',
+    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '112X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '112X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v6',
+    'run1_data'         :   '112X_dataRun2_v7',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v6',
+    'run2_data'         :   '112X_dataRun2_v7',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v6',
+    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v7',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v6',
+    'run2_data_relval'  :   '112X_dataRun2_relval_v7',
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
@@ -59,15 +59,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '112X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v5',
+    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v5',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v5',
+    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '112X_upgrade2018cosmics_realistic_deco_v5',
+    'phase1_2018_cosmics'      :  '112X_upgrade2018cosmics_realistic_deco_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v5',
+    'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v6',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '112X_mcRun3_2021_design_v11', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR updates the quark-gluon likelihood tag for 2016 and 2018 MC and Run 2 data; 2017 MC already has the correct tag. The update has already been included in the 102X series for the nanoAOD campaign but the change was never propagated to 10_6_X and master.

See the [HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4357.html) for details.

This PR may or may not be final. I have requested clarification from QGL experts whether Run 3 MC should receive this update as well. However, since the Run 3 updates will not be backported to 10_6_X, the portion that will be backported to 10_6_X is final.

The GT diffs are as follows:

**Run 1 proton-heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun1_pA_v1/112X_mcRun1_pA_v2

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_asymptotic_preVFP_v1/112X_mcRun2_asymptotic_preVFP_v2

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_asymptotic_v1/112X_mcRun2_asymptotic_v2

**2016 cosmics (asymptotic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2cosmics_asymptotic_deco_v1/112X_mcRun2cosmics_asymptotic_deco_v2

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_v6/112X_dataRun2_v7

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HEfail_v6/112X_dataRun2_HEfail_v7

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_relval_v6/112X_dataRun2_relval_v7

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_v5/112X_upgrade2018_realistic_v6

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HEfail_v5/112X_upgrade2018_realistic_HEfail_v6

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_deco_v5/112X_upgrade2018cosmics_realistic_deco_v6

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_peak_v5/112X_upgrade2018cosmics_realistic_peak_v6

There is an additional technical update in this PR to the Run 1 proton-HI GT to remove the obsolete record of type `PGeometricDetExtraRcd` that is no longer defined. This should have been done in PR #31780. The problem was not noticed because the autoCond key `run1_mc_pa` is not used anywhere in CMSSW.

#### PR validation:

These tags have already been validated and are in use in the 10_2_X series.

In addition, a technical test was performed: `runTheMatrix.py -l limited,1325.516,7.22,136.8642,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 10_6_X.