### PR TITLE
drop type spec in CommonTools

### DIFF
--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -28,13 +28,13 @@ from RecoBTag.SecondaryVertex.pfCombinedInclusiveSecondaryVertexV2BJetTags_cfi i
 #### condenses information into the new "particleFlow" collection.            ####
 
 
-pfPileUpEI = pfPileUp.clone( PFCandidates = cms.InputTag('particleFlowPtrs') )
-pfNoPileUpEI = pfNoPileUp.clone( bottomCollection = cms.InputTag('particleFlowPtrs'),
-                                 topCollection = cms.InputTag('pfPileUpEI') )
+pfPileUpEI   = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
+pfNoPileUpEI = pfNoPileUp.clone( bottomCollection = 'particleFlowPtrs',
+                                 topCollection = 'pfPileUpEI' )
 
-pfPileUpJMEEI = pfPileUpJME.clone( PFCandidates = cms.InputTag('particleFlowPtrs') )
-pfNoPileUpJMEEI = pfNoPileUpJME.clone( bottomCollection = cms.InputTag('particleFlowPtrs'),
-                                       topCollection = cms.InputTag('pfPileUpJMEEI') )
+pfPileUpJMEEI   = pfPileUpJME.clone( PFCandidates = 'particleFlowPtrs' )
+pfNoPileUpJMEEI = pfNoPileUpJME.clone( bottomCollection = 'particleFlowPtrs',
+                                       topCollection = 'pfPileUpJMEEI' )
 
 
 #### Muons ####
@@ -47,7 +47,7 @@ pfAllMuonsEI = cms.EDFilter(
     makeClones = cms.bool(True)
 )
 
-pfMuonsFromVertexEI = pfMuonsFromVertex.clone( src = cms.InputTag('pfAllMuonsEI') )
+pfMuonsFromVertexEI = pfMuonsFromVertex.clone( src = 'pfAllMuonsEI' )
 
 pfIsolatedMuonsEI = cms.EDFilter(
     "PFCandidateFwdPtrCollectionStringFilter",
@@ -83,7 +83,7 @@ pfAllElectronsEI = cms.EDFilter(
     makeClones = cms.bool(True)
 )
 
-pfElectronsFromVertexEI = pfElectronsFromVertex.clone( src = cms.InputTag('pfAllElectronsEI') )
+pfElectronsFromVertexEI = pfElectronsFromVertex.clone( src = 'pfAllElectronsEI' )
 
 pfIsolatedElectronsEI = cms.EDFilter(
     "PFCandidateFwdPtrCollectionStringFilter",
@@ -110,22 +110,22 @@ pfNoElectronJME.bottomCollection = 'pfNoMuonJME'
 #### Jets ####
 
 pfJetsEI = pfJets.clone()
-pfJetsPtrsEI = pfJetsPtrs.clone(src=cms.InputTag("pfJetsEI"))
+pfJetsPtrsEI = pfJetsPtrs.clone( src = "pfJetsEI" )
 
 pfJetSequenceEI = cms.Sequence( pfJetsEI+ pfJetsPtrsEI )
 
 pfNoJetEI = pfNoJet.clone(
     topCollection = 'pfJetsPtrsEI',
     bottomCollection = 'pfNoElectronJME'
-    )
+)
 
 #### Taus ####
 pfTausEI = pfTaus.clone()
-pfTausPtrsEI = pfTausPtrs.clone(src=cms.InputTag("pfTausEI") )
+pfTausPtrsEI = pfTausPtrs.clone( src = "pfTausEI" )
 pfNoTauEI = pfNoTau.clone(
-    topCollection = cms.InputTag('pfTausPtrsEI'),
-    bottomCollection = cms.InputTag('pfJetsPtrsEI')
-    )
+    topCollection = 'pfTausPtrsEI',
+    bottomCollection = 'pfJetsPtrsEI'
+)
 
 pfTauEISequence = cms.Sequence(
     pfTausPreSequence+
@@ -136,20 +136,20 @@ pfTauEISequence = cms.Sequence(
 
 #### B-tagging ####
 pfImpactParameterTagInfosEI = pfImpactParameterTagInfos.clone(
-    jets = cms.InputTag( 'pfJetsEI' )
-    )
+    jets =  'pfJetsEI'
+)
 pfInclusiveSecondaryVertexFinderTagInfosEI = pfInclusiveSecondaryVertexFinderTagInfos.clone(
-    trackIPTagInfos = cms.InputTag( 'pfImpactParameterTagInfosEI' )
-    )
+    trackIPTagInfos =  'pfImpactParameterTagInfosEI'
+)
 pfCombinedInclusiveSecondaryVertexV2BJetTagsEI = pfCombinedInclusiveSecondaryVertexV2BJetTags.clone(
-    tagInfos = cms.VInputTag(cms.InputTag("pfImpactParameterTagInfosEI"),
-                             cms.InputTag("pfInclusiveSecondaryVertexFinderTagInfosEI"))
-    )
+    tagInfos = ["pfImpactParameterTagInfosEI",
+                "pfInclusiveSecondaryVertexFinderTagInfosEI"]
+)
 
 
 
 #### MET ####
-pfMetEI = pfMET.clone(srcJets=cms.InputTag("pfJetsEI"))
+pfMetEI = pfMET.clone(srcJets="pfJetsEI")
 
 #EITopPAG = cms.Sequence(
 EIsequence = cms.Sequence(

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -75,11 +75,13 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfSelectedPhotons_cfi import *
 pfSelectedPhotonsPFBRECO = pfSelectedPhotons.clone( src = 'pfAllPhotonsPFBRECO' )
 from CommonTools.ParticleFlow.Isolation.pfPhotonIsolationPFBRECO_cff import *
 from CommonTools.ParticleFlow.Isolation.pfIsolatedPhotons_cfi import *
-pfIsolatedPhotonsPFBRECO = pfIsolatedPhotons.clone( src = 'pfSelectedPhotonsPFBRECO',
-                                                    isolationValueMapsCharged = cms.VInputTag( cms.InputTag("phPFIsoValueCharged04PFIdPFBRECO") ),
-                                                    isolationValueMapsNeutral = cms.VInputTag( cms.InputTag("phPFIsoValueNeutral04PFIdPFBRECO"),
-                                                                                               cms.InputTag("phPFIsoValueGamma04PFIdPFBRECO") ),
-                                                    deltaBetaIsolationValueMap = 'phPFIsoValuePU04PFIdPFBRECO' )
+pfIsolatedPhotonsPFBRECO = pfIsolatedPhotons.clone( 
+    src = 'pfSelectedPhotonsPFBRECO',
+    isolationValueMapsCharged = ["phPFIsoValueCharged04PFIdPFBRECO"],
+    isolationValueMapsNeutral = ["phPFIsoValueNeutral04PFIdPFBRECO",
+                                 "phPFIsoValueGamma04PFIdPFBRECO"],
+    deltaBetaIsolationValueMap = 'phPFIsoValuePU04PFIdPFBRECO' 
+)
 pfPhotonPFBRECOSequence = cms.Sequence(
     pfSelectedPhotonsPFBRECO +
     pfPhotonIsolationPFBRECOSequence +
@@ -91,7 +93,7 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfMuonsFromVertex_cfi import *
 pfMuonsFromVertexPFBRECO = pfMuonsFromVertex.clone( src = 'pfAllMuonsPFBRECO' )
 from CommonTools.ParticleFlow.Isolation.pfIsolatedMuons_cfi import *
 pfIsolatedMuonsPFBRECO = pfIsolatedMuons.clone( src = 'pfMuonsFromVertexPFBRECO' )
-pfMuonsPFBRECO = pfIsolatedMuonsPFBRECO.clone(cut = cms.string("pt > 5 & muonRef.isAvailable()"))
+pfMuonsPFBRECO = pfIsolatedMuonsPFBRECO.clone(cut = "pt > 5 & muonRef.isAvailable()")
 pfMuonPFBRECOSequence = cms.Sequence(
     pfAllMuonsPFBRECO +
     pfMuonsFromVertexPFBRECO +
@@ -103,7 +105,7 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfElectronsFromVertex_cfi import
 pfElectronsFromVertexPFBRECO = pfElectronsFromVertex.clone( src = 'pfAllElectronsPFBRECO' )
 from CommonTools.ParticleFlow.Isolation.pfIsolatedElectrons_cfi import *
 pfIsolatedElectronsPFBRECO = pfIsolatedElectrons.clone( src = 'pfElectronsFromVertexPFBRECO' )
-pfElectronsPFBRECO = pfIsolatedElectronsPFBRECO.clone( cut = cms.string(" pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.hitPattern().numberOfLostHits('MISSING_INNER_HITS')<2"))
+pfElectronsPFBRECO = pfIsolatedElectronsPFBRECO.clone( cut = " pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.hitPattern().numberOfLostHits('MISSING_INNER_HITS')<2")
 pfElectronPFBRECOSequence = cms.Sequence(
     pfAllElectronsPFBRECO +
     pfElectronsFromVertexPFBRECO +

--- a/CommonTools/ParticleFlow/python/goodOnlinePrimaryVertices_cfi.py
+++ b/CommonTools/ParticleFlow/python/goodOnlinePrimaryVertices_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.pvSelector_cfi import pvSelector
 
 goodOnlinePrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
-    filterParams = pvSelector.clone( minNdof = cms.double(4.0), maxZ = cms.double(24.0) ),
-    src=cms.InputTag('offlinePrimaryVertices')
+    filterParams = pvSelector.clone( minNdof = 4.0, maxZ = 24.0 ),
+    src = cms.InputTag('offlinePrimaryVertices')
 )

--- a/CommonTools/ParticleFlow/python/pfElectrons_cff.py
+++ b/CommonTools/ParticleFlow/python/pfElectrons_cff.py
@@ -5,7 +5,7 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfElectronsFromVertex_cfi import
 from CommonTools.ParticleFlow.Isolation.pfIsolatedElectrons_cfi import *
 
 
-pfElectrons = pfIsolatedElectrons.clone( cut = cms.string(" pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.hitPattern().numberOfLostHits('MISSING_INNER_HITS')<2"))
+pfElectrons = pfIsolatedElectrons.clone( cut = " pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.hitPattern().numberOfLostHits('MISSING_INNER_HITS')<2")
 
 pfElectronSequence = cms.Sequence(
     pfAllElectrons +

--- a/CommonTools/ParticleFlow/python/pfMET_cfi.py
+++ b/CommonTools/ParticleFlow/python/pfMET_cfi.py
@@ -4,11 +4,12 @@ import FWCore.ParameterSet.Config as cms
 from RecoMET.METProducers.pfMet_cfi import *
 
 # Should the name be changed se it is similar to pfMet from reco ??
-pfMET = pfMet.clone(alias="pfMET")
+pfMET = pfMet.clone(
+    alias = "pfMET",
 
-# Use PF2PAT cleaned jet collection (pfJets) for MET significance
-# instead of standard collection (ak4PFJets)?
-# It requires that MET is produced at the end.
-pfMET.srcJets = cms.InputTag("pfJets")
-
+    # Use PF2PAT cleaned jet collection (pfJets) for MET significance
+    # instead of standard collection (ak4PFJets)?
+    # It requires that MET is produced at the end.
+    srcJets = "pfJets"
+)
 # print 'PF2PAT: Jet collection used for pfMET significance: ', pfMET.jets

--- a/CommonTools/ParticleFlow/python/pfMuons_cff.py
+++ b/CommonTools/ParticleFlow/python/pfMuons_cff.py
@@ -5,7 +5,7 @@ from CommonTools.ParticleFlow.ParticleSelectors.pfMuonsFromVertex_cfi import *
 from CommonTools.ParticleFlow.Isolation.pfIsolatedMuons_cfi import *
 
 
-pfMuons = pfIsolatedMuons.clone(cut = cms.string("pt > 5 & muonRef.isAvailable()"))
+pfMuons = pfIsolatedMuons.clone(cut = "pt > 5 & muonRef.isAvailable()")
 
 
 pfMuonSequence = cms.Sequence(

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -53,14 +53,10 @@ pfTausSelectionDiscriminator = hpsSelectionDiscriminator.clone(
     PFTauProducer = "pfTausCombiner"
 )
 pfTausProducerSansRefs = hpsPFTauProducerSansRefs.clone(
-   src = "pfTausCombiner"
-)
-pfTausProducerSansRefs = cms.EDProducer(
-    "RecoTauCleaner",
-    src = cms.InputTag("pfTausCombiner"),
-    outputSelection = cms.string(""),
-    verbosity = cms.int32(0),
-    cleaners = cms.VPSet(
+    src = "pfTausCombiner",
+    outputSelection = "",
+    verbosity = 0,
+    cleaners = [
         cleaners.unitCharge,
         cms.PSet(
             name = cms.string("leadStripPtLt2_5"),
@@ -77,7 +73,7 @@ pfTausProducerSansRefs = cms.EDProducer(
             src = cms.InputTag("pfTausSelectionDiscriminator"),
         ),
         cleaners.combinedIsolation
-    )
+    ]
 )
 
 #cloning discriminants

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -28,75 +28,76 @@ selection is constructed by:
 
 # PiZeroProducers
 
-pfJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZeros.clone()
-pfJetsLegacyHPSPiZeros.jetSrc = cms.InputTag("ak4PFJets")
-
+pfJetsLegacyHPSPiZeros = ak4PFJetsLegacyHPSPiZeros.clone(
+    jetSrc = "ak4PFJets"
+)
 pfTauPFJetsRecoTauChargedHadrons = ak4PFJetsRecoTauChargedHadrons.clone()
 
-pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
-pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
-pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
-
+pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone(
+    PFCandidateProducer = jetConfig.ak4PFJets.src ,
+    PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
+)
 # Clone tau producer
-pfTausProducer = hpsPFTauProducer.clone()
+pfTausProducer = hpsPFTauProducer.clone(
+    src = "pfTausProducerSansRefs"
+)
 pfTausCombiner = combinatoricRecoTaus.clone(
-    jetSrc = "ak4PFJets",
-    piZeroSrc = "pfJetsLegacyHPSPiZeros",
+    jetSrc           = "ak4PFJets",
+    piZeroSrc        = "pfJetsLegacyHPSPiZeros",
     chargedHadronSrc = "pfTauPFJetsRecoTauChargedHadrons"
 )
 for mod in pfTausCombiner.modifiers:
     if mod.name == "TTIworkaround": mod.pfTauTagInfoSrc = "pfTauTagInfoProducer"
 
-pfTausSelectionDiscriminator = hpsSelectionDiscriminator.clone()
-pfTausSelectionDiscriminator.PFTauProducer = cms.InputTag("pfTausCombiner")
-pfTausProducerSansRefs = hpsPFTauProducerSansRefs.clone()
+pfTausSelectionDiscriminator = hpsSelectionDiscriminator.clone(
+    PFTauProducer = "pfTausCombiner"
+)
+pfTausProducerSansRefs = hpsPFTauProducerSansRefs.clone(
+   src = "pfTausCombiner"
+)
 pfTausProducerSansRefs = cms.EDProducer(
     "RecoTauCleaner",
     src = cms.InputTag("pfTausCombiner"),
     outputSelection = cms.string(""),
     verbosity = cms.int32(0),
     cleaners = cms.VPSet(
-    cleaners.unitCharge,
-    cms.PSet(
-    name = cms.string("leadStripPtLt2_5"),
-    plugin = cms.string("RecoTauStringCleanerPlugin"),
-    tolerance = cleaners.tolerance_default,
-    selection = cms.string("signalPiZeroCandidates().size() = 0 | signalPiZeroCandidates()[0].pt > 2.5"),
-    selectionPassFunction = cms.string("0"),
-    selectionFailValue = cms.double(1e3)
-    ),
-    cms.PSet(
-    name = cms.string("HPS_Select"),
-    plugin = cms.string("RecoTauDiscriminantCleanerPlugin"),
-    tolerance = cleaners.tolerance_default,
-    src = cms.InputTag("pfTausSelectionDiscriminator"),
-    ),
-    cleaners.combinedIsolation
+        cleaners.unitCharge,
+        cms.PSet(
+            name = cms.string("leadStripPtLt2_5"),
+            plugin = cms.string("RecoTauStringCleanerPlugin"),
+            tolerance = cleaners.tolerance_default,
+            selection = cms.string("signalPiZeroCandidates().size() = 0 | signalPiZeroCandidates()[0].pt > 2.5"),
+            selectionPassFunction = cms.string("0"),
+            selectionFailValue = cms.double(1e3)
+        ),
+        cms.PSet(
+            name = cms.string("HPS_Select"),
+            plugin = cms.string("RecoTauDiscriminantCleanerPlugin"),
+            tolerance = cleaners.tolerance_default,
+            src = cms.InputTag("pfTausSelectionDiscriminator"),
+        ),
+        cleaners.combinedIsolation
     )
 )
 
-
-
-pfTausProducerSansRefs.src=cms.InputTag("pfTausCombiner")
-pfTausProducer.src = cms.InputTag("pfTausProducerSansRefs")
-
 #cloning discriminants
 
-pfTausDiscriminationByDecayModeFinding = hpsPFTauDiscriminationByDecayModeFinding.clone()
-pfTausDiscriminationByDecayModeFinding.PFTauProducer="pfTausProducer"
-
-pfTausDiscriminationByIsolation= hpsPFTauBasicDiscriminators.clone()
-pfTausDiscriminationByIsolation.PFTauProducer="pfTausProducer"
+pfTausDiscriminationByDecayModeFinding = hpsPFTauDiscriminationByDecayModeFinding.clone(
+    PFTauProducer = "pfTausProducer"
+)
 
 pfTausrequireDecayMode = cms.PSet(
     BooleanOperator = cms.string("and"),
     decayMode = cms.PSet(
-    Producer = cms.InputTag('pfTausDiscriminationByDecayModeFinding'),
-    cut = cms.double(0.5)
+	Producer = cms.InputTag('pfTausDiscriminationByDecayModeFinding'),
+	cut = cms.double(0.5)
     )
 )
 
-pfTausDiscriminationByIsolation.Prediscriminants=pfTausrequireDecayMode.clone()
+pfTausDiscriminationByIsolation= hpsPFTauBasicDiscriminators.clone(
+    PFTauProducer = "pfTausProducer",
+    Prediscriminants = pfTausrequireDecayMode.clone()
+)
 
 # Sequence to reproduce taus and compute our cloned discriminants
 pfTausBaseSequence = cms.Sequence(
@@ -108,11 +109,12 @@ pfTausBaseSequence = cms.Sequence(
    pfTausProducer +
    pfTausDiscriminationByDecayModeFinding *
    pfTausDiscriminationByIsolation
-    )
+)
 
 # Associate track to pfJets
-pfJetTracksAssociatorAtVertex = ak4PFJetTracksAssociatorAtVertex.clone()
-pfJetTracksAssociatorAtVertex.jets= cms.InputTag("ak4PFJets")
+pfJetTracksAssociatorAtVertex = ak4PFJetTracksAssociatorAtVertex.clone(
+    jets = "ak4PFJets"
+)
 
 pfTauPileUpVertices = cms.EDFilter(
     "RecoTauPileUpVertexSelector",
@@ -122,10 +124,10 @@ pfTauPileUpVertices = cms.EDFilter(
 )
 
 
-pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
-pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
-pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
-
+pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone(
+    PFCandidateProducer = jetConfig.ak4PFJets.src ,
+    PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
+)
 pfTausPreSequence = cms.Sequence(
     pfJetTracksAssociatorAtVertex +
     recoTauAK4PFJets08Region +
@@ -134,21 +136,22 @@ pfTausPreSequence = cms.Sequence(
 )
 
 # Select taus from given collection that pass cloned discriminants
-pfTaus = pfTauSelector.clone()
-pfTaus.src = cms.InputTag("pfTausProducer")
-pfTaus.discriminators = cms.VPSet(
-        cms.PSet( discriminator=cms.InputTag("pfTausDiscriminationByDecayModeFinding"),selectionCut=cms.double(0.5) ),
-            )
-
+pfTaus = pfTauSelector.clone(
+    src = "pfTausProducer",
+    discriminators = cms.VPSet(
+        cms.PSet( 
+	    discriminator=cms.InputTag("pfTausDiscriminationByDecayModeFinding"),
+            selectionCut=cms.double(0.5) 
+	),
+    )
+)
 pfTausPtrs = cms.EDProducer("PFTauFwdPtrProducer",
-                             src=cms.InputTag("pfTaus")
-                                                        )
+                            src=cms.InputTag("pfTaus")
+)
 
 pfTauSequence = cms.Sequence(
     pfTausPreSequence +
     pfTausBaseSequence +
     pfTaus +
     pfTausPtrs
- )
-
-
+)

--- a/CommonTools/PileupAlgos/python/PUPuppi_cff.py
+++ b/CommonTools/PileupAlgos/python/PUPuppi_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from CommonTools.PileupAlgos.Puppi_cff import *
 
-pupuppi             = puppi.clone()
-pupuppi.invertPuppi = True
+pupuppi = puppi.clone(
+    invertPuppi = True
+)
 

--- a/CommonTools/RecoAlgos/python/vertexCompositeCandidateCollectionSelector_cfi.py
+++ b/CommonTools/RecoAlgos/python/vertexCompositeCandidateCollectionSelector_cfi.py
@@ -2,11 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 from CommonTools.RecoAlgos.VertexCompositeCandidateCollectionSelector_cfi import VertexCompositeCandidateCollectionSelector
 
-vertexCompositeCandidateCollectionSelector = VertexCompositeCandidateCollectionSelector.clone()
-vertexCompositeCandidateCollectionSelector.v0            = cms.InputTag('generalV0Candidates:Kshort') # generalV0Candidates:Lambda
-vertexCompositeCandidateCollectionSelector.beamSpot      = cms.InputTag('offlineBeamSpot')
-vertexCompositeCandidateCollectionSelector.primaryVertex = cms.InputTag('offlinePrimaryVertices')
-vertexCompositeCandidateCollectionSelector.pvNDOF        = cms.int32(4)
-vertexCompositeCandidateCollectionSelector.lxyCUT        = cms.double( 16.) # cm (2016 pixel layer3:10.2 cm ; 2017 pixel layer4: 16.0 cm)
-vertexCompositeCandidateCollectionSelector.lxyWRTbsCUT   = cms.double(  0.)  # cm
-#vertexCompositeCandidateCollectionSelector.debug         = cms.untracked.bool(False)
+vertexCompositeCandidateCollectionSelector = VertexCompositeCandidateCollectionSelector.clone(
+    v0            = 'generalV0Candidates:Kshort', # generalV0Candidates:Lambda
+    beamSpot      = 'offlineBeamSpot',
+    primaryVertex = 'offlinePrimaryVertices',
+    pvNDOF        = 4,
+    lxyCUT        = 16., # cm (2016 pixel layer3:10.2 cm ; 2017 pixel layer4: 16.0 cm)
+    lxyWRTbsCUT   = 0.,  # cm
+    #debug         = cms.untracked.bool(False)
+)

--- a/CommonTools/RecoUtils/python/pf_pu_assomap_cfi.py
+++ b/CommonTools/RecoUtils/python/pf_pu_assomap_cfi.py
@@ -138,6 +138,6 @@ Tracks2Vertex =	AssociationMaps.clone(
 	 
 	#Choose which map should be created
 	#"VertexToTracks", "TracksToVertex" or "Both"
-	AssociationType = cms.InputTag('TracksToVertex'),
+	AssociationType = 'TracksToVertex',
 	 	 
 )

--- a/CommonTools/RecoUtils/python/pfcand_assomap_cfi.py
+++ b/CommonTools/RecoUtils/python/pfcand_assomap_cfi.py
@@ -138,6 +138,5 @@ PFCands2Vertex = PFCandAssoMap.clone(
 	 
 	  #Choose which map should be created
 	  # "VertexToPFCands", "PFCandsToVertex" or "Both"
-	  AssociationType = cms.InputTag('PFCandsToVertex'),
-	 	 
+	  AssociationType = 'PFCandsToVertex',
 )


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- move all parameter inside the clone

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR for RecoHI is [PR#32031](https://github.com/cms-sw/cmssw/pull/32031), [PR#32386](https://github.com/cms-sw/cmssw/pull/32386), [PR#32396](https://github.com/cms-sw/cmssw/pull/32396))

In this PR, a total of 11 files changed. 

CommonTools/ParticleFlow : 7 files
CommonTools/PileupAlgos : 1 file
CommonTools/RecoAlgos   : 1 file
CommonTools/RecoUtils     : 2 files

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).