### PR TITLE
Trivial update to PFClusterFromHGCalMultiCluster.cc

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.cc
@@ -26,26 +26,23 @@ void PFClusterFromHGCalMultiCluster::buildClusters(const edm::Handle<reco::PFRec
   }
 
   int iMultiClus = -1;
-
   for (const auto& mcl : hgcalMultiClusters) {
     iMultiClus++;
-
+    // Skip empty multiclusters
+    if (mcl.hitsAndFractions().empty()) {
+      continue;
+    }
     // Filter using trackster PID
     if (filterByTracksterPID_) {
       float probTotal = 0.0f;
-
       for (int cat : filter_on_categories_) {
         probTotal += tracksters[iMultiClus].id_probabilities(cat);
       }
-
       if (probTotal < pid_threshold_) {
         continue;
       }
     }
 
-    if (mcl.hitsAndFractions().empty()) {
-      continue;
-    }
     DetId seed;
     double energy = 0.0, highest_energy = 0.0;
     output.emplace_back();


### PR DESCRIPTION
Check if the multicluster is empty and move to the next one before  having to compute the trackster PID, as it was implemented in the 11_1 "backport" PR #31907 (it avoids computing the probabilities when not needed)

@rovere @felicepantaleo, this is what I meant in the last paragraph of my comment https://github.com/cms-sw/cmssw/pull/31907#issuecomment-730613988: just let me know if you have anything in contrary
