### PR TITLE
[Bug fix] Avoid rejecting good events in PythiaFilterMultiAncestor.cc

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc
@@ -204,6 +204,8 @@ bool PythiaFilterMultiAncestor::filter(edm::StreamID, edm::Event& iEvent, const 
             accepted = false;
         }
       }
+    // only need to satisfy the conditions _once_
+    if(accepted) break;
     }
 
   } else {

--- a/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc
+++ b/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc
@@ -204,8 +204,9 @@ bool PythiaFilterMultiAncestor::filter(edm::StreamID, edm::Event& iEvent, const 
             accepted = false;
         }
       }
-    // only need to satisfy the conditions _once_
-    if(accepted) break;
+      // only need to satisfy the conditions _once_
+      if (accepted)
+        break;
     }
 
   } else {


### PR DESCRIPTION
#### PR description:

This PR fixes a logic loophole in the filter presented in https://github.com/cms-sw/cmssw/pull/32389.

The gen particle loop was never interrupted, even if a good particle (and ancestors and daughters) was found.
On the one hand this is inefficient, on the other hand this led to cases where an event that should be accepted is later discarded because another particle does not satisfy all conditions.

This was  discovered in events where two J/Ψ are present and the first one in the collection decays to muons (hence the event should be accepted) but the second one doesn't and triggers the event rejection [here](https://github.com/cms-sw/cmssw/blob/master/GeneratorInterface/GenFilters/plugins/PythiaFilterMultiAncestor.cc#L203-L204).

With the fix here proposed, this cannot happen as the loop if broken at the first occurrence of a particle that satisfies all conditions.

A backport to 10_6_X is coming too.