### PR TITLE
Fix in TauAnalysis/MCEmbeddingTools/python/customisers.py (lowPtGsfElectronTask)

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/python/customisers.py
+++ b/TauAnalysis/MCEmbeddingTools/python/customisers.py
@@ -408,10 +408,14 @@ def customiseMerging(process, changeProcessname=True,reselect=False):
  #   process.merge_step.remove(process.gedPhotonsTmp)
  #   process.merge_step.remove(process.particleFlowTmp)
     process.merge_step.remove(process.hcalnoise)
+    process.merge_step.remove(process.lowPtGsfElectronTask)
+    process.merge_step.remove(process.gsfTracksOpenConversions)
 
     process.load('CommonTools.ParticleFlow.genForPF2PAT_cff')
 
     process.merge_step += process.genForPF2PATSequence
+
+    process.slimmingTask.remove(process.slimmedLowPtElectronsTask)
 
     process.schedule.insert(0,process.merge_step)
     # process.load('PhysicsTools.PatAlgos.slimming.slimmedGenJets_cfi')


### PR DESCRIPTION
This PR fixes the unit test failure in `TauAnalysis/MCEmbeddingTools`(see https://github.com/cms-sw/cmssw/issues/32376).
This PR consists in removing three tasks (`slimmedLowPtElectronsTask`, `lowPtGsfElectronTask`, `gsfTracksOpenConversions`) added by #31220.

Validated by running 
```
cmsDriver.py MERGE -s PAT --filein file:simulated_and_cleaned.root  --fileout file:merged.root --era Run2_2016_HIPM --data --scenario pp --conditions auto:run2_data --eventcontent  MINIAODSIM --datatier USER --customise TauAnalysis/MCEmbeddingTools/customisers.customiseMerging --customise_commands "process.patTrigger.processName = cms.string('SIMembedding')" -n -1 
```
after having run `TauAnalysis/MCEmbeddingTools/test/runtests.sh`.