### PR TITLE
Remove wf 11642.911 from the limited matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -85,7 +85,6 @@ if __name__ == '__main__':
                      10824.0, #2018 ttbar
                      11624.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
-                     11642.911, #2021 DD4hep Zmm
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)
                      23434.999, #2026D49 ttbar premixing stage1+stage2, PU50


### PR DESCRIPTION
#### PR description:

This PR removes temporarily wf `11642.911` from the limited matrix. The other DD4HEP workflow (`11624.911`) will remain in the limited matrix.
As explained in #32283, this workflow was causing a lot of fake differences in the PR comparison test.
The two DD4HEP workflows were added by #32096.
