### PR TITLE
Removed debug globals used in Phase2L1ParticleFlow

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/src/BitwisePFAlgo.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/BitwisePFAlgo.cc
@@ -29,7 +29,6 @@ BitwisePFAlgo::BitwisePFAlgo(const edm::ParameterSet &iConfig) : PFAlgoBase(iCon
                                                bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_CALO"),
                                                bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_LOOSE"),
                                                bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_TIGHT"));
-    pfalgo3_ref_set_debug(debug_);
   } else if (algo == "pfalgo2hgc") {
     algo_ = AlgoChoice::algo2hgc;
     config_ = std::make_shared<pfalgo_config>(bitwiseConfig.getParameter<uint32_t>("NTRACK"),
@@ -40,7 +39,6 @@ BitwisePFAlgo::BitwisePFAlgo(const edm::ParameterSet &iConfig) : PFAlgoBase(iCon
                                               bitwiseConfig.getParameter<uint32_t>("DR2MAX_TK_CALO"),
                                               bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_LOOSE"),
                                               bitwiseConfig.getParameter<uint32_t>("TK_MAXINVPT_TIGHT"));
-    pfalgo2hgc_ref_set_debug(debug_);
   } else {
     throw cms::Exception("Configuration", "Unsupported bitwiseAlgo " + algo);
   }
@@ -157,14 +155,15 @@ void BitwisePFAlgo::runPF(Region &r) const {
                   outch.get(),
                   outpho.get(),
                   outne.get(),
-                  outmu.get());
+                  outmu.get(),
+                  debug_);
 
       fw2dpf::convert(config3->nTRACK, outch.get(), r.track, r.pf);  // FIXME works only with a 1-1 mapping
       fw2dpf::convert(config3->nPHOTON, outpho.get(), r.pf);
       fw2dpf::convert(config3->nSELCALO, outne.get(), r.pf);
     } break;
     case AlgoChoice::algo2hgc: {
-      pfalgo2hgc_ref(*config_, calo.get(), track.get(), mu.get(), outch.get(), outne.get(), outmu.get());
+      pfalgo2hgc_ref(*config_, calo.get(), track.get(), mu.get(), outch.get(), outne.get(), outmu.get(), debug_);
       fw2dpf::convert(config_->nTRACK, outch.get(), r.track, r.pf);  // FIXME works only with a 1-1 mapping
       fw2dpf::convert(config_->nSELCALO, outne.get(), r.pf);
     } break;

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.cpp
@@ -12,18 +12,15 @@
 #include <algorithm>
 #include <memory>
 
-int g_pfalgo2hgc_debug_ref_ = 0;
-
-void pfalgo2hgc_ref_set_debug(int debug) { g_pfalgo2hgc_debug_ref_ = debug; }
-
 void pfalgo2hgc_ref(const pfalgo_config &cfg,
                     const HadCaloObj calo[/*cfg.nCALO*/],
                     const TkObj track[/*cfg.nTRACK*/],
                     const MuObj mu[/*cfg.nMU*/],
                     PFChargedObj outch[/*cfg.nTRACK*/],
                     PFNeutralObj outne[/*cfg.nSELCALO*/],
-                    PFChargedObj outmu[/*cfg.nMU*/]) {
-  if (g_pfalgo2hgc_debug_ref_) {
+                    PFChargedObj outmu[/*cfg.nMU*/],
+                    bool debug) {
+  if (debug) {
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
     for (unsigned int i = 0; i < cfg.nTRACK; ++i) {
       if (track[i].hwPt == 0)
@@ -88,7 +85,7 @@ void pfalgo2hgc_ref(const pfalgo_config &cfg,
   ////////////////////////////////////////////////////
   // TK-MU Linking
   std::unique_ptr<bool[]> isMu(new bool[cfg.nTRACK]);
-  pfalgo_mu_ref(cfg, track, mu, &isMu[0], outmu, g_pfalgo2hgc_debug_ref_);
+  pfalgo_mu_ref(cfg, track, mu, &isMu[0], outmu, debug);
 
   ////////////////////////////////////////////////////
   // TK-HAD Linking
@@ -120,7 +117,7 @@ void pfalgo2hgc_ref(const pfalgo_config &cfg,
     if (track[it].hwPt > 0 && !isMu[it]) {
       int ibest = best_match_with_pt_ref<HadCaloObj>(cfg.nCALO, DR2MAX, calo, track[it]);
       if (ibest != -1) {
-        if (g_pfalgo2hgc_debug_ref_)
+        if (debug)
           printf("FW  \t track  %3d pt %7d matched to calo' %3d pt %7d\n",
                  it,
                  int(track[it].hwPt),
@@ -139,7 +136,7 @@ void pfalgo2hgc_ref(const pfalgo_config &cfg,
       pt_t ptdiff = calo[ic].hwPt - calo_sumtk[ic];
       int sigmamult =
           calo_sumtkErr2[ic];  //  + (calo_sumtkErr2[ic] >> 1)); // this multiplies by 1.5 = sqrt(1.5)^2 ~ (1.2)^2
-      if (g_pfalgo2hgc_debug_ref_ && (calo[ic].hwPt > 0)) {
+      if (debug && (calo[ic].hwPt > 0)) {
 #ifdef L1Trigger_Phase2L1ParticleFlow_DiscretePFInputs_MORE
         l1tpf_impl::CaloCluster floatcalo;
         fw2dpf::convert(calo[ic], floatcalo);
@@ -163,7 +160,7 @@ void pfalgo2hgc_ref(const pfalgo_config &cfg,
     } else {
       calo_subpt[ic] = calo[ic].hwPt;
     }
-    if (g_pfalgo2hgc_debug_ref_ && (calo[ic].hwPt > 0))
+    if (debug && (calo[ic].hwPt > 0))
       printf("FW  \t calo'  %3d pt %7d ---> %7d \n", ic, int(calo[ic].hwPt), int(calo_subpt[ic]));
   }
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo2hgc_ref.h
@@ -4,14 +4,13 @@
 #include "../firmware/pfalgo2hgc.h"
 #include "pfalgo_common_ref.h"
 
-void pfalgo2hgc_ref_set_debug(int debug);
-
 void pfalgo2hgc_ref(const pfalgo_config &cfg,
                     const HadCaloObj calo[/*cfg.nCALO*/],
                     const TkObj track[/*cfg.nTRACK*/],
                     const MuObj mu[/*cfg.nMU*/],
                     PFChargedObj outch[/*cfg.nTRACK*/],
                     PFNeutralObj outne[/*cfg.nSELCALO*/],
-                    PFChargedObj outmu[/*cfg.nMU*/]);
+                    PFChargedObj outmu[/*cfg.nMU*/],
+                    bool debug);
 
 #endif

--- a/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/src/ref/pfalgo3_ref.h
@@ -31,8 +31,6 @@ struct pfalgo3_config : public pfalgo_config {
   ~pfalgo3_config() override {}
 };
 
-void pfalgo3_ref_set_debug(int debug);
-
 void pfalgo3_em_ref(const pfalgo3_config &cfg,
                     const EmCaloObj emcalo[/*cfg.nEMCALO*/],
                     const HadCaloObj hadcalo[/*cfg.nCALO*/],
@@ -40,7 +38,8 @@ void pfalgo3_em_ref(const pfalgo3_config &cfg,
                     const bool isMu[/*cfg.nTRACK*/],
                     bool isEle[/*cfg.nTRACK*/],
                     PFNeutralObj outpho[/*cfg.nPHOTON*/],
-                    HadCaloObj hadcalo_out[/*cfg.nCALO*/]);
+                    HadCaloObj hadcalo_out[/*cfg.nCALO*/],
+                    bool debug);
 void pfalgo3_ref(const pfalgo3_config &cfg,
                  const EmCaloObj emcalo[/*cfg.nEMCALO*/],
                  const HadCaloObj hadcalo[/*cfg.nCALO*/],
@@ -49,7 +48,8 @@ void pfalgo3_ref(const pfalgo3_config &cfg,
                  PFChargedObj outch[/*cfg.nTRACK*/],
                  PFNeutralObj outpho[/*cfg.nPHOTON*/],
                  PFNeutralObj outne[/*cfg.nSELCALO*/],
-                 PFChargedObj outmu[/*cfg.nMU*/]);
+                 PFChargedObj outmu[/*cfg.nMU*/],
+                 bool debug);
 
 void pfalgo3_merge_neutrals_ref(const pfalgo3_config &cfg,
                                 const PFNeutralObj pho[/*cfg.nPHOTON*/],


### PR DESCRIPTION

#### PR description:

The globals were replaced by passing an argument to the relevant functions. This avoids a static analyzer warning.

#### PR validation:

The code compiles.