### PR TITLE
New HLT DEBUG object:  EgTrigSumObj : CMSSW_11_3_X

### DIFF
--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/RecoCandidate"/>
 <use name="DataFormats/EgammaCandidates"/>
+<use name="DataFormats/EgammaReco"/>
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/HcalIsolatedTrack"/>

--- a/DataFormats/HLTReco/interface/EgammaObject.h
+++ b/DataFormats/HLTReco/interface/EgammaObject.h
@@ -1,0 +1,64 @@
+#ifndef DataFormats_HLTReco_EgammaObject_h
+#define DataFormats_HLTReco_EgammaObject_h
+
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+
+#include <vector>
+#include <string>
+
+namespace reco {
+  class RecoEcalCandidate;
+}
+
+namespace trigger {
+  class EgammaObject : public TriggerObject {
+  public:
+    EgammaObject() : hasPixelMatch_(false) {}
+
+    EgammaObject(int id, float pt, float eta, float phi, float mass)
+        : TriggerObject(id, pt, eta, phi, mass), hasPixelMatch_(false) {}
+    EgammaObject(const reco::RecoEcalCandidate& ecalCand);
+
+    const reco::SuperClusterRef& superCluster() const { return superCluster_; }
+    const reco::GsfTrackRefVector& gsfTracks() const { return gsfTracks_; }
+    const reco::ElectronSeedRefVector& seeds() const { return seeds_; }
+
+    void setSuperCluster(const reco::SuperClusterRef& sc) { superCluster_ = sc; }
+    void setGsfTracks(reco::GsfTrackRefVector trks) { gsfTracks_ = std::move(trks); }
+    void setSeeds(reco::ElectronSeedRefVector seeds);
+
+    bool hasVar(const std::string& varName) const;
+    float var(const std::string& varName, bool raiseExcept = true) const;
+    const std::vector<std::pair<std::string, float>>& vars() const { return vars_; }
+    //varNames and varNamesStr are reasonably expensive functions and are more
+    //intended for debugging than normal use
+    std::vector<std::string> varNames() const;
+    std::string varNamesStr() const;
+    void setVars(std::vector<std::pair<std::string, float>> vars);
+    void clearVars() { vars_.clear(); }
+
+  private:
+    struct VarComparer {
+      bool operator()(const std::string& lhs, const std::pair<std::string, float>& rhs) const {
+        return lhs < rhs.first;
+      }
+      bool operator()(const std::pair<std::string, float>& lhs, const std::string& rhs) const {
+        return lhs.first < rhs;
+      }
+    };
+
+    bool hasPixelMatch_;
+    std::vector<std::pair<std::string, float>> vars_;
+
+    reco::SuperClusterRef superCluster_;
+    reco::GsfTrackRefVector gsfTracks_;
+    //currently these are pixel seeds but could be tracker seeds...
+    reco::ElectronSeedRefVector seeds_;
+  };
+
+}  // namespace trigger
+
+#endif

--- a/DataFormats/HLTReco/interface/EgammaObjectFwd.h
+++ b/DataFormats/HLTReco/interface/EgammaObjectFwd.h
@@ -1,0 +1,19 @@
+#ifndef DataFormats_HLTReco_EgammaObjectFwd_h
+#define DataFormats_HLTReco_EgammaObjectFwd_h
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefProd.h"
+
+namespace trigger {
+  class EgammaObject;
+
+  typedef std::vector<EgammaObject> EgammaObjectCollection;
+  typedef edm::Ref<EgammaObjectCollection> EgammaObjectRef;
+  typedef edm::RefProd<EgammaObjectCollection> EgammaObjectRefProd;
+  typedef edm::RefVector<EgammaObjectCollection> EgammaObjectRefVector;
+  typedef EgammaObjectRefVector::iterator EgammaObjectIterator;
+}  // namespace trigger
+
+#endif

--- a/DataFormats/HLTReco/src/EgammaObject.cc
+++ b/DataFormats/HLTReco/src/EgammaObject.cc
@@ -1,0 +1,62 @@
+#include "DataFormats/HLTReco/interface/EgammaObject.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+
+trigger::EgammaObject::EgammaObject(const reco::RecoEcalCandidate& ecalCand)
+    : TriggerObject(ecalCand), hasPixelMatch_(false), superCluster_(ecalCand.superCluster()) {}
+
+void trigger::EgammaObject::setSeeds(reco::ElectronSeedRefVector seeds) {
+  seeds_ = std::move(seeds);
+  hasPixelMatch_ = false;
+  for (const auto& seed : seeds_) {
+    if (!seed->hitInfo().empty()) {
+      hasPixelMatch_ = true;
+      break;
+    }
+  }
+}
+
+bool trigger::EgammaObject::hasVar(const std::string& varName) const {
+  return std::binary_search(vars_.begin(), vars_.end(), varName, VarComparer());
+}
+
+float trigger::EgammaObject::var(const std::string& varName, const bool raiseExcept) const {
+  //here we have a guaranteed sorted vector with unique entries
+  auto varIt = std::equal_range(vars_.begin(), vars_.end(), varName, VarComparer());
+  if (varIt.first != varIt.second)
+    return varIt.first->second;
+  else if (raiseExcept) {
+    cms::Exception ex("AttributeError");
+    ex << " error variable " << varName << " is not present, variables present are " << varNamesStr();
+    throw ex;
+  } else {
+    return std::numeric_limits<float>::max();
+  }
+}
+
+std::vector<std::string> trigger::EgammaObject::varNames() const {
+  std::vector<std::string> names;
+  for (const auto& var : vars_) {
+    names.push_back(var.first);
+  }
+  return names;
+}
+
+std::string trigger::EgammaObject::varNamesStr() const {
+  std::string retVal;
+  auto names = varNames();
+  for (const auto& name : names) {
+    if (!retVal.empty())
+      retVal += " ";
+    retVal += name;
+  }
+  return retVal;
+}
+
+void trigger::EgammaObject::setVars(std::vector<std::pair<std::string, float>> vars) {
+  vars_ = std::move(vars);
+  std::sort(vars_.begin(), vars_.end(), [](auto& lhs, auto& rhs) { return lhs.first < rhs.first; });
+}

--- a/DataFormats/HLTReco/src/classes.h
+++ b/DataFormats/HLTReco/src/classes.h
@@ -6,6 +6,7 @@
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
 #include "DataFormats/HLTReco/interface/HLTPrescaleTable.h"
+#include "DataFormats/HLTReco/interface/EgammaObject.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #include "DataFormats/Candidate/interface/CompositeCandidate.h"

--- a/DataFormats/HLTReco/src/classes_def.xml
+++ b/DataFormats/HLTReco/src/classes_def.xml
@@ -85,5 +85,17 @@
    <version ClassVersion="10" checksum="2181075001"/>
   </class>
   <class name="edm::Wrapper<trigger::HLTPrescaleTable>"/>
+  
+  <class name="trigger::EgammaObject" ClassVersion="3">
+   <version ClassVersion="3" checksum="2024664439"/>
+  </class>
+  <class name="std::vector<trigger::EgammaObject>"/>
+  <class name="edm::Wrapper<std::vector<trigger::EgammaObject> >"/>
+  <class name="edm::Ref<std::vector<trigger::EgammaObject>,trigger::EgammaObject,edm::refhelper::FindUsingAdvance<std::vector<trigger::EgammaObject>,trigger::EgammaObject> >"/>
+  <class name="edm::RefProd<std::vector<trigger::EgammaObject> >"/>
+  <class name="edm::RefVector<std::vector<trigger::EgammaObject>,trigger::EgammaObject,edm::refhelper::FindUsingAdvance<std::vector<trigger::EgammaObject>,trigger::EgammaObject> >"/>
+  <class name="edm::Wrapper<edm::RefVector<std::vector<trigger::EgammaObject>,trigger::EgammaObject,edm::refhelper::FindUsingAdvance<std::vector<trigger::EgammaObject>,trigger::EgammaObject> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<trigger::EgammaObject>,trigger::EgammaObject,edm::refhelper::FindUsingAdvance<std::vector<trigger::EgammaObject>,trigger::EgammaObject> > >"/>
+  <class name="edm::Wrapper<std::vector<edm::Ref<std::vector<trigger::EgammaObject>,trigger::EgammaObject,edm::refhelper::FindUsingAdvance<std::vector<trigger::EgammaObject>,trigger::EgammaObject> > > >"/>
 
 </lcgdict>

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTExtraProducer.cc
@@ -1,0 +1,465 @@
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/HLTReco/interface/EgammaObject.h"
+#include "DataFormats/HLTReco/interface/EgammaObjectFwd.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include <vector>
+
+class EgammaHLTExtraProducer : public edm::global::EDProducer<> {
+public:
+  explicit EgammaHLTExtraProducer(const edm::ParameterSet& pset);
+  ~EgammaHLTExtraProducer() override {}
+
+  void produce(edm::StreamID streamID, edm::Event& event, const edm::EventSetup& eventSetup) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  static void setVars(trigger::EgammaObject& egTrigObj,
+                      const reco::RecoEcalCandidateRef& ecalCandRef,
+                      const std::vector<edm::Handle<reco::RecoEcalCandidateIsolationMap>>& valueMapHandles);
+  static reco::GsfTrackRefVector matchingGsfTrks(const reco::SuperClusterRef& scRef,
+                                                 const edm::Handle<reco::GsfTrackCollection>& gsfTrksHandle);
+  static void setGsfTracks(trigger::EgammaObject& egTrigObj,
+                           const edm::Handle<reco::GsfTrackCollection>& gsfTrksHandle);
+  static void setSeeds(trigger::EgammaObject& egTrigObj, edm::Handle<reco::ElectronSeedCollection>& eleSeedsHandle);
+
+  //these three filter functions are overly similar but with annoying differences
+  //eg rechits needs to access geometry, trk dr is also w.r.t the track eta/phi
+  //still could collapse into a single function
+  template <typename RecHitCollection>
+  std::unique_ptr<RecHitCollection> filterRecHits(
+      const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjs,
+      const edm::Handle<RecHitCollection>& recHits,
+      const CaloGeometry& geom,
+      float maxDR2 = 0.4 * 0.4) const;
+
+  std::unique_ptr<reco::TrackCollection> filterTrks(
+      const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjs,
+      const edm::Handle<reco::TrackCollection>& trks,
+      float maxDR2 = 0.4 * 0.4) const;
+
+  std::unique_ptr<reco::PFClusterCollection> filterPFClusIso(
+      const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjs,
+      const edm::Handle<reco::PFClusterCollection>& pfClus,
+      float maxDR2 = 0.4 * 0.4) const;
+
+  struct Tokens {
+    //these are the tokens which comprise the E/gamma candidate (eg cand,gsf track, pixel seeds)
+    struct EgObjTokens {
+      edm::EDGetTokenT<reco::RecoEcalCandidateCollection> ecalCands;
+      edm::EDGetTokenT<reco::GsfTrackCollection> gsfTracks;
+      edm::EDGetTokenT<reco::ElectronSeedCollection> pixelSeeds;
+    };
+    std::vector<std::pair<EgObjTokens, std::string>> egCands;
+
+    std::vector<std::pair<edm::EDGetTokenT<EcalRecHitCollection>, std::string>> ecal;
+    std::vector<std::pair<edm::EDGetTokenT<HBHERecHitCollection>, std::string>> hcal;
+    std::vector<std::pair<edm::EDGetTokenT<reco::TrackCollection>, std::string>> trks;
+    std::vector<std::pair<edm::EDGetTokenT<reco::PFClusterCollection>, std::string>> pfClusIso;
+
+    template <typename T>
+    static void setToken(edm::EDGetTokenT<T>& token,
+                         edm::ConsumesCollector& cc,
+                         const edm::ParameterSet& pset,
+                         const std::string& tagname) {
+      token = cc.consumes<T>(pset.getParameter<edm::InputTag>(tagname));
+    }
+    template <typename T>
+    static void setToken(std::vector<edm::EDGetTokenT<T>>& tokens,
+                         edm::ConsumesCollector& cc,
+                         const edm::ParameterSet& pset,
+                         const std::string& tagname) {
+      auto inputTags = pset.getParameter<std::vector<edm::InputTag>>(tagname);
+      tokens.resize(inputTags.size());
+      for (size_t tagNr = 0; tagNr < inputTags.size(); tagNr++) {
+        tokens[tagNr] = cc.consumes<T>(inputTags[tagNr]);
+      }
+    }
+    template <typename T>
+    static void setToken(std::vector<std::pair<edm::EDGetTokenT<T>, std::string>>& tokens,
+                         edm::ConsumesCollector& cc,
+                         const edm::ParameterSet& pset,
+                         const std::string& tagname) {
+      const auto& collectionPSets = pset.getParameter<std::vector<edm::ParameterSet>>(tagname);
+      for (const auto& collPSet : collectionPSets) {
+        edm::EDGetTokenT<T> token = cc.consumes<T>(collPSet.getParameter<edm::InputTag>("src"));
+        std::string label = collPSet.getParameter<std::string>("label");
+        tokens.emplace_back(token, std::move(label));
+      }
+    }
+
+    static void setToken(std::vector<std::pair<EgObjTokens, std::string>>& tokens,
+                         edm::ConsumesCollector& cc,
+                         const edm::ParameterSet& pset,
+                         const std::string& tagname) {
+      const auto& collectionPSets = pset.getParameter<std::vector<edm::ParameterSet>>(tagname);
+      for (const auto& collPSet : collectionPSets) {
+        EgObjTokens objTokens;
+        setToken(objTokens.ecalCands, cc, collPSet, "ecalCands");
+        setToken(objTokens.gsfTracks, cc, collPSet, "gsfTracks");
+        setToken(objTokens.pixelSeeds, cc, collPSet, "pixelSeeds");
+        std::string label = collPSet.getParameter<std::string>("label");
+        tokens.emplace_back(objTokens, std::move(label));
+      }
+    }
+    Tokens(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc);
+  };
+
+  const Tokens tokens_;
+
+  float minPtToSaveHits_;
+  bool saveHitsPlusPi_;
+  bool saveHitsPlusHalfPi_;
+};
+
+EgammaHLTExtraProducer::Tokens::Tokens(const edm::ParameterSet& pset, edm::ConsumesCollector&& cc) {
+  setToken(egCands, cc, pset, "egCands");
+  setToken(ecal, cc, pset, "ecal");
+  setToken(hcal, cc, pset, "hcal");
+  setToken(trks, cc, pset, "trks");
+  setToken(pfClusIso, cc, pset, "pfClusIso");
+}
+
+EgammaHLTExtraProducer::EgammaHLTExtraProducer(const edm::ParameterSet& pset)
+    : tokens_(pset, consumesCollector()),
+      minPtToSaveHits_(pset.getParameter<double>("minPtToSaveHits")),
+      saveHitsPlusPi_(pset.getParameter<bool>("saveHitsPlusPi")),
+      saveHitsPlusHalfPi_(pset.getParameter<bool>("saveHitsPlusHalfPi")) {
+  consumesMany<reco::RecoEcalCandidateIsolationMap>();
+
+  for (auto& tokenLabel : tokens_.egCands) {
+    produces<trigger::EgammaObjectCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.ecal) {
+    produces<EcalRecHitCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.hcal) {
+    produces<HBHERecHitCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.trks) {
+    produces<reco::TrackCollection>(tokenLabel.second);
+  }
+  for (auto& tokenLabel : tokens_.pfClusIso) {
+    produces<reco::PFClusterCollection>(tokenLabel.second);
+  }
+}
+
+void EgammaHLTExtraProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("minPtToSaveHits", 0.);
+  desc.add<bool>("saveHitsPlusPi", false);
+  desc.add<bool>("saveHitsPlusHalfPi", true);
+
+  edm::ParameterSetDescription egCandsDesc;
+  egCandsDesc.add<edm::InputTag>("ecalCands", edm::InputTag(""));
+  egCandsDesc.add<edm::InputTag>("pixelSeeds", edm::InputTag(""));
+  egCandsDesc.add<edm::InputTag>("gsfTracks", edm::InputTag(""));
+  egCandsDesc.add<std::string>("label", "");
+  std::vector<edm::ParameterSet> egCandsDefaults(1);
+  egCandsDefaults[0].addParameter("ecalCands", edm::InputTag("hltEgammaCandidates"));
+  egCandsDefaults[0].addParameter("pixelSeeds", edm::InputTag("hltEgammaElectronPixelSeeds"));
+  egCandsDefaults[0].addParameter("gsfTracks", edm::InputTag("hltEgammaGsfTracks"));
+  egCandsDefaults[0].addParameter("label", std::string(""));
+
+  edm::ParameterSetDescription tokenLabelDesc;
+  tokenLabelDesc.add<edm::InputTag>("src", edm::InputTag(""));
+  tokenLabelDesc.add<std::string>("label", "");
+  std::vector<edm::ParameterSet> ecalDefaults(2);
+  ecalDefaults[0].addParameter("src", edm::InputTag("hltEcalRecHit", "EcalRecHitsEB"));
+  ecalDefaults[0].addParameter("label", std::string("EcalRecHitsEB"));
+  ecalDefaults[1].addParameter("src", edm::InputTag("hltEcalRecHit", "EcalRecHitsEE"));
+  ecalDefaults[1].addParameter("label", std::string("EcalRecHitsEE"));
+  std::vector<edm::ParameterSet> hcalDefaults(1);
+  hcalDefaults[0].addParameter("src", edm::InputTag("hltHbhereco"));
+  hcalDefaults[0].addParameter("label", std::string(""));
+  std::vector<edm::ParameterSet> trksDefaults(1);
+  trksDefaults[0].addParameter("src", edm::InputTag("generalTracks"));
+  trksDefaults[0].addParameter("label", std::string(""));
+  std::vector<edm::ParameterSet> pfClusIsoDefaults(3);
+  pfClusIsoDefaults[0].addParameter("src", edm::InputTag("hltParticleFlowClusterECALL1Seeded"));
+  pfClusIsoDefaults[0].addParameter("label", std::string("Ecal"));
+  pfClusIsoDefaults[1].addParameter("src", edm::InputTag("hltParticleFlowClusterECALUnseeded"));
+  pfClusIsoDefaults[1].addParameter("label", std::string("EcalUnseeded"));
+  pfClusIsoDefaults[2].addParameter("src", edm::InputTag("hltParticleFlowClusterHCAL"));
+  pfClusIsoDefaults[2].addParameter("label", std::string("Hcal"));
+
+  desc.addVPSet("egCands", egCandsDesc, egCandsDefaults);
+  desc.addVPSet("ecal", tokenLabelDesc, ecalDefaults);
+  desc.addVPSet("hcal", tokenLabelDesc, hcalDefaults);
+  desc.addVPSet("trks", tokenLabelDesc, trksDefaults);
+  desc.addVPSet("pfClusIso", tokenLabelDesc, pfClusIsoDefaults);
+
+  descriptions.add(("hltEgammaHLTExtraProducer"), desc);
+}
+
+void EgammaHLTExtraProducer::produce(edm::StreamID streamID,
+                                     edm::Event& event,
+                                     const edm::EventSetup& eventSetup) const {
+  std::vector<edm::Handle<reco::RecoEcalCandidateIsolationMap>> valueMapHandles;
+  event.getManyByType(valueMapHandles);
+
+  std::vector<std::unique_ptr<trigger::EgammaObjectCollection>> egTrigObjColls;
+  for (const auto& egCandsToken : tokens_.egCands) {
+    auto ecalCandsHandle = event.getHandle(egCandsToken.first.ecalCands);
+    auto gsfTrksHandle = event.getHandle(egCandsToken.first.gsfTracks);
+    auto pixelSeedsHandle = event.getHandle(egCandsToken.first.pixelSeeds);
+
+    auto egTrigObjs = std::make_unique<trigger::EgammaObjectCollection>();
+    for (size_t candNr = 0; ecalCandsHandle.isValid() && candNr < ecalCandsHandle->size(); candNr++) {
+      reco::RecoEcalCandidateRef candRef(ecalCandsHandle, candNr);
+      egTrigObjs->push_back(*candRef);
+      auto& egTrigObj = egTrigObjs->back();
+      setVars(egTrigObj, candRef, valueMapHandles);
+      setGsfTracks(egTrigObj, gsfTrksHandle);
+      setSeeds(egTrigObj, pixelSeedsHandle);
+    }
+    egTrigObjColls.emplace_back(std::move(egTrigObjs));
+  }
+
+  edm::ESHandle<CaloGeometry> caloGeomHandle;
+  eventSetup.get<CaloGeometryRecord>().get(caloGeomHandle);
+
+  auto filterAndStoreRecHits = [caloGeomHandle, &event, this](const auto& egTrigObjs, const auto& tokenLabels) {
+    for (const auto& tokenLabel : tokenLabels) {
+      auto handle = event.getHandle(tokenLabel.first);
+      auto recHits = filterRecHits(egTrigObjs, handle, *caloGeomHandle);
+      event.put(std::move(recHits), tokenLabel.second);
+    }
+  };
+  auto filterAndStore = [&event, this](const auto& egTrigObjs, const auto& tokenLabels, auto filterFunc) {
+    for (const auto& tokenLabel : tokenLabels) {
+      auto handle = event.getHandle(tokenLabel.first);
+      auto filtered = (this->*filterFunc)(egTrigObjs, handle, 0.4 * 0.4);
+      event.put(std::move(filtered), tokenLabel.second);
+    }
+  };
+
+  filterAndStoreRecHits(egTrigObjColls, tokens_.ecal);
+  filterAndStoreRecHits(egTrigObjColls, tokens_.hcal);
+  filterAndStore(egTrigObjColls, tokens_.pfClusIso, &EgammaHLTExtraProducer::filterPFClusIso);
+  filterAndStore(egTrigObjColls, tokens_.trks, &EgammaHLTExtraProducer::filterTrks);
+
+  for (size_t collNr = 0; collNr < egTrigObjColls.size(); collNr++) {
+    event.put(std::move(egTrigObjColls[collNr]), tokens_.egCands[collNr].second);
+  }
+}
+
+void EgammaHLTExtraProducer::setVars(
+    trigger::EgammaObject& egTrigObj,
+    const reco::RecoEcalCandidateRef& ecalCandRef,
+    const std::vector<edm::Handle<reco::RecoEcalCandidateIsolationMap>>& valueMapHandles) {
+  std::vector<std::pair<std::string, float>> vars;
+  for (auto& valueMapHandle : valueMapHandles) {
+    auto mapIt = valueMapHandle->find(ecalCandRef);
+    if (mapIt != valueMapHandle->end()) {
+      std::string name = valueMapHandle.provenance()->moduleLabel();
+      if (!valueMapHandle.provenance()->productInstanceName().empty()) {
+        name += "_" + valueMapHandle.provenance()->productInstanceName();
+      }
+      vars.emplace_back(std::move(name), mapIt->val);
+    }
+  }
+  egTrigObj.setVars(std::move(vars));
+}
+
+reco::GsfTrackRefVector EgammaHLTExtraProducer::matchingGsfTrks(
+    const reco::SuperClusterRef& scRef, const edm::Handle<reco::GsfTrackCollection>& gsfTrksHandle) {
+  if (!gsfTrksHandle.isValid()) {
+    return reco::GsfTrackRefVector();
+  }
+
+  reco::GsfTrackRefVector gsfTrkRefs(gsfTrksHandle.id());
+  for (size_t trkNr = 0; gsfTrksHandle.isValid() && trkNr < gsfTrksHandle->size(); trkNr++) {
+    reco::GsfTrackRef trkRef(gsfTrksHandle, trkNr);
+    edm::RefToBase<TrajectorySeed> seed = trkRef->extra()->seedRef();
+    reco::ElectronSeedRef eleSeed = seed.castTo<reco::ElectronSeedRef>();
+    edm::RefToBase<reco::CaloCluster> caloCluster = eleSeed->caloCluster();
+    reco::SuperClusterRef scRefFromTrk = caloCluster.castTo<reco::SuperClusterRef>();
+    if (scRefFromTrk == scRef) {
+      gsfTrkRefs.push_back(trkRef);
+    }
+  }
+  return gsfTrkRefs;
+}
+
+void EgammaHLTExtraProducer::setGsfTracks(trigger::EgammaObject& egTrigObj,
+                                          const edm::Handle<reco::GsfTrackCollection>& gsfTrksHandle) {
+  egTrigObj.setGsfTracks(matchingGsfTrks(egTrigObj.superCluster(), gsfTrksHandle));
+}
+
+void EgammaHLTExtraProducer::setSeeds(trigger::EgammaObject& egTrigObj,
+                                      edm::Handle<reco::ElectronSeedCollection>& eleSeedsHandle) {
+  if (!eleSeedsHandle.isValid()) {
+    egTrigObj.setSeeds(reco::ElectronSeedRefVector());
+  } else {
+    reco::ElectronSeedRefVector trigObjSeeds(eleSeedsHandle.id());
+
+    for (size_t seedNr = 0; eleSeedsHandle.isValid() && seedNr < eleSeedsHandle->size(); seedNr++) {
+      reco::ElectronSeedRef eleSeed(eleSeedsHandle, seedNr);
+      edm::RefToBase<reco::CaloCluster> caloCluster = eleSeed->caloCluster();
+      reco::SuperClusterRef scRefFromSeed = caloCluster.castTo<reco::SuperClusterRef>();
+
+      if (scRefFromSeed == egTrigObj.superCluster()) {
+        trigObjSeeds.push_back(eleSeed);
+      }
+    }
+    egTrigObj.setSeeds(std::move(trigObjSeeds));
+  }
+}
+
+template <typename RecHitCollection>
+std::unique_ptr<RecHitCollection> EgammaHLTExtraProducer::filterRecHits(
+    const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjColls,
+    const edm::Handle<RecHitCollection>& recHits,
+    const CaloGeometry& geom,
+    float maxDR2) const {
+  auto filteredHits = std::make_unique<RecHitCollection>();
+  if (!recHits.isValid())
+    return filteredHits;
+
+  std::vector<std::pair<float, float>> etaPhis;
+  for (const auto& egTrigObjs : egTrigObjColls) {
+    for (const auto& egTrigObj : *egTrigObjs) {
+      if (egTrigObj.pt() >= minPtToSaveHits_) {
+        etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi()});
+        if (saveHitsPlusPi_)
+          etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi() + 3.14159});
+        if (saveHitsPlusHalfPi_)
+          etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi() + 3.14159 / 2.});
+      }
+    }
+  }
+  auto deltaR2Match = [&etaPhis, &maxDR2](const GlobalPoint& pos) {
+    float eta = pos.eta();
+    float phi = pos.phi();
+    for (auto& etaPhi : etaPhis) {
+      if (reco::deltaR2(eta, phi, etaPhi.first, etaPhi.second) < maxDR2)
+        return true;
+    }
+    return false;
+  };
+
+  for (auto& hit : *recHits) {
+    const CaloSubdetectorGeometry* subDetGeom = geom.getSubdetectorGeometry(hit.id());
+    if (subDetGeom) {
+      auto cellGeom = subDetGeom->getGeometry(hit.id());
+      if (deltaR2Match(cellGeom->getPosition()))
+        filteredHits->push_back(hit);
+    } else {
+      throw cms::Exception("GeomError") << "could not get geometry for det id " << hit.id().rawId();
+    }
+  }
+  return filteredHits;
+}
+
+std::unique_ptr<reco::TrackCollection> EgammaHLTExtraProducer::filterTrks(
+    const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjColls,
+    const edm::Handle<reco::TrackCollection>& trks,
+    float maxDR2) const {
+  auto filteredTrks = std::make_unique<reco::TrackCollection>();
+  if (!trks.isValid())
+    return filteredTrks;
+
+  //so because each egamma object can have multiple eta/phi pairs
+  //easier to just make a temp vector and then copy that in with the +pi and  +pi/2
+  std::vector<std::pair<float, float>> etaPhisTmp;
+  for (const auto& egTrigObjs : egTrigObjColls) {
+    for (const auto& egTrigObj : *egTrigObjs) {
+      if (egTrigObj.pt() >= minPtToSaveHits_) {
+        etaPhisTmp.push_back({egTrigObj.eta(), egTrigObj.phi()});
+        //also save the eta /phi of all gsf tracks with the object
+        for (const auto& gsfTrk : egTrigObj.gsfTracks()) {
+          etaPhisTmp.push_back({gsfTrk->eta(), gsfTrk->phi()});
+        }
+      }
+    }
+  }
+  std::vector<std::pair<float, float>> etaPhis;
+  for (const auto& etaPhi : etaPhisTmp) {
+    etaPhis.push_back(etaPhi);
+    if (saveHitsPlusPi_)
+      etaPhis.push_back({etaPhi.first, etaPhi.second + 3.14159});
+    if (saveHitsPlusHalfPi_)
+      etaPhis.push_back({etaPhi.first, etaPhi.second + 3.14159 / 2.});
+  }
+
+  auto deltaR2Match = [&etaPhis, &maxDR2](float eta, float phi) {
+    for (auto& etaPhi : etaPhis) {
+      if (reco::deltaR2(eta, phi, etaPhi.first, etaPhi.second) < maxDR2)
+        return true;
+    }
+    return false;
+  };
+
+  for (auto& trk : *trks) {
+    if (deltaR2Match(trk.eta(), trk.phi()))
+      filteredTrks->push_back(trk);
+  }
+  return filteredTrks;
+}
+
+std::unique_ptr<reco::PFClusterCollection> EgammaHLTExtraProducer::filterPFClusIso(
+    const std::vector<std::unique_ptr<trigger::EgammaObjectCollection>>& egTrigObjColls,
+    const edm::Handle<reco::PFClusterCollection>& pfClus,
+    float maxDR2) const {
+  auto filteredPFClus = std::make_unique<reco::PFClusterCollection>();
+  if (!pfClus.isValid())
+    return filteredPFClus;
+
+  std::vector<std::pair<float, float>> etaPhis;
+  for (const auto& egTrigObjs : egTrigObjColls) {
+    for (const auto& egTrigObj : *egTrigObjs) {
+      if (egTrigObj.pt() >= minPtToSaveHits_) {
+        etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi()});
+        if (saveHitsPlusPi_)
+          etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi() + 3.14159});
+        if (saveHitsPlusHalfPi_)
+          etaPhis.push_back({egTrigObj.eta(), egTrigObj.phi() + 3.14159 / 2.});
+      }
+    }
+  }
+  auto deltaR2Match = [&etaPhis, &maxDR2](float eta, float phi) {
+    for (auto& etaPhi : etaPhis) {
+      if (reco::deltaR2(eta, phi, etaPhi.first, etaPhi.second) < maxDR2)
+        return true;
+    }
+    return false;
+  };
+
+  for (auto& clus : *pfClus) {
+    if (deltaR2Match(clus.eta(), clus.phi()))
+      filteredPFClus->push_back(clus);
+  }
+  return filteredPFClus;
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(EgammaHLTExtraProducer);

--- a/RecoEgamma/EgammaHLTProducers/python/hltEgammaHLTExtra_cfi.py
+++ b/RecoEgamma/EgammaHLTProducers/python/hltEgammaHLTExtra_cfi.py
@@ -1,0 +1,49 @@
+import FWCore.ParameterSet.Config as cms
+
+hltEgammaHLTExtra = cms.EDProducer("EgammaHLTExtraProducer",
+                                   egCands = cms.VPSet(
+                                       cms.PSet(
+                                           pixelSeeds = cms.InputTag("hltEgammaElectronPixelSeeds"),
+                                           ecalCands = cms.InputTag("hltEgammaCandidates"),
+                                           gsfTracks = cms.InputTag("hltEgammaGsfTracks"),
+                                           label = cms.string('')
+                                       ),
+                                       cms.PSet(
+                                           pixelSeeds = cms.InputTag("hltEgammaElectronPixelSeedsUnseeded"),
+                                           ecalCands = cms.InputTag("hltEgammaCandidatesUnseeded"),
+                                           gsfTracks = cms.InputTag("hltEgammaGsfTracksUnseeded"),
+                                           label = cms.string('Unseeded')
+                                       ),
+                                   ),                 
+                                   ecal = cms.VPSet(
+                                       cms.PSet(
+                                           src= cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+                                           label = cms.string("EcalRecHitsEB")
+                                       ),
+                                       cms.PSet(
+                                           src= cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+                                           label = cms.string("EcalRecHitsEE")
+                                       )
+                                   ),
+                                   pfClusIso = cms.VPSet(
+                                       cms.PSet(
+                                           src = cms.InputTag("hltParticleFlowClusterECALL1Seeded"),
+                                           label = cms.string("Ecal")
+                                       ),
+                                       cms.PSet(
+                                           src = cms.InputTag("hltParticleFlowClusterECALUnseeded"),
+                                           label = cms.string("EcalUnseeded")
+                                       ),
+                                       cms.PSet(
+                                           src = cms.InputTag("hltParticleFlowClusterHCAL"),
+                                           label = cms.string("Hcal")
+                                       ),
+                                   ),
+                                   hcal = cms.VPSet(cms.PSet(src=cms.InputTag("hltHbhereco"),label=cms.string(""))),
+                                   trks = cms.VPSet(cms.PSet(src=cms.InputTag("hltMergedTracks"),label=cms.string(""))),                                  
+                                   minPtToSaveHits = cms.double(8.),
+                                   saveHitsPlusHalfPi = cms.bool(True),
+                                   saveHitsPlusPi = cms.bool(False)
+                                   
+)
+


### PR DESCRIPTION
#### PR description:

This PR introduces a new trigger object, EgTrigSumObj. 

The purpose of this is for easing debugging, validation and trigger development. In a nutshell, this object packs all E/gamma ID reco and ID quantities into a single object which can be easily analysed offline. 

The reason this is necessary is that the HLT builds the e/gamma object bit by bit for CPU efficiency reasons. Therefore you have to associate the GsfTrack, the pixel seeds , the id variables to the supercluster when you want to analyse this. This class does all this for you.

At the same time, the producer of the class can also filter PFClusters, calo hits and tracks for further analysis offline. This greatly helps ID tuning as well as validation.  The class may evolve in the future with filtering of the pixel hits, gsf tracks and superclusters in the plans, however it is usable now. 

This is has been the core of the E/gamma Phase-II development (a separate class for which another PR will be made once this merges handles the phase-II specific things). 

The goal of this class once merged is to add it to the HLTDEBUG format for RelVals and also in any future Phase-II re-HLT.  Ultimately it may make it into other data tiers once it is stable but that depends on many other things. 

Finally the observant reader will notice that this has a lot of overlap with the scouting egamma format, both store very similar information. However right now they serve different purposes (this is a validation / debugging / trigger dev format) and scouting has an analysis format with strong space constraints. This does not preclude in the future that they merge but right now that is not in the plan. 

#### PR validation:

To get it to output, the following snippet can be added to an HLT workflow
```
process.load("RecoEgamma.EgammaHLTProducers.hltEgammaHLTExtra_cfi")
process.hltEgHLTOut = cms.EndPath(process.hltEgammaHLTExtra)
process.schedule.append(process.hltEgHLTOut)
process.FEVTDEBUGHLToutput.outputCommands.append("keep *_hltEgammaHLTExtra_*_*")
```

Happily used for phase-II HLT development.
