### PR TITLE
[TF] Accept const graphs in session creation

### DIFF
--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -76,24 +76,24 @@ namespace tensorflow {
   // given in order to load and initialize the variables, sessionOptions are predefined
   // an error is thrown when metaGraphDef is a nullptr or when the graph has no nodes
   // transfers ownership
-  Session* createSession(MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions);
+  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions);
 
   // return a new session that will contain an already loaded meta graph whose exportDir must be given
   // in order to load and initialize the variables, threading options are inferred from nThreads
   // an error is thrown when metaGraphDef is a nullptr or when the graph has no nodes
   // transfers ownership
-  Session* createSession(MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads = 1);
+  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads = 1);
 
   // return a new session that will contain an already loaded graph def, sessionOptions are predefined
   // an error is thrown when graphDef is a nullptr or when the grah has no nodes
   // transfers ownership
-  Session* createSession(GraphDef* graphDef, SessionOptions& sessionOptions);
+  Session* createSession(const GraphDef* graphDef, SessionOptions& sessionOptions);
 
   // return a new session that will contain an already loaded graph def, threading options are
   // inferred from nThreads
   // an error is thrown when graphDef is a nullptr or when the grah has no nodes
   // transfers ownership
-  Session* createSession(GraphDef* graphDef, int nThreads = 1);
+  Session* createSession(const GraphDef* graphDef, int nThreads = 1);
 
   // closes a session, calls its destructor, resets the pointer, and returns true on success
   bool closeSession(Session*& session);

--- a/PhysicsTools/TensorFlow/interface/TensorFlow.h
+++ b/PhysicsTools/TensorFlow/interface/TensorFlow.h
@@ -76,7 +76,9 @@ namespace tensorflow {
   // given in order to load and initialize the variables, sessionOptions are predefined
   // an error is thrown when metaGraphDef is a nullptr or when the graph has no nodes
   // transfers ownership
-  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions);
+  Session* createSession(const MetaGraphDef* metaGraphDef,
+                         const std::string& exportDir,
+                         SessionOptions& sessionOptions);
 
   // return a new session that will contain an already loaded meta graph whose exportDir must be given
   // in order to load and initialize the variables, threading options are inferred from nThreads
@@ -85,13 +87,13 @@ namespace tensorflow {
   Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads = 1);
 
   // return a new session that will contain an already loaded graph def, sessionOptions are predefined
-  // an error is thrown when graphDef is a nullptr or when the grah has no nodes
+  // an error is thrown when graphDef is a nullptr or when the graph has no nodes
   // transfers ownership
   Session* createSession(const GraphDef* graphDef, SessionOptions& sessionOptions);
 
   // return a new session that will contain an already loaded graph def, threading options are
   // inferred from nThreads
-  // an error is thrown when graphDef is a nullptr or when the grah has no nodes
+  // an error is thrown when graphDef is a nullptr or when the graph has no nodes
   // transfers ownership
   Session* createSession(const GraphDef* graphDef, int nThreads = 1);
 

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -104,7 +104,7 @@ namespace tensorflow {
     return createSession(sessionOptions);
   }
 
-  Session* createSession(MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions) {
+  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions) {
     // check for valid pointer
     if (metaGraphDef == nullptr) {
       throw cms::Exception("InvalidMetaGraphDef") << "error while creating session: metaGraphDef is nullptr";
@@ -151,7 +151,7 @@ namespace tensorflow {
     return session;
   }
 
-  Session* createSession(MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads) {
+  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, int nThreads) {
     // create session options and set thread options
     SessionOptions sessionOptions;
     setThreading(sessionOptions, nThreads);
@@ -159,7 +159,7 @@ namespace tensorflow {
     return createSession(metaGraphDef, exportDir, sessionOptions);
   }
 
-  Session* createSession(GraphDef* graphDef, SessionOptions& sessionOptions) {
+  Session* createSession(const GraphDef* graphDef, SessionOptions& sessionOptions) {
     // check for valid pointer
     if (graphDef == nullptr) {
       throw cms::Exception("InvalidGraphDef") << "error while creating session: graphDef is nullptr";
@@ -185,7 +185,7 @@ namespace tensorflow {
     return session;
   }
 
-  Session* createSession(GraphDef* graphDef, int nThreads) {
+  Session* createSession(const GraphDef* graphDef, int nThreads) {
     // create session options and set thread options
     SessionOptions sessionOptions;
     setThreading(sessionOptions, nThreads);

--- a/PhysicsTools/TensorFlow/src/TensorFlow.cc
+++ b/PhysicsTools/TensorFlow/src/TensorFlow.cc
@@ -104,7 +104,9 @@ namespace tensorflow {
     return createSession(sessionOptions);
   }
 
-  Session* createSession(const MetaGraphDef* metaGraphDef, const std::string& exportDir, SessionOptions& sessionOptions) {
+  Session* createSession(const MetaGraphDef* metaGraphDef,
+                         const std::string& exportDir,
+                         SessionOptions& sessionOptions) {
     // check for valid pointer
     if (metaGraphDef == nullptr) {
       throw cms::Exception("InvalidMetaGraphDef") << "error while creating session: metaGraphDef is nullptr";


### PR DESCRIPTION
#### PR description

This PR adds a small change to the TensorFlow interface that allows the `tensorflow::createSession` calls to accept pointers to *constant* `Graph` / `MetaGraph` objects. This allows making graph objects constant in global caches when running multi-threaded.

The change was suggested in [#32222  (comment)](https://github.com/cms-sw/cmssw/pull/32222/files#r529850491) and https://github.com/cms-sw/cmssw/pull/32128#issuecomment-726425146 and could benefit the ongoing integrations.


#### PR validation

The tests coming with the TF interface itself were not changed and still pass as changes are minimal and predictable.

@mialiu149 @makortel @vlimant 