### PR TITLE
Pr112x L1T Fractional Prescales implemented with Global Trigger 

### DIFF
--- a/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
+++ b/CommonTools/TriggerUtils/src/GenericTriggerEventFlag.cc
@@ -203,7 +203,7 @@ void GenericTriggerEventFlag::initRun(const edm::Run& run, const edm::EventSetup
     if (stage2_) {
       l1uGt_->retrieveL1Setup(setup);
 
-      const std::vector<std::pair<std::string, int> > prescales = l1uGt_->prescales();
+      const std::vector<std::pair<std::string, double> > prescales = l1uGt_->prescales();
       for (const auto& ip : prescales)
         algoNames.push_back(ip.first);
     } else {

--- a/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
+++ b/DQM/L1TMonitor/src/L1TdeStage2uGT.cc
@@ -146,7 +146,7 @@ void L1TdeStage2uGT::analyze(const edm::Event& event, const edm::EventSetup& es)
         if (it_data->getAlgoDecisionFinal(algoBit) != it_emul->getAlgoDecisionFinal(algoBit)) {
           bool unprescaled = true;
           // check the prescale factor
-          int prescale = -999;
+          double prescale = -999;
           bool dummy = gtUtil_.getPrescaleByBit(algoBit, prescale);
           if (not dummy)
             edm::LogWarning("L1TdeStage2uGT") << "Could not find prescale value for algobit: " << algoBit << std::endl;

--- a/HLTrigger/HLTcore/interface/FractionalPrescale.h
+++ b/HLTrigger/HLTcore/interface/FractionalPrescale.h
@@ -1,0 +1,7 @@
+#ifndef HLTrigger_HLTcore_FractionalPrescale_h
+#define HLTrigger_HLTcore_FractionalPrescale_h
+
+#include <boost/rational.hpp>
+using FractionalPrescale = boost::rational<int>;
+
+#endif

--- a/HLTrigger/HLTcore/interface/HLTConfigProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTConfigProvider.h
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 
 #include "HLTrigger/HLTcore/interface/HLTConfigData.h"
+#include "HLTrigger/HLTcore/interface/FractionalPrescale.h"
 
 #include <map>
 #include <string>
@@ -183,7 +184,13 @@ public:
   /// Number of HLT prescale sets
   unsigned int prescaleSize() const { return hltConfigData_->prescaleSize(); }
   /// HLT prescale value in specific prescale set for a specific trigger path
-  unsigned int prescaleValue(unsigned int set, const std::string& trigger) const {
+  template <typename T = unsigned int>
+  T prescaleValue(unsigned int set, const std::string& trigger) const {
+    //limit to only 4 allowed types
+    static_assert(std::is_same_v<T, unsigned int> or std::is_same_v<T, FractionalPrescale> or std::is_same_v<T, int> or
+                      std::is_same_v<T, double>,
+                  "Please use prescaleValue<unsigned int>, prescaleValue<int>, prescaleValue<double>, or "
+                  "prescaleValue<FractionalPrescale>,\n note int and unsigned int will be depreated soon");
     return hltConfigData_->prescaleValue(set, trigger);
   }
 

--- a/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
+++ b/HLTrigger/HLTcore/interface/HLTPrescaleProvider.h
@@ -15,6 +15,7 @@
  *  function calls were added. W. David Dagenhart
  */
 
+#include "HLTrigger/HLTcore/interface/FractionalPrescale.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 #include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
@@ -58,25 +59,53 @@ public:
   // negative == error
 
   /// combining the two methods above
-  unsigned int prescaleValue(const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger);
+  template <typename T = unsigned int>
+  T prescaleValue(const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger) {
+    const int set(prescaleSet(iEvent, iSetup));
+    //there is a template specialisation for unsigned in which returns +1 which
+    //emulates old behaviour
+    return set < 0 ? -1 : hltConfigProvider_.prescaleValue<T>(static_cast<unsigned int>(set), trigger);
+  }
 
   /// Combined L1T (pair.first) and HLT (pair.second) prescales per HLT path
-  std::pair<int, int> prescaleValues(const edm::Event& iEvent,
-                                     const edm::EventSetup& iSetup,
-                                     const std::string& trigger);
+  template <typename TL1 = int, typename THLT = TL1>
+  std::pair<TL1, THLT> prescaleValues(const edm::Event& iEvent,
+                                      const edm::EventSetup& iSetup,
+                                      const std::string& trigger) {
+    return {convertL1PS<TL1>(getL1PrescaleValue(iEvent, iSetup, trigger)),
+            prescaleValue<THLT>(iEvent, iSetup, trigger)};
+  }
   // any one negative => error in retrieving this (L1T or HLT) prescale
 
   // In case of a complex Boolean expression as L1 seed
-  std::pair<std::vector<std::pair<std::string, int> >, int> prescaleValuesInDetail(const edm::Event& iEvent,
-                                                                                   const edm::EventSetup& iSetup,
-                                                                                   const std::string& trigger);
+  template <typename TL1 = int, typename THLT = TL1>
+  std::pair<std::vector<std::pair<std::string, TL1> >, THLT> prescaleValuesInDetail(const edm::Event& iEvent,
+                                                                                    const edm::EventSetup& iSetup,
+                                                                                    const std::string& trigger) {
+    std::pair<std::vector<std::pair<std::string, TL1> >, THLT> retval;
+    for (auto& entry : getL1PrescaleValueInDetail(iEvent, iSetup, trigger)) {
+      retval.first.emplace_back(std::move(entry.first), convertL1PS<TL1>(entry.second));
+    }
+    retval.second = prescaleValue<THLT>(iEvent, iSetup, trigger);
+    return retval;
+  }
   // Event rejected by HLTPrescaler on ith HLT path?
   bool rejectedByHLTPrescaler(const edm::TriggerResults& triggerResults, unsigned int i) const;
+  static int l1PrescaleDenominator() { return kL1PrescaleDenominator_; }
 
 private:
   void checkL1GtUtils() const;
   void checkL1TGlobalUtil() const;
+  template <typename T>
+  T convertL1PS(double val) const {
+    return T(val);
+  }
 
+  double getL1PrescaleValue(const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger);
+  std::vector<std::pair<std::string, double> > getL1PrescaleValueInDetail(const edm::Event& iEvent,
+                                                                          const edm::EventSetup& iSetup,
+                                                                          const std::string& trigger);
+  static constexpr int kL1PrescaleDenominator_ = 100;
   HLTConfigProvider hltConfigProvider_;
   std::unique_ptr<L1GtUtils> l1GtUtils_;
   std::unique_ptr<l1t::L1TGlobalUtil> l1tGlobalUtil_;
@@ -97,4 +126,13 @@ HLTPrescaleProvider::HLTPrescaleProvider(edm::ParameterSet const& pset, edm::Con
     l1tGlobalUtil_ = std::make_unique<l1t::L1TGlobalUtil>(pset, iC, module, l1t::UseEventSetupIn::Run);
   }
 }
+
+template <>
+FractionalPrescale HLTPrescaleProvider::convertL1PS<FractionalPrescale>(double val) const;
+
+template <>
+unsigned int HLTPrescaleProvider::prescaleValue<unsigned int>(const edm::Event& iEvent,
+                                                              const edm::EventSetup& iSetup,
+                                                              const std::string& trigger);
+
 #endif

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleExample.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleExample.cc
@@ -1,0 +1,71 @@
+
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
+#include <iostream>
+
+class HLTPrescaleExample : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+public:
+  HLTPrescaleExample(edm::ParameterSet const& iPSet);
+
+  void beginJob() override {}
+  void beginRun(edm::Run const& iEvent, edm::EventSetup const&) override;
+  void analyze(edm::Event const& iEvent, edm::EventSetup const&) override;
+  void endRun(edm::Run const& iEvent, edm::EventSetup const&) override {}
+  void endJob() override {}
+
+private:
+  HLTPrescaleProvider hltPSProvider_;
+  std::string hltProcess_;
+  std::string hltPath_;
+};
+
+HLTPrescaleExample::HLTPrescaleExample(edm::ParameterSet const& iPSet)
+    : hltPSProvider_(iPSet.getParameter<edm::ParameterSet>("hltPSProvCfg"), consumesCollector(), *this),
+      hltProcess_(iPSet.getParameter<std::string>("hltProcess")),
+      hltPath_(iPSet.getParameter<std::string>("hltPath")) {}
+
+void HLTPrescaleExample::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {
+  bool changed = false;
+  hltPSProvider_.init(iRun, iSetup, hltProcess_, changed);
+}
+
+void HLTPrescaleExample::analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+  auto hltPSDouble = hltPSProvider_.prescaleValue<double>(iEvent, iSetup, hltPath_);
+  auto hltPSInt = hltPSProvider_.prescaleValue<int>(iEvent, iSetup, hltPath_);
+  auto hltPSUInt = hltPSProvider_.prescaleValue<unsigned int>(iEvent, iSetup, hltPath_);
+  auto hltPSFrac = hltPSProvider_.prescaleValue<FractionalPrescale>(iEvent, iSetup, hltPath_);
+
+  auto l1HLTPSDouble = hltPSProvider_.prescaleValues<double>(iEvent, iSetup, hltPath_);
+  auto l1HLTPSInt = hltPSProvider_.prescaleValues<int>(iEvent, iSetup, hltPath_);
+  auto l1HLTPSFrac = hltPSProvider_.prescaleValues<FractionalPrescale>(iEvent, iSetup, hltPath_);
+  auto l1HLTPSDoubleFrac = hltPSProvider_.prescaleValues<double, FractionalPrescale>(iEvent, iSetup, hltPath_);
+
+  auto l1HLTDetailPSDouble = hltPSProvider_.prescaleValuesInDetail<double>(iEvent, iSetup, hltPath_);
+  auto l1HLTDetailPSInt = hltPSProvider_.prescaleValuesInDetail<int>(iEvent, iSetup, hltPath_);
+  auto l1HLTDetailPSFrac = hltPSProvider_.prescaleValuesInDetail<FractionalPrescale>(iEvent, iSetup, hltPath_);
+
+  std::cout << "---------Begin Event--------" << std::endl;
+  std::cout << "hltDouble " << hltPSDouble << " hltInt " << hltPSInt << " hltPSUInt " << hltPSUInt << " hltFrac "
+            << hltPSFrac << std::endl;
+
+  std::cout << " l1HLTDouble " << l1HLTPSDouble.first << " " << l1HLTPSDouble.second << " l1HLTInt " << l1HLTPSInt.first
+            << " " << l1HLTPSInt.second << " l1HLTFrac " << l1HLTPSFrac.first << " " << l1HLTPSFrac.second
+            << " l1HLTDoubleFrac " << l1HLTPSDoubleFrac.first << " " << l1HLTPSDoubleFrac.second << std::endl;
+  auto printL1HLTDetail = [](const std::string& text, const auto& val, std::ostream& out) {
+    out << text;
+    for (const auto& entry : val.first) {
+      out << entry.first << ":" << entry.second << " ";
+    }
+    out << " HLT : " << val.second << std::endl;
+  };
+
+  printL1HLTDetail("l1HLTDetailDouble ", l1HLTDetailPSDouble, std::cout);
+  printL1HLTDetail("l1HLTDetailInt ", l1HLTDetailPSInt, std::cout);
+  printL1HLTDetail("l1HLTDetailFrac ", l1HLTDetailPSFrac, std::cout);
+  std::cout << "---------End Event--------" << std::endl << std::endl;
+}
+
+DEFINE_FWK_MODULE(HLTPrescaleExample);

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -90,7 +90,7 @@ int HLTPrescaleProvider::prescaleSet(const edm::Event& iEvent, const edm::EventS
   } else if (l1tType == 2) {
     checkL1TGlobalUtil();
     l1tGlobalUtil_->retrieveL1Event(iEvent, iSetup);
-    return static_cast<double>(l1tGlobalUtil_->prescaleColumn());
+    return static_cast<int>(l1tGlobalUtil_->prescaleColumn());
   } else {
     if (count_[0] < countMax) {
       count_[0] += 1;

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -90,7 +90,7 @@ int HLTPrescaleProvider::prescaleSet(const edm::Event& iEvent, const edm::EventS
   } else if (l1tType == 2) {
     checkL1TGlobalUtil();
     l1tGlobalUtil_->retrieveL1Event(iEvent, iSetup);
-    return static_cast<int>(l1tGlobalUtil_->prescaleColumn());
+    return static_cast<double>(l1tGlobalUtil_->prescaleColumn());
   } else {
     if (count_[0] < countMax) {
       count_[0] += 1;
@@ -117,7 +117,7 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
                                                         const edm::EventSetup& iSetup,
                                                         const std::string& trigger) {
   // start with setting both L1T and HLT prescale values to 0
-  std::pair<int, int> result(std::pair<int, int>(0, 0));
+  std::pair<double, int> result(std::pair<double, int>(0, 0));
 
   // get HLT prescale (possible if HLT prescale set index is correctly found)
   const int set(prescaleSet(iEvent, iSetup));
@@ -299,13 +299,13 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
       GlobalLogicParser l1tGlobalLogicParser = GlobalLogicParser(l1tname);
       const std::vector<GlobalLogicParser::OperandToken> l1tSeeds = l1tGlobalLogicParser.expressionSeedsOperandList();
       int l1error(0);
-      int l1tPrescale(-1);
+      double l1tPrescale(-1);
       for (auto const& i : l1tSeeds) {
         const string& l1tSeed = i.tokenName;
         if (!l1tGlobalUtil_->getPrescaleByName(l1tSeed, l1tPrescale)) {
           l1error += 1;
         }
-        result.first.push_back(std::pair<std::string, int>(l1tSeed, l1tPrescale));
+        result.first.push_back(std::pair<std::string, double>(l1tSeed, l1tPrescale));
       }
       if (l1error != 0) {
         if (count_[3] < countMax) {

--- a/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
+++ b/HLTrigger/HLTcore/src/HLTPrescaleProvider.cc
@@ -102,33 +102,26 @@ int HLTPrescaleProvider::prescaleSet(const edm::Event& iEvent, const edm::EventS
   }
 }
 
-unsigned int HLTPrescaleProvider::prescaleValue(const edm::Event& iEvent,
-                                                const edm::EventSetup& iSetup,
-                                                const std::string& trigger) {
-  const int set(prescaleSet(iEvent, iSetup));
-  if (set < 0) {
-    return 1;
-  } else {
-    return hltConfigProvider_.prescaleValue(static_cast<unsigned int>(set), trigger);
+template <>
+FractionalPrescale HLTPrescaleProvider::convertL1PS<FractionalPrescale>(double val) const {
+  int numer = static_cast<int>(val * kL1PrescaleDenominator_ + 0.5);
+  static constexpr double kL1RoundingEpsilon = 0.001;
+  if (std::abs(numer - val * kL1PrescaleDenominator_) > kL1RoundingEpsilon) {
+    edm::LogWarning("ValueError") << " Error, L1 prescale val " << val
+                                  << "does not appear to precisely expressable as int / " << kL1PrescaleDenominator_
+                                  << ", using a FractionalPrescale is a loss of precision";
   }
+
+  return {numer, kL1PrescaleDenominator_};
 }
 
-std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent,
-                                                        const edm::EventSetup& iSetup,
-                                                        const std::string& trigger) {
-  // start with setting both L1T and HLT prescale values to 0
-  std::pair<double, int> result(std::pair<double, int>(0, 0));
-
-  // get HLT prescale (possible if HLT prescale set index is correctly found)
-  const int set(prescaleSet(iEvent, iSetup));
-  if (set < 0) {
-    result.second = -1;
-  } else {
-    result.second = static_cast<int>(hltConfigProvider_.prescaleValue(static_cast<unsigned int>(set), trigger));
-  }
-
+double HLTPrescaleProvider::getL1PrescaleValue(const edm::Event& iEvent,
+                                               const edm::EventSetup& iSetup,
+                                               const std::string& trigger) {
   // get L1T prescale - works only for those hlt trigger paths with
   // exactly one L1GT seed module which has exactly one L1T name as seed
+
+  double result = -1;
 
   const unsigned int l1tType(hltConfigProvider_.l1tType());
   if (l1tType == 1) {
@@ -136,12 +129,12 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
     const unsigned int nL1GTSeedModules(hltConfigProvider_.hltL1GTSeeds(trigger).size());
     if (nL1GTSeedModules == 0) {
       // no L1 seed module on path hence no L1 seed hence formally no L1 prescale
-      result.first = 1;
+      result = 1;
     } else if (nL1GTSeedModules == 1) {
       l1GtUtils_->getL1GtRunCache(iEvent, iSetup, useL1EventSetup, useL1GtTriggerMenuLite);
       const std::string l1tname(hltConfigProvider_.hltL1GTSeeds(trigger).at(0).second);
       int l1error(0);
-      result.first = l1GtUtils_->prescaleFactor(iEvent, l1tname, l1error);
+      result = l1GtUtils_->prescaleFactor(iEvent, l1tname, l1error);
       if (l1error != 0) {
         if (count_[1] < countMax) {
           count_[1] += 1;
@@ -154,7 +147,7 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
               << " For seeds being complex logical expressions, try the new method 'prescaleValuesInDetail'."
               << std::endl;
         }
-        result.first = -1;
+        result = -1;
       }
     } else {
       /// error - can't handle properly multiple L1GTSeed modules
@@ -169,18 +162,18 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
             << nL1GTSeedModules << ", with L1 seeds: " << dump
             << ". (Note: at most one L1GTSeed module is allowed for a proper determination of the L1T prescale!)";
       }
-      result.first = -1;
+      result = -1;
     }
   } else if (l1tType == 2) {
     checkL1TGlobalUtil();
     const unsigned int nL1TSeedModules(hltConfigProvider_.hltL1TSeeds(trigger).size());
     if (nL1TSeedModules == 0) {
       // no L1 seed module on path hence no L1 seed hence formally no L1 prescale
-      result.first = 1;
+      result = 1;
     } else if (nL1TSeedModules == 1) {
       //    l1tGlobalUtil_->retrieveL1Event(iEvent,iSetup);
       const std::string l1tname(hltConfigProvider_.hltL1TSeeds(trigger).at(0));
-      bool l1error(!l1tGlobalUtil_->getPrescaleByName(l1tname, result.first));
+      bool l1error(!l1tGlobalUtil_->getPrescaleByName(l1tname, result));
       if (l1error) {
         if (count_[1] < countMax) {
           count_[1] += 1;
@@ -193,7 +186,7 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
               << " For seeds being complex logical expressions, try the new method 'prescaleValuesInDetail'."
               << std::endl;
         }
-        result.first = -1;
+        result = -1;
       }
     } else {
       /// error - can't handle properly multiple L1TSeed modules
@@ -208,34 +201,22 @@ std::pair<int, int> HLTPrescaleProvider::prescaleValues(const edm::Event& iEvent
             << nL1TSeedModules << ", with L1T seeds: " << dump
             << ". (Note: at most one L1TSeed module is allowed for a proper determination of the L1T prescale!)";
       }
-      result.first = -1;
+      result = -1;
     }
   } else {
     if (count_[1] < countMax) {
       count_[1] += 1;
       edm::LogError("HLTPrescaleProvider") << " Unknown L1T Type " << l1tType << " - can not determine L1T prescale! ";
     }
-    result.first = -1;
+    result = -1;
   }
 
   return result;
 }
 
-std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::prescaleValuesInDetail(
+std::vector<std::pair<std::string, double> > HLTPrescaleProvider::getL1PrescaleValueInDetail(
     const edm::Event& iEvent, const edm::EventSetup& iSetup, const std::string& trigger) {
-  std::pair<std::vector<std::pair<std::string, int> >, int> result;
-  result.first.clear();
-
-  // get HLT prescale (possible if HLT prescale set index is correctly found)
-  const int set(prescaleSet(iEvent, iSetup));
-  if (set < 0) {
-    result.second = -1;
-  } else {
-    result.second = static_cast<int>(hltConfigProvider_.prescaleValue(static_cast<unsigned int>(set), trigger));
-  }
-
-  // get L1T prescale - works only for those hlt trigger paths with
-  // exactly one L1GT seed module
+  std::vector<std::pair<std::string, double> > result;
 
   const unsigned int l1tType(hltConfigProvider_.l1tType());
   if (l1tType == 1) {
@@ -244,14 +225,19 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
     const unsigned int nL1GTSeedModules(hltConfigProvider_.hltL1GTSeeds(trigger).size());
     if (nL1GTSeedModules == 0) {
       // no L1 seed module on path hence no L1 seed hence formally no L1 prescale
-      result.first.clear();
+      result.clear();
     } else if (nL1GTSeedModules == 1) {
       l1GtUtils_->getL1GtRunCache(iEvent, iSetup, useL1EventSetup, useL1GtTriggerMenuLite);
       const std::string l1tname(hltConfigProvider_.hltL1GTSeeds(trigger).at(0).second);
       L1GtUtils::LogicalExpressionL1Results l1Logical(l1tname, *l1GtUtils_);
       l1Logical.logicalExpressionRunUpdate(iEvent.getRun(), iSetup, l1tname);
       const std::vector<std::pair<std::string, int> >& errorCodes(l1Logical.errorCodes(iEvent));
-      result.first = l1Logical.prescaleFactors();
+      auto resultInt = l1Logical.prescaleFactors();
+      result.clear();
+      for (const auto& entry : resultInt) {
+        result.push_back(entry);
+      }
+
       int l1error(l1Logical.isValid() ? 0 : 1);
       for (auto const& errorCode : errorCodes) {
         l1error += std::abs(errorCode.second);
@@ -264,13 +250,12 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
                   << l1tname << "' using L1GtUtils: " << std::endl
                   << " isValid=" << l1Logical.isValid() << " l1tname/error/prescale " << errorCodes.size() << std::endl;
           for (unsigned int i = 0; i < errorCodes.size(); ++i) {
-            message << " " << i << ":" << errorCodes[i].first << "/" << errorCodes[i].second << "/"
-                    << result.first[i].second;
+            message << " " << i << ":" << errorCodes[i].first << "/" << errorCodes[i].second << "/" << result[i].second;
           }
           message << ".";
           edm::LogError("HLTPrescaleProvider") << message.str();
         }
-        result.first.clear();
+        result.clear();
       }
     } else {
       /// error - can't handle properly multiple L1GTSeed modules
@@ -285,14 +270,14 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
             << nL1GTSeedModules << ", with L1 seeds: " << dump
             << ". (Note: at most one L1GTSeed module is allowed for a proper determination of the L1T prescale!)";
       }
-      result.first.clear();
+      result.clear();
     }
   } else if (l1tType == 2) {
     checkL1TGlobalUtil();
     const unsigned int nL1TSeedModules(hltConfigProvider_.hltL1TSeeds(trigger).size());
     if (nL1TSeedModules == 0) {
       // no L1 seed module on path hence no L1 seed hence formally no L1 prescale
-      result.first.clear();
+      result.clear();
     } else if (nL1TSeedModules == 1) {
       //    l1tGlobalUtil_->retrieveL1Event(iEvent,iSetup);
       std::string l1tname(hltConfigProvider_.hltL1TSeeds(trigger).at(0));
@@ -305,7 +290,7 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
         if (!l1tGlobalUtil_->getPrescaleByName(l1tSeed, l1tPrescale)) {
           l1error += 1;
         }
-        result.first.push_back(std::pair<std::string, double>(l1tSeed, l1tPrescale));
+        result.push_back(std::pair<std::string, double>(l1tSeed, l1tPrescale));
       }
       if (l1error != 0) {
         if (count_[3] < countMax) {
@@ -319,12 +304,12 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
           for (unsigned int i = 0; i < l1tSeeds.size(); ++i) {
             const string& l1tSeed = l1tSeeds[i].tokenName;
             message << " " << i << ":" << l1tSeed << "/" << l1tGlobalUtil_->getPrescaleByName(l1tSeed, l1tPrescale)
-                    << "/" << result.first[i].second;
+                    << "/" << result[i].second;
           }
           message << ".";
           edm::LogError("HLTPrescaleProvider") << message.str();
         }
-        result.first.clear();
+        result.clear();
       }
     } else {
       /// error - can't handle properly multiple L1TSeed modules
@@ -339,14 +324,14 @@ std::pair<std::vector<std::pair<std::string, int> >, int> HLTPrescaleProvider::p
             << nL1TSeedModules << ", with L1T seeds: " << dump
             << ". (Note: at most one L1TSeed module is allowed for a proper determination of the L1T prescale!)";
       }
-      result.first.clear();
+      result.clear();
     }
   } else {
     if (count_[3] < countMax) {
       count_[3] += 1;
       edm::LogError("HLTPrescaleProvider") << " Unknown L1T Type " << l1tType << " - can not determine L1T prescale! ";
     }
-    result.first.clear();
+    result.clear();
   }
 
   return result;
@@ -374,4 +359,12 @@ void HLTPrescaleProvider::checkL1TGlobalUtil() const {
                                              "the module configuration does not use the era properly\n"
                                              "or input is from mixed eras";
   }
+}
+
+template <>
+unsigned int HLTPrescaleProvider::prescaleValue<unsigned int>(const edm::Event& iEvent,
+                                                              const edm::EventSetup& iSetup,
+                                                              const std::string& trigger) {
+  const int set(prescaleSet(iEvent, iSetup));
+  return set < 0 ? 1 : hltConfigProvider_.prescaleValue<unsigned int>(static_cast<unsigned int>(set), trigger);
 }

--- a/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py
+++ b/HLTrigger/HLTcore/test/hltPrescaleExample_cfg.py
@@ -1,0 +1,54 @@
+
+import FWCore.ParameterSet.Config as cms
+process = cms.Process("HLTPSCheck")
+
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis') 
+options.register('globalTag','auto:run2_data',options.multiplicity.singleton,options.varType.string,"global tag to use")
+options.parseArguments()
+
+print options.inputFiles
+process.source = cms.Source("PoolSource",
+                            fileNames = cms.untracked.vstring(options.inputFiles),  
+                          )
+
+# initialize MessageLogger and output report
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(5000),
+    limit = cms.untracked.int32(10000000)
+)
+
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+
+
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+)
+
+
+process.hltPSExample = cms.EDAnalyzer("HLTPrescaleExample",
+                                      hltProcess=cms.string("HLT"),
+#                                      hltPath=cms.string("HLT_Photon50_v13"),
+                                      hltPath=cms.string("HLT_Photon33_v5"),                         
+                                      hltPSProvCfg=cms.PSet(
+                                          stageL1Trigger = cms.uint32(2)
+                                      )
+                                  )
+
+
+process.p = cms.Path(
+    process.hltPSExample
+)
+
+
+
+print "global tag: ",process.GlobalTag.globaltag
+
+
+

--- a/L1Trigger/L1TGlobal/interface/GlobalBoard.h
+++ b/L1Trigger/L1TGlobal/interface/GlobalBoard.h
@@ -106,7 +106,7 @@ namespace l1t {
                 const int iBxInEvent,
                 const int totalBxInEvent,
                 const unsigned int numberPhysTriggers,
-                const std::vector<int>& prescaleFactorsAlgoTrig,
+                const std::vector<double>& prescaleFactorsAlgoTrig,
                 const std::vector<unsigned int>& triggerMaskAlgoTrig,
                 const std::vector<int>& triggerMaskVetoAlgoTrig,
                 const bool algorithmTriggersUnprescaled,
@@ -226,7 +226,7 @@ namespace l1t {
     std::vector<AlgorithmEvaluation::ConditionEvaluationMap> m_conditionResultMaps;
 
     /// prescale counters: NumberPhysTriggers counters per bunch cross in event
-    std::vector<std::vector<int>> m_prescaleCounterAlgoTrig;
+    std::vector<std::vector<double>> m_prescaleCounterAlgoTrig;
 
     bool m_firstEv;
     bool m_firstEvLumiSegment;

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
@@ -9,8 +9,8 @@
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 
-#include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
-#include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
+#include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosFractRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetosFract.h"
 
 // Objects to produce for the output record.
 #include "DataFormats/L1TGlobal/interface/GlobalAlgBlk.h"
@@ -26,7 +26,7 @@
 
 #include "L1Trigger/L1TGlobal/interface/L1TGlobalUtilHelper.h"
 
-#include "L1Trigger/L1TGlobal/interface/PrescalesVetosHelper.h"
+#include "L1Trigger/L1TGlobal/interface/PrescalesVetosFractHelper.h"
 
 // forward declarations
 
@@ -102,7 +102,7 @@ namespace l1t {
     // It is provided only until prescales and masks are available as CondFormats...
     // Most users should simply ignore this method and use the default ctor only!
     // Will look for prescale csv file in L1Trigger/L1TGlobal/data/Luminosity/startup/<filename>
-    void OverridePrescalesAndMasks(std::string filename, unsigned int psColumn = 1);
+    void OverridePrescalesAndMasks(std::string filename, double psColumn = 1.);
 
     /// initialize the class (mainly reserve)
     void retrieveL1(const edm::Event& iEvent, const edm::EventSetup& evSetup);  // using helper
@@ -127,7 +127,7 @@ namespace l1t {
     const bool getFinalDecisionByBit(int& bit, bool& decision) const;
 
     // Access Prescale
-    const bool getPrescaleByBit(int& bit, int& prescale) const;
+    const bool getPrescaleByBit(int& bit, double& prescale) const;
 
     // Access Masks:
     // follows logic of uGT board:
@@ -143,7 +143,7 @@ namespace l1t {
     const bool getFinalDecisionByName(const std::string& algName, bool& decision) const;
 
     // Access Prescales
-    const bool getPrescaleByName(const std::string& algName, int& prescale) const;
+    const bool getPrescaleByName(const std::string& algName, double& prescale) const;
 
     // Access Masks (see note) above
     const bool getMaskByName(const std::string& algName, std::vector<int>& mask) const;
@@ -154,7 +154,7 @@ namespace l1t {
     inline const std::vector<std::pair<std::string, bool>>& decisionsFinal() { return m_decisionsFinal; }
 
     // Access all prescales
-    inline const std::vector<std::pair<std::string, int>>& prescales() { return m_prescales; }
+    inline const std::vector<std::pair<std::string, double>>& prescales() { return m_prescales; }
 
     // Access Masks (see note) above
     inline const std::vector<std::pair<std::string, std::vector<int>>>& masks() { return m_masks; }
@@ -165,7 +165,7 @@ namespace l1t {
     inline const std::string& gtTriggerMenuComment() const { return m_l1GtMenu->getComment(); }
 
     // Prescale Column
-    inline unsigned int prescaleColumn() const { return m_PreScaleColumn; }
+    inline double prescaleColumn() const { return m_PreScaleColumn; }
     inline unsigned int numberOfPreScaleColumns() const { return m_numberOfPreScaleColumns; }
 
   private:
@@ -186,7 +186,7 @@ namespace l1t {
 
     // prescale factors
     bool m_readPrescalesFromFile;
-    const l1t::PrescalesVetosHelper* m_l1GtPrescalesVetoes;
+    const l1t::PrescalesVetosFractHelper* m_l1GtPrescalesVetoes;
     unsigned long long m_l1GtPfAlgoCacheID;
 
     // prescales and masks
@@ -202,11 +202,11 @@ namespace l1t {
 
     //file  and container for prescale factors
     std::string m_preScaleFileName;
-    unsigned int m_PreScaleColumn;
+    double m_PreScaleColumn;
     unsigned int m_numberOfPreScaleColumns;
 
-    std::vector<std::vector<int>> m_initialPrescaleFactorsAlgoTrig;
-    const std::vector<std::vector<int>>* m_prescaleFactorsAlgoTrig;
+    std::vector<std::vector<double>> m_initialPrescaleFactorsAlgoTrig;
+    const std::vector<std::vector<double>>* m_prescaleFactorsAlgoTrig;
     const std::map<int, std::vector<int>> m_initialTriggerMaskAlgoTrig;
     const std::map<int, std::vector<int>>* m_triggerMaskAlgoTrig;  // vector stores the BX
 
@@ -220,7 +220,7 @@ namespace l1t {
     std::vector<std::pair<std::string, bool>> m_decisionsInitial;
     std::vector<std::pair<std::string, bool>> m_decisionsInterm;
     std::vector<std::pair<std::string, bool>> m_decisionsFinal;
-    std::vector<std::pair<std::string, int>> m_prescales;
+    std::vector<std::pair<std::string, double>> m_prescales;
     std::vector<std::pair<std::string, std::vector<int>>> m_masks;  // vector stores the bx's that are mask for given algo
 
     /// verbosity level
@@ -229,10 +229,10 @@ namespace l1t {
     std::unique_ptr<L1TGlobalUtilHelper> m_l1tGlobalUtilHelper;
 
     edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_L1TUtmTriggerMenuRunToken;
-    edm::ESGetToken<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd> m_L1TGlobalPrescalesVetosRunToken;
+    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_L1TGlobalPrescalesVetosFractRunToken;
 
     edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_L1TUtmTriggerMenuEventToken;
-    edm::ESGetToken<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd> m_L1TGlobalPrescalesVetosEventToken;
+    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_L1TGlobalPrescalesVetosFractEventToken;
   };
 
   template <typename T>

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
@@ -104,7 +104,7 @@ namespace l1t {
     // It is provided only until prescales and masks are available as CondFormats...
     // Most users should simply ignore this method and use the default ctor only!
     // Will look for prescale csv file in L1Trigger/L1TGlobal/data/Luminosity/startup/<filename>
-    void OverridePrescalesAndMasks(std::string filename, double psColumn = 1.);
+    void OverridePrescalesAndMasks(std::string filename, unsigned int psColumn = 1.);
 
     /// initialize the class (mainly reserve)
     void retrieveL1(const edm::Event& iEvent, const edm::EventSetup& evSetup);  // using helper
@@ -167,7 +167,7 @@ namespace l1t {
     inline const std::string& gtTriggerMenuComment() const { return m_l1GtMenu->getComment(); }
 
     // Prescale Column
-    inline double prescaleColumn() const { return m_PreScaleColumn; }
+    inline unsigned int prescaleColumn() const { return m_PreScaleColumn; }
     inline unsigned int numberOfPreScaleColumns() const { return m_numberOfPreScaleColumns; }
 
   private:
@@ -204,7 +204,7 @@ namespace l1t {
 
     //file  and container for prescale factors
     std::string m_preScaleFileName;
-    double m_PreScaleColumn;
+    unsigned int m_PreScaleColumn;
     unsigned int m_numberOfPreScaleColumns;
 
     std::vector<std::vector<double>> m_initialPrescaleFactorsAlgoTrig;

--- a/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
+++ b/L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h
@@ -4,6 +4,8 @@
 #define L1TGlobal_L1TGlobalUtil_h
 
 // system include files
+#include <memory>
+
 #include <vector>
 
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
@@ -229,10 +231,12 @@ namespace l1t {
     std::unique_ptr<L1TGlobalUtilHelper> m_l1tGlobalUtilHelper;
 
     edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_L1TUtmTriggerMenuRunToken;
-    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_L1TGlobalPrescalesVetosFractRunToken;
+    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>
+        m_L1TGlobalPrescalesVetosFractRunToken;
 
     edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_L1TUtmTriggerMenuEventToken;
-    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_L1TGlobalPrescalesVetosFractEventToken;
+    edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>
+        m_L1TGlobalPrescalesVetosFractEventToken;
   };
 
   template <typename T>
@@ -248,7 +252,7 @@ namespace l1t {
                                T& module,
                                UseEventSetupIn useEventSetupIn)
       : L1TGlobalUtil() {
-    m_l1tGlobalUtilHelper.reset(new L1TGlobalUtilHelper(pset, iC, module));
+    m_l1tGlobalUtilHelper = std::make_unique<L1TGlobalUtilHelper>(pset, iC, module);
     m_readPrescalesFromFile = m_l1tGlobalUtilHelper->readPrescalesFromFile();
     eventSetupConsumes(iC, useEventSetupIn);
   }
@@ -270,7 +274,8 @@ namespace l1t {
                                edm::InputTag const& l1tExtBlkInputTag,
                                UseEventSetupIn useEventSetupIn)
       : L1TGlobalUtil() {
-    m_l1tGlobalUtilHelper.reset(new L1TGlobalUtilHelper(pset, iC, module, l1tAlgBlkInputTag, l1tExtBlkInputTag));
+    m_l1tGlobalUtilHelper =
+        std::make_unique<L1TGlobalUtilHelper>(pset, iC, module, l1tAlgBlkInputTag, l1tExtBlkInputTag);
     m_readPrescalesFromFile = m_l1tGlobalUtilHelper->readPrescalesFromFile();
     eventSetupConsumes(iC, useEventSetupIn);
   }

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -232,7 +232,7 @@ namespace l1t {
         (m_algoSummary.find(name)->second).at(2) += 1;
 
       // get the prescale and mask (needs some error checking here)
-      int prescale = (prescales.at(i)).second;
+      double prescale = (prescales.at(i)).second;
       std::vector<int> mask = (masks.at(i)).second;
 
       if (m_dumpTriggerResults && name != "NULL")

--- a/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
+++ b/L1Trigger/L1TGlobal/plugins/GtRecordDump.cc
@@ -195,7 +195,7 @@ namespace l1t {
     const std::vector<std::pair<std::string, bool>> initialDecisions = m_gtUtil->decisionsInitial();
     const std::vector<std::pair<std::string, bool>> intermDecisions = m_gtUtil->decisionsInterm();
     const std::vector<std::pair<std::string, bool>> finalDecisions = m_gtUtil->decisionsFinal();
-    const std::vector<std::pair<std::string, int>> prescales = m_gtUtil->prescales();
+    const std::vector<std::pair<std::string, double>> prescales = m_gtUtil->prescales();
     const std::vector<std::pair<std::string, std::vector<int>>> masks = m_gtUtil->masks();
 
     LogDebug("GtRecordDump") << "retrieved all event vectors " << endl;

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -117,7 +117,7 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_l1GtStableParToken = esConsumes<L1TGlobalParameters, L1TGlobalParametersRcd>();
   m_l1GtMenuToken = esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
   if (!(m_algorithmTriggersUnprescaled && m_algorithmTriggersUnmasked)) {
-    m_l1GtPrescaleVetosToken = esConsumes<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd>();
+    m_l1GtPrescaleVetosToken = esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>();
   }
   if (m_getPrescaleColumnFromData || m_requireMenuToMatchAlgoBlkInput) {
     m_algoblkInputToken = consumes<BXVector<GlobalAlgBlk>>(m_algoblkInputTag);
@@ -225,9 +225,9 @@ L1TGlobalProducer::L1TGlobalProducer(const edm::ParameterSet& parSet)
   m_currentLumi = 0;
 
   // Set default, initial, dummy prescale factor table
-  std::vector<std::vector<int>> temp_prescaleTable;
+  std::vector<std::vector<double>> temp_prescaleTable;
 
-  temp_prescaleTable.push_back(std::vector<int>());
+  temp_prescaleTable.push_back(std::vector<double>());
   m_initialPrescaleFactorsAlgoTrig = temp_prescaleTable;
 }
 
@@ -385,15 +385,15 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
 
   // Only get event record if not unprescaled and not unmasked
   if (!(m_algorithmTriggersUnprescaled && m_algorithmTriggersUnmasked)) {
-    unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1TGlobalPrescalesVetosRcd>().cacheIdentifier();
+    unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1TGlobalPrescalesVetosFractRcd>().cacheIdentifier();
 
     if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-      edm::ESHandle<L1TGlobalPrescalesVetos> l1GtPrescalesVetoes = evSetup.getHandle(m_l1GtPrescaleVetosToken);
-      const L1TGlobalPrescalesVetos* es = l1GtPrescalesVetoes.product();
-      m_l1GtPrescalesVetoes = PrescalesVetosHelper::readFromEventSetup(es);
+      edm::ESHandle<L1TGlobalPrescalesVetosFract> l1GtPrescalesFractVetoes = evSetup.getHandle(m_l1GtPrescaleVetosToken);
+      const L1TGlobalPrescalesVetosFract* es = l1GtPrescalesFractVetoes.product();
+      m_l1GtPrescalesVetosFract = PrescalesVetosFractHelper::readFromEventSetup(es);
 
-      m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetoes->prescaleTable());
-      m_triggerMaskVetoAlgoTrig = &(m_l1GtPrescalesVetoes->triggerMaskVeto());
+      m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetosFract->prescaleTable());
+      m_triggerMaskVetoAlgoTrig = &(m_l1GtPrescalesVetosFract->triggerMaskVeto());
 
       m_l1GtPfAlgoCacheID = l1GtPfAlgoCacheID;
     }
@@ -539,7 +539,7 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     pfAlgoSetIndex = max;
   }
 
-  const std::vector<int>& prescaleFactorsAlgoTrig = (*m_prescaleFactorsAlgoTrig).at(pfAlgoSetIndex);
+  const std::vector<double>& prescaleFactorsAlgoTrig = (*m_prescaleFactorsAlgoTrig).at(pfAlgoSetIndex);
 
   // For now, set masks according to prescale value of 0
   m_initialTriggerMaskAlgoTrig.clear();

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.cc
@@ -388,7 +388,8 @@ void L1TGlobalProducer::produce(edm::Event& iEvent, const edm::EventSetup& evSet
     unsigned long long l1GtPfAlgoCacheID = evSetup.get<L1TGlobalPrescalesVetosFractRcd>().cacheIdentifier();
 
     if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
-      edm::ESHandle<L1TGlobalPrescalesVetosFract> l1GtPrescalesFractVetoes = evSetup.getHandle(m_l1GtPrescaleVetosToken);
+      edm::ESHandle<L1TGlobalPrescalesVetosFract> l1GtPrescalesFractVetoes =
+          evSetup.getHandle(m_l1GtPrescaleVetosToken);
       const L1TGlobalPrescalesVetosFract* es = l1GtPrescalesFractVetoes.product();
       m_l1GtPrescalesVetosFract = PrescalesVetosFractHelper::readFromEventSetup(es);
 

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalProducer.h
@@ -21,13 +21,13 @@
 
 #include "CondFormats/L1TObjects/interface/L1TGlobalParameters.h"
 #include "L1Trigger/L1TGlobal/interface/GlobalParamsHelper.h"
-#include "L1Trigger/L1TGlobal/interface/PrescalesVetosHelper.h"
+#include "L1Trigger/L1TGlobal/interface/PrescalesVetosFractHelper.h"
 #include "CondFormats/L1TObjects/interface/L1TUtmTriggerMenu.h"
 #include "CondFormats/DataRecord/interface/L1TUtmTriggerMenuRcd.h"
 #include "CondFormats/L1TObjects/interface/L1TGlobalParameters.h"
 #include "CondFormats/DataRecord/interface/L1TGlobalParametersRcd.h"
-#include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetos.h"
-#include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosRcd.h"
+#include "CondFormats/L1TObjects/interface/L1TGlobalPrescalesVetosFract.h"
+#include "CondFormats/DataRecord/interface/L1TGlobalPrescalesVetosFractRcd.h"
 
 class L1TGlobalParameters;
 class L1GtParameters;
@@ -91,11 +91,11 @@ private:
   unsigned long long m_l1GtBMCacheID;
 
   /// prescale factors
-  const l1t::PrescalesVetosHelper* m_l1GtPrescalesVetoes;
+  const l1t::PrescalesVetosFractHelper* m_l1GtPrescalesVetosFract;
   unsigned long long m_l1GtPfAlgoCacheID;
 
-  const std::vector<std::vector<int>>* m_prescaleFactorsAlgoTrig;
-  std::vector<std::vector<int>> m_initialPrescaleFactorsAlgoTrig;
+  const std::vector<std::vector<double>>* m_prescaleFactorsAlgoTrig;
+  std::vector<std::vector<double>> m_initialPrescaleFactorsAlgoTrig;
 
   /// CSV file for prescales
   std::string m_prescalesFile;
@@ -184,7 +184,7 @@ private:
 
   edm::ESGetToken<L1TGlobalParameters, L1TGlobalParametersRcd> m_l1GtStableParToken;
   edm::ESGetToken<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd> m_l1GtMenuToken;
-  edm::ESGetToken<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd> m_l1GtPrescaleVetosToken;
+  edm::ESGetToken<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd> m_l1GtPrescaleVetosToken;
 };
 
 #endif /*L1TGlobalProducer_h*/

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
@@ -180,7 +180,7 @@ void L1TGlobalSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     const std::vector<std::pair<std::string, bool>> initialDecisions = gtUtil_->decisionsInitial();
     const std::vector<std::pair<std::string, bool>> intermDecisions = gtUtil_->decisionsInterm();
     const std::vector<std::pair<std::string, bool>> finalDecisions = gtUtil_->decisionsFinal();
-    const std::vector<std::pair<std::string, int>> prescales = gtUtil_->prescales();
+    const std::vector<std::pair<std::string, double>> prescales = gtUtil_->prescales();
     const std::vector<std::pair<std::string, std::vector<int>>> masks = gtUtil_->masks();
 
     if ((decisionCount_.size() != gtUtil_->decisionsInitial().size()) ||

--- a/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
+++ b/L1Trigger/L1TGlobal/plugins/L1TGlobalSummary.cc
@@ -143,7 +143,7 @@ void L1TGlobalSummary::endRun(Run const&, EventSetup const&) {
 
         auto const& name = prescales.at(i).first;
         if (name != "NULL") {
-          int prescale = prescales.at(i).second;
+          double prescale = prescales.at(i).second;
           auto const& mask = masks.at(i).second;
           out << std::dec << setfill(' ') << "   " << setw(5) << i << "   " << setw(40) << name << "   " << setw(7)
               << resultInit << setw(7) << resultPre << setw(7) << resultFin << setw(10) << prescale << setw(11)
@@ -214,7 +214,7 @@ void L1TGlobalSummary::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       bool resultFin = (finalDecisions.at(i)).second;
 
       // get the prescale and mask (needs some error checking here)
-      int prescale = (prescales.at(i)).second;
+      double prescale = (prescales.at(i)).second;
       std::vector<int> mask = (masks.at(i)).second;
 
       if (resultInit)

--- a/L1Trigger/L1TGlobal/src/GlobalBoard.cc
+++ b/L1Trigger/L1TGlobal/src/GlobalBoard.cc
@@ -9,7 +9,8 @@
  *
  * \author: M. Fierro            - HEPHY Vienna - ORCA version
  * \author: Vasile Mihai Ghete   - HEPHY Vienna - CMSSW version
- * \author: Vladimir Rekovic - add correlation with overlap removal cases
+ * \author: Vladimir Rekovic     - add correlation with overlap removal cases
+ *                               - fractional prescales
  *
  * $Date$
  * $Revision$
@@ -830,7 +831,7 @@ void l1t::GlobalBoard::runFDL(edm::Event& iEvent,
                               const int iBxInEvent,
                               const int totalBxInEvent,
                               const unsigned int numberPhysTriggers,
-                              const std::vector<int>& prescaleFactorsAlgoTrig,
+                              const std::vector<double>& prescaleFactorsAlgoTrig,
                               const std::vector<unsigned int>& triggerMaskAlgoTrig,
                               const std::vector<int>& triggerMaskVetoAlgoTrig,
                               const bool algorithmTriggersUnprescaled,

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -57,7 +57,7 @@ l1t::L1TGlobalUtil::~L1TGlobalUtil() {
 /// check that the L1TGlobalUtil has been properly initialised
 bool l1t::L1TGlobalUtil::valid() const { return m_l1GtMenuCacheID != 0ULL and m_l1GtMenu != nullptr; }
 
-void l1t::L1TGlobalUtil::OverridePrescalesAndMasks(std::string filename, unsigned int psColumn) {
+void l1t::L1TGlobalUtil::OverridePrescalesAndMasks(std::string filename, double psColumn) {
   edm::FileInPath f1("L1Trigger/L1TGlobal/data/Luminosity/startup/" + filename);
   m_preScaleFileName = f1.fullPath();
   m_PreScaleColumn = psColumn;
@@ -109,7 +109,7 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup, bool is
   }
 
   if (!m_readPrescalesFromFile) {
-    auto vetosRcd = evSetup.get<L1TGlobalPrescalesVetosRcd>();
+    auto vetosRcd = evSetup.get<L1TGlobalPrescalesVetosFractRcd>();
     unsigned long long l1GtPfAlgoCacheID = vetosRcd.cacheIdentifier();
 
     if (m_l1GtPfAlgoCacheID != l1GtPfAlgoCacheID) {
@@ -122,13 +122,13 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup, bool is
       m_numberOfPreScaleColumns = 0;
       m_numberPhysTriggers = 0;
 
-      const L1TGlobalPrescalesVetos* es = nullptr;
+      const L1TGlobalPrescalesVetosFract* es = nullptr;
       if (isRun) {
-        es = &vetosRcd.get(m_L1TGlobalPrescalesVetosRunToken);
+        es = &vetosRcd.get(m_L1TGlobalPrescalesVetosFractRunToken);
       } else {
-        es = &vetosRcd.get(m_L1TGlobalPrescalesVetosEventToken);
+        es = &vetosRcd.get(m_L1TGlobalPrescalesVetosFractEventToken);
       }
-      m_l1GtPrescalesVetoes = PrescalesVetosHelper::readFromEventSetup(es);
+      m_l1GtPrescalesVetoes = PrescalesVetosFractHelper::readFromEventSetup(es);
 
       m_prescaleFactorsAlgoTrig = &(m_l1GtPrescalesVetoes->prescaleTable());
       m_numberOfPreScaleColumns = m_prescaleFactorsAlgoTrig->size();
@@ -163,7 +163,7 @@ void l1t::L1TGlobalUtil::retrieveL1Setup(const edm::EventSetup& evSetup, bool is
     m_PreScaleColumn = 0;
   }
   //std::cout << "Using prescale column: " << m_PreScaleColumn << std::endl;
-  const std::vector<int>& prescaleSet = (*m_prescaleFactorsAlgoTrig)[m_PreScaleColumn];
+  const std::vector<double>& prescaleSet = (*m_prescaleFactorsAlgoTrig)[m_PreScaleColumn];
 
   for (std::map<std::string, L1TUtmAlgorithm>::const_iterator itAlgo = m_algorithmMap->begin();
        itAlgo != m_algorithmMap->end();
@@ -240,7 +240,7 @@ void l1t::L1TGlobalUtil::retrieveL1Event(const edm::Event& iEvent,
           m_PreScaleColumn = 0;
         }
       }
-      const std::vector<int>& prescaleSet = (*m_prescaleFactorsAlgoTrig)[m_PreScaleColumn];
+      const std::vector<double>& prescaleSet = (*m_prescaleFactorsAlgoTrig)[m_PreScaleColumn];
 
       // Grab the final OR from the AlgBlk,
       m_finalOR = algBlk->getFinalOR();
@@ -285,7 +285,7 @@ void l1t::L1TGlobalUtil::loadPrescalesAndMasks() {
   inputPrescaleFile.open(m_preScaleFileName);
 
   std::vector<std::vector<int> > vec;
-  std::vector<std::vector<int> > prescale_vec;
+  std::vector<std::vector<double> > prescale_vec;
 
   if (inputPrescaleFile) {
     std::string prefix1("#");
@@ -339,7 +339,7 @@ void l1t::L1TGlobalUtil::loadPrescalesAndMasks() {
     if (NumPrescaleSets > 0) {
       // Fill default prescale set
       for (int iSet = 0; iSet < NumPrescaleSets; iSet++) {
-        prescale_vec.push_back(std::vector<int>());
+        prescale_vec.push_back(std::vector<double>());
         for (unsigned int iBit = 0; iBit < m_numberPhysTriggers; ++iBit) {
           int inputDefaultPrescale = 1;
           prescale_vec[iSet].push_back(inputDefaultPrescale);
@@ -380,7 +380,7 @@ void l1t::L1TGlobalUtil::loadPrescalesAndMasks() {
     m_PreScaleColumn = 0;
 
     for (int col = 0; col < 1; col++) {
-      prescale_vec.push_back(std::vector<int>());
+      prescale_vec.push_back(std::vector<double>());
       for (unsigned int iBit = 0; iBit < m_numberPhysTriggers; ++iBit) {
         int inputDefaultPrescale = 0;
         prescale_vec[col].push_back(inputDefaultPrescale);
@@ -399,14 +399,14 @@ void l1t::L1TGlobalUtil::eventSetupConsumes(edm::ConsumesCollector& iC, UseEvent
   if (useEventSetupIn == UseEventSetupIn::Run || useEventSetupIn == UseEventSetupIn::RunAndEvent) {
     m_L1TUtmTriggerMenuRunToken = iC.esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd, edm::Transition::BeginRun>();
     if (!m_readPrescalesFromFile) {
-      m_L1TGlobalPrescalesVetosRunToken =
-          iC.esConsumes<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd, edm::Transition::BeginRun>();
+      m_L1TGlobalPrescalesVetosFractRunToken =
+          iC.esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd, edm::Transition::BeginRun>();
     }
   }
   if (useEventSetupIn == UseEventSetupIn::Event || useEventSetupIn == UseEventSetupIn::RunAndEvent) {
     m_L1TUtmTriggerMenuEventToken = iC.esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
     if (!m_readPrescalesFromFile) {
-      m_L1TGlobalPrescalesVetosEventToken = iC.esConsumes<L1TGlobalPrescalesVetos, L1TGlobalPrescalesVetosRcd>();
+      m_L1TGlobalPrescalesVetosFractEventToken = iC.esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>();
     }
   }
 }
@@ -505,7 +505,7 @@ const bool l1t::L1TGlobalUtil::getFinalDecisionByBit(int& bit, bool& decision) c
 
   return false;  //couldn't get the information requested.
 }
-const bool l1t::L1TGlobalUtil::getPrescaleByBit(int& bit, int& prescale) const {
+const bool l1t::L1TGlobalUtil::getPrescaleByBit(int& bit, double& prescale) const {
   // Need some check that this is a valid bit
   if ((m_prescales[bit]).first != "NULL") {
     prescale = (m_prescales[bit]).second;
@@ -553,7 +553,7 @@ const bool l1t::L1TGlobalUtil::getFinalDecisionByName(const std::string& algName
 
   return false;  //trigger name was not the menu.
 }
-const bool l1t::L1TGlobalUtil::getPrescaleByName(const std::string& algName, int& prescale) const {
+const bool l1t::L1TGlobalUtil::getPrescaleByName(const std::string& algName, double& prescale) const {
   int bit = -1;
   if (getAlgBitFromName(algName, bit)) {
     prescale = (m_prescales[bit]).second;

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -57,7 +57,7 @@ l1t::L1TGlobalUtil::~L1TGlobalUtil() {
 /// check that the L1TGlobalUtil has been properly initialised
 bool l1t::L1TGlobalUtil::valid() const { return m_l1GtMenuCacheID != 0ULL and m_l1GtMenu != nullptr; }
 
-void l1t::L1TGlobalUtil::OverridePrescalesAndMasks(std::string filename, double psColumn) {
+void l1t::L1TGlobalUtil::OverridePrescalesAndMasks(std::string filename, unsigned int psColumn) {
   edm::FileInPath f1("L1Trigger/L1TGlobal/data/Luminosity/startup/" + filename);
   m_preScaleFileName = f1.fullPath();
   m_PreScaleColumn = psColumn;

--- a/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
+++ b/L1Trigger/L1TGlobal/src/L1TGlobalUtil.cc
@@ -406,7 +406,8 @@ void l1t::L1TGlobalUtil::eventSetupConsumes(edm::ConsumesCollector& iC, UseEvent
   if (useEventSetupIn == UseEventSetupIn::Event || useEventSetupIn == UseEventSetupIn::RunAndEvent) {
     m_L1TUtmTriggerMenuEventToken = iC.esConsumes<L1TUtmTriggerMenu, L1TUtmTriggerMenuRcd>();
     if (!m_readPrescalesFromFile) {
-      m_L1TGlobalPrescalesVetosFractEventToken = iC.esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>();
+      m_L1TGlobalPrescalesVetosFractEventToken =
+          iC.esConsumes<L1TGlobalPrescalesVetosFract, L1TGlobalPrescalesVetosFractRcd>();
     }
   }
 }


### PR DESCRIPTION
#### PR description:

11_2_X:  Use of fractional prescales in uGT emulator, by switching from legacy (int based) to new (double based) prescales.  The new Conditions format is available in CondDB as `L1TGlobalPrescalesVetosFractRcd`, in the `L1TGlobalPrescalesVetosFract_Stage2_v2_hlt` tag.

Candididate 

Attn: @christopheralanwest 
Note, to test central worfklow successfully, one must use a Candidate GlobalTag (`111X_dataRun3_HLT_Candidate_2020_11_06_11_24_15`).  

For example the worfklow 136.793

```
# in: /afs/cern.ch/work/r/rekovic/private/relaeses/11x/CMSSW_11_2_0_pre11/src going to execute cd 136.793_RunDoubleEG2017C+RunDoubleEG2017C+HLTDR2_2017+RECODR2_2017reHLT_skimDoubleEG_Prompt+HARVEST2017
 echo '{
"301998" : [[1, 150]]
}' > step1_lumiRanges.log  2>&1

cmsRun step2 --datatier FEVTDEBUGHLT --conditions 111X_dataRun3_HLT_Candidate_2020_11_06_11_24_15 -s L1REPACK:Full,HLT:@relval2017 --process reHLT --data --era Run2_2017 --eventcontent FEVTDEBUGHLT -n 100 --filein filelist:step1_dasquery.log --lumiToProcess step1_lumiRanges.log --fileout file:step2.root
```


#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of https://github.com/cms-sw/cmssw/pull/32741
