### PR TITLE
[DD4Hep] make sure that expectations for retrieving a numeric value are met

### DIFF
--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -572,14 +572,14 @@ std::string_view DDFilteredView::get<string_view>(const string& key) {
 
 template <>
 double DDFilteredView::get<double>(const string& key) {
-  double result(std::nan("0"));
-
   currentSpecPar_ = find(key);
   if (currentSpecPar_ != nullptr) {
-    result = getNextValue(key);
+    return getNextValue(key);
+  } else {
+    throw cms::Exception("DetectorDescription")
+        << "Request for a non-existent numeric parameter " << key << " Please, check that it is defined in XML "
+        << "and has an eval attribute set.";
   }
-
-  return result;
 }
 
 template <>

--- a/DetectorDescription/DDCMS/src/DDFilteredView.cc
+++ b/DetectorDescription/DDCMS/src/DDFilteredView.cc
@@ -572,7 +572,7 @@ std::string_view DDFilteredView::get<string_view>(const string& key) {
 
 template <>
 double DDFilteredView::get<double>(const string& key) {
-  double result(0.0);
+  double result(std::nan("0"));
 
   currentSpecPar_ = find(key);
   if (currentSpecPar_ != nullptr) {


### PR DESCRIPTION
#### PR description:

Force a request to get a numeric value for a **non-evaluated numeric value** to fail. 

This will allow us to trace all cases where XML may need an update without debugging the C++ code.
See https://github.com/cms-sw/cmssw/issues/32414

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
