### PR TITLE
Update EDProducer and EDAnalyzer skeletons and edmPythonConfigToCppValidation to show addWithDefaultLabel() in their examples

### DIFF
--- a/FWCore/ParameterSet/scripts/edmPythonConfigToCppValidation
+++ b/FWCore/ParameterSet/scripts/edmPythonConfigToCppValidation
@@ -257,8 +257,8 @@ if len(modulesTypes) > 1:
 moduleType = modulesTypes.pop()
 
 spacing = '  ';
-print('#include <FWCore/ParameterSet/interface/ConfigurationDescriptions.h>')
-print('#include <FWCore/ParameterSet/interface/ParameterSetDescription.h>')
+print('#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"')
+print('#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"')
 print()
 print('void')
 print(moduleType + '::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {')
@@ -273,6 +273,8 @@ for label, module in six.iteritems(modules):
   print(newSpacing + 'edm::ParameterSetDescription desc;')
   printParameterSetDescription(newSpacing, 'desc', module, 0)
   print(newSpacing + 'descriptions.add("' + label + '", desc);')
+  print(newSpacing + '// or use the following to generate the label from the module\'s C++ type')
+  print(newSpacing + '//descriptions.addWithDefaultLabel(desc);')
   if len(modules) > 1:
     print(spacing+'}')
 print('}')

--- a/FWCore/Skeletons/mkTemplates/EDAnalyzer/EDAnalyzer.cc
+++ b/FWCore/Skeletons/mkTemplates/EDAnalyzer/EDAnalyzer.cc
@@ -137,7 +137,7 @@ void __class__::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //To use, remove the default given above and uncomment below
   //ParameterSetDescription desc;
   //desc.addUntracked<edm::InputTag>("tracks","ctfWithMaterialTracks");
-  //descriptions.addDefault(desc);
+  //descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in

--- a/FWCore/Skeletons/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/mkTemplates/EDProducer/EDProducer.cc
@@ -210,7 +210,7 @@ void __class__::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 @example_myparticle  //ParameterSetDescription desc;
 @example_myparticle  //desc.add<edm::InputTag>("muons","muons");
 @example_myparticle  //desc.add<edm::InputTag>("electrons","pixelMatchGsfElectrons");
-@example_myparticle  //descriptions.addDefault(desc);
+@example_myparticle  //descriptions.addWithDefaultLabel(desc);
 }
 
 //define this as a plug-in


### PR DESCRIPTION
#### PR description:

The EDProducer and EDAnalyzer skeletons used `ConfigurationDescriptions::add()` as an example in the `fillDescriptions()`, that leads to `cfi` fragment file to not to be generated. Following a suggestion in #32282 this PR updates the skeletons to show `addWithDefaultLabel()`. This PR updates also `edmPythonConfigToCppValidation` to show `addWithDefaultLabel()` but leaves the decision of whether to use it or not to the caller of the script.

Resolves https://github.com/cms-sw/cmssw/issues/32282.

#### PR validation:

Ran `edmPythonConfigToCppValidation` on one `cfi` file and inspected the output visually.