### PR TITLE
removal of TH1::StatOverflows calls in FastTimerService?

### DIFF
--- a/HLTrigger/Timer/plugins/FastTimerService.cc
+++ b/HLTrigger/Timer/plugins/FastTimerService.cc
@@ -382,24 +382,30 @@ void FastTimerService::PlotsPerElement::book(dqm::reco::DQMStore::IBooker& booke
   std::string y_title_ms = fmt::sprintf("events / %.1f ms", ranges.time_resolution);
   std::string y_title_kB = fmt::sprintf("events / %.1f kB", ranges.memory_resolution);
 
+  // to enable underflows and overflows in the computation of mean and rms
+  // use getTH1()->SetStatOverflows(TH1::kConsider)
   time_thread_ =
       booker.book1D(name + " time_thread", title + " processing time (cpu)", time_bins, 0., ranges.time_range);
   time_thread_->setXTitle("processing time [ms]");
   time_thread_->setYTitle(y_title_ms);
+  time_thread_->getTH1()->SetStatOverflows(TH1::kConsider);
 
   time_real_ = booker.book1D(name + " time_real", title + " processing time (real)", time_bins, 0., ranges.time_range);
   time_real_->setXTitle("processing time [ms]");
   time_real_->setYTitle(y_title_ms);
+  time_real_->getTH1()->SetStatOverflows(TH1::kConsider);
 
   if (memory_usage::is_available()) {
     allocated_ = booker.book1D(name + " allocated", title + " allocated memory", mem_bins, 0., ranges.memory_range);
     allocated_->setXTitle("memory [kB]");
     allocated_->setYTitle(y_title_kB);
+    allocated_->getTH1()->SetStatOverflows(TH1::kConsider);
 
     deallocated_ =
         booker.book1D(name + " deallocated", title + " deallocated memory", mem_bins, 0., ranges.memory_range);
     deallocated_->setXTitle("memory [kB]");
     deallocated_->setYTitle(y_title_kB);
+    deallocated_->getTH1()->SetStatOverflows(TH1::kConsider);
   }
 
   if (not byls)
@@ -416,6 +422,7 @@ void FastTimerService::PlotsPerElement::book(dqm::reco::DQMStore::IBooker& booke
                                          " ");
   time_thread_byls_->setXTitle("lumisection");
   time_thread_byls_->setYTitle("processing time [ms]");
+  time_thread_byls_->getTProfile()->SetStatOverflows(TH1::kConsider);
 
   time_real_byls_ = booker.bookProfile(name + " time_real_byls",
                                        title + " processing time (real) vs. lumisection",
@@ -428,6 +435,7 @@ void FastTimerService::PlotsPerElement::book(dqm::reco::DQMStore::IBooker& booke
                                        " ");
   time_real_byls_->setXTitle("lumisection");
   time_real_byls_->setYTitle("processing time [ms]");
+  time_real_byls_->getTProfile()->SetStatOverflows(TH1::kConsider);
 
   if (memory_usage::is_available()) {
     allocated_byls_ = booker.bookProfile(name + " allocated_byls",
@@ -441,6 +449,7 @@ void FastTimerService::PlotsPerElement::book(dqm::reco::DQMStore::IBooker& booke
                                          " ");
     allocated_byls_->setXTitle("lumisection");
     allocated_byls_->setYTitle("memory [kB]");
+    allocated_byls_->getTProfile()->SetStatOverflows(TH1::kConsider);
 
     deallocated_byls_ = booker.bookProfile(name + " deallocated_byls",
                                            title + " deallocated memory vs. lumisection",
@@ -453,13 +462,11 @@ void FastTimerService::PlotsPerElement::book(dqm::reco::DQMStore::IBooker& booke
                                            " ");
     deallocated_byls_->setXTitle("lumisection");
     deallocated_byls_->setYTitle("memory [kB]");
+    deallocated_byls_->getTProfile()->SetStatOverflows(TH1::kConsider);
   }
 }
 
 void FastTimerService::PlotsPerElement::fill(Resources const& data, unsigned int lumisection) {
-  // enable underflows and overflows in the computation of mean and rms
-  TH1::StatOverflows(true);
-
   if (time_thread_)
     time_thread_->Fill(ms(data.time_thread));
 
@@ -486,9 +493,6 @@ void FastTimerService::PlotsPerElement::fill(Resources const& data, unsigned int
 }
 
 void FastTimerService::PlotsPerElement::fill(AtomicResources const& data, unsigned int lumisection) {
-  // enable underflows and overflows in the computation of mean and rms
-  TH1::StatOverflows(true);
-
   if (time_thread_)
     time_thread_->Fill(ms(boost::chrono::nanoseconds(data.time_thread.load())));
 
@@ -517,9 +521,6 @@ void FastTimerService::PlotsPerElement::fill(AtomicResources const& data, unsign
 void FastTimerService::PlotsPerElement::fill_fraction(Resources const& data,
                                                       Resources const& part,
                                                       unsigned int lumisection) {
-  // enable underflows and overflows in the computation of mean and rms
-  TH1::StatOverflows(true);
-
   float total;
   float fraction;
 
@@ -564,27 +565,33 @@ void FastTimerService::PlotsPerPath::book(dqm::reco::DQMStore::IBooker& booker,
                                           unsigned int lumisections,
                                           bool byls) {
   const std::string basedir = booker.pwd();
-  //  booker.setCurrentFolder(basedir + "/path " + path.name_);
   booker.setCurrentFolder(basedir + "/" + prefixDir + path.name_);
 
   total_.book(booker, "path", path.name_, ranges, lumisections, byls);
 
+  // to enable underflows and overflows in the computation of mean and rms
+  // use getTH1()->SetStatOverflows(TH1::kConsider)
   unsigned int bins = path.modules_and_dependencies_.size();
   module_counter_ = booker.book1DD("module_counter", "module counter", bins + 1, -0.5, bins + 0.5);
   module_counter_->setYTitle("events");
+  module_counter_->getTH1()->SetStatOverflows(TH1::kConsider);
   module_time_thread_total_ =
       booker.book1DD("module_time_thread_total", "total module time (cpu)", bins, -0.5, bins - 0.5);
   module_time_thread_total_->setYTitle("processing time [ms]");
+  module_time_thread_total_->getTH1()->SetStatOverflows(TH1::kConsider);
   module_time_real_total_ =
       booker.book1DD("module_time_real_total", "total module time (real)", bins, -0.5, bins - 0.5);
   module_time_real_total_->setYTitle("processing time [ms]");
+  module_time_real_total_->getTH1()->SetStatOverflows(TH1::kConsider);
   if (memory_usage::is_available()) {
     module_allocated_total_ =
         booker.book1DD("module_allocated_total", "total allocated memory", bins, -0.5, bins - 0.5);
     module_allocated_total_->setYTitle("memory [kB]");
+    module_allocated_total_->getTH1()->SetStatOverflows(TH1::kConsider);
     module_deallocated_total_ =
         booker.book1DD("module_deallocated_total", "total deallocated memory", bins, -0.5, bins - 0.5);
     module_deallocated_total_->setYTitle("memory [kB]");
+    module_deallocated_total_->getTH1()->SetStatOverflows(TH1::kConsider);
   }
   for (unsigned int bin : boost::irange(0u, bins)) {
     auto const& module = job[path.modules_and_dependencies_[bin]];


### PR DESCRIPTION
#### PR description:

I stumbled upon the fact that the calls to the static member function `TH1::StatOverflows` in the `FastTimerService` change some of the global TH1 settings, and can thus affect histograms produced by unrelated modules in the same job.

The PR suggests a change to avoid this, while keeping the outputs of the `FastTimerService` unchanged.

#### PR validation:

Verified that the mean/RMS of some of the `FastTimerService` outputs still include underflows and overflows after these updates (admittedly, a very thorough validation was not done).