### PR TITLE
[11.1.X] Update of geant4e

### DIFF
--- a/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
+++ b/TrackPropagation/Geant4e/interface/Geant4ePropagator.h
@@ -27,7 +27,8 @@ public:
    */
   Geant4ePropagator(const MagneticField *field = nullptr,
                     std::string particleName = "mu",
-                    PropagationDirection dir = alongMomentum);
+                    PropagationDirection dir = alongMomentum,
+                    double plimit = 1.0);
 
   ~Geant4ePropagator() override;
 
@@ -91,6 +92,7 @@ private:
   // The Geant4e manager. Does the real propagation
   G4ErrorPropagatorManager *theG4eManager;
   G4ErrorPropagatorData *theG4eData;
+  double plimit_;
 
   // Transform a CMS Reco detector surface into a Geant4 Target for the error
   // propagation

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.cc
@@ -16,6 +16,7 @@ using namespace edm;
 GeantPropagatorESProducer::GeantPropagatorESProducer(const edm::ParameterSet &p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pset_ = p;
+  plimit_ = pset_.getParameter<double>("PropagationPtotLimit");
   setWhatProduced(this, myname);
 }
 
@@ -32,10 +33,10 @@ std::unique_ptr<Propagator> GeantPropagatorESProducer::produce(const TrackingCom
 
   if (pdir == "oppositeToMomentum")
     dir = oppositeToMomentum;
-  if (pdir == "alongMomentum")
+  else if (pdir == "alongMomentum")
     dir = alongMomentum;
-  if (pdir == "anyDirection")
+  else if (pdir == "anyDirection")
     dir = anyDirection;
 
-  return std::make_unique<Geant4ePropagator>(&(*magfield), particleName, dir);
+  return std::make_unique<Geant4ePropagator>(&(*magfield), particleName, dir, plimit_);
 }

--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
@@ -23,6 +23,7 @@ public:
 
 private:
   edm::ParameterSet pset_;
+  double plimit_;
 };
 
 #endif

--- a/TrackPropagation/Geant4e/python/Geant4ePropagator_cfi.py
+++ b/TrackPropagation/Geant4e/python/Geant4ePropagator_cfi.py
@@ -7,5 +7,6 @@ import FWCore.ParameterSet.Config as cms
 Geant4ePropagator = cms.ESProducer("GeantPropagatorESProducer",
                                    ComponentName = cms.string("Geant4ePropagator"),
                                    PropagationDirection=cms.string("alongMomentum"),
-                                   ParticleName=cms.string("mu")
+                                   ParticleName=cms.string("mu"),
+                                   PropagationPtotLimit = cms.double(1.0) ## GeV/c
                                    )


### PR DESCRIPTION
backport of #32240 

#### PR description:

Crash in Geant4e backward propagator #31920 stops final alignment of Run-2 based on data.
This PR allows to avoid the crash by applying a momentum limit on propagated tracks 1 GeV/c.
This PR is needed also in 11.1.X as we have alignment samples also in this release cycle.

This modification should not affect release validation WFs.

#### PR validation:

Private.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of #32240 