### PR TITLE
Added "/dd4hep::cm" to RPCGeometryBuilder

### DIFF
--- a/Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDD4hep_cfg.py
+++ b/Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDD4hep_cfg.py
@@ -14,6 +14,13 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load("Geometry.RPCGeometryBuilder.rpcGeometry_cfi")
 
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
+
 process.valid = cms.EDAnalyzer("RPCGeometryValidate",
                                infileName = cms.untracked.string('cmsRecoGeom-2021.root'),
                                outfileName = cms.untracked.string('validateRPCGeometry.root'),

--- a/Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDDD_cfg.py
+++ b/Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDDD_cfg.py
@@ -14,6 +14,13 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load("Geometry.RPCGeometryBuilder.rpcGeometry_cfi")
 
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
+
 process.valid = cms.EDAnalyzer("RPCGeometryValidate",
                                infileName = cms.untracked.string('cmsRecoGeom-2021.root'),
                                outfileName = cms.untracked.string('validateRPCGeometry.root'),


### PR DESCRIPTION
**PR description:**

Added "/ ddhep::cm" to the DD4hep part of the RPCGeometryBuilder in order to simplify a possible future unit transition 

**PR validation:**

1) validation by "cmsRun Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDD4hep_cfg.py" and "cmsRun Geometry/RPCGeometryBuilder/test/python/validateRPCGeometryDDD_cfg.py" 

See attached picture (only one histo for DD4hep)

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

 2) validation by printouts (myLog.log), for both DD & DD4Hep, created by the validation scripts used above (for example please see, below, the parameters check for the 637566989 detid):

//DD

(1) detid: 637566989 name: MB1RPC_IGasLeft number of Strips: 90
(2), tran.x() 413.675 tran.y(): 37.6 tran.z(): -470.45
(3) dpar.size() == 3, width: 103 length: 58.45 thickness: 0.2

//DD4Hep

(1), detid: 637566989 name: MB1RPC_IGasLeft number of Strips: 90
(2), tran.x(): 413.675 tran.y(): 37.6 tran.z(): -470.45
(3), dd4hep::Box, width: 103 length: 58.45 thickness: 0.2
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

3) validation by "runTheMatrix.py -l 25202.1" :

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Sat Dec 12 08:02:43 2020-date Sat Dec 12 07:40:56 2020; exit: 0 0 0 0 1 1 1 1 tests passed, 0 0 0 0 failed


**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

![Schermata 2020-12-12 alle 07 44 13](https://user-images.githubusercontent.com/28751695/101978012-1dcea980-3c52-11eb-930a-ed95b594f012.png)
