### PR TITLE
MTD simulation: explicit unit conversions

### DIFF
--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -83,6 +83,12 @@ namespace geant_units {
     }
 
     template <class NumType>
+    inline constexpr NumType convertMeVToGeV(NumType mev)  // MeV -> GeV
+    {
+      return (mev * 0.001);
+    }
+
+    template <class NumType>
     inline constexpr NumType convertGeVToMeV(NumType gev)  // GeV -> MeV
     {
       return (gev * 1000.);

--- a/DataFormats/Math/interface/GeantUnits.h
+++ b/DataFormats/Math/interface/GeantUnits.h
@@ -82,6 +82,12 @@ namespace geant_units {
       return (mm3 / 1.e9);
     }
 
+    template <class NumType>
+    inline constexpr NumType convertGeVToMeV(NumType gev)  // GeV -> MeV
+    {
+      return (gev * 1000.);
+    }
+
     // Convert Geant units to desired units
     template <class NumType>
     inline constexpr NumType convertUnitsTo(long double desiredUnits, NumType val) {

--- a/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
@@ -1,4 +1,5 @@
 #include "SimFastTiming/FastTimingCommon/interface/BTLDeviceSim.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
@@ -35,6 +36,8 @@ void BTLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
                                    const edm::Handle<edm::PSimHitContainer>& hits,
                                    mtd_digitizer::MTDSimHitDataAccumulator* simHitAccumulator,
                                    CLHEP::HepRandomEngine* hre) {
+  using namespace geant_units::operators;
+
   //loop over sorted simHits
   for (auto const& hitRef : hitRefs) {
     const int hitidx = std::get<0>(hitRef);
@@ -62,7 +65,7 @@ void BTLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
     const RectangularMTDTopology& topo = static_cast<const RectangularMTDTopology&>(topoproxy.specificTopology());
     // calculate the simhit row and column
     const auto& pentry = hit.entryPoint();
-    Local3DPoint simscaled(0.1 * pentry.x(), 0.1 * pentry.y(), 0.1 * pentry.z());  // mm -> cm here is the switch
+    Local3DPoint simscaled(convertMmToCm(pentry.x()), convertMmToCm(pentry.y()), convertMmToCm(pentry.z()));
     // translate from crystal-local coordinates to module-local coordinates to get the row and column
     simscaled = topo.pixelToModuleLocalPoint(simscaled, btlid.row(topo.nrows()), btlid.column(topo.nrows()));
     const auto& thepixel = topo.pixel(simscaled);
@@ -82,11 +85,11 @@ void BTLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
         simHitAccumulator->emplace(mtd_digitizer::MTDCellId(id, row, col), mtd_digitizer::MTDCellInfo()).first;
 
     // --- Get the simHit energy and convert it from MeV to photo-electrons
-    float Npe = 1000. * hit.energyLoss() * LightYield_ * LightCollEff_ * PDE_;
+    float Npe = convertUnitsTo(0.001_MeV, hit.energyLoss()) * LightYield_ * LightCollEff_ * PDE_;
 
     // --- Calculate the light propagation time to the crystal bases (labeled L and R)
-    double distR = 0.5 * topo.pitch().first - 0.1 * hit.localPosition().x();
-    double distL = 0.5 * topo.pitch().first + 0.1 * hit.localPosition().x();
+    double distR = 0.5 * topo.pitch().first - convertMmToCm(hit.localPosition().x());
+    double distL = 0.5 * topo.pitch().first + convertMmToCm(hit.localPosition().x());
 
     double tR = std::get<2>(hitRef) + LightCollSlopeR_ * distR;
     double tL = std::get<2>(hitRef) + LightCollSlopeL_ * distL;

--- a/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/BTLDeviceSim.cc
@@ -85,7 +85,7 @@ void BTLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
         simHitAccumulator->emplace(mtd_digitizer::MTDCellId(id, row, col), mtd_digitizer::MTDCellInfo()).first;
 
     // --- Get the simHit energy and convert it from MeV to photo-electrons
-    float Npe = convertUnitsTo(0.001_MeV, hit.energyLoss()) * LightYield_ * LightCollEff_ * PDE_;
+    float Npe = convertGeVToMeV(hit.energyLoss()) * LightYield_ * LightCollEff_ * PDE_;
 
     // --- Calculate the light propagation time to the crystal bases (labeled L and R)
     double distR = 0.5 * topo.pitch().first - convertMmToCm(hit.localPosition().x());

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -53,7 +53,7 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
 
     const float toa = std::get<2>(hitRefs[i]) + tofDelay_;
     const PSimHit& hit = hits->at(hitidx);
-    const float charge = convertUnitsTo(0.001_MeV, hit.energyLoss()) * MIPPerMeV_;
+    const float charge = convertGeVToMeV(hit.energyLoss()) * MIPPerMeV_;
 
     // calculate the simhit row and column
     const auto& pentry = hit.entryPoint();

--- a/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
+++ b/SimFastTiming/FastTimingCommon/src/ETLDeviceSim.cc
@@ -1,5 +1,6 @@
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
 #include "SimFastTiming/FastTimingCommon/interface/ETLDeviceSim.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/ForwardDetId/interface/MTDDetId.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
@@ -23,6 +24,8 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
                                    const edm::Handle<edm::PSimHitContainer>& hits,
                                    mtd_digitizer::MTDSimHitDataAccumulator* simHitAccumulator,
                                    CLHEP::HepRandomEngine* hre) {
+  using namespace geant_units::operators;
+
   //loop over sorted hits
   const int nchits = hitRefs.size();
   for (int i = 0; i < nchits; ++i) {
@@ -50,13 +53,13 @@ void ETLDeviceSim::getHitsResponse(const std::vector<std::tuple<int, uint32_t, f
 
     const float toa = std::get<2>(hitRefs[i]) + tofDelay_;
     const PSimHit& hit = hits->at(hitidx);
-    const float charge = 1000.f * hit.energyLoss() * MIPPerMeV_;
+    const float charge = convertUnitsTo(0.001_MeV, hit.energyLoss()) * MIPPerMeV_;
 
     // calculate the simhit row and column
     const auto& pentry = hit.entryPoint();
     // ETL is already in module-local coordinates so just scale to cm from mm
-    Local3DPoint simscaled(0.1 * pentry.x(), 0.1 * pentry.y(), 0.1 * pentry.z());
-    const auto& thepixel = topo.pixel(simscaled);  // mm -> cm here is the switch
+    Local3DPoint simscaled(convertMmToCm(pentry.x()), convertMmToCm(pentry.y()), convertMmToCm(pentry.z()));
+    const auto& thepixel = topo.pixel(simscaled);
     const uint8_t row(thepixel.first), col(thepixel.second);
 
     auto simHitIt =


### PR DESCRIPTION
#### PR description:

This PR makes unit conversions explicit in the MTD simulation code. The code changes have been tested with the WF 33407.0: no differences in hits' energy and position.