### PR TITLE
feat: allow for not sorting during PATJetUpdater call

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.cc
@@ -26,6 +26,7 @@ PATJetUpdater::PATJetUpdater(const edm::ParameterSet& iConfig)
     : useUserData_(iConfig.exists("userData")), printWarning_(iConfig.getParameter<bool>("printWarning")) {
   // initialize configurables
   jetsToken_ = consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jetSource"));
+  sort_ = iConfig.getParameter<bool>("sort");
   addJetCorrFactors_ = iConfig.getParameter<bool>("addJetCorrFactors");
   if (addJetCorrFactors_) {
     jetCorrFactorsTokens_ = edm::vector_transform(
@@ -216,7 +217,9 @@ void PATJetUpdater::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
 
   // sort jets in pt
-  std::sort(patJets->begin(), patJets->end(), pTComparator_);
+  if (sort_) {
+    std::sort(patJets->begin(), patJets->end(), pTComparator_);
+  }
 
   // put genEvt  in Event
   iEvent.put(std::move(patJets));
@@ -231,6 +234,9 @@ void PATJetUpdater::fillDescriptions(edm::ConfigurationDescriptions& description
 
   // input source
   iDesc.add<edm::InputTag>("jetSource", edm::InputTag("no default"))->setComment("input collection");
+
+  // sort inputs (by pt)
+  iDesc.add<bool>("sort", true);
 
   // tag info
   iDesc.add<bool>("addTagInfos", true);

--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
@@ -42,6 +42,7 @@ namespace pat {
   private:
     // configurables
     edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
+    bool sort_;
     bool addJetCorrFactors_;
     std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
 

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetUpdater_cfi.py
@@ -25,6 +25,8 @@ updatedPatJets = cms.EDProducer("PATJetUpdater",
       userFunctions = cms.vstring(),
       userFunctionLabels = cms.vstring()
     ),
+    # sort
+    sort                 = cms.bool(True),
     # jet energy corrections
     addJetCorrFactors    = cms.bool(True),
     jetCorrFactorsSource = cms.VInputTag(cms.InputTag("updatedPatJetCorrFactors") ),


### PR DESCRIPTION
Allow for running `updateJetCollection` without resorting the jets. This is to be used when i.e. updating subjet btag discriminators, but they are already ordered/matched to FatJets.

Does not modify the default behaviour.

@alefisico 