### PR TITLE
Improve method to get largest module ID in ProcessCallGraph

### DIFF
--- a/HLTrigger/Timer/src/ProcessCallGraph.cc
+++ b/HLTrigger/Timer/src/ProcessCallGraph.cc
@@ -4,7 +4,6 @@
 
 #include <cassert>
 #include <iostream>
-#include <numeric>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -73,13 +72,7 @@ void ProcessCallGraph::preBeginJob(edm::PathsAndConsumesOfModulesBase const& pat
   boost::get_property(graph, boost::graph_name) = context.processName();
 
   // create graph vertices associated to all modules in the process
-  unsigned int size = 0;
-  if (auto const& allModules = pathsAndConsumes.allModules(); not allModules.empty()) {
-    size = std::accumulate(
-        allModules.begin(), allModules.end(), size, [](unsigned int s, edm::ModuleDescription const* module) {
-          return std::max(s, module->id());
-        });
-  }
+  unsigned int size = pathsAndConsumes.largestModuleID() - boost::num_vertices(graph) + 1;
   for (size_t i = 0; i < size; ++i)
     boost::add_vertex(graph);
 


### PR DESCRIPTION
#### PR description:

This PR is a follow-up to https://github.com/cms-sw/cmssw/pull/29584 and https://github.com/cms-sw/cmssw/pull/29553. It updates the method to get the largest module ID in `ProcessCallGraph` to be the same as was done for `DependencyGraph` in #29584. See https://github.com/cms-sw/cmssw/pull/29553/files#r435294147 for a bit more details.

#### PR validation:

Limited matrix runs.