### PR TITLE
[11_1_X] [Puppi] option to use generic PU proxy

### DIFF
--- a/CommonTools/PileupAlgos/interface/PuppiAlgo.h
+++ b/CommonTools/PileupAlgos/interface/PuppiAlgo.h
@@ -30,7 +30,7 @@ public:
   inline int algoId(unsigned int iAlgo) const { return fAlgoId.at(iAlgo); }
   inline bool isCharged(unsigned int iAlgo) const { return fCharged.at(iAlgo); }
   inline double coneSize(unsigned int iAlgo) const { return fConeSize.at(iAlgo); }
-  inline double neutralPt(int iNPV) const { return cur_NeutralPtMin + iNPV * cur_NeutralPtSlope; }
+  inline double neutralPt(double const iPUProxy) const { return cur_NeutralPtMin + iPUProxy * cur_NeutralPtSlope; }
 
   inline double rms() const { return cur_RMS; }
   inline double median() const { return cur_Med; }

--- a/CommonTools/PileupAlgos/interface/PuppiContainer.h
+++ b/CommonTools/PileupAlgos/interface/PuppiContainer.h
@@ -10,7 +10,7 @@ public:
   PuppiContainer(const edm::ParameterSet &iConfig);
   ~PuppiContainer();
   void initialize(const std::vector<RecoObj> &iRecoObjects);
-  void setNPV(int iNPV) { fNPV = iNPV; }
+  void setPUProxy(double const iPUProxy) { fPUProxy = iPUProxy; }
 
   std::vector<PuppiCandidate> const &pfParticles() const { return fPFParticles; }
   std::vector<double> const &puppiWeights();
@@ -61,7 +61,7 @@ protected:
   double fPtMaxNeutrals;
   double fPtMaxNeutralsStartSlope;
   int fNAlgos;
-  int fNPV;
+  double fPUProxy;
   std::vector<PuppiAlgo> fPuppiAlgo;
 };
 #endif

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -42,6 +42,12 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
   tokenPFCandidates_ = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("candName"));
   tokenVertices_ = consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexName"));
 
+  fUsePUProxyValue = iConfig.getParameter<bool>("usePUProxyValue");
+
+  if (fUsePUProxyValue) {
+    puProxyValueToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("PUProxyValue"));
+  }
+
   ptokenPupOut_ = produces<edm::ValueMap<float>>();
   ptokenP4PupOut_ = produces<edm::ValueMap<LorentzVector>>();
   ptokenValues_ = produces<edm::ValueMap<reco::CandidatePtr>>();
@@ -74,11 +80,14 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   iEvent.getByToken(tokenVertices_, hVertexProduct);
   const reco::VertexCollection* pvCol = hVertexProduct.product();
 
-  int npv = 0;
-  const reco::VertexCollection::const_iterator vtxEnd = pvCol->end();
-  for (reco::VertexCollection::const_iterator vtxIter = pvCol->begin(); vtxEnd != vtxIter; ++vtxIter) {
-    if (!vtxIter->isFake() && vtxIter->ndof() >= fVtxNdofCut && std::abs(vtxIter->z()) <= fVtxZCut)
-      npv++;
+  double puProxyValue = 0.;
+  if (fUsePUProxyValue) {
+    puProxyValue = iEvent.get(puProxyValueToken_);
+  } else {
+    for (auto const& vtx : *pvCol) {
+      if (!vtx.isFake() && vtx.ndof() >= fVtxNdofCut && std::abs(vtx.z()) <= fVtxZCut)
+        ++puProxyValue;
+    }
   }
 
   std::vector<double> lWeights;
@@ -224,7 +233,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     }
 
     fPuppiContainer->initialize(fRecoObjCollection);
-    fPuppiContainer->setNPV(npv);
+    fPuppiContainer->setPUProxy(puProxyValue);
 
     //Compute the weights and get the particles
     lWeights = fPuppiContainer->puppiWeights();
@@ -396,6 +405,8 @@ void PuppiProducer::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<bool>("invertPuppi", false);
   desc.add<bool>("useExp", false);
   desc.add<double>("MinPuppiWeight", .01);
+  desc.add<bool>("usePUProxyValue", false);
+  desc.add<edm::InputTag>("PUProxyValue", edm::InputTag(""));
 
   PuppiAlgo::fillDescriptionsPuppiAlgo(desc);
 

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.h
@@ -45,6 +45,7 @@ private:
   edm::EDGetTokenT<PuppiContainer> tokenPuppiContainer_;
   edm::EDGetTokenT<PFOutputCollection> tokenPuppiCandidates_;
   edm::EDGetTokenT<PackedOutputCollection> tokenPackedPuppiCandidates_;
+  edm::EDGetTokenT<double> puProxyValueToken_;
   edm::EDPutTokenT<edm::ValueMap<float>> ptokenPupOut_;
   edm::EDPutTokenT<edm::ValueMap<LorentzVector>> ptokenP4PupOut_;
   edm::EDPutTokenT<edm::ValueMap<reco::CandidatePtr>> ptokenValues_;
@@ -74,6 +75,7 @@ private:
   bool fClonePackedCands;
   int fVtxNdofCut;
   double fVtxZCut;
+  bool fUsePUProxyValue;
   std::unique_ptr<PuppiContainer> fPuppiContainer;
   std::vector<RecoObj> fRecoObjCollection;
 };

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -51,6 +51,8 @@ puppi = cms.EDProducer("PuppiProducer",#cms.PSet(#"PuppiProducer",
                        clonePackedCands   = cms.bool(False), # should only be set to True for MiniAOD
                        vtxNdofCut     = cms.int32(4),
                        vtxZCut        = cms.double(24),
+                       usePUProxyValue = cms.bool(False),
+                       PUProxyValue = cms.InputTag(''),
                        algos          = cms.VPSet( 
                         cms.PSet( 
                          etaMin = cms.vdouble(0.),

--- a/CommonTools/PileupAlgos/src/PuppiContainer.cc
+++ b/CommonTools/PileupAlgos/src/PuppiContainer.cc
@@ -39,7 +39,7 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
   fRawAlphas.resize(0);
   fAlphaMed.resize(0);
   fAlphaRMS.resize(0);
-  fNPV = 1.;
+  fPUProxy = 1.;
   //Link to the RecoObjects
   fRecoParticles = &iRecoObjects;
   fPFParticles.reserve(iRecoObjects.size());
@@ -71,7 +71,6 @@ void PuppiContainer::initialize(const std::vector<RecoObj> &iRecoObjects) {
     // charged candidates assigned to LV
     if (std::abs(rParticle.id) == 1)
       fPFParticlesForVarChargedPV.push_back(pCand);
-    // if(fNPV < rParticle.vtxId) fNPV = rParticle.vtxId;
   }
 }
 
@@ -304,7 +303,7 @@ std::vector<double> const &PuppiContainer::puppiWeights() {
                                    << " -- id :  " << rParticle.id << " --  NAlgos: " << lNAlgos << std::endl;
     }
     //Basic Cuts
-    if (pWeight * fPFParticles[i0].pt < fPuppiAlgo[pPupId].neutralPt(fNPV) && rParticle.id == 0)
+    if (pWeight * fPFParticles[i0].pt < fPuppiAlgo[pPupId].neutralPt(fPUProxy) && rParticle.id == 0)
       pWeight = 0;  //threshold cut on the neutral Pt
     // Protect high pT photons (important for gamma to hadronic recoil balance)
     if (fPtMaxPhotons > 0 && rParticle.pdgId == 22 && std::abs(fPFParticles[i0].eta) < fEtaMaxPhotons &&


### PR DESCRIPTION
#### PR description:

Backport of #32341.

Below, a copy of the description from the original PR:

---

This PR implements a small, backward-compatible, update to the `PuppiProducer`.

The Puppi algorithm uses the number of reconstructed primary vertices as a proxy for the amount of PU in the event; specifically, this is used in the threshold for the pT cut on neutral candidates. The PR just adds the functionality to select a different (generic) quantity as PU proxy, adding a switch (`usePUProxyValue`) and an `InputTag` to a `double` in the event. Some internal functions are renamed accordingly for clarity.

This small update is currently used in Phase-2 HLT-TDR studies, and the intention is to backport it to `11_1_X`.

Defaults are unchanged, so no changes are expected in the comparisons.

FYI: @lathomas @kirschen @fwyzard @trtomei @pallabidas

---

#### PR validation:

Verified in HLT-TDR studies that the updated code behaves as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

#32341

Backport needed for Phase-2 HLT-TDR studies in `11_1_X`.