### PR TITLE
Store energy fractions of gammas in packedPFCandidates (10_6_X)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -107,6 +107,7 @@ private:
   const bool storeHcalDepthEndcapOnly_;
 
   const bool storeTiming_;
+  const bool storePfGammaEnFr_;
 
   // for debugging
   float calcDxy(float dx, float dy, float phi) const {
@@ -177,11 +178,12 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(
           "pfCandidateTypesForHcalDepth")),
       storeHcalDepthEndcapOnly_(
           iConfig.getParameter<bool>("storeHcalDepthEndcapOnly")),
-      storeTiming_(iConfig.getParameter<bool>("storeTiming")) {
+      storeTiming_(iConfig.getParameter<bool>("storeTiming")),
+      storePfGammaEnFr_(iConfig.getParameter<bool>("storePfGammaEnFractions")) {
   std::vector<edm::InputTag> sv_tags =
       iConfig.getParameter<std::vector<edm::InputTag>>(
           "secondaryVerticesForWhiteList");
-  for (auto itag : sv_tags) {
+  for (const auto &itag : sv_tags) {
     SVWhiteLists_.push_back(consumes<edm::View<reco::Candidate>>(itag));
   }
 
@@ -419,7 +421,7 @@ void pat::PATPackedCandidateProducer::produce(
     if (abs(cand.pdgId()) == 1 || abs(cand.pdgId()) == 130) {
       outPtrP->back().setHcalFraction(cand.hcalEnergy() /
                                       (cand.ecalEnergy() + cand.hcalEnergy()));
-    } else if (cand.charge() && cand.pt() > 0.5) {
+    } else if ((cand.charge() || (storePfGammaEnFr_ && cand.pdgId() == 22)) && cand.pt() > 0.5) {
       outPtrP->back().setHcalFraction(cand.hcalEnergy() /
                                       (cand.ecalEnergy() + cand.hcalEnergy()));
       outPtrP->back().setCaloFraction((cand.hcalEnergy() + cand.ecalEnergy()) /

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -22,7 +22,8 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     covariancePackingSchemas = cms.vint32(8,264,520,776,0),   # more accurate schema +0.6kb/ev
     pfCandidateTypesForHcalDepth = cms.vint32(),
     storeHcalDepthEndcapOnly = cms.bool(False), # switch to store info only for endcap 
-    storeTiming = cms.bool(False)
+    storeTiming = cms.bool(False),
+    storePfGammaEnFractions = cms.bool(False)
 )
 
 from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
@@ -45,5 +46,7 @@ run3_common.toModify(packedPFCandidates,
 )
 
 from Configuration.Eras.Modifier_phase2_timing_cff import phase2_timing
-phase2_timing.toModify(packedPFCandidates, storeTiming = cms.bool(True))
+phase2_timing.toModify(packedPFCandidates, storeTiming = True)
 
+from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
+run2_miniAOD_UL.toModify(packedPFCandidates, storePfGammaEnFractions = True)


### PR DESCRIPTION
#### PR description:

This PR adds energy fractions of PFGammas (PFCandidates with pdgId==22) to packedPFCandidate collection in miniAOD. This completes information needed to build tau quantities based on energy fractions of its constituents. 

The addition is triggered only for UL re-miniAOD by `run2_miniAOD_UL` modifier.

Size increase estimated in the original PR with ttbar sample with PU is as follows:
* total size: +0.14% or +107 bytes/event,
* packedPFCandidates: +0.3%.

This PR is a partial backport of #30571. Changes other than energy fraction of PFGammas contained in the original PR can be a subject of another backport PR to 10_6_X series, but as they are not affecting event content will be postponed for more peaceful time.

#### PR validation:

Tested with standard miniAOD workflow with `run2_miniAOD_UL` modifier.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

It is a partial backport of #30571, needed for UL re-miniAOD production as agreed with XPOG.
