### PR TITLE
Set Run-3 CCLUT algo results in LCT (CCLUT-10) 

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -145,8 +145,14 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setGEM1(gem1);
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCTGEM);
     valid = doesWiregroupCrossStrip(keyWG, keyStrip) ? 1 : 0;
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(clct.getSlope());
+    if (runCCLUT_) {
+      thisLCT.setRun3(true);
+      // 4-bit slope value derived with the CCLUT algorithm
+      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setQuartStrip(clct.getQuartStrip());
+      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setRun3Pattern(clct.getRun3Pattern());
+    }
   } else if (alct.isValid() and clct.isValid() and not gem1.isValid() and gem2.isValid()) {
     pattern = encodePattern(clct.getPattern());
     if (runCCLUT_) {
@@ -164,8 +170,14 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setGEM2(gem2.second());
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCT2GEM);
     valid = doesWiregroupCrossStrip(keyWG, keyStrip) ? 1 : 0;
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(clct.getSlope());
+    if (runCCLUT_) {
+      thisLCT.setRun3(true);
+      // 4-bit slope value derived with the CCLUT algorithm
+      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setQuartStrip(clct.getQuartStrip());
+      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setRun3Pattern(clct.getRun3Pattern());
+    }
   } else if (alct.isValid() and gem2.isValid() and not clct.isValid()) {
     //in ME11
     //ME1b: keyWG >15,
@@ -232,8 +244,14 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     thisLCT.setGEM2(gem2.second());
     thisLCT.setType(CSCCorrelatedLCTDigi::CLCT2GEM);
     valid = true;
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(clct.getSlope());
+    if (runCCLUT_) {
+      thisLCT.setRun3(true);
+      // 4-bit slope value derived with the CCLUT algorithm
+      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setQuartStrip(clct.getQuartStrip());
+      thisLCT.setEightStrip(clct.getEightStrip());
+      thisLCT.setRun3Pattern(clct.getRun3Pattern());
+    }
   }
 
   if (valid == 0)
@@ -255,7 +273,6 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
   // Not used in Run-2. Will not be assigned in Run-3
   thisLCT.setSyncErr(0);
   thisLCT.setCSCID(theTrigChamber);
-  thisLCT.setRun3(true);
   // in Run-3 we plan to denote the presence of exotic signatures in the chamber
   if (useHighMultiplicityBits_)
     thisLCT.setHMT(highMultiplicityBits_);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -523,6 +523,9 @@ CSCCorrelatedLCTDigi CSCMotherboard::constructLCTs(const CSCALCTDigi& aLCT,
     thisLCT.setRun3(true);
     // 4-bit slope value derived with the CCLUT algorithm
     thisLCT.setSlope(cLCT.getSlope());
+    thisLCT.setQuartStrip(cLCT.getQuartStrip());
+    thisLCT.setEightStrip(cLCT.getEightStrip());
+    thisLCT.setRun3Pattern(cLCT.getRun3Pattern());
   }
 
   // in Run-3 we plan to denote the presence of exotic signatures in the chamber


### PR DESCRIPTION
#### PR description:

It was pointed out to me that the LCT was not yet storing the results from the Run-3 CCLUT algorithm (unlike the underlying CLCTs).

* When `isRun3` is set to False, `getStrip()` and `getPattern()` return the 1/2-strip and pattern number. That's the default case. 

* When `isRun3` is set to True, `getStrip(uint16_t n)` returns the 1/2-, 1/4-, or 1/8-strip position for n=2, n=4, or n=8. `getRun3Pattern()` returns the Run-3 pattern number. `getPattern()` returns the most compatible Run-2 pattern (for debugging purposes mainly). `getSlope()` returns the 4-bit bending value. The 1-bit bending `getBend()` (0: negative, 1: positive in delta strip / layer) and the 4-bit slope `getSlope()` combines into the 5-bit bending of the LCT.

I would like to have this in before CMSSW_11_2_0 is closed.

#### PR validation:

Code compiles. Tested with ```runTheMatrix.py -l limited -i all --ibeos```

Because the CCLUT algorithm is not switched on yet, there should be no differences in the comparisons with the baseline. 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

@tahuang1991 