### PR TITLE
Remove unused variable in HcalTopology

### DIFF
--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -289,7 +289,7 @@ private:
   static constexpr unsigned int kchanCalibHF2_ = 1;
   static constexpr unsigned int nCalibHF2_ = nEtaCalibHF_;
   static constexpr unsigned int kOffCalibHOX_ = kOffCalibHF2_ + nCalibHF2_;
-  static constexpr unsigned int nEtaCalibHOX_ = 2, ctypeHX_ = -999;
+  static constexpr unsigned int nEtaCalibHOX_ = 2;
   static constexpr int etaCalibHOX_[nEtaCalibHOX_] = {4, 15};
   static constexpr unsigned int mPhiCalibHOX_[nEtaCalibHOX_] = {2, 1};
   static constexpr unsigned int nPhiCalibHOX_[nEtaCalibHOX_] = {36, 72};


### PR DESCRIPTION
#### PR description:

Compilation with nvcc warns about
> warning: integer conversion resulted in a change of sign

due to assigning
```c++
static constexpr unsigned int ctypeHX_ -999;
```

As this variable is not used anywhere in CMSSW, just remove it.

#### PR validation:

None.