### PR TITLE
Clean some more BuildFiles

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/BuildFile.xml
+++ b/CalibTracker/SiStripLorentzAngle/BuildFile.xml
@@ -1,8 +1,10 @@
+<use name="CalibTracker/Records"/>
 <use name="CommonTools/ConditionDBWriter"/>
 <use name="DataFormats/SiStripDetId"/>
-<use name="root"/>
 <use name="DataFormats/TrackerCommon"/>
 <use name="DQMServices/Core"/>
+<use name="MagneticField/Records"/>
+<use name="root"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CalibTracker/SiStripLorentzAngle/plugins/BuildFile.xml
+++ b/CalibTracker/SiStripLorentzAngle/plugins/BuildFile.xml
@@ -16,9 +16,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiStripObjects"/>
-<use name="CalibTracker/Records"/>
 <use name="CalibTracker/SiStripCommon"/>
-<use name="CalibFormats/SiStripObjects"/>
 <use name="CalibTracker/SiStripLorentzAngle"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
 <use name="MagneticField/Engine"/>

--- a/DQM/SiOuterTracker/plugins/BuildFile.xml
+++ b/DQM/SiOuterTracker/plugins/BuildFile.xml
@@ -3,7 +3,5 @@
 <use name="DataFormats/Common"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="SimDataFormats/TrackingAnalysis"/>
-<use name="SimTracker/TrackTriggerAssociation"/>
 <use name="CommonTools/Statistics"/>
 <flags EDM_PLUGIN="1"/>

--- a/DataFormats/L1THGCal/BuildFile.xml
+++ b/DataFormats/L1THGCal/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Common"/>
-<use name="DataFormats/Candidate"/>
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/DetId"/>
 <use name="DataFormats/ForwardDetId"/>

--- a/L1Trigger/L1THGCal/BuildFile.xml
+++ b/L1Trigger/L1THGCal/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="Geometry/CaloTopology"/>
 <use name="Geometry/Records"/>
 <use name="DataFormats/L1THGCal"/>
-<use name="CommonTools/Utils"/>
 <use name="Geometry/HcalTowerAlgo"/>
 <use name="SimDataFormats/CaloTest"/>
 <export>

--- a/L1Trigger/L1THGCal/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCal/plugins/BuildFile.xml
@@ -1,16 +1,10 @@
 <library name="L1TriggerL1THGCalPlugins" file="*.cc">
-  <use name="Geometry/HGCalGeometry"/>
-  <use name="Geometry/HcalTowerAlgo"/>
-  <use name="Geometry/CaloTopology"/>
   <use name="L1Trigger/L1THGCal"/>
   <use name="Geometry/Records"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 
 <library name="L1TriggerL1THGCalPlugins_geometries" file="geometries/*.cc">
-  <use name="Geometry/HGCalGeometry"/>
-  <use name="Geometry/HcalTowerAlgo"/>
-  <use name="Geometry/CaloTopology"/>
   <use name="L1Trigger/L1THGCal"/>
   <use name="tbb"/>
   <flags EDM_PLUGIN="1"/>
@@ -18,13 +12,9 @@
 
 <library name="L1TriggerL1THGCalPlugins_fe_be" file="veryfrontend/*.cc, concentrator/*.cc, backend/*.cc">
   <use name="CommonTools/MVAUtils"/>
-  <use name="Geometry/HGCalGeometry"/>
-  <use name="Geometry/HcalTowerAlgo"/>
-  <use name="Geometry/CaloTopology"/>
   <use name="Geometry/Records"/>
   <use name="rootcore"/>
   <use name="L1Trigger/L1THGCal"/>
   <use name="DataFormats/L1THGCal"/>
-  <use name="SimDataFormats/CaloTest"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -1,11 +1,7 @@
 <use name="Geometry/HGCalGeometry"/>
-<use name="Geometry/HcalTowerAlgo"/>
-<use name="Geometry/CaloTopology"/>
 <use name="L1Trigger/L1THGCal"/>
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
-<use name="DataFormats/L1Trigger"/>
-<use name="SimDataFormats/CaloTest"/>
 <library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTester.cc,HGCalTriggerGeomTesterV9.cc,HGCalTriggerGeomTesterV9Imp2.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCalUtilities/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="FWCore/Framework"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/L1THGCal"/>
-<use name="CommonTools/Utils"/>
 <export>
   <lib name="1"/>
 </export>

--- a/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
+++ b/L1Trigger/L1THGCalUtilities/plugins/BuildFile.xml
@@ -4,12 +4,10 @@
   <use name="CommonTools/UtilAlgos"/>
   <use name="SimDataFormats/CaloTest"/>
   <use name="DataFormats/JetReco"/>
-  <use name="Geometry/HcalTowerAlgo"/>
   <use name="SimDataFormats/PileupSummaryInfo"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="TrackPropagation/RungeKutta"/>
   <use name="FastSimulation/Event"/>
-  <use name="FastSimulation/CaloGeometryTools"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
   <use name="heppdt"/>
@@ -26,7 +24,6 @@
 
 <library name="L1TriggerL1THGCalUtilitiesPlugins_calotruth" file="CaloTruthCellsProducer.cc">
   <use name="FWCore/Framework"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ParameterSet"/>
   <use name="Geometry/Records"/>
   <use name="SimDataFormats/CaloAnalysis"/>

--- a/RecoBTag/ONNXRuntime/BuildFile.xml
+++ b/RecoBTag/ONNXRuntime/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/BTauReco"/>
-<use name="PhysicsTools/ONNXRuntime"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
+++ b/RecoEgamma/EgammaPhotonProducers/BuildFile.xml
@@ -1,9 +1,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
-<use name="FWCore/PluginManager"/>
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/EgammaCandidates"/>
-<use name="DataFormats/TrajectorySeed"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackCandidate"/>
 <use name="DataFormats/TrackReco"/>
@@ -20,8 +18,6 @@
 <use name="RecoTracker/MeasurementDet"/>
 <use name="RecoTracker/CkfPattern"/>
 <use name="RecoTracker/TrackProducer"/>
-<use name="RecoVertex/KinematicFitPrimitives"/>
-<use name="RecoVertex/KinematicFit"/>
 <use name="DataFormats/HcalRecHit"/>
 <use name="RecoCaloTools/Selectors"/>
 <use name="clhep"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/32030).

This PR deals with some BuildFiles that were not processed by the BuildFile cleaning script so far and revisits some BuildFiles in the reco area that can be cleaned further after https://github.com/cms-sw/cmssw/pull/32266.

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
