### PR TITLE
Add evaluation of SpecPar numeric values in Phase II Tracker XMLs

### DIFF
--- a/Geometry/TrackerCommonData/data/PhaseII/InnerTracker621_50x50_2020_07/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/InnerTracker621_50x50_2020_07/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT800_IT621_2020_07_16.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="336"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="336"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="338"/>
-<Parameter name="PixelROCCols" value="434"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="338"/>
+<Parameter name="PixelROCCols" eval="true" value="434"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker/trackerStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker/trackerStructureTopology.xml
@@ -1007,2642 +1007,2642 @@ note: see Baseline_tilted_2016_04_12.cfg for full config files
 <SpecPar name="BModule1Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule19Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule19Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule20Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule20Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule21Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule21Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule21Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule21Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Lower2SactivePar">
 <PartSelector path="//BModule1Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Upper2SactivePar">
 <PartSelector path="//BModule1Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Lower2SactivePar">
 <PartSelector path="//BModule2Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Upper2SactivePar">
 <PartSelector path="//BModule2Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Lower2SactivePar">
 <PartSelector path="//BModule3Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Upper2SactivePar">
 <PartSelector path="//BModule3Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Lower2SactivePar">
 <PartSelector path="//BModule4Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Upper2SactivePar">
 <PartSelector path="//BModule4Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Lower2SactivePar">
 <PartSelector path="//BModule5Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Upper2SactivePar">
 <PartSelector path="//BModule5Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Lower2SactivePar">
 <PartSelector path="//BModule6Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Upper2SactivePar">
 <PartSelector path="//BModule6Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Lower2SactivePar">
 <PartSelector path="//BModule7Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Upper2SactivePar">
 <PartSelector path="//BModule7Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Lower2SactivePar">
 <PartSelector path="//BModule8Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Upper2SactivePar">
 <PartSelector path="//BModule8Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Lower2SactivePar">
 <PartSelector path="//BModule9Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Upper2SactivePar">
 <PartSelector path="//BModule9Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Lower2SactivePar">
 <PartSelector path="//BModule10Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Upper2SactivePar">
 <PartSelector path="//BModule10Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Lower2SactivePar">
 <PartSelector path="//BModule11Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Upper2SactivePar">
 <PartSelector path="//BModule11Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Lower2SactivePar">
 <PartSelector path="//BModule12Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Upper2SactivePar">
 <PartSelector path="//BModule12Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Lower2SactivePar">
 <PartSelector path="//BModule1Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Upper2SactivePar">
 <PartSelector path="//BModule1Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Lower2SactivePar">
 <PartSelector path="//BModule2Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Upper2SactivePar">
 <PartSelector path="//BModule2Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Lower2SactivePar">
 <PartSelector path="//BModule3Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Upper2SactivePar">
 <PartSelector path="//BModule3Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Lower2SactivePar">
 <PartSelector path="//BModule4Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Upper2SactivePar">
 <PartSelector path="//BModule4Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Lower2SactivePar">
 <PartSelector path="//BModule5Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Upper2SactivePar">
 <PartSelector path="//BModule5Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Lower2SactivePar">
 <PartSelector path="//BModule6Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Upper2SactivePar">
 <PartSelector path="//BModule6Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Lower2SactivePar">
 <PartSelector path="//BModule7Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Upper2SactivePar">
 <PartSelector path="//BModule7Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Lower2SactivePar">
 <PartSelector path="//BModule8Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Upper2SactivePar">
 <PartSelector path="//BModule8Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Lower2SactivePar">
 <PartSelector path="//BModule9Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Upper2SactivePar">
 <PartSelector path="//BModule9Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Lower2SactivePar">
 <PartSelector path="//BModule10Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Upper2SactivePar">
 <PartSelector path="//BModule10Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Lower2SactivePar">
 <PartSelector path="//BModule11Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Upper2SactivePar">
 <PartSelector path="//BModule11Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Lower2SactivePar">
 <PartSelector path="//BModule12Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Upper2SactivePar">
 <PartSelector path="//BModule12Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Lower2SactivePar">
 <PartSelector path="//BModule1Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Upper2SactivePar">
 <PartSelector path="//BModule1Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Lower2SactivePar">
 <PartSelector path="//BModule2Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Upper2SactivePar">
 <PartSelector path="//BModule2Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Lower2SactivePar">
 <PartSelector path="//BModule3Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Upper2SactivePar">
 <PartSelector path="//BModule3Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Lower2SactivePar">
 <PartSelector path="//BModule4Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Upper2SactivePar">
 <PartSelector path="//BModule4Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Lower2SactivePar">
 <PartSelector path="//BModule5Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Upper2SactivePar">
 <PartSelector path="//BModule5Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Lower2SactivePar">
 <PartSelector path="//BModule6Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Upper2SactivePar">
 <PartSelector path="//BModule6Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Lower2SactivePar">
 <PartSelector path="//BModule7Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Upper2SactivePar">
 <PartSelector path="//BModule7Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Lower2SactivePar">
 <PartSelector path="//BModule8Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Upper2SactivePar">
 <PartSelector path="//BModule8Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Lower2SactivePar">
 <PartSelector path="//BModule9Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Upper2SactivePar">
 <PartSelector path="//BModule9Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Lower2SactivePar">
 <PartSelector path="//BModule10Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Upper2SactivePar">
 <PartSelector path="//BModule10Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Lower2SactivePar">
 <PartSelector path="//BModule11Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Upper2SactivePar">
 <PartSelector path="//BModule11Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Lower2SactivePar">
 <PartSelector path="//BModule12Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Upper2SactivePar">
 <PartSelector path="//BModule12Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc6LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc6LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc6UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc6UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc6Lower2SactivePar">
 <PartSelector path="//EModule10Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc6Upper2SactivePar">
 <PartSelector path="//EModule10Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc6Lower2SactivePar">
 <PartSelector path="//EModule11Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc6Upper2SactivePar">
 <PartSelector path="//EModule11Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc6Lower2SactivePar">
 <PartSelector path="//EModule12Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc6Upper2SactivePar">
 <PartSelector path="//EModule12Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc6Lower2SactivePar">
 <PartSelector path="//EModule13Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc6Upper2SactivePar">
 <PartSelector path="//EModule13Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc6Lower2SactivePar">
 <PartSelector path="//EModule14Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc6Upper2SactivePar">
 <PartSelector path="//EModule14Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc6Lower2SactivePar">
 <PartSelector path="//EModule15Disc6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc6Upper2SactivePar">
 <PartSelector path="//EModule15Disc6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc7LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc7LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc7UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc7UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc7Lower2SactivePar">
 <PartSelector path="//EModule10Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc7Upper2SactivePar">
 <PartSelector path="//EModule10Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc7Lower2SactivePar">
 <PartSelector path="//EModule11Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc7Upper2SactivePar">
 <PartSelector path="//EModule11Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc7Lower2SactivePar">
 <PartSelector path="//EModule12Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc7Upper2SactivePar">
 <PartSelector path="//EModule12Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc7Lower2SactivePar">
 <PartSelector path="//EModule13Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc7Upper2SactivePar">
 <PartSelector path="//EModule13Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc7Lower2SactivePar">
 <PartSelector path="//EModule14Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc7Upper2SactivePar">
 <PartSelector path="//EModule14Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc7Lower2SactivePar">
 <PartSelector path="//EModule15Disc7Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc7Upper2SactivePar">
 <PartSelector path="//EModule15Disc7Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc8LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc8LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc8UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc8UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc8Lower2SactivePar">
 <PartSelector path="//EModule10Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc8Upper2SactivePar">
 <PartSelector path="//EModule10Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc8Lower2SactivePar">
 <PartSelector path="//EModule11Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc8Upper2SactivePar">
 <PartSelector path="//EModule11Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc8Lower2SactivePar">
 <PartSelector path="//EModule12Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc8Upper2SactivePar">
 <PartSelector path="//EModule12Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc8Lower2SactivePar">
 <PartSelector path="//EModule13Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc8Upper2SactivePar">
 <PartSelector path="//EModule13Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc8Lower2SactivePar">
 <PartSelector path="//EModule14Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc8Upper2SactivePar">
 <PartSelector path="//EModule14Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc8Lower2SactivePar">
 <PartSelector path="//EModule15Disc8Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc8Upper2SactivePar">
 <PartSelector path="//EModule15Disc8Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc9LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc9LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc9UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc9UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc9Lower2SactivePar">
 <PartSelector path="//EModule10Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc9Upper2SactivePar">
 <PartSelector path="//EModule10Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc9Lower2SactivePar">
 <PartSelector path="//EModule11Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc9Upper2SactivePar">
 <PartSelector path="//EModule11Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc9Lower2SactivePar">
 <PartSelector path="//EModule12Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc9Upper2SactivePar">
 <PartSelector path="//EModule12Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc9Lower2SactivePar">
 <PartSelector path="//EModule13Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc9Upper2SactivePar">
 <PartSelector path="//EModule13Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc9Lower2SactivePar">
 <PartSelector path="//EModule14Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc9Upper2SactivePar">
 <PartSelector path="//EModule14Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc9Lower2SactivePar">
 <PartSelector path="//EModule15Disc9Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc9Upper2SactivePar">
 <PartSelector path="//EModule15Disc9Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc10LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc10LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc10UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc10UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc10Lower2SactivePar">
 <PartSelector path="//EModule10Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc10Upper2SactivePar">
 <PartSelector path="//EModule10Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc10Lower2SactivePar">
 <PartSelector path="//EModule11Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc10Upper2SactivePar">
 <PartSelector path="//EModule11Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc10Lower2SactivePar">
 <PartSelector path="//EModule12Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc10Upper2SactivePar">
 <PartSelector path="//EModule12Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc10Lower2SactivePar">
 <PartSelector path="//EModule13Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc10Upper2SactivePar">
 <PartSelector path="//EModule13Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc10Lower2SactivePar">
 <PartSelector path="//EModule14Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc10Upper2SactivePar">
 <PartSelector path="//EModule14Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc10Lower2SactivePar">
 <PartSelector path="//EModule15Disc10Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc10Upper2SactivePar">
 <PartSelector path="//EModule15Disc10Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT613_200_IT4025_2017_03_28.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/trackerStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker4025/trackerStructureTopology.xml
@@ -674,2498 +674,2498 @@ note: see OT613_200_IT4025_2017_03_28.cfg for full config files
 <SpecPar name="BModule1Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule19Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule19Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule20Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule20Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Lower2SactivePar">
 <PartSelector path="//BModule1Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Upper2SactivePar">
 <PartSelector path="//BModule1Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Lower2SactivePar">
 <PartSelector path="//BModule2Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Upper2SactivePar">
 <PartSelector path="//BModule2Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Lower2SactivePar">
 <PartSelector path="//BModule3Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Upper2SactivePar">
 <PartSelector path="//BModule3Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Lower2SactivePar">
 <PartSelector path="//BModule4Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Upper2SactivePar">
 <PartSelector path="//BModule4Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Lower2SactivePar">
 <PartSelector path="//BModule5Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Upper2SactivePar">
 <PartSelector path="//BModule5Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Lower2SactivePar">
 <PartSelector path="//BModule6Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Upper2SactivePar">
 <PartSelector path="//BModule6Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Lower2SactivePar">
 <PartSelector path="//BModule7Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Upper2SactivePar">
 <PartSelector path="//BModule7Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Lower2SactivePar">
 <PartSelector path="//BModule8Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Upper2SactivePar">
 <PartSelector path="//BModule8Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Lower2SactivePar">
 <PartSelector path="//BModule9Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Upper2SactivePar">
 <PartSelector path="//BModule9Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Lower2SactivePar">
 <PartSelector path="//BModule10Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Upper2SactivePar">
 <PartSelector path="//BModule10Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Lower2SactivePar">
 <PartSelector path="//BModule11Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Upper2SactivePar">
 <PartSelector path="//BModule11Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Lower2SactivePar">
 <PartSelector path="//BModule12Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Upper2SactivePar">
 <PartSelector path="//BModule12Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Lower2SactivePar">
 <PartSelector path="//BModule1Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Upper2SactivePar">
 <PartSelector path="//BModule1Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Lower2SactivePar">
 <PartSelector path="//BModule2Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Upper2SactivePar">
 <PartSelector path="//BModule2Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Lower2SactivePar">
 <PartSelector path="//BModule3Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Upper2SactivePar">
 <PartSelector path="//BModule3Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Lower2SactivePar">
 <PartSelector path="//BModule4Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Upper2SactivePar">
 <PartSelector path="//BModule4Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Lower2SactivePar">
 <PartSelector path="//BModule5Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Upper2SactivePar">
 <PartSelector path="//BModule5Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Lower2SactivePar">
 <PartSelector path="//BModule6Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Upper2SactivePar">
 <PartSelector path="//BModule6Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Lower2SactivePar">
 <PartSelector path="//BModule7Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Upper2SactivePar">
 <PartSelector path="//BModule7Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Lower2SactivePar">
 <PartSelector path="//BModule8Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Upper2SactivePar">
 <PartSelector path="//BModule8Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Lower2SactivePar">
 <PartSelector path="//BModule9Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Upper2SactivePar">
 <PartSelector path="//BModule9Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Lower2SactivePar">
 <PartSelector path="//BModule10Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Upper2SactivePar">
 <PartSelector path="//BModule10Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Lower2SactivePar">
 <PartSelector path="//BModule11Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Upper2SactivePar">
 <PartSelector path="//BModule11Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Lower2SactivePar">
 <PartSelector path="//BModule12Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Upper2SactivePar">
 <PartSelector path="//BModule12Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Lower2SactivePar">
 <PartSelector path="//BModule1Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Upper2SactivePar">
 <PartSelector path="//BModule1Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Lower2SactivePar">
 <PartSelector path="//BModule2Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Upper2SactivePar">
 <PartSelector path="//BModule2Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Lower2SactivePar">
 <PartSelector path="//BModule3Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Upper2SactivePar">
 <PartSelector path="//BModule3Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Lower2SactivePar">
 <PartSelector path="//BModule4Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Upper2SactivePar">
 <PartSelector path="//BModule4Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Lower2SactivePar">
 <PartSelector path="//BModule5Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Upper2SactivePar">
 <PartSelector path="//BModule5Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Lower2SactivePar">
 <PartSelector path="//BModule6Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Upper2SactivePar">
 <PartSelector path="//BModule6Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Lower2SactivePar">
 <PartSelector path="//BModule7Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Upper2SactivePar">
 <PartSelector path="//BModule7Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Lower2SactivePar">
 <PartSelector path="//BModule8Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Upper2SactivePar">
 <PartSelector path="//BModule8Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Lower2SactivePar">
 <PartSelector path="//BModule9Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Upper2SactivePar">
 <PartSelector path="//BModule9Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Lower2SactivePar">
 <PartSelector path="//BModule10Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Upper2SactivePar">
 <PartSelector path="//BModule10Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Lower2SactivePar">
 <PartSelector path="//BModule11Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Upper2SactivePar">
 <PartSelector path="//BModule11Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Lower2SactivePar">
 <PartSelector path="//BModule12Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Upper2SactivePar">
 <PartSelector path="//BModule12Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc1Lower2SactivePar">
 <PartSelector path="//EModule11Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc1Upper2SactivePar">
 <PartSelector path="//EModule11Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc1Lower2SactivePar">
 <PartSelector path="//EModule12Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc1Upper2SactivePar">
 <PartSelector path="//EModule12Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc1Lower2SactivePar">
 <PartSelector path="//EModule13Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc1Upper2SactivePar">
 <PartSelector path="//EModule13Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc1Lower2SactivePar">
 <PartSelector path="//EModule14Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc1Upper2SactivePar">
 <PartSelector path="//EModule14Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc1Lower2SactivePar">
 <PartSelector path="//EModule15Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc1Upper2SactivePar">
 <PartSelector path="//EModule15Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc2Lower2SactivePar">
 <PartSelector path="//EModule11Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc2Upper2SactivePar">
 <PartSelector path="//EModule11Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc2Lower2SactivePar">
 <PartSelector path="//EModule12Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc2Upper2SactivePar">
 <PartSelector path="//EModule12Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc2Lower2SactivePar">
 <PartSelector path="//EModule13Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc2Upper2SactivePar">
 <PartSelector path="//EModule13Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc2Lower2SactivePar">
 <PartSelector path="//EModule14Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc2Upper2SactivePar">
 <PartSelector path="//EModule14Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc2Lower2SactivePar">
 <PartSelector path="//EModule15Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc2Upper2SactivePar">
 <PartSelector path="//EModule15Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc3Lower2SactivePar">
 <PartSelector path="//EModule11Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc3Upper2SactivePar">
 <PartSelector path="//EModule11Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc3Lower2SactivePar">
 <PartSelector path="//EModule12Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc3Upper2SactivePar">
 <PartSelector path="//EModule12Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc3Lower2SactivePar">
 <PartSelector path="//EModule13Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc3Upper2SactivePar">
 <PartSelector path="//EModule13Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc3Lower2SactivePar">
 <PartSelector path="//EModule14Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc3Upper2SactivePar">
 <PartSelector path="//EModule14Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc3Lower2SactivePar">
 <PartSelector path="//EModule15Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc3Upper2SactivePar">
 <PartSelector path="//EModule15Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc4Lower2SactivePar">
 <PartSelector path="//EModule11Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc4Upper2SactivePar">
 <PartSelector path="//EModule11Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc4Lower2SactivePar">
 <PartSelector path="//EModule12Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc4Upper2SactivePar">
 <PartSelector path="//EModule12Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc4Lower2SactivePar">
 <PartSelector path="//EModule13Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc4Upper2SactivePar">
 <PartSelector path="//EModule13Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc4Lower2SactivePar">
 <PartSelector path="//EModule14Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc4Upper2SactivePar">
 <PartSelector path="//EModule14Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc4Lower2SactivePar">
 <PartSelector path="//EModule15Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc4Upper2SactivePar">
 <PartSelector path="//EModule15Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc5Lower2SactivePar">
 <PartSelector path="//EModule11Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc5Upper2SactivePar">
 <PartSelector path="//EModule11Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc5Lower2SactivePar">
 <PartSelector path="//EModule12Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc5Upper2SactivePar">
 <PartSelector path="//EModule12Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc5Lower2SactivePar">
 <PartSelector path="//EModule13Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc5Upper2SactivePar">
 <PartSelector path="//EModule13Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc5Lower2SactivePar">
 <PartSelector path="//EModule14Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc5Upper2SactivePar">
 <PartSelector path="//EModule14Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc5Lower2SactivePar">
 <PartSelector path="//EModule15Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc5Upper2SactivePar">
 <PartSelector path="//EModule15Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT614_200_IT404_2017_12_12.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="656"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="656"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="660"/>
-<Parameter name="PixelROCCols" value="221"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="660"/>
+<Parameter name="PixelROCCols" eval="true" value="221"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker404/trackerStructureTopology.xml
@@ -674,2498 +674,2498 @@ note: see OT614_200_IT404_2017_12_12.cfg for full config files
 <SpecPar name="BModule1Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer1LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer1UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer2UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule1Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule1Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule2Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule2Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule3Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule3Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule4Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule4Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule5Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule5Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule6Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule6Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule7Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule7Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule8Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule8Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule9Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule9Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule10Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule10Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule11Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule11Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule12Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule12Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule13Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule13Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule13Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule14Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule14Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule14Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule15Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule15Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule15Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule16Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule16Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule16Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule17Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule17Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule17Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule18Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule18Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule18Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule19Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule19Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule19Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3LowerPSMacroPixelactivePar">
 <PartSelector path="//BModule20Layer3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule20Layer3UpperPSStripactivePar">
 <PartSelector path="//BModule20Layer3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Lower2SactivePar">
 <PartSelector path="//BModule1Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4Upper2SactivePar">
 <PartSelector path="//BModule1Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Lower2SactivePar">
 <PartSelector path="//BModule2Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4Upper2SactivePar">
 <PartSelector path="//BModule2Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Lower2SactivePar">
 <PartSelector path="//BModule3Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4Upper2SactivePar">
 <PartSelector path="//BModule3Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Lower2SactivePar">
 <PartSelector path="//BModule4Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4Upper2SactivePar">
 <PartSelector path="//BModule4Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Lower2SactivePar">
 <PartSelector path="//BModule5Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4Upper2SactivePar">
 <PartSelector path="//BModule5Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Lower2SactivePar">
 <PartSelector path="//BModule6Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer4Upper2SactivePar">
 <PartSelector path="//BModule6Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Lower2SactivePar">
 <PartSelector path="//BModule7Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer4Upper2SactivePar">
 <PartSelector path="//BModule7Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Lower2SactivePar">
 <PartSelector path="//BModule8Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer4Upper2SactivePar">
 <PartSelector path="//BModule8Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Lower2SactivePar">
 <PartSelector path="//BModule9Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer4Upper2SactivePar">
 <PartSelector path="//BModule9Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Lower2SactivePar">
 <PartSelector path="//BModule10Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer4Upper2SactivePar">
 <PartSelector path="//BModule10Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Lower2SactivePar">
 <PartSelector path="//BModule11Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer4Upper2SactivePar">
 <PartSelector path="//BModule11Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Lower2SactivePar">
 <PartSelector path="//BModule12Layer4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer4Upper2SactivePar">
 <PartSelector path="//BModule12Layer4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Lower2SactivePar">
 <PartSelector path="//BModule1Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer5Upper2SactivePar">
 <PartSelector path="//BModule1Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Lower2SactivePar">
 <PartSelector path="//BModule2Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer5Upper2SactivePar">
 <PartSelector path="//BModule2Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Lower2SactivePar">
 <PartSelector path="//BModule3Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer5Upper2SactivePar">
 <PartSelector path="//BModule3Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Lower2SactivePar">
 <PartSelector path="//BModule4Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer5Upper2SactivePar">
 <PartSelector path="//BModule4Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Lower2SactivePar">
 <PartSelector path="//BModule5Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer5Upper2SactivePar">
 <PartSelector path="//BModule5Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Lower2SactivePar">
 <PartSelector path="//BModule6Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer5Upper2SactivePar">
 <PartSelector path="//BModule6Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Lower2SactivePar">
 <PartSelector path="//BModule7Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer5Upper2SactivePar">
 <PartSelector path="//BModule7Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Lower2SactivePar">
 <PartSelector path="//BModule8Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer5Upper2SactivePar">
 <PartSelector path="//BModule8Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Lower2SactivePar">
 <PartSelector path="//BModule9Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer5Upper2SactivePar">
 <PartSelector path="//BModule9Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Lower2SactivePar">
 <PartSelector path="//BModule10Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer5Upper2SactivePar">
 <PartSelector path="//BModule10Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Lower2SactivePar">
 <PartSelector path="//BModule11Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer5Upper2SactivePar">
 <PartSelector path="//BModule11Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Lower2SactivePar">
 <PartSelector path="//BModule12Layer5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer5Upper2SactivePar">
 <PartSelector path="//BModule12Layer5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Lower2SactivePar">
 <PartSelector path="//BModule1Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer6Upper2SactivePar">
 <PartSelector path="//BModule1Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Lower2SactivePar">
 <PartSelector path="//BModule2Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer6Upper2SactivePar">
 <PartSelector path="//BModule2Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Lower2SactivePar">
 <PartSelector path="//BModule3Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer6Upper2SactivePar">
 <PartSelector path="//BModule3Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Lower2SactivePar">
 <PartSelector path="//BModule4Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer6Upper2SactivePar">
 <PartSelector path="//BModule4Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Lower2SactivePar">
 <PartSelector path="//BModule5Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer6Upper2SactivePar">
 <PartSelector path="//BModule5Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Lower2SactivePar">
 <PartSelector path="//BModule6Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule6Layer6Upper2SactivePar">
 <PartSelector path="//BModule6Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Lower2SactivePar">
 <PartSelector path="//BModule7Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule7Layer6Upper2SactivePar">
 <PartSelector path="//BModule7Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Lower2SactivePar">
 <PartSelector path="//BModule8Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule8Layer6Upper2SactivePar">
 <PartSelector path="//BModule8Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Lower2SactivePar">
 <PartSelector path="//BModule9Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule9Layer6Upper2SactivePar">
 <PartSelector path="//BModule9Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Lower2SactivePar">
 <PartSelector path="//BModule10Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule10Layer6Upper2SactivePar">
 <PartSelector path="//BModule10Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Lower2SactivePar">
 <PartSelector path="//BModule11Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule11Layer6Upper2SactivePar">
 <PartSelector path="//BModule11Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Lower2SactivePar">
 <PartSelector path="//BModule12Layer6Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule12Layer6Upper2SactivePar">
 <PartSelector path="//BModule12Layer6Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc1LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc1LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc1UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc1UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc1Lower2SactivePar">
 <PartSelector path="//EModule11Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc1Upper2SactivePar">
 <PartSelector path="//EModule11Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc1Lower2SactivePar">
 <PartSelector path="//EModule12Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc1Upper2SactivePar">
 <PartSelector path="//EModule12Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc1Lower2SactivePar">
 <PartSelector path="//EModule13Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc1Upper2SactivePar">
 <PartSelector path="//EModule13Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc1Lower2SactivePar">
 <PartSelector path="//EModule14Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc1Upper2SactivePar">
 <PartSelector path="//EModule14Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc1Lower2SactivePar">
 <PartSelector path="//EModule15Disc1Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc1Upper2SactivePar">
 <PartSelector path="//EModule15Disc1Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule1Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule1Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule2Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule2Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule3Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule3Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc2LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc2LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc2UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc2UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc2Lower2SactivePar">
 <PartSelector path="//EModule11Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc2Upper2SactivePar">
 <PartSelector path="//EModule11Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc2Lower2SactivePar">
 <PartSelector path="//EModule12Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc2Upper2SactivePar">
 <PartSelector path="//EModule12Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc2Lower2SactivePar">
 <PartSelector path="//EModule13Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc2Upper2SactivePar">
 <PartSelector path="//EModule13Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc2Lower2SactivePar">
 <PartSelector path="//EModule14Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc2Upper2SactivePar">
 <PartSelector path="//EModule14Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc2Lower2SactivePar">
 <PartSelector path="//EModule15Disc2Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc2Upper2SactivePar">
 <PartSelector path="//EModule15Disc2Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc3LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc3LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc3UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc3UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc3Lower2SactivePar">
 <PartSelector path="//EModule11Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc3Upper2SactivePar">
 <PartSelector path="//EModule11Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc3Lower2SactivePar">
 <PartSelector path="//EModule12Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc3Upper2SactivePar">
 <PartSelector path="//EModule12Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc3Lower2SactivePar">
 <PartSelector path="//EModule13Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc3Upper2SactivePar">
 <PartSelector path="//EModule13Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc3Lower2SactivePar">
 <PartSelector path="//EModule14Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc3Upper2SactivePar">
 <PartSelector path="//EModule14Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc3Lower2SactivePar">
 <PartSelector path="//EModule15Disc3Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc3Upper2SactivePar">
 <PartSelector path="//EModule15Disc3Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc4LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc4LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc4UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc4UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc4Lower2SactivePar">
 <PartSelector path="//EModule11Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc4Upper2SactivePar">
 <PartSelector path="//EModule11Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc4Lower2SactivePar">
 <PartSelector path="//EModule12Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc4Upper2SactivePar">
 <PartSelector path="//EModule12Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc4Lower2SactivePar">
 <PartSelector path="//EModule13Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc4Upper2SactivePar">
 <PartSelector path="//EModule13Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc4Lower2SactivePar">
 <PartSelector path="//EModule14Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc4Upper2SactivePar">
 <PartSelector path="//EModule14Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc4Lower2SactivePar">
 <PartSelector path="//EModule15Disc4Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc4Upper2SactivePar">
 <PartSelector path="//EModule15Disc4Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule4Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule4Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule5Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule5Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule6Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule6Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule6Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule7Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule7Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule7Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule8Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule8Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule8Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule9Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule9Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule9Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc5LowerPSMacroPixelactivePar">
 <PartSelector path="//EModule10Disc5LowerPSMacroPixelactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="16"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="16"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule10Disc5UpperPSStripactivePar">
 <PartSelector path="//EModule10Disc5UpperPSStripactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="240"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="4"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="240"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="4"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc5Lower2SactivePar">
 <PartSelector path="//EModule11Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule11Disc5Upper2SactivePar">
 <PartSelector path="//EModule11Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc5Lower2SactivePar">
 <PartSelector path="//EModule12Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule12Disc5Upper2SactivePar">
 <PartSelector path="//EModule12Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc5Lower2SactivePar">
 <PartSelector path="//EModule13Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule13Disc5Upper2SactivePar">
 <PartSelector path="//EModule13Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc5Lower2SactivePar">
 <PartSelector path="//EModule14Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule14Disc5Upper2SactivePar">
 <PartSelector path="//EModule14Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc5Lower2SactivePar">
 <PartSelector path="//EModule15Disc5Lower2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule15Disc5Upper2SactivePar">
 <PartSelector path="//EModule15Disc5Upper2Sactive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="127"/>
-<Parameter name="PixelROCCols" value="1"/>
-<Parameter name="PixelROC_X" value="8"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="127"/>
+<Parameter name="PixelROCCols" eval="true" value="1"/>
+<Parameter name="PixelROC_X" eval="true" value="8"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker405/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker405/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT613_200_IT405_2018_06_26.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="328"/>
-<Parameter name="PixelROCCols" value="440"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="328"/>
+<Parameter name="PixelROCCols" eval="true" value="440"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker613/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT616_200_IT613_2019_02_20.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>

--- a/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker700/pixelStructureTopology.xml
+++ b/Geometry/TrackerCommonData/data/PhaseII/TiltedTracker700/pixelStructureTopology.xml
@@ -112,578 +112,578 @@ note: see OT616_IT700_2019_12_16.cfg for full config files
 <SpecPar name="BModule1Layer1InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule1Layer1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer1InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule2Layer1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer1InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule3Layer1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer1InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule4Layer1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer1InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule5Layer1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer2InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule1Layer2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer2InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule2Layer2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer2InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule3Layer2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer2InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule4Layer2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer2InnerPixel3DActivePar">
 <PartSelector path="//pixel:BModule5Layer2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer3InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule1Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule1Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule2Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule2Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule3Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule3Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule4Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule4Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="BModule5Layer4InnerPixelActivePar">
 <PartSelector path="//pixel:BModule5Layer4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelBarrelDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc1InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc1InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc1InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc1InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc2InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc2InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc2InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc2InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc3InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc3InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc3InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc3InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc4InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc4InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc4InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc4InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc5InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc5InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc5InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc5InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc6InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc6InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc6InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc6InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc7InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc7InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc7InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc7InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc8InnerPixel3DActivePar">
 <PartSelector path="//pixel:EModule1Disc8InnerPixel3DActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="672"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="1"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="672"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="1"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc8InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc8InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc9InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc9InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc10InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc10InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc11InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc11InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule1Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule1Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule2Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule2Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule3Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule3Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule4Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule4Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 <SpecPar name="EModule5Disc12InnerPixelActivePar">
 <PartSelector path="//pixel:EModule5Disc12InnerPixelActive"/>
 <Parameter name="TkDDDStructure" value="PixelEndcapDet"/>
-<Parameter name="PixelROCRows" value="677"/>
-<Parameter name="PixelROCCols" value="217"/>
-<Parameter name="PixelROC_X" value="2"/>
-<Parameter name="PixelROC_Y" value="2"/>
+<Parameter name="PixelROCRows" eval="true" value="677"/>
+<Parameter name="PixelROCCols" eval="true" value="217"/>
+<Parameter name="PixelROC_X" eval="true" value="2"/>
+<Parameter name="PixelROC_Y" eval="true" value="2"/>
 </SpecPar>
 
 </SpecParSection>


### PR DESCRIPTION
This could help speeding-up the DD4hep workflows.

A recent change was added to the dd4hep-version of the FilteredView in CMSSW, in order to directly handle numerical values from XMLs, instead of first storing them as strings.

Mentioned in https://github.com/cms-sw/cmssw/issues/32414 
@ianna 


NB 1: Sim And Reco Phase II XMLs already had evaluated numerical values, nothing to do there.

NB 2: I noticed that there are other XML files with non-evaluated numeric values, outside of Phase II
(except Geometry/TrackerCommonData/data/PhaseI/trackerStructureTopology.xml, which was already fixed in https://github.com/cms-sw/cmssw/pull/32388/commits/32a0c74e01bb2178334538d817e4090810f84d6f):
Geometry/TrackerCommonData/data/trackerStructureTopology.xml
Geometry/TrackerCommonData/data/Pilot/trackerStructureTopology.xml
Geometry/TrackerCommonData/data/CRack/trackerStructureTopology.xml
Geometry/TwentyFivePercentTrackerCommonData/data/trackerStructureTopology_twentyfivepercent.xml
Geometry/TrackerCommonData/data/PhaseI/PixelForward/trackerStructureTopology.xml
Is it worth it modifying them as well, as they are either unused or pre-Run 3 ? I assume it is not.