### PR TITLE
[HeaderConsistency] set -O2 flag for header checks

### DIFF
--- a/PhysicsTools/PatAlgos/BuildFile.xml
+++ b/PhysicsTools/PatAlgos/BuildFile.xml
@@ -16,6 +16,7 @@
 <use name="PhysicsTools/PatUtils"/>
 <use name="PhysicsTools/TensorFlow"/>
 <use name="clhep"/>
+<flags HEADER_CHECKS="-O2"/>
 <export>
   <lib name="1"/>
 </export>

--- a/PhysicsTools/TensorFlow/BuildFile.xml
+++ b/PhysicsTools/TensorFlow/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="tensorflow-cc"/>
 <use name="FWCore/Utilities"/>
 <use name="FWCore/MessageLogger"/>
+<flags HEADER_CHECKS="-O2"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoTauTag/RecoTau/BuildFile.xml
+++ b/RecoTauTag/RecoTau/BuildFile.xml
@@ -26,6 +26,7 @@
 <use name="RecoLocalCalo/HGCalRecAlgos"/>
 <use name="roottmva"/>
 <use name="PhysicsTools/TensorFlow"/>
+<flags HEADER_CHECKS="-O2"/>
 <export>
   <lib name="1"/>
 </export>


### PR DESCRIPTION
With GCC9 as default compiler , we now see header consistency errors. For some strange reason when header checks are run without optimization flags (`-O2`). In past we had noticed that there were a lot of Internal Compilr Errors (ICE) for header checks when optimization flags are used that is why we have dropped the use of `-O*` for checker checks but now with GCC9 few files failed if optimization flags are not passed. 

This change allows to explicitly pass extra flags to header checks.