### PR TITLE
Produce nLayerIT variable in EgammaHLTGsfTrackVarProducer (backport of #32180)

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -207,7 +207,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
         }
 
 	// number of Layers crossed in inner tracker
-        if (gsfTracks[trkNr]->hitPattern().pixelLayersWithMeasurement()  > nLayerITValue) {
+        if (gsfTracks[trkNr]->hitPattern().pixelLayersWithMeasurement() > nLayerITValue) {
           nLayerITValue = gsfTracks[trkNr]->hitPattern().pixelLayersWithMeasurement();
         }
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTGsfTrackVarProducer.cc
@@ -64,6 +64,7 @@ private:
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> oneOverESeedMinusOneOverPMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> missingHitsMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> validHitsMapPutToken_;
+  const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> nLayerITMapPutToken_;
   const edm::EDPutTokenT<reco::RecoEcalCandidateIsolationMap> chi2MapPutToken_;
 };
 
@@ -87,6 +88,7 @@ EgammaHLTGsfTrackVarProducer::EgammaHLTGsfTrackVarProducer(const edm::ParameterS
       missingHitsMapPutToken_{
           produces<reco::RecoEcalCandidateIsolationMap>("MissingHits").setBranchAlias("missinghits")},
       validHitsMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("ValidHits").setBranchAlias("validhits")},
+      nLayerITMapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("NLayerIT").setBranchAlias("nlayerit")},
       chi2MapPutToken_{produces<reco::RecoEcalCandidateIsolationMap>("Chi2").setBranchAlias("chi2")} {}
 
 void EgammaHLTGsfTrackVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -119,6 +121,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
   reco::RecoEcalCandidateIsolationMap oneOverESeedMinusOneOverPMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap missingHitsMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap validHitsMap(recoEcalCandHandle);
+  reco::RecoEcalCandidateIsolationMap nLayerITMap(recoEcalCandHandle);
   reco::RecoEcalCandidateIsolationMap chi2Map(recoEcalCandHandle);
 
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoEcalCandHandle->size(); ++iRecoEcalCand) {
@@ -142,6 +145,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
       }
     }
 
+    int nLayerITValue = -1;
     int validHitsValue = 0;
     float chi2Value = 9999999.;
     float missingHitsValue = 9999999;
@@ -159,6 +163,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
                                       : useDefaultValuesForEndcap_ && nrTracks >= 1;
 
     if (rmCutsDueToNrTracks || useDefaultValues) {
+      nLayerITValue = 100;
       dEtaInValue = 0;
       dEtaSeedInValue = 0;
       dPhiInValue = 0;
@@ -201,6 +206,11 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
           validHitsValue = gsfTracks[trkNr]->numberOfValidHits();
         }
 
+	// number of Layers crossed in inner tracker
+        if (gsfTracks[trkNr]->hitPattern().pixelLayersWithMeasurement()  > nLayerITValue) {
+          nLayerITValue = gsfTracks[trkNr]->hitPattern().pixelLayersWithMeasurement();
+        }
+
         if (gsfTracks[trkNr]->normalizedChi2() < chi2Value) {
           chi2Value = gsfTracks[trkNr]->normalizedChi2();
         }
@@ -228,6 +238,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
     oneOverESeedMinusOneOverPMap.insert(recoEcalCandRef, oneOverESeedMinusOneOverPValue);
     missingHitsMap.insert(recoEcalCandRef, missingHitsValue);
     validHitsMap.insert(recoEcalCandRef, validHitsValue);
+    nLayerITMap.insert(recoEcalCandRef, nLayerITValue);
     chi2Map.insert(recoEcalCandRef, chi2Value);
   }
 
@@ -238,6 +249,7 @@ void EgammaHLTGsfTrackVarProducer::produce(edm::StreamID, edm::Event& iEvent, co
   iEvent.emplace(oneOverESeedMinusOneOverPMapPutToken_, oneOverESeedMinusOneOverPMap);
   iEvent.emplace(missingHitsMapPutToken_, missingHitsMap);
   iEvent.emplace(validHitsMapPutToken_, validHitsMap);
+  iEvent.emplace(nLayerITMapPutToken_, nLayerITMap);
   iEvent.emplace(chi2MapPutToken_, chi2Map);
 }
 


### PR DESCRIPTION
This PR is backport of #32180 and is adding one new variable in EgammaHLTGsfTrackVarProducer. More details can be found in #32180 PR description. This backport is needed for HLT TDR studies.

This is tested in CMSSW_11_1_5 with 
runTheMatrix.py -l 11634.0 #2021 ttbar
runTheMatrix.py -l 23234.0 #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)