### PR TITLE
feat: DDXv2.1 - discriminator shape fix, perf. ident.

### DIFF
--- a/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
+++ b/RecoBTag/ONNXRuntime/python/pfMassIndependentDeepDoubleXV2JetTags_cff.py
@@ -5,19 +5,19 @@ from .pfDeepDoubleCvLJetTags_cfi import pfDeepDoubleCvLJetTags
 from .pfDeepDoubleCvBJetTags_cfi import pfDeepDoubleCvBJetTags
 
 pfMassIndependentDeepDoubleBvLV2JetTags = pfDeepDoubleBvLJetTags.clone(
-    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/BvL.onnx",
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V021/BvL.onnx",
     input_names={"input_1", "input_2", "input_3", "input_4"},
     version="V2",
 )
 
 pfMassIndependentDeepDoubleCvLV2JetTags = pfDeepDoubleCvLJetTags.clone(
-    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvL.onnx",
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V021/CvL.onnx",
     input_names={"input_1", "input_2", "input_3", "input_4"},
     version="V2",
 )
 
 pfMassIndependentDeepDoubleCvBV2JetTags = pfDeepDoubleCvBJetTags.clone(
-    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V02/CvB.onnx",
+    model_path="RecoBTag/Combined/data/DeepDoubleX/102X/V021/CvB.onnx",
     input_names={"input_1", "input_2", "input_3", "input_4"},
     version="V2",
 )

--- a/RecoBTag/ONNXRuntime/test/plotDDX.py
+++ b/RecoBTag/ONNXRuntime/test/plotDDX.py
@@ -27,18 +27,15 @@ info['CvB'] = []
 for iev, event in enumerate(events_c):
     event.getByLabel (labelJ, handleJ)
     jets = handleJ.product()
-    print(iev)
+    #print(iev)
     for jet in jets:
-        #if jet.pt() < 300 or jet.pt() > 2000: continue
-        #if jet.mass() < 40 or jet.mass() > 200: continue
+        if jet.pt() < 300 or jet.pt() > 2000: continue
+        if jet.mass() < 40 or jet.mass() > 200: continue
 
         print(jet.pt(), jet.mass(), jet.eta())
-        print("DDB", jet.bDiscriminator("pfDeepDoubleBvLJetTags:probQCD"), jet.bDiscriminator("pfDeepDoubleBvLJetTags:probHbb"))
-        # print("DDB", jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleBvLJetTags:probHbb"))
-        print("DDCvL", jet.bDiscriminator("pfDeepDoubleCvLJetTags:probQCD"), jet.bDiscriminator("pfDeepDoubleCvLJetTags:probHcc"))
-        # print("DDCvL", jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvLJetTags:probHcc"))
-        print("DDCvB", jet.bDiscriminator("pfDeepDoubleCvBJetTags:probHbb"), jet.bDiscriminator("pfDeepDoubleCvBJetTags:probHcc") )
-        # print("DDCvB", jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHbb"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvBJetTags:probHcc"))
+        print("DDB", jet.bDiscriminator("pfMassIndependentDeepDoubleBvLV2JetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleBvLV2JetTags:probHbb"))
+        print("DDCvL", jet.bDiscriminator("pfMassIndependentDeepDoubleCvLV2JetTags:probQCD"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvLV2JetTags:probHcc"))
+        print("DDCvB", jet.bDiscriminator("pfMassIndependentDeepDoubleCvBV2JetTags:probHbb"), jet.bDiscriminator("pfMassIndependentDeepDoubleCvBV2JetTags:probHcc"))
         h_probQ_ddb.Fill(jet.bDiscriminator("pfDeepDoubleBvLJetTags:probQCD"))
         h_probH_ddb.Fill(jet.bDiscriminator("pfDeepDoubleBvLJetTags:probHbb"))
         h_probQ_ddc.Fill(jet.bDiscriminator("pfDeepDoubleCvLJetTags:probQCD"))
@@ -54,18 +51,18 @@ for iev, event in enumerate(events_c):
 with open('outputs.pkl', 'wb') as handle:
     pickle.dump(info, handle)
 
-c1a = ROOT.TCanvas()
-h_probH_ddb.Draw("HISTO")
-h_probH_ddb.SetLineColor(632)
-h_probH_ddb.SetLineStyle(10)
-h_probQ_ddb.Draw("SAME")
-c1a.Draw()
-c1a.SaveAs("ProbQ_vc_vb.png")
+# c1a = ROOT.TCanvas()
+# h_probH_ddb.Draw("HISTO")
+# h_probH_ddb.SetLineColor(632)
+# h_probH_ddb.SetLineStyle(10)
+# h_probQ_ddb.Draw("SAME")
+# c1a.Draw()
+# c1a.SaveAs("ProbQ_vc_vb.png")
 
-c1b = ROOT.TCanvas()
-h_probH_ddc.Draw("HISTO")
-h_probH_ddc.SetLineColor(632)
-h_probH_ddc.SetLineStyle(10)
-h_probQ_ddc.Draw("SAME")
-c1b.Draw()
-c1b.SaveAs("ProbH_vc_vb.png")
+# c1b = ROOT.TCanvas()
+# h_probH_ddc.Draw("HISTO")
+# h_probH_ddc.SetLineColor(632)
+# h_probH_ddc.SetLineStyle(10)
+# h_probQ_ddc.Draw("SAME")
+# c1b.Draw()
+# c1b.SaveAs("ProbH_vc_vb.png")

--- a/RecoBTag/ONNXRuntime/test/test_deep_doublex_cfg.py
+++ b/RecoBTag/ONNXRuntime/test/test_deep_doublex_cfg.py
@@ -80,11 +80,10 @@ process.source.fileNames = filesRelValTTbarPileUpMINIAODSIM
 process.source.fileNames = cms.untracked.vstring(
 #'/store/relval/CMSSW_10_3_0_pre2/RelValTTbar_13/MINIAODSIM/PU25ns_103X_upgrade2018_realistic_v2-v1/20000/85820ACA-657B-BC44-AC74-AACD6D54B348.root'
 #'/store/mc/RunIIFall17MiniAOD/GluGluHToBB_M125_13TeV_powheg_pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/20000/C8932584-5006-E811-9840-141877410512.root',
-#'/store/mc/RunIIFall17MiniAODv2/GluGluHToCC_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/72164088-CB67-E811-9D0D-008CFA197AC4.root',
-'file:72164088-CB67-E811-9D0D-008CFA197AC4.root',
+'/store/mc/RunIIFall17MiniAODv2/GluGluHToCC_M125_13TeV_powheg_pythia8/MINIAODSIM/PU2017_12Apr2018_94X_mc2017_realistic_v14-v2/30000/72164088-CB67-E811-9D0D-008CFA197AC4.root',
 #'/store/mc/RunIIFall17MiniAOD/QCD_HT700to1000_TuneCP5_13TeV-madgraph-pythia8/MINIAODSIM/94X_mc2017_realistic_v10-v1/20000/C0F304A4-23FA-E711-942E-E0071B6CAD20.root'
 )
-#process.maxEvents.input = 1000
+process.maxEvents.input = 10000
 
 from Configuration.EventContent.EventContent_cff import MINIAODSIMEventContent
 process.out.outputCommands.append('keep *_slimmedJetsAK8*_*_*')


### PR DESCRIPTION
DDXv2.1, same performance, fixed weighting scheme -> more even classifier shapes

Should be tested with https://github.com/cms-data/RecoBTag-Combined/pull/38

@mariadalfonso 

This PR should be merged if it can be done in time for the next campaign, replacing the discriminators under
```
pfMassIndependentDeepDoubleBvLV2JetTags
pfMassIndependentDeepDoubleCvLV2JetTags
pfMassIndependentDeepDoubleCvBV2JetTags
```
as there _should_ currently not be any production filed with these discriminators in them. 

If not we can forego it, since the performance is the same and we don't want have both V2 and V21 flying around.
