### PR TITLE
Updated configurations in OnlineDB to new MessageLogger syntax

### DIFF
--- a/OnlineDB/CSCCondDB/test/CSCCableReadTest_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCCableReadTest_cfg.py
@@ -2,12 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CSCCABLEREADTEST")
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/CSCCondDB/test/CSCCables_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCCables_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCCables.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrectionsPopCon_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrectionsPopCon_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCCables.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrectionsReadTest_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrectionsReadTest_cfg.py
@@ -2,12 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CSCCHAMBERTIMECORRECTIONSREADTEST")
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrections_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCChamberTimeCorrections_cfg.py
@@ -15,12 +15,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:/afs/cern.ch/user/d/deish
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb' 
 
 process.MessageLogger = cms.Service("MessageLogger",
-    cout = cms.untracked.PSet( 
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/CSCMap1Read_cfg.py
+++ b/OnlineDB/CSCCondDB/test/CSCMap1Read_cfg.py
@@ -2,12 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CSCMAP1READ")
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/CSCCondDB/test/stubs/writeChamberTimeCorrections_cfg.py
+++ b/OnlineDB/CSCCondDB/test/stubs/writeChamberTimeCorrections_cfg.py
@@ -14,12 +14,15 @@ process.CondDBCommon.connect = cms.string("sqlite_file:CSCChamberTimeCorr.db")
 process.CondDBCommon.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/writeChamberIndexValuesToDB_cfg.py
+++ b/OnlineDB/CSCCondDB/test/writeChamberIndexValuesToDB_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCChamberIndexValues_20X.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/writeChamberMapValuesToDB_cfg.py
+++ b/OnlineDB/CSCCondDB/test/writeChamberMapValuesToDB_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCChamberMapValues_20X.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/writeCrateMapValuesToDB_cfg.py
+++ b/OnlineDB/CSCCondDB/test/writeCrateMapValuesToDB_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCCrateMapValues_20X.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/CSCCondDB/test/writeDDUMapValuesToDB_cfg.py
+++ b/OnlineDB/CSCCondDB/test/writeDDUMapValuesToDB_cfg.py
@@ -12,12 +12,15 @@ process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.CondDBCommon.connect = cms.string("sqlite_file:CSCDDUMapValues_20X.db")
 
 process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
         default = cms.untracked.PSet(
             limit = cms.untracked.int32(0)
-        )
-    ),
-    destinations = cms.untracked.vstring('cout')
+        ),
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.source = cms.Source("EmptyIOVSource",

--- a/OnlineDB/SiStripO2O/test/configToPayloadTableCreator.py
+++ b/OnlineDB/SiStripO2O/test/configToPayloadTableCreator.py
@@ -3,11 +3,16 @@ import os
 
 process = cms.Process("test")
 
-process.MessageLogger = cms.Service( "MessageLogger",
-                                     debugModules = cms.untracked.vstring( "*" ),
-                                     cout = cms.untracked.PSet( threshold = cms.untracked.string( "DEBUG" ) ),
-                                     destinations = cms.untracked.vstring( "cout" )
-                                     )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('*')
+)
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32( 1 ) )
 

--- a/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_ApvGain_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_ApvGain_cfg.py
@@ -3,7 +3,12 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("o2o")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout')
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True)
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_ApvLatency_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_ApvLatency_cfg.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("o2o")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_CabPedNoiThrQua_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/UnitTest_fullPopCon_CabPedNoiThrQua_cfg.py
@@ -3,11 +3,14 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("o2o")
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('*'),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('DEBUG')
     ),
-    destinations = cms.untracked.vstring('cout')
+    debugModules = cms.untracked.vstring('*')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_ApvGain_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_ApvGain_cfg.py
@@ -8,9 +8,16 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.MessageLogger = cms.Service("MessageLogger", 
-    debugModules = cms.untracked.vstring(''), 
-    destinations = cms.untracked.vstring('SiStripApvGainReader.log') 
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring(''),
+    files = cms.untracked.PSet(
+        SiStripApvGainReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_Latency_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_Latency_cfg.py
@@ -6,13 +6,17 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     debugModules = cms.untracked.vstring('reader'),
-    threshold = cms.untracked.string('INFO'),
-    # Warning: debug output can be of ~ 250Mb for Noise and Pedestals
-    # threshold = cms.untracked.string('DEBUG'),
-    destinations = cms.untracked.vstring('SiStripLatencyReader.log')
+    files = cms.untracked.PSet(
+        SiStripLatencyReader = cms.untracked.PSet(
+
+        )
+    ),
+    threshold = cms.untracked.string('INFO')
 )
 
 process.maxEvents = cms.untracked.PSet(

--- a/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_Noise_cfg.py
+++ b/OnlineDB/SiStripO2O/test/testPopCon/read_UnitTest_Noise_cfg.py
@@ -8,8 +8,15 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Reader")
 
-process.MessageLogger = cms.Service("MessageLogger", 
-     destinations = cms.untracked.vstring('SiStripNoiseReader.log') 
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        SiStripNoiseReader = cms.untracked.PSet(
+
+        )
+    )
 )
 
 process.maxEvents = cms.untracked.PSet(


### PR DESCRIPTION
#### PR description:

All configurations in OnlineDB subsystem which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.