### PR TITLE
Correctly add HIPhotonIsolation to pat::photon

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -54,14 +54,6 @@ phase2_common.toModify(reducedEgamma,
         preshowerEcalHits = cms.InputTag(""),
 )
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(
-    reducedEgamma,
-    hiPhotonIsolationMapInput = cms.InputTag("photonIsolationHIProducerppGED"),
-    hiPhotonIsolationMapOutput = cms.string("photonIsolationHIProducerppGED")
-)
-
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(
     reducedEgamma, 
@@ -126,9 +118,13 @@ modifyReducedEGammaRun2MiniAOD = (
     run2_miniAOD_94XFall17 | run2_miniAOD_80XLegacy | run2_miniAOD_UL).makeProcessModifier(calibrateReducedEgamma)
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(reducedEgamma,
-    ootPhotons = cms.InputTag(""),
+
+pp_on_AA.toModify(
+    reducedEgamma,
+    ootPhotons = "",
     keepPhotons = "pt>15 && abs(eta)<2.5",
     slimRelinkPhotons = "pt>15 && abs(eta)<2.5",
-    relinkPhotons = "pt>15 && abs(eta)<2.5"
-    )
+    relinkPhotons = "pt>15 && abs(eta)<2.5",
+    hiPhotonIsolationMapInput = "photonIsolationHIProducerppGED",
+    hiPhotonIsolationMapOutput = "photonIsolationHIProducerppGED"
+)

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -32,6 +32,8 @@ reducedEgamma = cms.EDProducer("ReducedEGProducer",
   photonFloatValueMapOutput = cms.vstring(),
   ootPhotonFloatValueMapSources = cms.VInputTag(),
   ootPhotonFloatValueMapOutput = cms.vstring(),
+  hiPhotonIsolationMapInput = cms.InputTag(""),
+  hiPhotonIsolationMapOutput = cms.string(""),
   gsfElectronFloatValueMapSources = cms.VInputTag(),
   gsfElectronFloatValueMapOutput = cms.vstring(),
   applyPhotonCalibOnData = cms.bool(False),
@@ -56,8 +58,8 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
 (pp_on_AA_2018 | pp_on_PbPb_run3).toModify(
     reducedEgamma,
-    HIPhotonIsolationMapInput = cms.InputTag("photonIsolationHIProducerppGED"),
-    HIPhotonIsolationMapOutput = cms.string("photonIsolationHIProducerppGED")
+    hiPhotonIsolationMapInput = cms.InputTag("photonIsolationHIProducerppGED"),
+    hiPhotonIsolationMapOutput = cms.string("photonIsolationHIProducerppGED")
 )
 
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -52,6 +52,14 @@ phase2_common.toModify(reducedEgamma,
         preshowerEcalHits = cms.InputTag(""),
 )
 
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
+(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(
+    reducedEgamma,
+    HIPhotonIsolationMapInput = cms.InputTag("photonIsolationHIProducerppGED"),
+    HIPhotonIsolationMapOutput = cms.string("photonIsolationHIProducerppGED")
+)
+
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(
     reducedEgamma, 

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -48,7 +48,6 @@
 class ReducedEGProducer : public edm::stream::EDProducer<> {
 public:
   ReducedEGProducer(const edm::ParameterSet& ps);
-  ~ReducedEGProducer() override;
 
   void beginRun(edm::Run const&, const edm::EventSetup&) final;
   void produce(edm::Event& evt, const edm::EventSetup& es) final;
@@ -296,32 +295,23 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
   if (not aTag.label().empty())
     ootPhotonT_ = consumes<reco::PhotonCollection>(aTag);
 
-  const std::vector<edm::InputTag>& photonidinputs = config.getParameter<std::vector<edm::InputTag>>("photonIDSources");
-  for (const edm::InputTag& tag : photonidinputs) {
+  for (const edm::InputTag& tag : config.getParameter<std::vector<edm::InputTag>>("photonIDSources")) {
     photonIdTs_.emplace_back(consumes<edm::ValueMap<bool>>(tag));
   }
 
-  const std::vector<edm::InputTag>& gsfelectronidinputs =
-      config.getParameter<std::vector<edm::InputTag>>("gsfElectronIDSources");
-  for (const edm::InputTag& tag : gsfelectronidinputs) {
+  for (const edm::InputTag& tag : config.getParameter<std::vector<edm::InputTag>>("gsfElectronIDSources")) {
     gsfElectronIdTs_.emplace_back(consumes<edm::ValueMap<float>>(tag));
   }
 
-  const std::vector<edm::InputTag>& photonpfclusterisoinputs =
-      config.getParameter<std::vector<edm::InputTag>>("photonFloatValueMapSources");
-  for (const edm::InputTag& tag : photonpfclusterisoinputs) {
+  for (const edm::InputTag& tag : config.getParameter<std::vector<edm::InputTag>>("photonFloatValueMapSources")) {
     photonFloatValueMapTs_.emplace_back(consumes<edm::ValueMap<float>>(tag));
   }
 
-  const std::vector<edm::InputTag>& ootphotonpfclusterisoinputs =
-      config.getParameter<std::vector<edm::InputTag>>("ootPhotonFloatValueMapSources");
-  for (const edm::InputTag& tag : ootphotonpfclusterisoinputs) {
+  for (const edm::InputTag& tag : config.getParameter<std::vector<edm::InputTag>>("ootPhotonFloatValueMapSources")) {
     ootPhotonFloatValueMapTs_.emplace_back(consumes<edm::ValueMap<float>>(tag));
   }
 
-  const std::vector<edm::InputTag>& gsfelectronpfclusterisoinputs =
-      config.getParameter<std::vector<edm::InputTag>>("gsfElectronFloatValueMapSources");
-  for (const edm::InputTag& tag : gsfelectronpfclusterisoinputs) {
+  for (const edm::InputTag& tag : config.getParameter<std::vector<edm::InputTag>>("gsfElectronFloatValueMapSources")) {
     gsfElectronFloatValueMapTs_.emplace_back(consumes<edm::ValueMap<float>>(tag));
   }
 
@@ -383,8 +373,6 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
     produces<reco::HIPhotonIsolationMap>(recoHIPhotonIsolationMapOutputName_);
   }
 }
-
-ReducedEGProducer::~ReducedEGProducer() {}
 
 void ReducedEGProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) { hcalHitSel_.setup(iSetup); }
 
@@ -680,9 +668,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     }
 
     // Save additional ambiguous gsf tracks in a map:
-    for (reco::GsfTrackRefVector::const_iterator igsf = gsfElectron.ambiguousGsfTracksBegin();
-         igsf != gsfElectron.ambiguousGsfTracksEnd();
-         ++igsf) {
+    for (auto igsf = gsfElectron.ambiguousGsfTracksBegin(); igsf != gsfElectron.ambiguousGsfTracksEnd(); ++igsf) {
       const reco::GsfTrackRef& ambigGsfTrack = *igsf;
       if (!gsfTrackMap.count(ambigGsfTrack)) {
         gsfTracks->push_back(*ambigGsfTrack);
@@ -818,10 +804,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
   //CaloClusters
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const edm::OrphanHandle<reco::CaloClusterCollection>& outEBEEClusterHandle =
-      theEvent.put(std::move(ebeeClusters), outEBEEClusters_);
-  const edm::OrphanHandle<reco::CaloClusterCollection>& outESClusterHandle =
-      theEvent.put(std::move(esClusters), outESClusters_);
+  const auto& outEBEEClusterHandle = theEvent.put(std::move(ebeeClusters), outEBEEClusters_);
+  const auto& outESClusterHandle = theEvent.put(std::move(esClusters), outESClusters_);
   ;
 
   //Loop over SuperClusters and relink GEDPhoton + GSFElectron CaloClusters
@@ -843,14 +827,10 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     }
   }
   //put superclusters and conversions in the event
-  const edm::OrphanHandle<reco::SuperClusterCollection>& outSuperClusterHandle =
-      theEvent.put(std::move(superClusters), outSuperClusters_);
-  const edm::OrphanHandle<reco::ConversionCollection>& outConversionHandle =
-      theEvent.put(std::move(conversions), outConversions_);
-  const edm::OrphanHandle<reco::ConversionCollection>& outSingleConversionHandle =
-      theEvent.put(std::move(singleConversions), outSingleConversions_);
-  const edm::OrphanHandle<reco::GsfTrackCollection>& outGsfTrackHandle =
-      theEvent.put(std::move(gsfTracks), outGsfTracks_);
+  const auto& outSuperClusterHandle = theEvent.put(std::move(superClusters), outSuperClusters_);
+  const auto& outConversionHandle = theEvent.put(std::move(conversions), outConversions_);
+  const auto& outSingleConversionHandle = theEvent.put(std::move(singleConversions), outSingleConversions_);
+  const auto& outGsfTrackHandle = theEvent.put(std::move(gsfTracks), outGsfTracks_);
 
   //Loop over PhotonCores and relink GEDPhoton SuperClusters (and conversions)
   for (reco::PhotonCore& photonCore : *photonCores) {
@@ -883,13 +863,11 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
 
   //put photoncores and gsfelectroncores into the event
-  const edm::OrphanHandle<reco::PhotonCoreCollection>& outPhotonCoreHandle =
-      theEvent.put(std::move(photonCores), outPhotonCores_);
+  const auto& outPhotonCoreHandle = theEvent.put(std::move(photonCores), outPhotonCores_);
   edm::OrphanHandle<reco::PhotonCoreCollection> outOOTPhotonCoreHandle;
   if (!ootPhotonT_.isUninitialized())
     outOOTPhotonCoreHandle = theEvent.put(std::move(ootPhotonCores), outOOTPhotonCores_);
-  const edm::OrphanHandle<reco::GsfElectronCoreCollection>& outgsfElectronCoreHandle =
-      theEvent.put(std::move(gsfElectronCores), outGsfElectronCores_);
+  const auto& outgsfElectronCoreHandle = theEvent.put(std::move(gsfElectronCores), outGsfElectronCores_);
 
   //loop over photons, oot photons, and electrons and relink the cores
   for (reco::Photon& photon : *photons) {
@@ -909,9 +887,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     // Also in this loop let's relink ambiguous tracks
     std::vector<reco::GsfTrackRef> ambigTracksInThisElectron;
     // Here we loop over the ambiguous tracks and save them in a vector
-    for (reco::GsfTrackRefVector::const_iterator igsf = gsfElectron.ambiguousGsfTracksBegin();
-         igsf != gsfElectron.ambiguousGsfTracksEnd();
-         ++igsf) {
+    for (auto igsf = gsfElectron.ambiguousGsfTracksBegin(); igsf != gsfElectron.ambiguousGsfTracksEnd(); ++igsf) {
       ambigTracksInThisElectron.push_back(*igsf);
     }
 
@@ -936,12 +912,11 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
 
   //(finally) store the output photon and electron collections
-  const edm::OrphanHandle<reco::PhotonCollection>& outPhotonHandle = theEvent.put(std::move(photons), outPhotons_);
+  const auto& outPhotonHandle = theEvent.put(std::move(photons), outPhotons_);
   edm::OrphanHandle<reco::PhotonCollection> outOOTPhotonHandle;
   if (!ootPhotonT_.isUninitialized())
     outOOTPhotonHandle = theEvent.put(std::move(ootPhotons), outOOTPhotons_);
-  const edm::OrphanHandle<reco::GsfElectronCollection>& outGsfElectronHandle =
-      theEvent.put(std::move(gsfElectrons), outGsfElectrons_);
+  const auto& outGsfElectronHandle = theEvent.put(std::move(gsfElectrons), outGsfElectrons_);
 
   //still need to output relinked valuemaps
 
@@ -1280,7 +1255,6 @@ void ReducedEGProducer::calibrateElectron(reco::GsfElectron& electron,
   electron.setCorrectedEcalEnergy(newEcalEnergy);
   electron.setCorrectedEcalEnergyError(newEcalEnergyErr);
 
-  math::XYZTLorentzVector newP4 =
-      math::XYZTLorentzVector(oldP4.x() * corr, oldP4.y() * corr, oldP4.z() * corr, newEnergy);
+  math::XYZTLorentzVector newP4{oldP4.x() * corr, oldP4.y() * corr, oldP4.z() * corr, newEnergy};
   electron.correctMomentum(newP4, electron.trackMomentumError(), newEnergyErr);
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -243,11 +243,11 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
       gsfElectronPfCandMapT_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
           config.getParameter<edm::InputTag>("gsfElectronsPFValMap"))),
       recoHIPhotonIsolationMapInputToken_{
-          config.existsAs<edm::InputTag>("HIPhotonIsolationMapInput")
-              ? consumes<reco::HIPhotonIsolationMap>(config.getParameter<edm::InputTag>("HIPhotonIsolationMapInput"))
+          !config.getParameter<edm::InputTag>("hiPhotonIsolationMapInput").label().empty()
+              ? consumes<reco::HIPhotonIsolationMap>(config.getParameter<edm::InputTag>("hiPhotonIsolationMapInput"))
               : edm::EDGetTokenT<reco::HIPhotonIsolationMap>{}},
       recoHIPhotonIsolationMapOutputName_{!recoHIPhotonIsolationMapInputToken_.isUninitialized()
-                                              ? config.getParameter<std::string>("HIPhotonIsolationMapOutput")
+                                              ? config.getParameter<std::string>("hiPhotonIsolationMapOutput")
                                               : std::string{}},
       //calibration flags
       applyPhotonCalibOnData_(config.getParameter<bool>("applyPhotonCalibOnData")),

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -141,8 +141,7 @@ egammaHIPhotonIsolationModifier = cms.PSet(
     modifierName = cms.string('EGExtraInfoModifierFromHIPhotonIsolationValueMaps'),
     electron_config = cms.PSet(),
     photon_config = cms.PSet(
-        photonSrc = cms.InputTag("gedPhotons"),
-        photonIsolationHI = cms.InputTag("photonIsolationHIProducerppGED")
+        photonIsolationHI = cms.InputTag("reducedEgamma:photonIsolationHIProducerppGED")
         )
     )
 


### PR DESCRIPTION
#### PR description:

This is to address issue https://github.com/cms-sw/cmssw/issues/32451.

I was asked if there is a simpler python-level-only solution for that issue than to hard-code the propagation of the HI isolation value map in the ReducedEGProducer. Well, I couldn't find any and I don't think it's even possible because the HIPhotonIsolation is a custom class. Hence, we can't use the existing mechanisms for `int` and `float` ValueMaps.

Accordingly, this PR proposes the solution via editing the ReducedEGProducer source.

@mandrenguyen @ttrk 

#### PR validation:

CMSSW compiles, local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intened.