### PR TITLE
PUPPI v15 bug/crash fix for NANOAOD

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -223,7 +223,6 @@ def nanoAOD_recalibrateMETs(process,isData):
             reclusterJets = cms.untracked.bool(False),
             )
     run2_nanoAOD_106Xv1.toModify(nanoAOD_PuppiV15_switch,recoMetFromPFCs=True,reclusterJets=True)
-    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     if nanoAOD_PuppiV15_switch.reclusterJets:
         from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
         from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
@@ -242,11 +241,13 @@ def nanoAOD_recalibrateMETs(process,isData):
                             muSource =cms.InputTag( 'slimmedMuons'),
                             elSource = cms.InputTag('slimmedElectrons'),
                             genParticles= cms.InputTag('prunedGenParticles'),
-                            getJetMCFlavour=False
+                            getJetMCFlavour= not isData
         )
 
-        process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
-        process.patJetsPuppi.addGenJetMatch = cms.bool(False)
+        process.patJetsPuppi.addGenPartonMatch = cms.bool(not isData)
+        process.patJetsPuppi.addGenJetMatch = cms.bool(not isData)
+    
+    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
     return process
 

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -241,11 +241,11 @@ def nanoAOD_recalibrateMETs(process,isData):
                             muSource =cms.InputTag( 'slimmedMuons'),
                             elSource = cms.InputTag('slimmedElectrons'),
                             genParticles= cms.InputTag('prunedGenParticles'),
-                            getJetMCFlavour= not isData
+                            getJetMCFlavour= False
         )
 
-        process.patJetsPuppi.addGenPartonMatch = cms.bool(not isData)
-        process.patJetsPuppi.addGenJetMatch = cms.bool(not isData)
+        process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
+        process.patJetsPuppi.addGenJetMatch = cms.bool(False)
     
     runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))


### PR DESCRIPTION

#### PR description:
This is a fix to https://github.com/cms-sw/cmssw/pull/31927 that introduced a crash in NANOAOD workflows. 
For the record, the crash only happens when running the NANO step alone, but is not visible when both NANO and DQM:@nanoAODDQM steps are run (hence why it wasn't spotted earlier).
In addition, it was noticed that some booleans were not properly set for MC when recreating the jet PUPPI collection. This is now corrected.


#### PR validation:
The following command ran succesfully (and is crashing before this PR): 
`cmsDriver.py  --python_filename PPD-RunIISummer20UL17NanoAODv2-00001_1_cfg.py --eventcontent NANOAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --fileout file:nanoformat10kDY.root --conditions 112X_upgrade2018_realistic_v6 --step NANO --filein "dbs:/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18MiniAOD-Pilot_106X_upgrade2018_realistic_v11_L1v1-v2/MINIAODSIM" --era Run2_2018,run2_nanoAOD_106Xv1  --mc -n 1000
`
#### if this PR is a backport please specify the original PR and why you need to backport that PR:

