### PR TITLE
migrate Alignment/TrackerAlignment to use esConsumes

### DIFF
--- a/Alignment/OfflineValidation/plugins/ResidualRefitting.cc
+++ b/Alignment/OfflineValidation/plugins/ResidualRefitting.cc
@@ -38,7 +38,7 @@ ResidualRefitting::ResidualRefitting(const edm::ParameterSet& cfg)
     : magFieldToken_(esConsumes()),
       topoToken_(esConsumes()),
       trackingGeometryToken_(esConsumes()),
-      propagatorToken_(esConsumes(edm::ESInputTag(cfg.getParameter<std::string>("propagator")))),
+      propagatorToken_(esConsumes(edm::ESInputTag("", cfg.getParameter<std::string>("propagator")))),
       outputFileName_(cfg.getUntrackedParameter<std::string>("histoutputFile")),
       muons_(cfg.getParameter<edm::InputTag>("muons")),
       muonsRemake_(cfg.getParameter<edm::InputTag>("muonsRemake")),  //This Feels Misalignment

--- a/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaOverlapTagger.cc
@@ -2,7 +2,6 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -35,6 +34,7 @@ public:
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
   edm::InputTag src_;
   edm::InputTag srcClust_;
   bool rejectBadMods_;
@@ -44,7 +44,8 @@ private:
 };
 
 TkAlCaOverlapTagger::TkAlCaOverlapTagger(const edm::ParameterSet& iConfig)
-    : src_(iConfig.getParameter<edm::InputTag>("src")),
+    : topoToken_(esConsumes()),
+      src_(iConfig.getParameter<edm::InputTag>("src")),
       srcClust_(iConfig.getParameter<edm::InputTag>("Clustersrc")),
       rejectBadMods_(iConfig.getParameter<bool>("rejectBadMods")),
       BadModsList_(iConfig.getParameter<std::vector<uint32_t> >("BadMods")) {
@@ -55,9 +56,7 @@ TkAlCaOverlapTagger::~TkAlCaOverlapTagger() {}
 
 void TkAlCaOverlapTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* tTopo = &iSetup.getData(topoToken_);
 
   edm::Handle<TrajTrackAssociationCollection> assoMap;
   iEvent.getByLabel(src_, assoMap);

--- a/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.h
+++ b/Alignment/TrackerAlignment/plugins/TrackerSystematicMisalignments.h
@@ -37,6 +37,12 @@ private:
   //align::GlobalVector findSystematicMis( align::PositionType );
   align::GlobalVector findSystematicMis(const align::PositionType&, const bool blindToZ, const bool blindToR);
 
+  const edm::ESGetToken<GeometricDet, IdealGeometryRecord> geomDetToken_;
+  const edm::ESGetToken<PTrackerParameters, PTrackerParametersRcd> ptpToken_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<Alignments, TrackerAlignmentRcd> aliToken_;
+  const edm::ESGetToken<AlignmentErrorsExtended, TrackerAlignmentErrorExtendedRcd> aliErrorToken_;
+  const edm::ESGetToken<Alignments, GlobalPositionRcd> gprToken_;
   AlignableTracker* theAlignableTracker;
 
   // configurables needed for the systematic misalignment


### PR DESCRIPTION
#### PR description:

The purpose of this PR is to modernize the `Alignment/TrackerAlignment` subsystem, points addressed are:
   * `esConsumes` migration: part of #31061
   * correct one mistake accidentally introduced in https://github.com/cms-sw/cmssw/pull/32005 

#### PR validation:

Branch compiles and run the unit tests successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is not a backport and no backport is needed.

### CAVEAT 
There is a known potential merge conflict with PR  https://github.com/cms-sw/cmssw/pull/32278, once that's merged I will rebase mine. 
