### PR TITLE
Fix Dependency violation in muon geometry builders

### DIFF
--- a/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/CSCGeometryBuilder/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/MuonNumbering"/>
 <use name="Geometry/Records"/>
+<use name="Fireworks/Core"/>
 <library name="CSCGeometryPlugins" file="CSCGeometryESModule.cc">
   <use name="DetectorDescription/Core"/>
   <use name="DetectorDescription/DDCMS"/>
@@ -14,7 +15,6 @@
 </library>
 
 <library name="CSCGeometryValidationPlugins" file="CSCGeometryValidate.cc">
-  <use name="Fireworks/Core"/>
   <use name="Geometry/CSCGeometry"/>
   <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>

--- a/Geometry/GEMGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/GEMGeometryBuilder/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/MuonNumbering"/>
 <use name="Geometry/Records"/>
+<use name="Fireworks/Core"/>
 <library name="GEMGeometryPlugins" file="GEMGeometryESModule.cc">
   <use name="DetectorDescription/Core"/>
   <use name="DetectorDescription/DDCMS"/>
@@ -16,7 +17,6 @@
 </library>
 
 <library name="GEMGeometryValidationPlugins" file="GEMGeometryValidate.cc">
-  <use name="Fireworks/Core"/>
   <use name="Geometry/GEMGeometry"/>
   <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>
@@ -33,7 +33,6 @@
 </library>
 
 <library name="ME0GeometryValidationPlugins" file="ME0GeometryValidate.cc">
-  <use name="Fireworks/Core"/>
   <use name="Geometry/GEMGeometry"/>
   <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>

--- a/Geometry/RPCGeometryBuilder/plugins/BuildFile.xml
+++ b/Geometry/RPCGeometryBuilder/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/MuonNumbering"/>
 <use name="Geometry/Records"/>
+<use name="Fireworks/Core"/>
 <library name="RPCGeometryPlugins" file="RPCGeometryESModule.cc">
   <use name="DetectorDescription/Core"/>
   <use name="DetectorDescription/DDCMS"/>
@@ -14,7 +15,6 @@
 </library>
 
 <library name="RPCGeometryValidationPlugins" file="RPCGeometryValidate.cc">
-  <use name="Fireworks/Core"/>
   <use name="Geometry/RPCGeometry"/>
   <use name="rootgeom"/>
   <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

This PR solves the following dependency errors:
```
>> Checking dependency for Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
  ****ERROR: Dependency violation (direct): Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc Fireworks/Core/interface/FWGeometry.h
  ****ERROR: Dependency violation (direct): Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc Fireworks/Core/interface/FWRecoGeom.h
>> Done Checking dependency for Geometry/DTGeometryBuilder/plugins/DTGeometryValidate.cc
>> Checking dependency for Geometry/GEMGeometryBuilder/plugins/GEMGeometryValidate.cc
  ****ERROR: Dependency violation (direct): Geometry/GEMGeometryBuilder/plugins/GEMGeometryValidate.cc Fireworks/Core/interface/FWGeometry.h
  ****ERROR: Dependency violation (direct): Geometry/GEMGeometryBuilder/plugins/GEMGeometryValidate.cc Fireworks/Core/interface/FWRecoGeom.h
>> Done Checking dependency for Geometry/GEMGeometryBuilder/plugins/GEMGeometryValidate.cc
>> Checking dependency for Geometry/GEMGeometryBuilder/plugins/ME0GeometryValidate.cc
  ****ERROR: Dependency violation (direct): Geometry/GEMGeometryBuilder/plugins/ME0GeometryValidate.cc Fireworks/Core/interface/FWGeometry.h
  ****ERROR: Dependency violation (direct): Geometry/GEMGeometryBuilder/plugins/ME0GeometryValidate.cc Fireworks/Core/interface/FWRecoGeom.h
>> Done Checking dependency for Geometry/GEMGeometryBuilder/plugins/ME0GeometryValidate.cc
>> Checking dependency for Geometry/RPCGeometryBuilder/plugins/RPCGeometryValidate.cc
  ****ERROR: Dependency violation (direct): Geometry/RPCGeometryBuilder/plugins/RPCGeometryValidate.cc Fireworks/Core/interface/FWGeometry.h
  ****ERROR: Dependency violation (direct): Geometry/RPCGeometryBuilder/plugins/RPCGeometryValidate.cc Fireworks/Core/interface/FWRecoGeom.h
>> Done Checking dependency for Geometry/RPCGeometryBuilder/plugins/RPCGeometryValidate.cc
>> Checking dependency for L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc

```

See https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_2_X_2020-11-23-2300/depViolationLogs/Geometry/CSCGeometryBuilder

#### PR validation:

I tested `ReleaseDepsChecks.pl`and the errors disappeared after the fix .