### PR TITLE
Added protection to Geant4e track propagator

### DIFF
--- a/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
+++ b/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
@@ -27,7 +27,8 @@ public:
    */
   Geant4ePropagator(const MagneticField *field = nullptr,
                     std::string particleName = "mu",
-                    PropagationDirection dir = alongMomentum);
+                    PropagationDirection dir = alongMomentum,
+                    double plimit = 1.0);
 
   ~Geant4ePropagator() override;
 
@@ -91,6 +92,7 @@ private:
   // The Geant4e manager. Does the real propagation
   G4ErrorPropagatorManager *theG4eManager;
   G4ErrorPropagatorData *theG4eData;
+  double plimit_;
 
   // Transform a CMS Reco detector surface into a Geant4 Target for the error
   // propagation

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
@@ -16,6 +16,7 @@ using namespace edm;
 GeantPropagatorESProducer::GeantPropagatorESProducer(const edm::ParameterSet &p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
+  plimit_ = pset_.getParameter<double>("PropagationPtotLimit");
   setWhatProduced(this, myname);
 }
 
@@ -32,10 +33,10 @@ std::unique_ptr<Propagator> GeantPropagatorESProducer::produce(const TrackingCom
 
   if (pdir == "oppositeToMomentum")
     dir = oppositeToMomentum;
-  if (pdir == "alongMomentum")
+  else if (pdir == "alongMomentum")
     dir = alongMomentum;
-  if (pdir == "anyDirection")
+  else if (pdir == "anyDirection")
     dir = anyDirection;
 
-  return std::make_unique<Geant4ePropagator>(&(*magfield), particleName, dir);
+  return std::make_unique<Geant4ePropagator>(&(*magfield), particleName, dir, plimit_);
 }

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
@@ -23,6 +23,7 @@ public:
 
 private:
   edm::ParameterSet pset_;
+  double plimit_;
 };
 
 #endif

--- a/TrackPropagation/Geant4e/python/Geant4ePropagator_cfi.py
+++ b/TrackPropagation/Geant4e/python/Geant4ePropagator_cfi.py
@@ -7,5 +7,6 @@ import FWCore.ParameterSet.Config as cms
 Geant4ePropagator = cms.ESProducer("GeantPropagatorESProducer",
                                    ComponentName = cms.string("Geant4ePropagator"),
                                    PropagationDirection=cms.string("alongMomentum"),
-                                   ParticleName=cms.string("mu")
+                                   ParticleName=cms.string("mu"),
+                                   PropagationPtotLimit = cms.double(1.0) ## GeV/c
                                    )

--- a/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
+++ b/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
@@ -36,12 +36,13 @@
 
 /** Constructor.
  */
-Geant4ePropagator::Geant4ePropagator(const MagneticField *field, std::string particleName, PropagationDirection dir)
+Geant4ePropagator::Geant4ePropagator(const MagneticField *field, std::string particleName, PropagationDirection dir, double plimit)
     : Propagator(dir),
       theField(field),
       theParticleName(particleName),
       theG4eManager(G4ErrorPropagatorManager::GetErrorPropagatorManager()),
-      theG4eData(G4ErrorPropagatorData::GetErrorPropagatorData()) {
+      theG4eData(G4ErrorPropagatorData::GetErrorPropagatorData()),
+      plimit_(plimit) {
   LogDebug("Geant4e") << "Geant4e Propagator initialized";
 
   // has to be called here, doing it later will not load the G4 physics list
@@ -72,7 +73,7 @@ void Geant4ePropagator::ensureGeant4eIsInitilized(bool forceInit) const {
   if ((G4ErrorPropagatorData::GetErrorPropagatorData()->GetState() == G4ErrorState_PreInit) || forceInit) {
     LogDebug("Geant4e") << "Initializing G4 propagator" << std::endl;
 
-    G4UImanager::GetUIpointer()->ApplyCommand("/exerror/setField -10. kilogauss");
+    //G4UImanager::GetUIpointer()->ApplyCommand("/exerror/setField -10. kilogauss");
 
     theG4eManager->InitGeant4e();
 
@@ -85,10 +86,7 @@ void Geant4ePropagator::ensureGeant4eIsInitilized(bool forceInit) const {
     LogDebug("Geant4e") << "G4 not in preinit state: " << G4ErrorPropagatorData::GetErrorPropagatorData()->GetState()
                         << std::endl;
   }
-
-  // example code uses
-  // G4UImanager::GetUIpointer()->ApplyCommand("/geant4e/limits/stepLength 100
-  // mm");
+  // define 10 mm step limit for propagator
   G4UImanager::GetUIpointer()->ApplyCommand("/geant4e/limits/stepLength 10.0 mm");
 }
 
@@ -161,6 +159,7 @@ bool Geant4ePropagator::configureAnyPropagation(G4ErrorMode &mode,
                                                 Plane const &pDest,
                                                 GlobalPoint const &cmsInitPos,
                                                 GlobalVector const &cmsInitMom) const {
+  if (cmsInitMom.mag() < plimit_) return false;
   if (pDest.localZ(cmsInitPos) * pDest.localZ(cmsInitMom) < 0) {
     mode = G4ErrorMode_PropForwards;
     LogDebug("Geant4e") << "G4e -  Propagator mode is \'forwards\' indirect "
@@ -181,6 +180,7 @@ bool Geant4ePropagator::configureAnyPropagation(G4ErrorMode &mode,
                                                 Cylinder const &pDest,
                                                 GlobalPoint const &cmsInitPos,
                                                 GlobalVector const &cmsInitMom) const {
+  if (cmsInitMom.mag() < plimit_) return false;
   //------------------------------------
   // For cylinder assume outside is backwards, inside is along
   // General use for particles from collisions
@@ -204,6 +204,7 @@ bool Geant4ePropagator::configurePropagation(G4ErrorMode &mode,
                                              SurfaceType const &pDest,
                                              GlobalPoint const &cmsInitPos,
                                              GlobalVector const &cmsInitMom) const {
+  if (cmsInitMom.mag() < plimit_) return false;
   if (propagationDirection() == oppositeToMomentum) {
     mode = G4ErrorMode_PropBackwards;
     LogDebug("Geant4e") << "G4e -  Propagator mode is \'backwards\' " << std::endl;
@@ -461,7 +462,7 @@ void Geant4ePropagator::debugReportTrackState(std::string const &currentContext,
                                               GlobalVector const &cmsInitMom,
                                               CLHEP::Hep3Vector const &g4InitMom,
                                               const SurfaceType &pDest) const {
-  LogDebug("Geant4e") << "G3 -- Current Context: " << currentContext;
+  LogDebug("Geant4e") << "G4e - Current Context: " << currentContext;
   LogDebug("Geant4e") << "G4e -  CMS point position:" << cmsInitPos << "cm\n"
                       << "G4e -              (Ro, eta, phi): (" << cmsInitPos.perp() << " cm, " << cmsInitPos.eta()
                       << ", " << cmsInitPos.phi().degrees() << " deg)\n"

--- a/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
+++ b/TrackPropagation/Geant4e/src/Geant4ePropagator.cc
@@ -36,7 +36,10 @@
 
 /** Constructor.
  */
-Geant4ePropagator::Geant4ePropagator(const MagneticField *field, std::string particleName, PropagationDirection dir, double plimit)
+Geant4ePropagator::Geant4ePropagator(const MagneticField *field,
+                                     std::string particleName,
+                                     PropagationDirection dir,
+                                     double plimit)
     : Propagator(dir),
       theField(field),
       theParticleName(particleName),
@@ -159,7 +162,8 @@ bool Geant4ePropagator::configureAnyPropagation(G4ErrorMode &mode,
                                                 Plane const &pDest,
                                                 GlobalPoint const &cmsInitPos,
                                                 GlobalVector const &cmsInitMom) const {
-  if (cmsInitMom.mag() < plimit_) return false;
+  if (cmsInitMom.mag() < plimit_)
+    return false;
   if (pDest.localZ(cmsInitPos) * pDest.localZ(cmsInitMom) < 0) {
     mode = G4ErrorMode_PropForwards;
     LogDebug("Geant4e") << "G4e -  Propagator mode is \'forwards\' indirect "
@@ -180,7 +184,8 @@ bool Geant4ePropagator::configureAnyPropagation(G4ErrorMode &mode,
                                                 Cylinder const &pDest,
                                                 GlobalPoint const &cmsInitPos,
                                                 GlobalVector const &cmsInitMom) const {
-  if (cmsInitMom.mag() < plimit_) return false;
+  if (cmsInitMom.mag() < plimit_)
+    return false;
   //------------------------------------
   // For cylinder assume outside is backwards, inside is along
   // General use for particles from collisions
@@ -204,7 +209,8 @@ bool Geant4ePropagator::configurePropagation(G4ErrorMode &mode,
                                              SurfaceType const &pDest,
                                              GlobalPoint const &cmsInitPos,
                                              GlobalVector const &cmsInitMom) const {
-  if (cmsInitMom.mag() < plimit_) return false;
+  if (cmsInitMom.mag() < plimit_)
+    return false;
   if (propagationDirection() == oppositeToMomentum) {
     mode = G4ErrorMode_PropBackwards;
     LogDebug("Geant4e") << "G4e -  Propagator mode is \'backwards\' " << std::endl;


### PR DESCRIPTION
#### PR description:
Crash in Geant4e backward propagator #31920 stops final alignment of Run-2 based on data. 
This PR allows to avoid the crash by applying a momentum limit on propagated tracks 1 GeV/c.

This modification should not affect release validation WFs. 

#### PR validation:
private


#### if this PR is a backport please specify the original PR and why you need to backport that PR:
This PR should be backported to 10_6_X


