### PR TITLE
migrate to ESconsumes GeantPropagatorESProducer

### DIFF
--- a/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
+++ b/TrackPropagation/Geant4e/plugins/GeantPropagatorESProducer.h
@@ -5,6 +5,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include <memory>
 
 /*
@@ -23,6 +25,7 @@ public:
 
 private:
   edm::ParameterSet pset_;
+  edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> magFieldToken_;
   double plimit_;
 };
 


### PR DESCRIPTION
#### PR description:

This PR is an attempt to solve the issue reported at https://github.com/cms-sw/cmssw/issues/31920#issuecomment-715333630
Running the following [test configuration](https://gist.github.com/mmusich/12227a1a1d90e13ebae9502ac512c7d3) in `CMSSW_11_2_X_2020-11-23-2300` results in:

```
----- Begin Fatal Exception 24-Nov-2020 14:17:38 CET-----------------------
An exception of category 'MustUseESGetToken' occurred while
   [0] Processing  Event run: 315322 lumi: 622 event: 425073957 stream: 0
   [1] Running path 'g4RefitPath'
   [2] Calling method for module TrackRefitter/'Geant4eTrackRefitter'
   [3] Using EventSetup component KFFittingSmootherESProducer/'G4eFitterSmoother' to make data TrajectoryFitter/'G4eFitterSmoother' in record TrajectoryFitterRecord
   [4] Running EventSetup component GeantPropagatorESProducer/'Geant4ePropagator
Exception Message:
Called EventSetupRecord::get without using a ESGetToken.
 While requesting data type:MagneticField label:''
----- End Fatal Exception -------------------------------------------------
```

#### PR validation:

Tested with the configuration linked above, unfortunately resulting into a segmentation fault.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
