### PR TITLE
Strip payload inspector: add class to retrieve list of dead modules from JSON

### DIFF
--- a/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
+++ b/CondCore/BeamSpotPlugins/interface/BeamSpotPayloadInspectorHelper.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <sstream>
 #include "TCanvas.h"
+#include "TStyle.h"
 #include "TH2F.h"
 #include "TLatex.h"
 
@@ -219,6 +220,8 @@ namespace BeamSpotPI {
       auto tagname = tag.name;
       auto iov = tag.iovs.front();
 
+      gStyle->SetHistMinimumZero(kTRUE);
+
       m_payload = this->fetchPayload(std::get<1>(iov));
 
       TCanvas canvas("Beam Spot Parameters Summary", "BeamSpot Parameters summary", isOnline_ ? 1500 : 1000, 1000);
@@ -310,9 +313,9 @@ namespace BeamSpotPI {
       auto ltx = TLatex();
       ltx.SetTextFont(62);
       if (isOnline_) {
-        ltx.SetTextSize(0.040);
+        ltx.SetTextSize(0.030);
       } else {
-        ltx.SetTextSize(0.032);
+        ltx.SetTextSize(0.025);
       }
       ltx.SetTextAlign(11);
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -95,18 +95,22 @@ namespace {
   /************************************************
     TrackerMap of SiStripBadStrip (bad strip per detid)
   *************************************************/
-  class SiStripBadModuleTrackerMap : public cond::payloadInspector::PlotImage<SiStripBadStrip> {
+  class SiStripBadModuleTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripBadModuleTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip>("Tracker Map of SiStrip Bad Strips") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStrip Bad Strips") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
-      std::string titleMap = "Module with at least a bad Strip (payload : " + std::get<1>(iov) + ")";
+      auto theIOVsince = std::to_string(std::get<0>(iov));
+
+      std::string titleMap = "Modules w/ at least 1 bad Strip, Run: " + theIOVsince + " (tag: " + tagname + ")";
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripBadStrips");
       tmap->setTitle(titleMap);
@@ -131,21 +135,25 @@ namespace {
   /************************************************
     TrackerMap of SiStripBadStrip (bad strips fraction)
   *************************************************/
-  class SiStripBadStripFractionTrackerMap : public cond::payloadInspector::PlotImage<SiStripBadStrip> {
+  class SiStripBadStripFractionTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripBadStripFractionTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip>("Tracker Map of SiStrip Bad Components fraction") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStrip Bad Components fraction") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
       SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
 
-      std::string titleMap = "Fraction of bad Strips per module (payload : " + std::get<1>(iov) + ")";
+      auto theIOVsince = std::to_string(std::get<0>(iov));
+
+      std::string titleMap = "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag: " + tagname + ")";
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripBadStrips");
       tmap->setTitle(titleMap);

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -95,3 +95,17 @@ getPayloadData.py \
     --test;
 
 mv *.png $W_DIR/results/SiStripConfObjectDisplay.png
+
+######################
+# Test DetVOff
+######################
+getPayloadData.py \
+    --plugin pluginSiStripDetVOff_PayloadInspector \
+    --plot plot_SiStripDetVOffTest \
+    --tag SiStripDetVOff_v3_offline \
+    --time_type Time \
+    --iovs '{"start_iov": "685006631803433472", "end_iov": "6850066318803433472"}' \
+    --db Prod \
+    --test ;
+
+getPayloadData.py --plugin pluginSiStripDetVOff_PayloadInspector --plot plot_SiStripLVOffListOfModules --tag SiStripDetVOff_v3_offline --time_type Time --iovs '{"start_iov": "6850066318803433472", "end_iov": "6850066318803433472"}' --db Prod --test > & out.out &

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -108,4 +108,14 @@ getPayloadData.py \
     --db Prod \
     --test ;
 
-getPayloadData.py --plugin pluginSiStripDetVOff_PayloadInspector --plot plot_SiStripLVOffListOfModules --tag SiStripDetVOff_v3_offline --time_type Time --iovs '{"start_iov": "6850066318803433472", "end_iov": "6850066318803433472"}' --db Prod --test > & out.out &
+######################
+# Test dumping of switched off modules
+######################
+getPayloadData.py \
+    --plugin pluginSiStripDetVOff_PayloadInspector \
+    --plot plot_SiStripLVOffListOfModules \
+    --tag SiStripDetVOff_v3_offline \
+    --time_type Time \
+    --iovs '{"start_iov": "6850066318803433472", "end_iov": "6850066318803433472"}' \
+    --db Prod \
+    --test;

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -12,6 +12,7 @@
 #include <type_traits>
 
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <boost/python/list.hpp>
 #include <boost/python/dict.hpp>
@@ -74,6 +75,9 @@ namespace cond {
         if (value.first) {
           ss << "\"" << entryLabel << "\":" << value.second;
         }
+      } else if constexpr (std::is_same_v<V, double>) {
+        ss.precision(0);
+        ss << "\"" << entryLabel << "\":" << std::fixed << value;
       } else {
         ss << "\"" << entryLabel << "\":" << value;
       }
@@ -701,21 +705,31 @@ namespace cond {
     };
 
     //
-    template <typename PayloadType, IOVMultiplicity IOV_M = UNSPECIFIED_IOV>
-    class Histogram1D : public Plot2D<PayloadType, float, float, IOV_M, 1> {
+    template <typename AxisType, typename PayloadType, IOVMultiplicity IOV_M = UNSPECIFIED_IOV>
+    class Histogram1 : public Plot2D<PayloadType, AxisType, AxisType, IOV_M, 1> {
     public:
-      typedef Plot2D<PayloadType, float, float, IOV_M, 1> Base;
+      typedef Plot2D<PayloadType, AxisType, AxisType, IOV_M, 1> Base;
       // naive implementation, essentially provided as an example...
-      Histogram1D(const std::string& title,
-                  const std::string& xLabel,
-                  size_t nbins,
-                  float min,
-                  float max,
-                  const std::string& yLabel = "entries")
+      Histogram1(const std::string& title,
+                 const std::string& xLabel,
+                 size_t nbins,
+                 float min,
+                 float max,
+                 const std::string& yLabel = "entries")
           : Base("Histo1D", title, xLabel, yLabel), m_nbins(nbins), m_min(min), m_max(max) {}
 
       //
       void init() override {
+        if (m_nbins < 1) {
+          edm::LogError("payloadInspector::Histogram1D()")
+              << " trying to book an histogram with less then 1 bin!" << std::endl;
+        }
+
+        if (m_min > m_max) {
+          edm::LogError("payloadInspector::Histogram1D()")
+              << " trying to book an histogram with minimum " << m_min << "> maximum" << m_max << " !" << std::endl;
+        }
+
         Base::m_plotData.clear();
         float binSize = (m_max - m_min) / m_nbins;
         if (binSize > 0) {
@@ -728,7 +742,7 @@ namespace cond {
       }
 
       // to be used to fill the histogram!
-      void fillWithValue(float value, float weight = 1) {
+      void fillWithValue(AxisType value, AxisType weight = 1) {
         // ignoring underflow/overflows ( they can be easily added - the total entries as well  )
         if (!Base::m_plotData.empty() && (value < m_max) && (value >= m_min)) {
           size_t ibin = (value - m_min) / m_binSize;
@@ -737,7 +751,7 @@ namespace cond {
       }
 
       // to be used to fill the histogram!
-      void fillWithBinAndValue(size_t bin, float weight = 1) {
+      void fillWithBinAndValue(size_t bin, AxisType weight = 1) {
         if (bin < Base::m_plotData.size()) {
           std::get<1>(Base::m_plotData[bin]) = weight;
         }
@@ -749,7 +763,7 @@ namespace cond {
         for (auto iov : tag.iovs) {
           std::shared_ptr<PayloadType> payload = Base::fetchPayload(std::get<1>(iov));
           if (payload.get()) {
-            float value = getFromPayload(*payload);
+            AxisType value = getFromPayload(*payload);
             fillWithValue(value);
           }
         }
@@ -757,7 +771,7 @@ namespace cond {
       }
 
       // implement this one if you use the default fill implementation, otherwise ignore it...
-      virtual float getFromPayload(PayloadType& payload) { return 0; }
+      virtual AxisType getFromPayload(PayloadType& payload) { return 0; }
 
     private:
       float m_binSize = 0;
@@ -765,6 +779,16 @@ namespace cond {
       float m_min;
       float m_max;
     };
+
+    // clever way to reduce the number of templated arguments
+    // see https://stackoverflow.com/questions/3881633/reducing-number-of-template-arguments-for-class
+    // for reference
+
+    template <typename PayloadType, IOVMultiplicity IOV_M = UNSPECIFIED_IOV>
+    using Histogram1D = Histogram1<float, PayloadType, UNSPECIFIED_IOV>;
+
+    template <typename PayloadType, IOVMultiplicity IOV_M = UNSPECIFIED_IOV>
+    using Histogram1DD = Histogram1<double, PayloadType, UNSPECIFIED_IOV>;
 
     //
     template <typename PayloadType, IOVMultiplicity IOV_M = UNSPECIFIED_IOV>

--- a/CondCore/Utilities/interface/PayloadInspector.h
+++ b/CondCore/Utilities/interface/PayloadInspector.h
@@ -815,6 +815,22 @@ namespace cond {
 
       //
       void init() override {
+        // some protections
+        if ((m_nxbins < 1) || (m_nybins < 1)) {
+          edm::LogError("payloadInspector::Histogram2D()")
+              << " trying to book an histogram with less then 1 bin!" << std::endl;
+        }
+
+        if (m_xmin > m_xmax) {
+          edm::LogError("payloadInspector::Histogram2D()") << " trying to book an histogram with x-minimum " << m_xmin
+                                                           << "> x-maximum" << m_xmax << " !" << std::endl;
+        }
+
+        if (m_ymin > m_ymax) {
+          edm::LogError("payloadInspector::Histogram2D()") << " trying to book an histogram with y-minimum " << m_ymin
+                                                           << "> y-maximum" << m_ymax << " !" << std::endl;
+        }
+
         Base::m_plotData.clear();
         float xbinSize = (m_xmax - m_xmin) / m_nxbins;
         float ybinSize = (m_ymax - m_ymin) / m_nybins;


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to add a new class to the Strip Payload inspector, to retrieve the list of dead modules in JSON format from the `SiStripDetVOff` DB record.
In order to achieve that, as double precision is needed in order to store the module `DetIds` as `float`s, a new  class `Histogram1` inheriting from `Plot2D` has been added. The existing class `Histogram1D` is now made to derive from `Histogram1` along with `Histogram1DD` which addressed the issue above, via class templates.
I profit of this PR to add protections to `Histogram1` and `Histogram2D` in order to yield framework warnings in case the provided binning does not make sense, and also few miscellaneous graphical adjustments to some of the existing plots. 

#### PR validation:

Relies on existing unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.