### PR TITLE
PUPPI v15 bug/crash fix for NANOAOD (106X backport) 

### DIFF
--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -119,7 +119,8 @@ phase2_common.toModify(
 )
 
 from Configuration.ProcessModifiers.run2_miniAOD_UL_cff import run2_miniAOD_UL
-run2_miniAOD_UL.toModify(
+from Configuration.Eras.Modifier_run2_nanoAOD_106Xv1_cff import run2_nanoAOD_106Xv1
+(run2_miniAOD_UL|run2_nanoAOD_106Xv1).toModify(
     puppi,
     EtaMinUseDeltaZ = 2.4,
     PtMaxCharged = 20.,

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -242,10 +242,10 @@ def nanoAOD_recalibrateMETs(process,isData):
                             muSource =cms.InputTag( 'slimmedMuons'),
                             elSource = cms.InputTag('slimmedElectrons'),
                             genParticles= cms.InputTag('prunedGenParticles'),
-                            getJetMCFlavour= not isData
+                            getJetMCFlavour= False
         )
-        process.patJetsPuppi.addGenPartonMatch = cms.bool(not isData)
-        process.patJetsPuppi.addGenJetMatch = cms.bool(not isData)
+        process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
+        process.patJetsPuppi.addGenJetMatch = cms.bool(False)
     
     runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))

--- a/PhysicsTools/NanoAOD/python/nano_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_cff.py
@@ -224,7 +224,6 @@ def nanoAOD_recalibrateMETs(process,isData):
             reclusterJets = cms.untracked.bool(False),
             )
     run2_nanoAOD_106Xv1.toModify(nanoAOD_PuppiV15_switch,recoMetFromPFCs=True,reclusterJets=True)
-    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     if nanoAOD_PuppiV15_switch.reclusterJets:
         from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
         from PhysicsTools.PatAlgos.tools.helpers import getPatAlgosToolsTask, addToProcessAndTask
@@ -243,11 +242,12 @@ def nanoAOD_recalibrateMETs(process,isData):
                             muSource =cms.InputTag( 'slimmedMuons'),
                             elSource = cms.InputTag('slimmedElectrons'),
                             genParticles= cms.InputTag('prunedGenParticles'),
-                            getJetMCFlavour=False
+                            getJetMCFlavour= not isData
         )
-
-        process.patJetsPuppi.addGenPartonMatch = cms.bool(False)
-        process.patJetsPuppi.addGenJetMatch = cms.bool(False)
+        process.patJetsPuppi.addGenPartonMatch = cms.bool(not isData)
+        process.patJetsPuppi.addGenJetMatch = cms.bool(not isData)
+    
+    runMetCorAndUncFromMiniAOD(process,isData=isData,metType="Puppi",postfix="Puppi",jetFlavor="AK4PFPuppi", recoMetFromPFCs=bool(nanoAOD_PuppiV15_switch.recoMetFromPFCs), reclusterJets=bool(nanoAOD_PuppiV15_switch.reclusterJets))
     process.nanoSequenceCommon.insert(process.nanoSequenceCommon.index(process.jetSequence),cms.Sequence(process.puppiMETSequence+process.fullPatMetSequencePuppi))
     return process
 


### PR DESCRIPTION
#### PR description:

This is a fix to https://github.com/cms-sw/cmssw/pull/32076 that introduced a crash in NANOAOD workflows. 
For the record, the crash only happens when running the NANO step alone, but is not visible when both NANO and DQM:@nanoAODDQM steps are run (hence why it wasn't spotted earlier).

The fix consists to rearrange the order of some modules.  
In addition, it was noticed that some booleans were not properly set for MC when recreating the jet PUPPI collection. This is now corrected.

Finally, the V15 PUPPI was in fact NOT enabled in the previous PR for reNANOAOD since only the run2_miniAOD_UL modifier was considered. This is also corrected. (That last item is not a backport because V15 is run by default in master) 

#### PR validation:

The two following commands (used in NANOAOD v8 validation and that previously failed) are now running fine. 

`cmsDriver.py  --python_filename PPD-RunIISummer20UL17NanoAODv2-00001_1_cfg.py --eventcontent NANOEDMAODSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAODSIM --fileout file:PPD-RunIISummer20UL17NanoAODv2-00001.root --conditions 106X_mc2017_realistic_v8 --step NANO --filein "dbs:/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17MiniAOD-Pilot_106X_mc2017_realistic_v6-v2/MINIAODSIM" --era Run2_2017,run2_nanoAOD_106Xv1  --mc -n 1000`

`cmsDriver.py RECO --conditions 106X_dataRun2_v32 --customise Configuration/DataProcessing/Utils.addMonitoring --datatier NANOAOD --era Run2_2017,run2_nanoAOD_106Xv1 --eventcontent NANOEDMAOD --filein /store/data/Run2017F/JetHT/MINIAOD/09Aug2019_UL2017-v1/270000/1B3CEF31-C191-CA4B-A5F1-447647399163.root --fileout "file:ReReco-Run2017C-JetHT-02Dec2020_UL2017_pilot-00001.root" --nThreads 2  --number 1000 --python_filename "ReReco-Run2017C-JetHT-02Dec2020_UL2017_pilot-00001_0_cfg.py" --scenario pp --step NANO --data `
 


The PUPPIMET is indeed different when running this command on 10_6_19 and on 10_6_19_patch1 with this PR added. 
It is identical when the commands above are run without the run2_nanoAOD_106Xv1 modifier. 


![puppimet_modifier](https://user-images.githubusercontent.com/4995867/100560743-1654eb00-32b7-11eb-9d64-ff9806de0caf.png)

![puppimet_nomodifier](https://user-images.githubusercontent.com/4995867/100560741-148b2780-32b7-11eb-99bb-e575efe0f7fc.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/32328 
