### PR TITLE
TrackerDQM: Migration of modules to use esConsumes

### DIFF
--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -105,10 +105,8 @@ OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster() {
 // member functions
 //
 void OuterTrackerMonitorTTCluster::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &(iSetup.getData(geomToken_));
+  tTopo_ = &(iSetup.getData(topoToken_));
 }
 
 // ------------ method called for each event  ------------

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -46,14 +46,13 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-
 class OuterTrackerMonitorTTCluster : public DQMEDAnalyzer {
 public:
   explicit OuterTrackerMonitorTTCluster(const edm::ParameterSet &);
   ~OuterTrackerMonitorTTCluster() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
   // TTCluster stacks
   MonitorElement *Cluster_IMem_Barrel = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Disc = nullptr;
@@ -81,17 +80,17 @@ private:
   std::string topFolderName_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const TrackerGeometry* tkGeom_ = nullptr;
-  const TrackerTopology* tTopo_ = nullptr;
+  const TrackerGeometry *tkGeom_ = nullptr;
+  const TrackerTopology *tTopo_ = nullptr;
 };
 
 //
 // constructors and destructor
 //
-OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet &iConfig) : 
-  conf_(iConfig),
-  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
+OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   tagTTClustersToken_ = consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
       conf_.getParameter<edm::InputTag>("TTClusters"));
@@ -105,7 +104,7 @@ OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster() {
 //
 // member functions
 //
-void OuterTrackerMonitorTTCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+void OuterTrackerMonitorTTCluster::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
   tkGeom_ = &(*geomHandle);
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTCluster.cc
@@ -17,33 +17,35 @@
 //
 
 // system include files
-#include <fstream>
-#include <iostream>
 #include <memory>
 #include <numeric>
 #include <vector>
 
 // user include files
-#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
 
 class OuterTrackerMonitorTTCluster : public DQMEDAnalyzer {
 public:
@@ -51,7 +53,7 @@ public:
   ~OuterTrackerMonitorTTCluster() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
   // TTCluster stacks
   MonitorElement *Cluster_IMem_Barrel = nullptr;
   MonitorElement *Cluster_IMem_Endcap_Disc = nullptr;
@@ -77,12 +79,19 @@ private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tagTTClustersToken_;
   std::string topFolderName_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;
 };
 
 //
 // constructors and destructor
 //
-OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+OuterTrackerMonitorTTCluster::OuterTrackerMonitorTTCluster(const edm::ParameterSet &iConfig) : 
+  conf_(iConfig),
+  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   tagTTClustersToken_ = consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
       conf_.getParameter<edm::InputTag>("TTClusters"));
@@ -96,23 +105,18 @@ OuterTrackerMonitorTTCluster::~OuterTrackerMonitorTTCluster() {
 //
 // member functions
 //
+void OuterTrackerMonitorTTCluster::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
+  tkGeom_ = &(*geomHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
+  tTopo_ = tTopoHandle.product();
+}
 
 // ------------ method called for each event  ------------
 void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
   /// Track Trigger Clusters
   edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTClusterHandle;
   iEvent.getByToken(tagTTClustersToken_, Phase2TrackerDigiTTClusterHandle);
-
-  /// Geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  const TrackerTopology *tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  tTopo = tTopoHandle.product();
-
-  edm::ESHandle<TrackerGeometry> tGeometryHandle;
-  const TrackerGeometry *theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tGeometryHandle);
-  theTrackerGeometry = tGeometryHandle.product();
 
   /// Loop over the input Clusters
   typename edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
@@ -129,12 +133,12 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::
       edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>> tempCluRef =
           edmNew::makeRefTo(Phase2TrackerDigiTTClusterHandle, contentIter);
 
-      DetId detIdClu = theTrackerGeometry->idToDet(tempCluRef->getDetId())->geographicalId();
+      DetId detIdClu = tkGeom_->idToDet(tempCluRef->getDetId())->geographicalId();
       unsigned int memberClu = tempCluRef->getStackMember();
       unsigned int widClu = tempCluRef->findWidth();
 
       MeasurementPoint mp = tempCluRef->findAverageLocalCoordinates();
-      const GeomDet *theGeomDet = theTrackerGeometry->idToDet(detIdClu);
+      const GeomDet *theGeomDet = tkGeom_->idToDet(detIdClu);
       Global3DPoint posClu = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
 
       double r = posClu.perp();
@@ -149,9 +153,9 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::
       if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TOB))  // Phase 2 Outer Tracker Barrel
       {
         if (memberClu == 0)
-          Cluster_IMem_Barrel->Fill(tTopo->layer(detIdClu));
+          Cluster_IMem_Barrel->Fill(tTopo_->layer(detIdClu));
         else
-          Cluster_OMem_Barrel->Fill(tTopo->layer(detIdClu));
+          Cluster_OMem_Barrel->Fill(tTopo_->layer(detIdClu));
 
         Cluster_Barrel_XY->Fill(posClu.x(), posClu.y());
 
@@ -159,25 +163,25 @@ void OuterTrackerMonitorTTCluster::analyze(const edm::Event &iEvent, const edm::
       else if (detIdClu.subdetId() == static_cast<int>(StripSubdetector::TID))  // Phase 2 Outer Tracker Endcap
       {
         if (memberClu == 0) {
-          Cluster_IMem_Endcap_Disc->Fill(tTopo->layer(detIdClu));  // returns wheel
-          Cluster_IMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
+          Cluster_IMem_Endcap_Disc->Fill(tTopo_->layer(detIdClu));  // returns wheel
+          Cluster_IMem_Endcap_Ring->Fill(tTopo_->tidRing(detIdClu));
         } else {
-          Cluster_OMem_Endcap_Disc->Fill(tTopo->layer(detIdClu));  // returns wheel
-          Cluster_OMem_Endcap_Ring->Fill(tTopo->tidRing(detIdClu));
+          Cluster_OMem_Endcap_Disc->Fill(tTopo_->layer(detIdClu));  // returns wheel
+          Cluster_OMem_Endcap_Ring->Fill(tTopo_->tidRing(detIdClu));
         }
 
         if (posClu.z() > 0) {
           Cluster_Endcap_Fw_XY->Fill(posClu.x(), posClu.y());
           if (memberClu == 0)
-            Cluster_IMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
+            Cluster_IMem_Endcap_Ring_Fw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
           else
-            Cluster_OMem_Endcap_Ring_Fw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
+            Cluster_OMem_Endcap_Ring_Fw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
         } else {
           Cluster_Endcap_Bw_XY->Fill(posClu.x(), posClu.y());
           if (memberClu == 0)
-            Cluster_IMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
+            Cluster_IMem_Endcap_Ring_Bw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
           else
-            Cluster_OMem_Endcap_Ring_Bw[tTopo->layer(detIdClu) - 1]->Fill(tTopo->tidRing(detIdClu));
+            Cluster_OMem_Endcap_Ring_Bw[tTopo_->layer(detIdClu) - 1]->Fill(tTopo_->tidRing(detIdClu));
         }
 
       }  // end if isEndcap

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -18,33 +18,37 @@
 //
 
 // system include files
-#include <fstream>
-#include <iostream>
+//#include <fstream>
+//#include <iostream>
 #include <memory>
 #include <numeric>
 #include <vector>
 
 // user include files
-#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
 
 class OuterTrackerMonitorTTStub : public DQMEDAnalyzer {
 public:
@@ -52,6 +56,7 @@ public:
   ~OuterTrackerMonitorTTStub() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 
   // TTStub stacks
   // Global position of the stubs
@@ -97,14 +102,21 @@ private:
   edm::ParameterSet conf_;
   edm::EDGetTokenT<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> tagTTStubsToken_;
   std::string topFolderName_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
+  const TrackerTopology* tTopo_ = nullptr;  
 };
 
 // constructors and destructor
-OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet &iConfig) : conf_(iConfig) {
+OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet &iConfig) : 
+  conf_(iConfig),
+  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) { 
   // now do what ever initialization is needed
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   tagTTStubsToken_ =
-      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
+    consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
 }
 
 OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
@@ -112,6 +124,12 @@ OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
   // (e.g. close files, deallocate resources etc.)
 }
 
+void OuterTrackerMonitorTTStub::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
+  tkGeom_ = &(*geomHandle);
+  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
+  tTopo_ = tTopoHandle.product();
+}
 // member functions
 
 // ------------ method called for each event  ------------
@@ -119,17 +137,6 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
   /// Track Trigger Stubs
   edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> Phase2TrackerDigiTTStubHandle;
   iEvent.getByToken(tagTTStubsToken_, Phase2TrackerDigiTTStubHandle);
-
-  /// Geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  const TrackerTopology *tTopo;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  tTopo = tTopoHandle.product();
-
-  edm::ESHandle<TrackerGeometry> tGeometryHandle;
-  const TrackerGeometry *theTrackerGeometry;
-  iSetup.get<TrackerDigiGeometryRecord>().get(tGeometryHandle);
-  theTrackerGeometry = tGeometryHandle.product();
 
   /// Loop over input Stubs
   typename edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
@@ -147,7 +154,7 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
 
       /// Get det ID (place of the stub)
       //  tempStubRef->getDetId() gives the stackDetId, not rawId
-      DetId detIdStub = theTrackerGeometry->idToDet((tempStubRef->clusterRef(0))->getDetId())->geographicalId();
+      DetId detIdStub = tkGeom_->idToDet((tempStubRef->clusterRef(0))->getDetId())->geographicalId();
 
       /// Get trigger displacement/offset
       double rawBend = tempStubRef->rawBend();
@@ -155,7 +162,7 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
 
       /// Define position stub by position inner cluster
       MeasurementPoint mp = (tempStubRef->clusterRef(0))->findAverageLocalCoordinates();
-      const GeomDet *theGeomDet = theTrackerGeometry->idToDet(detIdStub);
+      const GeomDet *theGeomDet = tkGeom_->idToDet(detIdStub);
       Global3DPoint posStub = theGeomDet->surface().toGlobal(theGeomDet->topology().localPosition(mp));
 
       Stub_Eta->Fill(posStub.eta());
@@ -169,13 +176,13 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
       Stub_isPS->Fill(tempStubRef->moduleTypePS());
 
       if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
-        Stub_Barrel->Fill(tTopo->layer(detIdStub));
+        Stub_Barrel->Fill(tTopo_->layer(detIdStub));
         Stub_Barrel_XY->Fill(posStub.x(), posStub.y());
-        Stub_Barrel_W->Fill(tTopo->layer(detIdStub), rawBend - bendOffset);
-        Stub_Barrel_O->Fill(tTopo->layer(detIdStub), bendOffset);
+        Stub_Barrel_W->Fill(tTopo_->layer(detIdStub), rawBend - bendOffset);
+        Stub_Barrel_O->Fill(tTopo_->layer(detIdStub), bendOffset);
       } else if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID)) {  // Phase 2 Outer Tracker Endcap
-        int disc = tTopo->layer(detIdStub);                                          // returns wheel
-        int ring = tTopo->tidRing(detIdStub);
+        int disc = tTopo_->layer(detIdStub);                                          // returns wheel
+        int ring = tTopo_->tidRing(detIdStub);
         Stub_Endcap_Disc->Fill(disc);
         Stub_Endcap_Ring->Fill(ring);
         Stub_Endcap_Disc_W->Fill(disc, rawBend - bendOffset);

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -18,8 +18,6 @@
 //
 
 // system include files
-//#include <fstream>
-//#include <iostream>
 #include <memory>
 #include <numeric>
 #include <vector>

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -122,10 +122,8 @@ OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
 }
 
 void OuterTrackerMonitorTTStub::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
-  edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
-  tTopo_ = tTopoHandle.product();
+  tkGeom_ = &(iSetup.getData(geomToken_));
+  tTopo_ = &(iSetup.getData(topoToken_));
 }
 // member functions
 

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -47,14 +47,13 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-
 class OuterTrackerMonitorTTStub : public DQMEDAnalyzer {
 public:
   explicit OuterTrackerMonitorTTStub(const edm::ParameterSet &);
   ~OuterTrackerMonitorTTStub() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+  void dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) override;
 
   // TTStub stacks
   // Global position of the stubs
@@ -102,19 +101,19 @@ private:
   std::string topFolderName_;
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
-  const TrackerGeometry* tkGeom_ = nullptr;
-  const TrackerTopology* tTopo_ = nullptr;  
+  const TrackerGeometry *tkGeom_ = nullptr;
+  const TrackerTopology *tTopo_ = nullptr;
 };
 
 // constructors and destructor
-OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet &iConfig) : 
-  conf_(iConfig),
-  geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
-  topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) { 
+OuterTrackerMonitorTTStub::OuterTrackerMonitorTTStub(const edm::ParameterSet &iConfig)
+    : conf_(iConfig),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()),
+      topoToken_(esConsumes<TrackerTopology, TrackerTopologyRcd, edm::Transition::BeginRun>()) {
   // now do what ever initialization is needed
   topFolderName_ = conf_.getParameter<std::string>("TopFolderName");
   tagTTStubsToken_ =
-    consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
+      consumes<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>>(conf_.getParameter<edm::InputTag>("TTStubs"));
 }
 
 OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
@@ -122,7 +121,7 @@ OuterTrackerMonitorTTStub::~OuterTrackerMonitorTTStub() {
   // (e.g. close files, deallocate resources etc.)
 }
 
-void OuterTrackerMonitorTTStub::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+void OuterTrackerMonitorTTStub::dqmBeginRun(const edm::Run &iRun, const edm::EventSetup &iSetup) {
   edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
   tkGeom_ = &(*geomHandle);
   edm::ESHandle<TrackerTopology> tTopoHandle = iSetup.getHandle(topoToken_);
@@ -179,7 +178,7 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
         Stub_Barrel_W->Fill(tTopo_->layer(detIdStub), rawBend - bendOffset);
         Stub_Barrel_O->Fill(tTopo_->layer(detIdStub), bendOffset);
       } else if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TID)) {  // Phase 2 Outer Tracker Endcap
-        int disc = tTopo_->layer(detIdStub);                                          // returns wheel
+        int disc = tTopo_->layer(detIdStub);                                         // returns wheel
         int ring = tTopo_->tidRing(detIdStub);
         Stub_Endcap_Disc->Fill(disc);
         Stub_Endcap_Ring->Fill(ring);

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTTrack.cc
@@ -5,8 +5,6 @@
 // Modified by: Emily MacDonald (emily.kaelyn.macdonald@cern.ch)
 
 // system include files
-#include <fstream>
-#include <iostream>
 #include <memory>
 #include <numeric>
 #include <string>
@@ -14,37 +12,30 @@
 #include <bitset>
 
 // user include files
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
 #include "DataFormats/L1TrackTrigger/interface/TTStub.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
-#include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
-#include "SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h"
+
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "DataFormats/Common/interface/DetSetVectorNew.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
 
 class OuterTrackerMonitorTTTrack : public DQMEDAnalyzer {
 public:
@@ -52,7 +43,6 @@ public:
   ~OuterTrackerMonitorTTTrack() override;
   void analyze(const edm::Event &, const edm::EventSetup &) override;
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
-
   /// Low-quality TTTracks (All tracks)
   MonitorElement *Track_All_N = nullptr;                 // Number of tracks per event
   MonitorElement *Track_All_NStubs = nullptr;            // Number of stubs per track
@@ -121,8 +111,6 @@ OuterTrackerMonitorTTTrack::~OuterTrackerMonitorTTTrack() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 }
-
-// member functions
 
 // ------------ method called for each event  ------------
 void OuterTrackerMonitorTTTrack::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup) {

--- a/DQM/TrackerCommon/interface/TriggerHelper.h
+++ b/DQM/TrackerCommon/interface/TriggerHelper.h
@@ -121,18 +121,16 @@ private:
 
 template <typename T>
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &&iC, T &module)
-    : TriggerHelper(config, iC, module) 
-{
-  gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");      
+    : TriggerHelper(config, iC, module) {
+  gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");
   gtInputToken_ = iC.consumes<L1GlobalTriggerReadoutRecord>(gtInputTag_);
 }
 
 template <typename T>
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC, T &module)
-    : TriggerHelper(config)
-{
+    : TriggerHelper(config) {
   if (onL1_ && (!l1DBKey_.empty() || !l1LogicalExpressions_.empty())) {
-    l1Gt_.reset(new L1GtUtils(config, iC, false, module, L1GtUtils::UseEventSetupIn::Event));
+    l1Gt_ = std::make_unique<L1GtUtils>(config, iC, false, module, L1GtUtils::UseEventSetupIn::Event);
   }
 }
 

--- a/DQM/TrackerCommon/interface/TriggerHelper.h
+++ b/DQM/TrackerCommon/interface/TriggerHelper.h
@@ -18,7 +18,6 @@
   \author   Volker Adler
 */
 
-#include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
@@ -27,11 +26,14 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 
 #include <memory>
 
+class AlCaRecoTriggerBits;
+class AlCaRecoTriggerBitsRcd;
 namespace edm {
   class ConsumesCollector;
   class ParameterSet;
@@ -57,6 +59,7 @@ class TriggerHelper {
   bool errorReplyGt_;
   bool andOrL1_;
   std::string l1DBKey_;
+  edm::ESGetToken<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd> alcaRecotriggerBitsToken_;
   std::vector<std::string> l1LogicalExpressions_;
   bool errorReplyL1_;
   bool andOrHlt_;
@@ -124,6 +127,7 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesColle
     : TriggerHelper(config, iC, module) {
   gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");
   gtInputToken_ = iC.consumes<L1GlobalTriggerReadoutRecord>(gtInputTag_);
+  alcaRecotriggerBitsToken_ = iC.esConsumes<AlCaRecoTriggerBits, AlCaRecoTriggerBitsRcd>();
 }
 
 template <typename T>

--- a/DQM/TrackerCommon/interface/TriggerHelper.h
+++ b/DQM/TrackerCommon/interface/TriggerHelper.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 
@@ -50,6 +51,7 @@ class TriggerHelper {
   bool errorReplyDcs_;
   bool andOrGt_;
   edm::InputTag gtInputTag_;
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> gtInputToken_;
   std::string gtDBKey_;
   std::vector<std::string> gtLogicalExpressions_;
   bool errorReplyGt_;
@@ -119,11 +121,16 @@ private:
 
 template <typename T>
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &&iC, T &module)
-    : TriggerHelper(config, iC, module) {}
+    : TriggerHelper(config, iC, module) 
+{
+  gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");      
+  gtInputToken_ = iC.consumes<L1GlobalTriggerReadoutRecord>(gtInputTag_);
+}
 
 template <typename T>
 TriggerHelper::TriggerHelper(const edm::ParameterSet &config, edm::ConsumesCollector &iC, T &module)
-    : TriggerHelper(config) {
+    : TriggerHelper(config)
+{
   if (onL1_ && (!l1DBKey_.empty() || !l1LogicalExpressions_.empty())) {
     l1Gt_.reset(new L1GtUtils(config, iC, false, module, L1GtUtils::UseEventSetupIn::Event));
   }

--- a/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
+++ b/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
@@ -37,9 +37,10 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
         } else
           detectorOn_ = false;
         //if (verbose_)
-	edm::LogInfo("DetectorStatusFilter") << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
-					    << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX) << " FPix "
-					    << (*dcsStatus)[0].ready(DcsStatus::FPIX) << " Detector State " << detectorOn_ << std::endl;
+        edm::LogInfo("DetectorStatusFilter")
+            << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+            << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX) << " FPix " << (*dcsStatus)[0].ready(DcsStatus::FPIX)
+            << " Detector State " << detectorOn_ << std::endl;
       } else if (detectorType_ == "sistrip" && !dcsStatus->empty()) {
         if ((*dcsStatus)[0].ready(DcsStatus::TIBTID) && (*dcsStatus)[0].ready(DcsStatus::TOB) &&
             (*dcsStatus)[0].ready(DcsStatus::TECp) && (*dcsStatus)[0].ready(DcsStatus::TECm)) {
@@ -48,11 +49,11 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
         } else
           detectorOn_ = false;
         //if (verbose_)
-	edm::LogInfo("DetectorStatusFilter") << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
-					     << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm) << " TEC+ "
-					     << (*dcsStatus)[0].ready(DcsStatus::TECp) << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID)
-					     << " TOB " << (*dcsStatus)[0].ready(DcsStatus::TOB) << " Detector States " << detectorOn_
-					     << std::endl;
+        edm::LogInfo("DetectorStatusFilter")
+            << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+            << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm) << " TEC+ " << (*dcsStatus)[0].ready(DcsStatus::TECp)
+            << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID) << " TOB "
+            << (*dcsStatus)[0].ready(DcsStatus::TOB) << " Detector States " << detectorOn_ << std::endl;
       }
     } else {
       edm::LogError("DetectorStatusFilter") << "ERROR: DcsStatusCollection not found !";
@@ -61,8 +62,8 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
     detectorOn_ = true;
     nSelectedEvents_++;
     //if (verbose_)
-    edm::LogInfo("DetectorStatusFilter") << "Total MC Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " Detector States "
-					 << detectorOn_ << std::endl;
+    edm::LogInfo("DetectorStatusFilter") << "Total MC Events " << nEvents_ << " Selected Events " << nSelectedEvents_
+                                         << " Detector States " << detectorOn_ << std::endl;
   }
   return detectorOn_;
 }

--- a/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
+++ b/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
@@ -6,9 +6,6 @@
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-
-#include <iostream>
-
 //
 // -- Constructor
 //
@@ -39,10 +36,10 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
           nSelectedEvents_++;
         } else
           detectorOn_ = false;
-        if (verbose_)
-          std::cout << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
-                    << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX) << " FPix "
-                    << (*dcsStatus)[0].ready(DcsStatus::FPIX) << " Detector State " << detectorOn_ << std::endl;
+        //if (verbose_)
+	edm::LogInfo("DetectorStatusFilter") << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+					    << " BPix " << (*dcsStatus)[0].ready(DcsStatus::BPIX) << " FPix "
+					    << (*dcsStatus)[0].ready(DcsStatus::FPIX) << " Detector State " << detectorOn_ << std::endl;
       } else if (detectorType_ == "sistrip" && !dcsStatus->empty()) {
         if ((*dcsStatus)[0].ready(DcsStatus::TIBTID) && (*dcsStatus)[0].ready(DcsStatus::TOB) &&
             (*dcsStatus)[0].ready(DcsStatus::TECp) && (*dcsStatus)[0].ready(DcsStatus::TECm)) {
@@ -50,12 +47,12 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
           nSelectedEvents_++;
         } else
           detectorOn_ = false;
-        if (verbose_)
-          std::cout << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
-                    << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm) << " TEC+ "
-                    << (*dcsStatus)[0].ready(DcsStatus::TECp) << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID)
-                    << " TOB " << (*dcsStatus)[0].ready(DcsStatus::TOB) << " Detector States " << detectorOn_
-                    << std::endl;
+        //if (verbose_)
+	edm::LogInfo("DetectorStatusFilter") << " Total Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " DCS States : "
+					     << " TEC- " << (*dcsStatus)[0].ready(DcsStatus::TECm) << " TEC+ "
+					     << (*dcsStatus)[0].ready(DcsStatus::TECp) << " TIB/TID " << (*dcsStatus)[0].ready(DcsStatus::TIBTID)
+					     << " TOB " << (*dcsStatus)[0].ready(DcsStatus::TOB) << " Detector States " << detectorOn_
+					     << std::endl;
       }
     } else {
       edm::LogError("DetectorStatusFilter") << "ERROR: DcsStatusCollection not found !";
@@ -63,9 +60,9 @@ bool DetectorStateFilter::filter(edm::Event &evt, edm::EventSetup const &es) {
   } else {
     detectorOn_ = true;
     nSelectedEvents_++;
-    if (verbose_)
-      std::cout << "Total MC Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " Detector States "
-                << detectorOn_ << std::endl;
+    //if (verbose_)
+    edm::LogInfo("DetectorStatusFilter") << "Total MC Events " << nEvents_ << " Selected Events " << nSelectedEvents_ << " Detector States "
+					 << detectorOn_ << std::endl;
   }
   return detectorOn_;
 }

--- a/DQM/TrackerCommon/plugins/SimpleEventFilter.cc
+++ b/DQM/TrackerCommon/plugins/SimpleEventFilter.cc
@@ -19,7 +19,7 @@ bool SimpleEventFilter::filter(edm::Event &, edm::EventSetup const &) {
   if (nEvent_ % nInterval_ != 0)
     ret = false;
   //if (verbose_ && !ret)
-  if(!ret)
+  if (!ret)
     edm::LogInfo("SimpleEventFilter") << ">>> filtering event" << nEvent_ << std::endl;
   return ret;
 }

--- a/DQM/TrackerCommon/plugins/SimpleEventFilter.cc
+++ b/DQM/TrackerCommon/plugins/SimpleEventFilter.cc
@@ -1,6 +1,5 @@
 #include "DQM/TrackerCommon/plugins/SimpleEventFilter.h"
-#include <iostream>
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 //
 // -- Constructor
 //
@@ -19,8 +18,9 @@ bool SimpleEventFilter::filter(edm::Event &, edm::EventSetup const &) {
   bool ret = true;
   if (nEvent_ % nInterval_ != 0)
     ret = false;
-  if (verbose_ && !ret)
-    std::cout << ">>> filtering event" << nEvent_ << std::endl;
+  //if (verbose_ && !ret)
+  if(!ret)
+    edm::LogInfo("SimpleEventFilter") << ">>> filtering event" << nEvent_ << std::endl;
   return ret;
 }
 

--- a/DQM/TrackerCommon/plugins/SimpleEventFilter.h
+++ b/DQM/TrackerCommon/plugins/SimpleEventFilter.h
@@ -1,10 +1,10 @@
 #ifndef SimpleEventFilter_H
 #define SimpleEventFilter_H
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class SimpleEventFilter : public edm::EDFilter {
+class SimpleEventFilter : public edm::stream::EDFilter<> {
 public:
   SimpleEventFilter(const edm::ParameterSet &);
   ~SimpleEventFilter() override;

--- a/DQM/TrackerCommon/src/TriggerHelper.cc
+++ b/DQM/TrackerCommon/src/TriggerHelper.cc
@@ -1,9 +1,8 @@
 //
 //
-
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
+#include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
-
 #include "DQM/TrackerCommon/interface/TriggerHelper.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
@@ -437,8 +436,7 @@ bool TriggerHelper::acceptHltLogicalExpression(const edm::Handle<edm::TriggerRes
 
 /// Reads and returns logical expressions from DB
 std::vector<std::string> TriggerHelper::expressionsFromDB(const std::string &key, const edm::EventSetup &setup) {
-  edm::ESHandle<AlCaRecoTriggerBits> logicalExpressions;
-  setup.get<AlCaRecoTriggerBitsRcd>().get(logicalExpressions);
+  const AlCaRecoTriggerBits *logicalExpressions = &(setup.getData(alcaRecotriggerBitsToken_));
   const std::map<std::string, std::string> &expressionMap = logicalExpressions->m_alcarecoToTrig;
   std::map<std::string, std::string>::const_iterator listIter = expressionMap.find(key);
   if (listIter == expressionMap.end()) {

--- a/DQM/TrackerCommon/src/TriggerHelper.cc
+++ b/DQM/TrackerCommon/src/TriggerHelper.cc
@@ -1,13 +1,11 @@
 //
 //
 
-#include "DQM/TrackerCommon/interface/TriggerHelper.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtLogicParser.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "DQM/TrackerCommon/interface/TriggerHelper.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
 #include <vector>
 
@@ -45,7 +43,6 @@ TriggerHelper::TriggerHelper(const edm::ParameterSet &config)
     }
     if (config.exists("andOrGt")) {
       andOrGt_ = config.getParameter<bool>("andOrGt");
-      gtInputTag_ = config.getParameter<edm::InputTag>("gtInputTag");
       gtLogicalExpressions_ = config.getParameter<std::vector<std::string>>("gtStatusBits");
       errorReplyGt_ = config.getParameter<bool>("errorReplyGt");
       if (config.exists("gtDBKey"))
@@ -216,10 +213,10 @@ bool TriggerHelper::acceptGt(const edm::Event &event) {
 
   // Accessing the L1GlobalTriggerReadoutRecord
   edm::Handle<L1GlobalTriggerReadoutRecord> gtReadoutRecord;
-  event.getByLabel(gtInputTag_, gtReadoutRecord);
+  event.getByToken(gtInputToken_, gtReadoutRecord);
   if (!gtReadoutRecord.isValid()) {
-    edm::LogError("TriggerHelper") << "L1GlobalTriggerReadoutRecord product with InputTag \"" << gtInputTag_.encode()
-                                   << "\" not in event ==> decision: " << errorReplyGt_;
+    //edm::LogError("TriggerHelper") << "L1GlobalTriggerReadoutRecord product with InputTag \"" << gtInputTag_.encode()
+    //                               << "\" not in event ==> decision: " << errorReplyGt_;
     return errorReplyGt_;
   }
 

--- a/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
+++ b/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
@@ -102,7 +102,7 @@ private:
 
   unsigned long long m_cacheID_;
 
-  edm::ESGetToken <RunInfo, RunInfoRcd> runInfoToken_;
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
   const RunInfo* sumFED_ = nullptr;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
   edm::ESWatcher<SiStripDetCablingRcd> fedDetCablingWatcher_;

--- a/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
+++ b/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
@@ -25,13 +25,15 @@
 
 #include "DQMServices/Core/interface/DQMStore.h"
 
-#include <iostream>
 #include <fstream>
 #include <string>
 #include <vector>
 #include <map>
 
 class SiStripDetCabling;
+class SiStripDetCablingRcd;
+class RunInfo;
+class RunInfoRcd;
 
 class TrackingCertificationInfo : public DQMEDHarvester {
 public:
@@ -86,7 +88,6 @@ private:
 
   MonitorElement* TrackingLSCertification;
 
-  edm::ESHandle<SiStripDetCabling> detCabling_;
   edm::ParameterSet pSet_;
 
   bool trackingCertificationBooked_;
@@ -99,6 +100,11 @@ private:
   bool checkPixelFEDs_;
 
   unsigned long long m_cacheID_;
+
+  edm::ESGetToken <RunInfo, RunInfoRcd> runInfoToken_;
+  const RunInfo* sumFED_ = nullptr;
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
+  const SiStripDetCabling* detCabling_ = nullptr;
 
   std::vector<std::string> SubDetFolder;
 };

--- a/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
+++ b/DQM/TrackingMonitorClient/interface/TrackingCertificationInfo.h
@@ -19,6 +19,7 @@
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -104,7 +105,8 @@ private:
   edm::ESGetToken <RunInfo, RunInfoRcd> runInfoToken_;
   const RunInfo* sumFED_ = nullptr;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
-  const SiStripDetCabling* detCabling_ = nullptr;
+  edm::ESWatcher<SiStripDetCablingRcd> fedDetCablingWatcher_;
+  const SiStripDetCabling* detCabling_;
 
   std::vector<std::string> SubDetFolder;
 };

--- a/DQM/TrackingMonitorClient/interface/TrackingQualityChecker.h
+++ b/DQM/TrackingMonitorClient/interface/TrackingQualityChecker.h
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <map>

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
@@ -95,10 +95,8 @@ void TrackingAnalyser::beginRun(edm::Run const& run, edm::EventSetup const& eSet
   if (fedCablingWatcher_.check(eSetup)) {  //this should check if cabling record has changed
     edm::LogInfo("TrackingAnalyser") << "beginRun: "
                                      << " Change in Cabling, recrated TrackerMap";
-    edm::ESHandle<SiStripFedCabling> fedcabHandle = eSetup.getHandle(fedCablingToken_);
-    fedCabling_ = fedcabHandle.product();
-    edm::ESHandle<SiStripDetCabling> detcabHandle = eSetup.getHandle(detCablingToken_);
-    detCabling_ = detcabHandle.product();
+    fedCabling_ = &eSetup.getData(fedCablingToken_);
+    detCabling_ = &eSetup.getData(detCablingToken_);
   }
 }
 //

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
@@ -38,10 +38,9 @@
 // -- Constructor
 //
 TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
-  : verbose_(ps.getUntrackedParameter<bool>("verbose", false)),
-    fedCablingToken_(esConsumes<SiStripFedCabling, SiStripFedCablingRcd, edm::Transition::BeginRun>()),
-    detCablingToken_(esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>())
-{
+    : verbose_(ps.getUntrackedParameter<bool>("verbose", false)),
+      fedCablingToken_(esConsumes<SiStripFedCabling, SiStripFedCablingRcd, edm::Transition::BeginRun>()),
+      detCablingToken_(esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>()) {
   edm::LogInfo("TrackingAnalyser") << "Creating TrackingAnalyser ";
 
   // Get TkMap ParameterSet
@@ -53,7 +52,7 @@ TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
 
   if (!fin) {
     edm::LogError("TrackingAnalyzer") << "Input File: loader.html"
-				      << " could not be opened!" << std::endl;
+                                      << " could not be opened!" << std::endl;
     return;
   }
 
@@ -81,9 +80,7 @@ TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
 //
 // -- Destructor
 //
-TrackingAnalyser::~TrackingAnalyser() {
-  edm::LogInfo("TrackingAnalyser") << "Deleting TrackingAnalyser ";
-}
+TrackingAnalyser::~TrackingAnalyser() { edm::LogInfo("TrackingAnalyser") << "Deleting TrackingAnalyser "; }
 //
 // -- Begin Job
 //
@@ -95,7 +92,7 @@ void TrackingAnalyser::beginRun(edm::Run const& run, edm::EventSetup const& eSet
   edm::LogInfo("TrackingAnalyser") << " Begining of Run";
 
   // Check latest Fed cabling and create TrackerMapCreator
-  if(fedCablingWatcher_.check(eSetup)) { //this should check if cabling record has changed
+  if (fedCablingWatcher_.check(eSetup)) {  //this should check if cabling record has changed
     edm::LogInfo("TrackingAnalyser") << "beginRun: "
                                      << " Change in Cabling, recrated TrackerMap";
     edm::ESHandle<SiStripFedCabling> fedcabHandle = eSetup.getHandle(fedCablingToken_);
@@ -127,7 +124,7 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
 
   if (verbose_)
     edm::LogInfo("TrackingAnalyser") << "[TrackingAnalyser::endLuminosityBlock] globalStatusFilling_ "
-              << (globalStatusFilling_ ? "YES" : "NOPE") << std::endl;
+                                     << (globalStatusFilling_ ? "YES" : "NOPE") << std::endl;
   if (globalStatusFilling_)
     actionExecutor_->createGlobalStatus(ibooker_, igetter_);
 
@@ -136,10 +133,10 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
   checkTrackerFEDsWdataInLS(igetter_, iLS);
   if (verbose_)
     edm::LogInfo("TrackingAnalyser") << "endLuminosityBlock trackerFEDsFound_ " << (trackerFEDsFound_ ? "YES" : "NOPE")
-              << std::endl;
+                                     << std::endl;
   if (verbose_)
     edm::LogInfo("TrackingAnalyser") << "endLuminosityBlock trackerFEDsWdataFound_ "
-              << (trackerFEDsWdataFound_ ? "YES" : "NOPE") << std::endl;
+                                     << (trackerFEDsWdataFound_ ? "YES" : "NOPE") << std::endl;
 
   if (!trackerFEDsFound_) {
     actionExecutor_->fillDummyGlobalStatus();
@@ -160,7 +157,8 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
   if (verbose_)
     edm::LogInfo("TrackingAnalyser") << "====================================================== " << std::endl;
   if (verbose_)
-    edm::LogInfo("TrackingAnalyser") << " ===> Iteration # " << nLumiSecs_ << " " << lumiSeg.luminosityBlock() << std::endl;
+    edm::LogInfo("TrackingAnalyser") << " ===> Iteration # " << nLumiSecs_ << " " << lumiSeg.luminosityBlock()
+                                     << std::endl;
   if (verbose_)
     edm::LogInfo("TrackingAnalyser") << "====================================================== " << std::endl;
 }
@@ -203,8 +201,8 @@ void TrackingAnalyser::checkTrackerFEDsWdataInLS(DQMStore::IGetter& igetter, dou
   double nFEDinLS = 0.;
   MonitorElement* tmpME = igetter.get(nFEDinfoDir_ + "/" + nFEDinWdataVsLSname_);
   if (verbose_)
-    edm::LogInfo("TrackingAnalyser") << "found " << nFEDinfoDir_ << "/" << nFEDinWdataVsLSname_ << " ? " << (tmpME ? "YES" : "NOPE")
-              << std::endl;
+    edm::LogInfo("TrackingAnalyser") << "found " << nFEDinfoDir_ << "/" << nFEDinWdataVsLSname_ << " ? "
+                                     << (tmpME ? "YES" : "NOPE") << std::endl;
   if (tmpME) {
     TProfile* tmpP = tmpME->getTProfile();
     size_t ibin = tmpP->GetXaxis()->FindBin(iLS);

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
@@ -39,7 +39,10 @@
 // -- Constructor
 //
 TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
-    : verbose_(ps.getUntrackedParameter<bool>("verbose", false)) {
+  : verbose_(ps.getUntrackedParameter<bool>("verbose", false)),
+    fedCablingToken_(esConsumes<SiStripFedCabling, SiStripFedCablingRcd, edm::Transition::BeginRun>()),
+    detCablingToken_(esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>())
+{
   if (verbose_)
     std::cout << "[TrackingAnalyser::TrackingAnalyser]" << std::endl;
   // Get TkMap ParameterSet
@@ -101,8 +104,10 @@ void TrackingAnalyser::beginRun(edm::Run const& run, edm::EventSetup const& eSet
     m_cacheID_ = cacheID;
     edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser::beginRun: "
                                      << " Change in Cabling, recrated TrackerMap";
-    eSetup.get<SiStripFedCablingRcd>().get(fedCabling_);
-    eSetup.get<SiStripDetCablingRcd>().get(detCabling_);
+    edm::ESHandle<SiStripFedCabling> fedcabHandle = eSetup.getHandle(fedCablingToken_);
+    fedCabling_ = fedcabHandle.product();
+    edm::ESHandle<SiStripDetCabling> detcabHandle = eSetup.getHandle(detCablingToken_);
+    detCabling_ = detcabHandle.product();
   }
 }
 //

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
@@ -42,7 +42,7 @@ TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
     fedCablingToken_(esConsumes<SiStripFedCabling, SiStripFedCablingRcd, edm::Transition::BeginRun>()),
     detCablingToken_(esConsumes<SiStripDetCabling, SiStripDetCablingRcd, edm::Transition::BeginRun>())
 {
-  edm::LogInfo("TrackingAnalyser") << " TrackingAnalyser::Creating TrackingAnalyser ";
+  edm::LogInfo("TrackingAnalyser") << "Creating TrackingAnalyser ";
 
   // Get TkMap ParameterSet
   //  tkMapPSet_ = ps.getParameter<edm::ParameterSet>("TkmapParameters");
@@ -82,7 +82,7 @@ TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps)
 // -- Destructor
 //
 TrackingAnalyser::~TrackingAnalyser() {
-  edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser::Deleting TrackingAnalyser ";
+  edm::LogInfo("TrackingAnalyser") << "Deleting TrackingAnalyser ";
 }
 //
 // -- Begin Job
@@ -92,19 +92,16 @@ void TrackingAnalyser::beginJob() { nLumiSecs_ = 0; }
 // -- Begin Run
 //
 void TrackingAnalyser::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser:: Begining of Run";
+  edm::LogInfo("TrackingAnalyser") << " Begining of Run";
 
   // Check latest Fed cabling and create TrackerMapCreator
-  //unsigned long long cacheID = eSetup.get<SiStripFedCablingRcd>().cacheIdentifier();
-  //if (m_cacheID_ != cacheID) {
-  //  m_cacheID_ = cacheID;
   if(fedCablingWatcher_.check(eSetup)) { //this should check if cabling record has changed
-    edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser::beginRun: "
+    edm::LogInfo("TrackingAnalyser") << "beginRun: "
                                      << " Change in Cabling, recrated TrackerMap";
     edm::ESHandle<SiStripFedCabling> fedcabHandle = eSetup.getHandle(fedCablingToken_);
-    const SiStripFedCabling* fedCabling_ = fedcabHandle.product();
+    fedCabling_ = fedcabHandle.product();
     edm::ESHandle<SiStripDetCabling> detcabHandle = eSetup.getHandle(detCablingToken_);
-    const SiStripDetCabling *detCabling_ = detcabHandle.product();
+    detCabling_ = detcabHandle.product();
   }
 }
 //
@@ -114,7 +111,7 @@ void TrackingAnalyser::dqmBeginLuminosityBlock(DQMStore::IBooker& ibooker_,
                                                DQMStore::IGetter& igetter_,
                                                edm::LuminosityBlock const& lumiSeg,
                                                edm::EventSetup const& eSetup) {
-  edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser:: Begin of LS transition";
+  edm::LogInfo("TrackingAnalyser") << " Begin of LS transition";
 }
 
 //
@@ -124,7 +121,7 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
                                              DQMStore::IGetter& igetter_,
                                              edm::LuminosityBlock const& lumiSeg,
                                              edm::EventSetup const& eSetup) {
-  edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser:: End of LS transition, performing the DQM client operation";
+  edm::LogInfo("TrackingAnalyser") << " End of LS transition, performing the DQM client operation";
 
   nLumiSecs_++;
 
@@ -138,10 +135,10 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
   checkTrackerFEDsInLS(igetter_, iLS);
   checkTrackerFEDsWdataInLS(igetter_, iLS);
   if (verbose_)
-    edm::LogInfo("TrackingAnalyser") << "[TrackingAnalyser::endLuminosityBlock] trackerFEDsFound_ " << (trackerFEDsFound_ ? "YES" : "NOPE")
+    edm::LogInfo("TrackingAnalyser") << "endLuminosityBlock trackerFEDsFound_ " << (trackerFEDsFound_ ? "YES" : "NOPE")
               << std::endl;
   if (verbose_)
-    edm::LogInfo("TrackingAnalyser") << "[TrackingAnalyser::endLuminosityBlock] trackerFEDsWdataFound_ "
+    edm::LogInfo("TrackingAnalyser") << "endLuminosityBlock trackerFEDsWdataFound_ "
               << (trackerFEDsWdataFound_ ? "YES" : "NOPE") << std::endl;
 
   if (!trackerFEDsFound_) {
@@ -172,7 +169,7 @@ void TrackingAnalyser::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
 // -- End Job
 //
 void TrackingAnalyser::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
-  edm::LogInfo("TrackingAnalyser") << "TrackingAnalyser:: endjob called!";
+  edm::LogInfo("TrackingAnalyser") << " endjob called!";
 
   if (globalStatusFilling_)
     actionExecutor_->createGlobalStatus(ibooker_, igetter_);

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
@@ -74,6 +74,8 @@ private:
   edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCablingToken_;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
   edm::ESWatcher<SiStripFedCablingRcd> fedCablingWatcher_;
+  const SiStripFedCabling* fedCabling_;
+  const SiStripDetCabling* detCabling_;
   TrackingActionExecutor* actionExecutor_;
 
   unsigned long long m_cacheID_;

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
@@ -8,7 +8,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 #include <iostream>
@@ -73,9 +73,7 @@ private:
   edm::ParameterSet tkMapPSet_;
   edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCablingToken_;
   edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
-  const SiStripFedCabling* fedCabling_ = nullptr;
-  const SiStripDetCabling* detCabling_ = nullptr;
-
+  edm::ESWatcher<SiStripFedCablingRcd> fedCablingWatcher_;
   TrackingActionExecutor* actionExecutor_;
 
   unsigned long long m_cacheID_;

--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.h
@@ -21,6 +21,8 @@ class SiStripFedCabling;
 class SiStripDetCabling;
 class TrackingActionExecutor;
 class FEDRawDataCollection;
+class SiStripFedCablingRcd;
+class SiStripDetCablingRcd;
 
 class TrackingAnalyser : public DQMEDHarvester {
 public:
@@ -69,8 +71,11 @@ private:
   std::string outputFileName_;
 
   edm::ParameterSet tkMapPSet_;
-  edm::ESHandle<SiStripFedCabling> fedCabling_;
-  edm::ESHandle<SiStripDetCabling> detCabling_;
+  edm::ESGetToken<SiStripFedCabling, SiStripFedCablingRcd> fedCablingToken_;
+  edm::ESGetToken<SiStripDetCabling, SiStripDetCablingRcd> detCablingToken_;
+  const SiStripFedCabling* fedCabling_ = nullptr;
+  const SiStripDetCabling* detCabling_ = nullptr;
+
   TrackingActionExecutor* actionExecutor_;
 
   unsigned long long m_cacheID_;

--- a/DQM/TrackingMonitorClient/plugins/TrackingDQMClientHeavyIons.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingDQMClientHeavyIons.h
@@ -3,9 +3,9 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DQMServices/Core/interface/DQMEDHarvester.h"
+#include "DQMServices/Core/interface/DQMStore.h"
 #include <set>
 #include <string>
-#include "DQMServices/Core/interface/DQMStore.h"
 #include <vector>
 #include <TH1.h>
 #include <TEfficiency.h>

--- a/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
@@ -89,7 +89,7 @@ void TrackingOfflineDQM::beginJob() { edm::LogInfo("BeginJobDone") << "TrackingO
 *  Event Setup object with Geometry, Magnetic Field, etc.
 */
 void TrackingOfflineDQM::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  edm::LogInfo("BeginRun") << "TrackingOfflineDQM:: Begining of Run";
+  edm::LogInfo("BeginRun") << " Begining of Run";
 
   int nFEDs = 0;
   int nPixelFEDs = 0;
@@ -128,7 +128,7 @@ void TrackingOfflineDQM::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
                                                DQMStore::IGetter& igetter_,
                                                edm::LuminosityBlock const& lumiSeg,
                                                edm::EventSetup const& iSetup) {
-  edm::LogInfo("TrackingOfflineDQM") << "TrackingOfflineDQM::dqmBeginLuminosityBlock";
+  edm::LogInfo("TrackingOfflineDQM") << "dqmBeginLuminosityBlock";
 
   if (globalStatusFilling_ > 0) {
     actionExecutor_->createLSStatus(ibooker_, igetter_);
@@ -146,7 +146,7 @@ void TrackingOfflineDQM::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker_,
  *
 */
 void TrackingOfflineDQM::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
-  edm::LogInfo("TrackingOfflineDQM") << "TrackingOfflineDQM::dqmEndJob";
+  edm::LogInfo("TrackingOfflineDQM") << "dqmEndJob";
 
   if (globalStatusFilling_ > 0) {
     actionExecutor_->createGlobalStatus(ibooker_, igetter_);

--- a/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.cc
@@ -53,10 +53,8 @@
 * @param roPARAMETER_SET 
 *   Regular Parameter Set that represent read configuration file
 */
-TrackingOfflineDQM::TrackingOfflineDQM(edm::ParameterSet const& pSet):
-          configPar_(pSet),
-	  runInfoToken_(esConsumes<RunInfo, RunInfoRcd, edm::Transition::BeginRun>())
- {
+TrackingOfflineDQM::TrackingOfflineDQM(edm::ParameterSet const& pSet)
+    : configPar_(pSet), runInfoToken_(esConsumes<RunInfo, RunInfoRcd, edm::Transition::BeginRun>()) {
   // Action Executor
   actionExecutor_ = new TrackingActionExecutor(pSet);
 
@@ -96,7 +94,7 @@ void TrackingOfflineDQM::beginRun(edm::Run const& run, edm::EventSetup const& eS
   edm::ESHandle<RunInfo> runInfoRec = eSetup.getHandle(runInfoToken_);
   if (runInfoRec.isValid()) {
     sumFED_ = runInfoRec.product();
-    if (sumFED_!=nullptr) {
+    if (sumFED_ != nullptr) {
       const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
       const int siStripFedIdMax = FEDNumbering::MAXSiStripFEDID;
       const int siPixelFedIdMin = FEDNumbering::MINSiPixelFEDID;

--- a/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.h
@@ -38,6 +38,8 @@
 
 class TrackingActionExecutor;
 class SiStripDetCabling;
+class RunInfo;
+class RunInfoRcd;
 
 class TrackingOfflineDQM : public DQMEDHarvester {
 public:
@@ -67,7 +69,6 @@ private:
   bool openInputFile();
 
   TrackingActionExecutor* actionExecutor_;
-
   std::string inputFileName_;
   std::string outputFileName_;
   int globalStatusFilling_;
@@ -76,5 +77,7 @@ private:
   bool allpixelFEDsFound_;
 
   edm::ParameterSet configPar_;
+  edm::ESGetToken <RunInfo, RunInfoRcd> runInfoToken_;
+  const RunInfo* sumFED_ = nullptr;
 };
 #endif

--- a/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.h
+++ b/DQM/TrackingMonitorClient/plugins/TrackingOfflineDQM.h
@@ -77,7 +77,7 @@ private:
   bool allpixelFEDsFound_;
 
   edm::ParameterSet configPar_;
-  edm::ESGetToken <RunInfo, RunInfoRcd> runInfoToken_;
+  edm::ESGetToken<RunInfo, RunInfoRcd> runInfoToken_;
   const RunInfo* sumFED_ = nullptr;
 };
 #endif

--- a/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
@@ -41,8 +41,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
   verbose_ = pSet_.getUntrackedParameter<bool>("verbose", false);
   TopFolderName_ = pSet_.getUntrackedParameter<std::string>("TopFolderName", "Tracking");
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "TopFolderName_: " << TopFolderName_
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "TopFolderName_: " << TopFolderName_ << std::endl;
 
   TrackingMEs tracking_mes;
   // load variables for Global certification
@@ -61,8 +60,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
     tracking_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap"
-                << std::endl;
+      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap" << std::endl;
     TrackingMEsMap.insert(std::pair<std::string, TrackingMEs>(QTname, tracking_mes));
   }
 
@@ -75,8 +73,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
     tracking_ls_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap"
-                << std::endl;
+      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap" << std::endl;
     TrackingLSMEsMap.insert(std::pair<std::string, TrackingLSMEs>(QTname, tracking_ls_mes));
   }
 
@@ -104,7 +101,7 @@ void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup co
   if (m_cacheID_ != cacheID) {
     m_cacheID_ = cacheID;
   }
-  
+
   nFEDConnected_ = 0;
   int nPixelFEDConnected_ = 0;
   const int siStripFedIdMin = FEDNumbering::MINSiStripFEDID;
@@ -116,7 +113,7 @@ void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup co
   edm::ESHandle<RunInfo> runInfoRec = eSetup.getHandle(runInfoToken_);
   if (runInfoRec.isValid()) {
     sumFED_ = runInfoRec.product();
-    if (sumFED_!=nullptr) {
+    if (sumFED_ != nullptr) {
       std::vector<int> FedsInIds = sumFED_->m_fed_in;
       for (auto fedID : FedsInIds) {
         if (fedID >= siPixelFedIdMin && fedID <= siPixelFedIdMax) {
@@ -137,8 +134,9 @@ void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup co
 //
 void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: "
-					      << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: " << trackingCertificationBooked_
+        << std::endl;
 
   if (!trackingCertificationBooked_) {
     ibooker_.cd();
@@ -176,9 +174,8 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
         edm::LogInfo("TrackingCertificationInfo") << "bookStatus meQTname: " << meQTname << std::endl;
       it->second.TrackingFlag = ibooker_.bookFloat("Track" + meQTname);
       if (verbose_)
-        edm::LogInfo("TrackingCertificationInfo") << "bookStatus " 
-						  << it->first << " exists ? " << it->second.TrackingFlag
-						  << std::endl;
+        edm::LogInfo("TrackingCertificationInfo")
+            << "bookStatus " << it->first << " exists ? " << it->second.TrackingFlag << std::endl;
     }
 
     trackingCertificationBooked_ = true;
@@ -186,8 +183,8 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
   }
 
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "bookStatus trackingCertificationBooked_: "
-              << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "bookStatus trackingCertificationBooked_: " << trackingCertificationBooked_ << std::endl;
 }
 
 //
@@ -196,8 +193,9 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
 void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBooker& ibooker_,
                                                                    DQMStore::IGetter& igetter_) {
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: "
-					      << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: " << trackingCertificationBooked_
+        << std::endl;
 
   if (!trackingLSCertificationBooked_) {
     ibooker_.cd();
@@ -223,9 +221,8 @@ void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBo
         edm::LogInfo("TrackingCertificationInfo") << "bookStatus meQTname: " << meQTname << std::endl;
       it->second.TrackingFlag = ibooker_.bookFloat("Track" + meQTname);
       if (verbose_)
-        edm::LogInfo("TrackingCertificationInfo") << "bookStatus " 
-						  << it->first << " exists ? " << it->second.TrackingFlag
-						  << std::endl;
+        edm::LogInfo("TrackingCertificationInfo")
+            << "bookStatus " << it->first << " exists ? " << it->second.TrackingFlag << std::endl;
     }
 
     trackingLSCertificationBooked_ = true;
@@ -233,8 +230,9 @@ void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBo
   }
 
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "[TrackingCertificationInfo::bookStatus] trackingCertificationBooked_: "
-					      << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "[TrackingCertificationInfo::bookStatus] trackingCertificationBooked_: " << trackingCertificationBooked_
+        << std::endl;
 }
 //
 
@@ -259,7 +257,6 @@ void TrackingCertificationInfo::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker
 // -- End of Run
 //
 void TrackingCertificationInfo::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
-  
   edm::LogInfo("TrackingCertificationInfo") << "dqmEndJob" << std::endl;
 
   bookTrackingCertificationMEs(ibooker_, igetter_);
@@ -285,8 +282,8 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
   std::string tracking_dir = "";
   TrackingUtility::getTopFolderPath(ibooker_, igetter_, TopFolderName_, tracking_dir);
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs tracking_dir: " << tracking_dir
-					      << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "fillTrackingCertificationMEs tracking_dir: " << tracking_dir << std::endl;
   std::vector<MonitorElement*> all_mes = igetter_.getContents(tracking_dir + "/EventInfo/reportSummaryContents");
   float fval = 1.0;
 
@@ -305,8 +302,8 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
         it->second.TrackingFlag->Fill(val);
         TH2F* th2d = TrackingCertificationSummaryMap->getTH2F();
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs xbin: " << xbin << " val: " << val
-						    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo")
+              << "fillTrackingCertificationMEs xbin: " << xbin << " val: " << val << std::endl;
         th2d->SetBinContent(xbin + 1, 1, val);
       }
       xbin++;
@@ -328,40 +325,36 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
       for (std::map<std::string, TrackingMEs>::const_iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end();
            it++) {
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs ME: " 
-						    << it->first << " ["
-						    << it->second.TrackingFlag->getFullname() << "] flag: " 
-						    << it->second.TrackingFlag->getFloatValue()
-						    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo")
+              << "fillTrackingCertificationMEs ME: " << it->first << " [" << it->second.TrackingFlag->getFullname()
+              << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
         std::string type = it->first;
         if (name.find(type) != std::string::npos) {
           if (verbose_)
-            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs type: " << type
-						      << " <---> name: " << name << std::endl;
+            edm::LogInfo("TrackingCertificationInfo")
+                << "fillTrackingCertificationMEs type: " << type << " <---> name: " << name << std::endl;
           it->second.TrackingFlag->Fill(val);
           if (verbose_)
-            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs xbin: " 
-						      << xbin << " val: " << val
-						      << std::endl;
+            edm::LogInfo("TrackingCertificationInfo")
+                << "fillTrackingCertificationMEs xbin: " << xbin << " val: " << val << std::endl;
           TH2F* th2d = TrackingCertificationSummaryMap->getTH2F();
           th2d->SetBinContent(xbin + 1, 1, val);
           xbin++;
           break;
         }
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "[TrackingCertificationInfo::fillTrackingCertificationMEs] ME: " 
-						    << it->first << " ["
-						    << it->second.TrackingFlag->getFullname() << "] flag: " 
-						    << it->second.TrackingFlag->getFloatValue()
-						    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo")
+              << "[TrackingCertificationInfo::fillTrackingCertificationMEs] ME: " << it->first << " ["
+              << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
+              << std::endl;
       }
       fval = fminf(fval, val);
     }
   }
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs TrackingCertification: " << fval
-					      << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "fillTrackingCertificationMEs TrackingCertification: " << fval << std::endl;
   TrackingCertification->Fill(fval);
 }
 
@@ -434,8 +427,7 @@ void TrackingCertificationInfo::fillDummyTrackingCertificationAtLumi(DQMStore::I
 void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBooker& ibooker_,
                                                                    DQMStore::IGetter& igetter_) {
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi starting .." 
-					      << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi starting .." << std::endl;
   if (!trackingLSCertificationBooked_) {
     return;
   }
@@ -445,13 +437,12 @@ void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBo
   std::string tracking_dir = "";
   TrackingUtility::getTopFolderPath(ibooker_, igetter_, TopFolderName_, tracking_dir);
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi tracking_dir: " << tracking_dir
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "fillTrackingCertificationMEsAtLumi tracking_dir: " << tracking_dir << std::endl;
 
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi tracking_dir: " 
-					      << tracking_dir
-					      << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "fillTrackingCertificationMEsAtLumi tracking_dir: " << tracking_dir << std::endl;
   std::vector<MonitorElement*> all_mes = igetter_.getContents(tracking_dir + "/EventInfo/reportSummaryContents");
 
   if (verbose_)
@@ -462,42 +453,38 @@ void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBo
     if (!me)
       continue;
     if (verbose_)
-      edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi me: " 
-						<< me->getName() << std::endl;
+      edm::LogInfo("TrackingCertificationInfo")
+          << "fillTrackingCertificationMEsAtLumi me: " << me->getName() << std::endl;
     if (me->kind() == MonitorElement::Kind::REAL) {
       const std::string& name = me->getName();
       float val = me->getFloatValue();
       if (verbose_)
-        edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi val:  " 
-						  << val << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi val:  " << val << std::endl;
 
       for (std::map<std::string, TrackingLSMEs>::const_iterator it = TrackingLSMEsMap.begin();
            it != TrackingLSMEsMap.end();
            it++) {
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi ME: " 
-						    << it->first << " ["
-						    << it->second.TrackingFlag->getFullname() << "] flag: " 
-						    << it->second.TrackingFlag->getFloatValue()
-						    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo")
+              << "fillTrackingCertificationMEsAtLumi ME: " << it->first << " ["
+              << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
+              << std::endl;
 
         std::string type = it->first;
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi type: " 
-						    << type << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi type: " << type << std::endl;
         if (name.find(type) != std::string::npos) {
           if (verbose_)
-            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi type: " << type
-						      << " <---> name: " << name << std::endl;
+            edm::LogInfo("TrackingCertificationInfo")
+                << "fillTrackingCertificationMEsAtLumi type: " << type << " <---> name: " << name << std::endl;
           it->second.TrackingFlag->Fill(val);
           break;
         }
         if (verbose_)
-          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi ME: " 
-						    << it->first << " ["
-						    << it->second.TrackingFlag->getFullname() 
-						    << "] flag: " << it->second.TrackingFlag->getFloatValue()
-						    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo")
+              << "fillTrackingCertificationMEsAtLumi ME: " << it->first << " ["
+              << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
+              << std::endl;
       }
     }
   }
@@ -508,9 +495,8 @@ void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBo
   if (me_dqm && me_dqm->kind() == MonitorElement::Kind::REAL)
     global_dqm_flag = me_dqm->getFloatValue();
   if (verbose_)
-    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi global_dqm_flag: " 
-					      << global_dqm_flag
-					      << std::endl;
+    edm::LogInfo("TrackingCertificationInfo")
+        << "fillTrackingCertificationMEsAtLumi global_dqm_flag: " << global_dqm_flag << std::endl;
 
   TrackingLSCertification->Reset();
   TrackingLSCertification->Fill(global_dqm_flag);

--- a/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
@@ -41,7 +41,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
   verbose_ = pSet_.getUntrackedParameter<bool>("verbose", false);
   TopFolderName_ = pSet_.getUntrackedParameter<std::string>("TopFolderName", "Tracking");
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::TrackingCertificationInfo] TopFolderName_: " << TopFolderName_
+    edm::LogInfo("TrackingCertificationInfo") << "TopFolderName_: " << TopFolderName_
               << std::endl;
 
   TrackingMEs tracking_mes;
@@ -61,7 +61,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
     tracking_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::TrackingCertificationInfo] inserting " << QTname << " in TrackingMEsMap"
+      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap"
                 << std::endl;
     TrackingMEsMap.insert(std::pair<std::string, TrackingMEs>(QTname, tracking_mes));
   }
@@ -75,7 +75,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
     tracking_ls_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::TrackingCertificationInfo] inserting " << QTname << " in TrackingMEsMap"
+      edm::LogInfo("TrackingCertificationInfo") << " inserting " << QTname << " in TrackingMEsMap"
                 << std::endl;
     TrackingLSMEsMap.insert(std::pair<std::string, TrackingLSMEs>(QTname, tracking_ls_mes));
   }
@@ -86,7 +86,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
 }
 
 TrackingCertificationInfo::~TrackingCertificationInfo() {
-  edm::LogInfo("TrackingCertificationInfo") << "TrackingCertificationInfo::Deleting TrackingCertificationInfo ";
+  edm::LogInfo("TrackingCertificationInfo") << "Deleting TrackingCertificationInfo ";
 }
 //
 // -- Begin Job
@@ -96,12 +96,9 @@ void TrackingCertificationInfo::beginJob() {}
 // -- Begin Run
 //
 void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup const& eSetup) {
-  if (verbose_)
-    std::cout << "[TrackingCertificationInfo::beginRun] starting .." << std::endl;
+  edm::LogInfo("TrackingCertificationInfo") << "beginRun starting .." << std::endl;
 
-  edm::LogInfo("TrackingCertificationInfo") << "TrackingCertificationInfo:: Begining of Run";
-  edm::ESHandle<SiStripDetCabling> detcabHandle = eSetup.getHandle(detCablingToken_);
-  detCabling_ = detcabHandle.product();
+  detCabling_ = &(eSetup.getData(detCablingToken_));
 
   unsigned long long cacheID = eSetup.get<SiStripDetCablingRcd>().cacheIdentifier();
   if (m_cacheID_ != cacheID) {
@@ -140,8 +137,8 @@ void TrackingCertificationInfo::beginRun(edm::Run const& run, edm::EventSetup co
 //
 void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::bookTrackingCertificationMEs] starting .. trackingCertificationBooked_: "
-              << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: "
+					      << trackingCertificationBooked_ << std::endl;
 
   if (!trackingCertificationBooked_) {
     ibooker_.cd();
@@ -176,11 +173,12 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
     for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
       std::string meQTname = it->first;
       if (verbose_)
-        std::cout << "[TrackingCertificationInfo::bookStatus] meQTname: " << meQTname << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "bookStatus meQTname: " << meQTname << std::endl;
       it->second.TrackingFlag = ibooker_.bookFloat("Track" + meQTname);
       if (verbose_)
-        std::cout << "[TrackingCertificationInfo::bookStatus] " << it->first << " exists ? " << it->second.TrackingFlag
-                  << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "bookStatus " 
+						  << it->first << " exists ? " << it->second.TrackingFlag
+						  << std::endl;
     }
 
     trackingCertificationBooked_ = true;
@@ -188,7 +186,7 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
   }
 
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::bookStatus] trackingCertificationBooked_: "
+    edm::LogInfo("TrackingCertificationInfo") << "bookStatus trackingCertificationBooked_: "
               << trackingCertificationBooked_ << std::endl;
 }
 
@@ -198,8 +196,8 @@ void TrackingCertificationInfo::bookTrackingCertificationMEs(DQMStore::IBooker& 
 void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBooker& ibooker_,
                                                                    DQMStore::IGetter& igetter_) {
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::bookTrackingCertificationMEs] starting .. trackingCertificationBooked_: "
-              << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "bookTrackingCertificationMEs starting .. trackingCertificationBooked_: "
+					      << trackingCertificationBooked_ << std::endl;
 
   if (!trackingLSCertificationBooked_) {
     ibooker_.cd();
@@ -222,11 +220,12 @@ void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBo
          it++) {
       std::string meQTname = it->first;
       if (verbose_)
-        std::cout << "[TrackingCertificationInfo::bookStatus] meQTname: " << meQTname << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "bookStatus meQTname: " << meQTname << std::endl;
       it->second.TrackingFlag = ibooker_.bookFloat("Track" + meQTname);
       if (verbose_)
-        std::cout << "[TrackingCertificationInfo::bookStatus] " << it->first << " exists ? " << it->second.TrackingFlag
-                  << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "bookStatus " 
+						  << it->first << " exists ? " << it->second.TrackingFlag
+						  << std::endl;
     }
 
     trackingLSCertificationBooked_ = true;
@@ -234,8 +233,8 @@ void TrackingCertificationInfo::bookTrackingCertificationMEsAtLumi(DQMStore::IBo
   }
 
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::bookStatus] trackingCertificationBooked_: "
-              << trackingCertificationBooked_ << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "[TrackingCertificationInfo::bookStatus] trackingCertificationBooked_: "
+					      << trackingCertificationBooked_ << std::endl;
 }
 //
 
@@ -246,7 +245,7 @@ void TrackingCertificationInfo::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker
                                                       DQMStore::IGetter& igetter_,
                                                       edm::LuminosityBlock const& lumiSeg,
                                                       edm::EventSetup const& eSetup) {
-  edm::LogInfo("TrackingDaqInfo") << "TrackingDaqInfo::endLuminosityBlock";
+  edm::LogInfo("TrackingCertificationInfo") << "endLuminosityBlock";
   bookTrackingCertificationMEsAtLumi(ibooker_, igetter_);
   fillDummyTrackingCertificationAtLumi(ibooker_, igetter_);
 
@@ -260,10 +259,9 @@ void TrackingCertificationInfo::dqmEndLuminosityBlock(DQMStore::IBooker& ibooker
 // -- End of Run
 //
 void TrackingCertificationInfo::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
-  if (verbose_)
-    std::cout << "[TrackingCertificationInfo::dqmEndJob]" << std::endl;
+  
+  edm::LogInfo("TrackingCertificationInfo") << "dqmEndJob" << std::endl;
 
-  edm::LogInfo("TrackingCertificationInfo") << "TrackingCertificationInfo:: End Run";
   bookTrackingCertificationMEs(ibooker_, igetter_);
   fillDummyTrackingCertification(ibooker_, igetter_);
 
@@ -272,15 +270,14 @@ void TrackingCertificationInfo::dqmEndJob(DQMStore::IBooker& ibooker_, DQMStore:
   else
     fillDummyTrackingCertification(ibooker_, igetter_);
 
-  if (verbose_)
-    std::cout << "[TrackingCertificationInfo::endRun] DONE" << std::endl;
+  edm::LogInfo("TrackingCertificationInfo") << "[TrackingCertificationInfo::endRun] DONE" << std::endl;
 }
 //
 // --Fill Tracking Certification
 //
 void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& ibooker_, DQMStore::IGetter& igetter_) {
   if (!trackingCertificationBooked_) {
-    //    edm::LogError("TrackingCertificationInfo") << " TrackingCertificationInfo::fillTrackingCertificationMEs : MEs missing ";
+    edm::LogError("TrackingCertificationInfo") << "fillTrackingCertificationMEs : MEs missing " << std::endl;
     return;
   }
 
@@ -288,13 +285,13 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
   std::string tracking_dir = "";
   TrackingUtility::getTopFolderPath(ibooker_, igetter_, TopFolderName_, tracking_dir);
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] tracking_dir: " << tracking_dir
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs tracking_dir: " << tracking_dir
+					      << std::endl;
   std::vector<MonitorElement*> all_mes = igetter_.getContents(tracking_dir + "/EventInfo/reportSummaryContents");
   float fval = 1.0;
 
   if (verbose_)
-    std::cout << "all_mes: " << all_mes.size() << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "all_mes: " << all_mes.size() << std::endl;
 
   if (checkPixelFEDs_) {
     float val = 1.;
@@ -308,8 +305,8 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
         it->second.TrackingFlag->Fill(val);
         TH2F* th2d = TrackingCertificationSummaryMap->getTH2F();
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] xbin: " << xbin << " val: " << val
-                    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs xbin: " << xbin << " val: " << val
+						    << std::endl;
         th2d->SetBinContent(xbin + 1, 1, val);
       }
       xbin++;
@@ -323,7 +320,7 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
     if (!me)
       continue;
     if (verbose_)
-      std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] me: " << me->getName() << std::endl;
+      edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs me: " << me->getName() << std::endl;
     if (me->kind() == MonitorElement::Kind::REAL) {
       const std::string& name = me->getName();
       float val = me->getFloatValue();
@@ -331,35 +328,40 @@ void TrackingCertificationInfo::fillTrackingCertificationMEs(DQMStore::IBooker& 
       for (std::map<std::string, TrackingMEs>::const_iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end();
            it++) {
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] ME: " << it->first << " ["
-                    << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs ME: " 
+						    << it->first << " ["
+						    << it->second.TrackingFlag->getFullname() << "] flag: " 
+						    << it->second.TrackingFlag->getFloatValue()
+						    << std::endl;
 
         std::string type = it->first;
         if (name.find(type) != std::string::npos) {
           if (verbose_)
-            std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] type: " << type
-                      << " <---> name: " << name << std::endl;
+            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs type: " << type
+						      << " <---> name: " << name << std::endl;
           it->second.TrackingFlag->Fill(val);
           if (verbose_)
-            std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] xbin: " << xbin << " val: " << val
-                      << std::endl;
+            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs xbin: " 
+						      << xbin << " val: " << val
+						      << std::endl;
           TH2F* th2d = TrackingCertificationSummaryMap->getTH2F();
           th2d->SetBinContent(xbin + 1, 1, val);
           xbin++;
           break;
         }
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] ME: " << it->first << " ["
-                    << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "[TrackingCertificationInfo::fillTrackingCertificationMEs] ME: " 
+						    << it->first << " ["
+						    << it->second.TrackingFlag->getFullname() << "] flag: " 
+						    << it->second.TrackingFlag->getFloatValue()
+						    << std::endl;
       }
       fval = fminf(fval, val);
     }
   }
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEs] TrackingCertification: " << fval
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEs TrackingCertification: " << fval
+					      << std::endl;
   TrackingCertification->Fill(fval);
 }
 
@@ -432,7 +434,8 @@ void TrackingCertificationInfo::fillDummyTrackingCertificationAtLumi(DQMStore::I
 void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBooker& ibooker_,
                                                                    DQMStore::IGetter& igetter_) {
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] starting .." << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi starting .." 
+					      << std::endl;
   if (!trackingLSCertificationBooked_) {
     return;
   }
@@ -442,51 +445,59 @@ void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBo
   std::string tracking_dir = "";
   TrackingUtility::getTopFolderPath(ibooker_, igetter_, TopFolderName_, tracking_dir);
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] tracking_dir: " << tracking_dir
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi tracking_dir: " << tracking_dir
               << std::endl;
 
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] tracking_dir: " << tracking_dir
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi tracking_dir: " 
+					      << tracking_dir
+					      << std::endl;
   std::vector<MonitorElement*> all_mes = igetter_.getContents(tracking_dir + "/EventInfo/reportSummaryContents");
 
   if (verbose_)
-    std::cout << "all_mes: " << all_mes.size() << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "all_mes: " << all_mes.size() << std::endl;
 
   for (std::vector<MonitorElement*>::const_iterator ime = all_mes.begin(); ime != all_mes.end(); ime++) {
     MonitorElement* me = (*ime);
     if (!me)
       continue;
     if (verbose_)
-      std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] me: " << me->getName() << std::endl;
+      edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi me: " 
+						<< me->getName() << std::endl;
     if (me->kind() == MonitorElement::Kind::REAL) {
       const std::string& name = me->getName();
       float val = me->getFloatValue();
       if (verbose_)
-        std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] val:  " << val << std::endl;
+        edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi val:  " 
+						  << val << std::endl;
 
       for (std::map<std::string, TrackingLSMEs>::const_iterator it = TrackingLSMEsMap.begin();
            it != TrackingLSMEsMap.end();
            it++) {
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] ME: " << it->first << " ["
-                    << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi ME: " 
+						    << it->first << " ["
+						    << it->second.TrackingFlag->getFullname() << "] flag: " 
+						    << it->second.TrackingFlag->getFloatValue()
+						    << std::endl;
 
         std::string type = it->first;
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] type: " << type << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi type: " 
+						    << type << std::endl;
         if (name.find(type) != std::string::npos) {
           if (verbose_)
-            std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] type: " << type
-                      << " <---> name: " << name << std::endl;
+            edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi type: " << type
+						      << " <---> name: " << name << std::endl;
           it->second.TrackingFlag->Fill(val);
           break;
         }
         if (verbose_)
-          std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] ME: " << it->first << " ["
-                    << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                    << std::endl;
+          edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi ME: " 
+						    << it->first << " ["
+						    << it->second.TrackingFlag->getFullname() 
+						    << "] flag: " << it->second.TrackingFlag->getFloatValue()
+						    << std::endl;
       }
     }
   }
@@ -497,8 +508,9 @@ void TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi(DQMStore::IBo
   if (me_dqm && me_dqm->kind() == MonitorElement::Kind::REAL)
     global_dqm_flag = me_dqm->getFloatValue();
   if (verbose_)
-    std::cout << "[TrackingCertificationInfo::fillTrackingCertificationMEsAtLumi] global_dqm_flag: " << global_dqm_flag
-              << std::endl;
+    edm::LogInfo("TrackingCertificationInfo") << "fillTrackingCertificationMEsAtLumi global_dqm_flag: " 
+					      << global_dqm_flag
+					      << std::endl;
 
   TrackingLSCertification->Reset();
   TrackingLSCertification->Fill(global_dqm_flag);

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -33,13 +33,11 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_mes.HistoDir = meQTset.getParameter<std::string>("dir");
     tracking_mes.HistoName = meQTset.getParameter<std::string>("name");
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname
-                                             << " in TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << " inserting " << QTname << " in TrackingMEsMap" << std::endl;
     TrackingMEsMap.insert(std::pair<std::string, TrackingMEs>(QTname, tracking_mes));
   }
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker")
-        << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << " created TrackingMEsMap" << std::endl;
 
   TrackingLSMEs tracking_ls_mes;
   std::vector<edm::ParameterSet> TrackingLSQualityMEs =
@@ -53,13 +51,11 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_ls_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname
-                                             << " in TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << " inserting " << QTname << " in TrackingMEsMap" << std::endl;
     TrackingLSMEsMap.insert(std::pair<std::string, TrackingLSMEs>(QTname, tracking_ls_mes));
   }
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker")
-        << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingLSMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << " created TrackingLSMEsMap" << std::endl;
 }
 //
 // --  Destructor
@@ -298,9 +294,9 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   int ibin = 0;
   for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
-                                             << it->second.TrackingFlag->getFullname()
-                                             << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "fillTrackingStatus ME: " << it->first << " [" << it->second.TrackingFlag->getFullname()
+          << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
     ibin++;
 
@@ -309,8 +305,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker")
-          << "[TrackingQualityChecker::fillTrackingStatus] tmpMEvec: " << tmpMEvec.size() << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus tmpMEvec: " << tmpMEvec.size() << std::endl;
     MonitorElement* me = nullptr;
 
     size_t nMEs = 0;
@@ -325,8 +320,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     }
     // only one ME found
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker")
-          << "[TrackingQualityChecker::fillTrackingStatus] nMEs: " << nMEs << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus nMEs: " << nMEs << std::endl;
     if (nMEs == 1) {
       float status = 0.;
       for (auto ime : tmpMEvec) {
@@ -346,60 +340,54 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
       if (!me)
         continue;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker")
-            << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus status: " << status << std::endl;
       std::vector<QReport*> qt_reports = me->getQReports();
       size_t nQTme = qt_reports.size();
       if (verbose_)
         edm::LogInfo("TrackingQualityChecker") << "nQTme: " << nQTme << std::endl;
       if (nQTme != 0) {
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker")
-              << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
+          edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus qt_reports: " << qt_reports.size() << std::endl;
         // loop on possible QTs
         for (auto iQT : qt_reports) {
           status += iQT->getQTresult();
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker")
-                << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus iQT: " << iQT->getQRName() << std::endl;
           if (verbose_)
             edm::LogInfo("TrackingQualityChecker")
-                << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
-                << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
-                << it->second.TrackingFlag << std::endl;
+                << "fillTrackingStatus MEname: " << MEname << " status: " << iQT->getQTresult() << " exists ? "
+                << (it->second.TrackingFlag ? "yes " : "no ") << it->second.TrackingFlag << std::endl;
           if (verbose_)
             edm::LogInfo("TrackingQualityChecker")
-                << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
+                << "fillTrackingStatus iQT message: " << iQT->getMessage() << std::endl;
           if (verbose_)
             edm::LogInfo("TrackingQualityChecker")
-                << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
+                << "fillTrackingStatus iQT status: " << iQT->getStatus() << std::endl;
         }
         status = status / float(nQTme);
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
-                                                 << " status: " << status << std::endl;
+          edm::LogInfo("TrackingQualityChecker")
+              << "fillTrackingStatus MEname: " << MEname << " status: " << status << std::endl;
         it->second.TrackingFlag->Fill(status);
         if (verbose_)
           edm::LogInfo("TrackingQualityChecker")
-              << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
-              << TrackGlobalSummaryReportMap << std::endl;
+              << "fillTrackingStatus TrackGlobalSummaryReportMap: " << TrackGlobalSummaryReportMap << std::endl;
         fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
       }
 
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus
-                                               << " x status: " << status << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "fillTrackingStatus gstatus: " << gstatus << " x status: " << status << std::endl;
       if (status < 0.)
         gstatus = -1.;
       else
         gstatus += status;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker")
-            << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus ===> gstatus: " << gstatus << std::endl;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first
-                                               << " [" << it->second.TrackingFlag->getFullname()
-                                               << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "fillTrackingStatus ME: " << it->first << " [" << it->second.TrackingFlag->getFullname()
+            << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
     } else {  // more than 1 ME w/ the same root => they need to be considered together
       float status = 1.;
@@ -410,8 +398,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
           me = ime;
 
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker")
-                << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus status: " << status << std::endl;
           std::vector<QReport*> qt_reports = me->getQReports();
           size_t nQTme = qt_reports.size();
           if (verbose_)
@@ -420,24 +407,22 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
           if (nQTme != 0) {
             if (verbose_)
               edm::LogInfo("TrackingQualityChecker")
-                  << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
+                  << "fillTrackingStatus qt_reports: " << qt_reports.size() << std::endl;
             // loop on possible QTs
             for (auto iQT : qt_reports) {
               tmp_status += iQT->getQTresult();
               if (verbose_)
-                edm::LogInfo("TrackingQualityChecker")
-                    << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+                edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus iQT: " << iQT->getQRName() << std::endl;
               if (verbose_)
                 edm::LogInfo("TrackingQualityChecker")
-                    << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
-                    << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
-                    << it->second.TrackingFlag << std::endl;
+                    << "fillTrackingStatus MEname: " << MEname << " status: " << iQT->getQTresult() << " exists ? "
+                    << (it->second.TrackingFlag ? "yes " : "no ") << it->second.TrackingFlag << std::endl;
               if (verbose_)
                 edm::LogInfo("TrackingQualityChecker")
-                    << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
+                    << "fillTrackingStatus iQT message: " << iQT->getMessage() << std::endl;
               if (verbose_)
                 edm::LogInfo("TrackingQualityChecker")
-                    << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
+                    << "fillTrackingStatus iQT status: " << iQT->getStatus() << std::endl;
             }
             tmp_status = tmp_status / float(nQTme);
           }
@@ -450,12 +435,11 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
         gstatus += status;
       if (verbose_)
         edm::LogInfo("TrackingQualityChecker")
-            << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status << std::endl;
+            << "fillTrackingStatus MEname: " << MEname << " status: " << status << std::endl;
       it->second.TrackingFlag->Fill(status);
       if (verbose_)
         edm::LogInfo("TrackingQualityChecker")
-            << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
-            << TrackGlobalSummaryReportMap << std::endl;
+            << "fillTrackingStatus TrackGlobalSummaryReportMap: " << TrackGlobalSummaryReportMap << std::endl;
 
       fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
     }
@@ -474,8 +458,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   }
 
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker")
-        << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus gstatus: " << gstatus << std::endl;
   size_t nQT = TrackingMEsMap.size();
   if (gstatus < 1.)
     gstatus = -1.;
@@ -483,13 +466,12 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     gstatus = gstatus / float(nQT);
 
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker")
-        << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus ===> gstatus: " << gstatus << std::endl;
   TrackGlobalSummaryReportGlobal->Fill(gstatus);
   ibooker.cd();
 
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] DONE" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "fillTrackingStatus DONE" << std::endl;
 }
 
 //

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -33,12 +33,13 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_mes.HistoDir = meQTset.getParameter<std::string>("dir");
     tracking_mes.HistoName = meQTset.getParameter<std::string>("name");
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
-                << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname
+                                             << " in TrackingMEsMap" << std::endl;
     TrackingMEsMap.insert(std::pair<std::string, TrackingMEs>(QTname, tracking_mes));
   }
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingMEsMap" << std::endl;
 
   TrackingLSMEs tracking_ls_mes;
   std::vector<edm::ParameterSet> TrackingLSQualityMEs =
@@ -52,12 +53,13 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_ls_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
-                << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname
+                                             << " in TrackingMEsMap" << std::endl;
     TrackingLSMEsMap.insert(std::pair<std::string, TrackingLSMEs>(QTname, tracking_ls_mes));
   }
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingLSMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingLSMEsMap" << std::endl;
 }
 //
 // --  Destructor
@@ -72,7 +74,7 @@ TrackingQualityChecker::~TrackingQualityChecker() {
 void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] already booked ? "
-              << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
 
   if (!bookedTrackingGlobalStatus_) {
     ibooker.cd();
@@ -107,10 +109,11 @@ void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
       std::string meQTname = it->first;
       it->second.TrackingFlag = ibooker.bookFloat("Track" + meQTname);
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] " << it->first << " exists ? "
-                  << it->second.TrackingFlag << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] " << it->first
+                                               << " exists ? " << it->second.TrackingFlag << std::endl;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::bookGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
     }
 
     bookedTrackingGlobalStatus_ = true;
@@ -121,7 +124,7 @@ void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
 void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] already booked ? "
-              << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
 
   if (!bookedTrackingLSStatus_) {
     ibooker.cd();
@@ -149,10 +152,11 @@ void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::
       std::string meQTname = it->first;
       it->second.TrackingFlag = ibooker.bookFloat("Track" + meQTname);
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] " << it->first << " exists ? " << it->second.TrackingFlag
-                  << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] " << it->first << " exists ? "
+                                               << it->second.TrackingFlag << std::endl;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::bookLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
     }
 
     bookedTrackingLSStatus_ = true;
@@ -165,12 +169,13 @@ void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::
 //
 void TrackingQualityChecker::fillDummyGlobalStatus() {
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] starting ..." << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::fillDummyGlobalStatus] starting ..." << std::endl;
 
   resetGlobalStatus();
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] already booked ? "
-              << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingGlobalStatus_) {
     TrackGlobalSummaryReportGlobal->Fill(-1.0);
 
@@ -181,7 +186,8 @@ void TrackingQualityChecker::fillDummyGlobalStatus() {
     for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++)
       it->second.TrackingFlag->Fill(-1.0);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillDummyGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
   }
 }
 void TrackingQualityChecker::fillDummyLSStatus() {
@@ -191,14 +197,15 @@ void TrackingQualityChecker::fillDummyLSStatus() {
   resetLSStatus();
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyLSStatus] already booked ? "
-              << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingLSStatus_) {
     TrackLSSummaryReportGlobal->Fill(-1.0);
     for (std::map<std::string, TrackingLSMEs>::iterator it = TrackingLSMEsMap.begin(); it != TrackingLSMEsMap.end();
          it++)
       it->second.TrackingFlag->Fill(-1.0);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillDummyLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
   }
 }
 
@@ -208,7 +215,7 @@ void TrackingQualityChecker::fillDummyLSStatus() {
 void TrackingQualityChecker::resetGlobalStatus() {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] already booked ? "
-              << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingGlobalStatus_) {
     TrackGlobalSummaryReportGlobal->Reset();
     TrackGlobalSummaryReportMap->Reset();
@@ -216,30 +223,34 @@ void TrackingQualityChecker::resetGlobalStatus() {
     for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
       MonitorElement* me = it->second.TrackingFlag;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] " << it->second.HistoName << " exist ? "
-                  << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::resetGlobalStatus] " << it->second.HistoName << " exist ? "
+            << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
       me->Reset();
     }
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::resetGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
   }
 }
 void TrackingQualityChecker::resetLSStatus() {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] already booked ? "
-              << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingLSStatus_) {
     TrackLSSummaryReportGlobal->Reset();
     for (std::map<std::string, TrackingLSMEs>::iterator it = TrackingLSMEsMap.begin(); it != TrackingLSMEsMap.end();
          it++) {
       MonitorElement* me = it->second.TrackingFlag;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] " << it->second.HistoLSName << " exist ? "
-                  << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::resetLSStatus] " << it->second.HistoLSName << " exist ? "
+            << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
       me->Reset();
     }
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::resetLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
   }
 }
 
@@ -249,7 +260,7 @@ void TrackingQualityChecker::resetLSStatus() {
 void TrackingQualityChecker::fillGlobalStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillGlobalStatus] already booked ? "
-              << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (!bookedTrackingGlobalStatus_)
     bookGlobalStatus(ibooker, igetter);
 
@@ -263,7 +274,7 @@ void TrackingQualityChecker::fillGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
 void TrackingQualityChecker::fillLSStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
     edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillLSStatus] already booked ? "
-              << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
+                                           << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (!bookedTrackingLSStatus_)
     bookLSStatus(ibooker, igetter);
 
@@ -288,8 +299,8 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
     if (verbose_)
       edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
-                << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                << std::endl;
+                                             << it->second.TrackingFlag->getFullname()
+                                             << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
     ibin++;
 
@@ -298,7 +309,8 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] tmpMEvec: " << tmpMEvec.size() << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillTrackingStatus] tmpMEvec: " << tmpMEvec.size() << std::endl;
     MonitorElement* me = nullptr;
 
     size_t nMEs = 0;
@@ -313,7 +325,8 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     }
     // only one ME found
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] nMEs: " << nMEs << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillTrackingStatus] nMEs: " << nMEs << std::endl;
     if (nMEs == 1) {
       float status = 0.;
       for (auto ime : tmpMEvec) {
@@ -323,61 +336,70 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
         if (name.find(MEname) != std::string::npos) {
           me = ime;
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "inside the loop nQTme: " << me->getQReports().size() << "[" << ime->getFullname() << "]"
-                      << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "inside the loop nQTme: " << me->getQReports().size() << "["
+                                                   << ime->getFullname() << "]" << std::endl;
         }
       }
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "me: " << me << "[" << me->getName() << ", " << me->getFullname() << "]" << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "me: " << me << "[" << me->getName() << ", " << me->getFullname() << "]" << std::endl;
       if (!me)
         continue;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
       std::vector<QReport*> qt_reports = me->getQReports();
       size_t nQTme = qt_reports.size();
       if (verbose_)
         edm::LogInfo("TrackingQualityChecker") << "nQTme: " << nQTme << std::endl;
       if (nQTme != 0) {
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
+          edm::LogInfo("TrackingQualityChecker")
+              << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
         // loop on possible QTs
         for (auto iQT : qt_reports) {
           status += iQT->getQTresult();
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
-                      << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
-                      << it->second.TrackingFlag << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
+                << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
+                << it->second.TrackingFlag << std::endl;
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
         }
         status = status / float(nQTme);
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
-                    << std::endl;
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
+                                                 << " status: " << status << std::endl;
         it->second.TrackingFlag->Fill(status);
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
-                    << TrackGlobalSummaryReportMap << std::endl;
+          edm::LogInfo("TrackingQualityChecker")
+              << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
+              << TrackGlobalSummaryReportMap << std::endl;
         fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
       }
 
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << " x status: " << status
-                  << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus
+                                               << " x status: " << status << std::endl;
       if (status < 0.)
         gstatus = -1.;
       else
         gstatus += status;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
-                  << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                  << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first
+                                               << " [" << it->second.TrackingFlag->getFullname()
+                                               << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
     } else {  // more than 1 ME w/ the same root => they need to be considered together
       float status = 1.;
@@ -388,30 +410,34 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
           me = ime;
 
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
           std::vector<QReport*> qt_reports = me->getQReports();
           size_t nQTme = qt_reports.size();
           if (verbose_)
-            edm::LogInfo("TrackingQualityChecker") << "nQTme: " << nQTme << "[" << name << ", " << ime->getFullname() << "]" << std::endl;
+            edm::LogInfo("TrackingQualityChecker")
+                << "nQTme: " << nQTme << "[" << name << ", " << ime->getFullname() << "]" << std::endl;
           if (nQTme != 0) {
             if (verbose_)
-              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size()
-                        << std::endl;
+              edm::LogInfo("TrackingQualityChecker")
+                  << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
             // loop on possible QTs
             for (auto iQT : qt_reports) {
               tmp_status += iQT->getQTresult();
               if (verbose_)
-                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+                edm::LogInfo("TrackingQualityChecker")
+                    << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
               if (verbose_)
-                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
-                          << " status: " << iQT->getQTresult() << " exists ? "
-                          << (it->second.TrackingFlag ? "yes " : "no ") << it->second.TrackingFlag << std::endl;
+                edm::LogInfo("TrackingQualityChecker")
+                    << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
+                    << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
+                    << it->second.TrackingFlag << std::endl;
               if (verbose_)
-                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage()
-                          << std::endl;
+                edm::LogInfo("TrackingQualityChecker")
+                    << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
               if (verbose_)
-                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus()
-                          << std::endl;
+                edm::LogInfo("TrackingQualityChecker")
+                    << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
             }
             tmp_status = tmp_status / float(nQTme);
           }
@@ -423,12 +449,13 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
       else
         gstatus += status;
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
-                  << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status << std::endl;
       it->second.TrackingFlag->Fill(status);
       if (verbose_)
-        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
-                  << TrackGlobalSummaryReportMap << std::endl;
+        edm::LogInfo("TrackingQualityChecker")
+            << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
+            << TrackGlobalSummaryReportMap << std::endl;
 
       fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
     }
@@ -447,7 +474,8 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   }
 
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;
   size_t nQT = TrackingMEsMap.size();
   if (gstatus < 1.)
     gstatus = -1.;
@@ -455,7 +483,8 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     gstatus = gstatus / float(nQT);
 
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
   TrackGlobalSummaryReportGlobal->Fill(gstatus);
   ibooker.cd();
 
@@ -477,7 +506,8 @@ void TrackingQualityChecker::fillStatusHistogram(MonitorElement* me, int xbin, i
 //
 void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] starting .. " << std::endl;
+    edm::LogInfo("TrackingQualityChecker")
+        << "[TrackingQualityChecker::fillTrackingStatusAtLumi] starting .. " << std::endl;
   float gstatus = 1.0;
 
   ibooker.cd();
@@ -488,9 +518,9 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
   for (std::map<std::string, TrackingLSMEs>::iterator it = TrackingLSMEsMap.begin(); it != TrackingLSMEsMap.end();
        it++) {
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
-                << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first
+                                             << " [" << it->second.TrackingFlag->getFullname()
+                                             << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
 
     ibin++;
 
@@ -503,7 +533,8 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmpMEvec: " << tmpMEvec.size() << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmpMEvec: " << tmpMEvec.size() << std::endl;
 
     MonitorElement* me = nullptr;
 
@@ -529,8 +560,9 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
       if (me->kind() == MonitorElement::Kind::TH1F) {
         float x_mean = me->getMean();
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << " x_mean: " << x_mean
-                    << std::endl;
+          edm::LogInfo("TrackingQualityChecker")
+              << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << " x_mean: " << x_mean
+              << std::endl;
         if (x_mean <= lower_cut || x_mean > upper_cut)
           status = 0.0;
         else
@@ -548,35 +580,40 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
           if (me->kind() == MonitorElement::Kind::TH1F) {
             float x_mean = me->getMean();
             if (verbose_)
-              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << "["
-                        << me->getName() << "]  x_mean: " << x_mean << std::endl;
+              edm::LogInfo("TrackingQualityChecker")
+                  << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << "[" << me->getName()
+                  << "]  x_mean: " << x_mean << std::endl;
             if (x_mean <= lower_cut || x_mean > upper_cut)
               tmp_status = 0.0;
             else
               tmp_status = 1.0;
             if (verbose_)
-              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmp_status: " << tmp_status << std::endl;
+              edm::LogInfo("TrackingQualityChecker")
+                  << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmp_status: " << tmp_status << std::endl;
           }
         }
         status = fminf(tmp_status, status);
         if (verbose_)
-          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ==> status: " << status << std::endl;
+          edm::LogInfo("TrackingQualityChecker")
+              << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ==> status: " << status << std::endl;
       }  // loop on tmpMEvec
     }
     it->second.TrackingFlag->Fill(status);
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> status: " << status << " [" << gstatus
-                << "]" << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> status: " << status << " [" << gstatus << "]"
+          << std::endl;
     if (status == 0.0)
       gstatus = -1.0;
     else
       gstatus = gstatus * status;
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> gstatus: " << gstatus << std::endl;
+      edm::LogInfo("TrackingQualityChecker")
+          << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> gstatus: " << gstatus << std::endl;
     if (verbose_)
-      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
-                << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
-                << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first
+                                             << " [" << it->second.TrackingFlag->getFullname()
+                                             << "] flag: " << it->second.TrackingFlag->getFloatValue() << std::endl;
   }
   TrackLSSummaryReportGlobal->Fill(gstatus);
   ibooker.cd();

--- a/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingQualityChecker.cc
@@ -33,12 +33,12 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_mes.HistoDir = meQTset.getParameter<std::string>("dir");
     tracking_mes.HistoName = meQTset.getParameter<std::string>("name");
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
                 << std::endl;
     TrackingMEsMap.insert(std::pair<std::string, TrackingMEs>(QTname, tracking_mes));
   }
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingMEsMap" << std::endl;
 
   TrackingLSMEs tracking_ls_mes;
   std::vector<edm::ParameterSet> TrackingLSQualityMEs =
@@ -52,12 +52,12 @@ TrackingQualityChecker::TrackingQualityChecker(edm::ParameterSet const& ps)
     tracking_ls_mes.TrackingFlag = nullptr;
 
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] inserting " << QTname << " in TrackingMEsMap"
                 << std::endl;
     TrackingLSMEsMap.insert(std::pair<std::string, TrackingLSMEs>(QTname, tracking_ls_mes));
   }
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingLSMEsMap" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::TrackingQualityChecker] created TrackingLSMEsMap" << std::endl;
 }
 //
 // --  Destructor
@@ -71,7 +71,7 @@ TrackingQualityChecker::~TrackingQualityChecker() {
 //
 void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::bookGlobalStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] already booked ? "
               << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
 
   if (!bookedTrackingGlobalStatus_) {
@@ -91,7 +91,7 @@ void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
 
     size_t nQT = TrackingMEsMap.size();
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::bookGlobalStatus] nQT: " << nQT << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] nQT: " << nQT << std::endl;
     TrackGlobalSummaryReportMap = ibooker.book2D(hname, htitle, nQT, 0.5, float(nQT) + 0.5, 1, 0.5, 1.5);
     TrackGlobalSummaryReportMap->setAxisTitle("Track Quality Type", 1);
     TrackGlobalSummaryReportMap->setAxisTitle("QTest Flag", 2);
@@ -107,10 +107,10 @@ void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
       std::string meQTname = it->first;
       it->second.TrackingFlag = ibooker.bookFloat("Track" + meQTname);
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::bookGlobalStatus] " << it->first << " exists ? "
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] " << it->first << " exists ? "
                   << it->second.TrackingFlag << std::endl;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::bookGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
     }
 
     bookedTrackingGlobalStatus_ = true;
@@ -120,7 +120,7 @@ void TrackingQualityChecker::bookGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
 
 void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::bookLSStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] already booked ? "
               << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
 
   if (!bookedTrackingLSStatus_) {
@@ -140,7 +140,7 @@ void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::
 
     if (verbose_) {
       size_t nQT = TrackingLSMEsMap.size();
-      std::cout << "[TrackingQualityChecker::bookLSStatus] nQT: " << nQT << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] nQT: " << nQT << std::endl;
     }
 
     ibooker.setCurrentFolder(TopFolderName_ + "/EventInfo/reportSummaryContents");
@@ -149,10 +149,10 @@ void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::
       std::string meQTname = it->first;
       it->second.TrackingFlag = ibooker.bookFloat("Track" + meQTname);
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::bookLSStatus] " << it->first << " exists ? " << it->second.TrackingFlag
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] " << it->first << " exists ? " << it->second.TrackingFlag
                   << std::endl;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::bookLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::bookLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
     }
 
     bookedTrackingLSStatus_ = true;
@@ -165,11 +165,11 @@ void TrackingQualityChecker::bookLSStatus(DQMStore::IBooker& ibooker, DQMStore::
 //
 void TrackingQualityChecker::fillDummyGlobalStatus() {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillDummyGlobalStatus] starting ..." << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] starting ..." << std::endl;
 
   resetGlobalStatus();
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillDummyGlobalStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] already booked ? "
               << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingGlobalStatus_) {
     TrackGlobalSummaryReportGlobal->Fill(-1.0);
@@ -181,16 +181,16 @@ void TrackingQualityChecker::fillDummyGlobalStatus() {
     for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++)
       it->second.TrackingFlag->Fill(-1.0);
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillDummyGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
   }
 }
 void TrackingQualityChecker::fillDummyLSStatus() {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillDummyLSStatus] starting ..." << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyLSStatus] starting ..." << std::endl;
 
   resetLSStatus();
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillDummyLSStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyLSStatus] already booked ? "
               << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingLSStatus_) {
     TrackLSSummaryReportGlobal->Fill(-1.0);
@@ -198,7 +198,7 @@ void TrackingQualityChecker::fillDummyLSStatus() {
          it++)
       it->second.TrackingFlag->Fill(-1.0);
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillDummyLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillDummyLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
   }
 }
 
@@ -207,7 +207,7 @@ void TrackingQualityChecker::fillDummyLSStatus() {
 //
 void TrackingQualityChecker::resetGlobalStatus() {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::resetGlobalStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] already booked ? "
               << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingGlobalStatus_) {
     TrackGlobalSummaryReportGlobal->Reset();
@@ -216,17 +216,17 @@ void TrackingQualityChecker::resetGlobalStatus() {
     for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
       MonitorElement* me = it->second.TrackingFlag;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::resetGlobalStatus] " << it->second.HistoName << " exist ? "
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] " << it->second.HistoName << " exist ? "
                   << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
       me->Reset();
     }
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::resetGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetGlobalStatus] DONE w/ TrackingMEsMap" << std::endl;
   }
 }
 void TrackingQualityChecker::resetLSStatus() {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::resetLSStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] already booked ? "
               << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (bookedTrackingLSStatus_) {
     TrackLSSummaryReportGlobal->Reset();
@@ -234,12 +234,12 @@ void TrackingQualityChecker::resetLSStatus() {
          it++) {
       MonitorElement* me = it->second.TrackingFlag;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::resetLSStatus] " << it->second.HistoLSName << " exist ? "
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] " << it->second.HistoLSName << " exist ? "
                   << (it->second.TrackingFlag == nullptr ? "nope" : "yes") << " ---> " << me << std::endl;
       me->Reset();
     }
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::resetLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::resetLSStatus] DONE w/ TrackingLSMEsMap" << std::endl;
   }
 }
 
@@ -248,7 +248,7 @@ void TrackingQualityChecker::resetLSStatus() {
 //
 void TrackingQualityChecker::fillGlobalStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillGlobalStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillGlobalStatus] already booked ? "
               << (bookedTrackingGlobalStatus_ ? "yes" : "nope") << std::endl;
   if (!bookedTrackingGlobalStatus_)
     bookGlobalStatus(ibooker, igetter);
@@ -256,13 +256,13 @@ void TrackingQualityChecker::fillGlobalStatus(DQMStore::IBooker& ibooker, DQMSto
   fillDummyGlobalStatus();
   fillTrackingStatus(ibooker, igetter);
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillGlobalStatus] DONE" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillGlobalStatus] DONE" << std::endl;
   ibooker.cd();
 }
 
 void TrackingQualityChecker::fillLSStatus(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillLSStatus] already booked ? "
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillLSStatus] already booked ? "
               << (bookedTrackingLSStatus_ ? "yes" : "nope") << std::endl;
   if (!bookedTrackingLSStatus_)
     bookLSStatus(ibooker, igetter);
@@ -270,7 +270,7 @@ void TrackingQualityChecker::fillLSStatus(DQMStore::IBooker& ibooker, DQMStore::
   fillDummyLSStatus();
   fillTrackingStatusAtLumi(ibooker, igetter);
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillLSStatus] DONE" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillLSStatus] DONE" << std::endl;
   ibooker.cd();
 }
 
@@ -287,7 +287,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   int ibin = 0;
   for (std::map<std::string, TrackingMEs>::iterator it = TrackingMEsMap.begin(); it != TrackingMEsMap.end(); it++) {
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
                 << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
                 << std::endl;
 
@@ -298,14 +298,14 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatus] tmpMEvec: " << tmpMEvec.size() << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] tmpMEvec: " << tmpMEvec.size() << std::endl;
     MonitorElement* me = nullptr;
 
     size_t nMEs = 0;
     for (auto ime : tmpMEvec) {
       std::string name = ime->getName();
       if (verbose_)
-        std::cout << "name: " << name << " <-- --> " << MEname << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "name: " << name << " <-- --> " << MEname << std::endl;
       if (name.find(MEname) != std::string::npos) {
         me = ime;
         nMEs++;
@@ -313,69 +313,69 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     }
     // only one ME found
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatus] nMEs: " << nMEs << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] nMEs: " << nMEs << std::endl;
     if (nMEs == 1) {
       float status = 0.;
       for (auto ime : tmpMEvec) {
         std::string name = ime->getName();
         if (verbose_)
-          std::cout << "name: " << name << " [" << MEname << "]" << std::endl;
+          edm::LogInfo("TrackingQualityChecker") << "name: " << name << " [" << MEname << "]" << std::endl;
         if (name.find(MEname) != std::string::npos) {
           me = ime;
           if (verbose_)
-            std::cout << "inside the loop nQTme: " << me->getQReports().size() << "[" << ime->getFullname() << "]"
+            edm::LogInfo("TrackingQualityChecker") << "inside the loop nQTme: " << me->getQReports().size() << "[" << ime->getFullname() << "]"
                       << std::endl;
         }
       }
       if (verbose_)
-        std::cout << "me: " << me << "[" << me->getName() << ", " << me->getFullname() << "]" << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "me: " << me << "[" << me->getName() << ", " << me->getFullname() << "]" << std::endl;
       if (!me)
         continue;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
       std::vector<QReport*> qt_reports = me->getQReports();
       size_t nQTme = qt_reports.size();
       if (verbose_)
-        std::cout << "nQTme: " << nQTme << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "nQTme: " << nQTme << std::endl;
       if (nQTme != 0) {
         if (verbose_)
-          std::cout << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size() << std::endl;
         // loop on possible QTs
         for (auto iQT : qt_reports) {
           status += iQT->getQTresult();
           if (verbose_)
-            std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
           if (verbose_)
-            std::cout << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
+            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
                       << " status: " << iQT->getQTresult() << " exists ? " << (it->second.TrackingFlag ? "yes " : "no ")
                       << it->second.TrackingFlag << std::endl;
           if (verbose_)
-            std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage() << std::endl;
           if (verbose_)
-            std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus() << std::endl;
         }
         status = status / float(nQTme);
         if (verbose_)
-          std::cout << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
                     << std::endl;
         it->second.TrackingFlag->Fill(status);
         if (verbose_)
-          std::cout << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
                     << TrackGlobalSummaryReportMap << std::endl;
         fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
       }
 
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << " x status: " << status
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << " x status: " << status
                   << std::endl;
       if (status < 0.)
         gstatus = -1.;
       else
         gstatus += status;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ME: " << it->first << " ["
                   << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
                   << std::endl;
 
@@ -388,29 +388,29 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
           me = ime;
 
           if (verbose_)
-            std::cout << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] status: " << status << std::endl;
           std::vector<QReport*> qt_reports = me->getQReports();
           size_t nQTme = qt_reports.size();
           if (verbose_)
-            std::cout << "nQTme: " << nQTme << "[" << name << ", " << ime->getFullname() << "]" << std::endl;
+            edm::LogInfo("TrackingQualityChecker") << "nQTme: " << nQTme << "[" << name << ", " << ime->getFullname() << "]" << std::endl;
           if (nQTme != 0) {
             if (verbose_)
-              std::cout << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size()
+              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] qt_reports: " << qt_reports.size()
                         << std::endl;
             // loop on possible QTs
             for (auto iQT : qt_reports) {
               tmp_status += iQT->getQTresult();
               if (verbose_)
-                std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
+                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT: " << iQT->getQRName() << std::endl;
               if (verbose_)
-                std::cout << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
+                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname
                           << " status: " << iQT->getQTresult() << " exists ? "
                           << (it->second.TrackingFlag ? "yes " : "no ") << it->second.TrackingFlag << std::endl;
               if (verbose_)
-                std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage()
+                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT message: " << iQT->getMessage()
                           << std::endl;
               if (verbose_)
-                std::cout << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus()
+                edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] iQT status: " << iQT->getStatus()
                           << std::endl;
             }
             tmp_status = tmp_status / float(nQTme);
@@ -423,11 +423,11 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
       else
         gstatus += status;
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] MEname: " << MEname << " status: " << status
                   << std::endl;
       it->second.TrackingFlag->Fill(status);
       if (verbose_)
-        std::cout << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
+        edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] TrackGlobalSummaryReportMap: "
                   << TrackGlobalSummaryReportMap << std::endl;
 
       fillStatusHistogram(TrackGlobalSummaryReportMap, ibin, 1, status);
@@ -447,7 +447,7 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
   }
 
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] gstatus: " << gstatus << std::endl;
   size_t nQT = TrackingMEsMap.size();
   if (gstatus < 1.)
     gstatus = -1.;
@@ -455,12 +455,12 @@ void TrackingQualityChecker::fillTrackingStatus(DQMStore::IBooker& ibooker, DQMS
     gstatus = gstatus / float(nQT);
 
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] ===> gstatus: " << gstatus << std::endl;
   TrackGlobalSummaryReportGlobal->Fill(gstatus);
   ibooker.cd();
 
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillTrackingStatus] DONE" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatus] DONE" << std::endl;
 }
 
 //
@@ -477,7 +477,7 @@ void TrackingQualityChecker::fillStatusHistogram(MonitorElement* me, int xbin, i
 //
 void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker, DQMStore::IGetter& igetter) {
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] starting .. " << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] starting .. " << std::endl;
   float gstatus = 1.0;
 
   ibooker.cd();
@@ -488,7 +488,7 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
   for (std::map<std::string, TrackingLSMEs>::iterator it = TrackingLSMEsMap.begin(); it != TrackingLSMEsMap.end();
        it++) {
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
                 << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
                 << std::endl;
 
@@ -503,7 +503,7 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
 
     std::vector<MonitorElement*> tmpMEvec = igetter.getContents(ibooker.pwd() + "/" + localMEdirpath);
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmpMEvec: " << tmpMEvec.size() << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmpMEvec: " << tmpMEvec.size() << std::endl;
 
     MonitorElement* me = nullptr;
 
@@ -529,7 +529,7 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
       if (me->kind() == MonitorElement::Kind::TH1F) {
         float x_mean = me->getMean();
         if (verbose_)
-          std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << " x_mean: " << x_mean
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << " x_mean: " << x_mean
                     << std::endl;
         if (x_mean <= lower_cut || x_mean > upper_cut)
           status = 0.0;
@@ -548,33 +548,33 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
           if (me->kind() == MonitorElement::Kind::TH1F) {
             float x_mean = me->getMean();
             if (verbose_)
-              std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << "["
+              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] MEname: " << MEname << "["
                         << me->getName() << "]  x_mean: " << x_mean << std::endl;
             if (x_mean <= lower_cut || x_mean > upper_cut)
               tmp_status = 0.0;
             else
               tmp_status = 1.0;
             if (verbose_)
-              std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmp_status: " << tmp_status << std::endl;
+              edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] tmp_status: " << tmp_status << std::endl;
           }
         }
         status = fminf(tmp_status, status);
         if (verbose_)
-          std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ==> status: " << status << std::endl;
+          edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ==> status: " << status << std::endl;
       }  // loop on tmpMEvec
     }
     it->second.TrackingFlag->Fill(status);
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> status: " << status << " [" << gstatus
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> status: " << status << " [" << gstatus
                 << "]" << std::endl;
     if (status == 0.0)
       gstatus = -1.0;
     else
       gstatus = gstatus * status;
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> gstatus: " << gstatus << std::endl;
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ===> gstatus: " << gstatus << std::endl;
     if (verbose_)
-      std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
+      edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] ME: " << it->first << " ["
                 << it->second.TrackingFlag->getFullname() << "] flag: " << it->second.TrackingFlag->getFloatValue()
                 << std::endl;
   }
@@ -582,5 +582,5 @@ void TrackingQualityChecker::fillTrackingStatusAtLumi(DQMStore::IBooker& ibooker
   ibooker.cd();
 
   if (verbose_)
-    std::cout << "[TrackingQualityChecker::fillTrackingStatusAtLumi] DONE" << std::endl;
+    edm::LogInfo("TrackingQualityChecker") << "[TrackingQualityChecker::fillTrackingStatusAtLumi] DONE" << std::endl;
 }

--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -47,15 +47,12 @@ public:
 
 protected:
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
-  void processHit(const TrackingRecHit& recHit,
-                  edm::EventSetup const& iSetup,
-                  double wfac = 1);
-  void processClusters(edm::Event const& iEvent,
-                       edm::EventSetup const& iSetup,
-                       double wfac = 1);
+  void processHit(const TrackingRecHit& recHit, edm::EventSetup const& iSetup, double wfac = 1);
+  void processClusters(edm::Event const& iEvent, edm::EventSetup const& iSetup, double wfac = 1);
   void addClusterToMap(uint32_t detid, const SiStripCluster* cluster);
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
+
 private:
   edm::ParameterSet parameters_;
 
@@ -185,8 +182,7 @@ StandaloneTrackMonitor::StandaloneTrackMonitor(const edm::ParameterSet& ps)
       puScaleFactorFile_(
           parameters_.getUntrackedParameter<std::string>("puScaleFactorFile", "PileupScaleFactor_run203002.root")),
       verbose_(parameters_.getUntrackedParameter<bool>("verbose", false)),
-      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>())
-{
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>()) {
   trackEtaH_ = nullptr;
   trackEtaerrH_ = nullptr;
   trackCosThetaH_ = nullptr;
@@ -660,9 +656,7 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
   // off track cluster properties
   processClusters(iEvent, iSetup, wfac);
 }
-void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent,
-                                             edm::EventSetup const& iSetup,
-					     double wfac) {
+void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent, edm::EventSetup const& iSetup, double wfac) {
   // SiStripClusters
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusterHandle;
   iEvent.getByToken(clusterToken_, clusterHandle);
@@ -703,9 +697,7 @@ void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent,
     edm::LogError("StandaloneTrackMonitor") << "ClusterCollection " << clusterTag_ << " not valid!!" << std::endl;
   }
 }
-void StandaloneTrackMonitor::processHit(const TrackingRecHit& recHit,
-                                        edm::EventSetup const& iSetup,
-					double wfac) {
+void StandaloneTrackMonitor::processHit(const TrackingRecHit& recHit, edm::EventSetup const& iSetup, double wfac) {
   uint32_t detid = recHit.geographicalId();
   const GeomDetUnit* detUnit = tkGeom_->idToDetUnit(detid);
   float thickness = detUnit->surface().bounds().thickness();  // unit cm

--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -49,15 +49,13 @@ protected:
   void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) override;
   void processHit(const TrackingRecHit& recHit,
                   edm::EventSetup const& iSetup,
-                  const TrackerGeometry& tkGeom,
                   double wfac = 1);
   void processClusters(edm::Event const& iEvent,
                        edm::EventSetup const& iSetup,
-                       const TrackerGeometry& tkGeom,
                        double wfac = 1);
   void addClusterToMap(uint32_t detid, const SiStripCluster* cluster);
   void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
-
+  void dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) override;
 private:
   edm::ParameterSet parameters_;
 
@@ -157,6 +155,8 @@ private:
 
   std::vector<float> vpu_;
   std::map<uint32_t, std::set<const SiStripCluster*> > clusterMap_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
+  const TrackerGeometry* tkGeom_ = nullptr;
 };
 
 // -----------------------------
@@ -184,7 +184,9 @@ StandaloneTrackMonitor::StandaloneTrackMonitor(const edm::ParameterSet& ps)
       haveAllHistograms_(parameters_.getUntrackedParameter<bool>("haveAllHistograms", false)),
       puScaleFactorFile_(
           parameters_.getUntrackedParameter<std::string>("puScaleFactorFile", "PileupScaleFactor_run203002.root")),
-      verbose_(parameters_.getUntrackedParameter<bool>("verbose", false)) {
+      verbose_(parameters_.getUntrackedParameter<bool>("verbose", false)),
+      geomToken_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord, edm::Transition::BeginRun>())
+{
   trackEtaH_ = nullptr;
   trackEtaerrH_ = nullptr;
   trackCosThetaH_ = nullptr;
@@ -261,6 +263,11 @@ StandaloneTrackMonitor::StandaloneTrackMonitor(const edm::ParameterSet& ps)
       vpu_.push_back(h1->GetBinContent(i));
     f1->Close();
   }
+}
+
+void StandaloneTrackMonitor::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
+  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
+  tkGeom_ = &(*geomHandle);
 }
 
 void StandaloneTrackMonitor::bookHistograms(DQMStore::IBooker& iBook,
@@ -459,9 +466,6 @@ void StandaloneTrackMonitor::bookHistograms(DQMStore::IBooker& iBook,
 }
 void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
   // Get event setup (to get global transformation)
-  edm::ESHandle<TrackerGeometry> geomHandle;
-  iSetup.get<TrackerDigiGeometryRecord>().get(geomHandle);
-  const TrackerGeometry& tkGeom = (*geomHandle);
 
   siStripClusterInfo_.initEvent(iSetup);
 
@@ -631,7 +635,7 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
               ++nStripTID;
 
             // Find on-track clusters
-            processHit(hit, iSetup, tkGeom, wfac);
+            processHit(hit, iSetup, wfac);
           }
         }
       }
@@ -655,12 +659,11 @@ void StandaloneTrackMonitor::analyze(edm::Event const& iEvent, edm::EventSetup c
     nTracksH_->Fill(ntracks);
 
   // off track cluster properties
-  processClusters(iEvent, iSetup, tkGeom, wfac);
+  processClusters(iEvent, iSetup, wfac);
 }
 void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent,
                                              edm::EventSetup const& iSetup,
-                                             const TrackerGeometry& tkGeom,
-                                             double wfac) {
+					     double wfac) {
   // SiStripClusters
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusterHandle;
   iEvent.getByToken(clusterToken_, clusterHandle);
@@ -686,7 +689,7 @@ void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent,
         float charge = siStripClusterInfo_.charge();
         float width = siStripClusterInfo_.width();
 
-        const GeomDetUnit* detUnit = tkGeom.idToDetUnit(detId);
+        const GeomDetUnit* detUnit = tkGeom_->idToDetUnit(detId);
         float thickness = detUnit->surface().bounds().thickness();  // unit cm
         if (thickness > 0.035) {
           hOffTrkClusChargeThickH_->Fill(charge, wfac);
@@ -703,10 +706,9 @@ void StandaloneTrackMonitor::processClusters(edm::Event const& iEvent,
 }
 void StandaloneTrackMonitor::processHit(const TrackingRecHit& recHit,
                                         edm::EventSetup const& iSetup,
-                                        const TrackerGeometry& tkGeom,
-                                        double wfac) {
+					double wfac) {
   uint32_t detid = recHit.geographicalId();
-  const GeomDetUnit* detUnit = tkGeom.idToDetUnit(detid);
+  const GeomDetUnit* detUnit = tkGeom_->idToDetUnit(detid);
   float thickness = detUnit->surface().bounds().thickness();  // unit cm
 
   auto const& thit = static_cast<BaseTrackerRecHit const&>(recHit);

--- a/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
+++ b/DQM/TrackingMonitorSource/plugins/StandaloneTrackMonitor.cc
@@ -266,8 +266,7 @@ StandaloneTrackMonitor::StandaloneTrackMonitor(const edm::ParameterSet& ps)
 }
 
 void StandaloneTrackMonitor::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
-  edm::ESHandle<TrackerGeometry> geomHandle = iSetup.getHandle(geomToken_);
-  tkGeom_ = &(*geomHandle);
+  tkGeom_ = &(iSetup.getData(geomToken_));
 }
 
 void StandaloneTrackMonitor::bookHistograms(DQMStore::IBooker& iBook,


### PR DESCRIPTION
#### PR description:
This PR addresses the migration of Tracker/Tracking DQM modules to use esConsumes(issue  [#31061](https://github.com/cms-sw/cmssw/issues/31061)). Apart from that, cleanups of headers and replacing cout by LogInfo/LogError were done.

#### PR validation:
Code compiles and checked that wfs - 4.53, 136.7611, 136.8311, 10024, 23234, run.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
NA
