### PR TITLE
Readd 1624.911, #2021 DD4hep from short matrix

### DIFF
--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -83,6 +83,7 @@ if __name__ == '__main__':
                      10024.0, #2017 ttbar
                      10224.0, #2017 ttbar PU
                      10824.0, #2018 ttbar
+                     11624.911, #2021 DD4hep ttbar
                      11634.0, #2021 ttbar
                      12434.0, #2023 ttbar
                      23234.0, #2026D49 ttbar (HLT TDR baseline w/ HGCal v11)


### PR DESCRIPTION
Reverts cms-sw/cmssw#32313

After having merged #32371 , https://github.com/cms-sw/cmssw/issues/32181 is solved. So I think we should try to readd `1624.911` in the PR tests. @cms-sw/reconstruction-l2 @cms-sw/simulation-l2 what do you think?
