### PR TITLE
ParticleLevelProducer: check for leptonic decays of tag particles (106X)

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalysis.h
@@ -205,6 +205,22 @@ namespace Rivet {
         _fatjets   = applyProjection<FastJets>(event, "FatJets").jetsByPt(fatjet_cut);
         _neutrinos = applyProjection<FinalState>(event, "Neutrinos").particlesByPt();
         _met       = applyProjection<MissingMomentum>(event, "MET").missingMomentum().p3();
+
+        // check for leptonic decays of tag particles
+        for (auto& jet : _jets) {
+          for (auto& pt : jet.tags()) {
+            for (auto& p : pt.children(isLepton)) {
+              pt.addConstituent(p, false);
+            }
+          }
+        }
+        for (auto& jet : _fatjets) {
+          for (auto& pt : jet.tags()) {
+            for (auto& p : pt.children(isLepton)) {
+              pt.addConstituent(p, false);
+            }
+          }
+        }
       };
 
       // Do nothing here

--- a/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/ParticleLevelProducer.cc
@@ -91,6 +91,16 @@ void ParticleLevelProducer::addGenJet(Rivet::Jet jet,
     } else {
       tags->push_back(reco::GenParticle(p.charge(), p4(p) * 1e-20, genVertex_, p.pdgId(), 2, true));
       genJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, ++iTag)));
+      // Also save lepton+neutrino daughters of tag particles
+      int iTagMother = iTag;
+      for (auto const& d : p.constituents()) {
+        ++iTag;
+        int d_status = (d.isStable()) ? 1 : 2;
+        tags->push_back(reco::GenParticle(d.charge(), p4(d) * 1e-20, genVertex_, d.pid(), d_status, true));
+        tags->at(iTag).addMother(reco::GenParticleRef(tagsRefHandle, iTagMother));
+        tags->at(iTagMother).addDaughter(reco::GenParticleRef(tagsRefHandle, iTag));
+        genJet.addDaughter(edm::refToPtr(reco::GenParticleRef(tagsRefHandle, iTag)));
+      }
     }
   }
 

--- a/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
+++ b/GeneratorInterface/RivetInterface/test/particleLevel_cfg.py
@@ -6,7 +6,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 from TopQuarkAnalysis.TopEventProducers.tqafInputFiles_cff import relValTTbar
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring(relValTTbar)
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_10_2_0/RelValTTbar_14TeV/GEN-SIM/102X_upgrade2023_realistic_v7_2023D29noPU-v1/10000/3C679F61-298E-E811-AF92-0025905B85A2.root')
 )
 
 ## define maximal number of events to loop over


### PR DESCRIPTION
#### PR description:

Adds lepton+neutrino daughters of jet tag particles (heavy hadrons) to allow for calculation and correction of semileptonic branching ratios.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/32310 for TOP analysis
