### PR TITLE
[clang] Initialize data member to fix clang errors about explicit deleted def-constructor

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -142,7 +142,7 @@ namespace pat {
         map_[filter].push_back(PathAndFlags(path, pathIndex, lastFilter, l3Filter));
       }
       std::map<std::string, std::vector<PathAndFlags> > map_;
-      const std::vector<PathAndFlags> empty_;
+      const std::vector<PathAndFlags> empty_ = {};
     };
     ModuleLabelToPathAndFlags moduleLabelToPathAndFlags_;
   };


### PR DESCRIPTION
Since we moved to GCC9, the CLANG IBs (for 11.2.X and 11.3.X ) had compilation error [a]. This PR proposes to explicitly initialize the data member.

[a] https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_amd64_gcc900/CMSSW_11_3_CLANG_X_2020-11-26-2300/PhysicsTools/PatAlgos

```
  PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc:45:21: error: call to implicitly-deleted default constructor of 'pat::PATTriggerProducer::ModuleLabelToPathAndFlags'
 PATTriggerProducer::PATTriggerProducer(const ParameterSet& iConfig)
                    ^
PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h:145:39: note: default constructor of 'ModuleLabelToPathAndFlags' is implicitly deleted because field 'empty_' of const-qualified type 'const std::vector<PathAndFlags>' would not be initialized
      const std::vector<PathAndFlags> empty_;

```