### PR TITLE
Fix debug compilation, GCC900 for FWCore/Utilities

### DIFF
--- a/FWCore/Framework/interface/ESRecordsToProxyIndices.h
+++ b/FWCore/Framework/interface/ESRecordsToProxyIndices.h
@@ -47,7 +47,7 @@ namespace edm::eventsetup {
 
     static constexpr ESProxyIndex missingProxyIndex() noexcept { return ESProxyIndex{std::numeric_limits<int>::max()}; }
     static constexpr ESRecordIndex missingRecordIndex() noexcept {
-      return ESRecordIndex{std::numeric_limits<int>::max()};
+      return ESRecordIndex{ESRecordIndex::invalidValue()};
     }
 
     ESRecordIndex recordIndexFor(EventSetupRecordKey const& iRK) const noexcept;

--- a/FWCore/Framework/src/EventSetupImpl.cc
+++ b/FWCore/Framework/src/EventSetupImpl.cc
@@ -66,7 +66,7 @@ namespace edm {
   }
 
   eventsetup::EventSetupRecordImpl const* EventSetupImpl::findImpl(ESRecordIndex iKey) const {
-    if UNLIKELY (iKey.value() == std::numeric_limits<int>::max()) {
+    if UNLIKELY (iKey.value() == ESRecordIndex::invalidValue()) {
       return nullptr;
     }
     return recordImpls_[iKey.value()];

--- a/FWCore/Utilities/interface/ESIndices.h
+++ b/FWCore/Utilities/interface/ESIndices.h
@@ -94,8 +94,10 @@ namespace edm {
 
     constexpr Value_t value() const noexcept { return index_; }
 
+    static constexpr Value_t invalidValue() { return std::numeric_limits<Value_t>::max(); }
+
   private:
-    Value_t index_ = std::numeric_limits<int>::max();
+    Value_t index_ = std::numeric_limits<Value_t>::max();
   };
   inline std::ostream& operator<<(std::ostream& iOS, ESRecordIndex const& iIndex) {
     iOS << iIndex.value();


### PR DESCRIPTION
#### PR description:

This fixes compilation with debug options for FWCore/Utilities with GCC 900. The error was related to comparing an unsigned and signed integer. Although the previous version of the code was oddly using a signed value as the invalid value and an unsigned value as a data member of ESRecordIndex, it should have worked perfectly fine because it did it consistently. I expect nothing will change in the output or behavior of anything.

#### PR validation:

Relies on existing unit tests.
