### PR TITLE
Updated configurations in L1Trigger* to new MessageLogger syntax

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesProducerTest_cfg.py
@@ -15,32 +15,32 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring("log", "debug", "errors"),
-    statistics = cms.untracked.vstring("stat"),
-    # No constraint on log.txt content...
-    log = cms.untracked.PSet(
-        extension = cms.untracked.string(".txt"),
-        lineLength = cms.untracked.int32(132),
-        noLineBreaks = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    debug = cms.untracked.PSet(
-        extension = cms.untracked.string(".txt"),
-        threshold = cms.untracked.string("DEBUG"),
-        lineLength = cms.untracked.int32(132),
-        noLineBreaks = cms.untracked.bool(True)
-    ),
-    errors = cms.untracked.PSet(
-        extension = cms.untracked.string(".txt"),
-        threshold = cms.untracked.string("ERROR")
+    debugModules = cms.untracked.vstring('cscTriggerPrimitiveDigis'),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            extension = cms.untracked.string('.txt'),
+            lineLength = cms.untracked.int32(132),
+            noLineBreaks = cms.untracked.bool(True),
+            threshold = cms.untracked.string('DEBUG')
+        ),
+        errors = cms.untracked.PSet(
+            extension = cms.untracked.string('.txt'),
+            threshold = cms.untracked.string('ERROR')
+        ),
+        log = cms.untracked.PSet(
+            extension = cms.untracked.string('.txt'),
+            lineLength = cms.untracked.int32(132),
+            noLineBreaks = cms.untracked.bool(True)
+        )
     ),
     stat = cms.untracked.PSet(
-        extension = cms.untracked.string(".txt"),
-        threshold = cms.untracked.string("INFO")
-    ),
-    # turn on the following to get LogDebug output
-    # ============================================
-    # debugModules = cms.untracked.vstring("*"),
-    debugModules = cms.untracked.vstring("cscTriggerPrimitiveDigis")
+        enableStatistics = cms.untracked.bool(True),
+        extension = cms.untracked.string('.txt'),
+        threshold = cms.untracked.string('INFO')
+    )
 )
 
 # es_source of ideal geometry

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader_cfg.py
@@ -19,22 +19,18 @@ process.maxEvents = cms.untracked.PSet(
 # For LogTrace to take an effect, compile using
 # > scram b -j8 USER_CXXFLAGS="-DEDM_ML_DEBUG"
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring("debug"),
-    #	untracked vstring categories     = { "lctDigis" }
-    #	untracked vstring debugModules   = { "*" }
-    #	untracked PSet debugmessages.txt = {
-    #	    untracked string threshold = "DEBUG"
-    #	    untracked PSet INFO     = {untracked int32 limit = 0}
-    #	    untracked PSet DEBUG    = {untracked int32 limit = 0}
-    #	    untracked PSet lctDigis = {untracked int32 limit = 10000000}
-    #	}
-    debug = cms.untracked.PSet(
-        threshold = cms.untracked.string("DEBUG"),
-        extension = cms.untracked.string(".txt"),
-        lineLength = cms.untracked.int32(132),
-        noLineBreaks = cms.untracked.bool(True)
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    debugModules = cms.untracked.vstring("lctreader")
+    debugModules = cms.untracked.vstring('lctreader'),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+            extension = cms.untracked.string('.txt'),
+            lineLength = cms.untracked.int32(132),
+            noLineBreaks = cms.untracked.bool(True),
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 process.load('Configuration.StandardSequences.GeometryDB_cff')

--- a/L1Trigger/GlobalMuonTrigger/test/L1GmtTriggerSource_cfg.py
+++ b/L1Trigger/GlobalMuonTrigger/test/L1GmtTriggerSource_cfg.py
@@ -21,7 +21,12 @@ process.l1GmtTriggerSource = cms.EDAnalyzer("L1GmtTriggerSource",
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-   destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 # path to be run

--- a/L1Trigger/GlobalMuonTrigger/test/runGMTPattern_cfg.py
+++ b/L1Trigger/GlobalMuonTrigger/test/runGMTPattern_cfg.py
@@ -8,8 +8,15 @@ process.maxEvents = cms.untracked.PSet(
 
 # Message Logger
 process.MessageLogger = cms.Service("MessageLogger",
-   default = cms.untracked.PSet( limit = cms.untracked.int32(0)),
-   destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    ),
+    default = cms.untracked.PSet(
+        limit = cms.untracked.int32(0)
+    )
 )
     
 process.source = cms.Source("L1MuGMTHWFileReader",

--- a/L1Trigger/GlobalMuonTrigger/test/runGMTTest_cfg.py
+++ b/L1Trigger/GlobalMuonTrigger/test/runGMTTest_cfg.py
@@ -8,8 +8,12 @@ process.maxEvents = cms.untracked.PSet(
 
 # Message Logger
 process.MessageLogger = cms.Service("MessageLogger",
-#   default = cms.untracked.PSet( limit = cms.untracked.int32(0)),
-   destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("L1TriggerConfig.L1GeometryProducers.l1CaloGeometry_cfi")

--- a/L1Trigger/GlobalMuonTrigger/test/runGMTTree_cfg.py
+++ b/L1Trigger/GlobalMuonTrigger/test/runGMTTree_cfg.py
@@ -8,8 +8,12 @@ process.maxEvents = cms.untracked.PSet(
 
 # Message Logger
 process.MessageLogger = cms.Service("MessageLogger",
-#   default = cms.untracked.PSet( limit = cms.untracked.int32(0)),
-   destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.load("L1TriggerConfig.L1GeometryProducers.l1CaloGeometry_cfi")

--- a/L1Trigger/L1GctAnalyzer/test/gctErrorAnalyzerRaw_cfg.py
+++ b/L1Trigger/L1GctAnalyzer/test/gctErrorAnalyzerRaw_cfg.py
@@ -3,9 +3,16 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("GCTAnalyzerTest")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger = cms.Service ("MessageLogger", 
-	destinations = cms.untracked.vstring( "detailedInfo.txt" ),
-	threshold = cms.untracked.string ( 'WARNING' )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        detailedInfo = cms.untracked.PSet(
+            extension = cms.untracked.string('txt')
+        )
+    ),
+    threshold = cms.untracked.string('WARNING')
 )
 
 process.source = cms.Source ( "EmptySource" )

--- a/L1Trigger/L1GctAnalyzer/test/gctErrorAnalyzer_cfg.py
+++ b/L1Trigger/L1GctAnalyzer/test/gctErrorAnalyzer_cfg.py
@@ -3,9 +3,16 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("GCTAnalyzerTest")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger = cms.Service ("MessageLogger", 
-	destinations = cms.untracked.vstring( "detailedInfo.txt" ),
-	threshold = cms.untracked.string ( 'WARNING' )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        detailedInfo = cms.untracked.PSet(
+            extension = cms.untracked.string('txt')
+        )
+    ),
+    threshold = cms.untracked.string('WARNING')
 )
 
 process.source = cms.Source ( "PoolSource",

--- a/L1Trigger/L1GctAnalyzer/test/gctTimingAnalyzer_cfg.py
+++ b/L1Trigger/L1GctAnalyzer/test/gctTimingAnalyzer_cfg.py
@@ -6,10 +6,19 @@ process = cms.Process('TimingAnalyzer')
 #import FWCore.MessageLogger.MessageLogger_cfi
 
 #Logger
-process.MessageLogger = cms.Service ( "MessageLogger",
-  destinations = cms.untracked.vstring ( "debug.log" ),
-  debuglog = cms.untracked.PSet ( threshold = cms.untracked.string ( "DEBUG" ) ),
-  debugModules = cms.untracked.vstring ( "*" )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    debuglog = cms.untracked.PSet(
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    files = cms.untracked.PSet(
+        debug = cms.untracked.PSet(
+
+        )
+    )
 )
 
 #Input file

--- a/L1Trigger/L1TCalorimeter/test/TTbarRelVal_Stage1Test.py
+++ b/L1Trigger/L1TCalorimeter/test/TTbarRelVal_Stage1Test.py
@@ -60,17 +60,18 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 
 # enable debug message logging for our modules
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    destinations   = cms.untracked.vstring(
-	'detailedInfo',
-	'critical'
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
     ),
-    detailedInfo   = cms.untracked.PSet(
-	threshold  = cms.untracked.string('DEBUG') 
-    ),
-    debugModules = cms.untracked.vstring(
-	'l1tCaloStage1Digis'
+    debugModules = cms.untracked.vstring('l1tCaloStage1Digis'),
+    files = cms.untracked.PSet(
+        critical = cms.untracked.PSet(
+
+        ),
+        detailedInfo = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
     )
 )
 

--- a/L1Trigger/RPCTrigger/test/compareBase.py
+++ b/L1Trigger/RPCTrigger/test/compareBase.py
@@ -15,7 +15,14 @@ process.source = cms.Source("PoolSource",
 
 
 process.MessageLogger = cms.Service("MessageLogger",
- destinations = cms.untracked.vstring('log.txt')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        log = cms.untracked.PSet(
+            extension = cms.untracked.string('txt')
+        )
+    )
 )
 
 process.load("L1Trigger.HardwareValidation.L1HardwareValidation_cff")

--- a/L1Trigger/RPCTrigger/test/testRPCTrig.py
+++ b/L1Trigger/RPCTrigger/test/testRPCTrig.py
@@ -5,9 +5,15 @@ process = cms.Process("rpctest")
 
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-    log = cms.untracked.PSet( threshold = cms.untracked.string("DEBUG") ),
-    debugModules = cms.untracked.vstring("l1RpcEmulDigis"),
-    destinations = cms.untracked.vstring('log')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('l1RpcEmulDigis'),
+    files = cms.untracked.PSet(
+        log = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 # rpc geometry

--- a/L1Trigger/RPCTrigger/test/testRPCTrigGT.py
+++ b/L1Trigger/RPCTrigger/test/testRPCTrigGT.py
@@ -5,9 +5,15 @@ process = cms.Process("rpctest")
 
 #process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-    log = cms.untracked.PSet( threshold = cms.untracked.string("DEBUG") ),
-    debugModules = cms.untracked.vstring("rpcTriggerDigis"),
-    destinations = cms.untracked.vstring('log')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('rpcTriggerDigis'),
+    files = cms.untracked.PSet(
+        log = cms.untracked.PSet(
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
 )
 
 # rpc geometry

--- a/L1TriggerConfig/DTTPGConfigProducers/test/dumpPhasesToDB.py
+++ b/L1TriggerConfig/DTTPGConfigProducers/test/dumpPhasesToDB.py
@@ -29,18 +29,24 @@ process.dtTPGParamWriter = cms.EDAnalyzer("DTTPGParamsWriter",
 
 # message logger
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('*'),
-                                    destinations = cms.untracked.vstring('cout'),
-                                    categories = cms.untracked.vstring('DTLocalTriggerSynchTest'), 
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('DEBUG'),
-                                                              noLineBreaks = cms.untracked.bool(False),
-                                                              DEBUG = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              INFO = cms.untracked.PSet(
-                                                                      limit = cms.untracked.int32(0)),
-                                                              DTLocalTriggerSynchTest = cms.untracked.PSet(
-                                                                                   limit = cms.untracked.int32(-1))
-                                                              )
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        DEBUG = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        DTLocalTriggerSynchTest = cms.untracked.PSet(
+            limit = cms.untracked.int32(-1)
+        ),
+        INFO = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
+        ),
+        enable = cms.untracked.bool(True),
+        noLineBreaks = cms.untracked.bool(False),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.clientPath = cms.Path(process.dtTPGParamWriter)

--- a/L1TriggerConfig/GMTConfigProducers/test/GMTParameterGlobaTagTest_cfg.py
+++ b/L1TriggerConfig/GMTConfigProducers/test/GMTParameterGlobaTagTest_cfg.py
@@ -33,5 +33,10 @@ process.gmtDigis = cms.EDProducer("L1MuGlobalMuonTrigger",
 process.p = cms.Path(process.gmtDigis)
 
 process.MessageLogger = cms.Service("MessageLogger",
-   destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )

--- a/L1TriggerOffline/L1Analyzer/test/BscTrigger_cfg.py
+++ b/L1TriggerOffline/L1Analyzer/test/BscTrigger_cfg.py
@@ -16,68 +16,37 @@ process.GlobalTag.globaltag = 'STARTUP_V8::All'
 process.load("L1TriggerOffline.L1Analyzer.bscTrigger_cfi")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    suppressInfo = cms.untracked.vstring(),
-    debugs = cms.untracked.PSet(
-        placeholder = cms.untracked.bool(True)
-    ),
-    suppressDebug = cms.untracked.vstring(),
-    cout = cms.untracked.PSet(
-        placeholder = cms.untracked.bool(True)
-    ),
-    warnings = cms.untracked.PSet(
-        placeholder = cms.untracked.bool(True)
-    ),
-    default = cms.untracked.PSet(
-
-    ),
-    errors = cms.untracked.PSet(
-        placeholder = cms.untracked.bool(True)
-    ),
     cerr = cms.untracked.PSet(
-        noTimeStamps = cms.untracked.bool(False),
         BscSim = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(10000000)
+            limit = cms.untracked.int32(10000000),
+            reportEvery = cms.untracked.int32(1)
         ),
         FwkReport = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(10000000)
+            limit = cms.untracked.int32(10000000),
+            reportEvery = cms.untracked.int32(1)
+        ),
+        FwkSummary = cms.untracked.PSet(
+            limit = cms.untracked.int32(10000000),
+            reportEvery = cms.untracked.int32(1)
+        ),
+        Root_NoDictionary = cms.untracked.PSet(
+            limit = cms.untracked.int32(0)
         ),
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(10000000)
         ),
-        Root_NoDictionary = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkSummary = cms.untracked.PSet(
-            reportEvery = cms.untracked.int32(1),
-            limit = cms.untracked.int32(10000000)
-        ),
-        threshold = cms.untracked.string('DEBUG')
+        noTimeStamps = cms.untracked.bool(False),
+        threshold = cms.untracked.string('DEBUG'),
+        enableStatistics = cms.untracked.bool(True),
+        statisticsThreshold = cms.untracked.string('INFO')
     ),
-    suppressWarning = cms.untracked.vstring(),
-    statistics = cms.untracked.vstring('cerr_stats'),
-    cerr_stats = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO'),
-        output = cms.untracked.string('cerr')
-    ),
-    infos = cms.untracked.PSet(
-        Root_NoDictionary = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        placeholder = cms.untracked.bool(True)
-    ),
-    destinations = cms.untracked.vstring('warnings', 
-        'errors', 
-        'infos', 
-        'debugs', 
-        'cout', 
-        'cerr'),
     debugModules = cms.untracked.vstring('bscTrigger'),
-    categories = cms.untracked.vstring('BscSim',
-        'FwkReport', 
-        'FwkSummary', 
-        'Root_NoDictionary')
+    default = cms.untracked.PSet(
+
+    ),
+    suppressDebug = cms.untracked.vstring(),
+    suppressInfo = cms.untracked.vstring(),
+    suppressWarning = cms.untracked.vstring()
 )
 # import of standard configurations
 process.load('Configuration/StandardSequences/Services_cff')


### PR DESCRIPTION
#### PR description:

All configurations in L1Trigger* subsystems which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.