### PR TITLE
Throw an exception if esConsumes() is called outside EDModule constructors

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -245,6 +245,9 @@ namespace edm {
     void throwBranchMismatch(BranchType, EDGetToken) const;
     void throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const;
     void throwConsumesCallAfterFrozen(TypeToGet const&, InputTag const&) const;
+    void throwESConsumesCallAfterFrozen(eventsetup::EventSetupRecordKey const&,
+                                        eventsetup::heterocontainer::HCTypeTag const&,
+                                        edm::ESInputTag const&) const;
     void throwESConsumesInProcessBlock() const;
 
     edm::InputTag const& checkIfEmpty(edm::InputTag const& tag);

--- a/FWCore/Integration/test/ESTestAnalyzers.cc
+++ b/FWCore/Integration/test/ESTestAnalyzers.cc
@@ -232,6 +232,21 @@ namespace edmtest {
                                         << ": ED value " << intData.value << ": ES value = " << dataJ.value();
   }
 
+  class ESTestAnalyzerIncorrectConsumes : public edm::stream::EDAnalyzer<> {
+  public:
+    explicit ESTestAnalyzerIncorrectConsumes(edm::ParameterSet const& iConfig){};
+    void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  private:
+    edm::ESGetToken<ESTestDataJ, ESTestRecordJ> esToken_;
+  };
+
+  void ESTestAnalyzerIncorrectConsumes::analyze(edm::Event const& ev, edm::EventSetup const& es) {
+    esToken_ = esConsumes();
+    edm::LogAbsolute("ESTestAnalyzerIncorrectConsumes")
+        << "Succeeded to call esConsumes() in analyze(), should not happen!";
+  }
+
 }  // namespace edmtest
 using namespace edmtest;
 DEFINE_FWK_MODULE(ESTestAnalyzerA);
@@ -240,3 +255,4 @@ DEFINE_FWK_MODULE(ESTestAnalyzerK);
 DEFINE_FWK_MODULE(ESTestAnalyzerAZ);
 DEFINE_FWK_MODULE(ESTestAnalyzerJ);
 DEFINE_FWK_MODULE(ESTestAnalyzerL);
+DEFINE_FWK_MODULE(ESTestAnalyzerIncorrectConsumes);

--- a/FWCore/Integration/test/eventSetupTest.sh
+++ b/FWCore/Integration/test/eventSetupTest.sh
@@ -33,4 +33,7 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/testConcurrentIOVsESSource_cfg.py || di
 echo EventSetupTestCurrentProcess_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/EventSetupTestCurrentProcess_cfg.py || die 'Failed in EventSetupTestCurrentProcess_cfg.py' $?
 
+echo EventSetupIncorrectConsumes_cfg.py
+cmsRun ${LOCAL_TEST_DIR}/EventSetupIncorrectConsumes_cfg.py && die 'Failed in EventSetupIncorrectConsumes_cfg.py' 1
+
 popd


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/32093#discussion_r528866406 reported an assertion failure inside framework code. Closer inspection revealed that the user code was calling `esConsumes()` outside of the constructor (or `registerLateConsumes()`). It would be more helpful for users to get a clear exception message (like in ED `consumes()` case) instead of an assertion failure. This PR adds such an exception for `esConsumes()`.

#### PR validation:

Framework unit tests run.