### PR TITLE
[DD4hep] Fix infinite loop discovered in DD4hep workflows

### DIFF
--- a/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
+++ b/SimG4CMS/Forward/src/ZdcShowerLibrary.cc
@@ -203,15 +203,14 @@ int ZdcShowerLibrary::getEnergyFromLibrary(const G4ThreeVector& hitPoint,
     edis = 3.0;
   }
 
-  if (eav < 0. || edis < 0.) {
-    LogDebug("ZdcShower") << " Negative everage energy from parametrization \n"
+  if (eav < 0. || esig < 0.) {
+    LogDebug("ZdcShower") << " Negative everage energy or esigma from parametrization \n"
                           << " xin: " << xin << "(cm)"
                           << " yin: " << yin << "(cm)"
                           << " track en: " << energy << "(GeV)"
-                          << " eaverage: " << eav / GeV << " (GeV)"
-                          << " esigma: " << esig / GeV << "  (GeV)"
-                          << " edist: " << edis << " (GeV)"
-                          << " dE hit: " << nphotons / GeV << " (GeV)";
+                          << " eaverage: " << eav << " (GeV)"
+                          << " esigma: " << esig << "  (GeV)"
+                          << " edist: " << edis << " (GeV)";
     return 0;
   }
 


### PR DESCRIPTION
In the simulation step of ttbar and zmm DD4hep workflows, after a large number of events, the program would get stuck in an infinite loop. This problem was tracked to a loop in `ZdcShowerLibrary.cc`.

This code performs parameterizations to obtain the values of average energy and sigma. It does a check to see if the parameterization failed by producing negative energy or sigma values. However, the code had a typo, where, instead of checking whether sigma was negative, it was checking a variable that is always set explicitly to 1 or 3. Because the value of sigma was not being checked, in rare cases where sigma was negative, the program proceeded to a `while` loop that would go on endlessly because sigma had a nonsense value.

This PR fixes the typo so bad values of sigma cause the function to return immediately as intended rather than fall into the infinite loop.

There is still the open question of why DD4hep exposed this bug. It seems there is some small difference in ZDC geometry between old DD and DD4hep that somehow created these bad sigma values. That will require more investigation.

#### PR validation:

The ttbar DD4hep workflow was run with debugging messages, and that showed the negative sigma values were caught and the infinite loop was avoided.

No backport is needed.