### PR TITLE
[11.2.X][clang] Initialize data member to fix clang errors 

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -142,7 +142,7 @@ namespace pat {
         map_[filter].push_back(PathAndFlags(path, pathIndex, lastFilter, l3Filter));
       }
       std::map<std::string, std::vector<PathAndFlags> > map_;
-      const std::vector<PathAndFlags> empty_;
+      const std::vector<PathAndFlags> empty_ = {};
     };
     ModuleLabelToPathAndFlags moduleLabelToPathAndFlags_;
   };


### PR DESCRIPTION
backport of #32307 
This is needed in 11.2.X as soon we will move to GCC 9 for 11.2.X and then PR clang compilation will start failing