### PR TITLE
drop type spec in TrackingTools RecoMuon

### DIFF
--- a/RecoMuon/Configuration/python/DisplacedMuonSeededStep_cff.py
+++ b/RecoMuon/Configuration/python/DisplacedMuonSeededStep_cff.py
@@ -7,43 +7,44 @@ from RecoMuon.MuonIdentification.earlyMuons_cfi import earlyDisplacedMuons
 #for displaced global muons
 import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
 muonSeededSeedsOutInDisplaced = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
-    src = "earlyDisplacedMuons",
+    src        = "earlyDisplacedMuons",
+    fromVertex = False
 )
-muonSeededSeedsOutInDisplaced.fromVertex = cms.bool(False)
 ###------------- MeasurementEstimator, defining the searcgh window for pattern recongnition ----------------
 #for displaced global muons
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
 muonSeededMeasurementEstimatorForOutInDisplaced = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
-    ComponentName = cms.string('muonSeededMeasurementEstimatorForOutInDisplaced'),
-    MaxChi2 = cms.double(30.0), ## was 30 ## TO BE TUNED
-    nSigma  = cms.double(3.),    ## was 3  ## TO BE TUNED 
+    ComponentName = 'muonSeededMeasurementEstimatorForOutInDisplaced',
+    MaxChi2 = 30.0, ## was 30 ## TO BE TUNED
+    nSigma  = 3.,    ## was 3  ## TO BE TUNED 
 )
 
 ###------------- TrajectoryFilter, defining selections on the trajectories while building them ----------------
 #for displaced global muons
 import RecoTracker.IterativeTracking.MuonSeededStep_cff
-muonSeededTrajectoryFilterForOutInDisplaced = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTrajectoryFilterForInOut.clone()
-muonSeededTrajectoryFilterForOutInDisplaced.constantValueForLostHitsFractionFilter = 10 ## allow more lost hits
-muonSeededTrajectoryFilterForOutInDisplaced.minimumNumberOfHits = 5 ## allow more lost hits
+muonSeededTrajectoryFilterForOutInDisplaced = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTrajectoryFilterForInOut.clone(
+    constantValueForLostHitsFractionFilter = 10, ## allow more lost hits
+    minimumNumberOfHits = 5 ## allow more lost hits
+)
 ###------------- TrajectoryBuilders ----------------
 #for displaced global muons
 muonSeededTrajectoryBuilderForOutInDisplaced = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
-    foundHitBonus = cms.double(1000.0),  
-    lostHitPenalty = cms.double(1.0),   
-    maxCand   = cms.int32(3),
-    estimator = cms.string('muonSeededMeasurementEstimatorForOutInDisplaced'),
-    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutInDisplaced')),
-    inOutTrajectoryFilter = cms.PSet(refToPSet_ = cms.string('muonSeededTrajectoryFilterForOutInDisplaced')), # not sure if it is used
-    minNrOfHitsForRebuild    = cms.int32(5),
-    requireSeedHitsInRebuild = cms.bool(True), 
-    keepOriginalIfRebuildFails = cms.bool(False), 
+    foundHitBonus = 1000.0,
+    lostHitPenalty = 1.0,
+    maxCand   = 3,
+    estimator = 'muonSeededMeasurementEstimatorForOutInDisplaced',
+    trajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutInDisplaced'),
+    inOutTrajectoryFilter = dict(refToPSet_ = 'muonSeededTrajectoryFilterForOutInDisplaced'), # not sure if it is used
+    minNrOfHitsForRebuild    = 5,
+    requireSeedHitsInRebuild = True, 
+    keepOriginalIfRebuildFails = False, 
 )
 ######## TRACK CANDIDATE MAKERS
 #for displaced global muons
 muonSeededTrackCandidatesOutInDisplaced = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
-    src = cms.InputTag("muonSeededSeedsOutInDisplaced"),
-    TrajectoryBuilderPSet = cms.PSet(refToPSet_ = cms.string("muonSeededTrajectoryBuilderForOutInDisplaced")),
-    TrajectoryCleaner = cms.string('muonSeededTrajectoryCleanerBySharedHits'),
+    src = "muonSeededSeedsOutInDisplaced",
+    TrajectoryBuilderPSet = dict(refToPSet_ = "muonSeededTrajectoryBuilderForOutInDisplaced"),
+    TrajectoryCleaner = 'muonSeededTrajectoryCleanerBySharedHits',
     numHitsForSeedCleaner = cms.int32(50),
     onlyPixelHitsForSeedCleaner = cms.bool(False),
 )
@@ -51,15 +52,15 @@ muonSeededTrackCandidatesOutInDisplaced = RecoTracker.CkfPattern.CkfTrackCandida
 ######## TRACK PRODUCERS 
 #for displaced global muon
 muonSeededTracksOutInDisplaced = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
-    src = cms.InputTag("muonSeededTrackCandidatesOutInDisplaced"),
-    AlgorithmName = cms.string('muonSeededStepOutIn'),
-    Fitter = cms.string("muonSeededFittingSmootherWithOutliersRejectionAndRK"),
+    src = "muonSeededTrackCandidatesOutInDisplaced",
+    AlgorithmName = 'muonSeededStepOutIn',
+    Fitter = "muonSeededFittingSmootherWithOutliersRejectionAndRK",
 )
 
 #for displaced global muons
-muonSeededTracksOutInDisplacedClassifier = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTracksOutInClassifier.clone()
-muonSeededTracksOutInDisplacedClassifier.src='muonSeededTracksOutInDisplaced'
-
+muonSeededTracksOutInDisplacedClassifier = RecoTracker.IterativeTracking.MuonSeededStep_cff.muonSeededTracksOutInClassifier.clone(
+    src='muonSeededTracksOutInDisplaced'
+)
 
 #for displaced global muons
 muonSeededStepCoreDisplacedTask = cms.Task(

--- a/RecoMuon/L2MuonProducer/python/L2Muons_cff.py
+++ b/RecoMuon/L2MuonProducer/python/L2Muons_cff.py
@@ -5,25 +5,27 @@ import FWCore.ParameterSet.Config as cms
 # from Geometry.CommonTopologies.bareGlobalTrackingGeometry_cfi import *
 # from RecoMuon.DetLayers.muonDetLayerGeometry_cfi import *
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-EstimatorForSTA = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
+EstimatorForSTA = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'Chi2STA',
+    MaxChi2 = 1000.
+)
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
-KFTrajectoryFitterForSTA = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone()
+KFTrajectoryFitterForSTA = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterSTA',
+    Propagator = 'SteppingHelixPropagatorAny',
+    Estimator = 'Chi2STA'
+)
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
-KFTrajectorySmootherForSTA = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone()
+KFTrajectorySmootherForSTA = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherSTA',
+    Propagator = 'SteppingHelixPropagatorOpposite',
+    Estimator = 'Chi2STA'
+)
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
-KFFittingSmootheForSTA = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
+KFFittingSmootheForSTA = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName = 'KFFitterSmootherSTA',
+    Fitter = 'KFFitterSTA',
+    Smoother = 'KFSmootherSTA'
+)
 # Stand Alone Muons Producer
 from RecoMuon.L2MuonProducer.L2Muons_cfi import *
-EstimatorForSTA.ComponentName = 'Chi2STA'
-EstimatorForSTA.MaxChi2 = 1000.
-KFTrajectoryFitterForSTA.ComponentName = 'KFFitterSTA'
-KFTrajectoryFitterForSTA.Propagator = 'SteppingHelixPropagatorAny'
-KFTrajectoryFitterForSTA.Estimator = 'Chi2STA'
-KFTrajectorySmootherForSTA.ComponentName = 'KFSmootherSTA'
-KFTrajectorySmootherForSTA.Propagator = 'SteppingHelixPropagatorOpposite'
-KFTrajectorySmootherForSTA.Estimator = 'Chi2STA'
-KFFittingSmootheForSTA.ComponentName = 'KFFitterSmootherSTA'
-KFFittingSmootheForSTA.Fitter = 'KFFitterSTA'
-KFFittingSmootheForSTA.Smoother = 'KFSmootherSTA'
-
-

--- a/TrackingTools/GeomPropagators/python/AnalyticalPropagatorParabolicMf_cff.py
+++ b/TrackingTools/GeomPropagators/python/AnalyticalPropagatorParabolicMf_cff.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.GeomPropagators.AnalyticalPropagator_cfi import AnalyticalPropagator
 AnalyticalPropagatorParabolicMF = AnalyticalPropagator.clone(
     SimpleMagneticField = cms.string('ParabolicMf'),
-    ComponentName = cms.string('AnalyticalPropagatorParabolicMf')
+    ComponentName = 'AnalyticalPropagatorParabolicMf'
 )
 
 from TrackingTools.GeomPropagators.OppositeAnalyticalPropagator_cfi import OppositeAnalyticalPropagator
 OppositeAnalyticalPropagatorParabolicMF = OppositeAnalyticalPropagator.clone(
     SimpleMagneticField = cms.string('ParabolicMf'),
-    ComponentName = cms.string('AnalyticalPropagatorParabolicMfOpposite')
+    ComponentName = 'AnalyticalPropagatorParabolicMfOpposite'
 )

--- a/TrackingTools/GeomPropagators/python/BeamHaloPropagator_cff.py
+++ b/TrackingTools/GeomPropagators/python/BeamHaloPropagator_cff.py
@@ -1,34 +1,36 @@
 import FWCore.ParameterSet.Config as cms
 
-import copy
 from TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi import *
-# clone the steppinghelix propagators
-BeamHaloSHPropagatorAlong = copy.deepcopy(SteppingHelixPropagatorAlong)
-import copy
 from TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi import *
-BeamHaloSHPropagatorOpposite = copy.deepcopy(SteppingHelixPropagatorOpposite)
-import copy
 from TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi import *
-BeamHaloSHPropagatorAny = copy.deepcopy(SteppingHelixPropagatorAny)
-import copy
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import *
-# clone some material propagators
-BeamHaloMPropagatorAlong = copy.deepcopy(MaterialPropagator)
-import copy
 from TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi import *
-BeamHaloMPropagatorOpposite = copy.deepcopy(OppositeMaterialPropagator)
 #
 # special propagator
 from TrackingTools.GeomPropagators.BeamHaloPropagatorAlong_cfi import *
 from TrackingTools.GeomPropagators.BeamHaloPropagatorOpposite_cfi import *
 from TrackingTools.GeomPropagators.BeamHaloPropagatorAny_cfi import *
-BeamHaloSHPropagatorAlong.ComponentName = 'BeamHaloSHPropagatorAlong'
-BeamHaloSHPropagatorOpposite.ComponentName = 'BeamHaloSHPropagatorOpposite'
-BeamHaloSHPropagatorAny.ComponentName = 'BeamHaloSHPropagatorAny'
-BeamHaloMPropagatorAlong.ComponentName = 'BeamHaloMPropagatorAlong'
-BeamHaloMPropagatorAlong.MaxDPhi = 10000
-BeamHaloMPropagatorOpposite.ComponentName = 'BeamHaloMPropagatorOpposite'
-BeamHaloMPropagatorOpposite.MaxDPhi = 10000
 
-BeamHaloMPropagatorAlong.useRungeKutta = True
-BeamHaloMPropagatorOpposite.useRungeKutta = True
+
+# clone the steppinghelix propagators
+BeamHaloSHPropagatorAlong = SteppingHelixPropagatorAlong.clone(
+    ComponentName = 'BeamHaloSHPropagatorAlong'
+)
+BeamHaloSHPropagatorOpposite = SteppingHelixPropagatorOpposite.clone(
+    ComponentName = 'BeamHaloSHPropagatorOpposite'
+)
+BeamHaloSHPropagatorAny = SteppingHelixPropagatorAny.clone(
+    ComponentName = 'BeamHaloSHPropagatorAny'
+)
+# clone some material propagators
+BeamHaloMPropagatorAlong = MaterialPropagator.clone(
+    ComponentName = 'BeamHaloMPropagatorAlong',
+    MaxDPhi       = 10000,
+    useRungeKutta = True
+)
+
+BeamHaloMPropagatorOpposite = OppositeMaterialPropagator.clone(
+    ComponentName = 'BeamHaloMPropagatorOpposite',
+    MaxDPhi       = 10000,
+    useRungeKutta = True
+)

--- a/TrackingTools/GsfTracking/python/BwdElectronPropagator_cfi.py
+++ b/TrackingTools/GsfTracking/python/BwdElectronPropagator_cfi.py
@@ -4,7 +4,7 @@ import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
 #
 # "backward" propagator for electrons
 #
-bwdElectronPropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone()
-bwdElectronPropagator.Mass = 0.000511
-bwdElectronPropagator.ComponentName = 'bwdElectronPropagator'
-
+bwdElectronPropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'bwdElectronPropagator'
+)

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidateMaker_cff.py
@@ -2,64 +2,65 @@ import FWCore.ParameterSet.Config as cms
 
 #Chi2 estimator
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-ElectronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-ElectronChi2.ComponentName = 'ElectronChi2'
-ElectronChi2.MaxChi2 = 2000.
-ElectronChi2.nSigma = 3.
-ElectronChi2.MaxDisplacement = 100
-ElectronChi2.MaxSagitta = -1
-
+ElectronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'ElectronChi2',
+    MaxChi2 = 2000.,
+    nSigma = 3.,
+    MaxDisplacement = 100,
+    MaxSagitta = -1
+)
 # Trajectory Filter
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
 TrajectoryFilterForElectrons = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
-    chargeSignificance = cms.double(-1.0),
-    minPt = cms.double(2.0),
-    minHitsMinPt = cms.int32(-1),
-    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
-    maxLostHits = cms.int32(1),
-    maxNumberOfHits = cms.int32(-1),
-    maxConsecLostHits = cms.int32(1),
-    nSigmaMinPt = cms.double(5.0),
-    minimumNumberOfHits = cms.int32(5),
-    maxCCCLostHits = cms.int32(9999),
-    minGoodStripCharge = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    chargeSignificance = -1.0,
+    minPt = 2.0,
+    minHitsMinPt = -1,
+    ComponentType = 'CkfBaseTrajectoryFilter',
+    maxLostHits = 1,
+    maxNumberOfHits = -1,
+    maxConsecLostHits = 1,
+    nSigmaMinPt = 5.0,
+    minimumNumberOfHits = 5,
+    maxCCCLostHits = 9999,
+    minGoodStripCharge = dict(refToPSet_ = 'SiStripClusterChargeCutNone')
 )
 
 # Trajectory Builder
 import RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi
-TrajectoryBuilderForElectrons = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.CkfTrajectoryBuilder.clone()
-TrajectoryBuilderForElectrons.trajectoryFilter.refToPSet_ = 'TrajectoryFilterForElectrons'
-TrajectoryBuilderForElectrons.maxCand = 5
-TrajectoryBuilderForElectrons.intermediateCleaning = False
-TrajectoryBuilderForElectrons.propagatorAlong = 'fwdGsfElectronPropagator'
-TrajectoryBuilderForElectrons.propagatorOpposite = 'bwdGsfElectronPropagator'
-TrajectoryBuilderForElectrons.estimator = 'ElectronChi2'
-TrajectoryBuilderForElectrons.MeasurementTrackerName = ''
-TrajectoryBuilderForElectrons.lostHitPenalty = 90.
-TrajectoryBuilderForElectrons.alwaysUseInvalidHits = True
-TrajectoryBuilderForElectrons.TTRHBuilder = 'WithTrackAngle'
-TrajectoryBuilderForElectrons.updator = 'KFUpdator'
-
+TrajectoryBuilderForElectrons = RecoTracker.CkfPattern.CkfTrajectoryBuilder_cfi.CkfTrajectoryBuilder.clone(
+    trajectoryFilter = dict(refToPSet_ = 'TrajectoryFilterForElectrons'),
+    maxCand = 5,
+    intermediateCleaning = False,
+    propagatorAlong = 'fwdGsfElectronPropagator',
+    propagatorOpposite = 'bwdGsfElectronPropagator',
+    estimator = 'ElectronChi2',
+    MeasurementTrackerName = '',
+    lostHitPenalty = 90.,
+    alwaysUseInvalidHits = True,
+    TTRHBuilder = 'WithTrackAngle',
+    updator = 'KFUpdator'
+)
 
 
 
 # CKFTrackCandidateMaker
 from RecoTracker.CkfPattern.CkfTrackCandidates_cff import *
 import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
-electronCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone()
-electronCkfTrackCandidates.src = cms.InputTag('electronMergedSeeds')
-electronCkfTrackCandidates.TrajectoryBuilderPSet.refToPSet_ = 'TrajectoryBuilderForElectrons'
-#electronCkfTrackCandidates.TrajectoryCleaner = 'TrajectoryCleanerBySharedHits'
-electronCkfTrackCandidates.NavigationSchool = 'SimpleNavigationSchool'
-electronCkfTrackCandidates.RedundantSeedCleaner = 'CachingSeedCleanerBySharedInput'
+electronCkfTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = 'electronMergedSeeds',
+    TrajectoryBuilderPSet = dict(refToPSet_ = 'TrajectoryBuilderForElectrons'),
+    #TrajectoryCleaner = 'TrajectoryCleanerBySharedHits'
+    NavigationSchool = 'SimpleNavigationSchool',
+    RedundantSeedCleaner = 'CachingSeedCleanerBySharedInput',
+    TrajectoryCleaner = 'electronTrajectoryCleanerBySharedHits'
+)
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
 electronTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
-    ComponentName = cms.string('electronTrajectoryCleanerBySharedHits'),
-    ValidHitBonus = cms.double(1000.0),
-    MissingHitPenalty = cms.double(0.0)
-    )
-electronCkfTrackCandidates.TrajectoryCleaner = 'electronTrajectoryCleanerBySharedHits'
+    ComponentName = 'electronTrajectoryCleanerBySharedHits',
+    ValidHitBonus = 1000.0,
+    MissingHitPenalty = 0.0
+)
             
 
 # "backward" propagator for electrons
@@ -71,4 +72,3 @@ from TrackingTools.GsfTracking.fwdGsfElectronPropagator_cff import *
 electronCkfTrackCandidatesFromMultiCl = electronCkfTrackCandidates.clone(
   src = 'electronMergedSeedsFromMultiCl'
 )
-

--- a/TrackingTools/GsfTracking/python/CkfElectronCandidatesChi2_cfi.py
+++ b/TrackingTools/GsfTracking/python/CkfElectronCandidatesChi2_cfi.py
@@ -5,9 +5,8 @@ import FWCore.ParameterSet.Config as cms
 #   (definition should be moved?)
 #
 import TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi
-electronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone()
-electronChi2.ComponentName = cms.string('electronChi2')
-electronChi2.nSigma = 3.0
-electronChi2.MaxChi2 = 100.0
-
-
+electronChi2 = TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = 'electronChi2',
+    nSigma        = 3.0,
+    MaxChi2       = 100.0
+)

--- a/TrackingTools/GsfTracking/python/FwdElectronPropagator_cfi.py
+++ b/TrackingTools/GsfTracking/python/FwdElectronPropagator_cfi.py
@@ -4,7 +4,7 @@ import TrackingTools.MaterialEffects.MaterialPropagator_cfi
 #
 # "forward" propagator for electrons
 #
-fwdElectronPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone()
-fwdElectronPropagator.Mass = 0.000511
-fwdElectronPropagator.ComponentName = 'fwdElectronPropagator'
-
+fwdElectronPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'fwdElectronPropagator'
+)

--- a/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronFittingSmoother_cfi.py
@@ -1,9 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
-GsfElectronFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
-GsfElectronFittingSmoother.ComponentName = 'GsfElectronFittingSmoother'
-GsfElectronFittingSmoother.Fitter = 'GsfTrajectoryFitter'
-GsfElectronFittingSmoother.Smoother = 'GsfTrajectorySmoother'
-
-
+GsfElectronFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName = 'GsfElectronFittingSmoother',
+    Fitter        = 'GsfTrajectoryFitter',
+    Smoother      = 'GsfTrajectorySmoother'
+)

--- a/TrackingTools/GsfTracking/python/GsfElectronGsfFit_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronGsfFit_cff.py
@@ -4,13 +4,13 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.GsfTracking.fwdGsfElectronPropagator_cff import *
 from TrackingTools.GsfTracking.GsfElectronFit_cff import *
 import TrackingTools.GsfTracking.GsfElectronFit_cfi
-electronGsfTracks = TrackingTools.GsfTracking.GsfElectronFit_cfi.GsfGlobalElectronTest.clone()
-electronGsfTracks.src = 'electronCkfTrackCandidates'
-electronGsfTracks.Propagator = 'fwdGsfElectronPropagator'
-electronGsfTracks.Fitter = 'GsfElectronFittingSmoother'
-electronGsfTracks.TTRHBuilder = 'WithTrackAngle'
-electronGsfTracks.TrajectoryInEvent = False
-
+electronGsfTracks = TrackingTools.GsfTracking.GsfElectronFit_cfi.GsfGlobalElectronTest.clone(
+    src = 'electronCkfTrackCandidates',
+    Propagator = 'fwdGsfElectronPropagator',
+    Fitter = 'GsfElectronFittingSmoother',
+    TTRHBuilder = 'WithTrackAngle',
+    TrajectoryInEvent = False
+)
 # FastSim has no template fit on tracker hits
 # replace the ECAL driven electron track candidates with the FastSim emulated ones
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
@@ -21,4 +21,3 @@ fastSim.toModify(electronGsfTracks,
 electronGsfTracksFromMultiCl = electronGsfTracks.clone(
   src = 'electronCkfTrackCandidatesFromMultiCl'
 )
-

--- a/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
+++ b/TrackingTools/GsfTracking/python/GsfElectronTracking_cff.py
@@ -42,7 +42,7 @@ phase2_hgcal.toReplaceWith(
 )
 
 from SimTracker.TrackAssociation.trackTimeValueMapProducer_cfi import trackTimeValueMapProducer
-gsfTrackTimeValueMapProducer = trackTimeValueMapProducer.clone(trackSrc = cms.InputTag('electronGsfTracks'))
+gsfTrackTimeValueMapProducer = trackTimeValueMapProducer.clone(trackSrc = 'electronGsfTracks')
 
 electronGsfTrackingWithTimingTask = cms.Task(electronGsfTrackingTask.copy(),gsfTrackTimeValueMapProducer)
 electronGsfTrackingWithTiming = cms.Sequence(electronGsfTrackingWithTimingTask)

--- a/TrackingTools/GsfTracking/python/bwdGsfElectronPropagator_cff.py
+++ b/TrackingTools/GsfTracking/python/bwdGsfElectronPropagator_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
 # "backward" propagator for electrons
-bwdGsfElectronPropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone()
-bwdGsfElectronPropagator.Mass = 0.000511
-bwdGsfElectronPropagator.ComponentName = 'bwdGsfElectronPropagator'
-
+bwdGsfElectronPropagator = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'bwdGsfElectronPropagator'
+)

--- a/TrackingTools/GsfTracking/python/fwdGsfElectronPropagator_cff.py
+++ b/TrackingTools/GsfTracking/python/fwdGsfElectronPropagator_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.MaterialEffects.MaterialPropagator_cfi
 # "forward" propagator for electrons
-fwdGsfElectronPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone()
-fwdGsfElectronPropagator.Mass = 0.000511
-fwdGsfElectronPropagator.ComponentName = 'fwdGsfElectronPropagator'
-
+fwdGsfElectronPropagator = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
+    Mass          = 0.000511,
+    ComponentName = 'fwdGsfElectronPropagator'
+)

--- a/TrackingTools/MaterialEffects/python/MaterialPropagatorParabolicMf_cff.py
+++ b/TrackingTools/MaterialEffects/python/MaterialPropagatorParabolicMf_cff.py
@@ -2,13 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from TrackingTools.MaterialEffects.MaterialPropagator_cfi import MaterialPropagator
 MaterialPropagatorParabolicMF = MaterialPropagator.clone(
-    SimpleMagneticField = cms.string('ParabolicMf'),
-    ComponentName = cms.string('PropagatorWithMaterialParabolicMf')
+    SimpleMagneticField = 'ParabolicMf',
+    ComponentName       = 'PropagatorWithMaterialParabolicMf'
 )
 
 from TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi import OppositeMaterialPropagator
 OppositeMaterialPropagatorParabolicMF = OppositeMaterialPropagator.clone(
-    SimpleMagneticField = cms.string('ParabolicMf'),
-    ComponentName = cms.string('PropagatorWithMaterialParabolicMfOpposite')
+    SimpleMagneticField = 'ParabolicMf',
+    ComponentName       = 'PropagatorWithMaterialParabolicMfOpposite'
 )
-

--- a/TrackingTools/MaterialEffects/python/Propagators_PtMin09_cff.py
+++ b/TrackingTools/MaterialEffects/python/Propagators_PtMin09_cff.py
@@ -11,11 +11,12 @@ import FWCore.ParameterSet.Config as cms
 # but should probably not be used for track fitting.
 
 import TrackingTools.MaterialEffects.MaterialPropagator_cfi
-MaterialPropagatorPtMin09 = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone()
-MaterialPropagatorPtMin09.ComponentName = 'PropagatorWithMaterialPtMin09'
-MaterialPropagatorPtMin09.ptMin = 0.9
-
+MaterialPropagatorPtMin09 = TrackingTools.MaterialEffects.MaterialPropagator_cfi.MaterialPropagator.clone(
+    ComponentName = 'PropagatorWithMaterialPtMin09',
+    ptMin         = 0.9
+)
 import TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi
-OppositeMaterialPropagatorPtMin09 = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone()
-OppositeMaterialPropagatorPtMin09.ComponentName = 'PropagatorWithMaterialOppositePtMin09'
-OppositeMaterialPropagatorPtMin09.ptMin = 0.9
+OppositeMaterialPropagatorPtMin09 = TrackingTools.MaterialEffects.OppositeMaterialPropagator_cfi.OppositeMaterialPropagator.clone(
+    ComponentName = 'PropagatorWithMaterialOppositePtMin09',
+    ptMin         = 0.9
+)

--- a/TrackingTools/Producers/python/analyticalPropagatorESProducer_cff.py
+++ b/TrackingTools/Producers/python/analyticalPropagatorESProducer_cff.py
@@ -3,20 +3,19 @@ import FWCore.ParameterSet.Config as cms
 from TrackingTools.GeomPropagators.AnalyticalPropagator_cfi import AnalyticalPropagator
 
 anyDirectionAnalyticalPropagator = AnalyticalPropagator.clone(
-  MaxDPhi = cms.double( 1.6 ),
-  ComponentName = cms.string( "anyDirectionAnalyticalPropagator" ),
-  PropagationDirection = cms.string( "anyDirection" )
+  MaxDPhi =  1.6 ,
+  ComponentName =  "anyDirectionAnalyticalPropagator" ,
+  PropagationDirection =  "anyDirection" 
 )
 
 alongMomentumAnalyticalPropagator = AnalyticalPropagator.clone(
-  MaxDPhi = cms.double( 1.6 ),
-  ComponentName = cms.string( "alongMomentumAnalyticalPropagator" ),
-  PropagationDirection = cms.string( "alongMomentum" )
+  MaxDPhi =  1.6 ,
+  ComponentName =  "alongMomentumAnalyticalPropagator" ,
+  PropagationDirection =  "alongMomentum" 
 )
 
 oppositeToMomentumAnalyticalPropagator = AnalyticalPropagator.clone(
-  MaxDPhi = cms.double( 1.6 ),
-  ComponentName = cms.string( "oppositeToMomentumAnalyticalPropagator" ),
-  PropagationDirection = cms.string( "oppositeToMomentum" )
+  MaxDPhi =  1.6 ,
+  ComponentName =  "oppositeToMomentumAnalyticalPropagator" ,
+  PropagationDirection =  "oppositeToMomentum" 
 )
-

--- a/TrackingTools/TrackFitters/python/LooperFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/LooperFitters_cff.py
@@ -2,26 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 LooperTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
-    ComponentName = cms.string('LooperFitter'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers')
+    ComponentName = 'LooperFitter',
+    Propagator    = 'PropagatorWithMaterialForLoopers'
 )
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 LooperTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
-    ComponentName = cms.string('LooperSmoother'),
-    Propagator = cms.string('PropagatorWithMaterialForLoopers'),
-    errorRescaling = cms.double(10.0),
+    ComponentName  = 'LooperSmoother',
+    Propagator     = 'PropagatorWithMaterialForLoopers',
+    errorRescaling = 10.0,
 )
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 LooperFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
-    ComponentName = cms.string('LooperFittingSmoother'),
-    Fitter = cms.string('LooperFitter'),
-    Smoother = cms.string('LooperSmoother'),
-    EstimateCut = cms.double(20.0),
+    ComponentName = 'LooperFittingSmoother',
+    Fitter        = 'LooperFitter',
+    Smoother      = 'LooperSmoother',
+    EstimateCut   = 20.0,
     # ggiurgiu@fnal.gov : Any value lower than -15 turns off this cut.
     # Recommended default value: -14.0. This will reject only the worst hits with negligible loss in track efficiency.  
-    LogPixelProbabilityCut = cms.double(-14.0),                               
-    MinNumberOfHits = cms.int32(3)
+    LogPixelProbabilityCut = -14.0,
+    MinNumberOfHits = 3
 )
-

--- a/TrackingTools/TrackFitters/python/MRHFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/MRHFitters_cff.py
@@ -5,20 +5,19 @@ from TrackingTools.KalmanUpdators.MRHChi2MeasurementEstimatorESProducer_cfi impo
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 MRHTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
     ComponentName = 'MRHFitter',
-    Estimator = 'MRHChi2',
-    Propagator = 'RungeKuttaTrackerPropagator'
-    )
+    Estimator     = 'MRHChi2',
+    Propagator    = 'RungeKuttaTrackerPropagator'
+)
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 MRHTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
     ComponentName = 'MRHSmoother',
-    Estimator = 'MRHChi2',
-    Propagator = 'RungeKuttaTrackerPropagator'
-    )
+    Estimator     = 'MRHChi2',
+    Propagator    = 'RungeKuttaTrackerPropagator'
+)
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 MRHFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
     ComponentName = 'MRHFittingSmoother',
-    Fitter = 'MRHFitter',
-    Smoother = 'MRHSmoother'
-    )
-
+    Fitter        = 'MRHFitter',
+    Smoother      = 'MRHSmoother'
+)

--- a/TrackingTools/TrackFitters/python/RungeKutta1DFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/RungeKutta1DFitters_cff.py
@@ -2,27 +2,27 @@ import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
 RK1DTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
-    ComponentName = cms.string('RK1DFitter'),
-    Propagator = cms.string('RungeKuttaTrackerPropagator'),
-    Updator = cms.string('KFSwitching1DUpdator')
+    ComponentName = 'RK1DFitter',
+    Propagator    = 'RungeKuttaTrackerPropagator',
+    Updator       = 'KFSwitching1DUpdator'
 )
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
 RK1DTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
-    ComponentName = cms.string('RK1DSmoother'),
-    Propagator = cms.string('RungeKuttaTrackerPropagator'),
-    Updator = cms.string('KFSwitching1DUpdator')
+    ComponentName = 'RK1DSmoother',
+    Propagator    = 'RungeKuttaTrackerPropagator',
+    Updator       = 'KFSwitching1DUpdator'
 )
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
 RK1DFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
-    ComponentName = cms.string('RK1DFittingSmoother'),
-    Fitter = cms.string('RK1DFitter'),
-    Smoother = cms.string('RK1DSmoother')
+    ComponentName = 'RK1DFittingSmoother',
+    Fitter        = 'RK1DFitter',
+    Smoother      = 'RK1DSmoother'
 )
 
 RKOutliers1DFittingSmoother = RK1DFittingSmoother.clone(
-    ComponentName = cms.string('RKOutliers1DFittingSmoother'),
-    EstimateCut = cms.double(20.0),
-    MinNumberOfHits = cms.int32(3),
+    ComponentName   = 'RKOutliers1DFittingSmoother',
+    EstimateCut     = 20.0,
+    MinNumberOfHits = 3,
 )

--- a/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
@@ -1,26 +1,26 @@
 import FWCore.ParameterSet.Config as cms
 
 import TrackingTools.TrackFitters.KFTrajectoryFitter_cfi
-RKTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone()
-RKTrajectoryFitter.ComponentName = 'RKFitter'
-RKTrajectoryFitter.Propagator = 'RungeKuttaTrackerPropagator'
-
+RKTrajectoryFitter = TrackingTools.TrackFitters.KFTrajectoryFitter_cfi.KFTrajectoryFitter.clone(
+    ComponentName = 'RKFitter',
+    Propagator    = 'RungeKuttaTrackerPropagator'
+)
 
 import TrackingTools.TrackFitters.KFTrajectorySmoother_cfi
-RKTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone()
-RKTrajectorySmoother.ComponentName = 'RKSmoother'
-RKTrajectorySmoother.Propagator = 'RungeKuttaTrackerPropagator'
-
+RKTrajectorySmoother = TrackingTools.TrackFitters.KFTrajectorySmoother_cfi.KFTrajectorySmoother.clone(
+    ComponentName = 'RKSmoother',
+    Propagator    = 'RungeKuttaTrackerPropagator'
+)
 
 import TrackingTools.TrackFitters.KFFittingSmoother_cfi
-RKFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone()
-RKFittingSmoother.ComponentName = 'RKFittingSmoother'
-RKFittingSmoother.Fitter = 'RKFitter'
-RKFittingSmoother.Smoother = 'RKSmoother'
+RKFittingSmoother = TrackingTools.TrackFitters.KFFittingSmoother_cfi.KFFittingSmoother.clone(
+    ComponentName = 'RKFittingSmoother',
+    Fitter        = 'RKFitter',
+    Smoother      = 'RKSmoother'
+)
 
-
-KFFittingSmootherWithOutliersRejectionAndRK = RKFittingSmoother.clone()
-KFFittingSmootherWithOutliersRejectionAndRK.ComponentName = 'KFFittingSmootherWithOutliersRejectionAndRK'
-KFFittingSmootherWithOutliersRejectionAndRK.EstimateCut = 20.0                
-KFFittingSmootherWithOutliersRejectionAndRK.MinNumberOfHits = 3
-
+KFFittingSmootherWithOutliersRejectionAndRK = RKFittingSmoother.clone(
+    ComponentName   = 'KFFittingSmootherWithOutliersRejectionAndRK',
+    EstimateCut     = 20.0,
+    MinNumberOfHits = 3
+)

--- a/TrackingTools/TrackRefitter/python/TracksToTrajectories_cff.py
+++ b/TrackingTools/TrackRefitter/python/TracksToTrajectories_cff.py
@@ -13,46 +13,48 @@ from RecoTracker.TransientTrackingRecHit.TransientTrackingRecHitBuilder_cfi impo
 
 from TrackingTools.KalmanUpdators.Chi2MeasurementEstimator_cfi import *
 
-Chi2EstimatorForRefit = Chi2MeasurementEstimator.clone()
-Chi2EstimatorForRefit.ComponentName = cms.string('Chi2EstimatorForRefit')
-Chi2EstimatorForRefit.MaxChi2 = cms.double(100000.0)
-Chi2EstimatorForRefit.nSigma = cms.double(3.0)
-
+Chi2EstimatorForRefit = Chi2MeasurementEstimator.clone(
+    ComponentName = 'Chi2EstimatorForRefit',
+    MaxChi2 = 100000.0,
+    nSigma = 3.0
+)
 
 from TrackingTools.TrackFitters.KFTrajectoryFitter_cfi import *
 from TrackingTools.TrackFitters.KFTrajectorySmoother_cfi import *
 
-KFFitterForRefitOutsideIn = KFTrajectoryFitter.clone()
-KFFitterForRefitOutsideIn.ComponentName = cms.string('KFFitterForRefitOutsideIn')
-KFFitterForRefitOutsideIn.Propagator = cms.string('SmartPropagatorAnyRKOpposite')
-KFFitterForRefitOutsideIn.Updator = cms.string('KFUpdator')
-KFFitterForRefitOutsideIn.Estimator = cms.string('Chi2EstimatorForRefit')
-KFFitterForRefitOutsideIn.minHits = cms.int32(3)
+KFFitterForRefitOutsideIn = KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterForRefitOutsideIn',
+    Propagator = 'SmartPropagatorAnyRKOpposite',
+    Updator = 'KFUpdator',
+    Estimator = 'Chi2EstimatorForRefit',
+    minHits = 3
+)
 
-KFSmootherForRefitOutsideIn = KFTrajectorySmoother.clone()
-KFSmootherForRefitOutsideIn.ComponentName = cms.string('KFSmootherForRefitOutsideIn')
-KFSmootherForRefitOutsideIn.Propagator = cms.string('SmartPropagatorAnyRKOpposite')
-KFSmootherForRefitOutsideIn.Updator = cms.string('KFUpdator')
-KFSmootherForRefitOutsideIn.Estimator = cms.string('Chi2EstimatorForRefit')
-KFSmootherForRefitOutsideIn.errorRescaling = cms.double(100.0)
-KFSmootherForRefitOutsideIn.minHits = cms.int32(3)
-
+KFSmootherForRefitOutsideIn = KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherForRefitOutsideIn',
+    Propagator = 'SmartPropagatorAnyRKOpposite',
+    Updator = 'KFUpdator',
+    Estimator = 'Chi2EstimatorForRefit',
+    errorRescaling = 100.0,
+    minHits = 3
+)
 #
-KFFitterForRefitInsideOut = KFTrajectoryFitter.clone()
-KFFitterForRefitInsideOut.ComponentName = cms.string('KFFitterForRefitInsideOut')
-KFFitterForRefitInsideOut.Propagator = cms.string('SmartPropagatorAnyRK')
-KFFitterForRefitInsideOut.Updator = cms.string('KFUpdator')
-KFFitterForRefitInsideOut.Estimator = cms.string('Chi2EstimatorForRefit')
-KFFitterForRefitInsideOut.minHits = cms.int32(3)
+KFFitterForRefitInsideOut = KFTrajectoryFitter.clone(
+    ComponentName = 'KFFitterForRefitInsideOut',
+    Propagator = 'SmartPropagatorAnyRK',
+    Updator = 'KFUpdator',
+    Estimator = 'Chi2EstimatorForRefit',
+    minHits = 3
+)
 
-
-KFSmootherForRefitInsideOut = KFTrajectorySmoother.clone()
-KFSmootherForRefitInsideOut.ComponentName = cms.string('KFSmootherForRefitInsideOut')
-KFSmootherForRefitInsideOut.Propagator = cms.string('SmartPropagatorAnyRK')
-KFSmootherForRefitInsideOut.Updator = cms.string('KFUpdator')
-KFSmootherForRefitInsideOut.Estimator = cms.string('Chi2EstimatorForRefit')
-KFSmootherForRefitInsideOut.errorRescaling = cms.double(100.0)
-KFSmootherForRefitInsideOut.minHits = cms.int32(3)
+KFSmootherForRefitInsideOut = KFTrajectorySmoother.clone(
+    ComponentName = 'KFSmootherForRefitInsideOut',
+    Propagator = 'SmartPropagatorAnyRK',
+    Updator = 'KFUpdator',
+    Estimator = 'Chi2EstimatorForRefit',
+    errorRescaling = 100.0,
+    minHits = 3
+)
 
 from Configuration.Eras.Modifier_fastSim_cff import fastSim
 # FastSim doesn't use Runge Kute for propagation
@@ -61,4 +63,3 @@ fastSim.toModify(KFFitterForRefitOutsideIn, Propagator = 'SmartPropagatorAny')
 fastSim.toModify(KFSmootherForRefitOutsideIn, Propagator = 'SmartPropagator')
 fastSim.toModify(KFFitterForRefitInsideOut, Propagator = "SmartPropagatorAny")
 fastSim.toModify(KFSmootherForRefitInsideOut, Propagator = "SmartPropagatorAny")
-

--- a/TrackingTools/TrackRefitter/python/cosmicMuonTrajectories_cff.py
+++ b/TrackingTools/TrackRefitter/python/cosmicMuonTrajectories_cff.py
@@ -23,12 +23,14 @@ from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 cosmicMuons = cms.EDProducer("TracksToTrajectories",
                                   Type = cms.string("CosmicMuonsForAlignment"),
                                   Tracks = cms.InputTag("cosmicMuons"),
-                                  TrackTransformer = cms.PSet(	TrackerRecHitBuilder = cms.string('WithTrackAngle'),
-                                                              	MuonRecHitBuilder = cms.string('MuonRecHitBuilder'),
-                                                                MTDRecHitBuilder = cms.string('MTDRecHitBuilder'),
-                                                              	RefitRPCHits = cms.bool(True)
-                                                               )
-                                   )
+                                  TrackTransformer = cms.PSet(
+					TrackerRecHitBuilder = cms.string('WithTrackAngle'),
+     					MuonRecHitBuilder = cms.string('MuonRecHitBuilder'),
+        				MTDRecHitBuilder = cms.string('MTDRecHitBuilder'),
+     					RefitRPCHits = cms.bool(True)
+                                  )
+                             )
 
-MuAlCosmics = cosmicMuons.clone()
-MuAlCosmics.Tracks = cms.InputTag("ALCARECOMuAlGlobalCosmics","StandAlone")
+MuAlCosmics = cosmicMuons.clone(
+    Tracks = "ALCARECOMuAlGlobalCosmics:StandAlone"
+)

--- a/TrackingTools/TrackRefitter/python/globalCosmicMuonTrajectories_cff.py
+++ b/TrackingTools/TrackRefitter/python/globalCosmicMuonTrajectories_cff.py
@@ -16,23 +16,25 @@ from TrackingTools.TrackRefitter.TracksToTrajectories_cff import *
 globalCosmicMuons = cms.EDProducer("TracksToTrajectories",
                                    Type = cms.string("GlobalCosmicMuonsForAlignment"),
                                    Tracks = cms.InputTag("globalCosmicMuons"),
-                                   TrackTransformer = cms.PSet(TrackerRecHitBuilder = cms.string('WithTrackAngle'),
-                                                               MuonRecHitBuilder = cms.string('MuonRecHitBuilder'),
-                                                               MTDRecHitBuilder = cms.string('MTDRecHitBuilder'),
-                                                               RefitRPCHits = cms.bool(True),
-    															# muon station to be skipped //also kills RPCs in that station
-    															SkipStationDT	= cms.int32(-999),
-    															SkipStationCSC	= cms.int32(-999),
-    															# muon muon wheel to be skipped
-															    SkipWheelDT		= cms.int32(-999),
-    	 														# PXB = 1, PXF = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6
- 															    TrackerSkipSystem	= cms.int32(-999),
-    															# layer, wheel, or disk depending on the system
-    															TrackerSkipSection	= cms.int32(-999),
-                                                               )
-                                   )
+                                   TrackTransformer = cms.PSet(
+					TrackerRecHitBuilder = cms.string('WithTrackAngle'),
+					MuonRecHitBuilder = cms.string('MuonRecHitBuilder'),
+					MTDRecHitBuilder = cms.string('MTDRecHitBuilder'),
+					RefitRPCHits = cms.bool(True),
+					# muon station to be skipped //also kills RPCs in that station
+					SkipStationDT	= cms.int32(-999),
+					SkipStationCSC	= cms.int32(-999),
+					# muon muon wheel to be skipped
+					    SkipWheelDT		= cms.int32(-999),
+					# PXB = 1, PXF = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6
+					    TrackerSkipSystem	= cms.int32(-999),
+					# layer, wheel, or disk depending on the system
+					TrackerSkipSection	= cms.int32(-999),
+				   )
+                                )
 
 
 
-MuAlGlobalCosmics = globalCosmicMuons.clone()
-MuAlGlobalCosmics.Tracks = cms.InputTag("ALCARECOMuAlGlobalCosmics","GlobalMuon")
+MuAlGlobalCosmics = globalCosmicMuons.clone(
+    Tracks = "ALCARECOMuAlGlobalCosmics:GlobalMuon"
+)


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR for RecoHI is [PR#32031](https://github.com/cms-sw/cmssw/pull/32031), [PR#32386](https://github.com/cms-sw/cmssw/pull/32386))

In this PR, total 23 files changed. 

- RecoMuon/Configuration : 1 file
- RecoMuon/L2MuonProducer : 1 file

- TrackingTools/GeomPropagators : 2 files
- TrackingTools/GsfTracking            : 9 files
- TrackingTools/MaterialEffects       : 2 files
- TrackingTools/Producers              : 1 file
- TrackingTools/TrackFitters            : 4 files
- TrackingTools/TrackRefitter          : 3 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).