### PR TITLE
Rename external tool herwigpp to herwig7

### DIFF
--- a/GeneratorInterface/Herwig7Interface/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="boost"/>
 <use name="hepmc"/>
 <use name="thepeg"/>
-<use name="herwigpp"/>
+<use name="herwig7"/>
 <export>
   <lib name="GeneratorInterfaceHerwig7Interface"/>
 </export>

--- a/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
+++ b/GeneratorInterface/Herwig7Interface/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="SimDataFormats/GeneratorProducts"/>
-<use name="herwigpp"/>
+<use name="herwig7"/>
 <use name="GeneratorInterface/Herwig7Interface"/>
 <library name="GeneratorInterfaceHerwig7HadronizerPlugins" file="Herwig7Hadronizer.cc">
   <use name="GeneratorInterface/Core"/>


### PR DESCRIPTION
#### PR description:

Rename external library herwigpp to herwig7 for consistency with pull request https://github.com/cms-sw/cmsdist/pull/6499. 

#### PR validation:

Tested with runTheMatrix workflow 535 and test command from Herwig twiki.
