### PR TITLE
fix syntax warnings in matrix code

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -117,7 +117,7 @@ class InputInfo(object):
         self.dataSetParent = dataSetParent
         
     def das(self, das_options, dataset):
-        if len(self.run) is not 0 or self.ls:
+        if len(self.run) != 0 or self.ls:
             queries = self.queries(dataset)[:3]
             if len(self.run) != 0:
               command = ";".join(["dasgoclient %s --query '%s'" % (das_options, query) for query in queries])
@@ -184,7 +184,7 @@ class InputInfo(object):
                 site = " site=%s" % os.environ["CMSSW_DAS_QUERY_SITES"]
             else:
                 site = ""
-        if len(self.run) is not 0:
+        if len(self.run) != 0:
             return ["file {0}={1} run={2}{3}".format(query_by, query_source, query_run, site) for query_run in self.run]
             #return ["file {0}={1} run={2} ".format(query_by, query_source, query_run) for query_run in self.run]
         else:

--- a/Configuration/PyReleaseValidation/python/relval_upgrade.py
+++ b/Configuration/PyReleaseValidation/python/relval_upgrade.py
@@ -39,7 +39,7 @@ for year in upgradeKeys:
                 if 'HARVEST' in step: hasHarvest = True
 
                 for specialType,specialWF in six.iteritems(upgradeWFs):
-                    if (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
+                    if (specialType != 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
                         stepList[specialType].append(stepMaker(key,frag[:-4],step,specialWF.suffix))
                         # hack to add an extra step
                         if (specialType == 'ProdLike' or specialType == 'TestOldDigiProdLike') and 'RecoGlobal' in step:


### PR DESCRIPTION
#### PR description:

There were a few syntax warnings from the python3 checks (pointed out by @jpata in https://github.com/cms-sw/cmssw/pull/32128#issuecomment-740572127):
```
src/Configuration/PyReleaseValidation/python/MatrixUtil.py:120: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(self.run) is not 0 or self.ls:
src/Configuration/PyReleaseValidation/python/MatrixUtil.py:187: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if len(self.run) is not 0:
src/Configuration/PyReleaseValidation/python/relval_upgrade.py:42: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if (specialType is not 'baseline') and ( ('PU' in step and step.replace('PU','') in specialWF.PU) or (step in specialWF.steps) ):
```

These are now fixed.

#### PR validation:

runTheMatrix.py still works.