### PR TITLE
Fix Muon and RegionalMuonCand (un)packers

### DIFF
--- a/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gmtStage2Raw_cfi.py
@@ -13,7 +13,7 @@ gmtStage2Raw = cms.EDProducer(
     ImdInputLabelOMTFNeg = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFNeg"),
     ImdInputLabelOMTFPos = cms.InputTag("simGmtStage2Digis", "imdMuonsOMTFPos"),
     FedId = cms.int32(1402),
-    FWId = cms.uint32(0x4010000), # FW version in GMT with vtx-etrapolation
+    FWId = cms.uint32(0x6000000), # FW version in GMT with displaced muon information
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -33,4 +33,3 @@ stage2L1Trigger_2018.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simBm
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
 stage2L1Trigger_2021.toModify(gmtStage2Raw, BMTFInputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x6000000))
-

--- a/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/gtStage2Raw_cfi.py
@@ -12,7 +12,7 @@ gtStage2Raw = cms.EDProducer(
     JetInputTag    = cms.InputTag("simCaloStage2Digis"),
     EtSumInputTag  = cms.InputTag("simCaloStage2Digis"),
     FedId = cms.int32(1404),
-    FWId = cms.uint32(0x1120),  # FW w/ displaced muon info.
+    FWId = cms.uint32(0x1130),  # FW w/ displaced muon info.
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8)
 )
@@ -31,5 +31,4 @@ stage2L1Trigger_2018.toModify(gtStage2Raw, FWId = cms.uint32(0x10F2)) # FW w/ ne
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x1120)) # FW w/ displaced muon info.
-
+stage2L1Trigger_2021.toModify(gtStage2Raw, FWId = cms.uint32(0x1130)) # FW w/ displaced muon info.

--- a/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/MuonRawDigiTranslator.h
@@ -49,18 +49,30 @@ namespace l1t {
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
     static constexpr unsigned ptUnconstrainedShift_ = 21;
     static constexpr unsigned ptUnconstrainedIntermedidateShift_ = 0;
-    static constexpr unsigned absEtaMu1Shift_ = 12;   // For Run-3
-    static constexpr unsigned etaMu1SignShift_ = 20;  // For Run-3
-    static constexpr unsigned absEtaMu2Shift_ = 21;   // For Run-3
-    static constexpr unsigned etaMu2SignShift_ = 29;  // For Run-3
+    static constexpr unsigned absEtaMu1Shift_ = 13;   // For Run-3
+    static constexpr unsigned etaMu1SignShift_ = 21;  // For Run-3
+    static constexpr unsigned absEtaMu2Shift_ = 22;   // For Run-3
+    static constexpr unsigned etaMu2SignShift_ = 30;  // For Run-3
 
   private:
     static void fillMuonStableQuantities(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);
     static void fillMuonCoordinates2016(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);
     static void fillMuonCoordinatesFrom2017(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);
-    static void fillMuonQuantitiesRun3(
-        Muon& mu, uint32_t raw_data_spare, uint32_t raw_data_00_31, uint32_t raw_data_32_63, int muInBx);
+    static void fillMuonQuantitiesRun3(Muon& mu,
+                                       uint32_t raw_data_spare,
+                                       uint32_t raw_data_00_31,
+                                       uint32_t raw_data_32_63,
+                                       int muInBx,
+                                       bool wasSpecialMWGR = false);
     static void fillIntermediateMuonQuantitiesRun3(Muon& mu, uint32_t raw_data_00_31, uint32_t raw_data_32_63);
+    static void generatePackedDataWordsRun3(const Muon& mu,
+                                            int abs_eta,
+                                            int abs_eta_at_vtx,
+                                            uint32_t& raw_data_spare,
+                                            uint32_t& raw_data_00_31,
+                                            uint32_t& raw_data_32_63,
+                                            int muInBx,
+                                            bool wasSpecialMWGR = false);
   };
 }  // namespace l1t
 

--- a/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
+++ b/L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h
@@ -31,7 +31,7 @@ namespace l1t {
     static constexpr unsigned signShift_ = 0;
     static constexpr unsigned signValidShift_ = 1;
     static constexpr unsigned dxyMask_ = 0x3;
-    static constexpr unsigned dxyShift_ = 18;
+    static constexpr unsigned dxyShift_ = 2;
     static constexpr unsigned ptUnconstrainedMask_ = 0xFF;
     static constexpr unsigned ptUnconstrainedShift_ = 23;
     static constexpr unsigned trackAddressMask_ = 0x1FFFFFFF;


### PR DESCRIPTION
#### PR description:

During the November MWGR we noticed that the changes introduced in #31608 (and #31679) had the following issues:
* The Muon (un)packer was off by one bit when unpacking eta in muon station 2.
* The RegionalMuonCand unpacker was pointed at the wrong bit field for the impact parameter.

We generated a bitfile that put the eta values where the unpacker expected them to allow us to take data with displaced muon information.

This PR cleans up the unpackers in view of the above:
* I fixed the eta shift, but make an exception for the firmware version run in the past MWGR so we can still unpack those data.
* I fixed the shift for dXY.

attn @rekovic and @panoskatsoulis 

#### PR validation:

In addition to runTheMatrix suite I used these changes to run on streamer files taken in the past week: Both with the original firmware and the modified one. Got the expected results.
