### PR TITLE
[11.2.X]Remove 11624.911, #2021 DD4hep from short matrix (until it runs reliably)

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -83,7 +83,6 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
-                     11624.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
backport of #32313
This workflow fails for PR tests and blocks the running of comparison job. As suggested in #32313, we propose to remove it unless it runs reliably