### PR TITLE
Pr112x L1T Customization for Unprefireable Bit - Follow up

### DIFF
--- a/L1Trigger/Configuration/python/customiseUtils.py
+++ b/L1Trigger/Configuration/python/customiseUtils.py
@@ -145,7 +145,6 @@ def L1TGtStage2ComparisonRAWvsEMU(process):
 
 def L1TStage2SetPrefireVetoBit(process):
     process.load('L1Trigger.L1TGlobal.simGtExtFakeProd_cfi')
-    process.simGtExtFakeProd.tcdsRecordLabel = cms.InputTag("tcdsDigis","tcdsRecord")
-    process.l1tstage2gtext = cms.Path(process.simGtExtFakeProd)
+    process.l1tstage2gtext = cms.Path(process.simGtExtUnprefireable)
     process.schedule.insert(0,process.l1tstage2gtext)
     return process


### PR DESCRIPTION
#### PR description:

L1T customization clean up - use the cloned and already configured module instead of 
Follow up of https://github.com/cms-sw/cmssw/pull/31985, and now in sync with 10_6_X PR https://github.com/cms-sw/cmssw/pull/31984

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
