### PR TITLE
ETL v5 (D73)  x,y axes swapped and hardcoded offset removed

### DIFF
--- a/Geometry/MTDCommonData/data/etl/v5/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v5/etl.xml
@@ -11,36 +11,36 @@
     <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>
     <Constant name="Disc_thickness" value="27.9"/>
     <Constant name="Al_Disc_thickness" value="7.24"/>
-    <Constant name="Disc_Rmin" value="310"/>
-    <Constant name="Disc_Rmax" value="1190"/>   
-    <Constant name="DeltaY" value="0.5"/>
-    <Constant name="ServiceHybrid_X" value="34"/>  
-    <Constant name="ServiceHybrid_Y3" value="3*[SensorModule_Y]"/>
-    <Constant name="ServiceHybrid_Y6" value="6*[SensorModule_Y]"/> 
-    <Constant name="ServiceHybrid_Y7" value="7*[SensorModule_Y]"/>   
+    <Constant name="Disc_Rmin" value="300"/>
+    <Constant name="Disc_Rmax" value="1190"/>
+    <Constant name="DeltaX" value="0.5"/>
+    <Constant name="ServiceHybrid_Y" value="34"/>
+    <Constant name="ServiceHybrid_X3" value="3*[SensorModule_X]"/>
+    <Constant name="ServiceHybrid_X6" value="6*[SensorModule_X]"/>
+    <Constant name="ServiceHybrid_X7" value="7*[SensorModule_X]"/>
     <Constant name="ServiceHybrid_Z" value="10.33"/>
-    <Constant name="SensorModule_X" value="25.85"/>  <!-- 28.25mm - 2.4mm overlapping with SH -->
-    <Constant name="SensorModule_Y" value="43.1"/>
+    <Constant name="SensorModule_Y" value="25.85"/>  <!-- 28.25mm - 2.4mm overlapping with SH -->
+    <Constant name="SensorModule_X" value="43.1"/>
     <Constant name="SensorModule_Z" value="2.29"/>
-    <Constant name="DeltaX_ServiceModule" value="29.925"/>  <!-- ServiceHybrid_X/2 + SensorModule_X/2 -->
-    <Constant name="DeltaY_Service3_Service6" value="194.45"/>  <!-- DeltaY + ServiceHybrid_Y3/2 + ServiceHybrid_Y6/2 -->
-    <Constant name="DeltaY_Service3_Service7" value="216"/>  <!-- DeltaY + ServiceHybrid_Y3/2 + ServiceHybrid_Y7/2 -->
-    <Constant name="DeltaY_Service6_Service7" value="280.65"/>  <!-- DeltaY + ServiceHybrid_Y6/2 + ServiceHybrid_Y7/2 -->
-    <Constant name="LGADdx" value="21.2"/> 
-    <Constant name="LGADdy" value="42"/>
+    <Constant name="DeltaY_ServiceModule" value="29.925"/>  <!-- ServiceHybrid_Y/2 + SensorModule_Y/2 -->
+    <Constant name="DeltaX_Service3_Service6" value="194.45"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X6/2 -->
+    <Constant name="DeltaX_Service3_Service7" value="216"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X7/2 -->
+    <Constant name="DeltaX_Service6_Service7" value="280.65"/>  <!-- DeltaX + ServiceHybrid_X6/2 + ServiceHybrid_X7/2 -->
+    <Constant name="LGADdy" value="21.2"/>
+    <Constant name="LGADdx" value="42"/>
     <Constant name="EModule_Timingactive" value="0.05"/> 
     <Constant name="LGAD_Substrate" value="0.25"/>
     <Constant name="LGADdz" value="0.3"/>
-    <Constant name="lgadSep_X" value="0.25"/> 
-    <Constant name="lgadSep_Y" value="0.5"/>  
-    <Constant name="ETROCdx" value="22.3"/>
-    <Constant name="ETROCdy" value="20.8"/>
+    <Constant name="lgadSep_Y" value="0.25"/>
+    <Constant name="lgadSep_X" value="0.5"/>
+    <Constant name="ETROCdy" value="22.3"/>
+    <Constant name="ETROCdx" value="20.8"/>
     <Constant name="ETROCdz" value="0.25"/>
-    <Constant name="etrocSep_X" value="0.3"/>  
-    <Constant name="etrocSep_Y" value="0.1"/>
-    <Constant name="x_start_front" value="1190-33.05-[SensorModule_X]/2"/>
-    <Constant name="x_start_back" value="-1190+16.05+[ServiceHybrid_X]/2"/>
-    <Constant name="y_offset" value="1+[SensorModule_Y]/2"/>
+    <Constant name="etrocSep_Y" value="0.3"/>
+    <Constant name="etrocSep_X" value="0.1"/>
+    <Constant name="y_start_front" value="1190-33.05-[SensorModule_Y]/2"/>
+    <Constant name="y_start_back" value="-1190+16.05+[ServiceHybrid_Y]/2"/>
+    <Constant name="x_offset" value="1+[SensorModule_X]/2"/>
   </ConstantsSection>
 
 
@@ -50,18 +50,18 @@
     <Tubs name="Al_Disc" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[Al_Disc_thickness]*mm" startPhi="0*deg" deltaPhi="360*deg"/>
     
     <!-- FRONT: face closest to IP, BACK: furthest from IP -->
-    <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="0*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
-    <Tubs name="DiscSector_Back" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="0*deg" deltaPhi="180*deg"/> <!-- half-disc on back face -->
+    <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
+    <Tubs name="DiscSector_Back" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on back face -->
     
     <Box name="SensorModule" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*[SensorModule_Z]*mm"/>
-    <Box name="ServiceHybrid3" dx="0.5*[ServiceHybrid_X]*mm" dy="0.5*[ServiceHybrid_Y3]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
-    <Box name="ServiceHybrid6" dx="0.5*[ServiceHybrid_X]*mm" dy="0.5*[ServiceHybrid_Y6]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
-    <Box name="ServiceHybrid7" dx="0.5*[ServiceHybrid_X]*mm" dy="0.5*[ServiceHybrid_Y7]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
+    <Box name="ServiceHybrid3" dx="0.5*[ServiceHybrid_X3]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
+    <Box name="ServiceHybrid6" dx="0.5*[ServiceHybrid_X6]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
+    <Box name="ServiceHybrid7" dx="0.5*[ServiceHybrid_X7]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
     
     <Box name="ThermalPad" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*(0.25)*mm"/>
     <Box name="AlN_Carrier" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*(0.79)*mm"/>
-    <Box name="LairdFilm" dx="0.5*([ETROCdx]+0.5*[etrocSep_X])*mm" dy="0.5*([ETROCdy]*2+[etrocSep_Y])*mm" dz="0.5*(0.08)*mm"/> 
-    <Box name="ETROC" dx="0.5*[ETROCdx]*mm" dy="0.5*[ETROCdy]*mm" dz="0.5*(0.28)*mm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC --> 
+    <Box name="LairdFilm" dx="0.5*([ETROCdx]*2+[etrocSep_X])*mm" dy="0.5*([ETROCdy]+0.5*[etrocSep_Y])*mm" dz="0.5*(0.08)*mm"/>
+    <Box name="ETROC" dx="0.5*[ETROCdx]*mm" dy="0.5*[ETROCdy]*mm" dz="0.5*(0.28)*mm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC -->
     <Box name="LGAD" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[LGADdz]*mm"/>
     <Box name="EModule_Timingactive" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[EModule_Timingactive]*mm"/>
     <Box name="LGAD_Substrate" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[LGAD_Substrate]*mm"/>
@@ -88,15 +88,15 @@
   </Vector>
 
   <Vector name="Offset_Front_Right" type="numeric" nEntries="27">
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset],
-    [y_offset]+5*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+2*([SensorModule_Y]+[DeltaY]),
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset]
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset],
+    [x_offset]+5*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+2*([SensorModule_X]+[DeltaX]),
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset]
   </Vector>
 
   <Vector name="Offset_Front_Left" type="numeric" nEntries="27">
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], 
-    [y_offset]+2*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+5*([SensorModule_Y]+[DeltaY]),
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset]
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset],
+    [x_offset]+2*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+5*([SensorModule_X]+[DeltaX]),
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset]
   </Vector>
 
   <Vector name="StartCopyNo_Back_Right" type="numeric" nEntries="27">
@@ -110,13 +110,13 @@
   </Vector>
 
   <Vector name="Offset_Back_Right" type="numeric" nEntries="27">
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset]+3*([SensorModule_Y]+[DeltaY]),
-    [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), 0.8+[y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+4*([SensorModule_Y]+[DeltaY]), [y_offset],[y_offset], [y_offset], [y_offset], [y_offset], [y_offset], 
-    [y_offset], [y_offset], [y_offset], [y_offset]
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset]+3*([SensorModule_X]+[DeltaX]),
+    [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+4*([SensorModule_X]+[DeltaX]), [x_offset],[x_offset], [x_offset], [x_offset], [x_offset], [x_offset],
+    [x_offset], [x_offset], [x_offset], [x_offset]
   </Vector>
 
   <Vector name="Offset_Back_Left" type="numeric" nEntries="27">
-    [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset]+4*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), 0.8+[y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+8*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+7*([SensorModule_Y]+[DeltaY]), [y_offset]+6*([SensorModule_Y]+[DeltaY]), [y_offset]+3*([SensorModule_Y]+[DeltaY]), [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset], [y_offset]
+    [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset]+4*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+8*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+7*([SensorModule_X]+[DeltaX]), [x_offset]+6*([SensorModule_X]+[DeltaX]), [x_offset]+3*([SensorModule_X]+[DeltaX]), [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset], [x_offset]
   </Vector>
 
 
@@ -224,30 +224,30 @@
     <PosPart copyNumber="1">                                           
       <rParent name="caloBase:CALOECFront"/>               
       <rChild name="etl:EndcapTimingLayer"/>  
-      <Translation x="0." y="0." z="3024.68497*mm" /> 
+      <Translation x="0." y="0." z="3024.68497*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:EndcapTimingLayer"/>                         
       <rChild name="etl:Disc1Timing"/>  
-      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" /> 
+      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:EndcapTimingLayer"/>                         
       <rChild name="etl:Disc2Timing"/>  
-      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" /> 
+      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" />
     </PosPart> 
     
     <!-- Children volumes Disc1Timing -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:Al_Disc"/> 
-      <Translation x="0*mm" y="0*mm" z="0*mm" />  
+      <Translation x="0*mm" y="0*mm" z="0*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Front"/> 
       <rRotation name="etl:0"/> 
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />  
+      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
     </PosPart> 
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc1Timing"/>                         
@@ -259,7 +259,7 @@
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>  
       <rRotation name="etl:0"/>
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />  
+      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc1Timing"/>                         
@@ -272,13 +272,13 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:Al_Disc"/> 
-      <Translation x="0*mm" y="0*mm" z="0*mm" />  
+      <Translation x="0*mm" y="0*mm" z="0*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Front"/> 
       <rRotation name="etl:0"/> 
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />  
+      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
     </PosPart> 
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc2Timing"/>                         
@@ -290,7 +290,7 @@
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>  
       <rRotation name="etl:0"/>
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />  
+      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc2Timing"/>                         
@@ -313,22 +313,22 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="1.7" y="0." z="0.065*mm" />
+      <Translation x="0." y="1.7" z="0.065*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="1.625*mm" y="10.45*mm" z="-0.115*mm" />
+      <Translation x="10.45*mm" y="1.625*mm" z="-0.115*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="1.625*mm" y="-10.45*mm" z="-0.115*mm" />
+      <Translation x="-10.45*mm" y="1.625*mm" z="-0.115*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:LGAD"/>  
-      <Translation x="2.2*mm" y="0." z="-0.405*mm" />
+      <Translation x="0." y="2.2*mm" z="-0.405*mm" />
     </PosPart>
     <!-- definition of LGAD active/substrate volumes -->
     <PosPart copyNumber="1">                                           
@@ -344,7 +344,7 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="2.2*mm" y="0." z="-0.85*mm" /> 
+      <Translation x="0." y="2.2*mm" z="-0.85*mm" />
     </PosPart> 
     
     <!-- Elements composing SensorModule_Front_Left -->
@@ -361,27 +361,27 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="-0.17" y="0." z="0.065*mm" />
+      <Translation x="0." y="-0.17" z="0.065*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-1.625*mm" y="10.45*mm" z="-0.115*mm" />
+      <Translation x="10.45*mm" y="-1.625*mm" z="-0.115*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-1.625*mm" y="-10.45*mm" z="-0.115*mm" />
+      <Translation x="-10.45*mm" y="-1.625*mm" z="-0.115*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:LGAD"/>  
-      <Translation x="-2.2*mm" y="0." z="-0.405*mm" />
+      <Translation x="0." y="-2.2*mm" z="-0.405*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="-2.2*mm" y="0." z="-0.85*mm" /> 
+      <Translation x="0." y="-2.2*mm" z="-0.85*mm" />
     </PosPart>
 
     <!-- Elements composing SensorModule_Back_Left -->
@@ -398,28 +398,28 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="0.17" y="0." z="-0.065*mm" />
+      <Translation x="0." y="0.17" z="-0.065*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="1.625*mm" y="10.45*mm" z="0.115*mm" />
+      <Translation x="10.45*mm" y="1.625*mm" z="0.115*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="1.625*mm" y="-10.45*mm" z="0.115*mm" />
+      <Translation x="-10.45*mm" y="1.625*mm" z="0.115*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:LGAD"/>
       <rRotation name="etl:Reverse" />  
-      <Translation x="2.2*mm" y="0." z="0.405*mm" />
+      <Translation x="0." y="2.2*mm" z="0.405*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="2.2*mm" y="0." z="0.85*mm" /> 
+      <Translation x="0." y="2.2*mm" z="0.85*mm" />
     </PosPart>
 
     <!-- Elements composing SensorModule_Back_Right -->
@@ -436,28 +436,28 @@
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="-0.17" y="0." z="-0.065*mm" />
+      <Translation x="0." y="-0.17" z="-0.065*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-1.625*mm" y="10.45*mm" z="0.115*mm" />
+      <Translation x="10.45*mm" y="-1.625*mm" z="0.115*mm" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-1.625*mm" y="-10.45*mm" z="0.115*mm" />
+      <Translation x="-10.45*mm" y="-1.625*mm" z="0.115*mm" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:LGAD"/>  
       <rRotation name="etl:Reverse" />
-      <Translation x="-2.2*mm" y="0." z="0.405*mm" />
+      <Translation x="0." y="-2.2*mm" z="0.405*mm" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="-2.2*mm" y="0." z="0.85*mm" />
+      <Translation x="0." y="-2.2*mm" z="0.85*mm" />
     </PosPart>     
   </PosPartSection> 
 
@@ -474,10 +474,10 @@
     <Numeric name="N" value="6"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -487,10 +487,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-[DeltaX_ServiceModule])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_front]-[DeltaY_ServiceModule])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -500,10 +500,10 @@
     <Numeric name="N" value="7"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-2*[DeltaX_ServiceModule])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-2*[DeltaY_ServiceModule])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -513,10 +513,10 @@
     <Numeric name="N" value="11"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-2*[DeltaX_ServiceModule]-[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-2*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -526,10 +526,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-3*[DeltaX_ServiceModule]-[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -539,10 +539,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-3*[DeltaX_ServiceModule]-[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -552,10 +552,10 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-4*[DeltaX_ServiceModule]-[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-4*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -565,10 +565,10 @@
     <Numeric name="N" value="15"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-4*[DeltaX_ServiceModule]-2*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-4*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -578,10 +578,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-5*[DeltaX_ServiceModule]-2*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -591,10 +591,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-5*[DeltaX_ServiceModule]-2*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -604,10 +604,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-5*[DeltaX_ServiceModule]-2*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -617,10 +617,10 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-6*[DeltaX_ServiceModule]-2*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-6*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -630,10 +630,10 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-6*[DeltaX_ServiceModule]-3*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-6*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -643,10 +643,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-7*[DeltaX_ServiceModule]-3*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-7*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -656,10 +656,10 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="37"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-8*[DeltaX_ServiceModule]-3*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-8*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -669,10 +669,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="50"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-8*[DeltaX_ServiceModule]-4*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-8*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -682,10 +682,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-9*[DeltaX_ServiceModule]-4*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -695,10 +695,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-9*[DeltaX_ServiceModule]-4*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -708,10 +708,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="55"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-10*[DeltaX_ServiceModule]-4*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-10*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -721,10 +721,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="69"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-10*[DeltaX_ServiceModule]-5*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-10*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -734,10 +734,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-11*[DeltaX_ServiceModule]-5*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -747,10 +747,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-11*[DeltaX_ServiceModule]-5*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -760,10 +760,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-11*[DeltaX_ServiceModule]-5*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -773,10 +773,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="75"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-12*[DeltaX_ServiceModule]-5*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-12*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -786,10 +786,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="90"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-12*[DeltaX_ServiceModule]-6*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -799,10 +799,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-13*[DeltaX_ServiceModule]-6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -812,10 +812,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-13*[DeltaX_ServiceModule]-6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -825,10 +825,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-13*[DeltaX_ServiceModule]-6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -838,10 +838,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="97"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-14*[DeltaX_ServiceModule]-6*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-14*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -851,10 +851,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="112"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-14*[DeltaX_ServiceModule]-7*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -864,10 +864,10 @@
     <Numeric name="N" value="4"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-15*[DeltaX_ServiceModule]-7*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-15*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -877,10 +877,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="120"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-16*[DeltaX_ServiceModule]-7*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-16*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -890,10 +890,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="136"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-16*[DeltaX_ServiceModule]-8*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-16*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -903,10 +903,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-17*[DeltaX_ServiceModule]-8*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -916,10 +916,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-17*[DeltaX_ServiceModule]-8*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+2*[ServiceHybrid_Y6]+2*[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -929,10 +929,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="144"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-18*[DeltaX_ServiceModule]-8*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-18*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -942,10 +942,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="161"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-18*[DeltaX_ServiceModule]-9*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -955,10 +955,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-19*[DeltaX_ServiceModule]-9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -968,10 +968,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-19*[DeltaX_ServiceModule]-9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -981,10 +981,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-19*[DeltaX_ServiceModule]-9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -994,10 +994,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="169"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-20*[DeltaX_ServiceModule]-9*[SensorModule_X])*mm, ([y_offset]+2*[SensorModule_Y]+2*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX])*mm, ([y_start_front]-20*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1007,10 +1007,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="186"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-20*[DeltaX_ServiceModule]-10*[SensorModule_X])*mm, ([y_offset]+5*[SensorModule_Y]+5*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX])*mm, ([y_start_front]-20*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1020,10 +1020,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-21*[DeltaX_ServiceModule]-10*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1033,10 +1033,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-21*[DeltaX_ServiceModule]-10*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1046,10 +1046,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="193"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-22*[DeltaX_ServiceModule]-10*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-22*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1059,10 +1059,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="207"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-22*[DeltaX_ServiceModule]-11*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-22*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1072,10 +1072,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-23*[DeltaX_ServiceModule]-11*[SensorModule_X])*mm, (5.78+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1085,10 +1085,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-23*[DeltaX_ServiceModule]-11*[SensorModule_X])*mm, (5.78+[y_offset]+7*[SensorModule_Y]+6*[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1098,10 +1098,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="213"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-24*[DeltaX_ServiceModule]-11*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-24*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1111,10 +1111,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="227"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-24*[DeltaX_ServiceModule]-12*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-24*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1124,10 +1124,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-25*[DeltaX_ServiceModule]-12*[SensorModule_X])*mm, (5.7+[y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1137,10 +1137,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="12"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-25*[DeltaX_ServiceModule]-12*[SensorModule_X])*mm, (5.7+[y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1150,10 +1150,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="233"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-26*[DeltaX_ServiceModule]-12*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-26*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1163,10 +1163,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="247"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-26*[DeltaX_ServiceModule]-13*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-26*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1176,10 +1176,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-27*[DeltaX_ServiceModule]-13*[SensorModule_X])*mm, ([y_offset]+9*[SensorModule_Y]+9*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1189,10 +1189,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="24"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-27*[DeltaX_ServiceModule]-13*[SensorModule_X])*mm, ([y_offset]+9*[SensorModule_Y]+9*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1202,10 +1202,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-27*[DeltaX_ServiceModule]-13*[SensorModule_X])*mm, ([y_offset]+9*[SensorModule_Y]+9*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1215,10 +1215,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="252"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-28*[DeltaX_ServiceModule]-13*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-28*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1228,10 +1228,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="266"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-28*[DeltaX_ServiceModule]-14*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-28*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1241,10 +1241,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="12"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-29*[DeltaX_ServiceModule]-14*[SensorModule_X])*mm, (5.7+[y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1254,10 +1254,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-29*[DeltaX_ServiceModule]-14*[SensorModule_X])*mm, (5.7+[y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1267,10 +1267,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="271"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-30*[DeltaX_ServiceModule]-14*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-30*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1280,10 +1280,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="285"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-30*[DeltaX_ServiceModule]-15*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-30*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1293,10 +1293,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-31*[DeltaX_ServiceModule]-15*[SensorModule_X])*mm, (5.78+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1306,10 +1306,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-31*[DeltaX_ServiceModule]-15*[SensorModule_X])*mm, (5.78+[y_offset]+7*[SensorModule_Y]+6*[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1319,10 +1319,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="291"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-32*[DeltaX_ServiceModule]-15*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-32*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1332,10 +1332,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="305"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-32*[DeltaX_ServiceModule]-16*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-32*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1345,10 +1345,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-33*[DeltaX_ServiceModule]-16*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1358,10 +1358,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-33*[DeltaX_ServiceModule]-16*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1371,10 +1371,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="311"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-34*[DeltaX_ServiceModule]-16*[SensorModule_X])*mm, ([y_offset]+5*[SensorModule_Y]+5*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX])*mm, ([y_start_front]-34*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1384,10 +1384,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="325"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-34*[DeltaX_ServiceModule]-17*[SensorModule_X])*mm, ([y_offset]+2*[SensorModule_Y]+2*[DeltaY])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX])*mm, ([y_start_front]-34*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1397,10 +1397,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-35*[DeltaX_ServiceModule]-17*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1410,10 +1410,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="31"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-35*[DeltaX_ServiceModule]-17*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1423,10 +1423,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-35*[DeltaX_ServiceModule]-17*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1436,10 +1436,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="332"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-36*[DeltaX_ServiceModule]-17*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-36*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1449,10 +1449,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="349"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-36*[DeltaX_ServiceModule]-18*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1462,10 +1462,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="32"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-37*[DeltaX_ServiceModule]-18*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1475,10 +1475,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-37*[DeltaX_ServiceModule]-18*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+2*[ServiceHybrid_Y6]+2*[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1488,10 +1488,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="357"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-38*[DeltaX_ServiceModule]-18*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-38*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1501,10 +1501,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="374"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-38*[DeltaX_ServiceModule]-19*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-38*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1514,10 +1514,10 @@
     <Numeric name="N" value="4"/>
     <Numeric name="StartCopyNo" value="35"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-39*[DeltaX_ServiceModule]-19*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-39*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1527,10 +1527,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="382"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-40*[DeltaX_ServiceModule]-19*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-40*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1540,10 +1540,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="398"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-40*[DeltaX_ServiceModule]-20*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1553,10 +1553,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-41*[DeltaX_ServiceModule]-20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1566,10 +1566,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="39"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-41*[DeltaX_ServiceModule]-20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1579,10 +1579,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-41*[DeltaX_ServiceModule]-20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1592,10 +1592,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="406"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-42*[DeltaX_ServiceModule]-20*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-42*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1605,10 +1605,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="421"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-42*[DeltaX_ServiceModule]-21*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1618,10 +1618,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-43*[DeltaX_ServiceModule]-21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1631,10 +1631,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="40"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-43*[DeltaX_ServiceModule]-21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1644,10 +1644,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="22"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-43*[DeltaX_ServiceModule]-21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1657,10 +1657,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="428"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-44*[DeltaX_ServiceModule]-21*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-44*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1670,10 +1670,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="443"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-44*[DeltaX_ServiceModule]-22*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-44*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1683,10 +1683,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="42"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-45*[DeltaX_ServiceModule]-22*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1696,10 +1696,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-45*[DeltaX_ServiceModule]-22*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1709,10 +1709,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="449"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-46*[DeltaX_ServiceModule]-22*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-46*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1722,10 +1722,10 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="463"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-46*[DeltaX_ServiceModule]-23*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-46*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1735,10 +1735,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="43"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-47*[DeltaX_ServiceModule]-23*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-47*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1748,10 +1748,10 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="468"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-48*[DeltaX_ServiceModule]-23*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-48*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1761,10 +1761,10 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="481"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-48*[DeltaX_ServiceModule]-24*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-48*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1774,10 +1774,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-49*[DeltaX_ServiceModule]-24*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1787,10 +1787,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="46"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-49*[DeltaX_ServiceModule]-24*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1800,10 +1800,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-49*[DeltaX_ServiceModule]-24*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1813,10 +1813,10 @@
     <Numeric name="N" value="15"/>
     <Numeric name="StartCopyNo" value="485"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-50*[DeltaX_ServiceModule]-24*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-50*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1826,10 +1826,10 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="497"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-50*[DeltaX_ServiceModule]-25*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-50*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1839,10 +1839,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="47"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-51*[DeltaX_ServiceModule]-25*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1852,10 +1852,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="26"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-51*[DeltaX_ServiceModule]-25*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1865,10 +1865,10 @@
     <Numeric name="N" value="11"/>
     <Numeric name="StartCopyNo" value="500"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-52*[DeltaX_ServiceModule]-25*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-52*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1878,10 +1878,10 @@
     <Numeric name="N" value="7"/>
     <Numeric name="StartCopyNo" value="510"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-52*[DeltaX_ServiceModule]-26*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-52*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1891,10 +1891,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="27"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-53*[DeltaX_ServiceModule]-26*[SensorModule_X])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_front]-53*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1904,10 +1904,10 @@
     <Numeric name="N" value="6"/>
     <Numeric name="StartCopyNo" value="511"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_front]-54*[DeltaX_ServiceModule]-26*[SensorModule_X])*mm, ([y_offset])*mm, 4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-54*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1924,10 +1924,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1937,10 +1937,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+[DeltaX_ServiceModule])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+[DeltaY_ServiceModule])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1950,10 +1950,10 @@
     <Numeric name="N" value="9"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+[DeltaX_ServiceModule]+[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+[DeltaY_ServiceModule]+[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1963,10 +1963,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+2*[DeltaX_ServiceModule]+[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1976,10 +1976,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+2*[DeltaX_ServiceModule]+[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -1989,10 +1989,10 @@
     <Numeric name="N" value="10"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+3*[DeltaX_ServiceModule]+[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+3*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2002,10 +2002,10 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+3*[DeltaX_ServiceModule]+2*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+3*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2015,10 +2015,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+4*[DeltaX_ServiceModule]+2*[SensorModule_X])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+4*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2028,10 +2028,10 @@
     <Numeric name="N" value="14"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+5*[DeltaX_ServiceModule]+2*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2041,10 +2041,10 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+5*[DeltaX_ServiceModule]+3*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+5*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2054,10 +2054,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+6*[DeltaX_ServiceModule]+3*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2067,10 +2067,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+6*[DeltaX_ServiceModule]+3*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2080,10 +2080,10 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+7*[DeltaX_ServiceModule]+3*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+7*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2093,10 +2093,10 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="39"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+7*[DeltaX_ServiceModule]+4*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+7*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2106,10 +2106,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+8*[DeltaX_ServiceModule]+4*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2119,10 +2119,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+8*[DeltaX_ServiceModule]+4*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2132,10 +2132,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="45"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+9*[DeltaX_ServiceModule]+4*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+9*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2145,10 +2145,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="57"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+9*[DeltaX_ServiceModule]+5*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+9*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2158,10 +2158,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+10*[DeltaX_ServiceModule]+5*[SensorModule_X])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+10*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2171,10 +2171,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="64"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+11*[DeltaX_ServiceModule]+5*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2184,10 +2184,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="77"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+11*[DeltaX_ServiceModule]+6*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+11*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2197,10 +2197,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+12*[DeltaX_ServiceModule]+6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2210,10 +2210,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+12*[DeltaX_ServiceModule]+6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2223,10 +2223,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+12*[DeltaX_ServiceModule]+6*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2236,10 +2236,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="85"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+13*[DeltaX_ServiceModule]+6*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2249,10 +2249,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="99"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+13*[DeltaX_ServiceModule]+7*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+13*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2262,10 +2262,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="5"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+14*[DeltaX_ServiceModule]+7*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2275,10 +2275,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="5"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+14*[DeltaX_ServiceModule]+7*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2288,10 +2288,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="11"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+14*[DeltaX_ServiceModule]+7*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2301,10 +2301,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="107"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+15*[DeltaX_ServiceModule]+7*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+15*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2314,10 +2314,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="122"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+15*[DeltaX_ServiceModule]+8*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+15*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2327,10 +2327,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+16*[DeltaX_ServiceModule]+8*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2340,10 +2340,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+16*[DeltaX_ServiceModule]+8*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2353,10 +2353,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="130"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+17*[DeltaX_ServiceModule]+8*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+17*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2366,10 +2366,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="146"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+17*[DeltaX_ServiceModule]+9*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+17*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2379,10 +2379,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+18*[DeltaX_ServiceModule]+9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2392,10 +2392,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+18*[DeltaX_ServiceModule]+9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2405,10 +2405,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+18*[DeltaX_ServiceModule]+9*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2418,10 +2418,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="154"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+19*[DeltaX_ServiceModule]+9*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2431,10 +2431,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="171"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+19*[DeltaX_ServiceModule]+10*[SensorModule_X])*mm, ([y_offset]+3*[SensorModule_Y]+3*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX])*mm, ([y_start_back]+19*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2444,10 +2444,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+20*[DeltaX_ServiceModule]+10*[SensorModule_X])*mm, ([y_offset]+4*[SensorModule_Y]+4*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2457,10 +2457,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+20*[DeltaX_ServiceModule]+10*[SensorModule_X])*mm, ([y_offset]+4*[SensorModule_Y]+4*[DeltaY]+2*[ServiceHybrid_Y3]+2*[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2470,10 +2470,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="179"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+21*[DeltaX_ServiceModule]+10*[SensorModule_X])*mm, (1+[y_offset]+4*[SensorModule_Y]+4*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+21*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2483,10 +2483,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="194"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+21*[DeltaX_ServiceModule]+11*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+21*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2496,10 +2496,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+22*[DeltaX_ServiceModule]+11*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2509,10 +2509,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+22*[DeltaX_ServiceModule]+11*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2522,10 +2522,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="201"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+23*[DeltaX_ServiceModule]+11*[SensorModule_X])*mm, (1+[y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+23*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2535,10 +2535,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="214"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+23*[DeltaX_ServiceModule]+12*[SensorModule_X])*mm, (0.8+[SensorModule_Y]/2+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+23*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2548,10 +2548,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+24*[DeltaX_ServiceModule]+12*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2561,10 +2561,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+24*[DeltaX_ServiceModule]+12*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2574,10 +2574,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="221"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+25*[DeltaX_ServiceModule]+12*[SensorModule_X])*mm, (0.8+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+25*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2587,10 +2587,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="234"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+25*[DeltaX_ServiceModule]+13*[SensorModule_X])*mm, (0.8+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+25*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2600,10 +2600,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+26*[DeltaX_ServiceModule]+13*[SensorModule_X])*mm, (5+[y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2613,10 +2613,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+26*[DeltaX_ServiceModule]+13*[SensorModule_X])*mm, (5+[y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2626,10 +2626,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="241"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+27*[DeltaX_ServiceModule]+13*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2639,10 +2639,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="254"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+27*[DeltaX_ServiceModule]+14*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+27*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2652,10 +2652,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+28*[DeltaX_ServiceModule]+14*[SensorModule_X])*mm, (5+[y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2665,10 +2665,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="22"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+28*[DeltaX_ServiceModule]+14*[SensorModule_X])*mm, (5+[y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2678,10 +2678,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="260"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+29*[DeltaX_ServiceModule]+14*[SensorModule_X])*mm, (0.8+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+29*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2691,10 +2691,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="273"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+29*[DeltaX_ServiceModule]+15*[SensorModule_X])*mm, (0.8+[y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+29*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2704,10 +2704,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+30*[DeltaX_ServiceModule]+15*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2717,10 +2717,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="24"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+30*[DeltaX_ServiceModule]+15*[SensorModule_X])*mm, ([y_offset]+8*[SensorModule_Y]+8*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2730,10 +2730,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="280"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+31*[DeltaX_ServiceModule]+15*[SensorModule_X])*mm, (0.8+[SensorModule_Y]/2+7*[SensorModule_Y]+7*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+31*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2743,10 +2743,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="293"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+31*[DeltaX_ServiceModule]+16*[SensorModule_X])*mm, (1+[y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+31*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2756,10 +2756,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+32*[DeltaX_ServiceModule]+16*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2769,10 +2769,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="26"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+32*[DeltaX_ServiceModule]+16*[SensorModule_X])*mm, ([y_offset]+7*[SensorModule_Y]+7*[DeltaY]+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2782,10 +2782,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="300"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+33*[DeltaX_ServiceModule]+16*[SensorModule_X])*mm, ([y_offset]+6*[SensorModule_Y]+6*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+33*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2795,10 +2795,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="313"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+33*[DeltaX_ServiceModule]+17*[SensorModule_X])*mm, (1+[y_offset]+4*[SensorModule_Y]+4*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+33*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2808,10 +2808,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+34*[DeltaX_ServiceModule]+17*[SensorModule_X])*mm, ([y_offset]+4*[SensorModule_Y]+4*[DeltaY])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2821,10 +2821,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+34*[DeltaX_ServiceModule]+17*[SensorModule_X])*mm, ([y_offset]+4*[SensorModule_Y]+4*[DeltaY]+2*[ServiceHybrid_Y3]+2*[DeltaY]+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2834,10 +2834,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="320"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+35*[DeltaX_ServiceModule]+17*[SensorModule_X])*mm, ([y_offset]+3*[SensorModule_Y]+3*[DeltaY])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX])*mm, ([y_start_back]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2847,10 +2847,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="335"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+35*[DeltaX_ServiceModule]+18*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+35*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2860,10 +2860,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+36*[DeltaX_ServiceModule]+18*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2873,10 +2873,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="11"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+36*[DeltaX_ServiceModule]+18*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2886,10 +2886,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="30"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+36*[DeltaX_ServiceModule]+18*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2899,10 +2899,10 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="343"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+37*[DeltaX_ServiceModule]+18*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+37*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2912,10 +2912,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="360"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+37*[DeltaX_ServiceModule]+19*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+37*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2925,10 +2925,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="30"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+38*[DeltaX_ServiceModule]+19*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2938,10 +2938,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+38*[DeltaX_ServiceModule]+19*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[ServiceHybrid_Y3]+[DeltaY]+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2951,10 +2951,10 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="368"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+39*[DeltaX_ServiceModule]+19*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+39*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2964,10 +2964,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="384"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+39*[DeltaX_ServiceModule]+20*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+39*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2977,10 +2977,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="32"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+40*[DeltaX_ServiceModule]+20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -2990,10 +2990,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+40*[DeltaX_ServiceModule]+20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3003,10 +3003,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="31"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+40*[DeltaX_ServiceModule]+20*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3016,10 +3016,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="392"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+41*[DeltaX_ServiceModule]+20*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3029,10 +3029,10 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="407"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+41*[DeltaX_ServiceModule]+21*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+41*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3042,10 +3042,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+42*[DeltaX_ServiceModule]+21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3055,10 +3055,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+42*[DeltaX_ServiceModule]+21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3068,10 +3068,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+42*[DeltaX_ServiceModule]+21*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service6]+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3081,10 +3081,10 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="415"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+43*[DeltaX_ServiceModule]+21*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3094,10 +3094,10 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="430"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+43*[DeltaX_ServiceModule]+22*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+43*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3107,10 +3107,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="34"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+44*[DeltaX_ServiceModule]+22*[SensorModule_X])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+44*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3120,10 +3120,10 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="437"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+45*[DeltaX_ServiceModule]+22*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+45*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3133,10 +3133,10 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="451"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+45*[DeltaX_ServiceModule]+23*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+45*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3146,10 +3146,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y6]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+46*[DeltaX_ServiceModule]+23*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3159,10 +3159,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="37"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+46*[DeltaX_ServiceModule]+23*[SensorModule_X])*mm, (1+[ServiceHybrid_Y6]/2+[ServiceHybrid_Y6]+[DeltaY]+[DeltaY_Service6_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3172,10 +3172,10 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="457"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+47*[DeltaX_ServiceModule]+23*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+47*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3185,10 +3185,10 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="470"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+47*[DeltaX_ServiceModule]+24*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+47*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3198,10 +3198,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="34"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+48*[DeltaX_ServiceModule]+24*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3211,10 +3211,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="38"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+48*[DeltaX_ServiceModule]+24*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3224,10 +3224,10 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="475"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+49*[DeltaX_ServiceModule]+24*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3237,10 +3237,10 @@
     <Numeric name="N" value="14"/>
     <Numeric name="StartCopyNo" value="487"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+49*[DeltaX_ServiceModule]+25*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+49*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3250,10 +3250,10 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="40"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+50*[DeltaX_ServiceModule]+25*[SensorModule_X])*mm, (1+[ServiceHybrid_Y7]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+50*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3263,10 +3263,10 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="491"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+51*[DeltaX_ServiceModule]+25*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+51*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3276,10 +3276,10 @@
     <Numeric name="N" value="10"/>
     <Numeric name="StartCopyNo" value="501"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+51*[DeltaX_ServiceModule]+26*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+51*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3289,10 +3289,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="35"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+52*[DeltaX_ServiceModule]+26*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3302,10 +3302,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="42"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y7]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+52*[DeltaX_ServiceModule]+26*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2+[DeltaY_Service3_Service7])*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3315,10 +3315,10 @@
     <Numeric name="N" value="9"/>
     <Numeric name="StartCopyNo" value="504"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+53*[DeltaX_ServiceModule]+26*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+53*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3328,10 +3328,10 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="511"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_Y]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+53*[DeltaX_ServiceModule]+27*[SensorModule_X])*mm, ([y_offset])*mm, -4.02*mm </Vector> 
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+53*[DeltaY_ServiceModule]+27*[SensorModule_Y])*mm, -4.02*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>
@@ -3341,10 +3341,10 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="36"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_Y3]+[DeltaY])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_start_back]+54*[DeltaX_ServiceModule]+27*[SensorModule_X])*mm, (1+[ServiceHybrid_Y3]/2)*mm, 0.*mm </Vector> 
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+54*[DeltaY_ServiceModule]+27*[SensorModule_Y])*mm, 0.*mm </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
-    <Numeric name="Phi" value="90.*deg"/>
+    <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
     <Numeric name="Phi_obj" value="0.*deg"/>
   </Algorithm>

--- a/Geometry/MTDCommonData/data/etl/v5/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v5/etl.xml
@@ -2,7 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/mms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/mms/DDL ../../../../DetectorDescription/Schema/DDLSchema.xsd">
 
   <!-- Unit of measurement: mm  -->
-  <ConstantsSection label="etl.xml" eval="true/false">
+  <ConstantsSection label="etl.xml" eval="true">
     <Constant name="ETLthickness" value="([caloBase:Zpos110]-[caloBase:Zpos100])-0.4*mm"/>
     <Constant name="ETLcenter" value="0.5*([caloBase:Zpos110]+[caloBase:Zpos100])"/>
     <Constant name="Disc1center" value="3000.42*mm+0.2*mm"/>


### PR DESCRIPTION
#### PR description:

X and y axes, along which ETL modules and service hybrids are placed, have been swapped, and the phi angle of the disks has been properly adapted. In addition, hardcoded offsets previously introduced have been removed. These changes fix the errors present in the previous version, according to what has been presented by N. Koss at the [last CMS week](https://indico.cern.ch/event/976439/contributions/4112355/attachments/2155795/3636313/2020-12-03_MTD%20mechanics%20and%20services.pdf)

#### PR validation:
Visualization of the geometry with Fireworks
Verified there are no overlaps with g4OverlapCheck_cfg.py
Check of the modules position by comparing x,y,z coordinates with the ones in the log produced by testMTDinDD4hep.py

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
