### PR TITLE
Fix number of bits for the CLCT slope value (CCLUT-9)

### DIFF
--- a/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
+++ b/DataFormats/CSCDigi/interface/CSCCLCTDigi.h
@@ -75,7 +75,7 @@ public:
   void setSlope(const uint16_t slope);
 
   /// slope in number of half-strips/layer
-  float getFractionalSlope(const uint16_t slope = 5) const;
+  float getFractionalSlope(const uint16_t slope = 4) const;
 
   /// return striptype
   uint16_t getStripType() const { return striptype_; }


### PR DESCRIPTION
#### PR description:

Number of bits for the CLCT slope value is 4, not 5. The total number of bits is 5 if you include the sign of the bending (left or right). 

#### PR validation:

The function `getFractionalSlope` is not used in the emulator, only in the analysis code, so there should be no difference in performance. Tested on 9,000 events with low-pT displaced muons from /RelValDisplacedMuPt2To10/CMSSW_11_0_0-110X_mcRun4_realistic_v2_2026D49noPU-v1/GEN-SIM-DIGI-RAW. Validation plots are shown below. The plots will be incorporated in detector note [DN-19-059](https://gitlab.cern.ch/tdr/notes/DN-19-059), describing the Run-3 CSC local trigger algorithm.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991