### PR TITLE
HBHE: Avoid double counting of correlated term

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/MahiFit.cc
@@ -85,13 +85,17 @@ void MahiFit::phase1Apply(const HBHEChannelInfo& channelData,
 
   useTriple = false;
   if (tstrig > ts4Thresh_ && tsTOT > 0) {
-    //Average pedestal width (for covariance matrix constraint)
-    nnlsWork_.pedVal = 0.25f * (channelData.tsPedestalWidth(0) * channelData.tsPedestalWidth(0) +
-                                channelData.tsPedestalWidth(1) * channelData.tsPedestalWidth(1) +
-                                channelData.tsPedestalWidth(2) * channelData.tsPedestalWidth(2) +
-                                channelData.tsPedestalWidth(3) * channelData.tsPedestalWidth(3));
-
     nnlsWork_.noisecorr = channelData.noisecorr();
+
+    if (nnlsWork_.noisecorr != 0) {
+      nnlsWork_.pedVal = 0.f;
+    } else {
+      //Average pedestal width (for covariance matrix constraint)
+      nnlsWork_.pedVal = 0.25f * (channelData.tsPedestalWidth(0) * channelData.tsPedestalWidth(0) +
+                                  channelData.tsPedestalWidth(1) * channelData.tsPedestalWidth(1) +
+                                  channelData.tsPedestalWidth(2) * channelData.tsPedestalWidth(2) +
+                                  channelData.tsPedestalWidth(3) * channelData.tsPedestalWidth(3));
+    }
 
     // only do pre-fit with 1 pulse if chiSq threshold is positive
     if (chiSqSwitch_ > 0) {


### PR DESCRIPTION
Remove double counting of correlated noise in the covariance matrix to account for the dark current.
For Run2 we have an approximate average term correlating all TS.
For Run3 we have the proper one correlating only two adjacent TS.

See improvements in Run3-2024 (the high dark current scenario)
https://indico.cern.ch/event/973995/contributions/4139599/attachments/2157184/3638663/Yihui_20201203.pdf
More event validation plots here, including event display
https://indico.cern.ch/event/973995/contributions/4139599/attachments/2157184/3648961/Effect-of-PR-32394.pdf

No changes are expected in Phase2-tests as currently we have not propagated the correlated term in the GT (to not interfere with HLT-TDR calibrations).
