### PR TITLE
Make globals used by DTTrigPhase2Prod const

### DIFF
--- a/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTTriggerPhase2/plugins/DTTrigPhase2Prod.cc
@@ -155,7 +155,7 @@ namespace {
     bool operator()(std::pair<DTLayerId, DTDigi> a, std::pair<DTLayerId, DTDigi> b) const {
       return (a.second.time() < b.second.time());
     }
-  } DigiTimeOrdering;
+  } const DigiTimeOrdering;
 }  // namespace
 
 DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset)

--- a/L1Trigger/DTTriggerPhase2/src/HoughGrouping.cc
+++ b/L1Trigger/DTTriggerPhase2/src/HoughGrouping.cc
@@ -46,7 +46,7 @@ namespace {
       else
         return (sumdista < sumdistb);  // abs. dist. to digis
     }
-  } HoughOrdering;
+  } const HoughOrdering;
 }  // namespace
 // ============================================================================
 // Constructors and destructor


### PR DESCRIPTION
#### PR description:

This avoids a static analyzer warning.

#### PR validation:

The code compiles.