### PR TITLE
New JEC for 2018 HI re-miniAOD [11_2_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -34,7 +34,7 @@ autoCond = {
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
     'run2_data_relval'  :   '112X_dataRun2_relval_v7',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v3',
+    'run2_data_promptlike_hi' : '112X_dataRun2_PromptLike_HI_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v10',
     # GlobalTag for Run2 HLT: it points to the online GT
@@ -61,7 +61,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
     'phase1_2018_realistic'    :  '112X_upgrade2018_realistic_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v5',
+    'phase1_2018_realistic_hi' :  '112X_upgrade2018_realistic_HI_v6',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
     'phase1_2018_realistic_HEfail' :  '112X_upgrade2018_realistic_HEfail_v6',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode


### PR DESCRIPTION
#### PR description:

This PR is a backport of PR #32375. The content of this PR is identical to that of #32375, though I squashed the commits to remove a commit with an incorrect GT.

This PR updates the HI JEC for the re-miniAOD of the 2018 HI run. The 2018 HI MC as well as the 2018 HI IOVs of the prompt-like data JEC tags are updated. The GT diffs are as follows:

**Prompt-like data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_dataRun2_PromptLike_HI_v3/112X_dataRun2_PromptLike_HI_v5

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_upgrade2018_realistic_HI_v5/112X_upgrade2018_realistic_HI_v6

#### PR validation:

See the [HN thread for details](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4356.html). In addition, a technical test was performed: `runTheMatrix.py -l limited --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #32375. It it being backported because it intended for use in a HI re-miniAOD in 11_2_X.