### PR TITLE
Fix Dependency violation in L1Trigger/L1THGCalUtilities

### DIFF
--- a/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="FastSimulation/Event"/>
 <library name="L1TriggerL1THGCalUtilitiesPlugins_ntuples" file="ntuples/*.cc">
   <use name="L1Trigger/L1THGCal"/>
   <use name="L1Trigger/L1THGCalUtilities"/>
@@ -8,7 +9,6 @@
   <use name="SimDataFormats/PileupSummaryInfo"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="TrackPropagation/RungeKutta"/>
-  <use name="FastSimulation/Event"/>
   <use name="FastSimulation/CaloGeometryTools"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>


### PR DESCRIPTION
#### PR description:

(Similar to https://github.com/cms-sw/cmssw/pull/32256)

This PR solves the following dependency errors:
```
>> Checking dependency for L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FSimTrack.h
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FSimVertex.h
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FBaseSimEvent.h
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FSimVertex.icc
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FSimEvent.h
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FBaseSimEvent.icc
  ****ERROR: Dependency violation (direct): L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc FastSimulation/Event/interface/FSimTrack.icc
>> Done Checking dependency for L1Trigger/L1THGCalUtilities/plugins/ntuples/HGCalTriggerNtupleGen.cc

```

See https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_2_X_2020-11-23-2300/depViolationLogs/L1Trigger/L1THGCalUtilities

#### PR validation:

I tested `ReleaseDepsChecks.pl`and the errors disappeared after the fix .