### PR TITLE
Fix some code checks warnings in FWCore

### DIFF
--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -51,7 +51,7 @@ namespace edm {
     std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
     std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(
-        unsigned int moduleID, BranchType branchType = InEvent) const override;
+        unsigned int moduleID, BranchType branchType) const override;
 
     std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
 

--- a/FWCore/ServiceRegistry/interface/ServiceMaker.h
+++ b/FWCore/ServiceRegistry/interface/ServiceMaker.h
@@ -68,7 +68,9 @@ namespace edm {
     class ServiceMaker : public ServiceMakerBase {
     public:
       ServiceMaker() {}
-      //virtual ~ServiceMaker();
+
+      ServiceMaker(ServiceMaker const&) = delete;
+      ServiceMaker const& operator=(ServiceMaker const&) = delete;
 
       // ---------- const member functions ---------------------
       std::type_info const& serviceType() const override { return typeid(T); }
@@ -87,17 +89,6 @@ namespace edm {
       bool processWideService() const override {
         return service::isProcessWideService(static_cast<typename TMaker::concrete_t const*>(nullptr));
       }
-
-      // ---------- static member functions --------------------
-
-      // ---------- member functions ---------------------------
-
-    private:
-      ServiceMaker(ServiceMaker const&) = delete;  // stop default
-
-      ServiceMaker const& operator=(ServiceMaker const&) = delete;  // stop default
-
-      // ---------- member data --------------------------------
     };
   }  // namespace serviceregistry
 }  // namespace edm

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -54,6 +54,9 @@ namespace edm {
       RandomNumberGeneratorService(ParameterSet const& pset, ActivityRegistry& activityRegistry);
       ~RandomNumberGeneratorService() override;
 
+      RandomNumberGeneratorService(RandomNumberGeneratorService const&) = delete;
+      RandomNumberGeneratorService const& operator=(RandomNumberGeneratorService const&) = delete;
+
       /// Use the next 2 functions to get the random number engine.
       /// These are the only functions most modules should call.
 
@@ -160,9 +163,6 @@ namespace edm {
         edm::propagate_const<LabelAndEngine*> labelAndEngine_;
         unsigned int moduleID_;
       };
-
-      RandomNumberGeneratorService(RandomNumberGeneratorService const&) = delete;
-      RandomNumberGeneratorService const& operator=(RandomNumberGeneratorService const&) = delete;
 
       void preModuleStreamCheck(StreamContext const& sc, ModuleCallingContext const& mcc);
       void postModuleStreamCheck(StreamContext const& sc, ModuleCallingContext const& mcc);


### PR DESCRIPTION
#### PR description:

While trying to reproduce code-checks failure in https://github.com/cms-sw/cmssw/pull/32373#issuecomment-737414067 `scram b code-checks` complained a few explicitly deleted function being in `private:` section rather than in `public:` section. This PR moves those functions to `public:`.

Motivated by https://github.com/cms-sw/cmssw/pull/32373#issuecomment-737414067 itself this PR removes the offending (even if I wasn't able to reproduce the code-checks failure locally) default value of a parameter in an overridden member function. I suppose it should have never been added as I can't see any purpose for it now.

#### PR validation:

Framework unit tests run.