### PR TITLE
Change Minuit logger for CMS MessageLogger

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
@@ -14,6 +14,7 @@
 // Implementation file for class HybridMinimizer
 
 #include "RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "Math/IFunction.h"
 #include "Math/IOptions.h"
@@ -169,7 +170,7 @@ namespace PSFitter {
 
     if (step <= 0) {
       std::string txtmsg = "Parameter " + name + "  has zero or invalid step size - consider it as constant ";
-      MN_INFO_MSG2("HybridMinimizer::SetVariable", txtmsg);
+      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg << std::endl;
       fState.Add(name, val);
     } else
       fState.Add(name, val, step);
@@ -177,8 +178,8 @@ namespace PSFitter {
     unsigned int minuit2Index = fState.Index(name);
     if (minuit2Index != ivar) {
       std::string txtmsg("Wrong index used for the variable " + name);
-      MN_INFO_MSG2("HybridMinimizer::SetVariable", txtmsg);
-      MN_INFO_VAL2("HybridMinimizer::SetVariable", minuit2Index);
+      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg << std::endl;
+      edm::LogInfo("HybridMinimizer::SetVariable") << minuit2Index << std::endl;
       return false;
     }
     fState.RemoveLimits(ivar);
@@ -267,7 +268,8 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodFunction *>(&func);
       if (!fcnfunc) {
-        MN_ERROR_MSG("HybridMinimizer: Wrong Fit method function for Fumili");
+        edm::LogInfo("HybridMinimizer::SetFunction")
+            << "HybridMinimizer: Wrong Fit method function for Fumili" << std::endl;
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodFunction>(*fcnfunc, fDim, ErrorDef());
@@ -285,7 +287,8 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodGradFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(&func);
       if (!fcnfunc) {
-        MN_ERROR_MSG("HybridMinimizer: Wrong Fit method function for Fumili");
+        edm::LogInfo("HybridMinimizer::SetFunction")
+            << "HybridMinimizer: Wrong Fit method function for Fumili" << std::endl;
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodGradFunction>(*fcnfunc, fDim, ErrorDef());
@@ -296,7 +299,7 @@ namespace PSFitter {
     // perform the minimization
     // store a copy of FunctionMinimum
     if (!fMinuitFCN) {
-      MN_ERROR_MSG2("HybridMinimizer::Minimize", "FCN function has not been set");
+      edm::LogInfo("HybridMinimizer::Minimize") << "FCN function has not been set" << std::endl;
       return false;
     }
 
@@ -327,7 +330,7 @@ namespace PSFitter {
    */
 
     // internal minuit messages
-    MnPrint::SetLevel(PrintLevel());
+    //MnPrint::SetLevel(PrintLevel());
 
     // switch off Minuit2 printing
     int prev_level = (PrintLevel() <= 0) ? TurnOffPrintInfoLevel() : -2;
@@ -450,7 +453,7 @@ namespace PSFitter {
     if (validMinimum) {
       // print a warning message in case something is not ok
       if (fStatus != 0 && debugLevel > 0)
-        MN_INFO_MSG2("HybridMinimizer::Minimize", txt);
+        edm::LogInfo("HybridMinimizer::Minimize") << txt << std::endl;
     } else {
       // minimum is not valid when state is not valid and edm is over max or has passed call limits
       if (fStatus == 0) {
@@ -459,7 +462,7 @@ namespace PSFitter {
         fStatus = 5;
       }
       std::string msg = "Minimization did NOT converge, " + txt;
-      MN_INFO_MSG2("HybridMinimizer::Minimize", msg);
+      edm::LogInfo("HybridMinimizer::Minimize") << msg << std::endl;
     }
 
     if (debugLevel >= 1)
@@ -666,7 +669,7 @@ namespace PSFitter {
 
     int debugLevel = PrintLevel();
     // internal minuit messages
-    MnPrint::SetLevel(debugLevel);
+    //MnPrint::SetLevel(debugLevel);
 
     // to run minos I need function minimum class
     // redo minimization from current state
@@ -674,12 +677,12 @@ namespace PSFitter {
     //       GetMinimizer()->Minimize(*GetFCN(),fState, ROOT::Minuit2::MnStrategy(strategy), MaxFunctionCalls(), Tolerance());
     //    fState = min.UserState();
     if (fMinimum == nullptr) {
-      MN_ERROR_MSG("HybridMinimizer::GetMinosErrors:  failed - no function minimum existing");
+      edm::LogInfo("HybridMinimizer::GetMinosErrors") << "  failed - no function minimum existing" << std::endl;
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      MN_ERROR_MSG("HybridMinimizer::MINOS failed due to invalid function minimum");
+      edm::LogInfo("HybridMinimizer::MINOS") << " failed due to invalid function minimum" << std::endl;
       return false;
     }
 
@@ -807,19 +810,20 @@ namespace PSFitter {
     // if the errors  are also zero then scan from min and max of parameter range
 
     if (!fMinuitFCN) {
-      MN_ERROR_MSG2("HybridMinimizer::Scan", " Function must be set before using Scan");
+      edm::LogInfo("HybridMinimizer::Scan") << " Function must be set before using Scan" << std::endl;
       return false;
     }
 
     if (ipar > fState.MinuitParameters().size()) {
-      MN_ERROR_MSG2("HybridMinimizer::Scan", " Invalid number. Minimizer variables must be set before using Scan");
+      edm::LogInfo("HybridMinimizer::Scan")
+          << " Invalid number. Minimizer variables must be set before using Scan" << std::endl;
       return false;
     }
 
     // switch off Minuit2 printing
     int prev_level = (PrintLevel() <= 0) ? TurnOffPrintInfoLevel() : -2;
 
-    MnPrint::SetLevel(PrintLevel());
+    //MnPrint::SetLevel(PrintLevel());
 
     // set the precision if needed
     if (Precision() > 0)
@@ -835,7 +839,7 @@ namespace PSFitter {
       RestoreGlobalPrintLevel(prev_level);
 
     if (result.size() != nstep) {
-      MN_ERROR_MSG2("HybridMinimizer::Scan", " Invalid result from MnParameterScan");
+      edm::LogInfo("HybridMinimizer::Scan") << " Invalid result from MnParameterScan" << std::endl;
       return false;
     }
     // sort also the returned points in x
@@ -850,7 +854,7 @@ namespace PSFitter {
     // use that as new minimum
     if (scan.Fval() < amin) {
       if (PrintLevel() > 0)
-        MN_INFO_MSG2("HybridMinimizer::Scan", "A new minimum has been found");
+        edm::LogInfo("HybridMinimizer::Scan") << "A new minimum has been found" << std::endl;
       fState.SetValue(ipar, scan.Parameters().Value(ipar));
     }
 
@@ -861,12 +865,13 @@ namespace PSFitter {
     // contour plot for parameter i and j
     // need a valid FunctionMinimum otherwise exits
     if (fMinimum == nullptr) {
-      MN_ERROR_MSG2("HybridMinimizer::Contour", " no function minimum existing. Must minimize function before");
+      edm::LogInfo("HybridMinimizer::Contour")
+          << " no function minimum existing. Must minimize function before" << std::endl;
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      MN_ERROR_MSG2("HybridMinimizer::Contour", "Invalid function minimum");
+      edm::LogInfo("HybridMinimizer::Contour") << "Invalid function minimum" << std::endl;
       return false;
     }
     assert(fMinuitFCN);
@@ -879,7 +884,7 @@ namespace PSFitter {
     // switch off Minuit2 printing (for level of  0,1)
     int prev_level = (PrintLevel() <= 1) ? TurnOffPrintInfoLevel() : -2;
 
-    MnPrint::SetLevel(PrintLevel());
+    //MnPrint::SetLevel(PrintLevel());
 
     // set the precision if needed
     if (Precision() > 0)
@@ -893,7 +898,7 @@ namespace PSFitter {
 
     std::vector<std::pair<double, double> > result = contour(ipar, jpar, npoints);
     if (result.size() != npoints) {
-      MN_ERROR_MSG2("HybridMinimizer::Contour", " Invalid result from MnContours");
+      edm::LogInfo("HybridMinimizer::Contour") << " Invalid result from MnContours" << std::endl;
       return false;
     }
     for (unsigned int i = 0; i < npoints; ++i) {
@@ -911,7 +916,7 @@ namespace PSFitter {
     // appended in the function minimum
 
     if (!fMinuitFCN) {
-      MN_ERROR_MSG2("HybridMinimizer::Hesse", "FCN function has not been set");
+      edm::LogInfo("HybridMinimizer::Hesse") << "FCN function has not been set" << std::endl;
       return false;
     }
 
@@ -921,7 +926,7 @@ namespace PSFitter {
     // switch off Minuit2 printing
     int prev_level = (PrintLevel() <= 0) ? TurnOffPrintInfoLevel() : -2;
 
-    MnPrint::SetLevel(PrintLevel());
+    //MnPrint::SetLevel(PrintLevel());
 
     // set the precision if needed
     if (Precision() > 0)
@@ -953,7 +958,7 @@ namespace PSFitter {
     if (!fState.HasCovariance()) {
       // if false means error is not valid and this is due to a failure in Hesse
       if (PrintLevel() > 0)
-        MN_INFO_MSG2("HybridMinimizer::Hesse", "Hesse failed ");
+        edm::LogInfo("HybridMinimizer::Hesse") << "Hesse failed " << std::endl;
       // update minimizer error status
       int hstatus = 4;
       // information on error state can be retrieved only if fMinimum is available

--- a/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
@@ -170,7 +170,7 @@ namespace PSFitter {
 
     if (step <= 0) {
       std::string txtmsg = "Parameter " + name + "  has zero or invalid step size - consider it as constant ";
-      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg << std::endl;
+      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg;
       fState.Add(name, val);
     } else
       fState.Add(name, val, step);
@@ -178,8 +178,8 @@ namespace PSFitter {
     unsigned int minuit2Index = fState.Index(name);
     if (minuit2Index != ivar) {
       std::string txtmsg("Wrong index used for the variable " + name);
-      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg << std::endl;
-      edm::LogInfo("HybridMinimizer::SetVariable") << minuit2Index << std::endl;
+      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg;
+      edm::LogInfo("HybridMinimizer::SetVariable") << minuit2Index;
       return false;
     }
     fState.RemoveLimits(ivar);
@@ -268,8 +268,7 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodFunction *>(&func);
       if (!fcnfunc) {
-        edm::LogInfo("HybridMinimizer::SetFunction")
-            << "HybridMinimizer: Wrong Fit method function for Fumili" << std::endl;
+        edm::LogInfo("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodFunction>(*fcnfunc, fDim, ErrorDef());
@@ -287,8 +286,7 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodGradFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(&func);
       if (!fcnfunc) {
-        edm::LogInfo("HybridMinimizer::SetFunction")
-            << "HybridMinimizer: Wrong Fit method function for Fumili" << std::endl;
+        edm::LogInfo("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodGradFunction>(*fcnfunc, fDim, ErrorDef());
@@ -299,7 +297,7 @@ namespace PSFitter {
     // perform the minimization
     // store a copy of FunctionMinimum
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Minimize") << "FCN function has not been set" << std::endl;
+      edm::LogInfo("HybridMinimizer::Minimize") << "FCN function has not been set";
       return false;
     }
 
@@ -453,7 +451,7 @@ namespace PSFitter {
     if (validMinimum) {
       // print a warning message in case something is not ok
       if (fStatus != 0 && debugLevel > 0)
-        edm::LogInfo("HybridMinimizer::Minimize") << txt << std::endl;
+        edm::LogInfo("HybridMinimizer::Minimize") << txt;
     } else {
       // minimum is not valid when state is not valid and edm is over max or has passed call limits
       if (fStatus == 0) {
@@ -462,7 +460,7 @@ namespace PSFitter {
         fStatus = 5;
       }
       std::string msg = "Minimization did NOT converge, " + txt;
-      edm::LogInfo("HybridMinimizer::Minimize") << msg << std::endl;
+      edm::LogInfo("HybridMinimizer::Minimize") << msg;
     }
 
     if (debugLevel >= 1)
@@ -677,12 +675,12 @@ namespace PSFitter {
     //       GetMinimizer()->Minimize(*GetFCN(),fState, ROOT::Minuit2::MnStrategy(strategy), MaxFunctionCalls(), Tolerance());
     //    fState = min.UserState();
     if (fMinimum == nullptr) {
-      edm::LogInfo("HybridMinimizer::GetMinosErrors") << "  failed - no function minimum existing" << std::endl;
+      edm::LogInfo("HybridMinimizer::GetMinosErrors") << "  failed - no function minimum existing";
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      edm::LogInfo("HybridMinimizer::MINOS") << " failed due to invalid function minimum" << std::endl;
+      edm::LogInfo("HybridMinimizer::MINOS") << " failed due to invalid function minimum";
       return false;
     }
 
@@ -810,13 +808,12 @@ namespace PSFitter {
     // if the errors  are also zero then scan from min and max of parameter range
 
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Scan") << " Function must be set before using Scan" << std::endl;
+      edm::LogInfo("HybridMinimizer::Scan") << " Function must be set before using Scan";
       return false;
     }
 
     if (ipar > fState.MinuitParameters().size()) {
-      edm::LogInfo("HybridMinimizer::Scan")
-          << " Invalid number. Minimizer variables must be set before using Scan" << std::endl;
+      edm::LogInfo("HybridMinimizer::Scan") << " Invalid number. Minimizer variables must be set before using Scan";
       return false;
     }
 
@@ -839,7 +836,7 @@ namespace PSFitter {
       RestoreGlobalPrintLevel(prev_level);
 
     if (result.size() != nstep) {
-      edm::LogInfo("HybridMinimizer::Scan") << " Invalid result from MnParameterScan" << std::endl;
+      edm::LogInfo("HybridMinimizer::Scan") << " Invalid result from MnParameterScan";
       return false;
     }
     // sort also the returned points in x
@@ -854,7 +851,7 @@ namespace PSFitter {
     // use that as new minimum
     if (scan.Fval() < amin) {
       if (PrintLevel() > 0)
-        edm::LogInfo("HybridMinimizer::Scan") << "A new minimum has been found" << std::endl;
+        edm::LogInfo("HybridMinimizer::Scan") << "A new minimum has been found";
       fState.SetValue(ipar, scan.Parameters().Value(ipar));
     }
 
@@ -865,13 +862,12 @@ namespace PSFitter {
     // contour plot for parameter i and j
     // need a valid FunctionMinimum otherwise exits
     if (fMinimum == nullptr) {
-      edm::LogInfo("HybridMinimizer::Contour")
-          << " no function minimum existing. Must minimize function before" << std::endl;
+      edm::LogInfo("HybridMinimizer::Contour") << " no function minimum existing. Must minimize function before";
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      edm::LogInfo("HybridMinimizer::Contour") << "Invalid function minimum" << std::endl;
+      edm::LogInfo("HybridMinimizer::Contour") << "Invalid function minimum";
       return false;
     }
     assert(fMinuitFCN);
@@ -898,7 +894,7 @@ namespace PSFitter {
 
     std::vector<std::pair<double, double> > result = contour(ipar, jpar, npoints);
     if (result.size() != npoints) {
-      edm::LogInfo("HybridMinimizer::Contour") << " Invalid result from MnContours" << std::endl;
+      edm::LogInfo("HybridMinimizer::Contour") << " Invalid result from MnContours";
       return false;
     }
     for (unsigned int i = 0; i < npoints; ++i) {
@@ -916,7 +912,7 @@ namespace PSFitter {
     // appended in the function minimum
 
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Hesse") << "FCN function has not been set" << std::endl;
+      edm::LogInfo("HybridMinimizer::Hesse") << "FCN function has not been set";
       return false;
     }
 
@@ -958,7 +954,7 @@ namespace PSFitter {
     if (!fState.HasCovariance()) {
       // if false means error is not valid and this is due to a failure in Hesse
       if (PrintLevel() > 0)
-        edm::LogInfo("HybridMinimizer::Hesse") << "Hesse failed " << std::endl;
+        edm::LogInfo("HybridMinimizer::Hesse") << "Hesse failed ";
       // update minimizer error status
       int hstatus = 4;
       // information on error state can be retrieved only if fMinimum is available

--- a/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
@@ -169,17 +169,15 @@ namespace PSFitter {
     //    std::cout << " add parameter " << name << "  " <<  val << " step " << step << std::endl;
 
     if (step <= 0) {
-      std::string txtmsg = "Parameter " + name + "  has zero or invalid step size - consider it as constant ";
-      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg;
+      edm::LogInfo("HybridMinimizer::SetVariable")
+          .format("Parameter {} has zero or invalid step size - consider it as constant", name);
       fState.Add(name, val);
     } else
       fState.Add(name, val, step);
 
     unsigned int minuit2Index = fState.Index(name);
     if (minuit2Index != ivar) {
-      std::string txtmsg("Wrong index used for the variable " + name);
-      edm::LogInfo("HybridMinimizer::SetVariable") << txtmsg;
-      edm::LogInfo("HybridMinimizer::SetVariable") << minuit2Index;
+      edm::LogInfo("HybridMinimizer::SetVariable").format("Wrong index used for the variable {} {}", name, minuit2Index);
       return false;
     }
     fState.RemoveLimits(ivar);
@@ -459,8 +457,7 @@ namespace PSFitter {
         txt = "unknown failure";
         fStatus = 5;
       }
-      std::string msg = "Minimization did NOT converge, " + txt;
-      edm::LogInfo("HybridMinimizer::Minimize") << msg;
+      edm::LogInfo("HybridMinimizer::Minimize").format("Minimization did NOT converge, {}", txt);
     }
 
     if (debugLevel >= 1)

--- a/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.cc
@@ -266,7 +266,7 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodFunction *>(&func);
       if (!fcnfunc) {
-        edm::LogInfo("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
+        edm::LogError("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodFunction>(*fcnfunc, fDim, ErrorDef());
@@ -284,7 +284,7 @@ namespace PSFitter {
       // for Fumili the fit method function interface is required
       const ROOT::Math::FitMethodGradFunction *fcnfunc = dynamic_cast<const ROOT::Math::FitMethodGradFunction *>(&func);
       if (!fcnfunc) {
-        edm::LogInfo("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
+        edm::LogError("HybridMinimizer::SetFunction") << "HybridMinimizer: Wrong Fit method function for Fumili";
         return;
       }
       fMinuitFCN = new ROOT::Minuit2::FumiliFCNAdapter<ROOT::Math::FitMethodGradFunction>(*fcnfunc, fDim, ErrorDef());
@@ -295,7 +295,7 @@ namespace PSFitter {
     // perform the minimization
     // store a copy of FunctionMinimum
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Minimize") << "FCN function has not been set";
+      edm::LogError("HybridMinimizer::Minimize") << "FCN function has not been set";
       return false;
     }
 
@@ -326,7 +326,7 @@ namespace PSFitter {
    */
 
     // internal minuit messages
-    //MnPrint::SetLevel(PrintLevel());
+    //MnPrint::SetLevel(PrintLevel()); // MnPrint::SetLevel is not a static method anymore. Using it requires an object to exist
 
     // switch off Minuit2 printing
     int prev_level = (PrintLevel() <= 0) ? TurnOffPrintInfoLevel() : -2;
@@ -672,12 +672,12 @@ namespace PSFitter {
     //       GetMinimizer()->Minimize(*GetFCN(),fState, ROOT::Minuit2::MnStrategy(strategy), MaxFunctionCalls(), Tolerance());
     //    fState = min.UserState();
     if (fMinimum == nullptr) {
-      edm::LogInfo("HybridMinimizer::GetMinosErrors") << "  failed - no function minimum existing";
+      edm::LogError("HybridMinimizer::GetMinosErrors") << "  failed - no function minimum existing";
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      edm::LogInfo("HybridMinimizer::MINOS") << " failed due to invalid function minimum";
+      edm::LogError("HybridMinimizer::MINOS") << " failed due to invalid function minimum";
       return false;
     }
 
@@ -805,12 +805,12 @@ namespace PSFitter {
     // if the errors  are also zero then scan from min and max of parameter range
 
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Scan") << " Function must be set before using Scan";
+      edm::LogError("HybridMinimizer::Scan") << " Function must be set before using Scan";
       return false;
     }
 
     if (ipar > fState.MinuitParameters().size()) {
-      edm::LogInfo("HybridMinimizer::Scan") << " Invalid number. Minimizer variables must be set before using Scan";
+      edm::LogError("HybridMinimizer::Scan") << " Invalid number. Minimizer variables must be set before using Scan";
       return false;
     }
 
@@ -833,7 +833,7 @@ namespace PSFitter {
       RestoreGlobalPrintLevel(prev_level);
 
     if (result.size() != nstep) {
-      edm::LogInfo("HybridMinimizer::Scan") << " Invalid result from MnParameterScan";
+      edm::LogError("HybridMinimizer::Scan") << " Invalid result from MnParameterScan";
       return false;
     }
     // sort also the returned points in x
@@ -859,12 +859,12 @@ namespace PSFitter {
     // contour plot for parameter i and j
     // need a valid FunctionMinimum otherwise exits
     if (fMinimum == nullptr) {
-      edm::LogInfo("HybridMinimizer::Contour") << " no function minimum existing. Must minimize function before";
+      edm::LogError("HybridMinimizer::Contour") << " no function minimum existing. Must minimize function before";
       return false;
     }
 
     if (!fMinimum->IsValid()) {
-      edm::LogInfo("HybridMinimizer::Contour") << "Invalid function minimum";
+      edm::LogError("HybridMinimizer::Contour") << "Invalid function minimum";
       return false;
     }
     assert(fMinuitFCN);
@@ -891,7 +891,7 @@ namespace PSFitter {
 
     std::vector<std::pair<double, double> > result = contour(ipar, jpar, npoints);
     if (result.size() != npoints) {
-      edm::LogInfo("HybridMinimizer::Contour") << " Invalid result from MnContours";
+      edm::LogError("HybridMinimizer::Contour") << " Invalid result from MnContours";
       return false;
     }
     for (unsigned int i = 0; i < npoints; ++i) {
@@ -909,7 +909,7 @@ namespace PSFitter {
     // appended in the function minimum
 
     if (!fMinuitFCN) {
-      edm::LogInfo("HybridMinimizer::Hesse") << "FCN function has not been set";
+      edm::LogError("HybridMinimizer::Hesse") << "FCN function has not been set";
       return false;
     }
 


### PR DESCRIPTION
#### PR description:

See https://github.com/cms-sw/cmssw/issues/32416
This makes use of LogInfo to substitute Minuit logger which was updated
One concern is what happens with the 
`MnPrint::SetLevel(PrintLevel())`
calls now commented since the old Minuit was globally setting the level and now MnPrint::SetLevel requires an object
From what I checked the LogInfo is used already within the same package:
https://github.com/cms-sw/cmssw/blob/master/RecoLocalCalo/HcalRecAlgos/src/HcalSeverityLevelComputer.cc#L292
nn the same manner.

#### PR validation:

it builds with latest ROOT master changes and it should work without MnPrint at all

