### PR TITLE
[Do not merge] Update classversion CLHEP::Hep3Vector

### DIFF
--- a/DataFormats/CLHEP/src/classes_def.xml
+++ b/DataFormats/CLHEP/src/classes_def.xml
@@ -1,6 +1,6 @@
 <lcgdict>
-  <class name="CLHEP::Hep3Vector" ClassVersion="10">
-   <version ClassVersion="10" checksum="3040806103"/>
+  <class name="CLHEP::Hep3Vector" ClassVersion="11">
+   <version ClassVersion="11" checksum="3438801427"/>
   </class>
   <class name="CLHEP::HepEulerAngles" ClassVersion="10">
    <version ClassVersion="10" checksum="2060568599"/>

--- a/DataFormats/CLHEP/src/classes_def.xml
+++ b/DataFormats/CLHEP/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   <class name="CLHEP::Hep3Vector" ClassVersion="11">
    <version ClassVersion="11" checksum="3438801427"/>
+   <version ClassVersion="10" checksum="3040806103"/>
   </class>
   <class name="CLHEP::HepEulerAngles" ClassVersion="10">
    <version ClassVersion="10" checksum="2060568599"/>


### PR DESCRIPTION
#### PR description:

This is needed for testing geant4 changes, since clhep is updated
We cannot have this in master, not until we use the updated version of clhep for our master on https://github.com/cms-sw/cmsdist

#### PR validation:

DataFormats/CLHEP is building

