### PR TITLE
Updated CosmicRateAnalyzer: MagField & Hits added, deleted latency

### DIFF
--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -6,9 +6,9 @@
 /**\class CosmicRateAnalyzer CosmicRateAnalyzer.cc CosmicTrackTool/CosmicRateAnalyzer/plugins/CosmicRateAnalyzer.cc
 
  Description :
-  This Analyzer creates tuple, having necessary infromation for cosmic track and event rate calculations.
-Tuple created by this analyzer also have some kinematical information. This tuple is input of some offline
-macros that make rate plots and kinematical plots.
+  This Analyzer creates tuple, having necessary infromation for Cosmic Track Rate and Event Rate calculations.
+  Tuples created by this analyzer also have some kinematic information. This tuple is input to some offline
+  macros that make Rate plots and Kinematical plots.
 
 Implementation : Documentation for running this tool is described in twiki :
 https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
@@ -16,7 +16,7 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 */
 // Originally created:  Justyna Magdalena Tomaszewska,,,
 // Revisited by: Ashutosh Bhardwaj and Kirti Ranjan
-// Further Developed by: Sumit Keshri (sumit.keshri@cern.ch)
+// Further Developed by: Sumit Keshri (sumit.keshri@cern.ch) & Saumya (saumya.saumya@cern.ch)
 //
 //         Created:  Sat, 30 May 2015 20:14:35 GMT
 //
@@ -55,10 +55,11 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-#include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
-#include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
+#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
@@ -96,7 +97,7 @@ private:
   edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster> > clustercollectionToken_;
   edm::EDGetTokenT<reco::MuonCollection> muonTags_;
   edm::RunNumber_t lastrunnum;
-  double lastruntime;
+  double lastruntime, magField;
   edm::Service<TFileService> fs;
 
   unsigned int DetectorID;
@@ -148,6 +149,13 @@ private:
   std::vector<double> dz;
   std::vector<double> nvh;
   std::vector<double> DTtime;
+  std::vector<int> nh_BPIX;
+  std::vector<int> nh_FPIX;
+  std::vector<int> nh_TIB;
+  std::vector<int> nh_TOB;
+  std::vector<int> nh_TID;
+  std::vector<int> nh_TEC;
+  
 };
 
 //
@@ -195,6 +203,12 @@ void CosmicRateAnalyzer::ClearInEventLoop() {
   dz.clear();
   nvh.clear();
   DTtime.clear();
+  nh_BPIX.clear();
+  nh_FPIX.clear();
+  nh_TIB.clear();
+  nh_TOB.clear();
+  nh_TID.clear();
+  nh_TEC.clear();
 }
 
 // ------------ method called for each event  ------------
@@ -205,8 +219,10 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
   edm::Handle<reco::TrackCollection> tracks;
   iEvent.getByToken(trackTags_, tracks);
 
-  edm::ESHandle<MagneticField> magfield;
-  iSetup.get<IdealMagneticFieldRecord>().get(magfield);
+  edm::ESHandle<MagneticField> magFieldHandle_;
+  iSetup.get<IdealMagneticFieldRecord>().get(magFieldHandle_);
+  magField=-9999;
+  magField = magFieldHandle_.product()->inTesla(GlobalPoint(0,0,0)).mag();
 
   edm::ESHandle<TrackerTopology> tTopo;
   iSetup.get<TrackerTopologyRcd>().get(tTopo);
@@ -218,9 +234,6 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   lastruntime = t_end - t_begin;
   lastrunnum = iEvent.getRun().run();
-
-  edm::ESHandle<SiStripLatency> apvlat;
-  iSetup.get<SiStripLatencyRcd>().get(apvlat);
 
   if (!tracks->empty())
     v_ntrk.push_back(tracks->size());
@@ -238,7 +251,13 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     d0.push_back(itTrack1->d0());
     dz.push_back(itTrack1->dz());
     nvh.push_back(itTrack1->numberOfValidHits());
-
+    nh_BPIX.push_back(itTrack1->hitPattern().numberOfValidPixelBarrelHits());
+    nh_FPIX.push_back(itTrack1->hitPattern().numberOfValidPixelEndcapHits());
+    nh_TIB.push_back(itTrack1->hitPattern().numberOfValidStripTIBHits());
+    nh_TOB.push_back(itTrack1->hitPattern().numberOfValidStripTOBHits());
+    nh_TID.push_back(itTrack1->hitPattern().numberOfValidStripTIDHits());
+    nh_TEC.push_back(itTrack1->hitPattern().numberOfValidStripTECHits());
+  
     int nhitinBPIX = 0;
     int nhitinFPIX = 0;
     int nhitinPIXEL = 0;
@@ -389,7 +408,14 @@ void CosmicRateAnalyzer::beginJob() {
   treeEvent->Branch("dz", &dz);
   treeEvent->Branch("nvh", &nvh);
   treeEvent->Branch("ntrk", &ntrk);
+  treeEvent->Branch("nHitsBPIX", &nh_BPIX);
+  treeEvent->Branch("nHitsFPIX", &nh_FPIX);
+  treeEvent->Branch("nHitsTIB", &nh_TIB);
+  treeEvent->Branch("nHitsTOB", &nh_TOB);
+  treeEvent->Branch("nHitsTID", &nh_TID);
+  treeEvent->Branch("nHitsTEC", &nh_TEC);
   treeEvent->Branch("DTtime", &DTtime);
+  treeEvent->Branch("magField",&magField);
   treeRun->Branch("run_time", &run_time);
   treeRun->Branch("runnum", &runnum);
   treeRun->Branch("number_of_events", &number_of_events);

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -153,7 +153,6 @@ private:
   std::vector<int> nh_TOB;
   std::vector<int> nh_TID;
   std::vector<int> nh_TEC;
-  
 };
 
 //
@@ -219,8 +218,8 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
 
   edm::ESHandle<MagneticField> magFieldHandle_;
   iSetup.get<IdealMagneticFieldRecord>().get(magFieldHandle_);
-  magField=-9999;
-  magField = magFieldHandle_.product()->inTesla(GlobalPoint(0,0,0)).mag();
+  magField = -9999;
+  magField = magFieldHandle_.product()->inTesla(GlobalPoint(0, 0, 0)).mag();
 
   edm::ESHandle<TrackerTopology> tTopo;
   iSetup.get<TrackerTopologyRcd>().get(tTopo);
@@ -255,7 +254,7 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
     nh_TOB.push_back(itTrack1->hitPattern().numberOfValidStripTOBHits());
     nh_TID.push_back(itTrack1->hitPattern().numberOfValidStripTIDHits());
     nh_TEC.push_back(itTrack1->hitPattern().numberOfValidStripTECHits());
-  
+
     int nhitinBPIX = 0;
     int nhitinFPIX = 0;
     int nhitinPIXEL = 0;
@@ -412,7 +411,7 @@ void CosmicRateAnalyzer::beginJob() {
   treeEvent->Branch("nHitsTID", &nh_TID);
   treeEvent->Branch("nHitsTEC", &nh_TEC);
   treeEvent->Branch("DTtime", &DTtime);
-  treeEvent->Branch("magField",&magField);
+  treeEvent->Branch("magField", &magField);
   treeRun->Branch("run_time", &run_time);
   treeRun->Branch("runnum", &runnum);
   treeRun->Branch("number_of_events", &number_of_events);

--- a/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
+++ b/Alignment/TrackerAlignment/plugins/CosmicRateAnalyzer.cc
@@ -55,8 +55,6 @@ https://twiki.cern.ch/twiki/bin/view/CMS/TkAlCosmicsRateMonitoring
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
-#include "DataFormats/SiPixelDetId/interface/PixelBarrelName.h"
-#include "DataFormats/SiPixelDetId/interface/PixelEndcapName.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -283,7 +281,6 @@ void CosmicRateAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
       if (PixelSubdetector::PixelBarrel == subdetId1) {
         ++nhitinBPIX;
         ++nhitinPIXEL;
-        PixelBarrelName pxbId1(detId1);
       }
       ///////////////////////////////////////////////////////////////////////////////////////////////////
       //			Hit information in PixelEndcap                                  	//

--- a/Alignment/TrackerAlignment/test/cosmicRateAnalyzer_cfg.py
+++ b/Alignment/TrackerAlignment/test/cosmicRateAnalyzer_cfg.py
@@ -24,13 +24,13 @@ import FWCore.Utilities.FileUtils as FileUtils
 readFiles = cms.untracked.vstring()
 
 
-readFiles = cms.untracked.vstring( FileUtils.loadListFromFile (os.environ['CMSSW_BASE']+'/src/CosmicRateTool/TrackAnalyzer/test/'+'fileList.txt') )
+readFiles = cms.untracked.vstring( FileUtils.loadListFromFile (os.environ['CMSSW_BASE']+'/src/Alignment/TrackerAlignment/test/'+'fileList.txt') )
 process.source = cms.Source("PoolSource",
 			   fileNames = readFiles,
 			   )
 
 process.TFileService = cms.Service("TFileService", fileName = cms.string("Cosmic_rate_tuple.root") )
 
-process.load("CosmicRateTool.TrackAnalyzer.cosmicRateAnalyzer_cfi")
+process.load("Alignment.TrackerAlignment.cosmicRateAnalyzer_cfi")
 process.p = cms.Path(process.cosmicRateAnalyzer)
 


### PR DESCRIPTION
Updated the Cosmic Rate Analyzer
- Magnetic field and Hits variables are added for Events. 
- Latency (not coming into use) removed.  
- cfi path location updated in Config File.

