### PR TITLE
Add low pT electron payloads to Run 2 data/MC and Run 3 MC GTs [10_6_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,40 +2,40 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '106X_mcRun1_design_v3',
+    'run1_design'       :   '106X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '106X_mcRun1_realistic_v3',
+    'run1_mc'           :   '106X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '106X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '106X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '106X_mcRun1_pA_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '106X_mcRun2_startup_v4',
+    'run2_mc_50ns'      :   '106X_mcRun2_startup_v5',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v4',
+    'run2_mc_l1stage1'  :   '106X_mcRun2_asymptotic_l1stage1_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '106X_mcRun2_design_v7',
+    'run2_design'       :   '106X_mcRun2_design_v8',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '106X_mcRun2_asymptotic_preVFP_v9',
+    'run2_mc_pre_vfp'   :   '106X_mcRun2_asymptotic_preVFP_v10',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '106X_mcRun2_asymptotic_v15',
+    'run2_mc'           :   '106X_mcRun2_asymptotic_v16',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_asymptotic_deco_v2',
+    'run2_mc_cosmics'   :   '106X_mcRun2cosmics_asymptotic_deco_v3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v4',
+    'run2_mc_hi'        :   '106X_mcRun2_HeavyIon_v5',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '106X_mcRun2_pA_v5',
+    'run2_mc_pa'        :   '106X_mcRun2_pA_v6',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '106X_dataRun2_v32',
+    'run1_data'         :   '106X_dataRun2_v33',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '106X_dataRun2_v32',
+    'run2_data'         :   '106X_dataRun2_v33',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '106X_dataRun2_relval_v30',
+    'run2_data_relval'  :   '106X_dataRun2_relval_v31',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v13',
+    'run2_data_promptlike_HEfail' : '106X_dataRun2_PromptLike_HEfail_v14',
     # GlobalTag for Run2 data 2016H relvals only: Prompt Conditions + fixed L1 menu (to be removed)
-    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v14',
-    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v14',
+    'run2_data_promptlike'    : '106X_dataRun2_PromptLike_v15',
+    'run2_data_promptlike_hi' : '106X_dataRun2_PromptLike_HI_v15',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v9',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -46,33 +46,33 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v9',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v5',
+    'phase1_2017_design'       :  '106X_mc2017_design_IdealBS_v6',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v8',
+    'phase1_2017_realistic'    :  '106X_mc2017_realistic_v9',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v3',
+    'phase1_2017_cosmics'      :  '106X_mc2017cosmics_realistic_deco_v4',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v3',
+    'phase1_2017_cosmics_peak' :  '106X_mc2017cosmics_realistic_peak_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '106X_upgrade2018_design_v6',
+    'phase1_2018_design'       :  '106X_upgrade2018_design_v8',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v15',
+    'phase1_2018_realistic'    :  '106X_upgrade2018_realistic_v16',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v6',
+    'phase1_2018_realistic_hi' :  '106X_upgrade2018_realistic_HI_v7',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v15',
+    'phase1_2018_realistic_HEfail' :  '106X_upgrade2018_realistic_HEfail_v16',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v12',
+    'phase1_2018_cosmics'      :   '106X_upgrade2018cosmics_realistic_deco_v13',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v12',
+    'phase1_2018_cosmics_peak' :   '106X_upgrade2018cosmics_realistic_peak_v13',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '106X_upgrade2021_design_v5', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '106X_upgrade2021_design_v6', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v11', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '106X_upgrade2021_realistic_v12', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'      : '106X_upgrade2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase2 2023
-    'phase2_realistic'         : '106X_upgrade2023_realistic_v5'
+    'phase2_realistic'         : '106X_upgrade2023_realistic_v6'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #32421; see the description of that PR for details. The GT diffs in this PR are identical to the corresponding PR to master.

The GT diffs are as follows:

**Run 1 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_design_v3/106X_mcRun1_design_v4

**Run 1 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_realistic_v3/106X_mcRun1_realistic_v4

**Run 1 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_HeavyIon_v3/106X_mcRun1_HeavyIon_v4

**Run 1 proton-heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun1_pA_v3/106X_mcRun1_pA_v4

**Run 2 startup**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_startup_v4/106X_mcRun2_startup_v5

**Run 2 (L1 trigger stage 1)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_l1stage1_v4/106X_mcRun2_asymptotic_l1stage1_v5

**2016 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_design_v7/106X_mcRun2_design_v8

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_preVFP_v9/106X_mcRun2_asymptotic_preVFP_v10

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_asymptotic_v15/106X_mcRun2_asymptotic_v16

**2016 cosmics (asymptotic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2cosmics_asymptotic_deco_v2/106X_mcRun2cosmics_asymptotic_deco_v3

**Run 2 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_HeavyIon_v4/106X_mcRun2_HeavyIon_v5

**Run 2 proton-lead**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mcRun2_pA_v5/106X_mcRun2_pA_v6

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_v32/106X_dataRun2_v33

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_relval_v30/106X_dataRun2_relval_v31

**Prompt-like data (HEM15/15 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HEfail_v13/106X_dataRun2_PromptLike_HEfail_v14

**Prompt-like data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_v14/106X_dataRun2_PromptLike_v15

**Prompt-like HI data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_dataRun2_PromptLike_HI_v14/106X_dataRun2_PromptLike_HI_v15

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_design_IdealBS_v5/106X_mc2017_design_IdealBS_v6

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017_realistic_v8/106X_mc2017_realistic_v9

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_deco_v3/106X_mc2017cosmics_realistic_deco_v4

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_mc2017cosmics_realistic_peak_v3/106X_mc2017cosmics_realistic_peak_v4

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_design_v6/106X_upgrade2018_design_v8

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_v15/106X_upgrade2018_realistic_v16

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HI_v6/106X_upgrade2018_realistic_HI_v7

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018_realistic_HEfail_v15/106X_upgrade2018_realistic_HEfail_v16

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_deco_v12/106X_upgrade2018cosmics_realistic_deco_v13

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2018cosmics_realistic_peak_v12/106X_upgrade2018cosmics_realistic_peak_v13

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_design_v5/106X_upgrade2021_design_v6

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021_realistic_v11/106X_upgrade2021_realistic_v12

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2021cosmics_realistic_deco_v4/106X_upgrade2021cosmics_realistic_deco_v5

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/106X_upgrade2023_realistic_v5/106X_upgrade2023_realistic_v6

#### PR validation:

See the description of the original PR #32421 for details. In addition, a technical test was performed:

`runTheMatrix.py -l limited,1325.516,7.22,136.8642,10424.0,7.21,11224.0,11024.2,7.4,12024.0,7.23,159.0,12834.0,1325.518,136.88811 --ibeos`

This technical test was done without the PR that consumes these conditions, however, as that PR is not yet available.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #32421. It is needed for an eventual re-miniAOD that includes low pT electrons.

