### PR TITLE
Set default value for jets w/o SV info in HI CSV tagger 

### DIFF
--- a/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
+++ b/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
@@ -92,6 +92,7 @@ float HeavyIonCSVTagger::discriminator(const TagInfoHelper &tagInfo) const {
         if (mva_var.name == "TagVarCSV_vertexMass") {
           if (inputs[mva_var.name] < 0)
             return -1;
+          noTrack = false;
         }
       }
     }

--- a/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
+++ b/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
@@ -76,11 +76,8 @@ float HeavyIonCSVTagger::discriminator(const TagInfoHelper &tagInfo) const {
 
   // Loop over input variables
   std::map<std::string, float> inputs;
-
   std::vector<float> tagValList = vars.getList(reco::btau::trackSip3dSig, false);
   bool noTrack = (tagValList.empty());
-  bool vtxChecked = false;
-  float vtxMassVal = 0.;
 
   for (auto &mva_var : variables_) {
     //vectorial tagging variable
@@ -91,17 +88,14 @@ float HeavyIonCSVTagger::discriminator(const TagInfoHelper &tagInfo) const {
     //single value tagging var
     else {
       inputs[mva_var.name] = vars.get(mva_var.id, mva_var.default_value);
-      if (!vtxChecked) {
+      if (noTrack) {
         if (mva_var.name == "TagVarCSV_vertexMass") {
-          vtxMassVal = inputs[mva_var.name];
-          vtxChecked = true;
+          if (inputs[mva_var.name] < 0)
+            return -1;
         }
       }
     }
   }
 
-  if (vtxMassVal < 0 && noTrack)
-    return -1;
-  else
-    return (mvaID_->evaluate(inputs) + 1.) / 2.;
+  return (mvaID_->evaluate(inputs) + 1.) / 2.;
 }

--- a/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
+++ b/RecoBTag/Combined/src/HeavyIonCSVTagger.cc
@@ -77,10 +77,10 @@ float HeavyIonCSVTagger::discriminator(const TagInfoHelper &tagInfo) const {
   // Loop over input variables
   std::map<std::string, float> inputs;
 
-  bool notTaggable = false;
   std::vector<float> tagValList = vars.getList(reco::btau::trackSip3dSig, false);
   bool noTrack = (tagValList.empty());
-  bool noVertex = (vars.get(reco::btau::vertexCategory, -1.0) == 2);
+  bool vtxChecked = false;
+  float vtxMassVal = 0.;
 
   for (auto &mva_var : variables_) {
     //vectorial tagging variable
@@ -91,17 +91,17 @@ float HeavyIonCSVTagger::discriminator(const TagInfoHelper &tagInfo) const {
     //single value tagging var
     else {
       inputs[mva_var.name] = vars.get(mva_var.id, mva_var.default_value);
+      if (!vtxChecked) {
+        if (mva_var.name == "TagVarCSV_vertexMass") {
+          vtxMassVal = inputs[mva_var.name];
+          vtxChecked = true;
+        }
+      }
     }
   }
 
-  if (noTrack && noVertex)
-    notTaggable = true;
-
-  //get the MVA output
-  float tag = (mvaID_->evaluate(inputs) + 1.) / 2.;
-
-  if (notTaggable)
-    tag = -1;
-
-  return tag;
+  if (vtxMassVal < 0 && noTrack)
+    return -1;
+  else
+    return (mvaID_->evaluate(inputs) + 1.) / 2.;
 }


### PR DESCRIPTION
#### PR description:

The heavy-ion version of the CSV tagger was introduced into 11_2 in #31660 
A peak is observed at a discriminator value of 0.30755
This was tracked down to change made during the review of #31660 which changed the way jets with no secondary vertex are identified.  
This PR reverts to the original logic, and these jets now take a value of -1, as they should. 
11_2_X backport is #32331 

#### PR validation:

Validated with wfs 140.5611 and 158.01


