### PR TITLE
Adding infra. for L1T object scaling constants from DB -- 11_1_X

### DIFF
--- a/CondCore/HLTPlugins/src/plugin.cc
+++ b/CondCore/HLTPlugins/src/plugin.cc
@@ -6,5 +6,9 @@
 #include "CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h"
 #include "CondFormats/DataRecord/interface/HLTPrescaleTableRcd.h"
 
+#include "CondFormats/HLTObjects/interface/L1TObjScalingConstants.h"
+#include "CondFormats/DataRecord/interface/L1TObjScalingRcd.h"
+
 REGISTER_PLUGIN(AlCaRecoTriggerBitsRcd, AlCaRecoTriggerBits);
 REGISTER_PLUGIN(HLTPrescaleTableRcd, trigger::HLTPrescaleTableCond);
+REGISTER_PLUGIN(L1TObjScalingRcd, L1TObjScalingConstants);

--- a/CondFormats/DataRecord/interface/L1TObjScalingRcd.h
+++ b/CondFormats/DataRecord/interface/L1TObjScalingRcd.h
@@ -1,0 +1,29 @@
+#ifndef L1TObjScalingRcd_L1TObjScalingRcd_h
+#define L1TObjScalingRcd_L1TObjScalingRcd_h
+// -*- C++ -*-
+//
+// Package:     HLTrigger/HLTcore
+// Class  :     L1TObjScalingRcd
+//
+/**\class L1TObjScalingRcd L1TObjScalingRcd.h HLTrigger/HLTcore/interface/L1TObjScalingRcd.h
+
+ Description: Holds scaling constants for L1T objects.
+
+ Usage:
+     Holds constants {A,B,C} such that the pt or Et of a L1T object
+     can be scaled by ptScaled = A + B*pt + C*pt^2.
+     A cut can then be applied on ptScaled.
+     Initial use case is the implementation of the "offline thresholds" 
+     in L1T Phase2 in CMS-TDR-021 described in CMS-TDR-021.
+
+*/
+//
+// Author:      Thiago Tomei
+// Created:     Fri, 04 Sep 2020 17:04:33 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class L1TObjScalingRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TObjScalingRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/L1TObjScalingRcd.cc
+++ b/CondFormats/DataRecord/src/L1TObjScalingRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     HLTrigger/HLTcore
+// Class  :     L1TObjScalingRcd
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Thiago Tomei
+// Created:     Fri, 04 Sep 2020 17:04:33 GMT
+
+#include "CondFormats/DataRecord/interface/L1TObjScalingRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TObjScalingRcd);

--- a/CondFormats/HLTObjects/interface/L1TObjScalingConstants.h
+++ b/CondFormats/HLTObjects/interface/L1TObjScalingConstants.h
@@ -1,0 +1,21 @@
+#ifndef HLTObjects_L1TObjScalingConstants_h
+#define HLTObjects_L1TObjScalingConstants_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+#include <vector>
+
+class L1TObjScalingConstants {
+public:
+  struct Scaling {
+    float m_constant;
+    float m_linear;
+    float m_quadratic;
+    COND_SERIALIZABLE;
+  };
+
+  std::vector<Scaling> m_constants;
+  COND_SERIALIZABLE;
+};
+
+#endif  // HLTObjects_L1TObjScalingConstants_h

--- a/CondFormats/HLTObjects/src/T_EventSetup_L1TObjScalingConstants.cc
+++ b/CondFormats/HLTObjects/src/T_EventSetup_L1TObjScalingConstants.cc
@@ -1,0 +1,6 @@
+// T_EventSetup_L1TObjScalingConstants.cc
+
+#include "CondFormats/HLTObjects/interface/L1TObjScalingConstants.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(L1TObjScalingConstants);

--- a/CondFormats/HLTObjects/src/classes.h
+++ b/CondFormats/HLTObjects/src/classes.h
@@ -1,2 +1,3 @@
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h"
+#include "CondFormats/HLTObjects/interface/L1TObjScalingConstants.h"

--- a/CondFormats/HLTObjects/src/classes_def.xml
+++ b/CondFormats/HLTObjects/src/classes_def.xml
@@ -4,5 +4,8 @@
  <class name="trigger::HLTPrescaleTableCond">
    <field name ="hltPrescaleTable_" mapping ="blob"/>
  </class>
+<class name="L1TObjScalingConstants" class_version="0"/>
+<class name="L1TObjScalingConstants::Scaling"/>
+<class name="std::vector<L1TObjScalingConstants::Scaling>"/>
 </lcgdict>   
 

--- a/CondFormats/HLTObjects/test/testSerializationHLTObjects.cpp
+++ b/CondFormats/HLTObjects/test/testSerializationHLTObjects.cpp
@@ -6,6 +6,8 @@ int main() {
   testSerialization<AlCaRecoTriggerBits>();
   testSerialization<std::pair<const std::string, std::vector<unsigned int>>>();
   //testSerialization<trigger::HLTPrescaleTableCond>(); never serialized in the old DB
-
+  testSerialization<L1TObjScalingConstants>();
+  testSerialization<std::vector<L1TObjScalingConstants>>();
+  testSerialization<std::vector<L1TObjScalingConstants::Scaling>>();
   return 0;
 }


### PR DESCRIPTION
This PR adds initial infrastructure for the L1T-HLT interface for Phase2.
We add a new CondFormat for the L1TObjScalingConstants and a new DataRecord to hold that new format in a DB.

 * We added it to the standard test:
`CondFormats/HLTObjects/test/testSerializationHLTObjects.cpp`

and ran `scram b runtests` with success!

 * We ran `runTheMatrix.py -l limited -i all --ibeos` with success.

This is a backport of #32137 . We need this to have a complete version of the Phase-2 HLT menu in CMSSW_11_1_X .