### PR TITLE
Update QGL tag for 2016 and 2018 MC and Run 2 data + Introduce scenario for 2016 cosmics with realistic conditions [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -20,7 +20,7 @@ autoCond = {
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
     'run2_mc'           :   '106X_mcRun2_asymptotic_v15',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v8',
+    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,21 +16,21 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '106X_mcRun2_design_v7',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '106X_mcRun2_asymptotic_preVFP_v8',
+    'run2_mc_pre_vfp'   :   '106X_mcRun2_asymptotic_preVFP_v9',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v13',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_v15',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v7',
+    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_startup_deco_v8',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v31',
+    'run1_data'         :   '106X_dataRun2_v32',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v31',
+    'run2_data'         :   '106X_dataRun2_v32',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v29',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v30',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
     'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
@@ -56,15 +56,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
     'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v13',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v15',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
     'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v14',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v15',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v11',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v12',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v11',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v12',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021


### PR DESCRIPTION
#### PR description:

This PR is a combined backport of PRs #32224 and #31846. It updates the quark-gluon likelihood tag for 2016 and 2018 MC and Run 2 data; 2017 MC already has the correct tag. The update has already been included in the 102X series for the nanoAOD campaign but the change was never propagated to 10_6_X and master.

See the [HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4357.html) for details.

Also, the 2016 Run 2 cosmics scenario is changed from representing conditions at Run 2 startup (which is no longer of interest) to realistic 2016 cosmics conditions (which remains of interest).

The GT diffs are as follows:

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_preVFP_v8/106X_mcRun2_asymptotic_preVFP_v9

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_v13/106X_mcRun2_asymptotic_v15

**2016 cosmics (realistic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2cosmics_startup_deco_v7/106X_mcRun2cosmics_asymptotic_deco_v2

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v31/106X_dataRun2_v32

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v29/106X_dataRun2_relval_v30

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v13/106X_upgrade2018_realistic_v15

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v14/106X_upgrade2018_realistic_HEfail_v15

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v11/106X_upgrade2018cosmics_realistic_deco_v12

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v11/106X_upgrade2018cosmics_realistic_peak_v12

The `106X_mcRun2_asymptotic_v15` GT in addition removes several obsolete records.

#### PR validation:

These tags have already been validated and are in use in the 10_2_X series.

In addition, a technical test was performed: `runTheMatrix.py -l limited,1325.516,7.22,136.8642,11024.2,7.4 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is backport of PRs #32224 and #31846.