### PR TITLE
Adopt ChargedHadronPFTrackIsolationProducer for PFTICL candidates (backport)

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/ChargedHadronPFTrackIsolationProducer.cc
@@ -59,14 +59,17 @@ void ChargedHadronPFTrackIsolationProducer::produce(edm::StreamID, edm::Event& e
         ((c.rawEcalEnergy() + c.rawHcalEnergy()) > minRawCaloEnergy_)) {
       const reco::PFCandidate::ElementsInBlocks& theElements = c.elementsInBlocks();
       if (theElements.empty())
-        continue;
-      const reco::PFBlockRef blockRef = theElements[0].first;
-      const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
-      // Find the tracks in the block
-      for (auto const& ele : elements) {
-        reco::PFBlockElement::Type type = ele.type();
-        if (type == reco::PFBlockElement::TRACK)
-          nTracks++;
+        nTracks = 1;  // the PFBlockElements is empty for pfTICL charged candidates
+      // because they don't go through PFBlocks machanism. We consider each charged candidate to be well isolated for now.
+      else {
+        const reco::PFBlockRef blockRef = theElements[0].first;
+        const edm::OwnVector<reco::PFBlockElement>& elements = blockRef->elements();
+        // Find the tracks in the block
+        for (auto const& ele : elements) {
+          reco::PFBlockElement::Type type = ele.type();
+          if (type == reco::PFBlockElement::TRACK)
+            nTracks++;
+        }
       }
     }
     values.push_back((nTracks == 1));


### PR DESCRIPTION
#### PR description:

This backport addresses PF to run with recent HGCAL update #31907. More in detail this will allow ChargedHadronPFTrackIsolationProducer to accommodate PF candidates which don't go through the PFBlock mechanism.

#### PR validation:

Tested with matrix test 23234.0 (ttbar 2026 D49) under CMSSW_11_1_5 with #31907 and --customise RecoHGCal/TICL/iterativeTICL_cff.injectTICLintoPF. With this PR, matrix test runs without a crash.

For more validation, see the original PR #32202.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a backport of #32202.

@bendavid @rovere @felicepantaleo @hqucms