### PR TITLE
[DQM/EcalMonitorTasks] Add MEM FE Status and Integrity Error Plots

### DIFF
--- a/DQM/EcalMonitorTasks/python/PNDiodeTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/PNDiodeTask_cfi.py
@@ -1,5 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
+statuses = [
+    'TOWERID',
+    'BLOCKSIZE',
+    'CHID',
+    'GAIN'
+]
+
 ecalPNDiodeTask = cms.untracked.PSet(
     MEs = cms.untracked.PSet(
         OccupancySummary = cms.untracked.PSet(
@@ -8,6 +15,24 @@ ecalPNDiodeTask = cms.untracked.PSet(
             otype = cms.untracked.string('Ecal2P'),
             btype = cms.untracked.string('Crystal'),
             description = cms.untracked.string('Occupancy of PN digis in calibration events.')
+        ),
+        MEMErrors = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/MEM/IntegrityTask MEMErrors'),
+            kind = cms.untracked.string('TH2F'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(55),
+                nbins = cms.untracked.int32(108),
+                low = cms.untracked.double(1),
+            ),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(3.5),
+                nbins = cms.untracked.int32(4),
+                low = cms.untracked.double(-0.5),
+                labels = cms.untracked.vstring(statuses)
+            ),
+            otype = cms.untracked.string('Ecal'),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Integrity error and error type counter for MEM boxes. Each x-axis tick corresponds to one SuperModule (SM) as indexed by DCC Id and contains two bins corresponding to the MEM boxes (DCC tower Ids = 69, 70). Nominally, this plot should be empty. Mapping from DCC Id to SM name appears below.<br/><pre>01:EE-07  19:EB-10  37:EB+10<br/>02:EE-08  20:EB-11  38:EB+11<br/>03:EE-09  21:EB-12  39:EB+12<br/>04:EE-01  22:EB-13  40:EB+13<br/>05:EE-02  23:EB-14  41:EB+14<br/>06:EE-03  24:EB-15  42:EB+15<br/>07:EE-04  25:EB-16  43:EB+16<br/>08:EE-05  26:EB-17  44:EB+17<br/>09:EE-06  27:EB-18  45:EB+18<br/>10:EB-01  28:EB+01  46:EE+07<br/>11:EB-02  29:EB+02  47:EE+08<br/>12:EB-03  30:EB+03  48:EE+09<br/>13:EB-04  31:EB+04  49:EE+01<br/>14:EB-05  32:EB+05  50:EE+02<br/>15:EB-06  33:EB+06  51:EE+03<br/>16:EB-07  34:EB+07  52:EE+04<br/>17:EB-08  35:EB+08  53:EE+05<br/>18:EB-09  36:EB+09  54:EE+06</pre>')
         ),
         MEMTowerId = cms.untracked.PSet(
 #            path = cms.untracked.string('Ecal/Errors/Integrity/MEMTowerId/'),

--- a/DQM/EcalMonitorTasks/python/PNDiodeTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/PNDiodeTask_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-statuses = [
+MEMErrorTypes = [
     'TOWERID',
     'BLOCKSIZE',
     'CHID',
@@ -28,7 +28,7 @@ ecalPNDiodeTask = cms.untracked.PSet(
                 high = cms.untracked.double(3.5),
                 nbins = cms.untracked.int32(4),
                 low = cms.untracked.double(-0.5),
-                labels = cms.untracked.vstring(statuses)
+                labels = cms.untracked.vstring(MEMErrorTypes)
             ),
             otype = cms.untracked.string('Ecal'),
             btype = cms.untracked.string('User'),

--- a/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/RawDataTask_cfi.py
@@ -285,8 +285,24 @@ ecalRawDataTask = cms.untracked.PSet(
             btype = cms.untracked.string('SuperCrystal'),
             perLumi = cms.untracked.bool(True),
             description = cms.untracked.string('FE status error occupancy map for this lumisection. Nominal FE status flags such as ENABLED, SUPPRESSED, FIFOFILL, FIFOFULLL1ADESYNC, and FORCEDZS are NOT included.')
+        ),
+        FEStatusMEM = cms.untracked.PSet(
+            path = cms.untracked.string('Ecal/MEM/StatusFlagsTask MEM front-end status bits'),
+            kind = cms.untracked.string('TH2F'),
+            xaxis = cms.untracked.PSet(
+                high = cms.untracked.double(55),
+                nbins = cms.untracked.int32(108),
+                low = cms.untracked.double(1),
+            ),
+            yaxis = cms.untracked.PSet(
+                high = cms.untracked.double(15.5),
+                nbins = cms.untracked.int32(16),
+                low = cms.untracked.double(-0.5),
+                labels = cms.untracked.vstring(statuses)
+            ),
+            otype = cms.untracked.string('Ecal'),
+            btype = cms.untracked.string('User'),
+            description = cms.untracked.string('Front-end (FE) status counter for MEM boxes. Each x-axis tick corresponds to one SuperModule (SM) as indexed by DCC Id and contains two bins corresponding to the MEM boxes (DCC tower Ids = 69, 70). Nominal status is SUPPRESSED. EE+/-2,3,7,8 are not connected to MEM boxes and instead appear with status DISABLED. Mapping from DCC Id to SM name appears below.<br/><pre>01:EE-07  19:EB-10  37:EB+10<br/>02:EE-08  20:EB-11  38:EB+11<br/>03:EE-09  21:EB-12  39:EB+12<br/>04:EE-01  22:EB-13  40:EB+13<br/>05:EE-02  23:EB-14  41:EB+14<br/>06:EE-03  24:EB-15  42:EB+15<br/>07:EE-04  25:EB-16  43:EB+16<br/>08:EE-05  26:EB-17  44:EB+17<br/>09:EE-06  27:EB-18  45:EB+18<br/>10:EB-01  28:EB+01  46:EE+07<br/>11:EB-02  29:EB+02  47:EE+08<br/>12:EB-03  30:EB+03  48:EE+09<br/>13:EB-04  31:EB+04  49:EE+01<br/>14:EB-05  32:EB+05  50:EE+02<br/>15:EB-06  33:EB+06  51:EE+03<br/>16:EB-07  34:EB+07  52:EE+04<br/>17:EB-08  35:EB+08  53:EE+05<br/>18:EB-09  36:EB+09  54:EE+06</pre>')
         )
     )
 )
-
-

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -28,36 +28,37 @@ namespace ecaldqm {
     if (_ids.empty())
       return;
 
-    MESet* set(nullptr);
+    MESet* meMEMErrors = &MEs_.at("MEMErrors");
 
+    // MEM Box Integrity Errors (TowerIds 69 and 70)
+    // errorType matches to the following labels in DQM plot
+    // 0 = TOWERID
+    // 1 = BLOCKSIZE
+    // 2 = CHID
+    // 3 = GAIN
+    int errorType(0);
     switch (_collection) {
       case kMEMTowerIdErrors:
-        set = &MEs_.at("MEMTowerId");
+        errorType = 0;
         break;
       case kMEMBlockSizeErrors:
-        set = &MEs_.at("MEMBlockSize");
+        errorType = 1;
         break;
       case kMEMChIdErrors:
-        set = &MEs_.at("MEMChId");
+        errorType = 2;
         break;
       case kMEMGainErrors:
-        set = &MEs_.at("MEMGain");
+        errorType = 3;
         break;
       default:
         return;
     }
 
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id) {
-      if (id.towerId() == 69) {
-        edm::LogWarning("EcalDQM")
-            << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection is unphysical in lumi "
-               "number "
-            << timestamp_.iLumi << ", event number "
-            << timestamp_
-                   .iEvt;  // Added March 2018 because some events have this unphysical tower ID and cause the ECAL calibration application to crash.
-      } else {
-        set->fill(EcalElectronicsId(id.dccId(), id.towerId(), 1, id.xtalId()));
-      }
+      if (id.towerId() == 69)
+        meMEMErrors->fill(id.dccId()+0.0, errorType);
+      else if (id.towerId() == 70)
+        meMEMErrors->fill(id.dccId()+0.5, errorType);
     });
   }
 

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -58,19 +58,20 @@ namespace ecaldqm {
     // Plot contains two bins per dccId. Integer number
     // bins correspond to towerId 69 and half integer
     // number bins correspond to towerId 70.
-    std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id) {
-      if (id.towerId() == 69)
-        meMEMErrors->fill(id.dccId()+0.0, errorType);
-      else if (id.towerId() == 70)
-        meMEMErrors->fill(id.dccId()+0.5, errorType);
-      else{
-        edm::LogWarning("EcalDQM")
-          << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection does not "
-          << "correspond to one of the MEM box towerIds (69/70) in lumi number "
-          << timestamp_.iLumi << ", event number "
-          << timestamp_.iEvt;
-      }
-    });
+    std::for_each(_ids.begin(),
+                  _ids.end(),
+                  [&](EcalElectronicsIdCollection::value_type const& id) {
+                    if (id.towerId() == 69)
+                      meMEMErrors->fill(id.dccId() + 0.0, errorType);
+                    else if (id.towerId() == 70)
+                      meMEMErrors->fill(id.dccId() + 0.5, errorType);
+                    else {
+                      edm::LogWarning("EcalDQM")
+                          << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection does not "
+                          << "correspond to one of the MEM box towerIds (69/70) in lumi number " << timestamp_.iLumi
+                          << ", event number " << timestamp_.iEvt;
+                    }
+                  });
   }
 
   void PNDiodeTask::runOnPnDigis(EcalPnDiodeDigiCollection const& _digis) {

--- a/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
+++ b/DQM/EcalMonitorTasks/src/PNDiodeTask.cc
@@ -36,7 +36,7 @@ namespace ecaldqm {
     // 1 = BLOCKSIZE
     // 2 = CHID
     // 3 = GAIN
-    int errorType(0);
+    int errorType(-1);
     switch (_collection) {
       case kMEMTowerIdErrors:
         errorType = 0;
@@ -54,11 +54,22 @@ namespace ecaldqm {
         return;
     }
 
+    // Integrity errors for MEM boxes (towerIds 69/70)
+    // Plot contains two bins per dccId. Integer number
+    // bins correspond to towerId 69 and half integer
+    // number bins correspond to towerId 70.
     std::for_each(_ids.begin(), _ids.end(), [&](EcalElectronicsIdCollection::value_type const& id) {
       if (id.towerId() == 69)
         meMEMErrors->fill(id.dccId()+0.0, errorType);
       else if (id.towerId() == 70)
         meMEMErrors->fill(id.dccId()+0.5, errorType);
+      else{
+        edm::LogWarning("EcalDQM")
+          << "PNDiodeTask::runOnErrors : one of the ids in the electronics ID collection does not "
+          << "correspond to one of the MEM box towerIds (69/70) in lumi number "
+          << timestamp_.iLumi << ", event number "
+          << timestamp_.iEvt;
+      }
     });
   }
 

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -156,6 +156,9 @@ namespace ecaldqm {
 
         if (iFE >= 68) {
           // FE Status for MEM boxes (towerIds 69 and 70)
+          // Plot contains two bins per dccId. Integer number
+          // bins correspond to towerId 69 and half integer
+          // number bins correspond to towerId 70.
           if (iFE+1 == 69)
             meFEStatusMEM.fill(dccId+0.0, status);
           else if (iFE+1 == 70)

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -70,6 +70,7 @@ namespace ecaldqm {
     MESet& meL1AFE(MEs_.at("L1AFE"));
     MESet& meFEStatus(MEs_.at("FEStatus"));
     MESet& meFEStatusErrMapByLumi(MEs_.at("FEStatusErrMapByLumi"));
+    MESet& meFEStatusMEM(MEs_.at("FEStatusMEM"));
     MESet& meDesyncByLumi(MEs_.at("DesyncByLumi"));
     MESet& meDesyncTotal(MEs_.at("DesyncTotal"));
     MESet& meFEByLumi(MEs_.at("FEByLumi"));
@@ -153,8 +154,14 @@ namespace ecaldqm {
           }
         }
 
-        if (iFE >= 68)
+        if (iFE >= 68) {
+          // FE Status for MEM boxes (towerIds 69 and 70)
+          if (iFE+1 == 69)
+            meFEStatusMEM.fill(dccId+0.0, status);
+          else if (iFE+1 == 70)
+            meFEStatusMEM.fill(dccId+0.5, status);
           continue;
+        }
 
         DetId id(getElectronicsMap()->dccTowerConstituents(dccId, iFE + 1).at(0));
         meFEStatus.fill(id, status);

--- a/DQM/EcalMonitorTasks/src/RawDataTask.cc
+++ b/DQM/EcalMonitorTasks/src/RawDataTask.cc
@@ -159,10 +159,10 @@ namespace ecaldqm {
           // Plot contains two bins per dccId. Integer number
           // bins correspond to towerId 69 and half integer
           // number bins correspond to towerId 70.
-          if (iFE+1 == 69)
-            meFEStatusMEM.fill(dccId+0.0, status);
-          else if (iFE+1 == 70)
-            meFEStatusMEM.fill(dccId+0.5, status);
+          if (iFE + 1 == 69)
+            meFEStatusMEM.fill(dccId + 0.0, status);
+          else if (iFE + 1 == 70)
+            meFEStatusMEM.fill(dccId + 0.5, status);
           continue;
         }
 


### PR DESCRIPTION
#### PR description:

During a MWGR in November 2020 (but also a few times in Run2) we noticed EcalElectronicsIds coming from the ECAL calibration stream with seemingly unphysical detector coordinates. Specifically, these were coming from the EcalIntegrityMemBlockSizeErrors collection and occurred for a number of events in runs 338624 and 338628. At least in run 338628, this was always occurring with the same unphysical coordinates:

MemBlockSizeError:
dccId: 24
towerId: 70

It turns out that towerIDs 69 and 70 correspond to the MEM boxes for most ECAL SMs. These MEM boxes also have a front-end (FE) status that was not being displayed, due to the code assuming these coordinates are unphysical.

Integrity errors for towerID 69 had been masked before not knowing that these towerIDs do have a meaning: https://github.com/cms-sw/cmssw/commit/95eed04a96ac618a285c8388001c3542a3f0445f

In this PR we now handle the two additional tower IDs and plots the FE status and integrity errors for these MEM boxes. The plots contain two bins for each SM corresponding to tower IDs 69 and 70, respectively. The plots are indexed by ECAL DCC ID, where each DCC ID corresponds to a SM. The mapping from DCC ID to SM name appears below.
```
01:EE-07  19:EB-10  37:EB+10
02:EE-08  20:EB-11  38:EB+11
03:EE-09  21:EB-12  39:EB+12
04:EE-01  22:EB-13  40:EB+13
05:EE-02  23:EB-14  41:EB+14
06:EE-03  24:EB-15  42:EB+15
07:EE-04  25:EB-16  43:EB+16
08:EE-05  26:EB-17  44:EB+17
09:EE-06  27:EB-18  45:EB+18
10:EB-01  28:EB+01  46:EE+07
11:EB-02  29:EB+02  47:EE+08
12:EB-03  30:EB+03  48:EE+09
13:EB-04  31:EB+04  49:EE+01
14:EB-05  32:EB+05  50:EE+02
15:EB-06  33:EB+06  51:EE+03
16:EB-07  34:EB+07  52:EE+04
17:EB-08  35:EB+08  53:EE+05
18:EB-09  36:EB+09  54:EE+06
```
#### PR validation:

New plots successfully generated with online ECAL DQM workflow and uploaded to a private DQM GUI without any issues.

#### Backport:

A backport of this PR to CMSSW_11_2_X has been submitted here: https://github.com/cms-sw/cmssw/pull/32481