### PR TITLE
EgHLT Phase-II showershape fix : 11_3_X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -80,6 +80,11 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);
+    if(recoecalcandref->superCluster()->seed()->seed().det()==DetId::HGCalEE ){ //HGCAL, skip for now
+      clshMap.insert(recoecalcandref, 0);
+      clsh5x5Map.insert(recoecalcandref, 0);
+      continue;
+    }
 
     std::vector<float> vCov;
     double sigmaee;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -68,6 +68,7 @@ void EgammaHLTClusterShapeProducer::fillDescriptions(edm::ConfigurationDescripti
 void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
                                             edm::Event& iEvent,
                                             const edm::EventSetup& iSetup) const {
+
   // Get the HLT filtered objects
   edm::Handle<reco::RecoEcalCandidateCollection> recoecalcandHandle;
   iEvent.getByToken(recoEcalCandidateProducer_, recoecalcandHandle);
@@ -80,7 +81,7 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);
-    if(recoecalcandref->superCluster()->seed()->seed().det()==DetId::HGCalEE ){ //HGCAL, skip for now
+    if(recoecalcandref->superCluster()->seed()->seed().det()!=DetId::Ecal ){ //HGCAL, skip for now
       clshMap.insert(recoecalcandref, 0);
       clsh5x5Map.insert(recoecalcandref, 0);
       continue;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -68,7 +68,6 @@ void EgammaHLTClusterShapeProducer::fillDescriptions(edm::ConfigurationDescripti
 void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
                                             edm::Event& iEvent,
                                             const edm::EventSetup& iSetup) const {
-
   // Get the HLT filtered objects
   edm::Handle<reco::RecoEcalCandidateCollection> recoecalcandHandle;
   iEvent.getByToken(recoEcalCandidateProducer_, recoecalcandHandle);
@@ -81,7 +80,7 @@ void EgammaHLTClusterShapeProducer::produce(edm::StreamID sid,
 
   for (unsigned int iRecoEcalCand = 0; iRecoEcalCand < recoecalcandHandle->size(); iRecoEcalCand++) {
     reco::RecoEcalCandidateRef recoecalcandref(recoecalcandHandle, iRecoEcalCand);
-    if(recoecalcandref->superCluster()->seed()->seed().det()!=DetId::Ecal ){ //HGCAL, skip for now
+    if (recoecalcandref->superCluster()->seed()->seed().det() != DetId::Ecal) {  //HGCAL, skip for now
       clshMap.insert(recoecalcandref, 0);
       clsh5x5Map.insert(recoecalcandref, 0);
       continue;

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTClusterShapeProducer.cc
@@ -12,7 +12,6 @@
 //
 //
 
-// user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"


### PR DESCRIPTION
#### PR description:

This PR disables the calculation of ECAL showershape variables for superclusters which are not in the ECAL. It sets the showershapes to zero so that by default they pass, this makes things easier to build a trigger as it avoids having to OR the ECAL and HGCAL showershape filters (which likely eventually will be made into a single  filter but that is not for today). 

No physics changes are expected, the change in behaviour is a crash is prevented for PhaseII

Backports will follow to 11_1 and 11_2

#### PR validation:

PhaseII E/gamma HLT workflows do not crash. 


