### PR TITLE
Remove Duplicate Labels from ECAL DQM Timing Plot

### DIFF
--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -19,7 +19,7 @@ for bxBinCounter in range(0, -1+len(bxBins)):
 nBXBins = len(bxBins)
 
 bxBinsFine = [i for i in range(1, 3601)]
-bxBinLabelsFine = [str(i) if (i%100 == 0) else "" for i in range(1, 3601)]
+bxBinLabelsFine = [str(i) for i in range(1, 3601)]
 nBXBinsFine = len(bxBinsFine)
 
 EaxisEdges = []


### PR DESCRIPTION
#### PR description:

An issue where two relvals were failing after the latest merge of ROOT6 IBs was presented here: https://github.com/cms-sw/cmssw/issues/32142

```
----- Begin Fatal Exception 23-Nov-2020 21:41:23 CET-----------------------
An exception of category 'FatalRootError' occurred while
   [0] Calling InputSource::readRun_
   Additional Info:
      [a] Fatal Root Error: @SUB=TH1Merger::CheckForDuplicateLabels
Histogram EBTMT Timing vs Finely Binned BX has duplicate labels in the x axis. Bin contents will be merged in a single bin

----- End Fatal Exception -------------------------------------------------
```

The issue appears to be ROOT not accepting multiple labels with the same name.

Based on this comment, it appears JetMET had experienced a similar issue: https://github.com/cms-sw/cmssw/issues/27472 and they fixed it here: https://github.com/cms-sw/cmssw/pull/27647. The exact change was to remove empty string labels from their trigger plots: https://github.com/cms-sw/cmssw/commit/31aa4b69057f2484150dcdb052446ebda67b39d6#diff-3cfdfb75470274b0bba01135411f7f84f8bbe01dfbefef1f011423780860f578

We tried something similar and removed multiple empty string labels from an ECAL DQM timing plot, fixing the issue. The offending line was:
https://github.com/cms-sw/cmssw/blob/master/DQM/EcalMonitorTasks/python/TimingTask_cfi.py#L22

#### PR validation:

The two failing relvals, 137.1 and 136.8861 were rerun to find no errors and the expected output.

runTheMatrix.py -i all -l 137.8,136.8861 --ibeos