### PR TITLE
Updated configurations in JetMETCorrections to new MessageLogger syntax

### DIFF
--- a/JetMETCorrections/Modules/test/METCorrectionLocalDBReader_cfg.py
+++ b/JetMETCorrections/Modules/test/METCorrectionLocalDBReader_cfg.py
@@ -6,18 +6,19 @@ process = cms.Process("metdbreader")
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations   = cms.untracked.vstring(
-      'myDebugOutputFile'
-      ),
-    myDebugOutputFile       = cms.untracked.PSet(
-      threshold = cms.untracked.string('DEBUG'),
-      default = cms.untracked.PSet(
-	limit = cms.untracked.int32(-1)
-	),
-      ),
-    debugModules = cms.untracked.vstring(
-      'demo1')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('demo1'),
+    files = cms.untracked.PSet(
+        myDebugOutputFile = cms.untracked.PSet(
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            threshold = cms.untracked.string('DEBUG')
+        )
     )
+)
 
 #process.load('Configuration.StandardSequences.Services_cff')
 #process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -2,12 +2,13 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('qgldb')
 
 process.MessageLogger = cms.Service("MessageLogger",
-            destinations = cms.untracked.vstring(
-                    'cout'
-            ),
-            cout = cms.untracked.PSet(
-                    threshold = cms.untracked.string( 'INFO' )
-            ),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 qgDatabaseVersion = 'v1'

--- a/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
@@ -3,8 +3,13 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("LikelihoodDBLocalReader")
 
 process.MessageLogger = cms.Service("MessageLogger",
-            destinations = cms.untracked.vstring('cout'),
-            cout = cms.untracked.PSet(threshold = cms.untracked.string( 'INFO' )),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 process.load('Configuration.StandardSequences.Services_cff')


### PR DESCRIPTION
#### PR description:

All configurations in JetMETCorrections subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.