### PR TITLE
Remove FastSim dependecy in Validation/RecoParticleFlow/plugins/PFAnalysis.cc

### DIFF
--- a/Validation/RecoParticleFlow/plugins/BuildFile.xml
+++ b/Validation/RecoParticleFlow/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="Geometry/HcalTowerAlgo"/>
   <use name="MagneticField/Records"/>
+  <use name="FastSimulation/CaloGeometryTools"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/Validation/RecoParticleFlow/plugins/BuildFile.xml
+++ b/Validation/RecoParticleFlow/plugins/BuildFile.xml
@@ -14,7 +14,6 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="Geometry/HcalTowerAlgo"/>
   <use name="MagneticField/Records"/>
-  <use name="FastSimulation/CaloGeometryTools"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/Validation/RecoParticleFlow/plugins/PFAnalysis.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysis.cc
@@ -45,7 +45,7 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "CommonTools/BaseParticlePropagator/interface/BaseParticlePropagator.h"
-#include "FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h"
+#include "Math/Transform3D.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h"
@@ -116,7 +116,7 @@ double detid_compare(const map<uint64_t, double>& rechits,
 
 class PFAnalysis : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
 public:
-  typedef ROOT::Math::Transform3DPJ::Point Point;
+  typedef ROOT::Math::Transform3D::Point Point;
 
   PFAnalysis();
   explicit PFAnalysis(const edm::ParameterSet&);


### PR DESCRIPTION
#### PR description:

This PR removes the FastSim dependency in Validation/RecoParticleFlow/plugins/PFAnalysis.cc by replacing `Transform3DPJ` with `Transform3D` from root. This PR fixes the error
```
  ****ERROR: Dependency violation (direct): Validation/RecoParticleFlow/plugins/PFAnalysis.cc FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h
  *Validation/RecoParticleFlow/plugins/PFAnalysis.cc (Validation/RecoParticleFlow/plugins/PFAnalysis.cc)
    *FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h (FastSimulation/CaloGeometryTools/interface/Transform3DPJ.h)
```
See https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc820/CMSSW_11_2_X_2020-11-23-2300/depViolationLogs/Validation/RecoParticleFlow

#### PR validation:

I tested `ReleaseDepsChecks.pl`and the errors has disappeared after the fix .