### PR TITLE
Add low pT electron payloads to Run 2 data/MC and Run 3 MC GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -16,25 +16,25 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '112X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '112X_mcRun2_asymptotic_preVFP_v2',
+    'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '112X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '113X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '112X_mcRun2cosmics_asymptotic_deco_v2',
+    'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
     'run2_mc_hi'        :   '112X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
     'run2_mc_pa'        :   '112X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '112X_dataRun2_v7',
+    'run1_data'         :   '113X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '112X_dataRun2_v7',
+    'run2_data'         :   '113X_dataRun2_v1',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '112X_dataRun2_HEfail_v7',
+    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v1',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '112X_dataRun2_relval_v7',
+    'run2_data_relval'  :   '113X_dataRun2_relval_v1',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v5',
+    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v1',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -47,39 +47,39 @@ autoCond = {
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'        :   '111X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v4',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '112X_mc2017_design_v1',
+    'phase1_2017_design'       :  '113X_mc2017_design_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '112X_mc2017_realistic_v3',
+    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '112X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '112X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '112X_upgrade2018_design_v3',
+    'phase1_2018_design'       :  '113X_upgrade2018_design_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v6',
+    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v6',
+    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v6',
+    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '112X_upgrade2018cosmics_realistic_deco_v6',
+    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v1',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '112X_upgrade2018cosmics_realistic_peak_v6',
+    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '112X_mcRun3_2021_design_v11', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v13', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v13',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v13',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v1',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v13', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v13', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '112X_mcRun4_realistic_v4'
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,19 +2,19 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '112X_mcRun1_design_v1',
+    'run1_design'       :   '113X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '112X_mcRun1_realistic_v1',
+    'run1_mc'           :   '113X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '112X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '113X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '112X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '113X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '112X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '113X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '112X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '112X_mcRun2_design_v1',
+    'run2_design'       :   '113X_mcRun2_design_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
     'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
@@ -22,9 +22,9 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
     'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '112X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '112X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '113X_mcRun2_pA_v1',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   '113X_dataRun2_v1',
     # GlobalTag for Run2 data reprocessing
@@ -81,7 +81,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '112X_mcRun4_realistic_v4'
+    'phase2_realistic'         : '113X_mcRun4_realistic_v1'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR adds low pT electron payloads to Run 2 data/MC and Run 3 MC GTs as requested at https://indico.cern.ch/event/983008/#40-low-pt-electron-tags. Separate payloads are used for 2016, 2017 and 2018 MC and the 2018 MC payloads are used for Run 3. The data payloads are a composition of the 2016-2018 payloads for each IOV range. The GT diffs are as follows:

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_asymptotic_preVFP_v2/113X_mcRun2_asymptotic_preVFP_v1

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2_asymptotic_v2/113X_mcRun2_asymptotic_v1

**2016 cosmics (asymptotic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun2cosmics_asymptotic_deco_v2/113X_mcRun2cosmics_asymptotic_deco_v1

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_v7/113X_dataRun2_v1

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_HEfail_v7/113X_dataRun2_HEfail_v1

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_relval_v7/113X_dataRun2_relval_v1

**Prompt-like data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_PromptLike_HI_v5/113X_dataRun2_PromptLike_HI_v1

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v4/111X_dataRun3_Prompt_v5

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017_design_v1/113X_mc2017_design_v1

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017_realistic_v3/113X_mc2017_realistic_v1

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017cosmics_realistic_deco_v3/113X_mc2017cosmics_realistic_deco_v1

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mc2017cosmics_realistic_peak_v3/113X_mc2017cosmics_realistic_peak_v1

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_design_v3/113X_upgrade2018_design_v1

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_v6/113X_upgrade2018_realistic_v1

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HI_v6/113X_upgrade2018_realistic_HI_v1

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HEfail_v6/113X_upgrade2018_realistic_HEfail_v1

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_deco_v6/113X_upgrade2018cosmics_realistic_deco_v1

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018cosmics_realistic_peak_v6/113X_upgrade2018cosmics_realistic_peak_v1

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_design_v11/113X_mcRun3_2021_design_v1

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v13/113X_mcRun3_2021_realistic_v1

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v13/113X_mcRun3_2021cosmics_realistic_deco_v1

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v13/113X_mcRun3_2021_realistic_HI_v1

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v13/113X_mcRun3_2023_realistic_v1

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v13/113X_mcRun3_2024_realistic_v1

#### PR validation:

See https://indico.cern.ch/event/983008/#40-low-pt-electron-tags for details.

In addition, a technical test was performed:

`runTheMatrix.py -l limited,1325.516,7.22,136.8642,10424.0,7.21,11224.0,11024.2,7.4,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 10_6_X for usage in an upcoming re-miniAOD.
