### PR TITLE
skip empty lines in JetCorrectorParameters ctor

### DIFF
--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -116,6 +116,8 @@ JetCorrectorParameters::JetCorrectorParameters(const std::string& fFile, const s
   std::string line;
   std::string currentDefinitions = "";
   while (std::getline(input, line)) {
+    if (line.empty())
+      continue;
     std::string section = getSection(line);
     std::string tmp = getDefinitions(line);
     if (!section.empty() && tmp.empty()) {


### PR DESCRIPTION
#### PR description:

While testing with the class `JetCorrectorDBWriter`, I encountered a seg-fault coming from `JetCorrectorParameters`.

What led to the crash was the fact that the input `.txt` file I was using had an empty line in it (afaik, empty lines are absent in standard JEC txt files, thus no crashes).

This PR applies a quick fix, skipping empty lines in `JetCorrectorParameters`, and making the sw a bit more robust; a more sophisticated fix is left to experts of this package [*].

No changes expected.

FYI: @lathomas @kirschen @juska @glatino @pallabidas @sparedes

[*] The core issue is that the ctor of [`JetCorrectorParameters::Record`](https://github.com/cms-sw/cmssw/blob/bed3c304eaf10536ae7e0b384fde9fb7a9615fe7/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc#L74) does not throw an error if the input string has an invalid format (e.g. empty); in those cases, the `mMin`/`mMax` vectors are not filled, and accessing `xMin(i)` later on [here](https://github.com/cms-sw/cmssw/blob/bed3c304eaf10536ae7e0b384fde9fb7a9615fe7/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc#L136) leads to a crash.

#### PR validation:

Validated with private tests.