### PR TITLE
Fix reflection in tower mapping in Integrity error plots

### DIFF
--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -730,7 +730,9 @@ namespace ecaldqm {
           case kSM:
           case kEBSM:
             xbin = (towerid - 1) / 4 + 1;
-            ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+	    //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
+	    //whereas using iphi it flips for EB- and EB+ 
+            ybin = (towerid - 1) % 4 + 1;
             nbinsX = 17;
             break;
           default:

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -730,8 +730,8 @@ namespace ecaldqm {
           case kSM:
           case kEBSM:
             xbin = (towerid - 1) / 4 + 1;
-	    //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
-	    //whereas using iphi it flips for EB- and EB+ 
+            //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
+            //whereas using iphi it flips for EB- and EB+
             ybin = (towerid - 1) % 4 + 1;
             nbinsX = 17;
             break;


### PR DESCRIPTION
#### PR description:

An issue with the Integrity quality summary plot was presented here [1], where the problematic tower mappings were "reflected" relative to the FE Status plot which showed the correct mapping. 
The following plots were affected with this issue:
1) Integrity Quality Summary, EB+ side only [2]
2) Integrity Quality by SM, all EB+ plots [3] 
3) Integrity Error Occupancy maps by SM, all EB+ plots, tower-level integrity errors only: TTIdErrors [4], BlockSizeErrors (empty for this run) [5]

The error appears to be with a wrong binning set up for the filling of the histogram which is done here [6], where it was assumed that for EB+ supermodules there will be a reflection or flip of the tower y binning, when in fact it remains the same as for EB-. The flip only happens when using iphi coordinates to define the y binning, not the tower id which has been used in this case.

We have fixed this by removing the separate condition for EB+, and making it the same as for EB-. 

#### PR validation:
We redid the plots with an offline ecal dqm workflow on 2018 runs (T0 turned off for offending run) by introducing integrity errors on EB+. Using a test GUI we found that it now shows the correct tower positions. We also made sure that if the error happened on EB- this still gave the correct tower mapping, and no other plots were affected. 

#### A backport of this PR is submitted to CMSSW_11_2_X here: #32334 

[1] http://cmsonline.cern.ch/cms-elog/1112563
[2] https://cmsweb.cern.ch/dqm/online/start?runnr=338628;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Ecal;size=M;root=Ecal/Layouts/01%20Raw%20Data;focus=EcalBarrel/EBSummaryClient/EBIT%20integrity%20quality%20summary;zoom=yes;
[3] https://cmsweb.cern.ch/dqm/online/start?runnr=338628;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Ecal;size=M;root=Ecal/Layouts/01%20Raw%20Data/By%20SuperModule/Integrity%20Quality;focus=;zoom=no;
[4] https://cmsweb.cern.ch/dqm/online/start?runnr=338628;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Ecal;size=M;root=EcalBarrel/EBIntegrityTask/TTId;focus=;zoom=no;
[5] https://cmsweb.cern.ch/dqm/online/start?runnr=338628;dataset=/Global/Online/ALL;sampletype=online_data;filter=all;referencepos=overlay;referenceshow=customise;referencenorm=True;referenceobj1=refobj;referenceobj2=none;referenceobj3=none;referenceobj4=none;search=;striptype=object;stripruns=;stripaxis=run;stripomit=none;workspace=Ecal;size=M;root=EcalBarrel/EBIntegrityTask/TTBlockSize;focus=;zoom=no;
[6] : https://github.com/cms-sw/cmssw/blob/master/DQM/EcalCommon/src/MESetBinningUtils2.cc#L733
