### PR TITLE
Demote module deletion printout to INFO

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -579,7 +579,7 @@ namespace edm {
           not unusedModules.empty()) {
         pathsAndConsumesOfModules_.removeModules(unusedModules);
 
-        edm::LogWarning("DeleteModules").log([&unusedModules](auto& l) {
+        edm::LogInfo("DeleteModules").log([&unusedModules](auto& l) {
           l << "Following modules are not in any Path or EndPath, nor is their output consumed by any other module, "
                "and "
                "therefore they are deleted before beginJob transition.";

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -247,7 +247,7 @@ namespace edm {
           not unusedModules.empty()) {
         pathsAndConsumesOfModules_.removeModules(unusedModules);
 
-        edm::LogWarning("DeleteModules").log([&unusedModules, this](auto& l) {
+        edm::LogInfo("DeleteModules").log([&unusedModules, this](auto& l) {
           l << "Following modules are not in any Path or EndPath, nor is their output consumed by any other module, "
                "and "
                "therefore they are deleted from SubProcess "


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/29553 included a WARNING level printout for the modules being deleted to aid debugging of possible problems in IBs. Such problems have not appeared after several days, so I think it is safe to demote the printout to INFO (as anticipated in https://github.com/cms-sw/cmssw/pull/29553#discussion_r414235449)

After #32244 gets merged, the list of deleted modules can be printed with
```py
process.MessageLogger.cerr.threshold = "INFO"
process.MessageLogger.cerr.DeleteModules = dict()
```

#### PR validation:

Workflow 25.0 step3 is clean from the printout present in the IB.