### PR TITLE
Plugins for Phase-2 L1T-HLT (11.1.x backport)

### DIFF
--- a/HLTrigger/HLTfilters/plugins/L1TEnergySumFilterT.h
+++ b/HLTrigger/HLTfilters/plugins/L1TEnergySumFilterT.h
@@ -1,0 +1,132 @@
+#ifndef HLTrigger_HLTfilters_L1TEnergySumFilterT_h
+#define HLTrigger_HLTfilters_L1TEnergySumFilterT_h
+
+#include <vector>
+#include <iterator>
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+template <typename T>
+class L1TEnergySumFilterT : public HLTFilter {
+public:
+  explicit L1TEnergySumFilterT(const edm::ParameterSet&);
+  ~L1TEnergySumFilterT() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 edm::EventSetup const&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag const l1tSumTag_;
+  edm::EDGetTokenT<std::vector<T>> const l1tSumToken_;
+
+  trigger::TriggerObjectType const l1tSumType_;
+  double const minPt_;
+
+  edm::ParameterSet scalings_;
+  std::vector<double> theScalings_;
+
+  static trigger::TriggerObjectType typeOfL1TSum(std::string const&);
+
+  double offlineEnergySum(double const Et) const;
+};
+
+template <typename T>
+L1TEnergySumFilterT<T>::L1TEnergySumFilterT(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1tSumTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+      l1tSumToken_(consumes<std::vector<T>>(l1tSumTag_)),
+      l1tSumType_(typeOfL1TSum(iConfig.getParameter<std::string>("TypeOfSum"))),
+      minPt_(iConfig.getParameter<double>("MinPt")) {
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  theScalings_ = scalings_.getParameter<std::vector<double>>("theScalings");
+}
+
+template <typename T>
+L1TEnergySumFilterT<T>::~L1TEnergySumFilterT() = default;
+
+template <typename T>
+trigger::TriggerObjectType L1TEnergySumFilterT<T>::typeOfL1TSum(std::string const& typeOfSum) {
+  trigger::TriggerObjectType sumEnum;
+
+  if (typeOfSum == "MET")
+    sumEnum = trigger::TriggerObjectType::TriggerL1PFMET;
+  else if (typeOfSum == "ETT")
+    sumEnum = trigger::TriggerObjectType::TriggerL1PFETT;
+  else if (typeOfSum == "HT")
+    sumEnum = trigger::TriggerObjectType::TriggerL1PFHT;
+  else if (typeOfSum == "MHT")
+    sumEnum = trigger::TriggerObjectType::TriggerL1PFMHT;
+  else {
+    throw cms::Exception("ConfigurationError")
+        << "Wrong type of energy sum: \"" << typeOfSum << "\" (valid choices are: MET, ETT, HT, MHT)";
+  }
+
+  return sumEnum;
+}
+
+template <typename T>
+void L1TEnergySumFilterT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("L1PFEnergySums"));
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double>>("theScalings", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  desc.add<std::string>("TypeOfSum", "HT");
+  desc.add<double>("MinPt", -1.);
+  descriptions.add(defaultModuleLabel<L1TEnergySumFilterT<T>>(), desc);
+}
+
+template <typename T>
+bool L1TEnergySumFilterT<T>::hltFilter(edm::Event& iEvent,
+                                       edm::EventSetup const& iSetup,
+                                       trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1tSumTag_);
+  }
+
+  auto const& l1tSums = iEvent.getHandle(l1tSumToken_);
+
+  int nSum(0);
+  for (auto iSum = l1tSums->begin(); iSum != l1tSums->end(); ++iSum) {
+    double offlinePt = 0.0;
+    // pt or sumEt?
+    if (l1tSumType_ == trigger::TriggerObjectType::TriggerL1PFMET or
+        l1tSumType_ == trigger::TriggerObjectType::TriggerL1PFMHT) {
+      offlinePt = offlineEnergySum(iSum->pt());
+    } else if (l1tSumType_ == trigger::TriggerObjectType::TriggerL1PFETT or
+               l1tSumType_ == trigger::TriggerObjectType::TriggerL1PFHT) {
+      offlinePt = offlineEnergySum(iSum->sumEt());
+    }
+
+    if (offlinePt >= minPt_) {
+      ++nSum;
+      edm::Ref<std::vector<T>> ref(l1tSums, std::distance(l1tSums->begin(), iSum));
+      filterproduct.addObject(l1tSumType_, ref);
+    }
+  }
+
+  // return final filter decision
+  return nSum > 0;
+}
+
+template <typename T>
+double L1TEnergySumFilterT<T>::offlineEnergySum(double const Et) const {
+  return (theScalings_.at(0) + Et * theScalings_.at(1) + Et * Et * theScalings_.at(2));
+}
+
+#endif  // HLTrigger_HLTfilters_L1TEnergySumFilterT_h

--- a/HLTrigger/HLTfilters/plugins/L1THPSPFTauFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/L1THPSPFTauFilter.cc
@@ -1,0 +1,121 @@
+/** \class L1THPSPFTauFilter
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Martin Grunewald
+ *  \author Sandeep Bhowmik 
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "L1THPSPFTauFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+L1THPSPFTauFilter::L1THPSPFTauFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1HPSPFTauTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+      hpspfTauToken_(consumes<l1t::HPSPFTauCollection>(l1HPSPFTauTag_)) {
+  min_Pt_ = iConfig.getParameter<double>("MinPt");
+  min_N_ = iConfig.getParameter<int>("MinN");
+  min_Eta_ = iConfig.getParameter<double>("MinEta");
+  max_Eta_ = iConfig.getParameter<double>("MaxEta");
+  max_RelChargedIso_ = iConfig.getParameter<double>("MaxRelChargedIso");
+  min_LeadTrackPt_ = iConfig.getParameter<double>("MinLeadTrackPt");
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double> >("barrel");
+  overlapScalings_ = scalings_.getParameter<std::vector<double> >("overlap");
+  endcapScalings_ = scalings_.getParameter<std::vector<double> >("endcap");
+}
+
+L1THPSPFTauFilter::~L1THPSPFTauFilter() = default;
+
+//
+// member functions
+//
+
+void L1THPSPFTauFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<double>("MaxRelChargedIso", 1.0E9);
+  desc.add<double>("MinLeadTrackPt", -1.0);
+  desc.add<int>("MinN", 1);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("L1HPSPFTaus"));
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double> >("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("overlap", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add("L1THPSPFTauFilter", desc);
+}
+
+// ------------ method called to produce the data  ------------
+bool L1THPSPFTauFilter::hltFilter(edm::Event& iEvent,
+                                  const edm::EventSetup& iSetup,
+                                  trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  using namespace trigger;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1HPSPFTauTag_);
+  }
+
+  // Specific filter code
+
+  // get hold of products from Event
+  Handle<l1t::HPSPFTauCollection> HPSPFTaus;
+  iEvent.getByToken(hpspfTauToken_, HPSPFTaus);
+
+  // pftau
+  int npftau(0);
+  auto apftaus(HPSPFTaus->begin());
+  auto opftaus(HPSPFTaus->end());
+  l1t::HPSPFTauCollection::const_iterator iHPSPFTau;
+  for (iHPSPFTau = apftaus; iHPSPFTau != opftaus; iHPSPFTau++) {
+    double offlinePt = this->HPSPFTauOfflineEt(iHPSPFTau->pt(), iHPSPFTau->eta());
+    if (offlinePt >= min_Pt_ && iHPSPFTau->eta() <= max_Eta_ && iHPSPFTau->eta() >= min_Eta_ &&
+        (iHPSPFTau->sumChargedIso() / iHPSPFTau->pt()) < max_RelChargedIso_ &&
+        (iHPSPFTau->leadChargedPFCand()->pfTrack()->pt()) > min_LeadTrackPt_) {
+      npftau++;
+      l1t::HPSPFTauRef ref(l1t::HPSPFTauRef(HPSPFTaus, distance(apftaus, iHPSPFTau)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1PFTau, ref);
+    }
+  }
+
+  // return with final filter decision
+  const bool accept(npftau >= min_N_);
+  return accept;
+}
+
+double L1THPSPFTauFilter::HPSPFTauOfflineEt(double Et, double Eta) const {
+  if (std::abs(Eta) < 1.5)
+    return (barrelScalings_.at(0) + Et * barrelScalings_.at(1) + Et * Et * barrelScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+}

--- a/HLTrigger/HLTfilters/plugins/L1THPSPFTauFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1THPSPFTauFilter.h
@@ -1,0 +1,50 @@
+#ifndef L1THPSPFTauFilter_h
+#define L1THPSPFTauFilter_h
+
+/** \class L1THPSPFTauFilter
+ *
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a very basic
+ *  HLT trigger acting on HPSPFTau candidates
+ *
+ *
+ *
+ *  \author Sandeep Bhowmik
+ *  \author Thiago Tomei
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTauFwd.h"
+
+//
+// class declaration
+//
+
+class L1THPSPFTauFilter : public HLTFilter {
+public:
+  explicit L1THPSPFTauFilter(const edm::ParameterSet&);
+  ~L1THPSPFTauFilter() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag l1HPSPFTauTag_;                              // input tag for L1 HPSPFTau product
+  edm::EDGetTokenT<l1t::HPSPFTauCollection> hpspfTauToken_;  // token identifying product containing L1 HPSPFTaus
+  double min_Pt_;                                            // min pt cut
+  int min_N_;                                                // min number of candidates above pT cut
+  double min_Eta_;                                           // min eta cut
+  double max_Eta_;                                           // max eta cut
+  double max_RelChargedIso_;                                 // max relative charged isolation
+  double min_LeadTrackPt_;                                   // min leading track pT
+  edm::ParameterSet scalings_;           // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;   // barrel scalings
+  std::vector<double> overlapScalings_;  // overlap scalings
+  std::vector<double> endcapScalings_;   // endcap scalings
+
+  double HPSPFTauOfflineEt(double Et, double Eta) const;
+};
+
+#endif  //L1THPSPFTauFilter_h

--- a/HLTrigger/HLTfilters/plugins/L1TJetFilterT.h
+++ b/HLTrigger/HLTfilters/plugins/L1TJetFilterT.h
@@ -1,0 +1,132 @@
+#ifndef HLTrigger_HLTfilters_L1TJetFilterT_h
+#define HLTrigger_HLTfilters_L1TJetFilterT_h
+
+#include <vector>
+#include <cmath>
+#include <iterator>
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+template <class T>
+class L1TJetFilterT : public HLTFilter {
+public:
+  explicit L1TJetFilterT(const edm::ParameterSet&);
+  ~L1TJetFilterT() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag const l1tJetTag_;
+  edm::EDGetTokenT<std::vector<T>> const l1tJetToken_;
+
+  double const minPt_;
+  double const minEta_;
+  double const maxEta_;
+  int const minN_;
+
+  edm::ParameterSet scalings_;           // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;   // barrel scalings
+  std::vector<double> overlapScalings_;  // overlap scalings
+  std::vector<double> endcapScalings_;   // endcap scalings
+
+  double offlineJetPt(double const pt, double const eta) const;
+};
+
+template <class T>
+L1TJetFilterT<T>::L1TJetFilterT(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1tJetTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+      l1tJetToken_(consumes<std::vector<T>>(l1tJetTag_)),
+      minPt_(iConfig.getParameter<double>("MinPt")),
+      minEta_(iConfig.getParameter<double>("MinEta")),
+      maxEta_(iConfig.getParameter<double>("MaxEta")),
+      minN_(iConfig.getParameter<int>("MinN")) {
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double>>("barrel");
+  overlapScalings_ = scalings_.getParameter<std::vector<double>>("overlap");
+  endcapScalings_ = scalings_.getParameter<std::vector<double>>("endcap");
+}
+
+template <class T>
+L1TJetFilterT<T>::~L1TJetFilterT() = default;
+
+template <class T>
+void L1TJetFilterT<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("ak4PFL1PuppiCorrected"));
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<int>("MinN", 1);
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double>>("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double>>("overlap", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double>>("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add(defaultModuleLabel<L1TJetFilterT<T>>(), desc);
+}
+
+template <class T>
+bool L1TJetFilterT<T>::hltFilter(edm::Event& iEvent,
+                                 const edm::EventSetup& iSetup,
+                                 trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1tJetTag_);
+  }
+
+  auto const& l1tJets = iEvent.getHandle(l1tJetToken_);
+
+  int nJet(0);
+  for (auto iJet = l1tJets->begin(); iJet != l1tJets->end(); ++iJet) {
+    if (offlineJetPt(iJet->pt(), iJet->eta()) >= minPt_ && iJet->eta() <= maxEta_ && iJet->eta() >= minEta_) {
+      ++nJet;
+      edm::Ref<std::vector<T>> ref(l1tJets, std::distance(l1tJets->begin(), iJet));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1PFJet, ref);
+    }
+  }
+
+  // return with final filter decision
+  return nJet >= minN_;
+}
+
+template <class T>
+double L1TJetFilterT<T>::offlineJetPt(double const pt, double const eta) const {
+  if (std::abs(eta) < 1.5)
+    return (barrelScalings_.at(0) + pt * barrelScalings_.at(1) + pt * pt * barrelScalings_.at(2));
+  else if (std::abs(eta) < 2.4)
+    return (overlapScalings_.at(0) + pt * overlapScalings_.at(1) + pt * pt * overlapScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + pt * endcapScalings_.at(1) + pt * pt * endcapScalings_.at(2));
+
+  /*
+  uint const scIdx = std::abs(eta) < 1.5 ? 0 : (std::abs(eta) < 2.4 ? 1 : 2);
+
+  if (scIdx >= scalingConstants.m_constants.size()) {
+    throw cms::Exception("Input") << "out-of-range index for L1TObjScalingConstants vector (size="
+                                  << scalingConstants.m_constants.size() << ") [jet: pt=" << pt << ", eta=" << eta
+                                  << "]";
+  }
+
+  return scalingConstants.m_constants.at(scIdx).m_constant + pt * scalingConstants.m_constants.at(scIdx).m_linear +
+         pt * pt * scalingConstants.m_constants.at(scIdx).m_quadratic;
+  */
+}
+
+#endif  // HLTrigger_HLTfilters_L1TJetFilterT_h

--- a/HLTrigger/HLTfilters/plugins/L1TPFTauFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/L1TPFTauFilter.cc
@@ -1,0 +1,124 @@
+/** \class L1TPFTauFilter
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Martin Grunewald
+ *  \author Sandeep Bhowmik 
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "L1TPFTauFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+L1TPFTauFilter::L1TPFTauFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1PFTauTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+      pfTauToken_(consumes<l1t::PFTauCollection>(l1PFTauTag_)) {
+  min_Pt_ = iConfig.getParameter<double>("MinPt");
+  min_N_ = iConfig.getParameter<int>("MinN");
+  min_Eta_ = iConfig.getParameter<double>("MinEta");
+  max_Eta_ = iConfig.getParameter<double>("MaxEta");
+  maxChargedIso_ = iConfig.getParameter<double>("MaxChargedIso");
+  maxFullIso_ = iConfig.getParameter<double>("MaxFullIso");
+  passLooseNN_ = iConfig.getParameter<int>("PassLooseNN");
+  passTightNN_ = iConfig.getParameter<int>("PassTightNN");
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double> >("barrel");
+  endcapScalings_ = scalings_.getParameter<std::vector<double> >("endcap");
+}
+
+L1TPFTauFilter::~L1TPFTauFilter() = default;
+
+//
+// member functions
+//
+
+void L1TPFTauFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<int>("MinN", 1);
+  desc.add<double>("MaxChargedIso", 1.0E9);  // could use std::numeric_limits<double>::max(), but it is overkill...
+  desc.add<double>("MaxFullIso", 1.0E9);
+  desc.add<int>("PassLooseNN", -1);
+  desc.add<int>("PassTightNN", -1);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("L1PFTausNN"));
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double> >("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("overlap", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add("L1TPFTauFilter", desc);
+}
+
+// ------------ method called to produce the data  ------------
+bool L1TPFTauFilter::hltFilter(edm::Event& iEvent,
+                               const edm::EventSetup& iSetup,
+                               trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  using namespace trigger;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1PFTauTag_);
+  }
+
+  // Specific filter code
+
+  // get hold of products from Event
+  Handle<l1t::PFTauCollection> PFTaus;
+  iEvent.getByToken(pfTauToken_, PFTaus);
+
+  // pftau
+  int npftau(0);
+  auto apftaus(PFTaus->begin());
+  auto opftaus(PFTaus->end());
+  l1t::PFTauCollection::const_iterator iPFTau;
+  for (iPFTau = apftaus; iPFTau != opftaus; iPFTau++) {
+    double offlinePt = this->PFTauOfflineEt(iPFTau->pt(), iPFTau->eta());
+    if (offlinePt >= min_Pt_ && iPFTau->eta() <= max_Eta_ && iPFTau->eta() >= min_Eta_ &&
+        iPFTau->passLooseNN() > passLooseNN_ && iPFTau->passTightNN() > passTightNN_ &&
+        iPFTau->chargedIso() < maxChargedIso_ && iPFTau->fullIso() < maxFullIso_) {
+      npftau++;
+      l1t::PFTauRef ref(l1t::PFTauRef(PFTaus, distance(apftaus, iPFTau)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1PFTau, ref);
+    }
+  }
+
+  // return with final filter decision
+  const bool accept(npftau >= min_N_);
+  return accept;
+}
+
+double L1TPFTauFilter::PFTauOfflineEt(double Et, double Eta) const {
+  if (std::abs(Eta) < 1.5)
+    return (barrelScalings_.at(0) + Et * barrelScalings_.at(1) + Et * Et * barrelScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+}

--- a/HLTrigger/HLTfilters/plugins/L1TPFTauFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TPFTauFilter.h
@@ -1,0 +1,49 @@
+#ifndef L1TPFTauFilter_h
+#define L1TPFTauFilter_h
+
+/** \class L1TPFTauFilter
+ *
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a very basic
+ *  HLT trigger acting on PFTau (NN) candidates
+ *
+ *
+ *
+ *  \author Thiago Tomei
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+
+//
+// class declaration
+//
+
+class L1TPFTauFilter : public HLTFilter {
+public:
+  explicit L1TPFTauFilter(const edm::ParameterSet&);
+  ~L1TPFTauFilter() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag l1PFTauTag_;                           //input tag for L1 PFTau product
+  edm::EDGetTokenT<l1t::PFTauCollection> pfTauToken_;  // token identifying product containing L1 PFTaus
+  double min_Pt_;                                      // min pt cut
+  int min_N_;                                          // min number of candidates above pT cut
+  double min_Eta_;                                     //min eta cut
+  double max_Eta_;                                     //max eta cut
+  double maxChargedIso_;                               // Cut on charged isolation
+  double maxFullIso_;                                  // Cut on full isolation
+  int passLooseNN_;                                    // Pass loose NN cut... for some implementation of the NN
+  int passTightNN_;                                    // Pass tight NN cut... for some implementation of the NN
+  edm::ParameterSet scalings_;                         // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;                 // barrel scalings
+  std::vector<double> endcapScalings_;                 // endcap scalings
+
+  double PFTauOfflineEt(double Et, double Eta) const;
+};
+
+#endif  //L1TPFTauFilter_h

--- a/HLTrigger/HLTfilters/plugins/L1TTkEleFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/L1TTkEleFilter.cc
@@ -1,0 +1,199 @@
+/** \class L1TTkEleFilter
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Martin Grunewald
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "L1TTkEleFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+L1TTkEleFilter::L1TTkEleFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1TkEleTag1_(iConfig.getParameter<edm::InputTag>("inputTag1")),
+      l1TkEleTag2_(iConfig.getParameter<edm::InputTag>("inputTag2")),
+      tkEleToken1_(consumes<TkEleCollection>(l1TkEleTag1_)),
+      tkEleToken2_(consumes<TkEleCollection>(l1TkEleTag2_)) {
+  min_Pt_ = iConfig.getParameter<double>("MinPt");
+  min_N_ = iConfig.getParameter<int>("MinN");
+  min_Eta_ = iConfig.getParameter<double>("MinEta");
+  max_Eta_ = iConfig.getParameter<double>("MaxEta");
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double> >("barrel");
+  endcapScalings_ = scalings_.getParameter<std::vector<double> >("endcap");
+  etaBinsForIsolation_ = iConfig.getParameter<std::vector<double> >("EtaBinsForIsolation");
+  trkIsolation_ = iConfig.getParameter<std::vector<double> >("TrkIsolation");
+  quality1_ = iConfig.getParameter<int>("Quality1");
+  quality2_ = iConfig.getParameter<int>("Quality2");
+  qual1IsMask_ = iConfig.getParameter<bool>("Qual1IsMask");
+  qual2IsMask_ = iConfig.getParameter<bool>("Qual2IsMask");
+  applyQual1_ = iConfig.getParameter<bool>("ApplyQual1");
+  applyQual2_ = iConfig.getParameter<bool>("ApplyQual2");
+
+  if (etaBinsForIsolation_.size() != (trkIsolation_.size() + 1))
+    throw cms::Exception("ConfigurationError")
+        << "Vector of isolation values should have same size of vector of eta bins plus one.";
+}
+
+L1TTkEleFilter::~L1TTkEleFilter() = default;
+
+//
+// member functions
+//
+
+void L1TTkEleFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+
+  makeHLTFilterDescription(desc);
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<int>("MinN", 1);
+  desc.add<edm::InputTag>("inputTag1", edm::InputTag("L1TkElectrons1"));
+  desc.add<edm::InputTag>("inputTag2", edm::InputTag("L1TkElectrons2"));
+  desc.add<std::vector<double> >("EtaBinsForIsolation", {0.0, 1.479});
+  desc.add<std::vector<double> >("TrkIsolation",
+                                 {
+                                     99999.9,
+                                 });
+  desc.add<int>("Quality1", 0);
+  desc.add<int>("Quality2", 0);
+  desc.add<bool>("Qual1IsMask", false);
+  desc.add<bool>("Qual2IsMask", false);
+  desc.add<bool>("ApplyQual1", false);
+  desc.add<bool>("ApplyQual2", false);
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double> >("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add("L1TTkEleFilter", desc);
+}
+
+// ------------ method called to produce the data  ------------
+bool L1TTkEleFilter::hltFilter(edm::Event& iEvent,
+                               const edm::EventSetup& iSetup,
+                               trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  using namespace trigger;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1TkEleTag1_);
+    filterproduct.addCollectionTag(l1TkEleTag2_);
+  }
+
+  // Specific filter code
+
+  // get hold of products from Event
+
+  /// Barrel colleciton
+  Handle<l1t::TkElectronCollection> tkEles1;
+  iEvent.getByToken(tkEleToken1_, tkEles1);
+
+  /// Endcap collection
+  Handle<l1t::TkElectronCollection> tkEles2;
+  iEvent.getByToken(tkEleToken2_, tkEles2);
+
+  int ntrkEle(0);
+  // Loop over first collection
+  auto atrkEles(tkEles1->begin());
+  auto otrkEles(tkEles1->end());
+  TkEleCollection::const_iterator itkEle;
+  for (itkEle = atrkEles; itkEle != otrkEles; itkEle++) {
+    double offlinePt = this->TkEleOfflineEt(itkEle->pt(), itkEle->eta());
+    bool passQuality(false);
+    bool passIsolation(false);
+
+    if (applyQual1_) {
+      if (qual1IsMask_)
+        passQuality = (itkEle->EGRef()->hwQual() & quality1_);
+      else
+        passQuality = (itkEle->EGRef()->hwQual() == quality1_);
+    } else
+      passQuality = true;
+
+    // There has to be a better way to do this.
+    for (unsigned int etabin = 1; etabin != etaBinsForIsolation_.size(); ++etabin) {
+      if (std::abs(itkEle->eta()) < etaBinsForIsolation_.at(etabin) and
+          std::abs(itkEle->eta()) > etaBinsForIsolation_.at(etabin - 1) and
+          itkEle->trkIsol() < trkIsolation_.at(etabin - 1))
+        passIsolation = true;
+    }
+
+    if (offlinePt >= min_Pt_ && itkEle->eta() <= max_Eta_ && itkEle->eta() >= min_Eta_ && passQuality &&
+        passIsolation) {
+      ntrkEle++;
+      l1t::TkElectronRef ref1(l1t::TkElectronRef(tkEles1, distance(atrkEles, itkEle)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkEle, ref1);
+    }
+  }
+
+  // Loop over second collection. Notice we don't reset ntrkEle
+  atrkEles = tkEles2->begin();
+  otrkEles = tkEles2->end();
+  for (itkEle = atrkEles; itkEle != otrkEles; itkEle++) {
+    double offlinePt = this->TkEleOfflineEt(itkEle->pt(), itkEle->eta());
+    bool passQuality(false);
+    bool passIsolation(false);
+
+    if (applyQual2_) {
+      if (qual2IsMask_)
+        passQuality = (itkEle->EGRef()->hwQual() & quality2_);
+      else
+        passQuality = (itkEle->EGRef()->hwQual() == quality2_);
+    } else
+      passQuality = true;
+
+    for (unsigned int etabin = 1; etabin != etaBinsForIsolation_.size(); ++etabin) {
+      if (std::abs(itkEle->eta()) < etaBinsForIsolation_.at(etabin) and
+          std::abs(itkEle->eta()) > etaBinsForIsolation_.at(etabin - 1) and
+          itkEle->trkIsol() < trkIsolation_.at(etabin - 1))
+        passIsolation = true;
+    }
+
+    if (offlinePt >= min_Pt_ && itkEle->eta() <= max_Eta_ && itkEle->eta() >= min_Eta_ && passQuality &&
+        passIsolation) {
+      ntrkEle++;
+      l1t::TkElectronRef ref2(l1t::TkElectronRef(tkEles2, distance(atrkEles, itkEle)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkEle, ref2);
+    }
+  }
+
+  // return with final filter decision
+  const bool accept(ntrkEle >= min_N_);
+  return accept;
+}
+
+double L1TTkEleFilter::TkEleOfflineEt(double Et, double Eta) const {
+  if (std::abs(Eta) < 1.5)
+    return (barrelScalings_.at(0) + Et * barrelScalings_.at(1) + Et * Et * barrelScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+}

--- a/HLTrigger/HLTfilters/plugins/L1TTkEleFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TTkEleFilter.h
@@ -1,0 +1,60 @@
+#ifndef L1TTkEleFilter_h
+#define L1TTkEleFilter_h
+
+/** \class L1TTkEleFilter
+ *
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a very basic
+ *  HLT trigger acting on TkEle candidates
+ *  This has support for *two* collections, since electrons can come
+ *  either from crystal calo or HGCAL
+ *
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+#include "DataFormats/L1TCorrelator/interface/TkElectronFwd.h"
+
+//
+// class declaration
+//
+
+class L1TTkEleFilter : public HLTFilter {
+public:
+  explicit L1TTkEleFilter(const edm::ParameterSet&);
+  ~L1TTkEleFilter() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag l1TkEleTag1_;  //input tag for L1 Tk Ele product
+  edm::InputTag l1TkEleTag2_;  //input tag for L1 Tk Ele product
+
+  typedef std::vector<l1t::TkElectron> TkEleCollection;
+  edm::EDGetTokenT<TkEleCollection> tkEleToken1_;  // token identifying product containing L1 TkEles
+  edm::EDGetTokenT<TkEleCollection> tkEleToken2_;  // token identifying product containing L1 TkEles
+
+  double min_Pt_;                            // min pt cut
+  int min_N_;                                // min number of candidates above pT cut
+  double min_Eta_;                           // min eta cut
+  double max_Eta_;                           // max eta cut
+  edm::ParameterSet scalings_;               // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;       // barrel scalings
+  std::vector<double> endcapScalings_;       // endcap scalings
+  std::vector<double> etaBinsForIsolation_;  // abs. eta bin edges for isolation. First edge at 0.0 must be explicit!
+  std::vector<double> trkIsolation_;         // values for track isolation in the bins defined above
+  int quality1_;                             // quality for electrons of 1st collection
+  int quality2_;                             // quality for electrons of 2nd collection
+  int qual1IsMask_;                          // is qual for electrons of 1st collection a mask?
+  int qual2IsMask_;                          // is qual for electrons of 2nd collection a mask?
+  bool applyQual1_;                          // should we apply quality 1?
+  bool applyQual2_;                          // should we apply quality 2?
+
+  double TkEleOfflineEt(double Et, double Eta) const;
+};
+
+#endif  //L1TTkEleFilter_h

--- a/HLTrigger/HLTfilters/plugins/L1TTkEmFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/L1TTkEmFilter.cc
@@ -1,0 +1,197 @@
+/** \class L1TTkEmFilter
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Martin Grunewald
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "L1TTkEmFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+L1TTkEmFilter::L1TTkEmFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1TkEmTag1_(iConfig.getParameter<edm::InputTag>("inputTag1")),
+      l1TkEmTag2_(iConfig.getParameter<edm::InputTag>("inputTag2")),
+      tkEmToken1_(consumes<TkEmCollection>(l1TkEmTag1_)),
+      tkEmToken2_(consumes<TkEmCollection>(l1TkEmTag2_)) {
+  min_Pt_ = iConfig.getParameter<double>("MinPt");
+  min_N_ = iConfig.getParameter<int>("MinN");
+  min_Eta_ = iConfig.getParameter<double>("MinEta");
+  max_Eta_ = iConfig.getParameter<double>("MaxEta");
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double> >("barrel");
+  endcapScalings_ = scalings_.getParameter<std::vector<double> >("endcap");
+  etaBinsForIsolation_ = iConfig.getParameter<std::vector<double> >("EtaBinsForIsolation");
+  etaBinsForIsolation_ = iConfig.getParameter<std::vector<double> >("EtaBinsForIsolation");
+  trkIsolation_ = iConfig.getParameter<std::vector<double> >("TrkIsolation");
+  quality1_ = iConfig.getParameter<int>("Quality1");
+  quality2_ = iConfig.getParameter<int>("Quality2");
+  qual1IsMask_ = iConfig.getParameter<bool>("Qual1IsMask");
+  qual2IsMask_ = iConfig.getParameter<bool>("Qual2IsMask");
+  applyQual1_ = iConfig.getParameter<bool>("ApplyQual1");
+  applyQual2_ = iConfig.getParameter<bool>("ApplyQual2");
+
+  if (etaBinsForIsolation_.size() != (trkIsolation_.size() + 1))
+    throw cms::Exception("ConfigurationError")
+        << "Vector of isolation values should have same size of vector of eta bins plus one.";
+}
+
+L1TTkEmFilter::~L1TTkEmFilter() = default;
+
+//
+// member functions
+//
+
+void L1TTkEmFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<int>("MinN", 1);
+  desc.add<edm::InputTag>("inputTag1", edm::InputTag("L1TkEms1"));
+  desc.add<edm::InputTag>("inputTag2", edm::InputTag("L1TkEms2"));
+  desc.add<std::vector<double> >("EtaBinsForIsolation", {0.0, 1.479});
+  desc.add<std::vector<double> >("TrkIsolation",
+                                 {
+                                     99999.9,
+                                 });
+  desc.add<int>("Quality1", 0);
+  desc.add<int>("Quality2", 0);
+  desc.add<bool>("Qual1IsMask", false);
+  desc.add<bool>("Qual2IsMask", false);
+  desc.add<bool>("ApplyQual1", false);
+  desc.add<bool>("ApplyQual2", false);
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double> >("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add("L1TTkEmFilter", desc);
+}
+
+// ------------ method called to produce the data  ------------
+bool L1TTkEmFilter::hltFilter(edm::Event& iEvent,
+                              const edm::EventSetup& iSetup,
+                              trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  using namespace trigger;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1TkEmTag1_);
+    filterproduct.addCollectionTag(l1TkEmTag2_);
+  }
+
+  // Specific filter code
+
+  // get hold of products from Event
+
+  /// Barrel collection
+  Handle<l1t::TkEmCollection> tkEms1;
+  iEvent.getByToken(tkEmToken1_, tkEms1);
+
+  /// Endcap collection
+  Handle<l1t::TkEmCollection> tkEms2;
+  iEvent.getByToken(tkEmToken2_, tkEms2);
+
+  int ntrkEm(0);
+  // Loop over first collection
+  auto atrkEms(tkEms1->begin());
+  auto otrkEms(tkEms1->end());
+  TkEmCollection::const_iterator itkEm;
+  for (itkEm = atrkEms; itkEm != otrkEms; itkEm++) {
+    double offlinePt = this->TkEmOfflineEt(itkEm->pt(), itkEm->eta());
+    bool passQuality(false);
+    bool passIsolation(false);
+
+    if (applyQual1_) {
+      if (qual1IsMask_)
+        passQuality = (itkEm->EGRef()->hwQual() & quality1_);
+      else
+        passQuality = (itkEm->EGRef()->hwQual() == quality1_);
+    } else
+      passQuality = true;
+
+    // There has to be a better way to do this.
+    for (unsigned int etabin = 1; etabin != etaBinsForIsolation_.size(); ++etabin) {
+      if (std::abs(itkEm->eta()) < etaBinsForIsolation_.at(etabin) and
+          std::abs(itkEm->eta()) > etaBinsForIsolation_.at(etabin - 1) and
+          itkEm->trkIsol() < trkIsolation_.at(etabin - 1))
+        passIsolation = true;
+    }
+
+    if (offlinePt >= min_Pt_ && itkEm->eta() <= max_Eta_ && itkEm->eta() >= min_Eta_ && passQuality && passIsolation) {
+      ntrkEm++;
+      l1t::TkEmRef ref1(l1t::TkEmRef(tkEms1, distance(atrkEms, itkEm)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkEm, ref1);
+    }
+  }
+
+  // Loop over second collection. Notice we don't reset ntrkEm
+  atrkEms = tkEms2->begin();
+  otrkEms = tkEms2->end();
+  for (itkEm = atrkEms; itkEm != otrkEms; itkEm++) {
+    double offlinePt = this->TkEmOfflineEt(itkEm->pt(), itkEm->eta());
+    bool passQuality(false);
+    bool passIsolation(false);
+
+    if (applyQual2_) {
+      if (qual2IsMask_)
+        passQuality = (itkEm->EGRef()->hwQual() & quality2_);
+      else
+        passQuality = (itkEm->EGRef()->hwQual() == quality2_);
+    } else
+      passQuality = true;
+
+    for (unsigned int etabin = 1; etabin != etaBinsForIsolation_.size(); ++etabin) {
+      if (std::abs(itkEm->eta()) < etaBinsForIsolation_.at(etabin) and
+          std::abs(itkEm->eta()) > etaBinsForIsolation_.at(etabin - 1) and
+          itkEm->trkIsol() < trkIsolation_.at(etabin - 1))
+        passIsolation = true;
+    }
+
+    if (offlinePt >= min_Pt_ && itkEm->eta() <= max_Eta_ && itkEm->eta() >= min_Eta_ && passQuality && passIsolation) {
+      ntrkEm++;
+      l1t::TkEmRef ref2(l1t::TkEmRef(tkEms2, distance(atrkEms, itkEm)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkEm, ref2);
+    }
+  }
+
+  // return with final filter decision
+  const bool accept(ntrkEm >= min_N_);
+  return accept;
+}
+
+double L1TTkEmFilter::TkEmOfflineEt(double Et, double Eta) const {
+  if (std::abs(Eta) < 1.5)
+    return (barrelScalings_.at(0) + Et * barrelScalings_.at(1) + Et * Et * barrelScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+}

--- a/HLTrigger/HLTfilters/plugins/L1TTkEmFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TTkEmFilter.h
@@ -1,0 +1,60 @@
+#ifndef L1TTkEmFilter_h
+#define L1TTkEmFilter_h
+
+/** \class L1TTkEmFilter
+ *
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a very basic
+ *  HLT trigger acting on TkEm candidates
+ *  This has support for *two* collections, since photons can come
+ *  either from crystal calo or HGCAL
+ *
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+#include "DataFormats/L1TCorrelator/interface/TkEmFwd.h"
+
+//
+// class declaration
+//
+
+class L1TTkEmFilter : public HLTFilter {
+public:
+  explicit L1TTkEmFilter(const edm::ParameterSet&);
+  ~L1TTkEmFilter() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag l1TkEmTag1_;  //input tag for L1 Tk Em product
+  edm::InputTag l1TkEmTag2_;  //input tag for L1 Tk Em product
+
+  typedef std::vector<l1t::TkEm> TkEmCollection;
+  edm::EDGetTokenT<TkEmCollection> tkEmToken1_;  // token identifying product containing L1 TkEms
+  edm::EDGetTokenT<TkEmCollection> tkEmToken2_;  // token identifying product containing L1 TkEms
+
+  double min_Pt_;                            // min pt cut
+  int min_N_;                                // min number of candidates above pT cut
+  double min_Eta_;                           //min eta cut
+  double max_Eta_;                           //max eta cut
+  edm::ParameterSet scalings_;               // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;       // barrel scalings
+  std::vector<double> endcapScalings_;       // endcap scalings
+  std::vector<double> etaBinsForIsolation_;  // abs. eta bin edges for isolation. First edge at 0.0 must be explicit!
+  std::vector<double> trkIsolation_;         // values for track isolation in the bins defined above
+  int quality1_;                             // quality for photons of 1st collection
+  int quality2_;                             // quality for photons of 2nd collection
+  int qual1IsMask_;                          // is qual for photons of 1st collection a mask?
+  int qual2IsMask_;                          // is qual for photons of 2nd collection a mask?
+  bool applyQual1_;                          // should we apply quality 1?
+  bool applyQual2_;                          // should we apply quality 2?
+
+  double TkEmOfflineEt(double Et, double Eta) const;
+};
+
+#endif  //L1TTkEmFilter_h

--- a/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.cc
+++ b/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.cc
@@ -1,0 +1,117 @@
+/** \class L1TTkMuonFilter
+ *
+ * See header file for documentation
+ *
+ *
+ *  \author Martin Grunewald
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ *
+ */
+
+#include "L1TTkMuonFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+//
+// constructors and destructor
+//
+
+L1TTkMuonFilter::L1TTkMuonFilter(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      l1TkMuonTag_(iConfig.getParameter<edm::InputTag>("inputTag")),
+      tkMuonToken_(consumes<TkMuonCollection>(l1TkMuonTag_)) {
+  min_Pt_ = iConfig.getParameter<double>("MinPt");
+  min_N_ = iConfig.getParameter<int>("MinN");
+  min_Eta_ = iConfig.getParameter<double>("MinEta");
+  max_Eta_ = iConfig.getParameter<double>("MaxEta");
+  scalings_ = iConfig.getParameter<edm::ParameterSet>("Scalings");
+  barrelScalings_ = scalings_.getParameter<std::vector<double> >("barrel");
+  overlapScalings_ = scalings_.getParameter<std::vector<double> >("overlap");
+  endcapScalings_ = scalings_.getParameter<std::vector<double> >("endcap");
+}
+
+L1TTkMuonFilter::~L1TTkMuonFilter() = default;
+
+//
+// member functions
+//
+
+void L1TTkMuonFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<double>("MinPt", -1.0);
+  desc.add<double>("MinEta", -5.0);
+  desc.add<double>("MaxEta", 5.0);
+  desc.add<int>("MinN", 1);
+  desc.add<edm::InputTag>("inputTag", edm::InputTag("L1TkMuons"));
+
+  edm::ParameterSetDescription descScalings;
+  descScalings.add<std::vector<double> >("barrel", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("overlap", {0.0, 1.0, 0.0});
+  descScalings.add<std::vector<double> >("endcap", {0.0, 1.0, 0.0});
+  desc.add<edm::ParameterSetDescription>("Scalings", descScalings);
+
+  descriptions.add("L1TTkMuonFilter", desc);
+}
+
+// ------------ method called to produce the data  ------------
+bool L1TTkMuonFilter::hltFilter(edm::Event& iEvent,
+                                const edm::EventSetup& iSetup,
+                                trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  using namespace std;
+  using namespace edm;
+  using namespace reco;
+  using namespace trigger;
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+  // The filter object
+  if (saveTags()) {
+    filterproduct.addCollectionTag(l1TkMuonTag_);
+  }
+
+  // Specific filter code
+
+  // get hold of products from Event
+  Handle<l1t::TkMuonCollection> tkMuons;
+  iEvent.getByToken(tkMuonToken_, tkMuons);
+
+  // trkMuon
+  int ntrkmuon(0);
+  auto atrkmuons(tkMuons->begin());
+  auto otrkmuons(tkMuons->end());
+  TkMuonCollection::const_iterator itkMuon;
+  for (itkMuon = atrkmuons; itkMuon != otrkmuons; itkMuon++) {
+    double offlinePt = this->TkMuonOfflineEt(itkMuon->pt(), itkMuon->eta());
+    if (offlinePt >= min_Pt_ && itkMuon->eta() <= max_Eta_ && itkMuon->eta() >= min_Eta_) {
+      ntrkmuon++;
+      l1t::TkMuonRef ref(l1t::TkMuonRef(tkMuons, distance(atrkmuons, itkMuon)));
+      filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkMu, ref);
+    }
+  }
+
+  // return with final filter decision
+  const bool accept(ntrkmuon >= min_N_);
+  return accept;
+}
+
+double L1TTkMuonFilter::TkMuonOfflineEt(double Et, double Eta) const {
+  if (std::abs(Eta) < 0.9)
+    return (barrelScalings_.at(0) + Et * barrelScalings_.at(1) + Et * Et * barrelScalings_.at(2));
+  else if (std::abs(Eta) < 1.2)
+    return (overlapScalings_.at(0) + Et * overlapScalings_.at(1) + Et * Et * overlapScalings_.at(2));
+  else
+    return (endcapScalings_.at(0) + Et * endcapScalings_.at(1) + Et * Et * endcapScalings_.at(2));
+}

--- a/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
+++ b/HLTrigger/HLTfilters/plugins/L1TTkMuonFilter.h
@@ -1,0 +1,50 @@
+#ifndef L1TTkMuonFilter_h
+#define L1TTkMuonFilter_h
+
+/** \class L1TTkMuonFilter
+ *
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a very basic
+ *  HLT trigger acting on TkMuon candidates
+ *
+ *
+ *
+ *  \author Simone Gennai
+ *  \author Thiago Tomei
+ */
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+//
+// class declaration
+//
+
+class L1TTkMuonFilter : public HLTFilter {
+public:
+  explicit L1TTkMuonFilter(const edm::ParameterSet&);
+  ~L1TTkMuonFilter() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  edm::InputTag l1TkMuonTag_;  //input tag for L1 Tk Muon product
+  typedef std::vector<l1t::TkMuon> TkMuonCollection;
+  edm::EDGetTokenT<TkMuonCollection> tkMuonToken_;  // token identifying product containing L1 TkMuons
+
+  double min_Pt_;                        // min pt cut
+  int min_N_;                            // min number of candidates above pT cut
+  double min_Eta_;                       // min eta cut
+  double max_Eta_;                       // max eta cut
+  edm::ParameterSet scalings_;           // all scalings. An indirection level allows extra flexibility
+  std::vector<double> barrelScalings_;   // barrel scalings
+  std::vector<double> overlapScalings_;  // overlap scalings
+  std::vector<double> endcapScalings_;   // endcap scalings
+
+  double TkMuonOfflineEt(double Et, double Eta) const;
+};
+
+#endif  //L1TTkMuonFilter_h

--- a/HLTrigger/HLTfilters/plugins/plugins.cc
+++ b/HLTrigger/HLTfilters/plugins/plugins.cc
@@ -39,6 +39,14 @@ using namespace trigger;
 #include "HLTSinglet.h"
 #include "HLTSinglet.cc"
 
+#include "L1TTkEleFilter.h"
+#include "L1TTkEmFilter.h"
+#include "L1TTkMuonFilter.h"
+#include "L1TPFTauFilter.h"
+#include "L1THPSPFTauFilter.h"
+#include "L1TJetFilterT.h"
+#include "L1TEnergySumFilterT.h"
+
 // filter for HLT candidates
 typedef HLTSinglet<RecoEcalCandidate> HLT1Photon;
 typedef HLTSinglet<Electron> HLT1Electron;
@@ -61,6 +69,12 @@ typedef HLTSinglet<l1extra::L1EtMissParticle>
 typedef HLTSinglet<l1extra::L1JetParticle>
     HLTLevel1Jet;  // the actual type is ovrridden object-by-object (TriggerL1CenJet, TriggerL1ForJet or TriggerL1TauJet)
 typedef HLTSinglet<l1extra::L1MuonParticle> HLTLevel1Muon;
+
+// filters for Phase-2
+typedef L1TJetFilterT<reco::CaloJet> L1TJetFilter;
+typedef L1TJetFilterT<l1t::PFJet> L1TPFJetFilter;
+typedef L1TEnergySumFilterT<reco::MET> L1TEnergySumFilter;
+typedef L1TEnergySumFilterT<reco::PFMET> L1TPFEnergySumFilter;
 
 #include "HLTSmartSinglet.h"
 #include "HLTSmartSinglet.cc"
@@ -156,6 +170,17 @@ DEFINE_FWK_MODULE(HLTLevel1EG);
 DEFINE_FWK_MODULE(HLTLevel1MET);
 DEFINE_FWK_MODULE(HLTLevel1Jet);
 DEFINE_FWK_MODULE(HLTLevel1Muon);
+
+// Phase-2
+DEFINE_FWK_MODULE(L1TTkEleFilter);
+DEFINE_FWK_MODULE(L1TTkEmFilter);
+DEFINE_FWK_MODULE(L1TTkMuonFilter);
+DEFINE_FWK_MODULE(L1TPFTauFilter);
+DEFINE_FWK_MODULE(L1THPSPFTauFilter);
+DEFINE_FWK_MODULE(L1TJetFilter);
+DEFINE_FWK_MODULE(L1TPFJetFilter);
+DEFINE_FWK_MODULE(L1TEnergySumFilter);
+DEFINE_FWK_MODULE(L1TPFEnergySumFilter);
 
 DEFINE_FWK_MODULE(HLTGlobalSumsPFMET);
 DEFINE_FWK_MODULE(HLTGlobalSumsCaloMET);

--- a/HLTrigger/HLTfilters/test/test_Phase2L1THLT.py
+++ b/HLTrigger/HLTfilters/test/test_Phase2L1THLT.py
@@ -1,0 +1,201 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("HLTX")
+
+### Load all ESSources, ESProducers and PSets
+# process.load("HLTrigger.Configuration.Phase2.hltPhase2Setup_cff")
+
+### GlobalTag
+# process.load("Configuration.StandardSequences.CondDBESSource_cff")
+# process.GlobalTag.globaltag = "112X_mcRun4_realistic_T15_v2"
+
+process.l1tEle7 = cms.EDFilter(
+    "L1TTkEleFilter",
+    MinPt=cms.double(7.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+    inputTag1=cms.InputTag("L1TkElectronsEllipticMatchCrystal", "EG"),
+    inputTag2=cms.InputTag("L1TkElectronsEllipticMatchHGC", "EG"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(0.805095, 1.18336, 0.0),
+        endcap=cms.vdouble(0.453144, 1.26205, 0.0),
+    ),
+    EtaBinsForIsolation=cms.vdouble(0.0, 9999.9),
+    TrkIsolation=cms.vdouble(99999.9),  # No isolation
+    ApplyQual1=cms.bool(True),
+    ApplyQual2=cms.bool(True),
+    Quality1=cms.int32(2),  # 0x2
+    Quality2=cms.int32(5),
+    Qual1IsMask=cms.bool(True),
+    Qual2IsMask=cms.bool(False),
+)
+
+process.l1tIsoEle7 = cms.EDFilter(
+    "L1TTkEleFilter",
+    MinPt=cms.double(7.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+    inputTag1=cms.InputTag("L1TkElectronsEllipticMatchCrystal", "EG"),
+    inputTag2=cms.InputTag("L1TkElectronsEllipticMatchHGC", "EG"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(0.434262, 1.20586, 0.0),
+        endcap=cms.vdouble(0.266186, 1.25976, 0.0),
+    ),
+    EtaBinsForIsolation=cms.vdouble(0.0, 1.479, 9999.9),
+    TrkIsolation=cms.vdouble(0.12, 0.2),
+    ApplyQual1=cms.bool(False),
+    ApplyQual2=cms.bool(True),
+    Quality1=cms.int32(-1),
+    Quality2=cms.int32(5),
+    Qual1IsMask=cms.bool(False),
+    Qual2IsMask=cms.bool(False),
+)
+
+process.l1tIsoPho7 = cms.EDFilter(
+    "L1TTkEmFilter",
+    MinPt=cms.double(7.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+    inputTag1=cms.InputTag("L1TkPhotonsCrystal", "EG"),
+    inputTag2=cms.InputTag("L1TkPhotonsHGC", "EG"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(2.54255, 1.08749, 0.0),
+        endcap=cms.vdouble(2.11186, 1.15524, 0.0),
+    ),
+    EtaBinsForIsolation=cms.vdouble(0.0, 1.479, 9999.9),
+    TrkIsolation=cms.vdouble(0.28, 0.35),
+    ApplyQual1=cms.bool(False),
+    ApplyQual2=cms.bool(True),
+    Quality1=cms.int32(2),  # 0x2 "second bit"
+    Quality2=cms.int32(5),
+    Qual1IsMask=cms.bool(True),
+    Qual2IsMask=cms.bool(False),
+)
+
+process.l1tMuon7 = cms.EDFilter(
+    "L1TTkMuonFilter",
+    MinPt=cms.double(7.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+    inputTag=cms.InputTag("L1TkMuons"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(0.802461, 1.04193, 0.0),
+        overlap=cms.vdouble(0.921315, 1.03611, 0.0),
+        endcap=cms.vdouble(0.828802, 1.03447, 0.0),
+    ),
+)
+
+process.l1tDoubleMuon7 = cms.EDFilter(
+    "L1TTkMuonFilter",
+    MinN=cms.int32(2),
+    MinPt=cms.double(7.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+    inputTag=cms.InputTag("L1TkMuons"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(0.802461, 1.04193, 0.0),
+        overlap=cms.vdouble(0.921315, 1.03611, 0.0),
+        endcap=cms.vdouble(0.828802, 1.03447, 0.0),
+    ),
+)
+
+process.l1tDoubleMuon7DZ0p33 = cms.EDFilter(
+    "HLT2L1TkMuonL1TkMuonDZ",
+    originTag1=cms.VInputTag(
+        "L1TkMuons",
+    ),
+    originTag2=cms.VInputTag(
+        "L1TkMuons",
+    ),
+    inputTag1=cms.InputTag("l1tDoubleMuon7"),
+    inputTag2=cms.InputTag("l1tDoubleMuon7"),
+    triggerType1=cms.int32(-114),  # L1TkMuon
+    triggerType2=cms.int32(-114),  # L1TkMuon
+    MinDR=cms.double(-1),
+    MaxDZ=cms.double(0.33),
+    MinPixHitsForDZ=cms.int32(0),  # Immaterial
+    checkSC=cms.bool(False),  # Immaterial
+    MinN=cms.int32(1),
+)
+
+process.l1tPFJet64 = cms.EDFilter(
+    "L1TPFJetFilter",
+    inputTag=cms.InputTag("ak4PFL1PuppiCorrected"),
+    Scalings=cms.PSet(
+        barrel=cms.vdouble(11.1254, 1.40627, 0),
+        overlap=cms.vdouble(24.8375, 1.4152, 0),
+        endcap=cms.vdouble(42.4039, 1.33052, 0),
+    ),
+    MinPt=cms.double(64.0),
+    MinEta=cms.double(-2.4),
+    MaxEta=cms.double(2.4),
+)
+
+process.L1PFHtMht = cms.EDProducer(
+    "HLTHtMhtProducer",
+    jetsLabel=cms.InputTag("ak4PFL1PuppiCorrected"),
+    minPtJetHt=cms.double(30),
+    maxEtaJetHt=cms.double(2.4),
+)
+
+# ### Notice that there is no MHT seed in the Phase-II Level-1 Menu...
+# # Possible choices for TypeOfSum are: MET, MHT, ETT, HT
+# # but notice that if you are using a MET seed you
+# # should probably use the precomputed one.
+
+# # We don't have scaling for MHT...
+process.l1tPFMht40 = cms.EDFilter(
+    "L1TEnergySumFilter",
+    inputTag=cms.InputTag("L1PFHtMht"),
+    Scalings=cms.PSet(
+        theScalings=cms.vdouble(0, 1, 0),
+    ),
+    TypeOfSum=cms.string("MHT"),
+    MinPt=cms.double(40.0),
+)
+
+process.l1tPFHt90 = cms.EDFilter(
+    "L1TEnergySumFilter",
+    inputTag=cms.InputTag("L1PFHtMht"),
+    Scalings=cms.PSet(
+        # theScalings = cms.vdouble(-7.12716,1.03067,0), # PFPhase1HTOfflineEtCut
+        theScalings=cms.vdouble(50.0182, 1.0961, 0),  # PFPhase1HT090OfflineEtCut
+    ),
+    TypeOfSum=cms.string("MHT"),
+    MinPt=cms.double(90.0),
+)
+
+process.l1tPFMet90 = cms.EDFilter(
+    "L1TPFEnergySumFilter",
+    inputTag=cms.InputTag("l1PFMetPuppi"),
+    Scalings=cms.PSet(
+        # theScalings = cms.vdouble(-7.24159,1.20973,0), # PuppiMETOfflineEtCut
+        theScalings=cms.vdouble(54.2859, 1.39739, 0),  # PuppiMET090OfflineEtCut
+        # theScalings = cms.vdouble(0,0,0),
+    ),
+    TypeOfSum=cms.string("MET"),
+    MinPt=cms.double(90.0),
+)
+
+process.HLT_SingleEle7 = cms.Path(process.l1tEle7)
+process.HLT_SingleIsoEle7 = cms.Path(process.l1tIsoEle7)
+process.HLT_SingleIsoPhoton7 = cms.Path(process.l1tIsoPho7)
+process.HLT_SingleMu7 = cms.Path(process.l1tMuon7)
+process.HLT_DoubleMu7_DZ0p33 = cms.Path(
+    process.l1tDoubleMuon7 + process.l1tDoubleMuon7DZ0p33
+)
+process.HLT_SingleJet64 = cms.Path(process.l1tPFJet64)
+process.HLT_MHT40 = cms.Path(process.L1PFHtMht + process.l1tPFMht40)
+process.HLT_HT90 = cms.Path(process.L1PFHtMht + process.l1tPFHt90)
+process.HLT_MET90 = cms.Path(process.l1tPFMet90)
+
+process.source = cms.Source(
+    "PoolSource",
+    fileNames=cms.untracked.vstring(
+        "/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/FEVT/PU200_pilot_111X_mcRun4_realistic_T15_v1-v1/270000/FF7BF0E2-1380-2D48-BB19-F79E6907CD5D.root",
+        # "/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/SingleElectron_PT2to200/FEVT/PU200_111X_mcRun4_realistic_T15_v1_ext2-v1/270000/0064D31F-F48B-3144-8CB9-17F820065E01.root",
+    ),
+)
+
+process.maxEvents.input = cms.untracked.int32(-1)
+process.options = cms.untracked.PSet(wantSummary=cms.untracked.bool(True))

--- a/HLTrigger/JetMET/interface/HLTHtMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTHtMhtProducer.h
@@ -19,10 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/JetReco/interface/Jet.h"
-#include "DataFormats/JetReco/interface/JetCollection.h"
-#include "DataFormats/METReco/interface/MET.h"
-#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
@@ -62,7 +59,7 @@ private:
   edm::InputTag jetsLabel_;
   edm::InputTag pfCandidatesLabel_;
 
-  edm::EDGetTokenT<reco::JetView> m_theJetToken;
+  edm::EDGetTokenT<reco::CandidateView> m_theJetToken;
   edm::EDGetTokenT<reco::PFCandidateCollection> m_thePFCandidateToken;
 };
 

--- a/HLTrigger/JetMET/interface/HLTMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTMhtProducer.h
@@ -18,10 +18,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/View.h"
-#include "DataFormats/JetReco/interface/Jet.h"
-#include "DataFormats/JetReco/interface/JetCollection.h"
-#include "DataFormats/METReco/interface/MET.h"
-#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
@@ -58,7 +55,7 @@ private:
   edm::InputTag jetsLabel_;
   edm::InputTag pfCandidatesLabel_;
 
-  edm::EDGetTokenT<reco::JetView> m_theJetToken;
+  edm::EDGetTokenT<reco::CandidateView> m_theJetToken;
   edm::EDGetTokenT<reco::PFCandidateCollection> m_thePFCandidateToken;
 };
 

--- a/HLTrigger/JetMET/src/HLTMhtProducer.cc
+++ b/HLTrigger/JetMET/src/HLTMhtProducer.cc
@@ -13,6 +13,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/METFwd.h"
+
 // Constructor
 HLTMhtProducer::HLTMhtProducer(const edm::ParameterSet& iConfig)
     : usePt_(iConfig.getParameter<bool>("usePt")),
@@ -22,7 +25,7 @@ HLTMhtProducer::HLTMhtProducer(const edm::ParameterSet& iConfig)
       maxEtaJet_(iConfig.getParameter<double>("maxEtaJet")),
       jetsLabel_(iConfig.getParameter<edm::InputTag>("jetsLabel")),
       pfCandidatesLabel_(iConfig.getParameter<edm::InputTag>("pfCandidatesLabel")) {
-  m_theJetToken = consumes<edm::View<reco::Jet>>(jetsLabel_);
+  m_theJetToken = consumes<reco::CandidateView>(jetsLabel_);
   if (pfCandidatesLabel_.label().empty())
     excludePFMuons_ = false;
   if (excludePFMuons_)
@@ -54,7 +57,7 @@ void HLTMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   // Create a pointer to the products
   std::unique_ptr<reco::METCollection> result(new reco::METCollection());
 
-  edm::Handle<reco::JetView> jets;
+  edm::Handle<reco::CandidateView> jets;
   iEvent.getByToken(m_theJetToken, jets);
 
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
@@ -64,28 +67,26 @@ void HLTMhtProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   int nj = 0;
   double sumet = 0., mhx = 0., mhy = 0.;
 
-  if (!jets->empty()) {
-    for (reco::JetView::const_iterator j = jets->begin(); j != jets->end(); ++j) {
-      double pt = usePt_ ? j->pt() : j->et();
-      double eta = j->eta();
-      double phi = j->phi();
-      double px = usePt_ ? j->px() : j->et() * cos(phi);
-      double py = usePt_ ? j->py() : j->et() * sin(phi);
+  for (auto const& aJet : *jets) {
+    double const pt = usePt_ ? aJet.pt() : aJet.et();
+    double const eta = aJet.eta();
+    double const phi = aJet.phi();
+    double const px = usePt_ ? aJet.px() : aJet.et() * cos(phi);
+    double const py = usePt_ ? aJet.py() : aJet.et() * sin(phi);
 
-      if (pt > minPtJet_ && std::abs(eta) < maxEtaJet_) {
-        mhx -= px;
-        mhy -= py;
-        sumet += pt;
-        ++nj;
-      }
+    if (pt > minPtJet_ && std::abs(eta) < maxEtaJet_) {
+      mhx -= px;
+      mhy -= py;
+      sumet += pt;
+      ++nj;
     }
   }
 
   if (excludePFMuons_) {
-    for (auto const& j : *pfCandidates) {
-      if (std::abs(j.pdgId()) == 13) {
-        mhx += j.px();
-        mhy += j.py();
+    for (auto const& aCand : *pfCandidates) {
+      if (std::abs(aCand.pdgId()) == 13) {
+        mhx += aCand.px();
+        mhy += aCand.py();
       }
     }
   }


### PR DESCRIPTION
backport of #32454

This PR adds additional infrastructure for the L1T-HLT interface for Phase2.
It is a sister PR to #32425 .
We add a set of modules to implement selections on the L1T Phase-2 candidates

We ran scram b runtests with success.

We ran runTheMatrix.py -l limited -i all --ibeos with success.

And the `test/test_Phase2L1THLT.py` that we added runs succesfully!

```
$ cmsRun test_Phase2L1THLT.py
14-Dec-2020 15:05:52 CET  Initiating request to open file root://eoscms.cern.ch//eos/cms/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/FEVT/PU200_pilot_111X_mcRun4_realistic_T15_v1-v1/270000/FF7BF0E2-1380-2D48-BB19-F79E6907CD5D.root
%MSG-w XrdAdaptor:  file_open 14-Dec-2020 15:05:55 CET pre-events
Data is served from cern.ch instead of original site eoscms
%MSG
14-Dec-2020 15:06:10 CET  Successfully opened file root://eoscms.cern.ch//eos/cms/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/FEVT/PU200_pilot_111X_mcRun4_realistic_T15_v1-v1/270000/FF7BF0E2-1380-2D48-BB19-F79E6907CD5D.root
Begin processing the 1st record. Run 1, Event 194609, LumiSection 1113 on stream 0 at 14-Dec-2020 15:06:23.501 CET
Begin processing the 2nd record. Run 1, Event 194605, LumiSection 1113 on stream 0 at 14-Dec-2020 15:06:25.834 CET
...
TrigReport ---------- Module Summary ------------
TrigReport    Visited   Executed     Passed     Failed      Error Name
TrigReport        175        175        175          0          0 HLT_DoubleMu7_DZ0p33
TrigReport        175        175        175          0          0 HLT_HT90
TrigReport        175        175        175          0          0 HLT_MET90
TrigReport        175        175        175          0          0 HLT_MHT40
TrigReport        175        175        175          0          0 HLT_SingleEle7
TrigReport        175        175        175          0          0 HLT_SingleIsoEle7
TrigReport        175        175        175          0          0 HLT_SingleIsoPhoton7
TrigReport        175        175        175          0          0 HLT_SingleJet64
TrigReport        175        175        175          0          0 HLT_SingleMu7
TrigReport        350        175        175          0          0 L1PFHtMht
TrigReport        175        175        175          0          0 TriggerResults
TrigReport        175        175         20        155          0 l1tDoubleMuon7
TrigReport         20         20         19          1          0 l1tDoubleMuon7DZ0p33
TrigReport        175        175         68        107          0 l1tEle7
TrigReport        175        175         60        115          0 l1tIsoEle7
TrigReport        175        175        107         68          0 l1tIsoPho7
TrigReport        175        175         38        137          0 l1tMuon7
TrigReport        175        175         72        103          0 l1tPFHt90
TrigReport        175        175        117         58          0 l1tPFJet64
TrigReport        175        175         93         82          0 l1tPFMet90
TrigReport        175        175         67        108          0 l1tPFMht40
```

Only missing in the test are the flavours of L1T PFTau (`l1t::PFTau` and `l1t::HPSPFTau`), because we don't have samples with those objects yet.