### PR TITLE
esConsume migration for APE and removing other static warnings

### DIFF
--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -111,7 +111,6 @@
 /////////
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/GeometrySurface/interface/Bounds.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -181,6 +180,9 @@ private:
 
   // ----------member data ---------------------------
   const edm::ParameterSet parameterSet_;
+  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
+  const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleDepRcd> lorentzAngleToken_;
+  
   std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
   TrackerDetectorStruct tkDetector_;
   SiStripClusterInfo siStripClusterInfo_;
@@ -204,6 +206,10 @@ private:
   const bool calculateApe_;
 
   unsigned int counter1, counter2, counter3, counter4, counter5, counter6;
+  
+  
+  
+  
 };
 
 //
@@ -218,7 +224,10 @@ private:
 // constructors and destructor
 //
 ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig)
-    : parameterSet_(iConfig),
+    : 
+      parameterSet_(iConfig),
+      magFieldToken_(esConsumes()),
+      lorentzAngleToken_(esConsumes()),
       siStripClusterInfo_(consumesCollector(), std::string("")),
       tjTagToken_(
           consumes<TrajTrackAssociationCollection>(parameterSet_.getParameter<edm::InputTag>("tjTkAssociationMapTag"))),
@@ -227,7 +236,8 @@ ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig)
       maxTracksPerEvent_(parameterSet_.getParameter<unsigned int>("maxTracksPerEvent")),
       minGoodHitsPerTrack_(parameterSet_.getParameter<unsigned int>("minGoodHitsPerTrack")),
       analyzerMode_(parameterSet_.getParameter<bool>("analyzerMode")),
-      calculateApe_(parameterSet_.getParameter<bool>("calculateApe")) {
+      calculateApe_(parameterSet_.getParameter<bool>("calculateApe"))
+       {
   counter1 = counter2 = counter3 = counter4 = counter5 = counter6 = 0;
 }
 
@@ -1658,16 +1668,12 @@ TrackStruct::HitParameterStruct ApeEstimator::fillHitVariables(const TrajectoryM
       return hitParams;
     }
 
-    edm::ESHandle<MagneticField> magFieldHandle;
-    iSetup.get<IdealMagneticFieldRecord>().get(magFieldHandle);
 
-    edm::ESHandle<SiStripLorentzAngle> lorentzAngleHandle;
-    iSetup.get<SiStripLorentzAngleDepRcd>().get(lorentzAngleHandle);  //MODIFIED BY LOIC QUERTENMONT
+    const MagneticField *magField = &iSetup.getData(magFieldToken_);
+    const SiStripLorentzAngle *lorentzAngle = &iSetup.getData(lorentzAngleToken_);
 
     const StripGeomDetUnit* stripDet = (const StripGeomDetUnit*)(&detUnit);
-    const MagneticField* magField(magFieldHandle.product());
     LocalVector bField = (stripDet->surface()).toLocal(magField->inTesla(stripDet->surface().position()));
-    const SiStripLorentzAngle* lorentzAngle(lorentzAngleHandle.product());
     float tanLorentzAnglePerTesla = lorentzAngle->getLorentzAngle(stripDet->geographicalId().rawId());
 
     float dirX = -tanLorentzAnglePerTesla * bField.y();

--- a/Alignment/APEEstimation/plugins/ApeEstimator.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimator.cc
@@ -182,7 +182,7 @@ private:
   const edm::ParameterSet parameterSet_;
   const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   const edm::ESGetToken<SiStripLorentzAngle, SiStripLorentzAngleDepRcd> lorentzAngleToken_;
-  
+
   std::map<unsigned int, TrackerSectorStruct> m_tkSector_;
   TrackerDetectorStruct tkDetector_;
   SiStripClusterInfo siStripClusterInfo_;
@@ -206,10 +206,6 @@ private:
   const bool calculateApe_;
 
   unsigned int counter1, counter2, counter3, counter4, counter5, counter6;
-  
-  
-  
-  
 };
 
 //
@@ -224,8 +220,7 @@ private:
 // constructors and destructor
 //
 ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig)
-    : 
-      parameterSet_(iConfig),
+    : parameterSet_(iConfig),
       magFieldToken_(esConsumes()),
       lorentzAngleToken_(esConsumes()),
       siStripClusterInfo_(consumesCollector(), std::string("")),
@@ -236,8 +231,7 @@ ApeEstimator::ApeEstimator(const edm::ParameterSet& iConfig)
       maxTracksPerEvent_(parameterSet_.getParameter<unsigned int>("maxTracksPerEvent")),
       minGoodHitsPerTrack_(parameterSet_.getParameter<unsigned int>("minGoodHitsPerTrack")),
       analyzerMode_(parameterSet_.getParameter<bool>("analyzerMode")),
-      calculateApe_(parameterSet_.getParameter<bool>("calculateApe"))
-       {
+      calculateApe_(parameterSet_.getParameter<bool>("calculateApe")) {
   counter1 = counter2 = counter3 = counter4 = counter5 = counter6 = 0;
 }
 
@@ -1668,9 +1662,8 @@ TrackStruct::HitParameterStruct ApeEstimator::fillHitVariables(const TrajectoryM
       return hitParams;
     }
 
-
-    const MagneticField *magField = &iSetup.getData(magFieldToken_);
-    const SiStripLorentzAngle *lorentzAngle = &iSetup.getData(lorentzAngleToken_);
+    const MagneticField* magField = &iSetup.getData(magFieldToken_);
+    const SiStripLorentzAngle* lorentzAngle = &iSetup.getData(lorentzAngleToken_);
 
     const StripGeomDetUnit* stripDet = (const StripGeomDetUnit*)(&detUnit);
     LocalVector bField = (stripDet->surface()).toLocal(magField->inTesla(stripDet->surface().position()));

--- a/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
@@ -26,7 +26,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -35,6 +34,7 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 #include "CLHEP/Matrix/SymMatrix.h"
 
@@ -78,6 +78,8 @@ private:
 
   // ----------member data ---------------------------
   const edm::ParameterSet parameterSet_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> alignmentErrorToken_;
+  
 
   bool firstEvent = true;
 
@@ -99,7 +101,7 @@ private:
 // constructors and destructor
 //
 ApeEstimatorSummary::ApeEstimatorSummary(const edm::ParameterSet& iConfig)
-    : parameterSet_(iConfig), inputFile_(nullptr) {}
+    : parameterSet_(iConfig), alignmentErrorToken_(esConsumes()), inputFile_(nullptr) {}
 
 ApeEstimatorSummary::~ApeEstimatorSummary() {}
 
@@ -364,9 +366,8 @@ void ApeEstimatorSummary::calculateApe() {
   TTree* sectorNameTree(nullptr);
   iterationFile->GetObject("nameTree;1", sectorNameTree);
 
-  bool firstIter(false);
-  if (!iterationTreeX) {  // should be always true in setBaseline mode, since file is recreated
-    firstIter = true;
+  const bool firstIter(!iterationTreeX);
+  if (firstIter) {  // should be always true in setBaseline mode, since file is recreated
     if (!setBaseline) {
       iterationTreeX = new TTree("iterTreeX", "Tree for APE x values of all iterations");
       iterationTreeY = new TTree("iterTreeY", "Tree for APE y values of all iterations");
@@ -438,9 +439,12 @@ void ApeEstimatorSummary::calculateApe() {
   }
 
   // Check whether sector definitions are identical with the ones of previous iterations and with the ones in baseline file
+  bool failed(false);
   for (auto& i_sector : m_tkSector_) {
     const std::string& name(i_sector.second.name);
-    if (!firstIter) {
+    if (firstIter) {
+      a_sectorName[i_sector.first] = new std::string(name);
+    }else{
       const std::string& nameLastIter(*a_sectorName[i_sector.first]);
       if (name != nameLastIter) {
         edm::LogError("CalculateAPE") << "Inconsistent sector definition in iterationFile for sector " << i_sector.first
@@ -448,24 +452,32 @@ void ApeEstimatorSummary::calculateApe() {
                                       << "Recent iteration has name \"" << name << "\", while previous had \""
                                       << nameLastIter << "\"\n"
                                       << "...APE calculation stopped. Please check sector definitions in config!\n";
-        return;
+        failed = true;
       }
-    } else {
-      a_sectorName[i_sector.first] = new std::string(name);
+      
     }
     if (!setBaseline && baselineFile) {
       const std::string& nameBaseline(*a_sectorBaselineName[i_sector.first]);
       if (name != nameBaseline) {
+        failed = true;
         edm::LogError("CalculateAPE") << "Inconsistent sector definition in baselineFile for sector " << i_sector.first
                                       << ",\n"
                                       << "Recent iteration has name \"" << name << "\", while baseline had \""
                                       << nameBaseline << "\"\n"
                                       << "...APE calculation stopped. Please check sector definitions in config!\n";
-        return;
       }
     }
   }
-
+  
+  if (failed){
+    if (firstIter){
+          for (auto& i_sector : m_tkSector_) {
+            delete a_sectorName[i_sector.first];
+          }
+    }
+    return;
+  }
+  
   // Set up text file for writing out APE values per module
   std::ofstream apeOutputFile;
   if (!setBaseline) {
@@ -634,13 +646,13 @@ void ApeEstimatorSummary::calculateApe() {
       double correctionY_1 = correctionY2_1 >= 0. ? std::sqrt(correctionY2_1) : -std::sqrt(-correctionY2_1);
       double correctionY_2 = correctionY2_2 >= 0. ? std::sqrt(correctionY2_2) : -std::sqrt(-correctionY2_2);
       // Meanwhile, this got very bad default values, or? (negative corrections allowed)
-      if (isnan(correctionX_1))
+      if (edm::isNotFinite(correctionX_1))
         correctionX_1 = -0.0010;
-      if (isnan(correctionX_2))
+      if (edm::isNotFinite(correctionX_2))
         correctionX_2 = -0.0010;
-      if (isnan(correctionY_1))
+      if (edm::isNotFinite(correctionY_1))
         correctionY_1 = -0.0010;
-      if (isnan(correctionY_2))
+      if (edm::isNotFinite(correctionY_2))
         correctionY_2 = -0.0010;
 
       if (entriesX < minHitsPerInterval) {
@@ -876,6 +888,10 @@ void ApeEstimatorSummary::calculateApe() {
   if (firstIter) {
     sectorNameTree->Fill();
     sectorNameTree->Write("nameTree");
+    for (auto& i_sector : m_tkSector_) {
+      delete a_sectorName[i_sector.first];
+    }
+    
   }
   iterationFile->Close();
   delete iterationFile;
@@ -894,9 +910,8 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     // Set baseline or calculate APE value?
     const bool setBaseline(parameterSet_.getParameter<bool>("setBaseline"));
 
-    edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-    iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
-
+    const AlignmentErrorsExtended *alignmentErrors = &iSetup.getData(alignmentErrorToken_);
+  
     // Read in baseline file for calculation of APE value (if not setting baseline)
     // Has same format as iterationFile
     const std::string baselineFileName(parameterSet_.getParameter<std::string>("BaselineFile"));
@@ -932,9 +947,8 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     TTree* sectorNameTree(nullptr);
     defaultFile->GetObject("nameTree;1", sectorNameTree);
 
-    bool firstIter(false);
-    if (!defaultTreeX) {  // should be always true in setBaseline mode, since file is recreated
-      firstIter = true;
+    const bool firstIter(!defaultTreeX);
+    if (firstIter) {  // should be always true in setBaseline mode, since file is recreated
       defaultTreeX = new TTree("iterTreeX", "Tree for default APE x values from GT");
       defaultTreeY = new TTree("iterTreeY", "Tree for default APE y values from GT");
       edm::LogInfo("CalculateAPE") << "First APE iteration (number 0.), create default file with TTree";
@@ -986,9 +1000,12 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     }
 
     // Check whether sector definitions are identical with the ones of previous iterations and with the ones in baseline file
+    bool failed(false);
     for (auto& i_sector : m_tkSector_) {
       const std::string& name(i_sector.second.name);
-      if (!firstIter) {
+      if (firstIter) {
+        a_sectorName[i_sector.first] = new std::string(name);
+      } else {
         const std::string& nameLastIter(*a_sectorName[i_sector.first]);
         if (name != nameLastIter) {
           edm::LogError("CalculateAPE") << "Inconsistent sector definition in iterationFile for sector "
@@ -996,10 +1013,9 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
                                         << "Recent iteration has name \"" << name << "\", while previous had \""
                                         << nameLastIter << "\"\n"
                                         << "...APE calculation stopped. Please check sector definitions in config!\n";
-          return;
+          failed = true;
         }
-      } else
-        a_sectorName[i_sector.first] = new std::string(name);
+      }
       if (!setBaseline && baselineFile) {
         const std::string& nameBaseline(*a_sectorBaselineName[i_sector.first]);
         if (name != nameBaseline) {
@@ -1008,10 +1024,23 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
                                         << "Recent iteration has name \"" << name << "\", while baseline had \""
                                         << nameBaseline << "\"\n"
                                         << "...APE calculation stopped. Please check sector definitions in config!\n";
-          return;
+          failed = true;
         }
       }
     }
+    
+    if (failed){
+      if (firstIter){
+            delete defaultTreeX;
+            delete defaultTreeY;
+            delete sectorNameTree;
+            for (auto& i_sector : m_tkSector_) {
+              delete a_sectorName[i_sector.first];
+            }
+      }
+      return;
+    }
+    
 
     // Loop over sectors for calculating getting default APE
     for (auto& i_sector : m_tkSector_) {
@@ -1040,14 +1069,23 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     defaultTreeX->Write("iterTreeX");
     defaultTreeY->Fill();
     defaultTreeY->Write("iterTreeY");
-
+    
     defaultFile->Close();
-    delete defaultFile;
-
     if (baselineFile) {
       baselineFile->Close();
       delete baselineFile;
     }
+    
+    delete defaultFile;
+    if (firstIter){
+      for (auto& i_sector : m_tkSector_) {
+        delete a_sectorName[i_sector.first];
+      }
+      delete sectorNameTree;
+      delete defaultTreeX;
+      delete defaultTreeY;
+    }
+    
 
     firstEvent = false;
   }

--- a/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
+++ b/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc
@@ -79,7 +79,6 @@ private:
   // ----------member data ---------------------------
   const edm::ParameterSet parameterSet_;
   const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> alignmentErrorToken_;
-  
 
   bool firstEvent = true;
 
@@ -444,7 +443,7 @@ void ApeEstimatorSummary::calculateApe() {
     const std::string& name(i_sector.second.name);
     if (firstIter) {
       a_sectorName[i_sector.first] = new std::string(name);
-    }else{
+    } else {
       const std::string& nameLastIter(*a_sectorName[i_sector.first]);
       if (name != nameLastIter) {
         edm::LogError("CalculateAPE") << "Inconsistent sector definition in iterationFile for sector " << i_sector.first
@@ -454,7 +453,6 @@ void ApeEstimatorSummary::calculateApe() {
                                       << "...APE calculation stopped. Please check sector definitions in config!\n";
         failed = true;
       }
-      
     }
     if (!setBaseline && baselineFile) {
       const std::string& nameBaseline(*a_sectorBaselineName[i_sector.first]);
@@ -468,16 +466,16 @@ void ApeEstimatorSummary::calculateApe() {
       }
     }
   }
-  
-  if (failed){
-    if (firstIter){
-          for (auto& i_sector : m_tkSector_) {
-            delete a_sectorName[i_sector.first];
-          }
+
+  if (failed) {
+    if (firstIter) {
+      for (auto& i_sector : m_tkSector_) {
+        delete a_sectorName[i_sector.first];
+      }
     }
     return;
   }
-  
+
   // Set up text file for writing out APE values per module
   std::ofstream apeOutputFile;
   if (!setBaseline) {
@@ -891,7 +889,6 @@ void ApeEstimatorSummary::calculateApe() {
     for (auto& i_sector : m_tkSector_) {
       delete a_sectorName[i_sector.first];
     }
-    
   }
   iterationFile->Close();
   delete iterationFile;
@@ -910,8 +907,8 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     // Set baseline or calculate APE value?
     const bool setBaseline(parameterSet_.getParameter<bool>("setBaseline"));
 
-    const AlignmentErrorsExtended *alignmentErrors = &iSetup.getData(alignmentErrorToken_);
-  
+    const AlignmentErrorsExtended* alignmentErrors = &iSetup.getData(alignmentErrorToken_);
+
     // Read in baseline file for calculation of APE value (if not setting baseline)
     // Has same format as iterationFile
     const std::string baselineFileName(parameterSet_.getParameter<std::string>("BaselineFile"));
@@ -1028,19 +1025,18 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
         }
       }
     }
-    
-    if (failed){
-      if (firstIter){
-            delete defaultTreeX;
-            delete defaultTreeY;
-            delete sectorNameTree;
-            for (auto& i_sector : m_tkSector_) {
-              delete a_sectorName[i_sector.first];
-            }
+
+    if (failed) {
+      if (firstIter) {
+        delete defaultTreeX;
+        delete defaultTreeY;
+        delete sectorNameTree;
+        for (auto& i_sector : m_tkSector_) {
+          delete a_sectorName[i_sector.first];
+        }
       }
       return;
     }
-    
 
     // Loop over sectors for calculating getting default APE
     for (auto& i_sector : m_tkSector_) {
@@ -1069,15 +1065,15 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
     defaultTreeX->Write("iterTreeX");
     defaultTreeY->Fill();
     defaultTreeY->Write("iterTreeY");
-    
+
     defaultFile->Close();
     if (baselineFile) {
       baselineFile->Close();
       delete baselineFile;
     }
-    
+
     delete defaultFile;
-    if (firstIter){
+    if (firstIter) {
       for (auto& i_sector : m_tkSector_) {
         delete a_sectorName[i_sector.first];
       }
@@ -1085,7 +1081,6 @@ void ApeEstimatorSummary::analyze(const edm::Event& iEvent, const edm::EventSetu
       delete defaultTreeX;
       delete defaultTreeY;
     }
-    
 
     firstEvent = false;
   }

--- a/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
+++ b/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
@@ -102,8 +102,7 @@ private:
 // constructors and destructor
 //
 ApeTreeCreateDefault::ApeTreeCreateDefault(const edm::ParameterSet& iConfig)
-    : 
-      alignmentErrorToken_(esConsumes()),
+    : alignmentErrorToken_(esConsumes()),
       resultFile_(iConfig.getParameter<std::string>("resultFile")),
       trackerTreeFile_(iConfig.getParameter<std::string>("trackerTreeFile")),
       sectors_(iConfig.getParameter<std::vector<edm::ParameterSet>>("sectors")) {}
@@ -401,7 +400,7 @@ void ApeTreeCreateDefault::analyze(const edm::Event& iEvent, const edm::EventSet
   // Same procedure as in ApeEstimatorSummary.cc minus reading of baseline tree
 
   // Load APEs from the GT and write them to root files similar to the ones from calculateAPE()
-  const AlignmentErrorsExtended *alignmentErrors = &iSetup.getData(alignmentErrorToken_);
+  const AlignmentErrorsExtended* alignmentErrors = &iSetup.getData(alignmentErrorToken_);
 
   // Set up root file for default APE values
   const std::string defaultFileName(resultFile_);

--- a/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
+++ b/Alignment/APEEstimation/plugins/ApeTreeCreateDefault.cc
@@ -25,7 +25,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -81,6 +80,7 @@ private:
   bool checkModulePositions(const float, const std::vector<double>&) const;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> alignmentErrorToken_;
   const std::string resultFile_;
   const std::string trackerTreeFile_;
   const std::vector<edm::ParameterSet> sectors_;
@@ -102,7 +102,9 @@ private:
 // constructors and destructor
 //
 ApeTreeCreateDefault::ApeTreeCreateDefault(const edm::ParameterSet& iConfig)
-    : resultFile_(iConfig.getParameter<std::string>("resultFile")),
+    : 
+      alignmentErrorToken_(esConsumes()),
+      resultFile_(iConfig.getParameter<std::string>("resultFile")),
       trackerTreeFile_(iConfig.getParameter<std::string>("trackerTreeFile")),
       sectors_(iConfig.getParameter<std::vector<edm::ParameterSet>>("sectors")) {}
 
@@ -399,8 +401,7 @@ void ApeTreeCreateDefault::analyze(const edm::Event& iEvent, const edm::EventSet
   // Same procedure as in ApeEstimatorSummary.cc minus reading of baseline tree
 
   // Load APEs from the GT and write them to root files similar to the ones from calculateAPE()
-  edm::ESHandle<AlignmentErrorsExtended> alignmentErrors;
-  iSetup.get<TrackerAlignmentErrorExtendedRcd>().get(alignmentErrors);
+  const AlignmentErrorsExtended *alignmentErrors = &iSetup.getData(alignmentErrorToken_);
 
   // Set up root file for default APE values
   const std::string defaultFileName(resultFile_);


### PR DESCRIPTION
#### PR description:

This PR includes some fixes to static warnings that showed up for the code in Alignment/APEEstimation. This includes removing the usage of isnan, including esConsume statements for thread safety warnings and fixing some potential memory leaks. 

Currently, there is still one warning about a potential memory leak left that I think might just be the compiler not understanding the code correctly. The warning is:

/afs/cern.ch/work/m/mteroerd/Alignment/CMSSW_11_2_0_pre9/src/Alignment/APEEstimation/plugins/ApeEstimatorSummary.cc:1071:5: warning: Potential memory leak
    defaultTreeX->Fill();

Marco suggested that I create a PR to see if experts know more about this. In any way, this should not be an important memory leak if there is in fact one.