### PR TITLE
Useful items for new MessageLogger syntax

### DIFF
--- a/FWCore/MessageService/Readme.md
+++ b/FWCore/MessageService/Readme.md
@@ -1,0 +1,52 @@
+# Useful MessageLogger Configuration Changes
+
+## Turning off the end of job statistics
+This requires setting the parameter of cerr
+```python
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.enableStatistics = False
+```
+
+## Switching from cerr to cout
+One needs to switch off cerr and switch on cout
+
+```python
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.enable = False
+process.MessageLogger.cout.enable = True
+```
+
+## Writing the standard output to a file
+Assing the file you want to write is name `my_file.log` then
+
+```python
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.files.my_file = dict()
+```
+
+The `MessageLogger` PSet knows that all parameters of `files` must be `cms.untracked.PSet` so one can use a python `dict` to allow the default values to be used.
+
+## Have specific info messages be displayed
+By default the `cerr` will reject all messages below `FWKINFO` (i.e. `threshold = "FWKINFO"`) and the defaut for `INFO` is set to print no output ,i.e. `limit = 0`. In order to see messages for the category 'MyCat' the threshold must be lowered and the category must be explicitly mentioned
+
+```python
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.MyCat = dict()
+```
+
+## Have debug message show for a given module
+By default, all `LogDebug` code is actually removed at compilation time so any messages you want to see have to be recompiled after setting the `EDM_ML_DEBUG` compilation parameter
+
+```bash
+> export EDM_ML_DEBUG=1
+> scram b ...
+```
+
+Then in the `MessageLogger` configuration you need to lower the `threshold` to `"DEBUG"` and then say you want debug messages from the module. So if your module uses the label `myModule` in the configuration, you'd specify
+
+```python
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["myModule"]
+```

--- a/FWCore/MessageService/Readme.md
+++ b/FWCore/MessageService/Readme.md
@@ -3,7 +3,7 @@
 ## Turning off the end of job statistics
 This requires setting the parameter of cerr
 ```python
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.enableStatistics = False
 ```
 
@@ -11,42 +11,88 @@ process.MessageLogger.cerr.enableStatistics = False
 One needs to switch off cerr and switch on cout
 
 ```python
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.enable = False
 process.MessageLogger.cout.enable = True
 ```
 
 ## Writing the standard output to a file
-Assing the file you want to write is name `my_file.log` then
+Assuming the file you want to write is name `my_file.log` then
 
 ```python
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.files.my_file = dict()
 ```
 
 The `MessageLogger` PSet knows that all parameters of `files` must be `cms.untracked.PSet` so one can use a python `dict` to allow the default values to be used.
 
+NOTE: The messages are still routed to cerr. If you only want messages to go to the file, also add
+```python
+process.MessageLogger.cerr.enable = False
+```
+## Have all  messages from a certain level be displayed
+By default the `cerr` will reject all messages below `FWKINFO` (i.e. `threshold = "FWKINFO"`) and the defaut for `INFO` is set to print no output ,i.e. `limit = 0`. So to see all `INFO` messages one would do
+
+```python
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "INFO"
+process.MessageLogger.cerr.INFO.limit = -1
+```
+
+All messages above `FWKINFO` by default are set to be displayed, that is they have `limit = -1`. You can explicitly set that by doing
+```python
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.WARNING = dict(limit = -1)
+```
+
+The `MessageLogger.cerr` PSet knows that all _extra_ parameter labels must be of type `cms.untracked.PSet` so one can use a python `dict` set specific parameters for that PSet and allow all other parameters to use their default default values.
+
+
 ## Have specific info messages be displayed
 By default the `cerr` will reject all messages below `FWKINFO` (i.e. `threshold = "FWKINFO"`) and the defaut for `INFO` is set to print no output ,i.e. `limit = 0`. In order to see messages for the category 'MyCat' the threshold must be lowered and the category must be explicitly mentioned
 
 ```python
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "INFO"
 process.MessageLogger.cerr.MyCat = dict()
 ```
+
+The `MessageLogger.cerr` PSet knows that all _extra_ parameter labels must be of type `cms.untracked.PSet` so one can use a python `dict` set specific parameters for that PSet and allow all other parameters to use their default default values.
+
+
+## Suppressing a particular category
+In order to supporess messages for a given category, e.g. 'MyCat', the limit should be set to 0
+
+```python
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.MyCat = dict(limit = 0)
+```
+
+The `MessageLogger` PSet knows that all _extra_ parameter labels must be of type `cms.untracked.PSet` so one can use a python `dict` set specific parameters for that PSet and allow all other parameters to use their default default values.
+
+
 
 ## Have debug message show for a given module
 By default, all `LogDebug` code is actually removed at compilation time so any messages you want to see have to be recompiled after setting the `EDM_ML_DEBUG` compilation parameter
 
 ```bash
-> export EDM_ML_DEBUG=1
+> export USER_CXXFLAGS="-DEDM_ML_DEBUG"
 > scram b ...
 ```
 
 Then in the `MessageLogger` configuration you need to lower the `threshold` to `"DEBUG"` and then say you want debug messages from the module. So if your module uses the label `myModule` in the configuration, you'd specify
 
 ```python
-process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = "DEBUG"
 process.MessageLogger.debugModules = ["myModule"]
 ```
+
+If you are not interested in a particular module but instead want to see all debug messages, you can instead set `debugModules` using `*`
+
+```python
+process.load("FWCore.MessageService.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = "DEBUG"
+process.MessageLogger.debugModules = ["*"]
+```
+

--- a/FWCore/MessageService/bin/edm_modernize_messagelogger.py
+++ b/FWCore/MessageService/bin/edm_modernize_messagelogger.py
@@ -2,6 +2,23 @@ import sys
 
 args = sys.argv
 
+if len(args) == 1:
+    print("file names must be passed as arguments")
+    exit(-1)
+if args[1] == '-h' or args[1] == '--help':
+    print(
+"""python edm_modernize_messagelogger.py [-h/--help] filename [...]
+    
+   Converts explicit constructions of cms.Service("MessageLogger") from old MessageLogger
+   configration syntax to new the new syntax.
+   The script expects a list of files to be modified in place.
+    
+   NOTE: The script is known to miss some corner-cases in the conversion so always check
+   the results of the transformation.
+"""
+    )
+    exit(0)
+
 for arg in args[1:]:
     execfile(arg)
     

--- a/FWCore/MessageService/bin/edm_modernize_messagelogger.py
+++ b/FWCore/MessageService/bin/edm_modernize_messagelogger.py
@@ -1,0 +1,53 @@
+import sys
+
+args = sys.argv
+
+for arg in args[1:]:
+    execfile(arg)
+    
+    ml = process.MessageLogger.clone()
+    if hasattr(process.MessageLogger, "statistics"):
+        stat = process.MessageLogger.statistics
+        for s in stat:
+            dest = getattr(ml, s.value())
+            dest.enableStatistics = cms.untracked.bool(True)
+        del ml.statistics
+    dest = process.MessageLogger.destinations
+    files = cms.untracked.PSet()
+    if 'cerr' not in dest:
+        ml.cerr = cms.untracked.PSet(enable = cms.untracked.bool(False))
+    for d in dest:
+        if 'cout' == d:
+            continue
+        if 'cerr' == d:
+            continue
+        setattr(files, d, getattr(ml,d.value()))
+        delattr(ml, d)
+            
+    if hasattr(ml,'categories'):
+        del ml.categories
+    del ml.destinations
+    
+    f = open(arg)
+    newF = open(arg+"new", "w")
+    
+    processingML = False
+    parenthesis = 0
+    for l in f.readlines():
+        if not processingML:
+            if 'process.MessageLogger' == l[0:21]:
+                processingML = True
+                parenthesis = l.count('(')
+                parenthesis -= l.count(')')
+                if 0 == parenthesis:
+                    processingML = False
+                continue
+            newF.write(l)
+        else:
+            parenthesis += l.count('(')
+            parenthesis -= l.count(')')
+            if 0 == parenthesis:
+                processingML = False
+                newF.write('process.MessageLogger = '+ml.dumpPython())
+        
+    


### PR DESCRIPTION
#### PR description:

- Added a script that can convert old MessageLogger configurations to the new syntax
- Added a 'How To' page for configuration changes people most often apply to the MessageLogger

#### PR validation:

- The script was used to do much of the migration of configurations containing explicit MessageLogger `Service` creations.