### PR TITLE
Added "/dd4hep::cm" to the DTGeometryBuilder Class 

### DIFF
--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
@@ -40,6 +40,7 @@
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DTGeometryBuilder.h"
 #include "DD4hep/Detector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <memory>
 #include <string>
@@ -50,6 +51,8 @@ using namespace std;
 using namespace cms;
 
 void DTGeometryBuilder::buildGeometry(DDFilteredView& fview, DTGeometry& geom, const MuonGeometryConstants& num) const {
+  edm::LogVerbatim("DTGeometryBuilder") << "(0) DTGeometryBuilder - DD4Hep ";
+
   bool doChamber = fview.firstChild();
 
   while (doChamber) {
@@ -96,7 +99,11 @@ DTChamber* DTGeometryBuilder::buildChamber(DDFilteredView& fview, const MuonGeom
   DTChamberId detId(rawid);
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  edm::LogVerbatim("DTGeometryBuilder") << "(1) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
+
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
 
   DTChamber* chamber = new DTChamber(detId, surf);
 
@@ -114,7 +121,11 @@ DTSuperLayer* DTGeometryBuilder::buildSuperLayer(DDFilteredView& fview,
 
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  edm::LogVerbatim("DTGeometryBuilder") << "(2) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
+
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
 
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
 
@@ -134,13 +145,20 @@ DTLayer* DTGeometryBuilder::buildLayer(DDFilteredView& fview,
 
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  edm::LogVerbatim("DTGeometryBuilder") << "(3) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
+
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
 
   fview.down();
   bool doWire = fview.sibling();
   int firstWire = fview.volume()->GetNumber();
   auto const& wpar = fview.parameters();
-  float wireLength = wpar[1];
+  float wireLength = wpar[1] / dd4hep::cm;
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(4) detId: " << rawid << " wpar[1]: " << wpar[1] / dd4hep::cm
+                                        << " firstWire: " << firstWire;
 
   int WCounter = 0;
   while (doWire) {

--- a/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
+++ b/Geometry/DTGeometryBuilder/plugins/dd4hep/DTGeometryBuilder.cc
@@ -86,7 +86,7 @@ DTGeometryBuilder::RCPPlane DTGeometryBuilder::plane(const DDFilteredView& fview
   const Double_t* rot = fview.rot();
 
   return RCPPlane(
-      new Plane(Surface::PositionType(tr[0], tr[1], tr[2]),
+      new Plane(Surface::PositionType(tr[0] / dd4hep::cm, tr[1] / dd4hep::cm, tr[2] / dd4hep::cm),
                 Surface::RotationType(rot[0], rot[3], rot[6], rot[1], rot[4], rot[7], rot[2], rot[5], rot[8]),
                 bounds));
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDD4Hep.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDD4Hep.cc
@@ -38,6 +38,7 @@
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DTGeometryBuilderFromDD4Hep.h"
 #include "DD4hep/Detector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <memory>
 #include <string>
@@ -49,6 +50,8 @@ using namespace std;
 void DTGeometryBuilderFromDD4Hep::buildGeometry(cms::DDFilteredView& fview,
                                                 DTGeometry& geom,
                                                 const MuonGeometryConstants& num) const {
+  edm::LogVerbatim("DTGeometryBuilder") << "(0) DTGeometryBuilder - DD4Hep ";
+
   bool doChamber = fview.firstChild();
 
   while (doChamber) {
@@ -97,7 +100,11 @@ DTChamber* DTGeometryBuilderFromDD4Hep::buildChamber(cms::DDFilteredView& fview,
   DTChamberId detId(rawid);
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(1) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
 
   DTChamber* chamber = new DTChamber(detId, surf);
 
@@ -115,7 +122,11 @@ DTSuperLayer* DTGeometryBuilderFromDD4Hep::buildSuperLayer(cms::DDFilteredView& 
 
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(2) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
 
   DTSuperLayer* slayer = new DTSuperLayer(slId, surf, chamber);
 
@@ -135,13 +146,20 @@ DTLayer* DTGeometryBuilderFromDD4Hep::buildLayer(cms::DDFilteredView& fview,
 
   auto const& par = fview.parameters();
 
-  RCPPlane surf(plane(fview, new RectangularPlaneBounds(par[0], par[1], par[2])));
+  RCPPlane surf(
+      plane(fview, new RectangularPlaneBounds(par[0] / dd4hep::cm, par[1] / dd4hep::cm, par[2] / dd4hep::cm)));
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(3) detId: " << rawid << " par[0]: " << par[0] / dd4hep::cm
+                                        << " par[1]: " << par[1] / dd4hep::cm << " par[2]: " << par[2] / dd4hep::cm;
 
   fview.down();
   bool doWire = fview.sibling();
   int firstWire = fview.volume()->GetNumber();
   auto const& wpar = fview.parameters();
-  float wireLength = wpar[1];
+  float wireLength = wpar[1] / dd4hep::cm;
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(4) detId: " << rawid << " wpar[1]: " << wpar[1] / dd4hep::cm
+                                        << " firstWire: " << firstWire;
 
   int WCounter = 0;
   while (doWire) {

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDD4Hep.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDD4Hep.cc
@@ -86,7 +86,7 @@ DTGeometryBuilderFromDD4Hep::RCPPlane DTGeometryBuilderFromDD4Hep::plane(const c
   const Double_t* rot = fview.rot();
 
   return RCPPlane(
-      new Plane(Surface::PositionType(tr[0], tr[1], tr[2]),
+      new Plane(Surface::PositionType(tr[0] / dd4hep::cm, tr[1] / dd4hep::cm, tr[2] / dd4hep::cm),
                 Surface::RotationType(rot[0], rot[3], rot[6], rot[1], rot[4], rot[7], rot[2], rot[5], rot[8]),
                 bounds));
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -16,9 +16,8 @@
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/DTNumberingScheme.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <string>
 
 using namespace std;
@@ -54,6 +53,8 @@ void DTGeometryBuilderFromDDD::build(DTGeometry& theGeometry,
 void DTGeometryBuilderFromDDD::buildGeometry(DTGeometry& theGeometry,
                                              DDFilteredView& fv,
                                              const MuonGeometryConstants& muonConstants) const {
+  edm::LogVerbatim("DTGeometryBuilder") << "(0) DTGeometryBuilder - DDD ";
+
   bool doChamber = fv.firstChild();
 
   // Loop on chambers
@@ -119,6 +120,9 @@ DTChamber* DTGeometryBuilderFromDDD::buildChamber(DDFilteredView& fv,
   // length is along local Y. z      dimension - constant 125.55 cm
   // thickness is long local Z. radial thickness - almost constant about 18 cm
 
+  edm::LogVerbatim("DTGeometryBuilder") << "(1) detId: " << rawid << " par[0]: " << par[0] << " par[1]: " << par[1]
+                                        << " par[2]: " << par[2];
+
   RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
   DTChamber* chamber = new DTChamber(detId, surf);
@@ -137,6 +141,9 @@ DTSuperLayer* DTGeometryBuilderFromDDD::buildSuperLayer(DDFilteredView& fv,
 
   // Slayer specific parameter (size)
   vector<double> par = extractParameters(fv);
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(2) detId: " << rawid << " par[0]: " << par[0] << " par[1]: " << par[1]
+                                        << " par[2]: " << par[2];
 
   // r-phi  dimension - different in different chambers
   // z      dimension - constant 126.8 cm
@@ -172,12 +179,20 @@ DTLayer* DTGeometryBuilderFromDDD::buildLayer(DDFilteredView& fv,
 
   RCPPlane surf(plane(fv, dtGeometryBuilder::getRecPlaneBounds(par.begin())));
 
+  edm::LogVerbatim("DTGeometryBuilder") << "(3) detId: " << rawid << " par[0]: " << par[0] << " par[1]: " << par[1]
+                                        << " par[2]: " << par[2];
+
   // Loop on wires
   bool doWire = fv.firstChild();
   int WCounter = 0;
   int firstWire = fv.copyno();
   par = extractParameters(fv);
   float wireLength = convertMmToCm(par[1]);
+
+  edm::LogVerbatim("DTGeometryBuilder") << "(4) detId: " << rawid
+                                        << " wireLenght in ddd, wpar[1] in dd4hep: " << wireLength
+                                        << " firstWire: " << firstWire;
+
   while (doWire) {
     WCounter++;
     doWire = fv.nextSibling();  // next wire

--- a/Geometry/DTGeometryBuilder/test/python/validateDTGeometryDDD_cfg.py
+++ b/Geometry/DTGeometryBuilder/test/python/validateDTGeometryDDD_cfg.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+ 
+process = cms.Process('VALID',Run3)
+ 
+process.source = cms.Source('EmptySource')
+
+process.maxEvents = cms.untracked.PSet(
+     input = cms.untracked.int32(1)
+     )
+
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
+process.load("Geometry.DTGeometryBuilder.dtGeometry_cfi")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
+
+process.valid = cms.EDAnalyzer("DTGeometryValidate",
+                                infileName = cms.untracked.string('cmsRecoGeom-2021.root'),
+                                outfileName = cms.untracked.string('validateDTGeometryDDD.root'),
+                                )
+ 
+process.p = cms.Path(process.valid)

--- a/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
+++ b/Geometry/DTGeometryBuilder/test/python/validateDTGeometry_cfg.py
@@ -13,6 +13,12 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
 
 process.DTGeometryESProducer = cms.ESProducer("DTGeometryESProducer",
                                               DDDetector = cms.ESInputTag('',''),


### PR DESCRIPTION
**PR description:**

Added "/ ddhep::cm" to the DD4hep part of the DTGeometryBuilder Class in order to simplify a possible future unit transition 

**PR validation:**

1) validation by "cmsRun Geometry/RPCGeometryBuilder/test/python/validateDTGeometry_cfg.py" and "cmsRun Geometry/RPCGeometryBuilder/test/python/validateDTGeometryDDD_cfg.py" 

See attached picture (only one histo for DD4hep)

+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

 2) validation by printouts (myLog.log), for both DD & DD4Hep, created by the validation scripts used above (for example please see, below, the parameters check for the 574914560 (Chamber) detid, 574922752 (SLayer) detid, 574923776 (Layer) detid ):

//DDD

(0) DTGeometryBuilder - DDD 
(1) detId: 574914560, par[0]: 1090 mm, par[1]: 1255.5 mm, par[2]: 181 mm
(2) detId: 574922752, par[0]: 1063.2 mm, par[1]: 1255.5 mm, par[2]: 26.75 mm
(3) detId: 574923776, par[0]: 1029.65 mm, par[1]: 1199 mm, par[2]: 5.75 mm
(4) detId: 574923776 ,wireLenght in ddd, (wpar[1] in dd4hep): 117.4 cm, firstWire: 1

//DD4Hep

(0) DTGeometryBuilder - DD4Hep 
(1) detId: 574914560, par[0]: 109 cm, par[1]: 125.55 cm, par[2]: 18.1 cm
(2) detId: 574922752, par[0]: 106.32 cm, par[1]: 125.55 cm, par[2]: 2.675 cm
(3) detId: 574923776, par[0]: 102.965 cm, par[1]: 119.9 cm, par[2]: 0.575 cm
(4) detId: 574923776, wpar[1]: 117.4 cm, firstWire: 1  
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

3) validation by "runTheMatrix.py -l 25202.1" :

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Mon Dec 14 18:32:47 2020-date Mon Dec 14 18:10:42 2020; exit: 0 0 0 0  1 1 1 1 tests passed, 0 0 0 0 failed

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

![Schermata 2020-12-14 alle 17 16 53](https://user-images.githubusercontent.com/28751695/102125756-6fda1f80-3e4a-11eb-8ddd-9a6659783c41.png)
