### PR TITLE
Remove obsolete record SiPixelCPEGenericErrorParmRcd from frozen HLT GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,14 +36,14 @@ autoCond = {
     # GlobalTag for Run2 HI data
     'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
+    'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
+    'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v9',
-    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v5',
+    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v10',
+    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v6',
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
-    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v10',
+    'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v11',
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'        :   '111X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals


### PR DESCRIPTION
#### PR description:

This PR removes the obsolete record SiPixelCPEGenericErrorParmRcd from the "frozen" HLT GTs, as requested by pixel experts in [a HN thread](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4361.html) that follows up on https://github.com/cms-sw/cmssw/pull/32093#issuecomment-734804387. This change is purely technical as the record was obsolete even in the 10_1_X series.

The GT diffs are as follows:

**Data (Frozen HLT GT)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLT_frozen_v10/101X_dataRun2_HLT_frozen_v11

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_v9/103X_dataRun2_HLT_relval_v10

**Run 2 HI HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_HI_v5/103X_dataRun2_HLT_relval_HI_v6

**Run 2 HLT for HI (not 2018 HI)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/101X_dataRun2_HLTHI_frozen_v10/101X_dataRun2_HLTHI_frozen_v11

#### PR validation:

`runTheMatrix.py -l limited --ibeos` and `addOnTests.py`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and should not be backported.