### PR TITLE
backport of cp5crx card fix to 10_6

### DIFF
--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5CR1TuneSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5CR1TuneSettings_cfi.py
@@ -4,7 +4,6 @@ pythia8CP5CR1TuneSettingsBlock = cms.PSet(
     pythia8CP5CR1TuneSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
-	'PDF:pSet=20',
 	'MultipartonInteractions:alphaSvalue=0.118',
 	'MultipartonInteractions:alphaSorder=2',
 	'MultipartonInteractions:bProfile=2',
@@ -28,5 +27,9 @@ pythia8CP5CR1TuneSettingsBlock = cms.PSet(
 	'TimeShower:alphaSorder=2',
 	'TimeShower:alphaSvalue=0.118',
 	'SigmaTotal:zeroAXB=off',
+        'SigmaTotal:mode = 0',
+        'SigmaTotal:sigmaEl = 21.89',
+        'SigmaTotal:sigmaTot = 100.309',
+        'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118',
     )
 )

--- a/Configuration/Generator/python/MCTunes2017/PythiaCP5CR2TuneSettings_cfi.py
+++ b/Configuration/Generator/python/MCTunes2017/PythiaCP5CR2TuneSettings_cfi.py
@@ -4,7 +4,6 @@ pythia8CP5CR2TuneSettingsBlock = cms.PSet(
     pythia8CP5CR2TuneSettings = cms.vstring(
 	'Tune:pp 14',
 	'Tune:ee 7',
-	'PDF:pSet=20',
 	'MultipartonInteractions:bProfile=2',
 	'MultipartonInteractions:pT0Ref=1.454',
 	'MultipartonInteractions:ecmPow=0.0555',
@@ -22,5 +21,9 @@ pythia8CP5CR2TuneSettingsBlock = cms.PSet(
 	'MultipartonInteractions:alphaSorder=2',
 	'TimeShower:alphaSorder=2',
 	'TimeShower:alphaSvalue=0.118',
+        'SigmaTotal:mode = 0',
+        'SigmaTotal:sigmaEl = 21.89',
+        'SigmaTotal:sigmaTot = 100.309',
+        'PDF:pSet=LHAPDF6:NNPDF31_nnlo_as_0118',
     )
 )


### PR DESCRIPTION
#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of https://github.com/cms-sw/cmssw/pull/32319 to 10_6 for UL top sample production with color reconnection varied tunes, adjusted settings needed for > P8.240 