### PR TITLE
Remove temporarily ctppsProtons from recoCTPPSTask (Run-3 only, 11_2_X backport)

### DIFF
--- a/RecoPPS/Configuration/python/recoCTPPS_cff.py
+++ b/RecoPPS/Configuration/python/recoCTPPS_cff.py
@@ -19,4 +19,10 @@ recoCTPPSTask = cms.Task(
     ctppsLocalTrackLiteProducer ,
     ctppsProtons
 )
+
+#temporarily remove ctppsProtons in Run-3 (see issue #32340)
+from Configuration.Eras.Modifier_ctpps_2021_cff import ctpps_2021
+_ctpps_2021_recoCTPPSTask = recoCTPPSTask.copyAndExclude([ctppsProtons])
+ctpps_2021.toReplaceWith(recoCTPPSTask, _ctpps_2021_recoCTPPSTask)
+
 recoCTPPS = cms.Sequence(recoCTPPSTask)


### PR DESCRIPTION
#### PR description:

We need a new global tag to solve https://github.com/cms-sw/cmssw/issues/32340. This PR temporarily removes `ctppsProtons` from `recoCTPPSTask` to move on the validation of `CMSSW_11_2_0_pre10`, if the preparation of the new global tag will take too much time.

#### PR validation:

`cmsDriver.py step3  --conditions auto:phase1_2021_realistic -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT,VALIDATION:@standardValidation+@miniAODValidation,DQM:@standardDQM+@ExtraHLT+@miniAODDQM --datatier GEN-SIM-RECO,MINIAODSIM,DQMIO -n 10 --geometry DB:Extended --era Run3 --eventcontent RECOSIM,MINIAODSIM,DQM --filein file:/afs/cern.ch/user/s/sdonato/ORPlxplus/CMSSW_11_2_0_pre10/src/debug_PPS/badd237c-4857-4f48-b10f-52c832f57f02_ev1126.root` (see https://github.com/cms-sw/cmssw/issues/32340.)

backport of #32352