### PR TITLE
Fixing Stat Overflows consideration on DQM modules

### DIFF
--- a/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
+++ b/DQMOffline/EGamma/src/ElectronDqmHarvesterBase.cc
@@ -204,7 +204,7 @@ ElectronDqmHarvesterBase::MonitorElement *ElectronDqmHarvesterBase::bookH1(DQMSt
     me->setOption(option);
   }
   if (bookStatOverflowFlag_) {
-    me->getTH1F()->StatOverflows(kTRUE);
+    me->setStatOverflows(kTRUE);
   }
   return me;
 }

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -907,9 +907,9 @@ namespace dqm::impl {
   void MonitorElement::setStatOverflows(unsigned int value) {
     auto access = this->accessMut();
     if (value == kTRUE)
-      access.value.object_->StatOverflows(TH1::kConsider);
+      access.value.object_->SetStatOverflows(TH1::kConsider);
     else
-      access.value.object_->StatOverflows(value);
+      access.value.object_->SetStatOverflows(TH1::kIgnore);
   }
 
   int64_t MonitorElement::getIntValue() const {

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -906,10 +906,10 @@ namespace dqm::impl {
 
   void MonitorElement::setStatOverflows(unsigned int value) {
     auto access = this->accessMut();
-    if (value==kTRUE)
-           access.value.object_->StatOverflows(TH1::kConsider);
+    if (value == kTRUE)
+      access.value.object_->StatOverflows(TH1::kConsider);
     else
-           access.value.object_->StatOverflows(value);
+      access.value.object_->StatOverflows(value);
   }
 
   int64_t MonitorElement::getIntValue() const {

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -906,7 +906,10 @@ namespace dqm::impl {
 
   void MonitorElement::setStatOverflows(unsigned int value) {
     auto access = this->accessMut();
-    access.value.object_->StatOverflows(value);
+    if (value==kTRUE)
+           access.value.object_->StatOverflows(TH1::kConsider);
+    else
+           access.value.object_->StatOverflows(value);
   }
 
   int64_t MonitorElement::getIntValue() const {


### PR DESCRIPTION
#### PR description:

This PR tries to fix the problem mentioned in https://github.com/cms-sw/cmssw/pull/32343#issuecomment-736862320 

The proposed solution goes directly to DQM core setStatOverflows method instead of using teh ROOT method SetStatOverflow since DQM Monitor Elements inherit from there and this prevents modifying many DQM modules around.

I let coding experts to decide if this solution is preferred to directly modify 
DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
DQMOffline/EGamma/src/ElectronDqmAnalyzerBase.cc
as suggested on https://github.com/cms-sw/cmssw/pull/3234 instead.

I can switch to that strategy if preferred.

I have also noticed that there are many Alignment classes suffering from this too:
https://github.com/cms-sw/cmssw/search?p=1&q=StatOverflows


#### PR validation:

Checked compilation and some wf running
