### PR TITLE
adding configuration files for Matchbox and standalone H7

### DIFF
--- a/GeneratorInterface/Herwig7Interface/python/Herwig7_Matchbox_ppToee_cff.py
+++ b/GeneratorInterface/Herwig7Interface/python/Herwig7_Matchbox_ppToee_cff.py
@@ -1,0 +1,48 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+    herwig7StableParticlesForDetectorBlock,
+    herwig7CH3SettingsBlock,
+    run = cms.string('InterfaceMatchboxTest'),
+    dumpConfig = cms.untracked.string('HerwigConfig.in'),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    filterEfficiency = cms.untracked.double(1.0),
+    Matchbox = cms.vstring( 'read snippets/Matchbox.in',
+    'read snippets/PPCollider.in',
+    'cd /Herwig/EventHandlers',
+    'set EventHandler:LuminosityFunction:Energy 13000*GeV',
+    '## Model assumptions',
+    'read Matchbox/StandardModelLike.in',
+    'read Matchbox/DiagonalCKM.in',
+    '## Set the order of the couplings',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:OrderInAlphaS 0',
+    'set Factory:OrderInAlphaEW 2',
+    '## Select the process',
+    'do Factory:Process p p -> e+ e-',
+    '# read Matchbox/MadGraph-GoSam.in',
+    '# read Matchbox/MadGraph-MadGraph.in',
+    'read Matchbox/MadGraph-OpenLoops.in',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MinMass 60*GeV',
+    'set /Herwig/Cuts/ChargedLeptonPairMassCut:MaxMass 120*GeV',
+    'cd /Herwig/MatrixElements/Matchbox',
+    'set Factory:ScaleChoice /Herwig/MatrixElements/Matchbox/Scales/LeptonPairMassScale',
+    'read Matchbox/MCatNLO-DefaultShower.in',
+    '# read Matchbox/NLO-NoShower.in',
+    '# read Matchbox/LO-NoShower.in',
+    'read Matchbox/FiveFlavourScheme.in',
+    'read Matchbox/MMHT2014.in',
+    'do /Herwig/MatrixElements/Matchbox/Factory:ProductionMode',
+    ),
+    parameterSets = cms.vstring('herwig7CH3PDF', 'herwig7CH3AlphaS', 'herwig7StableParticlesForDetector', 'Matchbox'),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/GeneratorInterface/Herwig7Interface/python/Herwig7_Standalone_DYLO_cff.py
+++ b/GeneratorInterface/Herwig7Interface/python/Herwig7_Standalone_DYLO_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Herwig7Settings.Herwig7StableParticlesForDetector_cfi import *
+from Configuration.Generator.Herwig7Settings.Herwig7CH3TuneSettings_cfi import *
+
+
+generator = cms.EDFilter("Herwig7GeneratorFilter",
+    herwig7StableParticlesForDetectorBlock,
+    herwig7CH3SettingsBlock,
+    run = cms.string('InterfaceMatchboxTest'),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    pptoll = cms.vstring(
+                'read snippets/PPCollider.in',
+                'cd /Herwig/Generators',
+                'set EventGenerator:EventHandler:LuminosityFunction:Energy 13000.0',
+                'cd /Herwig/MatrixElements/',
+                'insert SubProcess:MatrixElements[0] MEqq2gZ2ff'),
+    parameterSets = cms.vstring('herwig7CH3PDF', 'herwig7CH3AlphaS', 'herwig7StableParticlesForDetector', 'pptoll'),
+    filterEfficiency = cms.untracked.double(1.0),
+)
+
+ProductionFilterSequence = cms.Sequence(generator)

--- a/GeneratorInterface/Herwig7Interface/test/Herwig7_Matchbox_ppToee_cfg.py
+++ b/GeneratorInterface/Herwig7Interface/test/Herwig7_Matchbox_ppToee_cfg.py
@@ -1,0 +1,198 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: GeneratorInterface/Herwig7Interface/python/Herwig7_Matchbox_ppToee_cff.py --eventcontent RAWSIM --datatier GEN --conditions auto:run2_mc --step GEN --python_filename Herwig7_Matchbox_ppToee_cfg.py --no_exec -n 100
+import FWCore.ParameterSet.Config as cms
+
+
+
+process = cms.Process('GEN')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('GeneratorInterface/Herwig7Interface/python/Herwig7_Matchbox_ppToee_cff.py nevts:100'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('Herwig7_Matchbox_ppToee_cff_py_GEN.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+process.generator = cms.EDFilter("Herwig7GeneratorFilter",
+    Matchbox = cms.vstring(
+        'read snippets/Matchbox.in', 
+        'read snippets/PPCollider.in', 
+        'cd /Herwig/EventHandlers', 
+        'set EventHandler:LuminosityFunction:Energy 13000*GeV', 
+        '## Model assumptions', 
+        'read Matchbox/StandardModelLike.in', 
+        'read Matchbox/DiagonalCKM.in', 
+        '## Set the order of the couplings', 
+        'cd /Herwig/MatrixElements/Matchbox', 
+        'set Factory:OrderInAlphaS 0', 
+        'set Factory:OrderInAlphaEW 2', 
+        '## Select the process', 
+        'do Factory:Process p p -> e+ e-', 
+        '# read Matchbox/MadGraph-GoSam.in', 
+        '# read Matchbox/MadGraph-MadGraph.in', 
+        'read Matchbox/MadGraph-OpenLoops.in', 
+        'set /Herwig/Cuts/ChargedLeptonPairMassCut:MinMass 60*GeV', 
+        'set /Herwig/Cuts/ChargedLeptonPairMassCut:MaxMass 120*GeV', 
+        'cd /Herwig/MatrixElements/Matchbox', 
+        'set Factory:ScaleChoice /Herwig/MatrixElements/Matchbox/Scales/LeptonPairMassScale', 
+        'read Matchbox/MCatNLO-DefaultShower.in', 
+        '# read Matchbox/NLO-NoShower.in', 
+        '# read Matchbox/LO-NoShower.in', 
+        'read Matchbox/FiveFlavourScheme.in', 
+        'read Matchbox/MMHT2014.in', 
+        'do /Herwig/MatrixElements/Matchbox/Factory:ProductionMode'
+    ),
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    dumpConfig = cms.untracked.string('HerwigConfig.in'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    filterEfficiency = cms.untracked.double(1.0),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    herwig7CH3AlphaS = cms.vstring(
+        'cd /Herwig/Shower', 
+        'set AlphaQCD:AlphaIn 0.118', 
+        'cd /'
+    ),
+    herwig7CH3MPISettings = cms.vstring(
+        'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.4712', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.04', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.284', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:Power 0.1362'
+    ),
+    herwig7CH3PDF = cms.vstring(
+        'cd /Herwig/Partons', 
+        'create ThePEG::LHAPDF PDFSet_nnlo ThePEGLHAPDF.so', 
+        'set PDFSet_nnlo:PDFName NNPDF31_nnlo_as_0118.LHgrid', 
+        'set PDFSet_nnlo:RemnantHandler HadronRemnants', 
+        'set /Herwig/Particles/p+:PDF PDFSet_nnlo', 
+        'set /Herwig/Particles/pbar-:PDF PDFSet_nnlo', 
+        'set /Herwig/Partons/PPExtractor:FirstPDF  PDFSet_nnlo', 
+        'set /Herwig/Partons/PPExtractor:SecondPDF PDFSet_nnlo', 
+        'set /Herwig/Shower/ShowerHandler:PDFA PDFSet_nnlo', 
+        'set /Herwig/Shower/ShowerHandler:PDFB PDFSet_nnlo', 
+        'create ThePEG::LHAPDF PDFSet_lo ThePEGLHAPDF.so', 
+        'set PDFSet_lo:PDFName NNPDF31_lo_as_0130.LHgrid', 
+        'set PDFSet_lo:RemnantHandler HadronRemnants', 
+        'set /Herwig/Shower/ShowerHandler:PDFARemnant PDFSet_lo', 
+        'set /Herwig/Shower/ShowerHandler:PDFBRemnant PDFSet_lo', 
+        'set /Herwig/Partons/MPIExtractor:FirstPDF PDFSet_lo', 
+        'set /Herwig/Partons/MPIExtractor:SecondPDF PDFSet_lo', 
+        'cd /'
+    ),
+    herwig7StableParticlesForDetector = cms.vstring(
+        'set /Herwig/Decays/DecayHandler:MaxLifeTime 10*mm', 
+        'set /Herwig/Decays/DecayHandler:LifeTimeOption Average'
+    ),
+    parameterSets = cms.vstring(
+        'herwig7CH3PDF', 
+        'herwig7CH3AlphaS', 
+        'herwig7StableParticlesForDetector', 
+        'Matchbox'
+    ),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    run = cms.string('InterfaceMatchboxTest')
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/GeneratorInterface/Herwig7Interface/test/Herwig7_Standalone_DYLO_cfg.py
+++ b/GeneratorInterface/Herwig7Interface/test/Herwig7_Standalone_DYLO_cfg.py
@@ -1,0 +1,176 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: GeneratorInterface/Herwig7Interface/python/Herwig7_Standalone_DYLO_cff.py --eventcontent RAWSIM --datatier GEN --conditions auto:run2_mc --step GEN --python_filename Herwig7_Standalone_DYLO_cfg.py --no_exec -n 100
+import FWCore.ParameterSet.Config as cms
+
+
+
+process = cms.Process('GEN')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(1)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('GeneratorInterface/Herwig7Interface/python/Herwig7_Standalone_DYLO_cff.py nevts:100'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    ),
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(1),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN'),
+        filterName = cms.untracked.string('')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(20971520),
+    fileName = cms.untracked.string('Herwig7_Standalone_DYLO_cff_py_GEN.root'),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    splitLevel = cms.untracked.int32(0)
+)
+
+# Additional output definition
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
+
+process.generator = cms.EDFilter("Herwig7GeneratorFilter",
+    configFiles = cms.vstring(),
+    crossSection = cms.untracked.double(-1),
+    dataLocation = cms.string('${HERWIGPATH:-6}'),
+    eventHandlers = cms.string('/Herwig/EventHandlers'),
+    filterEfficiency = cms.untracked.double(1.0),
+    generatorModule = cms.string('/Herwig/Generators/EventGenerator'),
+    herwig7CH3AlphaS = cms.vstring(
+        'cd /Herwig/Shower', 
+        'set AlphaQCD:AlphaIn 0.118', 
+        'cd /'
+    ),
+    herwig7CH3MPISettings = cms.vstring(
+        'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.4712', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:pTmin0 3.04', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.284', 
+        'set /Herwig/UnderlyingEvent/MPIHandler:Power 0.1362'
+    ),
+    herwig7CH3PDF = cms.vstring(
+        'cd /Herwig/Partons', 
+        'create ThePEG::LHAPDF PDFSet_nnlo ThePEGLHAPDF.so', 
+        'set PDFSet_nnlo:PDFName NNPDF31_nnlo_as_0118.LHgrid', 
+        'set PDFSet_nnlo:RemnantHandler HadronRemnants', 
+        'set /Herwig/Particles/p+:PDF PDFSet_nnlo', 
+        'set /Herwig/Particles/pbar-:PDF PDFSet_nnlo', 
+        'set /Herwig/Partons/PPExtractor:FirstPDF  PDFSet_nnlo', 
+        'set /Herwig/Partons/PPExtractor:SecondPDF PDFSet_nnlo', 
+        'set /Herwig/Shower/ShowerHandler:PDFA PDFSet_nnlo', 
+        'set /Herwig/Shower/ShowerHandler:PDFB PDFSet_nnlo', 
+        'create ThePEG::LHAPDF PDFSet_lo ThePEGLHAPDF.so', 
+        'set PDFSet_lo:PDFName NNPDF31_lo_as_0130.LHgrid', 
+        'set PDFSet_lo:RemnantHandler HadronRemnants', 
+        'set /Herwig/Shower/ShowerHandler:PDFARemnant PDFSet_lo', 
+        'set /Herwig/Shower/ShowerHandler:PDFBRemnant PDFSet_lo', 
+        'set /Herwig/Partons/MPIExtractor:FirstPDF PDFSet_lo', 
+        'set /Herwig/Partons/MPIExtractor:SecondPDF PDFSet_lo', 
+        'cd /'
+    ),
+    herwig7StableParticlesForDetector = cms.vstring(
+        'set /Herwig/Decays/DecayHandler:MaxLifeTime 10*mm', 
+        'set /Herwig/Decays/DecayHandler:LifeTimeOption Average'
+    ),
+    parameterSets = cms.vstring(
+        'herwig7CH3PDF', 
+        'herwig7CH3AlphaS', 
+        'herwig7StableParticlesForDetector', 
+        'pptoll'
+    ),
+    pptoll = cms.vstring(
+        'read snippets/PPCollider.in', 
+        'cd /Herwig/Generators', 
+        'set EventGenerator:EventHandler:LuminosityFunction:Energy 13000.0', 
+        'cd /Herwig/MatrixElements/', 
+        'insert SubProcess:MatrixElements[0] MEqq2gZ2ff'
+    ),
+    repository = cms.string('${HERWIGPATH}/HerwigDefaults.rpo'),
+    run = cms.string('InterfaceMatchboxTest')
+)
+
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.endjob_step,process.RAWSIMoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path).insert(0, process.ProductionFilterSequence)
+
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
#### PR description:
 
  - adding python **_cff.py** and **_cfg.py** to run H7 in matchbox and LO standalone mode
  - matchbox cff/cfg have been made relying on Herwig7CH3TuneSettings for testing
  - no changes are expected in the output 
  - no dependencies to other PRs or externals

#### PR validation:
passed successfully the:
https://cms-sw.github.io/PRWorkflow.html  
