### PR TITLE
ParticleLevelProducer: check for leptonic decays of tag particles

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -198,6 +198,22 @@ namespace Rivet {
       _fatjets = apply<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
       _neutrinos = apply<FinalState>(event, "Neutrinos").particlesByPt();
       _met = apply<MissingMomentum>(event, "MET").missingMomentum().p3();
+
+      // check for leptonic decays of tag particles
+      for (auto& jet : _jets) {
+        for (auto& pt : jet.tags()) {
+          for (auto& p : pt.children(isLepton)) {
+            pt.addConstituent(p, false);
+          }
+        }
+      }
+      for (auto& jet : _fatjets) {
+        for (auto& pt : jet.tags()) {
+          for (auto& p : pt.children(isLepton)) {
+            pt.addConstituent(p, false);
+          }
+        }
+      }
     };
 
     // Do nothing here

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -92,7 +92,8 @@ void ParticleLevelProducer::addGenJet(Rivet::Jet jet,
       int iTagMother = iTag;
       for (auto const& d : p.constituents()) {
         ++iTag;
-        tags->push_back(reco::GenParticle(d.charge(), p4(d) * 1e-20, genVertex_, d.pid(), 2, true));
+        int d_status = (d.isStable()) ? 1 : 2;
+        tags->push_back(reco::GenParticle(d.charge(), p4(d) * 1e-20, genVertex_, d.pid(), d_status, true));
         tags->at(iTag).addMother(reco::GenParticleRef(tagsRefHandle, iTagMother));
         tags->at(iTagMother).addDaughter(reco::GenParticleRef(tagsRefHandle, iTag));
         genJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, iTag)));

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -88,6 +88,15 @@ void ParticleLevelProducer::addGenJet(Rivet::Jet jet,
     } else {
       tags->push_back(reco::GenParticle(p.charge(), p4(p) * 1e-20, genVertex_, p.pid(), 2, true));
       genJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, ++iTag)));
+      // Also save lepton+neutrino daughters of tag particles
+      int iTagMother = iTag;
+      for (auto const& d : p.constituents()) {
+        ++iTag;
+        tags->push_back(reco::GenParticle(d.charge(), p4(d) * 1e-20, genVertex_, d.pid(), 2, true));
+        tags->at(iTag).addMother(reco::GenParticleRef(tagsRefHandle, iTagMother));
+        tags->at(iTagMother).addDaughter(reco::GenParticleRef(tagsRefHandle, iTag));
+        genJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, iTag)));
+      }
     }
   }
 

--- a/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
@@ -8,7 +8,7 @@ from TopQuarkAnalysis.TopEventProducers.tqafInputFiles_cff import relValTTbar
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
             #relValTTbar
-            '/store/relval/CMSSW_11_0_0_pre4/RelValProdTTbar/AODSIM/106X_mcRun1_realistic_v3-v1/20000/26A4F099-D3A0-0C47-9E05-408C49CFD404.root'
+            '/store/relval/CMSSW_11_0_0/RelValTTbar_14TeV/GEN-SIM/110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/22BAADDB-EE84-794F-9A5D-812F341D8075.root'
         )
 )
 


### PR DESCRIPTION
#### PR description:

Adds lepton+neutrino daughters of jet tag particles (heavy hadrons) to allow for calculation and correction of semileptonic branching ratios.

#### PR validation:

Output is as expected:
```
root [3] Events->Scan("recoGenParticles_particleLevel_tags_TQAF.obj.m_state.pdgId_")
***********************************
*    Row   * Instance * recoGenPa *
***********************************
*        0 *        0 *       421 *
*        0 *        1 *      -421 *
*        0 *        2 *       521 *
*        0 *        3 *       431 * <-- this one decays leptonically
*        0 *        4 *       -13 * <-- decay product
*        0 *        5 *        14 * <-- decay product
```

Validated by @swertz to recover the Pythia 8 input BRs of B hadrons:
<img src="https://user-images.githubusercontent.com/1311783/100440220-da4a3c00-30a4-11eb-8fec-e36e41890394.png" width=50%/>