### PR TITLE
Fix race conditions in the PluginSystem

### DIFF
--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -61,7 +61,7 @@ namespace edmplugin {
       std::atomic<void*> m_ptr;
     };
 
-    typedef tbb::concurrent_vector<PluginMakerInfo> PMakers;
+    typedef tbb::concurrent_vector<PluginMakerInfo, tbb::zero_allocator<PluginMakerInfo>> PMakers;
     typedef tbb::concurrent_unordered_map<std::string, PMakers> Plugins;
 
     // ---------- const member functions ---------------------

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -75,6 +75,10 @@ namespace edmplugin {
             << "'\n but was not there.  This means the plugin cache is incorrect.  Please run 'EdmPluginRefresh " << lib
             << "'";
       }
+      //The item in the container can still be under construction so wait until the m_ptr has been set since that is done last
+      auto const& value = itFound->second.front();
+      while (value.m_ptr.load(std::memory_order_acquire) == nullptr) {
+      }
     } else {
       //The item in the container can still be under construction so wait until the m_ptr has been set since that is done last
       auto const& value = itFound->second.front();

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -251,7 +251,7 @@ namespace edmplugin {
             throw;
           }
         }
-        loadables_[p] = ptr;
+        loadables_.emplace(p, ptr);
         justLoaded_(*ptr);
         return *ptr;
       }


### PR DESCRIPTION
#### PR description:

- Use tbb::zero_allocator to be sure std::atomic is nullptr even before its constructor has finished
- Avoid having a temporary empty std::shared_ptr be placed in the map before being reset
- Be sure object is fully initialized before using it

#### PR validation:

Framework unit tests all pass.