### PR TITLE
Adapt Tracker Alignment PV Validation to work with phase-2 geometries

### DIFF
--- a/Alignment/OfflineValidation/interface/PVValidationHelpers.h
+++ b/Alignment/OfflineValidation/interface/PVValidationHelpers.h
@@ -20,8 +20,9 @@
 
 namespace PVValHelper {
 
-  const double max_eta_phase0 = 2.5;
-  const double max_eta_phase1 = 2.7;
+  constexpr double max_eta_phase0 = 2.5;
+  constexpr double max_eta_phase1 = 2.7;
+  constexpr double max_eta_phase2 = 4.0;
 
   // helper logarithmic bin generator
 
@@ -72,6 +73,13 @@ namespace PVValHelper {
     ladder = 5,
     modZ = 6,
     END_OF_PLOTS = 7,
+  };
+
+  enum detectorPhase {
+    phase0 = 0,
+    phase1 = 1,
+    phase2 = 2,
+    END_OF_PHASES = 3,
   };
 
   struct histodetails {

--- a/Alignment/OfflineValidation/macros/FitPVResiduals.C
+++ b/Alignment/OfflineValidation/macros/FitPVResiduals.C
@@ -351,7 +351,11 @@ void setStyle();
 // global variables
 
 std::ofstream outfile("FittedDeltaZ.txt");
+
+// use the maximum of the three supported phases
 Int_t nLadders_ = 20;
+Int_t nModZ_ = 9;
+
 const Int_t nPtBins_ = 48;
 Float_t _boundMin = -0.5;
 Float_t _boundSx = (nBins_ / 4.) - 0.5;
@@ -545,11 +549,11 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   TH1F *dzNormMapResiduals[nFiles_][nBins_][nBins_];
 
   // double-differential residuals L1
-  TH1F *dxyL1MapResiduals[nFiles_][nLadders_][8];
-  TH1F *dzL1MapResiduals[nFiles_][nLadders_][8];
+  TH1F *dxyL1MapResiduals[nFiles_][nLadders_][nModZ_];
+  TH1F *dzL1MapResiduals[nFiles_][nLadders_][nModZ_];
 
-  TH1F *dxyL1NormMapResiduals[nFiles_][nLadders_][8];
-  TH1F *dzL1NormMapResiduals[nFiles_][nLadders_][8];
+  TH1F *dxyL1NormMapResiduals[nFiles_][nLadders_][nModZ_];
+  TH1F *dzL1NormMapResiduals[nFiles_][nLadders_][nModZ_];
 
   // dca residuals vs pT
   TH1F *dzNormPtResiduals[nFiles_][nPtBins_];
@@ -565,21 +569,23 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   TH1F *dzLadderResiduals[nFiles_][nLadders_];
   TH1F *dxyLadderResiduals[nFiles_][nLadders_];
 
-  TH1F *dzNormModZResiduals[nFiles_][8];
-  TH1F *dxyNormModZResiduals[nFiles_][8];
+  TH1F *dzNormModZResiduals[nFiles_][nModZ_];
+  TH1F *dxyNormModZResiduals[nFiles_][nModZ_];
 
-  TH1F *dzModZResiduals[nFiles_][8];
-  TH1F *dxyModZResiduals[nFiles_][8];
+  TH1F *dzModZResiduals[nFiles_][nModZ_];
+  TH1F *dxyModZResiduals[nFiles_][nModZ_];
 
   // for sanity checks
   TH1F *theEtaHistos[nFiles_];
   TH1F *thebinsHistos[nFiles_];
   TH1F *theLaddersHistos[nFiles_];
+  TH1F *theModZHistos[nFiles_];
   TH1F *thePtInfoHistos[nFiles_];
 
   double theEtaMax_[nFiles_];
   double theNBINS[nFiles_];
   double theLadders[nFiles_];
+  double theModZ[nFiles_];
 
   double thePtMax[nFiles_];
   double thePtMin[nFiles_];
@@ -621,6 +627,15 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     } else {
       theLadders[i] = -1.;
       std::cout << "File n. " << i << " getting the default n. ladders: " << theLadders[i] << std::endl;
+    }
+
+    if (gDirectory->GetListOfKeys()->Contains("nModZ")) {
+      gDirectory->GetObject("nModZ", theModZHistos[i]);
+      theModZ[i] = theModZHistos[i]->GetBinContent(1) / theModZHistos[i]->GetEntries();
+      std::cout << "File n. " << i << " has theNModZ[" << i << "] = " << theModZ[i] << std::endl;
+    } else {
+      theModZ[i] = -1.;
+      std::cout << "File n. " << i << " getting the default n. modules along Z: " << theModZ[i] << std::endl;
     }
 
     if (gDirectory->GetListOfKeys()->Contains("pTinfo")) {
@@ -754,7 +769,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
 
     // residuals vs module number / ladder
 
-    if (theLadders[i] > 0) {
+    if (theLadders[i] > 0 && theModZ[i] > 0) {
       for (Int_t iLadder = 0; iLadder < theLadders[i]; iLadder++) {
         dzNormLadderResiduals[i][iLadder] =
             (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_ladder_Residuals/histo_norm_dz_ladder_plot%i", iLadder));
@@ -767,7 +782,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
             Form("PVValidation/Abs_Transv_ladderNoOverlap_Residuals/histo_dxy_ladder_plot%i", iLadder));
 
         if (do2DMaps) {
-          for (Int_t iMod = 0; iMod < 8; iMod++) {
+          for (Int_t iMod = 0; iMod < theModZ[i]; iMod++) {
             dxyL1MapResiduals[i][iLadder][iMod] =
                 (TH1F *)fins[i]->Get(Form("PVValidation/Abs_L1Residuals/histo_dxy_ladder%i_module%i", iLadder, iMod));
             dzL1MapResiduals[i][iLadder][iMod] =
@@ -780,8 +795,10 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
           }
         }
       }
+    }
 
-      for (Int_t iMod = 0; iMod < 8; iMod++) {
+    if (theModZ[i] > 0) {
+      for (Int_t iMod = 0; iMod < theModZ[i]; iMod++) {
         dzNormModZResiduals[i][iMod] =
             (TH1F *)fins[i]->Get(Form("PVValidation/Norm_Long_modZ_Residuals/histo_norm_dz_modZ_plot%i", iMod));
         dxyNormModZResiduals[i][iMod] =
@@ -852,6 +869,20 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     nLadders_ = theLadders[0];
     std::cout << "======================================================" << std::endl;
     std::cout << "FitPVResiduals::FitPVResiduals(): the number of ladders is: " << nLadders_ << std::endl;
+    std::cout << "======================================================" << std::endl;
+  }
+
+  // checks if the geometries are consistent to produce the moduleZ plots
+  if (check(theModZ, nFiles_)) {
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of modules in Z is different" << std::endl;
+    std::cout << "won't do the ladder analysis..." << std::endl;
+    std::cout << "======================================================" << std::endl;
+    nModZ_ = -1;
+  } else {
+    nModZ_ = theModZ[0];
+    std::cout << "======================================================" << std::endl;
+    std::cout << "FitPVResiduals::FitPVResiduals(): the number of modules in Z is: " << nModZ_ << std::endl;
     std::cout << "======================================================" << std::endl;
   }
 
@@ -1138,6 +1169,29 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
                                    mypT_bins.data());
     }
 
+    if (nModZ_ > 0) {
+      dxyModZMeanTrend[i] = new TH1F(Form("means_dxy_modZ_%i", i),
+                                     "#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",
+                                     theModZ[i],
+                                     0.,
+                                     theModZ[i]);
+      dxyModZWidthTrend[i] = new TH1F(Form("widths_dxy_modZ_%i", i),
+                                      "#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",
+                                      theModZ[i],
+                                      0.,
+                                      theModZ[i]);
+      dzModZMeanTrend[i] = new TH1F(Form("means_dz_modZ_%i", i),
+                                    "#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",
+                                    theModZ[i],
+                                    0.,
+                                    theModZ[i]);
+      dzModZWidthTrend[i] = new TH1F(Form("widths_dz_modZ_%i", i),
+                                     "#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",
+                                     theModZ[i],
+                                     0.,
+                                     theModZ[i]);
+    }
+
     if (nLadders_ > 0) {
       dxyLadderMeanTrend[i] = new TH1F(Form("means_dxy_ladder_%i", i),
                                        "#LT d_{xy} #GT vs Layer 1 ladder;ladder number;#LT d_{xy} #GT [#mum]",
@@ -1159,27 +1213,6 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
                                        theLadders[i],
                                        0.,
                                        theLadders[i]);
-
-      dxyModZMeanTrend[i] = new TH1F(Form("means_dxy_modZ_%i", i),
-                                     "#LT d_{xy} #GT vs Layer 1 module number;module number;#LT d_{xy} #GT [#mum]",
-                                     8,
-                                     0.,
-                                     8.);
-      dxyModZWidthTrend[i] = new TH1F(Form("widths_dxy_modZ_%i", i),
-                                      "#sigma(d_{xy}) vs Layer 1 module number;module number;#sigma(d_{xy}) [#mum]",
-                                      8,
-                                      0.,
-                                      8.);
-      dzModZMeanTrend[i] = new TH1F(Form("means_dz_modZ_%i", i),
-                                    "#LT d_{z} #GT vs Layer 1 module number;module number;#LT d_{z} #GT [#mum]",
-                                    8,
-                                    0.,
-                                    8.);
-      dzModZWidthTrend[i] = new TH1F(Form("widths_dz_modZ_%i", i),
-                                     "#sigma(d_{z}) vs Layer 1 module number;module number;#sigma(d_{z}) [#mum]",
-                                     8,
-                                     0.,
-                                     8.);
     }
 
     // DCA normalized trend plots
@@ -1282,31 +1315,33 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
                    theLadders[i],
                    0.,
                    theLadders[i]);
+    }
 
+    if (nModZ_ > 0) {
       dxyNormModZMeanTrend[i] = new TH1F(
           Form("means_dxyNorm_modZ_%i", i),
           "#LT d_{xy}/#sigma_{d_{xy}} #GT vs Layer 1 module number;module number;#LT d_{xy}/#sigma_{d_{xy}} #GT",
-          8,
+          theModZ[i],
           0.,
-          8.);
+          theModZ[i]);
       dxyNormModZWidthTrend[i] = new TH1F(
           Form("widths_dxyNorm_modZ_%i", i),
           "#sigma(d_{xy}/#sigma_{d_{xy}}) vs Layer 1 module number;module number;#sigma(d_{xy}/#sigma_{d_{xy}})",
-          8,
+          theModZ[i],
           0.,
-          8.);
+          theModZ[i]);
       dzNormModZMeanTrend[i] =
           new TH1F(Form("means_dzNorm_modZ_%i", i),
                    "#LT d_{z}/#sigma_{d_{z}} #GT vs Layer 1 module number;module number;#LT d_{z}/#sigma_{d_{z}} #GT",
-                   8,
+                   theModZ[i],
                    0.,
-                   8.);
+                   theModZ[i]);
       dzNormModZWidthTrend[i] =
           new TH1F(Form("widths_dzNorm_modZ_%i", i),
                    "#sigma(d_{z}/#sigma_{d_{z}}) vs Layer 1 module number;module number;#sigma(d_{z}/#sigma_{d_{z}})",
-                   8,
+                   theModZ[i],
                    0.,
-                   8.);
+                   theModZ[i]);
     }
 
     // 2D maps
@@ -1383,70 +1418,70 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
     // 2D maps L1
     dxyMeanL1Map[i] = new TH2F(Form("means_dxy_L1Map_%i", i),
                                "#LT d_{xy} #GT map;module number;ladder number;#LT d_{xy} #GT [#mum]",
-                               8,
+                               nModZ_,
                                -0.5,
-                               7.5,
+                               nModZ_ - 0.5,
                                nLadders_,
                                -0.5,
                                nLadders_ - 0.5);
     dzMeanL1Map[i] = new TH2F(Form("means_dz_L1Map_%i", i),
                               "#LT d_{z} #GT map;module number;ladder number;#LT d_{z} #GT [#mum]",
-                              8,
+                              nModZ_,
                               -0.5,
-                              7.5,
+                              nModZ_ - 0.5,
                               nLadders_,
                               -0.5,
                               nLadders_ - 0.5);
     dxyNormMeanL1Map[i] =
         new TH2F(Form("norm_means_dxy_L1Map_%i", i),
                  "#LT d_{xy}/#sigma_{d_{xy}} #GT map;module number;ladder number;#LT d_{xy}/#sigma_{d_{xy}} #GT",
-                 8,
+                 nModZ_,
                  -0.5,
-                 7.5,
+                 nModZ_ - 0.5,
                  nLadders_,
                  -0.5,
                  nLadders_ - 0.5);
     dzNormMeanL1Map[i] =
         new TH2F(Form("norm_means_dz_L1Map_%i", i),
                  "#LT d_{z}/#sigma_{d_{z}} #GT map;module number;ladder number;#LT d_{xy}/#sigma_{d_{z}} #GT",
-                 8,
+                 nModZ_,
                  -0.5,
-                 7.5,
+                 nModZ_ - 0.5,
                  nLadders_,
                  -0.5,
                  nLadders_ - 0.5);
 
     dxyWidthL1Map[i] = new TH2F(Form("widths_dxy_L1Map_%i", i),
                                 "#sigma_{d_{xy}} map;module number;ladder number;#sigma(d_{xy}) [#mum]",
-                                8,
+                                nModZ_,
                                 -0.5,
-                                7.5,
+                                nModZ_ - 0.5,
                                 nLadders_,
                                 -0.5,
                                 nLadders_ - 0.5);
     dzWidthL1Map[i] = new TH2F(Form("widths_dz_L1Map_%i", i),
                                "#sigma_{d_{z}} map;module number;ladder number;#sigma(d_{z}) [#mum]",
-                               8,
+                               nModZ_,
                                -0.5,
-                               7.5,
+                               nModZ_ - 0.5,
                                nLadders_,
                                -0.5,
                                nLadders_ - 0.5);
     dxyNormWidthL1Map[i] =
         new TH2F(Form("norm_widths_dxy_L1Map_%i", i),
                  "width(d_{xy}/#sigma_{d_{xy}}) map;module number;ladder number;#sigma(d_{xy}/#sigma_{d_{xy}})",
-                 8,
+                 nModZ_,
                  -0.5,
-                 7.5,
+                 nModZ_ - 0.5,
                  nLadders_,
                  -0.5,
                  nLadders_ - 0.5);
     dzNormWidthL1Map[i] =
         new TH2F(Form("norm_widths_dz_L1Map_%i", i),
                  "width(d_{z}/#sigma_{d_{z}}) map;module number;ladder number;#sigma(d_{z}/#sigma_{d_{z}})",
-                 8,
+                 nModZ_,
                  -0.5,
-                 7.5,
+                 nModZ_ - 0.5,
                  nLadders_,
                  -0.5,
                  nLadders_ - 0.5);
@@ -1495,11 +1530,13 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
       FillTrendPlot(dxyLadderWidthTrend[i], dxyLadderResiduals[i], params::WIDTH, "else", nLadders_);
       FillTrendPlot(dzLadderMeanTrend[i], dzLadderResiduals[i], params::MEAN, "else", nLadders_);
       FillTrendPlot(dzLadderWidthTrend[i], dzLadderResiduals[i], params::WIDTH, "else", nLadders_);
+    }
 
-      FillTrendPlot(dxyModZMeanTrend[i], dxyModZResiduals[i], params::MEAN, "else", 8);
-      FillTrendPlot(dxyModZWidthTrend[i], dxyModZResiduals[i], params::WIDTH, "else", 8);
-      FillTrendPlot(dzModZMeanTrend[i], dzModZResiduals[i], params::MEAN, "else", 8);
-      FillTrendPlot(dzModZWidthTrend[i], dzModZResiduals[i], params::WIDTH, "else", 8);
+    if (nModZ_ > 0) {
+      FillTrendPlot(dxyModZMeanTrend[i], dxyModZResiduals[i], params::MEAN, "else", nModZ_);
+      FillTrendPlot(dxyModZWidthTrend[i], dxyModZResiduals[i], params::WIDTH, "else", nModZ_);
+      FillTrendPlot(dzModZMeanTrend[i], dzModZResiduals[i], params::MEAN, "else", nModZ_);
+      FillTrendPlot(dzModZWidthTrend[i], dzModZResiduals[i], params::WIDTH, "else", nModZ_);
     }
 
     MakeNiceTrendPlotStyle(dxyPhiMeanTrend[i], colors[i], markers[i]);
@@ -1532,7 +1569,9 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
       MakeNiceTrendPlotStyle(dxyLadderWidthTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzLadderMeanTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzLadderWidthTrend[i], colors[i], markers[i]);
+    }
 
+    if (nModZ_ > 0) {
       MakeNiceTrendPlotStyle(dxyModZMeanTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dxyModZWidthTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzModZMeanTrend[i], colors[i], markers[i]);
@@ -1563,11 +1602,13 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
       FillTrendPlot(dxyNormLadderWidthTrend[i], dxyNormLadderResiduals[i], params::WIDTH, "else", nLadders_);
       FillTrendPlot(dzNormLadderMeanTrend[i], dzNormLadderResiduals[i], params::MEAN, "else", nLadders_);
       FillTrendPlot(dzNormLadderWidthTrend[i], dzNormLadderResiduals[i], params::WIDTH, "else", nLadders_);
+    }
 
-      FillTrendPlot(dxyNormModZMeanTrend[i], dxyNormModZResiduals[i], params::MEAN, "else", 8);
-      FillTrendPlot(dxyNormModZWidthTrend[i], dxyNormModZResiduals[i], params::WIDTH, "else", 8);
-      FillTrendPlot(dzNormModZMeanTrend[i], dzNormModZResiduals[i], params::MEAN, "else", 8);
-      FillTrendPlot(dzNormModZWidthTrend[i], dzNormModZResiduals[i], params::WIDTH, "else", 8);
+    if (nModZ_ > 0) {
+      FillTrendPlot(dxyNormModZMeanTrend[i], dxyNormModZResiduals[i], params::MEAN, "else", nModZ_);
+      FillTrendPlot(dxyNormModZWidthTrend[i], dxyNormModZResiduals[i], params::WIDTH, "else", nModZ_);
+      FillTrendPlot(dzNormModZMeanTrend[i], dzNormModZResiduals[i], params::MEAN, "else", nModZ_);
+      FillTrendPlot(dzNormModZWidthTrend[i], dzNormModZResiduals[i], params::WIDTH, "else", nModZ_);
     }
 
     MakeNiceTrendPlotStyle(dxyNormPhiMeanTrend[i], colors[i], markers[i]);
@@ -1592,7 +1633,9 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
       MakeNiceTrendPlotStyle(dxyNormLadderWidthTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzNormLadderMeanTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzNormLadderWidthTrend[i], colors[i], markers[i]);
+    }
 
+    if (nModZ_ > 0) {
       MakeNiceTrendPlotStyle(dxyNormModZMeanTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dxyNormModZWidthTrend[i], colors[i], markers[i]);
       MakeNiceTrendPlotStyle(dzNormModZMeanTrend[i], colors[i], markers[i]);
@@ -1688,7 +1731,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
         std::vector<TH1F *> a_temp_vec_z;
         std::vector<TH1F *> n_temp_vec_z;
 
-        for (Int_t index2 = 0; index2 < 8; index2++) {
+        for (Int_t index2 = 0; index2 < nModZ_; index2++) {
           a_temp_vec_xy.push_back(dxyL1MapResiduals[i][index1][index2]);
           a_temp_vec_z.push_back(dzL1MapResiduals[i][index1][index2]);
           n_temp_vec_xy.push_back(dxyL1NormMapResiduals[i][index1][index2]);
@@ -1701,15 +1744,15 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
         v_dzNormMap.push_back(n_temp_vec_z);
       }
 
-      FillMap(dxyMeanL1Map[i], v_dxyAbsMap, params::MEAN, 8, nLadders_);
-      FillMap(dxyWidthL1Map[i], v_dxyAbsMap, params::WIDTH, 8, nLadders_);
-      FillMap(dzMeanL1Map[i], v_dzAbsMap, params::MEAN, 8, nLadders_);
-      FillMap(dzWidthL1Map[i], v_dzAbsMap, params::WIDTH, 8, nLadders_);
+      FillMap(dxyMeanL1Map[i], v_dxyAbsMap, params::MEAN, nModZ_, nLadders_);
+      FillMap(dxyWidthL1Map[i], v_dxyAbsMap, params::WIDTH, nModZ_, nLadders_);
+      FillMap(dzMeanL1Map[i], v_dzAbsMap, params::MEAN, nModZ_, nLadders_);
+      FillMap(dzWidthL1Map[i], v_dzAbsMap, params::WIDTH, nModZ_, nLadders_);
 
-      FillMap(dxyNormMeanL1Map[i], v_dxyNormMap, params::MEAN, 8, nLadders_);
-      FillMap(dxyNormWidthL1Map[i], v_dxyNormMap, params::WIDTH, 8, nLadders_);
-      FillMap(dzNormMeanL1Map[i], v_dzNormMap, params::MEAN, 8, nLadders_);
-      FillMap(dzNormWidthL1Map[i], v_dzNormMap, params::WIDTH, 8, nLadders_);
+      FillMap(dxyNormMeanL1Map[i], v_dxyNormMap, params::MEAN, nModZ_, nLadders_);
+      FillMap(dxyNormWidthL1Map[i], v_dxyNormMap, params::WIDTH, nModZ_, nLadders_);
+      FillMap(dzNormMeanL1Map[i], v_dzNormMap, params::MEAN, nModZ_, nLadders_);
+      FillMap(dzNormWidthL1Map[i], v_dzNormMap, params::WIDTH, nModZ_, nLadders_);
 
       if (isDebugMode) {
         timer.Stop();
@@ -1929,8 +1972,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   BiasesCanvasXY->SaveAs("BiasesCanvasXY_" + theStrDate + theStrAlignment + ".png");
 
   // Bias plots (ladders and module number)
-
-  if (nLadders_ > 0) {
+  if (nLadders_ > 0 && nModZ_ > 0) {
     TCanvas *BiasesCanvasLayer1 = new TCanvas("BiasCanvasLayer1", "BiasCanvasLayer1", 1200, 1200);
     arrangeBiasCanvas(BiasesCanvasLayer1,
                       dxyLadderMeanTrend,
@@ -1944,7 +1986,6 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
 
     BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
     BiasesCanvasLayer1->SaveAs("BiasesCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
-
     delete BiasesCanvasLayer1;
   }
 
@@ -1978,7 +2019,6 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   delete dzEtaBiasCanvas;
 
   // Resolution plots
-
   TCanvas *ResolutionsCanvas = new TCanvas("ResolutionsCanvas", "ResolutionsCanvas", 1200, 1200);
   arrangeBiasCanvas(ResolutionsCanvas,
                     dxyPhiWidthTrend,
@@ -2007,7 +2047,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_" + theStrDate + theStrAlignment + ".pdf");
   ResolutionsCanvasXY->SaveAs("ResolutionsCanvasXY_" + theStrDate + theStrAlignment + ".png");
 
-  if (nLadders_ > 0) {
+  if (nLadders_ > 0 && nModZ_ > 0) {
     TCanvas *ResolutionsCanvasLayer1 = new TCanvas("ResolutionsCanvasLayer1", "ResolutionsCanvasLayer1", 1200, 1200);
     arrangeBiasCanvas(ResolutionsCanvasLayer1,
                       dxyLadderWidthTrend,
@@ -2021,12 +2061,10 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
 
     ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
     ResolutionsCanvasLayer1->SaveAs("ResolutionsCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
-
     delete ResolutionsCanvasLayer1;
   }
 
   // Pull plots
-
   TCanvas *PullsCanvas = new TCanvas("PullsCanvas", "PullsCanvas", 1200, 1200);
   arrangeBiasCanvas(PullsCanvas,
                     dxyNormPhiWidthTrend,
@@ -2041,7 +2079,7 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
   PullsCanvas->SaveAs("PullsCanvas_" + theStrDate + theStrAlignment + ".pdf");
   PullsCanvas->SaveAs("PullsCanvas_" + theStrDate + theStrAlignment + ".png");
 
-  if (nLadders_ > 0) {
+  if (nLadders_ > 0 && nModZ_ > 0) {
     TCanvas *PullsCanvasLayer1 = new TCanvas("PullsCanvasLayer1", "PullsCanvasLayer1", 1200, 1200);
     arrangeBiasCanvas(PullsCanvasLayer1,
                       dxyNormLadderWidthTrend,
@@ -2055,7 +2093,6 @@ void FitPVResiduals(TString namesandlabels, bool stdres, bool do2DMaps, TString 
 
     PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_" + theStrDate + theStrAlignment + ".pdf");
     PullsCanvasLayer1->SaveAs("PullsCanvasLayer1_" + theStrDate + theStrAlignment + ".png");
-
     delete PullsCanvasLayer1;
   }
 
@@ -3973,7 +4010,7 @@ void makeNewXAxis(TH1F *h)
     axmax = nLadders_ + 0.5;
   } else if (myTitle.Contains("modZ")) {
     axmin = 0.5;
-    axmax = 8.5;
+    axmax = nModZ_ + 0.5;
   } else if (myTitle.Contains("h_probe")) {
     ndiv = 505;
     axmin = h->GetXaxis()->GetBinCenter(h->GetXaxis()->GetFirst());

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.cc
@@ -273,10 +273,11 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
   edm::ESHandle<TrackerGeometry> pDD = iSetup.getHandle(geomToken_);
   edm::LogInfo("tracker geometry read") << "There are: " << pDD->dets().size() << " detectors";
 
-  // switch on the phase1
-  if ((pDD->isThere(GeomDetEnumerators::P1PXB)) || (pDD->isThere(GeomDetEnumerators::P1PXEC))) {
-    isPhase1_ = true;
+  // switch on the phase2
+  if ((pDD->isThere(GeomDetEnumerators::P2PXB)) || (pDD->isThere(GeomDetEnumerators::P2PXEC))) {
+    phase_ = PVValHelper::phase2;
     nLadders_ = 12;
+    nModZ_ = 9;
 
     if (h_dxy_ladderOverlap_.size() != nLadders_) {
       PVValHelper::shrinkHistVectorToFit(h_dxy_ladderOverlap_, nLadders_);
@@ -292,27 +293,86 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
     }
 
     if (debug_) {
-      edm::LogInfo("PrimaryVertexValidation") << " pixel phase1 setup, nLadders: " << nLadders_;
+      edm::LogInfo("PrimaryVertexValidation")
+          << " pixel phase2 setup, nLadders: " << nLadders_ << " nModules:" << nModZ_;
+    }
+
+  } else if ((pDD->isThere(GeomDetEnumerators::P1PXB)) || (pDD->isThere(GeomDetEnumerators::P1PXEC))) {
+    // switch on the phase1
+    phase_ = PVValHelper::phase1;
+    nLadders_ = 12;
+    nModZ_ = 8;
+
+    if (h_dxy_ladderOverlap_.size() != nLadders_) {
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderOverlap_, nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladderNoOverlap_, nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_dxy_ladder_, nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_dz_ladder_, nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_ladder_, nLadders_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dz_ladder_, nLadders_);
+
+      if (debug_) {
+        edm::LogInfo("PrimaryVertexValidation") << "checking size:" << h_dxy_ladder_.size() << std::endl;
+      }
+    }
+
+    if (h_dxy_modZ_.size() != nModZ_) {
+      PVValHelper::shrinkHistVectorToFit(h_dxy_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_dz_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_modZ_, nModZ_);
+
+      if (debug_) {
+        edm::LogInfo("PrimaryVertexValidation") << "checking size:" << h_dxy_modZ_.size() << std::endl;
+      }
+    }
+
+    if (debug_) {
+      edm::LogInfo("PrimaryVertexValidation")
+          << " pixel phase1 setup, nLadders: " << nLadders_ << " nModules:" << nModZ_;
     }
 
   } else {
-    isPhase1_ = false;
+    phase_ = PVValHelper::phase0;
     nLadders_ = 20;
+    nModZ_ = 8;
+
+    if (h_dxy_modZ_.size() != nModZ_) {
+      PVValHelper::shrinkHistVectorToFit(h_dxy_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_dz_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_modZ_, nModZ_);
+      PVValHelper::shrinkHistVectorToFit(h_norm_dxy_modZ_, nModZ_);
+
+      if (debug_) {
+        edm::LogInfo("PrimaryVertexValidation") << "checking size:" << h_dxy_modZ_.size() << std::endl;
+      }
+    }
+
     if (debug_) {
-      edm::LogInfo("PrimaryVertexValidation") << " pixel phase0 setup, nLadders: " << nLadders_;
+      edm::LogInfo("PrimaryVertexValidation")
+          << " pixel phase0 setup, nLadders: " << nLadders_ << " nModules:" << nModZ_;
     }
   }
 
-  if (isPhase1_) {
-    etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase1);
-  } else {
-    etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase0);
+  switch (phase_) {
+    case PVValHelper::phase0:
+      etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase0);
+      break;
+    case PVValHelper::phase1:
+      etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase1);
+      break;
+    case PVValHelper::phase2:
+      etaOfProbe_ = std::min(etaOfProbe_, PVValHelper::max_eta_phase2);
+      break;
+    default:
+      edm::LogWarning("LogicError") << "Unknown detector phase: " << phase_;
   }
 
   if (h_etaMax->GetEntries() == 0.) {
     h_etaMax->SetBinContent(1., etaOfProbe_);
     h_nbins->SetBinContent(1., nBins_);
     h_nLadders->SetBinContent(1., nLadders_);
+    h_nModZ->SetBinContent(1., nModZ_);
     h_pTinfo->SetBinContent(1., mypT_bins_.size());
     h_pTinfo->SetBinContent(2., minPt_);
     h_pTinfo->SetBinContent(3., maxPt_);
@@ -438,17 +498,17 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
           float etaL = theDetails_.trendbins[PVValHelper::eta][i + 1];
 
           if (tracketa >= etaF && tracketa < etaL) {
-            PVValHelper::fillByIndex(a_dxyEtaBiasResiduals, i, dxyRes * cmToum);
-            PVValHelper::fillByIndex(a_dzEtaBiasResiduals, i, dzRes * cmToum);
-            PVValHelper::fillByIndex(n_dxyEtaBiasResiduals, i, (dxyRes) / dxy_err);
-            PVValHelper::fillByIndex(n_dzEtaBiasResiduals, i, (dzRes) / dz_err);
+            PVValHelper::fillByIndex(a_dxyEtaBiasResiduals, i, dxyRes * cmToum, "1");
+            PVValHelper::fillByIndex(a_dzEtaBiasResiduals, i, dzRes * cmToum, "2");
+            PVValHelper::fillByIndex(n_dxyEtaBiasResiduals, i, (dxyRes) / dxy_err, "3");
+            PVValHelper::fillByIndex(n_dzEtaBiasResiduals, i, (dzRes) / dz_err, "4");
           }
 
           if (trackphi >= phiF && trackphi < phiL) {
-            PVValHelper::fillByIndex(a_dxyPhiBiasResiduals, i, dxyRes * cmToum);
-            PVValHelper::fillByIndex(a_dzPhiBiasResiduals, i, dzRes * cmToum);
-            PVValHelper::fillByIndex(n_dxyPhiBiasResiduals, i, (dxyRes) / dxy_err);
-            PVValHelper::fillByIndex(n_dzPhiBiasResiduals, i, (dzRes) / dz_err);
+            PVValHelper::fillByIndex(a_dxyPhiBiasResiduals, i, dxyRes * cmToum, "5");
+            PVValHelper::fillByIndex(a_dzPhiBiasResiduals, i, dzRes * cmToum, "6");
+            PVValHelper::fillByIndex(n_dxyPhiBiasResiduals, i, (dxyRes) / dxy_err, "7");
+            PVValHelper::fillByIndex(n_dzPhiBiasResiduals, i, (dzRes) / dz_err, "8");
 
             for (int j = 0; j < nBins_; j++) {
               float etaJ = theDetails_.trendbins[PVValHelper::eta][j];
@@ -630,11 +690,11 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
       int nhitinFPIX = hits.numberOfValidPixelEndcapHits();
       for (trackingRecHit_iterator iHit = theTTrack.recHitsBegin(); iHit != theTTrack.recHitsEnd(); ++iHit) {
         if ((*iHit)->isValid()) {
-          if (this->isHit2D(**iHit)) {
-            ++nRecHit2D;
-          } else {
-            ++nRecHit1D;
-          }
+          //if (this->isHit2D(**iHit)) {
+          //  ++nRecHit2D;
+          // } else {
+          ++nRecHit1D;
+          // }
         }
       }
 
@@ -867,19 +927,19 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
               if (std::abs(tracketa) < 1.5 && (trackpt >= pTF && trackpt < pTL)) {
                 if (debug_)
                   edm::LogInfo("PrimaryVertexValidation") << "passes this cut: " << mypT_bins_[ipTBin] << std::endl;
-                PVValHelper::fillByIndex(h_dxy_pT_, ipTBin, dxyFromMyVertex * cmToum);
-                PVValHelper::fillByIndex(h_dz_pT_, ipTBin, dzFromMyVertex * cmToum);
-                PVValHelper::fillByIndex(h_norm_dxy_pT_, ipTBin, dxyFromMyVertex / s_ip2dpv_err);
-                PVValHelper::fillByIndex(h_norm_dz_pT_, ipTBin, dzFromMyVertex / dz_err);
+                PVValHelper::fillByIndex(h_dxy_pT_, ipTBin, dxyFromMyVertex * cmToum, "9");
+                PVValHelper::fillByIndex(h_dz_pT_, ipTBin, dzFromMyVertex * cmToum, "10");
+                PVValHelper::fillByIndex(h_norm_dxy_pT_, ipTBin, dxyFromMyVertex / s_ip2dpv_err, "11");
+                PVValHelper::fillByIndex(h_norm_dz_pT_, ipTBin, dzFromMyVertex / dz_err, "12");
 
                 if (std::abs(tracketa) < 1.) {
                   if (debug_)
                     edm::LogInfo("PrimaryVertexValidation")
                         << "passes tight eta cut: " << mypT_bins_[ipTBin] << std::endl;
-                  PVValHelper::fillByIndex(h_dxy_Central_pT_, ipTBin, dxyFromMyVertex * cmToum);
-                  PVValHelper::fillByIndex(h_dz_Central_pT_, ipTBin, dzFromMyVertex * cmToum);
-                  PVValHelper::fillByIndex(h_norm_dxy_Central_pT_, ipTBin, dxyFromMyVertex / s_ip2dpv_err);
-                  PVValHelper::fillByIndex(h_norm_dz_Central_pT_, ipTBin, dzFromMyVertex / dz_err);
+                  PVValHelper::fillByIndex(h_dxy_Central_pT_, ipTBin, dxyFromMyVertex * cmToum, "13");
+                  PVValHelper::fillByIndex(h_dz_Central_pT_, ipTBin, dzFromMyVertex * cmToum, "14");
+                  PVValHelper::fillByIndex(h_norm_dxy_Central_pT_, ipTBin, dxyFromMyVertex / s_ip2dpv_err, "15");
+                  PVValHelper::fillByIndex(h_norm_dz_Central_pT_, ipTBin, dzFromMyVertex / dz_err, "16");
                 }
               }
             }
@@ -919,12 +979,12 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
               h_probeHits_->Fill(theTrack.numberOfValidHits());
               h_probeHits1D_->Fill(nRecHit1D);
               h_probeHits2D_->Fill(nRecHit2D);
-              h_probeHitsInTIB_->Fill(nhitinBPIX);
-              h_probeHitsInTOB_->Fill(nhitinFPIX);
-              h_probeHitsInTID_->Fill(nhitinTIB);
-              h_probeHitsInTEC_->Fill(nhitinTID);
-              h_probeHitsInBPIX_->Fill(nhitinTOB);
-              h_probeHitsInFPIX_->Fill(nhitinTEC);
+              h_probeHitsInTIB_->Fill(nhitinTIB);
+              h_probeHitsInTOB_->Fill(nhitinTOB);
+              h_probeHitsInTID_->Fill(nhitinTID);
+              h_probeHitsInTEC_->Fill(nhitinTEC);
+              h_probeHitsInBPIX_->Fill(nhitinBPIX);
+              h_probeHitsInFPIX_->Fill(nhitinFPIX);
 
               float dxyRecoV = theTrack.dz(theRecoVertex);
               float dzRecoV = theTrack.dxy(theRecoVertex);
@@ -974,14 +1034,14 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
 
               if (ladder_num > 0 && module_num > 0) {
                 LogDebug("PrimaryVertexValidation")
-                    << " ladder_num" << ladder_num << " module_num" << module_num << std::endl;
+                    << " ladder_num: " << ladder_num << " module_num: " << module_num << std::endl;
 
-                PVValHelper::fillByIndex(h_dxy_modZ_, module_num - 1, dxyFromMyVertex * cmToum);
-                PVValHelper::fillByIndex(h_dz_modZ_, module_num - 1, dzFromMyVertex * cmToum);
-                PVValHelper::fillByIndex(h_norm_dxy_modZ_, module_num - 1, dxyFromMyVertex / s_ip2dpv_err);
-                PVValHelper::fillByIndex(h_norm_dz_modZ_, module_num - 1, dzFromMyVertex / dz_err);
+                PVValHelper::fillByIndex(h_dxy_modZ_, module_num - 1, dxyFromMyVertex * cmToum, "17");
+                PVValHelper::fillByIndex(h_dz_modZ_, module_num - 1, dzFromMyVertex * cmToum, "18");
+                PVValHelper::fillByIndex(h_norm_dxy_modZ_, module_num - 1, dxyFromMyVertex / s_ip2dpv_err, "19");
+                PVValHelper::fillByIndex(h_norm_dz_modZ_, module_num - 1, dzFromMyVertex / dz_err, "20");
 
-                PVValHelper::fillByIndex(h_dxy_ladder_, ladder_num - 1, dxyFromMyVertex * cmToum);
+                PVValHelper::fillByIndex(h_dxy_ladder_, ladder_num - 1, dxyFromMyVertex * cmToum, "21");
 
                 LogDebug("PrimaryVertexValidation") << "h_dxy_ladder size:" << h_dxy_ladder_.size() << std::endl;
 
@@ -991,11 +1051,11 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
                   PVValHelper::fillByIndex(h_dxy_ladderOverlap_, ladder_num - 1, dxyFromMyVertex * cmToum);
                 }
 
-                PVValHelper::fillByIndex(h_dz_ladder_, ladder_num - 1, dzFromMyVertex * cmToum);
-                PVValHelper::fillByIndex(h_norm_dxy_ladder_, ladder_num - 1, dxyFromMyVertex / s_ip2dpv_err);
-                PVValHelper::fillByIndex(h_norm_dz_ladder_, ladder_num - 1, dzFromMyVertex / dz_err);
-
                 h2_probePassingLayer1Map_->Fill(module_num, ladder_num);
+
+                PVValHelper::fillByIndex(h_dz_ladder_, ladder_num - 1, dzFromMyVertex * cmToum, "22");
+                PVValHelper::fillByIndex(h_norm_dxy_ladder_, ladder_num - 1, dxyFromMyVertex / s_ip2dpv_err, "23");
+                PVValHelper::fillByIndex(h_norm_dz_ladder_, ladder_num - 1, dzFromMyVertex / dz_err, "24");
               }
 
               // filling the binned distributions
@@ -1007,37 +1067,37 @@ void PrimaryVertexValidation::analyze(const edm::Event& iEvent, const edm::Event
                 float etaL = theDetails_.trendbins[PVValHelper::eta][i + 1];
 
                 if (tracketa >= etaF && tracketa < etaL) {
-                  PVValHelper::fillByIndex(a_dxyEtaResiduals, i, dxyFromMyVertex * cmToum, "1");
-                  PVValHelper::fillByIndex(a_dxEtaResiduals, i, my_dx * cmToum, "2");
-                  PVValHelper::fillByIndex(a_dyEtaResiduals, i, my_dy * cmToum, "3");
-                  PVValHelper::fillByIndex(a_dzEtaResiduals, i, dzFromMyVertex * cmToum, "4");
-                  PVValHelper::fillByIndex(n_dxyEtaResiduals, i, dxyFromMyVertex / s_ip2dpv_err, "5");
-                  PVValHelper::fillByIndex(n_dzEtaResiduals, i, dzFromMyVertex / dz_err, "6");
-                  PVValHelper::fillByIndex(a_IP2DEtaResiduals, i, s_ip2dpv_corr * cmToum, "7");
-                  PVValHelper::fillByIndex(n_IP2DEtaResiduals, i, s_ip2dpv_corr / s_ip2dpv_err, "8");
-                  PVValHelper::fillByIndex(a_reszEtaResiduals, i, restrkz * cmToum, "9");
-                  PVValHelper::fillByIndex(n_reszEtaResiduals, i, pulltrkz, "10");
-                  PVValHelper::fillByIndex(a_d3DEtaResiduals, i, ip3d_corr * cmToum, "11");
-                  PVValHelper::fillByIndex(n_d3DEtaResiduals, i, ip3d_corr / ip3d_err, "12");
-                  PVValHelper::fillByIndex(a_IP3DEtaResiduals, i, s_ip3dpv_corr * cmToum, "13");
-                  PVValHelper::fillByIndex(n_IP3DEtaResiduals, i, s_ip3dpv_corr / s_ip3dpv_err, "14");
+                  PVValHelper::fillByIndex(a_dxyEtaResiduals, i, dxyFromMyVertex * cmToum, "25");
+                  PVValHelper::fillByIndex(a_dxEtaResiduals, i, my_dx * cmToum, "26");
+                  PVValHelper::fillByIndex(a_dyEtaResiduals, i, my_dy * cmToum, "27");
+                  PVValHelper::fillByIndex(a_dzEtaResiduals, i, dzFromMyVertex * cmToum, "28");
+                  PVValHelper::fillByIndex(n_dxyEtaResiduals, i, dxyFromMyVertex / s_ip2dpv_err, "29");
+                  PVValHelper::fillByIndex(n_dzEtaResiduals, i, dzFromMyVertex / dz_err, "30");
+                  PVValHelper::fillByIndex(a_IP2DEtaResiduals, i, s_ip2dpv_corr * cmToum, "31");
+                  PVValHelper::fillByIndex(n_IP2DEtaResiduals, i, s_ip2dpv_corr / s_ip2dpv_err, "32");
+                  PVValHelper::fillByIndex(a_reszEtaResiduals, i, restrkz * cmToum, "33");
+                  PVValHelper::fillByIndex(n_reszEtaResiduals, i, pulltrkz, "34");
+                  PVValHelper::fillByIndex(a_d3DEtaResiduals, i, ip3d_corr * cmToum, "35");
+                  PVValHelper::fillByIndex(n_d3DEtaResiduals, i, ip3d_corr / ip3d_err, "36");
+                  PVValHelper::fillByIndex(a_IP3DEtaResiduals, i, s_ip3dpv_corr * cmToum, "37");
+                  PVValHelper::fillByIndex(n_IP3DEtaResiduals, i, s_ip3dpv_corr / s_ip3dpv_err, "38");
                 }
 
                 if (trackphi >= phiF && trackphi < phiL) {
-                  PVValHelper::fillByIndex(a_dxyPhiResiduals, i, dxyFromMyVertex * cmToum, "15");
-                  PVValHelper::fillByIndex(a_dxPhiResiduals, i, my_dx * cmToum, "16");
-                  PVValHelper::fillByIndex(a_dyPhiResiduals, i, my_dy * cmToum, "17");
-                  PVValHelper::fillByIndex(a_dzPhiResiduals, i, dzFromMyVertex * cmToum, "18");
-                  PVValHelper::fillByIndex(n_dxyPhiResiduals, i, dxyFromMyVertex / s_ip2dpv_err, "19");
-                  PVValHelper::fillByIndex(n_dzPhiResiduals, i, dzFromMyVertex / dz_err, "20");
-                  PVValHelper::fillByIndex(a_IP2DPhiResiduals, i, s_ip2dpv_corr * cmToum, "21");
-                  PVValHelper::fillByIndex(n_IP2DPhiResiduals, i, s_ip2dpv_corr / s_ip2dpv_err, "22");
-                  PVValHelper::fillByIndex(a_reszPhiResiduals, i, restrkz * cmToum, "23");
-                  PVValHelper::fillByIndex(n_reszPhiResiduals, i, pulltrkz, "24");
-                  PVValHelper::fillByIndex(a_d3DPhiResiduals, i, ip3d_corr * cmToum, "25");
-                  PVValHelper::fillByIndex(n_d3DPhiResiduals, i, ip3d_corr / ip3d_err, "26");
-                  PVValHelper::fillByIndex(a_IP3DPhiResiduals, i, s_ip3dpv_corr * cmToum, "27");
-                  PVValHelper::fillByIndex(n_IP3DPhiResiduals, i, s_ip3dpv_corr / s_ip3dpv_err, "28");
+                  PVValHelper::fillByIndex(a_dxyPhiResiduals, i, dxyFromMyVertex * cmToum, "39");
+                  PVValHelper::fillByIndex(a_dxPhiResiduals, i, my_dx * cmToum, "40");
+                  PVValHelper::fillByIndex(a_dyPhiResiduals, i, my_dy * cmToum, "41");
+                  PVValHelper::fillByIndex(a_dzPhiResiduals, i, dzFromMyVertex * cmToum, "42");
+                  PVValHelper::fillByIndex(n_dxyPhiResiduals, i, dxyFromMyVertex / s_ip2dpv_err, "43");
+                  PVValHelper::fillByIndex(n_dzPhiResiduals, i, dzFromMyVertex / dz_err, "44");
+                  PVValHelper::fillByIndex(a_IP2DPhiResiduals, i, s_ip2dpv_corr * cmToum, "45");
+                  PVValHelper::fillByIndex(n_IP2DPhiResiduals, i, s_ip2dpv_corr / s_ip2dpv_err, "46");
+                  PVValHelper::fillByIndex(a_reszPhiResiduals, i, restrkz * cmToum, "47");
+                  PVValHelper::fillByIndex(n_reszPhiResiduals, i, pulltrkz, "48");
+                  PVValHelper::fillByIndex(a_d3DPhiResiduals, i, ip3d_corr * cmToum, "49");
+                  PVValHelper::fillByIndex(n_d3DPhiResiduals, i, ip3d_corr / ip3d_err, "50");
+                  PVValHelper::fillByIndex(a_IP3DPhiResiduals, i, s_ip3dpv_corr * cmToum, "51");
+                  PVValHelper::fillByIndex(n_IP3DPhiResiduals, i, s_ip3dpv_corr / s_ip3dpv_err, "52");
 
                   for (int j = 0; j < nBins_; j++) {
                     float etaJ = theDetails_.trendbins[PVValHelper::eta][j];
@@ -1113,7 +1173,7 @@ bool PrimaryVertexValidation::isHit2D(const TrackingRecHit& hit) const {
         else if (dynamic_cast<const ProjectedSiStripRecHit2D*>(&hit))
           return false;  // crazy hit...
         else {
-          edm::LogError("UnkownType") << "@SUB=AlignmentTrackSelector::isHit2D"
+          edm::LogError("UnkownType") << "@SUB=PrimaryVertexValidation::isHit2D"
                                       << "Tracker hit not in pixel and neither SiStripRecHit2D nor "
                                       << "SiStripMatchedRecHit2D nor ProjectedSiStripRecHit2D.";
           return false;
@@ -1276,7 +1336,7 @@ void PrimaryVertexValidation::beginJob() {
   }
 
   h_runFromEvent =
-      EventFeatures.make<TH1I>("h_runFromEvent", "run number from config;;run number (from event)", 1, -0.5, 0.5);
+      EventFeatures.make<TH1I>("h_runFromEvent", "run number from event;;run number (from event)", 1, -0.5, 0.5);
   h_nTracks =
       EventFeatures.make<TH1F>("h_nTracks", "number of tracks per event;n_{tracks}/event;n_{events}", 300, -0.5, 299.5);
   h_nClus =
@@ -1314,6 +1374,7 @@ void PrimaryVertexValidation::beginJob() {
 
   h_nbins = EventFeatures.make<TH1F>("nbins", "nbins", 1, -0.5, 0.5);
   h_nLadders = EventFeatures.make<TH1F>("nladders", "n. ladders", 1, -0.5, 0.5);
+  h_nModZ = EventFeatures.make<TH1F>("nModZ", "n. modules along z", 1, -0.5, 0.5);
 
   // probe track histograms
   TFileDirectory ProbeFeatures = fs->mkdir("ProbeTrackFeatures");
@@ -1322,23 +1383,24 @@ void PrimaryVertexValidation::beginJob() {
   h_probePtRebin_ = ProbeFeatures.make<TH1F>(
       "h_probePtRebin", "p_{T} of probe track;track p_{T} (GeV); tracks", mypT_bins_.size() - 1, mypT_bins_.data());
   h_probeP_ = ProbeFeatures.make<TH1F>("h_probeP", "momentum of probe track;track p (GeV); tracks", 100, 0., 100.);
-  h_probeEta_ = ProbeFeatures.make<TH1F>("h_probeEta", "#eta of the probe track;track #eta;tracks", 54, -2.8, 2.8);
+  h_probeEta_ = ProbeFeatures.make<TH1F>(
+      "h_probeEta", "#eta of the probe track;track #eta;tracks", 54, -etaOfProbe_, etaOfProbe_);
   h_probePhi_ = ProbeFeatures.make<TH1F>("h_probePhi", "#phi of probe track;track #phi (rad);tracks", 100, -3.15, 3.15);
 
   h2_probeEtaPhi_ =
       ProbeFeatures.make<TH2F>("h2_probeEtaPhi",
                                "probe track #phi vs #eta;#eta of probe track;track #phi of probe track (rad); tracks",
                                54,
-                               -2.8,
-                               2.8,
+                               -etaOfProbe_,
+                               etaOfProbe_,
                                100,
-                               -3.15,
-                               3.15);
+                               -M_PI,
+                               M_PI);
   h2_probeEtaPt_ = ProbeFeatures.make<TH2F>("h2_probeEtaPt",
                                             "probe track p_{T} vs #eta;#eta of probe track;track p_{T} (GeV); tracks",
                                             54,
-                                            -2.8,
-                                            2.8,
+                                            -etaOfProbe_,
+                                            etaOfProbe_,
                                             100,
                                             0.,
                                             50.);
@@ -1411,21 +1473,28 @@ void PrimaryVertexValidation::beginJob() {
   h_probeHitsInFPIX_ =
       ProbeFeatures.make<TH1F>("h_probeNRechitsFPIX", "N_{hits} FPIX;N_{hits} FPIX;tracks", 40, -0.5, 39.5);
 
-  h_probeL1Ladder_ =
-      ProbeFeatures.make<TH1F>("h_probeL1Ladder", "Ladder number (L1 hit); ladder number", 22, -1.5, 20.5);
-  h_probeL1Module_ =
-      ProbeFeatures.make<TH1F>("h_probeL1Module", "Module number (L1 hit); module number", 10, -1.5, 8.5);
+  h_probeL1Ladder_ = ProbeFeatures.make<TH1F>(
+      "h_probeL1Ladder", "Ladder number (L1 hit); ladder number", nLadders_ + 2, -1.5, nLadders_ + 0.5);
+  h_probeL1Module_ = ProbeFeatures.make<TH1F>(
+      "h_probeL1Module", "Module number (L1 hit); module number", nModZ_ + 2, -1.5, nModZ_ + 0.5);
 
-  h2_probeLayer1Map_ = ProbeFeatures.make<TH2F>(
-      "h2_probeLayer1Map", "Position in Layer 1 of first hit;module number;ladder number", 8, 0.5, 8.5, 12, 0.5, 12.5);
+  h2_probeLayer1Map_ = ProbeFeatures.make<TH2F>("h2_probeLayer1Map",
+                                                "Position in Layer 1 of first hit;module number;ladder number",
+                                                nModZ_,
+                                                0.5,
+                                                nModZ_ + 0.5,
+                                                nLadders_,
+                                                0.5,
+                                                nLadders_ + 0.5);
+
   h2_probePassingLayer1Map_ = ProbeFeatures.make<TH2F>("h2_probePassingLayer1Map",
                                                        "Position in Layer 1 of first hit;module number;ladder number",
-                                                       8,
+                                                       nModZ_,
                                                        0.5,
-                                                       8.5,
-                                                       12,
+                                                       nModZ_ + 0.5,
+                                                       nLadders_,
                                                        0.5,
-                                                       12.5);
+                                                       nLadders_ + 0.5);
   h_probeHasBPixL1Overlap_ =
       ProbeFeatures.make<TH1I>("h_probeHasBPixL1Overlap", "n. hits in L1;n. L1-BPix hits;tracks", 5, -0.5, 4.5);
   h_probeL1ClusterProb_ = ProbeFeatures.make<TH1F>(
@@ -1585,10 +1654,10 @@ void PrimaryVertexValidation::beginJob() {
   // book residuals vs module number
 
   TFileDirectory AbsTransModZRes = fs->mkdir("Abs_Transv_modZ_Residuals");
-  h_dxy_modZ_ = bookResidualsHistogram(AbsTransModZRes, 8, PVValHelper::dxy, PVValHelper::modZ);
+  h_dxy_modZ_ = bookResidualsHistogram(AbsTransModZRes, nModZ_, PVValHelper::dxy, PVValHelper::modZ);
 
   TFileDirectory AbsLongModZRes = fs->mkdir("Abs_Long_modZ_Residuals");
-  h_dz_modZ_ = bookResidualsHistogram(AbsLongModZRes, 8, PVValHelper::dz, PVValHelper::modZ);
+  h_dz_modZ_ = bookResidualsHistogram(AbsLongModZRes, nModZ_, PVValHelper::dz, PVValHelper::modZ);
 
   //  _  _                    _ _           _   ___        _    _           _
   // | \| |___ _ _ _ __  __ _| (_)______ __| | | _ \___ __(_)__| |_  _ __ _| |___
@@ -1597,10 +1666,10 @@ void PrimaryVertexValidation::beginJob() {
   //
 
   TFileDirectory NormTransModZRes = fs->mkdir("Norm_Transv_modZ_Residuals");
-  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes, 8, PVValHelper::norm_dxy, PVValHelper::modZ, true);
+  h_norm_dxy_modZ_ = bookResidualsHistogram(NormTransModZRes, nModZ_, PVValHelper::norm_dxy, PVValHelper::modZ, true);
 
   TFileDirectory NormLongModZRes = fs->mkdir("Norm_Long_modZ_Residuals");
-  h_norm_dz_modZ_ = bookResidualsHistogram(NormLongModZRes, 8, PVValHelper::norm_dz, PVValHelper::modZ, true);
+  h_norm_dz_modZ_ = bookResidualsHistogram(NormLongModZRes, nModZ_, PVValHelper::norm_dz, PVValHelper::modZ, true);
 
   TFileDirectory AbsTransLadderRes = fs->mkdir("Abs_Transv_ladder_Residuals");
   h_dxy_ladder_ = bookResidualsHistogram(AbsTransLadderRes, nLadders_, PVValHelper::dxy, PVValHelper::ladder);
@@ -1627,7 +1696,7 @@ void PrimaryVertexValidation::beginJob() {
   // book residuals as function of nLadders and nModules
 
   for (unsigned int iLadder = 0; iLadder < nLadders_; iLadder++) {
-    for (unsigned int iModule = 0; iModule < 8; iModule++) {
+    for (unsigned int iModule = 0; iModule < nModZ_; iModule++) {
       a_dxyL1ResidualsMap[iLadder][iModule] =
           AbsL1Map.make<TH1F>(Form("histo_dxy_ladder%i_module%i", iLadder, iModule),
                               Form("d_{xy} ladder=%i module=%i;d_{xy} [#mum];tracks", iLadder, iModule),
@@ -2593,6 +2662,14 @@ void PrimaryVertexValidation::beginJob() {
 }
 // ------------ method called once each job just after ending the event loop  ------------
 void PrimaryVertexValidation::endJob() {
+  // shring the histograms to fit
+  h_probeL1Ladder_->GetXaxis()->SetRangeUser(-1.5, nLadders_ + 0.5);
+  h_probeL1Module_->GetXaxis()->SetRangeUser(-1.5, nModZ_ + 0.5);
+  h2_probeLayer1Map_->GetXaxis()->SetRangeUser(0.5, nModZ_ + 0.5);
+  h2_probeLayer1Map_->GetYaxis()->SetRangeUser(0.5, nLadders_ + 0.5);
+  h2_probePassingLayer1Map_->GetXaxis()->SetRangeUser(0.5, nModZ_ + 0.5);
+  h2_probePassingLayer1Map_->GetYaxis()->SetRangeUser(0.5, nLadders_ + 0.5);
+
   TFileDirectory RunFeatures = fs->mkdir("RunFeatures");
   h_runStartTimes = RunFeatures.make<TH1I>(
       "runStartTimes", "run start times", runNumbersTimesLog_.size(), 0, runNumbersTimesLog_.size());
@@ -2713,18 +2790,18 @@ void PrimaryVertexValidation::endJob() {
 
   a_dxyL1MeanMap = Mean2DMapsDir.make<TH2F>("means_dxy_l1map",
                                             "#LT d_{xy} #GT map;module number [z];ladder number [#varphi]",
-                                            8,
+                                            nModZ_,
                                             0.,
-                                            8.,
+                                            nModZ_,
                                             nLadders_,
                                             0.,
                                             nLadders_);
 
   a_dzL1MeanMap = Mean2DMapsDir.make<TH2F>("means_dz_l1map",
                                            "#LT d_{z} #GT map;module number [z];ladder number [#varphi]",
-                                           8,
+                                           nModZ_,
                                            0.,
-                                           8.,
+                                           nModZ_,
                                            nLadders_,
                                            0.,
                                            nLadders_);
@@ -2732,36 +2809,36 @@ void PrimaryVertexValidation::endJob() {
   n_dxyL1MeanMap =
       Mean2DMapsDir.make<TH2F>("norm_means_dxy_l1map",
                                "#LT d_{xy}/#sigma_{d_{xy}} #GT map;module number [z];ladder number [#varphi]",
-                               8,
+                               nModZ_,
                                0.,
-                               8.,
+                               nModZ_,
                                nLadders_,
                                0.,
                                nLadders_);
 
   n_dzL1MeanMap = Mean2DMapsDir.make<TH2F>("norm_means_dz_l1map",
                                            "#LT d_{z}/#sigma_{d_{z}} #GT map;module number [z];ladder number [#varphi]",
-                                           8,
+                                           nModZ_,
                                            0.,
-                                           8.,
+                                           nModZ_,
                                            nLadders_,
                                            0.,
                                            nLadders_);
 
   a_dxyL1WidthMap = Width2DMapsDir.make<TH2F>("widths_dxy_l1map",
                                               "#sigma_{d_{xy}} map;module number [z];ladder number [#varphi]",
-                                              8,
+                                              nModZ_,
                                               0.,
-                                              8.,
+                                              nModZ_,
                                               nLadders_,
                                               0.,
                                               nLadders_);
 
   a_dzL1WidthMap = Width2DMapsDir.make<TH2F>("widths_dz_l1map",
                                              "#sigma_{d_{z}} map;module number [z];ladder number [#varphi]",
-                                             8,
+                                             nModZ_,
                                              0.,
-                                             8.,
+                                             nModZ_,
                                              nLadders_,
                                              0.,
                                              nLadders_);
@@ -2769,9 +2846,9 @@ void PrimaryVertexValidation::endJob() {
   n_dxyL1WidthMap =
       Width2DMapsDir.make<TH2F>("norm_widths_dxy_l1map",
                                 "width(d_{xy}/#sigma_{d_{xy}}) map;module number [z];ladder number [#varphi]",
-                                8,
+                                nModZ_,
                                 0.,
-                                8.,
+                                nModZ_,
                                 nLadders_,
                                 0.,
                                 nLadders_);
@@ -2779,9 +2856,9 @@ void PrimaryVertexValidation::endJob() {
   n_dzL1WidthMap =
       Width2DMapsDir.make<TH2F>("norm_widths_dz_l1map",
                                 "width(d_{z}/#sigma_{d_{z}}) map;module number [z];ladder number [#varphi]",
-                                8,
+                                nModZ_,
                                 0.,
-                                8.,
+                                nModZ_,
                                 nLadders_,
                                 0.,
                                 nLadders_);
@@ -2945,15 +3022,15 @@ void PrimaryVertexValidation::endJob() {
 
   // 2D Maps of residuals in bins of L1 modules
 
-  fillMap(a_dxyL1MeanMap, a_dxyL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
-  fillMap(a_dxyL1WidthMap, a_dxyL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
-  fillMap(a_dzL1MeanMap, a_dzL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
-  fillMap(a_dzL1WidthMap, a_dzL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
+  fillMap(a_dxyL1MeanMap, a_dxyL1ResidualsMap, PVValHelper::MEAN, nModZ_, nLadders_);
+  fillMap(a_dxyL1WidthMap, a_dxyL1ResidualsMap, PVValHelper::WIDTH, nModZ_, nLadders_);
+  fillMap(a_dzL1MeanMap, a_dzL1ResidualsMap, PVValHelper::MEAN, nModZ_, nLadders_);
+  fillMap(a_dzL1WidthMap, a_dzL1ResidualsMap, PVValHelper::WIDTH, nModZ_, nLadders_);
 
-  fillMap(n_dxyL1MeanMap, n_dxyL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
-  fillMap(n_dxyL1WidthMap, n_dxyL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
-  fillMap(n_dzL1MeanMap, n_dzL1ResidualsMap, PVValHelper::MEAN, 8, nLadders_);
-  fillMap(n_dzL1WidthMap, n_dzL1ResidualsMap, PVValHelper::WIDTH, 8, nLadders_);
+  fillMap(n_dxyL1MeanMap, n_dxyL1ResidualsMap, PVValHelper::MEAN, nModZ_, nLadders_);
+  fillMap(n_dxyL1WidthMap, n_dxyL1ResidualsMap, PVValHelper::WIDTH, nModZ_, nLadders_);
+  fillMap(n_dzL1MeanMap, n_dzL1ResidualsMap, PVValHelper::MEAN, nModZ_, nLadders_);
+  fillMap(n_dzL1WidthMap, n_dzL1ResidualsMap, PVValHelper::WIDTH, nModZ_, nLadders_);
 }
 
 //*************************************************************

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -83,7 +83,7 @@ private:
   void endJob() override;
   bool isBFieldConsistentWithMode(const edm::EventSetup& iSetup) const;
   std::pair<long long, long long> getRunTime(const edm::EventSetup& iSetup) const;
-  bool isHit2D(const TrackingRecHit& hit) const;
+  bool isHit2D(const TrackingRecHit& hit, const PVValHelper::detectorPhase& thePhase) const;
   bool hasFirstLayerPixelHits(const reco::TransientTrack& track);
   std::pair<bool, bool> pixelHitsCheck(const reco::TransientTrack& track);
   Measurement1D getMedian(TH1F* histo);

--- a/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
+++ b/Alignment/OfflineValidation/plugins/PrimaryVertexValidation.h
@@ -176,7 +176,7 @@ private:
   double pOfProbe_;
   double etaOfProbe_;
   double nHitsOfProbe_;
-  bool isPhase1_;
+  PVValHelper::detectorPhase phase_;
 
   // actual number of histograms
   int nBins_;
@@ -203,12 +203,13 @@ private:
   //=======================
   void SetVarToZero();
 
-  static const int nMaxtracks_ = 1000;
+  static const int nMaxtracks_ = 10000;
   static const int cmToum = 10000;
   static const int nPtBins_ = 48;
 
+  // use the maximum of each of the three phases
   unsigned int nLadders_ = 20;
-  unsigned int nModZ_ = 8;
+  unsigned int nModZ_ = 9;
 
   // pT binning as in paragraph 3.2 of CMS-PAS-TRK-10-005 (https://cds.cern.ch/record/1279383/files/TRK-10-005-pas.pdf)
 
@@ -308,6 +309,7 @@ private:
   TH1F* h_etaMax;
   TH1F* h_nbins;
   TH1F* h_nLadders;
+  TH1F* h_nModZ;
   TH1F* h_pTinfo;
 
   std::map<unsigned int, std::pair<long long, long long> > runNumbersTimesLog_;

--- a/Alignment/OfflineValidation/src/PVValidationHelpers.cc
+++ b/Alignment/OfflineValidation/src/PVValidationHelpers.cc
@@ -43,7 +43,7 @@ void PVValHelper::fillByIndex(std::vector<TH1F*>& h, unsigned int index, double 
 //*************************************************************
 {
   assert(!h.empty());
-  if (index <= h.size()) {
+  if (index < h.size()) {
     h[index]->Fill(x);
   } else {
     edm::LogWarning("PVValidationHelpers") << "Trying to fill non-existing Histogram with index " << index
@@ -224,7 +224,9 @@ std::pair<Measurement1D, Measurement1D> PVValHelper::fitResiduals(TH1* hist)
 //*************************************************************
 {
   //float fitResult(9999);
-  //if (hist->GetEntries() < 20) return ;
+  if (hist->GetEntries() < 1) {
+    return std::make_pair(Measurement1D(0., 0.), Measurement1D(0., 0.));
+  };
 
   float mean = hist->GetMean();
   float sigma = hist->GetRMS();


### PR DESCRIPTION
#### PR description:

The goal of this PR is to adapt the Tracker Alignment PV Validation tool to be able to cope with Phase-2 Tracker geometries.
The main things which are changed are:
   * probe track pseudo-rapidity acceptance is enlarged to cover up to  |η=4| (which is the maximal acceptance of TEPX)
   * the number of modules in one TBPX ladder along z is 9 and not 8 as for the phase-0/phase-1 detectors

Shown here for reference is the layout of the T15 (included in the D49) geometry, as used for the Phase-2 HLT TDR: 

![image](https://user-images.githubusercontent.com/5082376/100855993-21f90b00-348b-11eb-8568-72b3a51a81c7.png)

#### PR validation:

Relies on the existing unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport is needed.
