### PR TITLE
Update CSCMake2DRecHit.cc

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCMake2DRecHit.cc
@@ -165,16 +165,19 @@ CSCRecHit2D CSCMake2DRecHit::hitFromStripAndWire(const CSCDetId& id,
     //---- Calculate local position within the strip
     float xWithinChamber = lp11.x();
     quality = 0;
-    xMatchGatti_->findXOnStrip(id,
-                               layer_,
-                               sHit,
-                               centerStrip,
-                               xWithinChamber,
-                               stripWidth,
-                               tpeak,
-                               positionWithinTheStrip,
-                               sigmaWithinTheStrip,
-                               quality);
+    //check if strip wire intersect is within the sensitive area of chamber
+    if (layergeom_->inside(lp11)) {
+      xMatchGatti_->findXOnStrip(id,
+                                 layer_,
+                                 sHit,
+                                 centerStrip,
+                                 xWithinChamber,
+                                 stripWidth,
+                                 tpeak,
+                                 positionWithinTheStrip,
+                                 sigmaWithinTheStrip,
+                                 quality);
+    }
     lp0 = LocalPoint(xWithinChamber, ymiddle);
   }
 


### PR DESCRIPTION
Fix of issue https://github.com/cms-sw/cmssw/issues/32274
caused by changes in PR #32052

#### PR description:

It turned out that we need to keep the omitted "if"
7501f0c#diff-89c0bedb1d5ff71760f4a99102f4c06386cdac66bb8527527d41a7fe28e5dab8L160
We forgot that there is a difference in detid for wires in simulation and real
data. For real data all wires are labelled as ME11B. This "if" does not allow for a strip from ME11A to be assembled with a wire that geometrically is outside the ME11A sensitive area.