### PR TITLE
Era support for the BMTF Packer

### DIFF
--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.cc
@@ -1,7 +1,5 @@
 #include "BMTFPackerOutput.h"
-
 #include <vector>
-//#include <bitset>//debug
 
 // Implementation
 namespace l1t {
@@ -12,8 +10,9 @@ namespace l1t {
       auto muonToken = static_cast<const BMTFTokens*>(toks)->getOutputMuonToken();
 
       Blocks blocks;
-
       const int bmtfBlockID = 123;
+      edm::LogInfo("L1T-BMTFPackerOutput") << "Will use setup:"
+                                           << " isKalman->" << isKalman_;
 
       edm::Handle<RegionalMuonCandBxCollection> muons;
       event.getByToken(muonToken, muons);

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFPackerOutput.h
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "EventFilter/L1TRawToDigi/interface/Packer.h"
 #include "EventFilter/L1TRawToDigi/plugins/PackerFactory.h"

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
@@ -24,36 +24,12 @@ namespace l1t {
         for (unsigned int i = 1; i <= board_out.size(); i++) {
 	  auto packer_out = std::make_shared<BMTFPackerOutput>();
 	  auto packer_in  = PackerFactory::get()->make("stage2::BMTFPackerInputs");
-	  if (fw >= 2452619552) { // the 1st Kalman fw ver
+	  if (fw >= 2452619552) { // the 1st Kalman fw-ver value (0x95000160)
 	    packer_out->setKalmanAlgoTrue();
 	  }
 	  res[{i, board_out[i - 1]}] = {packer_out, packer_in};
         }
-      }  //if feds
-
-      /*
-	 if (fed == 1376) {
-	   std::cout << "fed is 1376" << std::endl;
-	   for (int i=1; i <= 12; i = i+2){//itr for amc_no = 1,3,5,7,9,11
-	     res[{i,board_out[i-1]}] = {PackerFactory::get()->make("stage2::BMTFPackerOutput"),
-					PackerFactory::get()->make("stage2::BMTFPackerInputs")};
-	   }
-
-	 }
-	 else if (fed == 1377) {
-	   std::cout << "fed is 1377" << std::endl;
-	   for (int i=2; i <=12; i = i+2){//itr for amc_no = 2,4,6,8,10,12
-	     res[{i,board_out[i-1]}] = {PackerFactory::get()->make("stage2::BMTFPackerOutput"),
-					PackerFactory::get()->make("stage2::BMTFPackerInputs")};
-	   }
-	
-	 }
-	 else{
-	   std::cout << std::endl;
-	   std::cout << "The given fed is not a BMTF fed (1376 or 1377)" << std::endl;
-	   std::cout << std::endl;
-	 }//if feds
-	   */
+      }  //if BMTF feds
 
       return res;
     }  //getPackers

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
@@ -22,12 +22,12 @@ namespace l1t {
         std::array<int, 12> board_out = {{1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12}};  //these are board_ids per amc_no-1
 
         for (unsigned int i = 1; i <= board_out.size(); i++) {
-	  auto packer_out = std::make_shared<BMTFPackerOutput>();
-	  auto packer_in  = PackerFactory::get()->make("stage2::BMTFPackerInputs");
-	  if (fw >= 2452619552) { // the 1st Kalman fw-ver value (0x95000160)
-	    packer_out->setKalmanAlgoTrue();
-	  }
-	  res[{i, board_out[i - 1]}] = {packer_out, packer_in};
+          auto packer_out = std::make_shared<BMTFPackerOutput>();
+          auto packer_in = PackerFactory::get()->make("stage2::BMTFPackerInputs");
+          if (fw >= 2452619552) {  // the 1st Kalman fw-ver value (0x95000160)
+            packer_out->setKalmanAlgoTrue();
+          }
+          res[{i, board_out[i - 1]}] = {packer_out, packer_in};
         }
       }  //if BMTF feds
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
@@ -19,7 +19,7 @@ namespace l1t {
       //res are in format res[amc_no, board_id]
 
       if (fed == 1376 || fed == 1377) {
-        for (auto board: boardIdPerSlot) {
+        for (auto board : boardIdPerSlot) {
           auto packer_out = std::make_shared<BMTFPackerOutput>();
           auto packer_in = PackerFactory::get()->make("stage2::BMTFPackerInputs");
           if (fw >= firstKalmanFwVer) {
@@ -46,7 +46,7 @@ namespace l1t {
     UnpackerMap BMTFSetup::getUnpackers(int fed, int board, int amc, unsigned int fw) {
       auto inputMuonsOld = UnpackerFactory::get()->make("stage2::BMTFUnpackerInputsOldQual");
       auto inputMuonsNew = UnpackerFactory::get()->make("stage2::BMTFUnpackerInputsNewQual");
-      auto outputMuon = std::make_shared<BMTFUnpackerOutput>(); // triggering collection
+      auto outputMuon = std::make_shared<BMTFUnpackerOutput>();        // triggering collection
       auto outputMuon2 = std::make_shared<BMTFUnpackerOutput>(false);  // secondary coll
       if (fw >= firstKalmanFwVer)
         outputMuon->setKalmanAlgoTrue();

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.cc
@@ -22,13 +22,12 @@ namespace l1t {
         std::array<int, 12> board_out = {{1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12}};  //these are board_ids per amc_no-1
 
         for (unsigned int i = 1; i <= board_out.size(); i++) {
-          if (i % 2 != 0) {  //maybe this check is not needed
-            res[{i, board_out[i - 1]}] = {PackerFactory::get()->make("stage2::BMTFPackerOutput"),
-                                          PackerFactory::get()->make("stage2::BMTFPackerInputs")};
-          } else {
-            res[{i, board_out[i - 1]}] = {PackerFactory::get()->make("stage2::BMTFPackerOutput"),
-                                          PackerFactory::get()->make("stage2::BMTFPackerInputs")};
-          }
+	  auto packer_out = std::make_shared<BMTFPackerOutput>();
+	  auto packer_in  = PackerFactory::get()->make("stage2::BMTFPackerInputs");
+	  if (fw >= 2452619552) { // the 1st Kalman fw ver
+	    packer_out->setKalmanAlgoTrue();
+	  }
+	  res[{i, board_out[i - 1]}] = {packer_out, packer_in};
         }
       }  //if feds
 

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
@@ -21,6 +21,14 @@ namespace l1t {
       void registerProducts(edm::ProducesCollector) override;
       std::unique_ptr<UnpackerCollections> getCollections(edm::Event& e) override;
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
+
+    private:
+      const std::map<int, int> boardIdPerSlot { // {slot, boardId}
+	{1, 1}, {3, 2}, {5, 3}, {7, 4}, {9, 5}, {11, 6}, // Top Crate
+	{2, 7}, {4, 8}, {6, 9}, {8, 10}, {10, 11}, {12, 12} // Bottom Crate
+      };
+      const unsigned int firstNewInputsFwVer = 0x92300120;
+      const unsigned int firstKalmanFwVer = 0x95000160;
     };
   }  // namespace stage2
 }  // namespace l1t

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
@@ -9,6 +9,7 @@
 #include "BMTFCollections.h"
 #include "BMTFTokens.h"
 #include "BMTFUnpackerOutput.h"
+#include "BMTFPackerOutput.h"
 
 namespace l1t {
   namespace stage2 {

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFSetup.h
@@ -23,9 +23,20 @@ namespace l1t {
       UnpackerMap getUnpackers(int fed, int board, int amc, unsigned int fw) override;
 
     private:
-      const std::map<int, int> boardIdPerSlot { // {slot, boardId}
-	{1, 1}, {3, 2}, {5, 3}, {7, 4}, {9, 5}, {11, 6}, // Top Crate
-	{2, 7}, {4, 8}, {6, 9}, {8, 10}, {10, 11}, {12, 12} // Bottom Crate
+      const std::map<int, int> boardIdPerSlot{
+          // {slot, boardId}
+          {1, 1},
+          {3, 2},
+          {5, 3},
+          {7, 4},
+          {9, 5},
+          {11, 6},  // Top Crate
+          {2, 7},
+          {4, 8},
+          {6, 9},
+          {8, 10},
+          {10, 11},
+          {12, 12}  // Bottom Crate
       };
       const unsigned int firstNewInputsFwVer = 0x92300120;
       const unsigned int firstKalmanFwVer = 0x95000160;

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -21,9 +21,8 @@ namespace l1t {
             block.getBxBlocks((unsigned int)6, false);  //it returnes 6-32bit bxBlocks originated from the amc13 Block
 
       edm::LogInfo("L1T") << "Will use the setup:"
-                          << " ZS_enabled->" << ZS_enabled
-                          << " isTriggeringAlgo->" << isTriggeringAlgo
-                          << " isKalman->" << isKalman;
+                          << " ZS_enabled->" << ZS_enabled << " isTriggeringAlgo->" << isTriggeringAlgo << " isKalman->"
+                          << isKalman;
 
       RegionalMuonCandBxCollection *res;
       if (isTriggeringAlgo)

--- a/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
+++ b/EventFilter/L1TRawToDigi/plugins/implementations_stage2/BMTFUnpackerOutput.cc
@@ -1,7 +1,5 @@
 #include "EventFilter/L1TRawToDigi/plugins/UnpackerFactory.h"
-
 #include "L1Trigger/L1TMuon/interface/RegionalMuonRawDigiTranslator.h"
-
 #include "BMTFUnpackerOutput.h"
 
 namespace l1t {
@@ -21,6 +19,11 @@ namespace l1t {
       else
         bxBlocks =
             block.getBxBlocks((unsigned int)6, false);  //it returnes 6-32bit bxBlocks originated from the amc13 Block
+
+      edm::LogInfo("L1T") << "Will use the setup:"
+                          << " ZS_enabled->" << ZS_enabled
+                          << " isTriggeringAlgo->" << isTriggeringAlgo
+                          << " isKalman->" << isKalman;
 
       RegionalMuonCandBxCollection *res;
       if (isTriggeringAlgo)
@@ -45,8 +48,7 @@ namespace l1t {
 
       int processor = block.amc().getBoardID() - 1;
       if (processor < 0 || processor > 11) {
-        edm::LogInfo("l1t:stage2::BMTFUnpackerOutput::unpack")
-            << "Processor found out of range so it will be calculated by the old way";
+        edm::LogInfo("L1T") << "Processor found out of range, it will be calculated by the old way";
         if (block.amc().getAMCNumber() % 2 != 0)
           processor = block.amc().getAMCNumber() / 2;
         else

--- a/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
@@ -6,6 +6,7 @@ bmtfDigis = cms.EDProducer(
     InputLabel = cms.InputTag("rawDataCollector"),
     FedIds = cms.vint32(1376,1377),
     FWId = cms.uint32(1),
+    FWOverride = cms.bool(True),
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8),
     lenAMCHeader = cms.untracked.int32(8),
@@ -13,3 +14,19 @@ bmtfDigis = cms.EDProducer(
     lenAMC13Header = cms.untracked.int32(8),
     lenAMC13Trailer = cms.untracked.int32(8)
 )
+
+## Era: Run2_2016
+from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
+stage2L1Trigger.toModify(bmtfDigis, FWId = cms.uint32(1))
+
+## Era: Run2_2017
+from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
+stage2L1Trigger_2017.toModify(bmtfDigis, FWId = cms.uint32(1))
+
+### Era: Run2_2018
+from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
+stage2L1Trigger_2018.toModify(bmtfDigis, FWId = cms.uint32(1))
+
+### Era: Run3_2021
+from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
+stage2L1Trigger_2021.toModify(bmtfDigis, FWId = cms.uint32(2499805536))

--- a/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
@@ -6,7 +6,7 @@ bmtfDigis = cms.EDProducer(
     InputLabel = cms.InputTag("rawDataCollector"),
     FedIds = cms.vint32(1376,1377),
     FWId = cms.uint32(1),
-    FWOverride = cms.bool(True),
+    FWOverride = cms.bool(False),
     lenSlinkHeader = cms.untracked.int32(8),
     lenSlinkTrailer = cms.untracked.int32(8),
     lenAMCHeader = cms.untracked.int32(8),
@@ -17,16 +17,16 @@ bmtfDigis = cms.EDProducer(
 
 ## Era: Run2_2016
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(bmtfDigis, FWId = cms.uint32(1))
+stage2L1Trigger.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
 
 ## Era: Run2_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(bmtfDigis, FWId = cms.uint32(1))
+stage2L1Trigger_2017.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
 
 ### Era: Run2_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
-stage2L1Trigger_2018.toModify(bmtfDigis, FWId = cms.uint32(1))
+stage2L1Trigger_2018.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(bmtfDigis, FWId = cms.uint32(2499805536))
+stage2L1Trigger_2021.toModify(bmtfDigis, FWId = cms.uint32(2500002144)) # 0x95030160

--- a/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfDigis_cfi.py
@@ -17,16 +17,16 @@ bmtfDigis = cms.EDProducer(
 
 ## Era: Run2_2016
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger.toModify(bmtfDigis, FWId = cms.uint32(0x93500160))
 
 ## Era: Run2_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger_2017.toModify(bmtfDigis, FWId = cms.uint32(0x93500160))
 
 ### Era: Run2_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
-stage2L1Trigger_2018.toModify(bmtfDigis, FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger_2018.toModify(bmtfDigis, FWId = cms.uint32(0x93500160))
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(bmtfDigis, FWId = cms.uint32(2500002144)) # 0x95030160
+stage2L1Trigger_2021.toModify(bmtfDigis, FWId = cms.uint32(0x95030160))

--- a/EventFilter/L1TRawToDigi/python/bmtfStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfStage2Raw_cfi.py
@@ -13,16 +13,16 @@ bmtfStage2Raw = cms.EDProducer(
 
 ## Era: Run2_2016
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(0x93500160))
 
 ## Era: Run2_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger_2017.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(0x93500160))
 
 ### Era: Run2_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
-stage2L1Trigger_2018.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
+stage2L1Trigger_2018.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(0x93500160))
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(2500002144)) # 0x95030160
+stage2L1Trigger_2021.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(0x95030160))

--- a/EventFilter/L1TRawToDigi/python/bmtfStage2Raw_cfi.py
+++ b/EventFilter/L1TRawToDigi/python/bmtfStage2Raw_cfi.py
@@ -13,16 +13,16 @@ bmtfStage2Raw = cms.EDProducer(
 
 ## Era: Run2_2016
 from Configuration.Eras.Modifier_stage2L1Trigger_cff import stage2L1Trigger
-stage2L1Trigger.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(1))
+stage2L1Trigger.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
 
 ## Era: Run2_2017
 from Configuration.Eras.Modifier_stage2L1Trigger_2017_cff import stage2L1Trigger_2017
-stage2L1Trigger_2017.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(1))
+stage2L1Trigger_2017.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
 
 ### Era: Run2_2018
 from Configuration.Eras.Modifier_stage2L1Trigger_2018_cff import stage2L1Trigger_2018
-stage2L1Trigger_2018.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(1))
+stage2L1Trigger_2018.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simBmtfDigis", "BMTF"), FWId = cms.uint32(2471493984)) # 0x93500160
 
 ### Era: Run3_2021
 from Configuration.Eras.Modifier_stage2L1Trigger_2021_cff import stage2L1Trigger_2021
-stage2L1Trigger_2021.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(2499805536))
+stage2L1Trigger_2021.toModify(bmtfStage2Raw, InputLabel = cms.InputTag("simKBmtfDigis", "BMTF"), FWId = cms.uint32(2500002144)) # 0x95030160


### PR DESCRIPTION
#### PR description:
- Introduces support for the `--era` arguments in the BMTF Packer (and Unpacker)
(The Kalman algorithm will be packed for the `Run3` era, while the old one will remain for all `Run2_...` eras.)
- Cleans up a little the `BMTFSetup.cc` file
- Introduces some logging via the MessageLogger under the category "L1T" 

#### PR validation:
Tested using 2 custom workflows with `--era Run2_2018` and `--era Run3` respectively
Steps of the workflows: `-s DIGI2RAW,L1,RAW2DIGI`

@rekovic please have a look into this