### PR TITLE
Implement the fillDescriptions method for RawStreamFileWriterForBU (11.2.x)

### DIFF
--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -1,34 +1,29 @@
-// $Id: RawEventFileWriterForBU.cc,v 1.1.2.6 2013/03/28 14:56:53 aspataru Exp $
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+//#include <boost/filesystem/fstream.hpp>
 
-#include "EventFilter/Utilities/plugins/RawEventFileWriterForBU.h"
+// CMSSW headers
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "EventFilter/Utilities/interface/FileIO.h"
 #include "EventFilter/Utilities/interface/JSONSerializer.h"
-#include "IOPool/Streamer/interface/FRDEventMessage.h"
-#include "IOPool/Streamer/interface/FRDFileHeader.h"
-
+#include "EventFilter/Utilities/plugins/RawEventFileWriterForBU.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Adler32Calculator.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include <iostream>
-#include <sstream>
-#include <cstdio>
-#include <cstdlib>
-#include <cerrno>
-#include <cstring>
-#include <boost/filesystem/fstream.hpp>
+#include "IOPool/Streamer/interface/FRDEventMessage.h"
+#include "IOPool/Streamer/interface/FRDFileHeader.h"
 
 using namespace jsoncollector;
 
 //TODO:get run directory information from DaqDirector
 
 RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps)
-    :  // default to .5ms sleep per event
-      microSleep_(ps.getUntrackedParameter<int>("microSleep", 0)),
-      frdFileVersion_(ps.getUntrackedParameter<unsigned int>("frdFileVersion", 0))
-//debug_(ps.getUntrackedParameter<bool>("debug", False))
-{
+    : microSleep_(ps.getParameter<int>("microSleep")),
+      frdFileVersion_(ps.getParameter<unsigned int>("frdFileVersion")) {
   //per-file JSD and FastMonitor
   rawJsonDef_.setDefaultGroup("legend");
   rawJsonDef_.addLegendItem("NEvents", "integer", DataPointDefinition::SUM);
@@ -307,4 +302,9 @@ void RawEventFileWriterForBU::makeRunPrefix(std::string const& destinationDir) {
   std::stringstream ss;
   ss << "run" << std::setfill('0') << std::setw(6) << run_;
   runPrefix_ = ss.str();
+}
+
+void RawEventFileWriterForBU::extendDescription(edm::ParameterSetDescription& desc) {
+  desc.add<int>("microSleep", 0);
+  desc.add<unsigned int>("frdFileVersion", 0);
 }

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -1,21 +1,22 @@
 #ifndef EVFRAWEVENTFILEWRITERFORBU
 #define EVFRAWEVENTFILEWRITERFORBU
 
-// $Id: RawEventFileWriterForBU.h,v 1.1.2.5 2013/03/28 14:56:53 aspataru Exp $
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "IOPool/Streamer/interface/FRDEventMessage.h"
-
-#include "EventFilter/Utilities/interface/FastMonitor.h"
-
-#include <fstream>
+// C++ headers
 #include <cstdio>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
+#include <fstream>
 #include <memory>
 #include <vector>
+
+// system headers
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+// CMSSW headers
+#include "EventFilter/Utilities/interface/FastMonitor.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "IOPool/Streamer/interface/FRDEventMessage.h"
 
 class RawEventFileWriterForBU {
 public:
@@ -33,6 +34,8 @@ public:
   void endOfLS(int ls);
   bool sharedMode() const { return false; }
   void makeRunPrefix(std::string const& destinationDir);
+
+  static void extendDescription(edm::ParameterSetDescription& desc);
 
 private:
   bool closefd() {

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -1,25 +1,26 @@
-#ifndef IOPool_Streamer_RawEventOutputModuleForBU_h
-#define IOPool_Streamer_RawEventOutputModuleForBU_h
-
-#include "FWCore/Framework/interface/EventForOutput.h"
-#include "FWCore/Framework/interface/one/OutputModule.h"
-#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
-#include "FWCore/Utilities/interface/EDGetToken.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
-#include "DataFormats/FEDRawData/interface/FEDRawData.h"
-#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
-
-#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
-#include "IOPool/Streamer/interface/FRDEventMessage.h"
-#include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
-#include "FWCore/Utilities/interface/Adler32Calculator.h"
-#include "EventFilter/Utilities/interface/crc32c.h"
+#ifndef IOPool_Streamer_interface_RawEventOutputModuleForBU_h
+#define IOPool_Streamer_interface_RawEventOutputModuleForBU_h
 
 #include <memory>
 #include <vector>
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "EventFilter/Utilities/interface/EvFDaqDirector.h"
+#include "EventFilter/Utilities/interface/crc32c.h"
+#include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
+#include "FWCore/Framework/interface/EventForOutput.h"
+#include "FWCore/Framework/interface/LuminosityBlockForOutput.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Adler32Calculator.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "IOPool/Streamer/interface/FRDEventMessage.h"
 
 template <class Consumer>
 class RawEventOutputModuleForBU : public edm::one::OutputModule<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
@@ -35,6 +36,8 @@ public:
   explicit RawEventOutputModuleForBU(edm::ParameterSet const& ps);
   ~RawEventOutputModuleForBU() override;
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
   void write(edm::EventForOutput const& e) override;
   void beginRun(edm::RunForOutput const&) override;
@@ -46,18 +49,16 @@ private:
   void endLuminosityBlock(edm::LuminosityBlockForOutput const&) override;
 
   std::unique_ptr<Consumer> templateConsumer_;
-  std::string label_;
-  std::string instance_;
-  edm::EDGetTokenT<FEDRawDataCollection> token_;
-  unsigned int numEventsPerFile_;
-  unsigned int frdVersion_;
-  unsigned long long totsize;
-  unsigned long long writtensize;
-  unsigned long long writtenSizeLast;
-  unsigned int totevents;
-  unsigned int index_;
+  const edm::EDGetTokenT<FEDRawDataCollection> token_;
+  const unsigned int numEventsPerFile_;
+  const unsigned int frdVersion_;
+  unsigned long long totsize = 0LL;
+  unsigned long long writtensize = 0LL;
+  unsigned long long writtenSizeLast = 0LL;
+  unsigned int totevents = 0;
+  unsigned int index_ = 0;
   timeval startOfLastLumi;
-  bool firstLumi_;
+  bool firstLumi_ = true;
 };
 
 template <class Consumer>
@@ -65,17 +66,9 @@ RawEventOutputModuleForBU<Consumer>::RawEventOutputModuleForBU(edm::ParameterSet
     : edm::one::OutputModuleBase::OutputModuleBase(ps),
       edm::one::OutputModule<edm::one::WatchRuns, edm::one::WatchLuminosityBlocks>(ps),
       templateConsumer_(new Consumer(ps)),
-      label_(ps.getUntrackedParameter<std::string>("ProductLabel", "source")),
-      instance_(ps.getUntrackedParameter<std::string>("ProductInstance", "")),
-      token_(consumes<FEDRawDataCollection>(edm::InputTag(label_, instance_))),
-      numEventsPerFile_(ps.getUntrackedParameter<unsigned int>("numEventsPerFile", 100)),
-      frdVersion_(ps.getUntrackedParameter<unsigned int>("frdVersion", 6)),
-      totsize(0LL),
-      writtensize(0LL),
-      writtenSizeLast(0LL),
-      totevents(0),
-      index_(0),
-      firstLumi_(true) {}
+      token_(consumes<FEDRawDataCollection>(ps.getParameter<edm::InputTag>("source"))),
+      numEventsPerFile_(ps.getParameter<unsigned int>("numEventsPerFile")),
+      frdVersion_(ps.getParameter<unsigned int>("frdVersion")) {}
 
 template <class Consumer>
 RawEventOutputModuleForBU<Consumer>::~RawEventOutputModuleForBU() {}
@@ -205,9 +198,22 @@ void RawEventOutputModuleForBU<Consumer>::beginLuminosityBlock(edm::LuminosityBl
   totsize = 0LL;
   firstLumi_ = false;
 }
+
 template <class Consumer>
 void RawEventOutputModuleForBU<Consumer>::endLuminosityBlock(edm::LuminosityBlockForOutput const& ls) {
   //  templateConsumer_->touchlock(ls.id().luminosityBlock(),basedir);
   templateConsumer_->endOfLS(ls.id().luminosityBlock());
 }
-#endif
+
+template <class Consumer>
+void RawEventOutputModuleForBU<Consumer>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("source", edm::InputTag("rawDataCollector"));
+  desc.add<unsigned int>("numEventsPerFile", 100);
+  desc.add<unsigned int>("frdVersion", 6);
+  Consumer::extendDescription(desc);
+
+  descriptions.addWithDefaultLabel(desc);
+}
+
+#endif  // IOPool_Streamer_interface_RawEventOutputModuleForBU_h

--- a/EventFilter/Utilities/plugins/modules.cc
+++ b/EventFilter/Utilities/plugins/modules.cc
@@ -1,39 +1,36 @@
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
-#include "EventFilter/Utilities/interface/FastMonitoringService.h"
 #include "EventFilter/Utilities/interface/EvFOutputModule.h"
-#include "EventFilter/Utilities/plugins/ExceptionGenerator.h"
+#include "EventFilter/Utilities/interface/FastMonitoringService.h"
+#include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+#include "EventFilter/Utilities/plugins/DaqFakeReader.h"
 #include "EventFilter/Utilities/plugins/EvFBuildingThrottle.h"
 #include "EventFilter/Utilities/plugins/EvFFEDSelector.h"
+#include "EventFilter/Utilities/plugins/ExceptionGenerator.h"
 #include "EventFilter/Utilities/plugins/RawEventFileWriterForBU.h"
-#include "EventFilter/Utilities/plugins/RecoEventWriterForFU.h"
-#include "EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h"
 #include "EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h"
-#include "EventFilter/Utilities/plugins/DaqFakeReader.h"
+#include "EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h"
+#include "EventFilter/Utilities/plugins/RecoEventWriterForFU.h"
 #include "FWCore/Framework/interface/InputSourceMacros.h"
-#include "EventFilter/Utilities/interface/FedRawDataInputSource.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 using namespace edm::serviceregistry;
 using namespace evf;
 
-//typedef edm::serviceregistry::AllArgsMaker<MicroStateService> MicroStateServiceMaker;
 typedef edm::serviceregistry::AllArgsMaker<MicroStateService, FastMonitoringService> FastMonitoringServiceMaker;
+DEFINE_FWK_SERVICE_MAKER(FastMonitoringService, FastMonitoringServiceMaker);
 
 typedef RawEventOutputModuleForBU<RawEventFileWriterForBU> RawStreamFileWriterForBU;
+DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
+
+// legacy name for ConfDB compatibility
 typedef RecoEventOutputModuleForFU<RecoEventWriterForFU> ShmStreamConsumer;
+DEFINE_FWK_MODULE(ShmStreamConsumer);
 
-//legacy name for ConfDB compatibility
-
-//DEFINE_FWK_SERVICE_MAKER(MicroStateService, MicroStateServiceMaker);
-
-DEFINE_FWK_SERVICE_MAKER(FastMonitoringService, FastMonitoringServiceMaker);
 DEFINE_FWK_SERVICE(EvFBuildingThrottle);
 DEFINE_FWK_SERVICE(EvFDaqDirector);
 DEFINE_FWK_MODULE(ExceptionGenerator);
-DEFINE_FWK_MODULE(RawStreamFileWriterForBU);
 DEFINE_FWK_MODULE(EvFFEDSelector);
 DEFINE_FWK_MODULE(EvFOutputModule);
-DEFINE_FWK_MODULE(ShmStreamConsumer);
 DEFINE_FWK_MODULE(DaqFakeReader);
 DEFINE_FWK_INPUT_SOURCE(FedRawDataInputSource);

--- a/EventFilter/Utilities/test/startBU.py
+++ b/EventFilter/Utilities/test/startBU.py
@@ -128,10 +128,10 @@ process.s = cms.EDProducer("DaqFakeReader",
                            )
 
 process.out = cms.OutputModule("RawStreamFileWriterForBU",
-    ProductLabel = cms.untracked.string("s"),
-    numEventsPerFile= cms.untracked.uint32(options.eventsPerFile),
-    frdFileVersion=cms.untracked.uint32(options.frdFileVersion),
-    frdVersion=cms.untracked.uint32(6),
+    source = cms.InputTag("s"),
+    numEventsPerFile = cms.uint32(options.eventsPerFile),
+    frdVersion = cms.uint32(6),
+    frdFileVersion = cms.uint32(options.frdFileVersion)
     )
 
 process.p = cms.Path(process.s+process.a)


### PR DESCRIPTION
#### PR description:

Implement the `fillDescriptions()` method for the `RawStreamFileWriterForBU` module.
Clean up the module's parameters and directly use an `InputTag` in the python configuration.

#### PR validation:

None.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32284