### PR TITLE
adjust cp5 cr fragments to compensate P8.240 changes

### DIFF
--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5CR1TuneSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5CR1TuneSettings_cfi.py
@@ -4,7 +4,6 @@ pythia8CP5CR1TuneSettingsBlock = cms.PSet(
     pythia8CP5CR1TuneSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
-	'PDF:pSet=20',
 	'MultipartonInteractions:alphaSvalue=0.118',
 	'MultipartonInteractions:alphaSorder=2',
 	'MultipartonInteractions:bProfile=2',
@@ -28,5 +27,9 @@ pythia8CP5CR1TuneSettingsBlock = cms.PSet(
 	'TimeShower:alphaSorder=2',
 	'TimeShower:alphaSvalue=0.118',
 	'SigmaTotal:zeroAXB=off',
+        'SigmaTotal:mode = 0',
+        'SigmaTotal:sigmaEl = 21.89',
+        'SigmaTotal:sigmaTot = 100.309',
+        'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118',
     )
 )

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5CR2TuneSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5CR2TuneSettings_cfi.py
@@ -4,7 +4,6 @@ pythia8CP5CR2TuneSettingsBlock = cms.PSet(
     pythia8CP5CR2TuneSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
-	'PDF:pSet=20',
 	'MultipartonInteractions:bProfile=2',
 	'MultipartonInteractions:pT0Ref=1.454',
 	'MultipartonInteractions:ecmPow=0.0555',
@@ -22,5 +21,9 @@ pythia8CP5CR2TuneSettingsBlock = cms.PSet(
 	'MultipartonInteractions:alphaSorder=2',
 	'TimeShower:alphaSorder=2',
 	'TimeShower:alphaSvalue=0.118',
+        'SigmaTotal:mode = 0',
+        'SigmaTotal:sigmaEl = 21.89',
+        'SigmaTotal:sigmaTot = 100.309',
+        'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118',
     )
 )


### PR DESCRIPTION
#### PR description:

P8.240 required changes in the CPx tune fragment. these were already done in this PR:
https://github.com/cms-sw/cmssw/commit/51db35e202e3b21fec78852b6793a5b68aebd116#diff-c1a2292179da27b1385f4602a3b7459a8026b7992b84c77241fe3bb284545ee1
but the CR1 and CR2 fragments were not included. Settings now updated to be in sync with the CP5 default. 

#### PR validation:

validation can be found in the talk by Sercan: 
https://indico.cern.ch/event/783789/contributions/3364815/attachments/1822138/2980824/2019_Apr2_Pythia8-240_and_PDF.pdf
no available workflow with this special fragment available 

