### PR TITLE
Fix reflection integrity

### DIFF
--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -730,7 +730,9 @@ namespace ecaldqm {
           case kSM:
           case kEBSM:
             xbin = (towerid - 1) / 4 + 1;
-            ybin = (isEBm ? towerid - 1 : 68 - towerid) % 4 + 1;
+	    //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
+	    //whereas using iphi it flips for EB- and EB+ 
+            ybin = (towerid - 1) % 4 + 1;
             nbinsX = 17;
             break;
           default:

--- a/DQM/EcalCommon/src/MESetBinningUtils2.cc
+++ b/DQM/EcalCommon/src/MESetBinningUtils2.cc
@@ -730,8 +730,8 @@ namespace ecaldqm {
           case kSM:
           case kEBSM:
             xbin = (towerid - 1) / 4 + 1;
-	    //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
-	    //whereas using iphi it flips for EB- and EB+ 
+            //In by SM plots, using towerid, the ybinning always increases from 1 to 4,
+            //whereas using iphi it flips for EB- and EB+
             ybin = (towerid - 1) % 4 + 1;
             nbinsX = 17;
             break;


### PR DESCRIPTION
#### PR description:

An issue with the Integrity quality summary plot was presented here: http://cmsonline.cern.ch/cms-elog/1112563, where the problematic tower mappings were "reflected" relative to the FE Status plot which showed the correct mapping. 

The error appears to be with a wrong binning set up for the filling of the histogram which is done here [6], where it was assumed that for EB+ supermodules there will be a reflection or flip of the tower y binning, when in fact it remains the same as for EB-. The flip only happens when using iphi coordinates to define the y binning, not the tower id which has been used in this case.

We have fixed this by removing the separate condition for EB+, and making it the same as for EB-.

#### PR validation:

We redid the plots with an offline ecal dqm workflow on 2018 runs (T0 turned off for offending run) by introducing integrity errors on EB+. Using a test GUI we found that it now shows the correct tower positions. We also made sure that if the error happened on EB- this still gave the correct tower mapping, and no other plots were affected.

#### This PR is a backport of the original PR here: https://github.com/cms-sw/cmssw/pull/32305
This is done to ensure the changes are available in CMSSW_11_2_X, which would be used in the next MWGR in February 2021. 
