### PR TITLE
Updated configurations in Reco* to new MessageLogger syntax

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/test/testGsfElectronConversionFinder_cff.py
+++ b/RecoEgamma/EgammaElectronAlgos/test/testGsfElectronConversionFinder_cff.py
@@ -17,10 +17,15 @@ process.source = cms.Source(
 
 process.testGsfElectronConversionFinder = cms.EDAnalyzer("TestGsfElectronConversionFinder")
 
-process.MessageLogger = cms.Service(
-    "MessageLogger",
-    destinations=cms.untracked.vstring("conversions"),
-    conversions=cms.untracked.PSet(threshold=cms.untracked.string("INFO")),
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        conversions = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 
 process.p = cms.Path(process.testGsfElectronConversionFinder)

--- a/RecoJets/JetProducers/validation/fastjetJetProducer_validation_cfg.py
+++ b/RecoJets/JetProducers/validation/fastjetJetProducer_validation_cfg.py
@@ -21,8 +21,13 @@ process.fileSaver = cms.EDFilter(
 
 # MESSAGELOGGER
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout         = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # DQMSTORE

--- a/RecoJets/JetProducers/validation/jetProducers_validation_cfg.py
+++ b/RecoJets/JetProducers/validation/jetProducers_validation_cfg.py
@@ -20,8 +20,13 @@ process.fileSaver = cms.EDFilter(
 
 # MESSAGELOGGER
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout         = cms.untracked.PSet(threshold = cms.untracked.string('WARNING'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # DQMSTORE

--- a/RecoLocalCalo/HcalRecAlgos/test/hcalsevlvlanalyzer_cfg.py
+++ b/RecoLocalCalo/HcalRecAlgos/test/hcalsevlvlanalyzer_cfg.py
@@ -4,8 +4,14 @@ process = cms.Process("Demo")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-        destinations = cms.untracked.vstring("cout"),
-        cout = cms.untracked.PSet(threshold = cms.untracked.string("INFO")))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/test/Clusters_productionAndTesting.py
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/test/Clusters_productionAndTesting.py
@@ -74,12 +74,15 @@ process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
 )
 
 # debug
-process.MessageLogger = cms.Service('MessageLogger',
-        debugModules = cms.untracked.vstring('siPhase2Clusters'),
-        destinations = cms.untracked.vstring('cout'),
-        cout = cms.untracked.PSet(
-                threshold = cms.untracked.string('ERROR')
-        )
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    ),
+    debugModules = cms.untracked.vstring('siPhase2Clusters')
 )
 
 # Analyzer

--- a/RecoLocalTracker/SiPhase2VectorHitBuilder/test/VHs_combinatorialStudies_PU200.py
+++ b/RecoLocalTracker/SiPhase2VectorHitBuilder/test/VHs_combinatorialStudies_PU200.py
@@ -75,15 +75,25 @@ process.RECOSIMoutput = cms.OutputModule("PoolOutputModule",
 
 # debug
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring("debugVH_PU200"),
-                                    debugModules = cms.untracked.vstring("*"),
-                                    categories = cms.untracked.vstring("VectorHitsBuilderValidation"),
-                                    debugVH_PU200 = cms.untracked.PSet(threshold = cms.untracked.string("DEBUG"),
-                                                                       DEBUG = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-                                                                       default = cms.untracked.PSet(limit = cms.untracked.int32(0)),
-                                                                       VectorHitsBuilderValidation = cms.untracked.PSet(limit = cms.untracked.int32(-1))
-                                                                       )
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('*'),
+    files = cms.untracked.PSet(
+        debugVH_PU200 = cms.untracked.PSet(
+            DEBUG = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            VectorHitsBuilderValidation = cms.untracked.PSet(
+                limit = cms.untracked.int32(-1)
+            ),
+            default = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            threshold = cms.untracked.string('DEBUG')
+        )
+    )
+)
 
 # Analyzer
 process.analysis = cms.EDAnalyzer('VectorHitsBuilderValidation',

--- a/RecoLocalTracker/SiPixelClusterizer/test/testClusters.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/testClusters.py
@@ -46,15 +46,14 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    debugModules = cms.untracked.vstring('siPixelClusters'),
-    destinations = cms.untracked.vstring('cout'),
-#    destinations = cms.untracked.vstring("log","cout"),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
-    )
-#    log = cms.untracked.PSet(
-#        threshold = cms.untracked.string('DEBUG')
-#    )
+    ),
+    debugModules = cms.untracked.vstring('siPixelClusters')
 )
 
 process.source = cms.Source("PoolSource",

--- a/RecoLocalTracker/SiPixelClusterizer/test/testTracks_cfg.py
+++ b/RecoLocalTracker/SiPixelClusterizer/test/testTracks_cfg.py
@@ -14,16 +14,13 @@ process.maxEvents = cms.untracked.PSet(
 )
        
 process.MessageLogger = cms.Service("MessageLogger",
-#    debugModules = cms.untracked.vstring('TestPixTracks'),
-    destinations = cms.untracked.vstring('cout'),
-#    destinations = cms.untracked.vstring("log","cout"),
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
     cout = cms.untracked.PSet(
-#        threshold = cms.untracked.string('DEBUG')
+        enable = cms.untracked.bool(True),
         threshold = cms.untracked.string('ERROR')
     )
-#    log = cms.untracked.PSet(
-#        threshold = cms.untracked.string('DEBUG')
-#    )
 )
 
 import HLTrigger.HLTfilters.hltHighLevel_cfi as hlt

--- a/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
+++ b/RecoLuminosity/LumiProducer/test/TestLumiProducerFromBrilcalc_cfg.py
@@ -4,12 +4,14 @@ process = cms.Process("TestLumiProducerFromBrilcalc")
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations   = cms.untracked.vstring("cout"),
-                                    categories     = cms.untracked.vstring("LumiProducerFromBrilcalc"),
-                                    debugModules   = cms.untracked.vstring("LumiInfo"),
-                                    cout           = cms.untracked.PSet(
-                                        threshold  = cms.untracked.string('DEBUG')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('DEBUG')
+    ),
+    debugModules = cms.untracked.vstring('LumiInfo')
 )
 
 # just use a random relval which has meaningless run/LS numbers, and then a corresponding test file

--- a/RecoLuminosity/LumiProducer/test/testLumiCalculator_cfg.py
+++ b/RecoLuminosity/LumiProducer/test/testLumiCalculator_cfg.py
@@ -13,16 +13,23 @@ process.maxLuminosityBlocks=cms.untracked.PSet(
 )
 
 process.MessageLogger = cms.Service("MessageLogger",
-   suppressInfo = cms.untracked.vstring(),
-   destinations = cms.untracked.vstring('lumioutput'),
-   categories = cms.untracked.vstring('LumiReport'),
-   lumioutput = cms.untracked.PSet(
-     threshold = cms.untracked.string('INFO'),
-     noLineBreaks = cms.untracked.bool(True),
-     noTimeStamps = cms.untracked.bool(True),
-     INFO = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
-     LumiReport = cms.untracked.PSet( limit = cms.untracked.int32(10000000) )
-   )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        lumioutput = cms.untracked.PSet(
+            INFO = cms.untracked.PSet(
+                limit = cms.untracked.int32(0)
+            ),
+            LumiReport = cms.untracked.PSet(
+                limit = cms.untracked.int32(10000000)
+            ),
+            noLineBreaks = cms.untracked.bool(True),
+            noTimeStamps = cms.untracked.bool(True),
+            threshold = cms.untracked.string('INFO')
+        )
+    ),
+    suppressInfo = cms.untracked.vstring()
 )
 process.source= cms.Source("PoolSource",
               processingMode=cms.untracked.string('RunsAndLumis'),          

--- a/RecoPPS/Local/test/re_alignment/reco_align_corr_cfg.py
+++ b/RecoPPS/Local/test/re_alignment/reco_align_corr_cfg.py
@@ -5,11 +5,13 @@ process = cms.Process('ReAlignment', eras.Run2_2018)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
-  statistics = cms.untracked.vstring(),
-  destinations = cms.untracked.vstring("cout"),
-  cout = cms.untracked.PSet(
-    threshold = cms.untracked.string("WARNING")
-  )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # raw data source

--- a/RecoPPS/Local/test/re_alignment/reco_base_align_cfg.py
+++ b/RecoPPS/Local/test/re_alignment/reco_base_align_cfg.py
@@ -5,11 +5,13 @@ process = cms.Process('TEST', eras.Run2_2018)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
-  statistics = cms.untracked.vstring(),
-  destinations = cms.untracked.vstring("cout"),
-  cout = cms.untracked.PSet(
-    threshold = cms.untracked.string("WARNING")
-  )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # raw data source

--- a/RecoPPS/Local/test/re_alignment/reco_full_align_cfg.py
+++ b/RecoPPS/Local/test/re_alignment/reco_full_align_cfg.py
@@ -5,11 +5,13 @@ process = cms.Process('TEST', eras.Run2_2018)
 
 # minimum of logs
 process.MessageLogger = cms.Service("MessageLogger",
-  statistics = cms.untracked.vstring(),
-  destinations = cms.untracked.vstring("cout"),
-  cout = cms.untracked.PSet(
-    threshold = cms.untracked.string("WARNING")
-  )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('WARNING')
+    )
 )
 
 # raw data source

--- a/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_DB_real_mem.py
+++ b/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_DB_real_mem.py
@@ -15,8 +15,14 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cclu_info'),
-    cclu_info = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        cclu_info = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 process.source = cms.Source("EmptyIOVSource",
     timetype = cms.string('runnumber'),

--- a/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_DAQ_TRK.py
+++ b/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_DAQ_TRK.py
@@ -18,8 +18,13 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    )
 )
 process.source = cms.Source("EmptyIOVSource",
     timetype = cms.string('runnumber'),

--- a/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_DB_real_mem.py
+++ b/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_DB_real_mem.py
@@ -15,8 +15,14 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('rec_info'),
-    rec_info = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    files = cms.untracked.PSet(
+        rec_info = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
 )
 process.source = cms.Source("EmptyIOVSource",
     timetype = cms.string('runnumber'),

--- a/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_mem_testDB_300811.py
+++ b/RecoPPS/Local/test/run_only_CTPPS_cfg_CLU_REC_mem_testDB_300811.py
@@ -18,8 +18,13 @@ process.maxEvents = cms.untracked.PSet(
         )
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout = cms.untracked.PSet( threshold = cms.untracked.string('ERROR'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('ERROR')
+    )
 )
 process.source = cms.Source("EmptyIOVSource",
     timetype = cms.string('runnumber'),

--- a/RecoPixelVertexing/PixelTrackFitting/test/test_cfg.py
+++ b/RecoPixelVertexing/PixelTrackFitting/test/test_cfg.py
@@ -18,12 +18,14 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 process.GlobalTag.globaltag = 'DESIGN_36_V3::All'
 
 process.MessageLogger = cms.Service("MessageLogger",
-    #debugModules = cms.untracked.vstring('pixelVertices'),
-    #debugModules = cms.untracked.vstring('pixelTracks'),
-    #debugModules = cms.untracked.vstring('*'),
-    debugModules = cms.untracked.vstring(''),
-    destinations = cms.untracked.vstring('cout'),
-    cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO'))
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    ),
+    debugModules = cms.untracked.vstring('')
 )
 
 process.load("RecoTracker.Configuration.RecoTracker_cff")

--- a/RecoTracker/GeometryESProducer/test/testTrackerRecoGeometry_cfg.py
+++ b/RecoTracker/GeometryESProducer/test/testTrackerRecoGeometry_cfg.py
@@ -12,13 +12,16 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 process.MessageLogger = cms.Service("MessageLogger",
-                                    debugModules = cms.untracked.vstring('TrackerRecoGeometryAnalyzer'),
-                                    destinations = cms.untracked.vstring('TrackerRecoGeometryAnalyzer_infos'),
-                                    TrackerRecoGeometryAnalyzer_infos = cms.untracked.PSet(
-                                      threshold = cms.untracked.string('INFO') 
-                                      ),
-                                    categories = cms.untracked.vstring('TrackerRecoGeometryAnalyzer')
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    debugModules = cms.untracked.vstring('TrackerRecoGeometryAnalyzer'),
+    files = cms.untracked.PSet(
+        TrackerRecoGeometryAnalyzer_infos = cms.untracked.PSet(
+            threshold = cms.untracked.string('INFO')
+        )
+    )
+)
 
 process.source = cms.Source("EmptySource")
 

--- a/RecoVertex/BeamSpotProducer/test/test_scalars.py
+++ b/RecoVertex/BeamSpotProducer/test/test_scalars.py
@@ -85,9 +85,14 @@ process.es_prefer_beamspot = cms.ESPrefer("PoolDBESSource","BeamSpotDBSource")
 
 
 process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations = cms.untracked.vstring('cout'),
-                                    cout = cms.untracked.PSet(threshold = cms.untracked.string('INFO'))
-                                    )
+    cerr = cms.untracked.PSet(
+        enable = cms.untracked.bool(False)
+    ),
+    cout = cms.untracked.PSet(
+        enable = cms.untracked.bool(True),
+        threshold = cms.untracked.string('INFO')
+    )
+)
 
 process.scalersRawToDigi = cms.EDProducer('ScalersRawToDigi')
 


### PR DESCRIPTION
#### PR description:

All configurations in Reco* subsystems which explicitly create a MessageLogger have been converted to the new syntax.
#### PR validation:

All files were passed to `python` and no failures as a result of these change were seen.