### PR TITLE
Make the skipBadFiles option work, add tests

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -199,6 +199,7 @@ namespace edm {
     edm::LuminosityBlockNumber_t nextLuminosityBlockID();
 
     void readFile();
+    bool fileBlockValid() { return fb_.get() != nullptr; }
     void closeInputFile(bool cleaningUpAfterException);
     void openOutputFiles();
     void closeOutputFiles();

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -773,7 +773,7 @@ namespace edm {
   }
 
   void EventProcessor::closeInputFile(bool cleaningUpAfterException) {
-    if (fb_.get() != nullptr) {
+    if (fileBlockValid()) {
       SendSourceTerminationSignalIfException sentry(actReg_.get());
       input_->closeFile(fb_.get(), cleaningUpAfterException);
       sentry.completedSuccessfully();
@@ -782,7 +782,7 @@ namespace edm {
   }
 
   void EventProcessor::openOutputFiles() {
-    if (fb_.get() != nullptr) {
+    if (fileBlockValid()) {
       schedule_->openOutputFiles(*fb_);
       for_all(subProcesses_, [this](auto& subProcess) { subProcess.openOutputFiles(*fb_); });
     }
@@ -790,17 +790,16 @@ namespace edm {
   }
 
   void EventProcessor::closeOutputFiles() {
-    if (fb_.get() != nullptr) {
-      schedule_->closeOutputFiles();
-      for_all(subProcesses_, [](auto& subProcess) { subProcess.closeOutputFiles(); });
-    }
+    schedule_->closeOutputFiles();
+    for_all(subProcesses_, [](auto& subProcess) { subProcess.closeOutputFiles(); });
+
     FDEBUG(1) << "\tcloseOutputFiles\n";
   }
 
   void EventProcessor::respondToOpenInputFile() {
-    for_all(subProcesses_,
-            [this](auto& subProcess) { subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); });
-    if (fb_.get() != nullptr) {
+    if (fileBlockValid()) {
+      for_all(subProcesses_,
+              [this](auto& subProcess) { subProcess.updateBranchIDListHelper(branchIDListHelper_->branchIDLists()); });
       schedule_->respondToOpenInputFile(*fb_);
       for_all(subProcesses_, [this](auto& subProcess) { subProcess.respondToOpenInputFile(*fb_); });
     }
@@ -808,7 +807,7 @@ namespace edm {
   }
 
   void EventProcessor::respondToCloseInputFile() {
-    if (fb_.get() != nullptr) {
+    if (fileBlockValid()) {
       schedule_->respondToCloseInputFile(*fb_);
       for_all(subProcesses_, [this](auto& subProcess) { subProcess.respondToCloseInputFile(*fb_); });
     }

--- a/FWCore/Framework/src/TransitionProcessors.icc
+++ b/FWCore/Framework/src/TransitionProcessors.icc
@@ -24,8 +24,10 @@ struct FileResources {
       if (!closingSequenceAlreadyFailed_) {
         ep_.respondToCloseInputFile();
         ep_.closeInputFile(cleaningUpAfterException_);
-        ep_.endProcessBlock(cleaningUpAfterException_, beginProcessBlockSucceeded_);
-        ep_.closeOutputFiles();
+        if (needToCloseOutputFiles_) {
+          ep_.endProcessBlock(cleaningUpAfterException_, beginProcessBlockSucceeded_);
+          ep_.closeOutputFiles();
+        }
       }
     } catch (...) {
       if (cleaningUpAfterException_ or not ep_.setDeferredException(std::current_exception())) {
@@ -42,6 +44,7 @@ struct FileResources {
   bool cleaningUpAfterException_ = true;
   bool closingSequenceAlreadyFailed_ = false;
   bool beginProcessBlockSucceeded_ = false;
+  bool needToCloseOutputFiles_ = false;
 };
 
 struct RunResources {
@@ -231,10 +234,12 @@ private:
 
   void readFirstFile(EventProcessor& iEP) {
     iEP.readFile();
+    assert(iEP.fileBlockValid());
     iEP.respondToOpenInputFile();
 
     iEP.openOutputFiles();
     filesOpen_ = std::make_unique<FileResources>(iEP);
+    filesOpen_->needToCloseOutputFiles_ = true;
 
     iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
     iEP.inputProcessBlocks();
@@ -251,6 +256,11 @@ private:
     iEP.closeInputFile(false);
 
     iEP.readFile();
+    if (!iEP.fileBlockValid()) {
+      // handle case with last file bad and
+      // skipBadFiles true
+      return;
+    }
     iEP.respondToOpenInputFile();
 
     iEP.inputProcessBlocks();
@@ -269,15 +279,22 @@ private:
       iEP.endProcessBlock(cleaningUpAfterException, filesOpen_->beginProcessBlockSucceeded_);
       iEP.closeOutputFiles();
 
+      filesOpen_->needToCloseOutputFiles_ = false;
       filesOpen_->closingSequenceAlreadyFailed_ = false;
     }
     {
       filesOpen_->beginProcessBlockSucceeded_ = false;
 
       iEP.readFile();
+      if (!iEP.fileBlockValid()) {
+        // handle case with last file bad and
+        // skipBadFiles true
+        return;
+      }
       iEP.respondToOpenInputFile();
 
       iEP.openOutputFiles();
+      filesOpen_->needToCloseOutputFiles_ = true;
 
       iEP.beginProcessBlock(filesOpen_->beginProcessBlockSucceeded_);
     }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -36,6 +36,7 @@ namespace edm {
     edm::LuminosityBlockNumber_t nextLuminosityBlockID();
 
     void readFile();
+    bool fileBlockValid() { return true; }
     void closeInputFile(bool cleaningUpAfterException);
     void openOutputFiles();
     void closeOutputFiles();

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_23.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_23.txt
@@ -31,7 +31,6 @@ Machine parameters:  mode = NOMERGE
 	throwing
 	respondToCloseInputFile
 	closeInputFile
-	closeOutputFiles
 caught test exception
 
 Machine parameters:  mode = FULLMERGE

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -80,7 +80,9 @@ namespace edm {
       }
     } else {
       if (!nextFile()) {
-        assert(0);
+        // handle case with last file bad and
+        // skipBadFiles true
+        return std::unique_ptr<FileBlock>();
       }
     }
     if (!rootFile()) {
@@ -144,13 +146,21 @@ namespace edm {
   }
 
   bool RootPrimaryFileSequence::nextFile() {
-    if (!noMoreFiles())
-      setAtNextFile();
-    if (noMoreFiles()) {
-      return false;
-    }
+    do {
+      if (!noMoreFiles())
+        setAtNextFile();
+      if (noMoreFiles()) {
+        return false;
+      }
 
-    initFile(input_.skipBadFiles());
+      initFile(input_.skipBadFiles());
+      if (rootFile()) {
+        break;
+      }
+      // If we are not skipping bad files and the file
+      // open failed, then initFile should have thrown
+      assert(input_.skipBadFiles());
+    } while (true);
 
     if (not rootFile()) {
       return false;

--- a/IOPool/Input/test/PoolEmptyTest_cfg.py
+++ b/IOPool/Input/test/PoolEmptyTest_cfg.py
@@ -1,5 +1,3 @@
-# The following comments couldn't be translated into the new config version:
-
 # Configuration file for PoolInputTest
 
 import FWCore.ParameterSet.Config as cms
@@ -7,18 +5,20 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("WRITEEMPTY")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
-process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(0)
-)
 process.Thing = cms.EDProducer("ThingProducer")
 
 process.output = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('PoolEmptyTest.root')
 )
 
-process.source = cms.Source("EmptySource")
+# Select lumis that we know are not in the input file so
+# that the output file is empty (contains no Runs, Lumis,
+# or Events, but it does have metadata)
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring('file:PoolInputTest.root'),
+                            lumisToProcess = cms.untracked.VLuminosityBlockRange('1:1')
+)
 
 process.p = cms.Path(process.Thing)
 process.ep = cms.EndPath(process.output)
-
 

--- a/IOPool/Input/test/PoolInputTest_skipBadFiles_cfg.py
+++ b/IOPool/Input/test/PoolInputTest_skipBadFiles_cfg.py
@@ -1,0 +1,35 @@
+# Test the skipBadFiles option of PoolSource
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TESTRECO")
+process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.intProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(3))
+
+process.a1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("intProducer") ),
+  expectedSum = cms.untracked.int32(54)
+)
+
+process.source = cms.Source("PoolSource",
+                            duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
+                            skipBadFiles = cms.untracked.bool(True),
+                            skipEvents = cms.untracked.uint32(15), #skips all events in first file
+                            fileNames = cms.untracked.vstring('file:PoolInputTest.root',
+                                                              'file:this_file_doesnt_exist.root',
+                                                              'file:this_file_doesnt_exist.root',
+                                                              'file:PoolInputTest.root',
+                                                              'file:this_file_doesnt_exist.root',
+                                                              'file:this_file_doesnt_exist.root',
+                                                              'file:PoolInputTest.root',
+                                                              'file:this_file_doesnt_exist.root',
+                                                              'file:this_file_doesnt_exist.root')
+)
+
+process.p = cms.Path(process.intProducer * process.a1)
+
+

--- a/IOPool/Input/test/TestPoolInput.sh
+++ b/IOPool/Input/test/TestPoolInput.sh
@@ -23,6 +23,7 @@ cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_cfg.py || die 'Failure us
 cmsRun  ${LOCAL_TEST_DIR}/PoolInputTest_noDelay_cfg.py >& ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt || die 'Failure using PoolInputTest_noDelay_cfg.py' $?
 grep 'event delayed read from source' ${LOCAL_TMP_DIR}/PoolInputTest_noDelay_cfg.txt && die 'Failure in PoolInputTest_noDelay_cfg.py, found delay reads from source' 1
 cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skip_with_failure_cfg.py || die 'Failure using PoolInputTest_skip_with_failure_cfg.py' $?
+cmsRun --parameter-set ${LOCAL_TEST_DIR}/PoolInputTest_skipBadFiles_cfg.py  || die 'Failure using PoolInputTest_skipBadFiles_cfg.py ' $?
 
 cmsRun ${LOCAL_TEST_DIR}/PrePool2FileInputTest_cfg.py || die 'Failure using PrePool2FileInputTest_cfg.py' $?
 cmsRun ${LOCAL_TEST_DIR}/Pool2FileInputTest_cfg.py || die 'Failure using Pool2FileInputTest_cfg.py' $?


### PR DESCRIPTION
#### PR description:

Bug fix. Make the skipBadFiles option work. I suspect this option was not being used at all given the number of problems with it and the lack of a good unit test... Anyway, this fixes it. I noticed this while testing ProcessBlock persistence (not from a user report). PoolInputTest_skip_with_failure_cfg.py was failing with the new ProcessBlock code.

#### PR validation:

Added a new unit test. Also, fixed the unit test that creates an empty file. That used to work by using EmptySource and setting maxEvents to zero, but now that does not create any output files at all.  Now the fixed unit test uses PoolSource and selects only lumis not in the input file.

As far as I know, RelVal type tests do not use the skipBadFiles option so this should not affect them.
