### PR TITLE
Fix debug-mode compile error in SimG4CMS/Calo

### DIFF
--- a/SimG4CMS/Calo/src/CaloSD.cc
+++ b/SimG4CMS/Calo/src/CaloSD.cc
@@ -309,7 +309,7 @@ bool CaloSD::isItFineCalo(const G4VTouchable* touch) {
       G4LogicalVolume* lv = touch->GetVolume(ii)->GetLogicalVolume();
       ok = (lv == detector.lv);
 #ifdef EDM_ML_DEBUG
-      std::string name = (lv == 0) ? "Unknown" : lv->GetName();
+      std::string name1 = (lv == 0) ? "Unknown" : lv->GetName();
       edm::LogVerbatim("CaloSim") << "CaloSD: volume " << name1 << ":" << detector.name << " at Level "
                                   << detector.level << " Flag " << ok;
 #endif


### PR DESCRIPTION
#### PR description:

Caused by a typo, prevents a debug-mode compilation for reco checks in #31719 with the following error:
```
$ scram b -j8 USER_CXXFLAGS+="-DEDM_ML_DEBUG" USER_CXXFLAGS+="-O" USER_CXXFLAGS+="-g"
home/joosep/reco/31719/new/CMSSW_11_2_X_2020-11-22-2300/src/SimG4CMS/Calo/src/CaloSD.cc: In member function 'bool CaloSD::isItFineCalo(const G4VTouchable*)':
/home/joosep/reco/31719/new/CMSSW_11_2_X_2020-11-22-2300/src/SimG4CMS/Calo/src/CaloSD.cc:313:59: error: 'name1' was not declared in this scope
       edm::LogVerbatim("CaloSim") << "CaloSD: volume " << name1 << ":" << detector.name << " at Level "
                                                           ^~~~~
/home/joosep/reco/31719/new/CMSSW_11_2_X_2020-11-22-2300/src/SimG4CMS/Calo/src/CaloSD.cc:313:59: note: suggested alternative: 'name'
       edm::LogVerbatim("CaloSim") << "CaloSD: volume " << name1 << ":" << detector.name << " at Level "
                                                           ^~~~~
                                                           name
```

#### PR description:
now compiles.