### PR TITLE
Set fixes for tau reco at miniAOD

### DIFF
--- a/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauChargedHadronProducer.cc
@@ -230,10 +230,16 @@ void PFRecoTauChargedHadronProducer::produce(edm::Event& evt, const edm::EventSe
             track = chargedPFCand->muonRef()->outerTrack().get();
           else if (chargedPFCand->gsfTrackRef().isNonnull())
             track = chargedPFCand->gsfTrackRef().get();
+        } else {
+          track = nextChargedHadron->getChargedPFCandidate()->bestTrack();
         }
       }
-      if (nextChargedHadron->getTrack().isNonnull() && !track) {
-        track = nextChargedHadron->getTrack().get();
+      if (track == nullptr) {
+        if (nextChargedHadron->getTrack().isNonnull()) {
+          track = nextChargedHadron->getTrack().get();
+        } else if (nextChargedHadron->getLostTrackCandidate().isNonnull()) {
+          track = nextChargedHadron->getLostTrackCandidate()->bestTrack();
+        }
       }
 
       // discard candidate in case its track is "used" by any ChargedHadron in the clean collection

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -317,8 +317,13 @@ namespace reco {
                 allTracksSumP += chargedHadronTrack->p();
                 allTracksSumPerr2 += getTrackPerr2(*chargedHadronTrack);
               } else {
-                edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
-                    << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                // don't print warning as it is caused by missing detailed track inforamtion in lostTrack in miniAOD
+                if (!(chargedHadron->algoIs(PFRecoTauChargedHadron::kTrack) &&
+                      chargedHadron->getLostTrackCandidate().isNonnull() &&
+                      chargedHadron->getLostTrackCandidate()->bestTrack() == nullptr)) {
+                  edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                      << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                }
                 if (verbosity_) {
                   chargedHadron->print();
                 }
@@ -401,8 +406,13 @@ namespace reco {
                   chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(
                       chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
                 } else {
-                  edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
-                      << "PFRecoTauChargedHadron has no associated reco::Track !!" << std::endl;
+                  // don't print warning as it is caused by missing detailed track inforamtion in lostTrack in miniAOD
+                  if (!(chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) &&
+                        chargedHadron.getLostTrackCandidate().isNonnull() &&
+                        chargedHadron.getLostTrackCandidate()->bestTrack() == nullptr)) {
+                    edm::LogWarning("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                        << "PFRecoTauChargedHadron has no associated reco::Track !!" << std::endl;
+                  }
                   if (verbosity_) {
                     chargedHadron.print();
                   }
@@ -466,8 +476,13 @@ namespace reco {
                     chargedHadronP4_modified = compChargedHadronP4fromPxPyPz(
                         chargedHadronPx_modified, chargedHadronPy_modified, chargedHadronPz_modified);
                   } else {
-                    edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
-                        << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                    // don't print warning as it is caused by missing detailed track inforamtion in lostTrack in miniAOD
+                    if (!(chargedHadron.algoIs(PFRecoTauChargedHadron::kTrack) &&
+                          chargedHadron.getLostTrackCandidate().isNonnull() &&
+                          chargedHadron.getLostTrackCandidate()->bestTrack() == nullptr)) {
+                      edm::LogInfo("PFRecoTauEnergyAlgorithmPlugin::operator()")
+                          << "PFRecoTauChargedHadron has no associated reco::Track !!";
+                    }
                     if (verbosity_) {
                       chargedHadron.print();
                     }

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -344,13 +344,29 @@ namespace reco {
                           << " HCAL = " << (pfCand)->hcalEnergy() << ","
                           << " HO = " << (pfCand)->hoEnergy() << std::endl;
               }
-              // TauReco@MiniAOD: This info is not yet available in miniAOD.
               if (edm::isFinite(pfCand->ecalEnergy()))
                 allNeutralsSumEn += pfCand->ecalEnergy();
               if (edm::isFinite(pfCand->hcalEnergy()))
                 allNeutralsSumEn += pfCand->hcalEnergy();
               if (edm::isFinite(pfCand->hoEnergy()))
                 allNeutralsSumEn += pfCand->hoEnergy();
+            } else {
+              // TauReco@MiniAOD: individual ECAL and HCAL energies recovered from fractions. Info on HO energy is not (yet?) available in miniAOD.
+              const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&*signalCand);
+              if (packedCand) {
+                double ecalEn = packedCand->caloFraction() * packedCand->energy() * (1. - packedCand->hcalFraction());
+                double hcalEn = packedCand->caloFraction() * packedCand->energy() * packedCand->hcalFraction();
+                if (verbosity_) {
+                  std::cout << "calorimeter energy:"
+                            << " ECAL = " << ecalEn << ","
+                            << " HCAL = " << hcalEn << ","
+                            << " HO unknown for PackedCand" << std::endl;
+                }
+                if (edm::isFinite(ecalEn))
+                  allNeutralsSumEn += ecalEn;
+                if (edm::isFinite(hcalEn))
+                  allNeutralsSumEn += hcalEn;
+              }
             }
           }
           allNeutralsSumEn += addNeutralsSumP4.energy();

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauEnergyAlgorithmPlugin.cc
@@ -358,20 +358,20 @@ namespace reco {
             } else {
               // TauReco@MiniAOD: individual ECAL and HCAL energies recovered from fractions. Info on HO energy is not (yet?) available in miniAOD.
               const pat::PackedCandidate* packedCand = dynamic_cast<const pat::PackedCandidate*>(&*signalCand);
-              if (packedCand) {
-                double ecalEn = packedCand->caloFraction() * packedCand->energy() * (1. - packedCand->hcalFraction());
-                double hcalEn = packedCand->caloFraction() * packedCand->energy() * packedCand->hcalFraction();
-                if (verbosity_) {
-                  std::cout << "calorimeter energy:"
-                            << " ECAL = " << ecalEn << ","
-                            << " HCAL = " << hcalEn << ","
-                            << " HO unknown for PackedCand" << std::endl;
-                }
-                if (edm::isFinite(ecalEn))
-                  allNeutralsSumEn += ecalEn;
-                if (edm::isFinite(hcalEn))
-                  allNeutralsSumEn += hcalEn;
+              assert(packedCand);  // Taus are built either from reco::PFCandidates or pat::PackedCandidates
+              double caloEn = packedCand->caloFraction() * packedCand->energy();
+              double hcalEn = caloEn * packedCand->hcalFraction();
+              double ecalEn = caloEn - hcalEn;
+              if (verbosity_) {
+                std::cout << "calorimeter energy:"
+                          << " ECAL = " << ecalEn << ","
+                          << " HCAL = " << hcalEn << ","
+                          << " HO unknown for PackedCand" << std::endl;
               }
+              if (edm::isFinite(ecalEn))
+                allNeutralsSumEn += ecalEn;
+              if (edm::isFinite(hcalEn))
+                allNeutralsSumEn += hcalEn;
             }
           }
           allNeutralsSumEn += addNeutralsSumP4.energy();

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -83,8 +83,16 @@ namespace reco {
         if (signal_pfcand != nullptr) {
           ecal_en_in_signal_pf_cands += signal_pfcand->ecalEnergy();
           hcal_en_in_signal_pf_cands += signal_pfcand->hcalEnergy();
+        } else {
+          // TauReco@MiniAOD: individual ECAL and HCAL energies recovered from fractions
+          const pat::PackedCandidate* signal_pcand = dynamic_cast<const pat::PackedCandidate*>(signal_cand.get());
+          if (signal_pcand != nullptr) {
+            ecal_en_in_signal_pf_cands +=
+                signal_pcand->caloFraction() * signal_pcand->energy() * (1. - signal_pcand->hcalFraction());
+            hcal_en_in_signal_pf_cands +=
+                signal_pcand->caloFraction() * signal_pcand->energy() * signal_pcand->hcalFraction();
+          }
         }
-        // TauReco@MiniAOD: recalculate for PackedCandidate if added to MiniAOD event content
       }
       float total = ecal_en_in_signal_pf_cands + hcal_en_in_signal_pf_cands;
       if (total == 0.) {

--- a/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
+++ b/RecoTauTag/RecoTau/src/PFRecoTauClusterVariables.cc
@@ -86,12 +86,10 @@ namespace reco {
         } else {
           // TauReco@MiniAOD: individual ECAL and HCAL energies recovered from fractions
           const pat::PackedCandidate* signal_pcand = dynamic_cast<const pat::PackedCandidate*>(signal_cand.get());
-          if (signal_pcand != nullptr) {
-            ecal_en_in_signal_pf_cands +=
-                signal_pcand->caloFraction() * signal_pcand->energy() * (1. - signal_pcand->hcalFraction());
-            hcal_en_in_signal_pf_cands +=
-                signal_pcand->caloFraction() * signal_pcand->energy() * signal_pcand->hcalFraction();
-          }
+          assert(signal_pcand);  // Taus are built either from reco::PFCandidates or pat::PackedCandidates
+          float calo_en = signal_pcand->caloFraction() * signal_pcand->energy();
+          ecal_en_in_signal_pf_cands += calo_en * (1. - signal_pcand->hcalFraction());
+          hcal_en_in_signal_pf_cands += calo_en * signal_pcand->hcalFraction();
         }
       }
       float total = ecal_en_in_signal_pf_cands + hcal_en_in_signal_pf_cands;


### PR DESCRIPTION
#### PR description:

This PR contains a set of fixes improving agreement between taus reconstructed with miniAOD inputs and default tau reconstruction with AOD inputs. The fixes are:
* Correct retrieval of track information contained in pat::PackedCandidates in TauChargedHadronProducer;
* Retrieval of individual ECAL and HCAL energies from energy fractions in pat::PackedCandidates in a helper function used by tauIDs and a tau energy algorithm.

Changes are not expected in official production workflows as updated code deals only with, still experimental, tau reconstruction with miniAOD inputs. The tau reconstruction with miniAOD inputs is run as part of tau reco unit tests and is defined by `RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py`
 

#### PR validation:

Reco tau unit tests passed, in particular one defined in `RecoTauTag/RecoTau/test/rerunTauRecoOnMiniAOD.py`
