### PR TITLE
Use cleaned PF candidates in UE subtraction in HI miniAOD (112X)

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -119,3 +119,4 @@ hiRecoPFJets = cms.Sequence(hiRecoPFJetsTask)
 
 from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
 run2_miniAOD_pp_on_AA_103X.toModify(akCs4PFJets,src = 'cleanedParticleFlow')
+run2_miniAOD_pp_on_AA_103X.toModify(PFTowers,src = 'cleanedParticleFlow')


### PR DESCRIPTION
#### PR description:

In #31668 a cleaning procedure was added to HI miniAOD to remove badly reconstructed particles. This procedure was applied prior to jet clustering (akCs4PFJets), but not applied to the towering algorithm (PFTowers) that is used for the UE subtraction. This leads to an inconsistency with our previous AOD-only workflow. The cleaning is only effective occasionally such that the net effect is a small migration of in the jet pt spectrum.


#### PR validation:

Wfs 140.5611 and 158.01

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32325
Needed for HI reMiniAOD in 11_2_X


