### PR TITLE
[11.1.X] add RecoLocalTracker_cff to TrackRefitters_cff

### DIFF
--- a/RecoTracker/TrackProducer/python/TrackRefitters_cff.py
+++ b/RecoTracker/TrackProducer/python/TrackRefitters_cff.py
@@ -1,9 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoLocalTracker.Configuration.RecoLocalTracker_cff import *
+
 from RecoTracker.Configuration.RecoTracker_cff import *
 from RecoTracker.Configuration.RecoTrackerP5_cff import *
 from RecoTracker.Configuration.RecoTrackerBHM_cff import *
-
 
 from RecoTracker.TrackProducer.TrackRefitter_cfi import *
 from RecoTracker.TrackProducer.TrackRefitterP5_cfi import *


### PR DESCRIPTION
backport of #32178

#### PR description:

Title says it all. Needed in CMSSW_11_1_X as well, as we have samples for alignment testing purposes produced in this cycle in the scope of the HLT TDR.

#### PR validation:

Described in https://github.com/cms-sw/cmssw/issues/32174#issue-745629042

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Verbatim backport of #32178

