### PR TITLE
ETL Validation code update and fixes

### DIFF
--- a/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
+++ b/RecoLocalFastTime/FTLRecProducers/python/mtdRecHits_cfi.py
@@ -14,7 +14,7 @@ _endcapAlgo = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
-phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005, calibrationConstant = 0.001 )
+phase2_etlV4.toModify(_endcapAlgo, thresholdToKeep = 0.005, calibrationConstant = 0.015 )
 
 mtdRecHits = cms.EDProducer(
     "MTDRecHitProducer",

--- a/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
+++ b/SimFastTiming/FastTimingCommon/python/mtdDigitizer_cfi.py
@@ -85,7 +85,7 @@ _endcap_MTDDigitizer = cms.PSet(
 )
 
 from Configuration.Eras.Modifier_phase2_etlV4_cff import phase2_etlV4
-phase2_etlV4.toModify(_endcap_MTDDigitizer.DeviceSimulation, meVPerMIP = 0.001 )
+phase2_etlV4.toModify(_endcap_MTDDigitizer.DeviceSimulation, meVPerMIP = 0.015 )
 
 from Configuration.ProcessModifiers.premix_stage1_cff import premix_stage1
 for _m in [_barrel_MTDDigitizer, _endcap_MTDDigitizer]:

--- a/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlDigiHitsValidation.cc
@@ -109,7 +109,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
   for (const auto& dataFrame : *etlDigiHitsHandle) {
     // --- Get the on-time sample
     int isample = 2;
-
+    double weight = 1.0;
     const auto& sample = dataFrame.sample(isample);
     ETLDetId detId = dataFrame.id();
     DetId geoId = detId.geographicalId();
@@ -138,6 +138,9 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
     }
 
     if (topo2Dis) {
+      if (detId.discSide() == 1) {
+        weight = -weight;
+      }
       if ((detId.zside() == -1) && (detId.nDisc() == 1)) {
         idet = 0;
       } else if ((detId.zside() == -1) && (detId.nDisc() == 2)) {
@@ -153,7 +156,7 @@ void EtlDigiHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSe
 
     meHitCharge_[idet]->Fill(sample.data());
     meHitTime_[idet]->Fill(sample.toa());
-    meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
+    meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
 
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
@@ -283,11 +286,11 @@ void EtlDigiHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL DIGI hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL DIGI hits Y (+Z, Second disk);Y_{DIGI} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -304.2, -303.4);
-  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -304.2, -303.4);
+      "EtlHitZZnegD1", "ETL DIGI hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, -302., -298.);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL DIGI hits Z (-Z, Second disk);Z_{DIGI} [cm]", 100, -304., -300.);
   meHitZ_[2] = ibook.book1D(
-      "EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 303.4, 304.2);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 303.4, 304.2);
+      "EtlHitZZposD1", "ETL DIGI hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{DIGI} [cm]", 100, 298., 302.);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL DIGI hits Z (+Z, Second disk);Z_{DIGI} [cm]", 100, 300., 304.);
 
   meHitPhi_[0] = ibook.book1D("EtlHitPhiZnegD1",
                               "ETL DIGI hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{DIGI} [rad]",

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -271,13 +271,13 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlNhitsZposD1", "Number of ETL RECO hits (+Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
   meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL RECO hits (+Z, Second disk);N_{RECO}", 100, 0., 5000.);
   meHitEnergy_[0] = ibook.book1D(
-      "EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3);
+      "EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
   meHitEnergy_[1] =
-      ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3);
+      ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
   meHitEnergy_[2] = ibook.book1D(
-      "EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3);
+      "EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
   meHitEnergy_[3] =
-      ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3);
+      ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
   meHitTime_[0] = ibook.book1D(
       "EtlHitTimeZnegD1", "ETL RECO hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL RECO hits ToA (-Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
@@ -333,7 +333,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL RECO hits Y (+Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL RECO hits Y (+Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -302., -298);
+      "EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -302., -298.);
   meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL RECO hits Z (-Z, Second Disk);Z_{RECO} [cm]", 100, -304., -300.);
   meHitZ_[2] = ibook.book1D(
       "EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 298., 302.);

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -119,7 +119,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   // --- Loop over the ELT RECO hits
 
   unsigned int n_reco_etl[4] = {0, 0, 0, 0};
+
   for (const auto& recHit : *etlRecHitsHandle) {
+    double weight = 1.0;
     ETLDetId detId = recHit.id();
     DetId geoId = detId.geographicalId();
     const MTDGeomDet* thedet = geom->idToDet(geoId);
@@ -144,6 +146,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     }
 
     if (topo2Dis) {
+      if (detId.discSide() == 1) {
+        weight = -weight;
+      }
       if ((detId.zside() == -1) && (detId.nDisc() == 1)) {
         idet = 0;
       } else if ((detId.zside() == -1) && (detId.nDisc() == 2)) {
@@ -162,7 +167,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
     meHitEnergy_[idet]->Fill(recHit.energy());
     meHitTime_[idet]->Fill(recHit.time());
 
-    meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
+    meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
     meHitX_[idet]->Fill(global_point.x());
     meHitY_[idet]->Fill(global_point.y());
     meHitZ_[idet]->Fill(global_point.z());
@@ -191,6 +196,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   // --- Loop over the ETL RECO clusters ---
   for (const auto& DetSetClu : *etlRecCluHandle) {
     for (const auto& cluster : DetSetClu) {
+      double weight = 1.0;
       if (topo1Dis) {
         if (cluster.energy() < hitMinEnergy1Dis_)
           continue;
@@ -225,6 +231,9 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       }
 
       if (topo2Dis) {
+        if (cluId.discSide() == 1) {
+          weight = -weight;
+        }
         if ((cluId.zside() == -1) && (cluId.nDisc() == 1)) {
           idet = 0;
         } else if ((cluId.zside() == -1) && (cluId.nDisc() == 2)) {
@@ -242,7 +251,7 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
       meCluTime_[idet]->Fill(cluster.time());
       meCluPhi_[idet]->Fill(global_point.phi());
       meCluEta_[idet]->Fill(global_point.eta());
-      meCluOccupancy_[idet]->Fill(global_point.x(), global_point.y());
+      meCluOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
       meCluHits_[idet]->Fill(cluster.size());
     }
   }
@@ -263,13 +272,13 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlNhitsZposD1", "Number of ETL RECO hits (+Z, Single(topo1D)/First(topo2D) disk);N_{RECO}", 100, 0., 5000.);
   meNhits_[3] = ibook.book1D("EtlNhitsZposD2", "Number of ETL RECO hits (+Z, Second disk);N_{RECO}", 100, 0., 5000.);
   meHitEnergy_[0] = ibook.book1D(
-      "EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+      "EtlHitEnergyZnegD1", "ETL RECO hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3);
   meHitEnergy_[1] =
-      ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+      ibook.book1D("EtlHitEnergyZnegD2", "ETL RECO hits energy (-Z, Second disk);E_{RECO} [MeV]", 100, 0., 3);
   meHitEnergy_[2] = ibook.book1D(
-      "EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3.);
+      "EtlHitEnergyZposD1", "ETL RECO hits energy (+Z, Single(topo1D)/First(topo2D) disk);E_{RECO} [MeV]", 100, 0., 3);
   meHitEnergy_[3] =
-      ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3.);
+      ibook.book1D("EtlHitEnergyZposD2", "ETL RECO hits energy (+Z, Second disk);E_{RECO} [MeV]", 100, 0., 3);
   meHitTime_[0] = ibook.book1D(
       "EtlHitTimeZnegD1", "ETL RECO hits ToA (-Z, Single(topo1D)/First(topo2D) disk);ToA_{RECO} [ns]", 100, 0., 25.);
   meHitTime_[1] = ibook.book1D("EtlHitTimeZnegD2", "ETL RECO hits ToA (-Z, Second disk);ToA_{RECO} [ns]", 100, 0., 25.);
@@ -325,11 +334,11 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL RECO hits Y (+Z, Single(topo1D)/First(topo2D) Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL RECO hits Y (+Z, Second Disk);Y_{RECO} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
-  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL RECO hits Z (-Z, Second Disk);Z_{RECO} [cm]", 100, -304.2, -303.4);
+      "EtlHitZZnegD1", "ETL RECO hits Z (-Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, -302., -298);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL RECO hits Z (-Z, Second Disk);Z_{RECO} [cm]", 100, -304., -300.);
   meHitZ_[2] = ibook.book1D(
-      "EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL RECO hits Z (+Z, Second Disk);Z_{RECO} [cm]", 100, 303.4, 304.2);
+      "EtlHitZZposD1", "ETL RECO hits Z (+Z, Single(topo1D)/First(topo2D) Disk);Z_{RECO} [cm]", 100, 298., 302.);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL RECO hits Z (+Z, Second Disk);Z_{RECO} [cm]", 100, 300., 304.);
   meHitPhi_[0] = ibook.book1D(
       "EtlHitPhiZnegD1", "ETL RECO hits #phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meHitPhi_[1] =
@@ -532,7 +541,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meCluHits_[3] =
       ibook.book1D("EtlCluHitNumberZposD2", "ETL hits per cluster (+Z, Second Disk);Cluster size", 10, 0, 10);
   meCluOccupancy_[0] =
-      ibook.book2D("EtlOccupancyZnegD1",
+      ibook.book2D("EtlCluOccupancyZnegD1",
                    "ETL cluster X vs Y (-Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
                    100,
                    -150.,
@@ -540,7 +549,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                    100,
                    -150,
                    150);
-  meCluOccupancy_[1] = ibook.book2D("EtlOccupancyZnegD2",
+  meCluOccupancy_[1] = ibook.book2D("EtlCluOccupancyZnegD2",
                                     "ETL cluster X vs Y (-Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
                                     100,
                                     -150.,
@@ -549,7 +558,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                                     -150,
                                     150);
   meCluOccupancy_[2] =
-      ibook.book2D("EtlOccupancyZposD1",
+      ibook.book2D("EtlCluOccupancyZposD1",
                    "ETL cluster X vs Y (+Z, Single(topo1D)/First(topo2D) Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
                    100,
                    -150.,
@@ -557,7 +566,7 @@ void EtlLocalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
                    100,
                    -150,
                    150);
-  meCluOccupancy_[3] = ibook.book2D("EtlOccupancyZposD2",
+  meCluOccupancy_[3] = ibook.book2D("EtlCluOccupancyZposD2",
                                     "ETL cluster X vs Y (+Z, Second Disk);X_{RECO} [cm]; Y_{RECO} [cm]",
                                     100,
                                     -150.,

--- a/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlLocalRecoValidation.cc
@@ -119,7 +119,6 @@ void EtlLocalRecoValidation::analyze(const edm::Event& iEvent, const edm::EventS
   // --- Loop over the ELT RECO hits
 
   unsigned int n_reco_etl[4] = {0, 0, 0, 0};
-
   for (const auto& recHit : *etlRecHitsHandle) {
     double weight = 1.0;
     ETLDetId detId = recHit.id();

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -194,6 +194,7 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
     }
 
     for (auto const& hit : m_etlHits[idet]) {
+      double weight = 1.0;
       if (topo1Dis) {
         if ((hit.second).energy < hitMinEnergy1Dis_)
           continue;
@@ -214,13 +215,17 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
           convertMmToCm((hit.second).x), convertMmToCm((hit.second).y), convertMmToCm((hit.second).z));
       const auto& global_point = thedet->toGlobal(local_point);
 
-      // --- Fill the histograms
+      if (topo2Dis) {
+        if (detId.discSide() == 1)
+          weight = -weight;
+      }
+
       meHitEnergy_[idet]->Fill((hit.second).energy);
       meHitTime_[idet]->Fill((hit.second).time);
       meHitXlocal_[idet]->Fill((hit.second).x);
       meHitYlocal_[idet]->Fill((hit.second).y);
       meHitZlocal_[idet]->Fill((hit.second).z);
-      meOccupancy_[idet]->Fill(global_point.x(), global_point.y());
+      meOccupancy_[idet]->Fill(global_point.x(), global_point.y(), weight);
       meHitX_[idet]->Fill(global_point.x());
       meHitY_[idet]->Fill(global_point.y());
       meHitZ_[idet]->Fill(global_point.z());
@@ -273,7 +278,6 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
                                    10.);
   meNtrkPerCell_[3] =
       ibook.book1D("EtlNtrkPerCellZposD2", "Number of tracks per ETL sensor (+Z, Second disk);N_{trk}", 10, 0., 10.);
-
   meHitEnergy_[0] = ibook.book1D(
       "EtlHitEnergyZnegD1", "ETL SIM hits energy (-Z, Single(topo1D)/First(topo2D) disk);E_{SIM} [MeV]", 100, 0., 3.);
   meHitEnergy_[1] =
@@ -381,11 +385,11 @@ void EtlSimHitsValidation::bookHistograms(DQMStore::IBooker& ibook,
       "EtlHitYZposD1", "ETL SIM hits Y (+Z, Single(topo1D)/First(topo2D) disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitY_[3] = ibook.book1D("EtlHitYZposD2", "ETL SIM hits Y (+Z, Second disk);Y_{SIM} [cm]", 100, -130., 130.);
   meHitZ_[0] = ibook.book1D(
-      "EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -304.2, -303.4);
-  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -304.2, -303.4);
+      "EtlHitZZnegD1", "ETL SIM hits Z (-Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, -302., -298.);
+  meHitZ_[1] = ibook.book1D("EtlHitZZnegD2", "ETL SIM hits Z (-Z, Second disk);Z_{SIM} [cm]", 100, -304., -300.);
   meHitZ_[2] = ibook.book1D(
-      "EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 303.4, 304.2);
-  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 303.4, 304.2);
+      "EtlHitZZposD1", "ETL SIM hits Z (+Z, Single(topo1D)/First(topo2D) disk);Z_{SIM} [cm]", 100, 298., 302.);
+  meHitZ_[3] = ibook.book1D("EtlHitZZposD2", "ETL SIM hits Z (+Z, Second disk);Z_{SIM} [cm]", 100, 300., 304.);
 
   meHitPhi_[0] = ibook.book1D(
       "EtlHitPhiZnegD1", "ETL SIM hits #phi (-Z, Single(topo1D)/First(topo2D) disk);#phi_{SIM} [rad]", 100, -3.15, 3.15);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -220,6 +220,8 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
           weight = -weight;
       }
 
+      // --- Fill the histograms
+
       meHitEnergy_[idet]->Fill((hit.second).energy);
       meHitTime_[idet]->Fill((hit.second).time);
       meHitXlocal_[idet]->Fill((hit.second).x);

--- a/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
+++ b/Validation/MtdValidation/plugins/EtlSimHitsValidation.cc
@@ -215,9 +215,8 @@ void EtlSimHitsValidation::analyze(const edm::Event& iEvent, const edm::EventSet
           convertMmToCm((hit.second).x), convertMmToCm((hit.second).y), convertMmToCm((hit.second).z));
       const auto& global_point = thedet->toGlobal(local_point);
 
-      if (topo2Dis) {
-        if (detId.discSide() == 1)
-          weight = -weight;
+      if (topo2Dis && (detId.discSide() == 1)) {
+        weight = -weight;
       }
 
       // --- Fill the histograms

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoHarvester.cc
@@ -27,9 +27,9 @@ private:
   MonitorElement* meBtlEtaEff_;
   MonitorElement* meBtlPhiEff_;
   MonitorElement* meBtlPtEff_;
-  MonitorElement* meEtlEtaEff_[4];
-  MonitorElement* meEtlPhiEff_[4];
-  MonitorElement* meEtlPtEff_[4];
+  MonitorElement* meEtlEtaEff_[2];
+  MonitorElement* meEtlPhiEff_[2];
+  MonitorElement* meEtlPtEff_[2];
 };
 
 // ------------ constructor and destructor --------------
@@ -50,29 +50,21 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
   MonitorElement* meETLTrackEffEtaTotZneg = igetter.get(folder_ + "TrackETLEffEtaTotZneg");
   MonitorElement* meETLTrackEffPhiTotZneg = igetter.get(folder_ + "TrackETLEffPhiTotZneg");
   MonitorElement* meETLTrackEffPtTotZneg = igetter.get(folder_ + "TrackETLEffPtTotZneg");
-  MonitorElement* meETLTrackEffEtaMtdZnegD1 = igetter.get(folder_ + "TrackETLEffEtaMtdZnegD1");
-  MonitorElement* meETLTrackEffEtaMtdZnegD2 = igetter.get(folder_ + "TrackETLEffEtaMtdZnegD2");
-  MonitorElement* meETLTrackEffPhiMtdZnegD1 = igetter.get(folder_ + "TrackETLEffPhiMtdZnegD1");
-  MonitorElement* meETLTrackEffPhiMtdZnegD2 = igetter.get(folder_ + "TrackETLEffPhiMtdZnegD2");
-  MonitorElement* meETLTrackEffPtMtdZnegD1 = igetter.get(folder_ + "TrackETLEffPtMtdZnegD1");
-  MonitorElement* meETLTrackEffPtMtdZnegD2 = igetter.get(folder_ + "TrackETLEffPtMtdZnegD2");
+  MonitorElement* meETLTrackEffEtaMtdZneg = igetter.get(folder_ + "TrackETLEffEtaMtdZneg");
+  MonitorElement* meETLTrackEffPhiMtdZneg = igetter.get(folder_ + "TrackETLEffPhiMtdZneg");
+  MonitorElement* meETLTrackEffPtMtdZneg = igetter.get(folder_ + "TrackETLEffPtMtdZneg");
   MonitorElement* meETLTrackEffEtaTotZpos = igetter.get(folder_ + "TrackETLEffEtaTotZpos");
   MonitorElement* meETLTrackEffPhiTotZpos = igetter.get(folder_ + "TrackETLEffPhiTotZpos");
   MonitorElement* meETLTrackEffPtTotZpos = igetter.get(folder_ + "TrackETLEffPtTotZpos");
-  MonitorElement* meETLTrackEffEtaMtdZposD1 = igetter.get(folder_ + "TrackETLEffEtaMtdZposD1");
-  MonitorElement* meETLTrackEffEtaMtdZposD2 = igetter.get(folder_ + "TrackETLEffEtaMtdZposD2");
-  MonitorElement* meETLTrackEffPhiMtdZposD1 = igetter.get(folder_ + "TrackETLEffPhiMtdZposD1");
-  MonitorElement* meETLTrackEffPhiMtdZposD2 = igetter.get(folder_ + "TrackETLEffPhiMtdZposD2");
-  MonitorElement* meETLTrackEffPtMtdZposD1 = igetter.get(folder_ + "TrackETLEffPtMtdZposD1");
-  MonitorElement* meETLTrackEffPtMtdZposD2 = igetter.get(folder_ + "TrackETLEffPtMtdZposD2");
+  MonitorElement* meETLTrackEffEtaMtdZpos = igetter.get(folder_ + "TrackETLEffEtaMtdZpos");
+  MonitorElement* meETLTrackEffPhiMtdZpos = igetter.get(folder_ + "TrackETLEffPhiMtdZpos");
+  MonitorElement* meETLTrackEffPtMtdZpos = igetter.get(folder_ + "TrackETLEffPtMtdZpos");
 
   if (!meBTLTrackEffEtaTot || !meBTLTrackEffPhiTot || !meBTLTrackEffPtTot || !meBTLTrackEffEtaMtd ||
       !meBTLTrackEffPhiMtd || !meBTLTrackEffPtMtd || !meETLTrackEffEtaTotZneg || !meETLTrackEffPhiTotZneg ||
-      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZnegD1 || !meETLTrackEffPhiMtdZnegD1 ||
-      !meETLTrackEffPtMtdZnegD1 || !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos ||
-      !meETLTrackEffEtaMtdZposD1 || !meETLTrackEffPhiMtdZposD1 || !meETLTrackEffPtMtdZposD1 ||
-      !meETLTrackEffEtaMtdZnegD2 || !meETLTrackEffPhiMtdZnegD2 || !meETLTrackEffPtMtdZnegD2 ||
-      !meETLTrackEffEtaMtdZposD2 || !meETLTrackEffPhiMtdZposD2 || !meETLTrackEffPtMtdZposD2) {
+      !meETLTrackEffPtTotZneg || !meETLTrackEffEtaMtdZneg || !meETLTrackEffPhiMtdZneg || !meETLTrackEffPtMtdZneg ||
+      !meETLTrackEffEtaTotZpos || !meETLTrackEffPhiTotZpos || !meETLTrackEffPtTotZpos || !meETLTrackEffEtaMtdZpos ||
+      !meETLTrackEffPhiMtdZpos || !meETLTrackEffPtMtdZpos) {
     edm::LogError("MtdGlobalRecoHarvester") << "Monitoring histograms not found!" << std::endl;
     return;
   }
@@ -94,72 +86,41 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
                              meBTLTrackEffPtTot->getNbinsX(),
                              meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmin(),
                              meBTLTrackEffPtTot->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[0] = ibook.book1D("EtlEtaEffZnegD1",
-                                 " Track Efficiency VS Eta (-Z, Single(topo1D)/First(topo2D) Disk);#eta;Efficiency",
+  meEtlEtaEff_[0] = ibook.book1D("EtlEtaEffZneg",
+                                 " Track Efficiency VS Eta (-Z);#eta;Efficiency",
                                  meETLTrackEffEtaTotZneg->getNbinsX(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[1] = ibook.book1D("EtlEtaEffZnegD2",
-                                 " Track Efficiency VS Eta (-Z, Second Disk);#eta;Efficiency",
-                                 meETLTrackEffEtaTotZneg->getNbinsX(),
-                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffEtaTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[0] =
-      ibook.book1D("EtlPhiEffZnegD1",
-                   "Track Efficiency VS Phi (-Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
-                   meETLTrackEffPhiTotZneg->getNbinsX(),
-                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                   meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZnegD2",
-                                 "Track Efficiency VS Phi (-Z, Second Disk);#phi [rad];Efficiency",
+  meEtlPhiEff_[0] = ibook.book1D("EtlPhiEffZneg",
+                                 "Track Efficiency VS Phi (-Z);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZneg->getNbinsX(),
                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPhiTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[0] = ibook.book1D("EtlPtEffZnegD1",
-                                "Track Efficiency VS Pt (-Z, Single(topo1D)/First(topo2D) Disk);Pt [GeV];Efficiency",
+  meEtlPtEff_[0] = ibook.book1D("EtlPtEffZneg",
+                                "Track Efficiency VS Pt (-Z);Pt [GeV];Efficiency",
                                 meETLTrackEffPtTotZneg->getNbinsX(),
                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
                                 meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[1] = ibook.book1D("EtlPtEffZnegD2",
-                                "Track Efficiency VS Pt (-Z, Second Disk);Pt [GeV];Efficiency",
-                                meETLTrackEffPtTotZneg->getNbinsX(),
-                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmin(),
-                                meETLTrackEffPtTotZneg->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[2] = ibook.book1D("EtlEtaEffZposD1",
-                                 " Track Efficiency VS Eta (+Z, Single(topo1D)/First(topo2D) Disk);#eta;Efficiency",
+  meEtlEtaEff_[1] = ibook.book1D("EtlEtaEffZpos",
+                                 " Track Efficiency VS Eta (+Z);#eta;Efficiency",
                                  meETLTrackEffEtaTotZpos->getNbinsX(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlEtaEff_[3] = ibook.book1D("EtlEtaEffZposD2",
-                                 " Track Efficiency VS Eta (+Z, Second Disk);#eta;Efficiency",
-                                 meETLTrackEffEtaTotZpos->getNbinsX(),
-                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                 meETLTrackEffEtaTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[2] =
-      ibook.book1D("EtlPhiEffZposD1",
-                   "Track Efficiency VS Phi (+Z, Single(topo1D)/First(topo2D) Disk);#phi [rad];Efficiency",
-                   meETLTrackEffPhiTotZpos->getNbinsX(),
-                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                   meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPhiEff_[3] = ibook.book1D("EtlPhiEffZposD2",
-                                 "Track Efficiency VS Phi (+Z, Second Disk);#phi [rad];Efficiency",
+  meEtlPhiEff_[1] = ibook.book1D("EtlPhiEffZpos",
+                                 "Track Efficiency VS Phi (+Z);#phi [rad];Efficiency",
                                  meETLTrackEffPhiTotZpos->getNbinsX(),
                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                  meETLTrackEffPhiTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[2] = ibook.book1D("EtlPtEffZposD1",
-                                "Track Efficiency VS Pt (+Z, Single(topo1D)/First(topo2D) Disk);Pt [GeV];Efficiency",
+  meEtlPtEff_[1] = ibook.book1D("EtlPtEffZpos",
+                                "Track Efficiency VS Pt (+Z);Pt [GeV];Efficiency",
                                 meETLTrackEffPtTotZpos->getNbinsX(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
                                 meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
-  meEtlPtEff_[3] = ibook.book1D("EtlPtEffZposD2",
-                                "Track Efficiency VS Pt (+Z, Second Disk);Pt [GeV];Efficiency",
-                                meETLTrackEffPtTotZpos->getNbinsX(),
-                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmin(),
-                                meETLTrackEffPtTotZpos->getTH1()->GetXaxis()->GetXmax());
+
   meBtlEtaEff_->getTH1()->SetMinimum(0.);
   meBtlPhiEff_->getTH1()->SetMinimum(0.);
   meBtlPtEff_->getTH1()->SetMinimum(0.);
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 2; i++) {
     meEtlEtaEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPhiEff_[i]->getTH1()->SetMinimum(0.);
     meEtlPtEff_[i]->getTH1()->SetMinimum(0.);
@@ -204,10 +165,10 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
   }
   // --- Calculate efficiency ETL
   for (int ibin = 1; ibin <= meETLTrackEffEtaTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZnegD1->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffEtaMtdZneg->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffEtaMtdZnegD1->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZnegD1->getBinContent(ibin))) /
+        sqrt((meETLTrackEffEtaMtdZneg->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZneg->getBinContent(ibin))) /
              pow(meETLTrackEffEtaTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffEtaTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -217,13 +178,13 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlEtaEff_[0]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZnegD2->getBinContent(ibin) / meETLTrackEffEtaTotZneg->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffEtaMtdZpos->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffEtaMtdZnegD2->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZneg->getBinContent(ibin) - meETLTrackEffEtaMtdZnegD2->getBinContent(ibin))) /
-             pow(meETLTrackEffEtaTotZneg->getBinContent(ibin), 3));
-    if (meETLTrackEffEtaTotZneg->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffEtaMtdZpos->getBinContent(ibin) *
+              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZpos->getBinContent(ibin))) /
+             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
@@ -231,39 +192,11 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlEtaEff_[1]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZposD1->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffEtaMtdZposD1->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZposD1->getBinContent(ibin))) /
-             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlEtaEff_[2]->setBinContent(ibin, eff);
-    meEtlEtaEff_[2]->setBinError(ibin, bin_err);
-  }
-
-  for (int ibin = 1; ibin <= meETLTrackEffEtaTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffEtaMtdZposD2->getBinContent(ibin) / meETLTrackEffEtaTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffEtaMtdZposD2->getBinContent(ibin) *
-              (meETLTrackEffEtaTotZpos->getBinContent(ibin) - meETLTrackEffEtaMtdZposD2->getBinContent(ibin))) /
-             pow(meETLTrackEffEtaTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffEtaTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlEtaEff_[3]->setBinContent(ibin, eff);
-    meEtlEtaEff_[3]->setBinError(ibin, bin_err);
-  }
-
   for (int ibin = 1; ibin <= meETLTrackEffPhiTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZnegD1->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffPhiMtdZneg->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPhiMtdZnegD1->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZnegD1->getBinContent(ibin))) /
+        sqrt((meETLTrackEffPhiMtdZneg->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZneg->getBinContent(ibin))) /
              pow(meETLTrackEffPhiTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffPhiTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -273,13 +206,13 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPhiEff_[0]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZnegD2->getBinContent(ibin) / meETLTrackEffPhiTotZneg->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPhiMtdZpos->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPhiMtdZnegD2->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZneg->getBinContent(ibin) - meETLTrackEffPhiMtdZnegD2->getBinContent(ibin))) /
-             pow(meETLTrackEffPhiTotZneg->getBinContent(ibin), 3));
-    if (meETLTrackEffPhiTotZneg->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffPhiMtdZpos->getBinContent(ibin) *
+              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZpos->getBinContent(ibin))) /
+             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
@@ -287,39 +220,11 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPhiEff_[1]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZposD1->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffPhiMtdZposD1->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZposD1->getBinContent(ibin))) /
-             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlPhiEff_[2]->setBinContent(ibin, eff);
-    meEtlPhiEff_[2]->setBinError(ibin, bin_err);
-  }
-
-  for (int ibin = 1; ibin <= meETLTrackEffPhiTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPhiMtdZposD2->getBinContent(ibin) / meETLTrackEffPhiTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffPhiMtdZposD2->getBinContent(ibin) *
-              (meETLTrackEffPhiTotZpos->getBinContent(ibin) - meETLTrackEffPhiMtdZposD2->getBinContent(ibin))) /
-             pow(meETLTrackEffPhiTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPhiTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlPhiEff_[3]->setBinContent(ibin, eff);
-    meEtlPhiEff_[3]->setBinError(ibin, bin_err);
-  }
-
   for (int ibin = 1; ibin <= meETLTrackEffPtTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZnegD1->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
+    double eff = meETLTrackEffPtMtdZneg->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPtMtdZnegD1->getBinContent(ibin) *
-              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZnegD1->getBinContent(ibin))) /
+        sqrt((meETLTrackEffPtMtdZneg->getBinContent(ibin) *
+              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZneg->getBinContent(ibin))) /
              pow(meETLTrackEffPtTotZneg->getBinContent(ibin), 3));
     if (meETLTrackEffPtTotZneg->getBinContent(ibin) == 0) {
       eff = 0;
@@ -329,46 +234,18 @@ void MtdGlobalRecoHarvester::dqmEndJob(DQMStore::IBooker& ibook, DQMStore::IGett
     meEtlPtEff_[0]->setBinError(ibin, bin_err);
   }
 
-  for (int ibin = 1; ibin <= meETLTrackEffPtTotZneg->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZnegD2->getBinContent(ibin) / meETLTrackEffPtTotZneg->getBinContent(ibin);
+  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
+    double eff = meETLTrackEffPtMtdZpos->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
     double bin_err =
-        sqrt((meETLTrackEffPtMtdZnegD2->getBinContent(ibin) *
-              (meETLTrackEffPtTotZneg->getBinContent(ibin) - meETLTrackEffPtMtdZnegD2->getBinContent(ibin))) /
-             pow(meETLTrackEffPtTotZneg->getBinContent(ibin), 3));
-    if (meETLTrackEffPtTotZneg->getBinContent(ibin) == 0) {
+        sqrt((meETLTrackEffPtMtdZpos->getBinContent(ibin) *
+              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZpos->getBinContent(ibin))) /
+             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
+    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
       eff = 0;
       bin_err = 0;
     }
     meEtlPtEff_[1]->setBinContent(ibin, eff);
     meEtlPtEff_[1]->setBinError(ibin, bin_err);
-  }
-
-  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZposD1->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffPtMtdZposD1->getBinContent(ibin) *
-              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZposD1->getBinContent(ibin))) /
-             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlPtEff_[2]->setBinContent(ibin, eff);
-    meEtlPtEff_[2]->setBinError(ibin, bin_err);
-  }
-
-  for (int ibin = 1; ibin <= meETLTrackEffPtTotZpos->getNbinsX(); ibin++) {
-    double eff = meETLTrackEffPtMtdZposD2->getBinContent(ibin) / meETLTrackEffPtTotZpos->getBinContent(ibin);
-    double bin_err =
-        sqrt((meETLTrackEffPtMtdZposD2->getBinContent(ibin) *
-              (meETLTrackEffPtTotZpos->getBinContent(ibin) - meETLTrackEffPtMtdZposD2->getBinContent(ibin))) /
-             pow(meETLTrackEffPtTotZpos->getBinContent(ibin), 3));
-    if (meETLTrackEffPtTotZpos->getBinContent(ibin) == 0) {
-      eff = 0;
-      bin_err = 0;
-    }
-    meEtlPtEff_[3]->setBinContent(ibin, eff);
-    meEtlPtEff_[3]->setBinError(ibin, bin_err);
   }
 }
 

--- a/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
+++ b/Validation/MtdValidation/plugins/MtdGlobalRecoValidation.cc
@@ -65,9 +65,9 @@ private:
   MonitorElement* meETLTrackEffEtaTot_[2];
   MonitorElement* meETLTrackEffPhiTot_[2];
   MonitorElement* meETLTrackEffPtTot_[2];
-  MonitorElement* meETLTrackEffEtaMtd_[4];
-  MonitorElement* meETLTrackEffPhiMtd_[4];
-  MonitorElement* meETLTrackEffPtMtd_[4];
+  MonitorElement* meETLTrackEffEtaMtd_[2];
+  MonitorElement* meETLTrackEffPhiMtd_[2];
+  MonitorElement* meETLTrackEffPtMtd_[2];
 
   MonitorElement* meTrackNumHits_;
 
@@ -172,18 +172,22 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
           if (topo2Dis) {
             if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 1)) {
               MTDEtlZnegD1 = true;
+              meETLTrackRPTime_[0]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
             if ((ETLHit.zside() == -1) && (ETLHit.nDisc() == 2)) {
               MTDEtlZnegD2 = true;
+              meETLTrackRPTime_[1]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
             if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 1)) {
               MTDEtlZposD1 = true;
+              meETLTrackRPTime_[2]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
             if ((ETLHit.zside() == 1) && (ETLHit.nDisc() == 2)) {
               MTDEtlZposD2 = true;
+              meETLTrackRPTime_[3]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
           }
@@ -191,10 +195,12 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
           if (topo1Dis) {
             if (ETLHit.zside() == -1) {
               MTDEtlZnegD1 = true;
+              meETLTrackRPTime_[0]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
             if (ETLHit.zside() == 1) {
               MTDEtlZposD1 = true;
+              meETLTrackRPTime_[2]->Fill(track.t0());
               numMTDEtlvalidhits++;
             }
           }
@@ -204,31 +210,17 @@ void MtdGlobalRecoValidation::analyze(const edm::Event& iEvent, const edm::Event
 
       // --- keeping only tracks with last hit in MTD ---
       if ((track.eta() < -trackMinEta_) && (track.eta() > -trackMaxEta_)) {
-        if (MTDEtlZnegD1 == true) {
+        if ((MTDEtlZnegD1 == true) || (MTDEtlZnegD2 == true)) {
           meETLTrackEffEtaMtd_[0]->Fill(track.eta());
           meETLTrackEffPhiMtd_[0]->Fill(track.phi());
           meETLTrackEffPtMtd_[0]->Fill(track.pt());
-          meETLTrackRPTime_[0]->Fill(track.t0());
-        }
-        if (MTDEtlZnegD2 == true) {
-          meETLTrackEffEtaMtd_[1]->Fill(track.eta());
-          meETLTrackEffPhiMtd_[1]->Fill(track.phi());
-          meETLTrackEffPtMtd_[1]->Fill(track.pt());
-          meETLTrackRPTime_[1]->Fill(track.t0());
         }
       }
       if ((track.eta() > trackMinEta_) && (track.eta() < trackMaxEta_)) {
-        if (MTDEtlZposD1 == true) {
-          meETLTrackEffEtaMtd_[2]->Fill(track.eta());
-          meETLTrackEffPhiMtd_[2]->Fill(track.phi());
-          meETLTrackEffPtMtd_[2]->Fill(track.pt());
-          meETLTrackRPTime_[2]->Fill(track.t0());
-        }
-        if (MTDEtlZposD2 == true) {
-          meETLTrackEffEtaMtd_[3]->Fill(track.eta());
-          meETLTrackEffPhiMtd_[3]->Fill(track.phi());
-          meETLTrackEffPtMtd_[3]->Fill(track.pt());
-          meETLTrackRPTime_[3]->Fill(track.t0());
+        if ((MTDEtlZposD1 == true) || (MTDEtlZposD2 == true)) {
+          meETLTrackEffEtaMtd_[1]->Fill(track.eta());
+          meETLTrackEffPhiMtd_[1]->Fill(track.phi());
+          meETLTrackEffPtMtd_[1]->Fill(track.pt());
         }
       }
     }
@@ -264,7 +256,7 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
       ibook.book1D("TrackBTLEffPhiMtd", "Track efficiency vs phi (Mtd);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meBTLTrackEffPtMtd_ = ibook.book1D("TrackBTLEffPtMtd", "Track efficiency vs pt (Mtd);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackRPTime_[0] =
-      ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, Firstl Disk);t0 [ns]", 100, -1, 3);
+      ibook.book1D("TrackETLRPTimeZnegD1", "Track t0 with respect to R.P. (-Z, First Disk);t0 [ns]", 100, -1, 3);
   meETLTrackRPTime_[1] =
       ibook.book1D("TrackETLRPTimeZnegD2", "Track t0 with respect to R.P. (-Z, Second Disk);t0 [ns]", 100, -1, 3);
   meETLTrackRPTime_[2] =
@@ -284,53 +276,17 @@ void MtdGlobalRecoValidation::bookHistograms(DQMStore::IBooker& ibook,
   meETLTrackEffPtTot_[1] =
       ibook.book1D("TrackETLEffPtTotZpos", "Track efficiency vs pt (Tot) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
   meETLTrackEffEtaMtd_[0] =
-      ibook.book1D("TrackETLEffEtaMtdZnegD1",
-                   "Track efficiency vs eta (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}",
-                   100,
-                   -3.2,
-                   -1.4);
-  meETLTrackEffEtaMtd_[1] = ibook.book1D(
-      "TrackETLEffEtaMtdZnegD2", "Track efficiency vs eta (Mtd) (-Z, Second Disk);#eta_{RECO}", 100, -3.2, -1.4);
-  meETLTrackEffEtaMtd_[2] =
-      ibook.book1D("TrackETLEffEtaMtdZposD1",
-                   "Track efficiency vs eta (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#eta_{RECO}",
-                   100,
-                   1.4,
-                   3.2);
-  meETLTrackEffEtaMtd_[3] = ibook.book1D(
-      "TrackETLEffEtaMtdZposD2", "Track efficiency vs eta (Mtd) (+Z, Second Disk);#eta_{RECO}", 100, 1.4, 3.2);
+      ibook.book1D("TrackETLEffEtaMtdZneg", "Track efficiency vs eta (Mtd) (-Z);#eta_{RECO}", 100, -3.2, -1.4);
+  meETLTrackEffEtaMtd_[1] =
+      ibook.book1D("TrackETLEffEtaMtdZpos", "Track efficiency vs eta (Mtd) (+Z);#eta_{RECO}", 100, 1.4, 3.2);
   meETLTrackEffPhiMtd_[0] =
-      ibook.book1D("TrackETLEffPhiMtdZnegD1",
-                   "Track efficiency vs phi (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]",
-                   100,
-                   -3.2,
-                   3.2);
-  meETLTrackEffPhiMtd_[1] = ibook.book1D(
-      "TrackETLEffPhiMtdZnegD2", "Track efficiency vs phi (Mtd) (-Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
-  meETLTrackEffPhiMtd_[2] =
-      ibook.book1D("TrackETLEffPhiMtdZposD1",
-                   "Track efficiency vs phi (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);#phi_{RECO} [rad]",
-                   100,
-                   -3.2,
-                   3.2);
-  meETLTrackEffPhiMtd_[3] = ibook.book1D(
-      "TrackETLEffPhiMtdZposD2", "Track efficiency vs phi (Mtd) (+Z, Second Disk);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+      ibook.book1D("TrackETLEffPhiMtdZneg", "Track efficiency vs phi (Mtd) (-Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
+  meETLTrackEffPhiMtd_[1] =
+      ibook.book1D("TrackETLEffPhiMtdZpos", "Track efficiency vs phi (Mtd) (+Z);#phi_{RECO} [rad]", 100, -3.2, 3.2);
   meETLTrackEffPtMtd_[0] =
-      ibook.book1D("TrackETLEffPtMtdZnegD1",
-                   "Track efficiency vs pt (Mtd) (-Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]",
-                   50,
-                   0,
-                   10);
-  meETLTrackEffPtMtd_[1] = ibook.book1D(
-      "TrackETLEffPtMtdZnegD2", "Track efficiency vs pt (Mtd) (-Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
-  meETLTrackEffPtMtd_[2] =
-      ibook.book1D("TrackETLEffPtMtdZposD1",
-                   "Track efficiency vs pt (Mtd) (+Z, Single(topo1D)/First(topo2D) Disk);pt_{RECO} [GeV]",
-                   50,
-                   0,
-                   10);
-  meETLTrackEffPtMtd_[3] = ibook.book1D(
-      "TrackETLEffPtMtdZposD2", "Track efficiency vs pt (Mtd) (+Z, Second Disk);pt_{RECO} [GeV]", 50, 0, 10);
+      ibook.book1D("TrackETLEffPtMtdZneg", "Track efficiency vs pt (Mtd) (-Z);pt_{RECO} [GeV]", 50, 0, 10);
+  meETLTrackEffPtMtd_[1] =
+      ibook.book1D("TrackETLEffPtMtdZpos", "Track efficiency vs pt (Mtd) (+Z);pt_{RECO} [GeV]", 50, 0, 10);
   meTrackNumHits_ = ibook.book1D("TrackNumHits", "Number of valid MTD hits per track ; Number of hits", 10, -5, 5);
   meVerZ_ = ibook.book1D("VerZ", "RECO Vertex Z;Z_{RECO} [cm]", 180, -18, 18);
   meVerTime_ = ibook.book1D("VerTime", "RECO Vertex Time;t0 [ns]", 100, -1, 1);


### PR DESCRIPTION
#### PR description:
The main changes this PR introduces in the code are the following (@fabiocos, @parbol):

1. The MeVtoMIP conversion value to be used for the new 2-discs ETL geometry validation has been fixed to the correct value of 0.015. 

2. The filling of the occupancy plots has been modified, introducing a negative weight to discriminate between the two sides of each ETL disc. 

3. The MTDGlobalReco plugins have been corrected, merging the two separate histograms used in the evaluation of the efficiencies, one for each of the two ETL discs, into a single one. This has been done since the efficiency is evaluated as:
Tracks with an associated deposit in negative (positive) side of ETL MTD/ All tracks with -3.2 < η < -1.5 (1.5 < η < 3.2),
where the numerator does not discriminate between tracks with an associated hit in the first or second ETL disc.

#### PR validation:
The new code has been tested in the release CMSSW_11_2_0_pre10

