### PR TITLE
MTD & Tracker DD4hep Units

### DIFF
--- a/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
+++ b/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
@@ -91,7 +91,7 @@ GeometricTimingDet::GeometricTimingDet(DDFilteredView* fv, GeometricTimingEnumTy
 }
 
 GeometricTimingDet::GeometricTimingDet(cms::DDFilteredView* fv, GeometricTimingEnumType type)
-  : trans_(fv->translation() / dd4hep::mm),
+    : trans_(fv->translation() / dd4hep::mm),
       rot_(fv->rotation()),
       shape_(fv->shape()),
       ddname_(fv->name()),

--- a/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
+++ b/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
@@ -5,7 +5,7 @@
 #include "CondFormats/GeometryObjects/interface/PGeometricTimingDet.h"
 
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
-#include "DataFormats/Math/interface/GeantUnits.h"
+#include <DD4hep/DD4hepUnits.h>
 
 #include <cfloat>
 #include <vector>
@@ -90,10 +90,8 @@ GeometricTimingDet::GeometricTimingDet(DDFilteredView* fv, GeometricTimingEnumTy
   ddd_ = nav_type(nt.begin(), nt.end());
 }
 
-using namespace geant_units::operators;
-
 GeometricTimingDet::GeometricTimingDet(cms::DDFilteredView* fv, GeometricTimingEnumType type)
-    : trans_(fv->translation()),
+  : trans_(fv->translation() / dd4hep::mm),
       rot_(fv->rotation()),
       shape_(fv->shape()),
       ddname_(fv->name()),
@@ -107,14 +105,10 @@ GeometricTimingDet::GeometricTimingDet(cms::DDFilteredView* fv, GeometricTimingE
       pixROCy_(fv->get<double>("PixelROC_Y")),
       stereo_(fv->get<std::string_view>("TrackerStereoDetectors") == strue),
       siliconAPVNum_(fv->get<double>("SiliconAPVNumber")) {
-  //
-  // Translate DD4hep lenghts from cm to mm
-  //
-  trans_.SetCoordinates(convertCmToMm(trans_.X()), convertCmToMm(trans_.Y()), convertCmToMm(trans_.Z()));
   phi_ = trans_.Phi();
   rho_ = trans_.Rho();
   for (size_t pit = 0; pit < params_.size(); pit++) {
-    params_[pit] = convertCmToMm(params_[pit]);
+    params_[pit] = params_[pit] / dd4hep::mm;
   }
   //
   // Not navPos(), as not properly working for DD4hep and not used

--- a/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
+++ b/Geometry/MTDNumberingBuilder/src/GeometricTimingDet.cc
@@ -4,7 +4,7 @@
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
 #include "CondFormats/GeometryObjects/interface/PGeometricTimingDet.h"
 
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
+#include "DataFormats/Math/interface/GeantUnits.h"
 #include <DD4hep/DD4hepUnits.h>
 
 #include <cfloat>
@@ -229,7 +229,9 @@ void GeometricTimingDet::deleteComponents() {
 }
 
 GeometricTimingDet::Position GeometricTimingDet::positionBounds() const {
-  Position pos(float(trans_.x() / cm), float(trans_.y() / cm), float(trans_.z() / cm));
+  Position pos(geant_units::operators::convertMmToCm(trans_.x()),
+               geant_units::operators::convertMmToCm(trans_.y()),
+               geant_units::operators::convertMmToCm(trans_.z()));
   return pos;
 }
 

--- a/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
+++ b/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
@@ -280,9 +280,7 @@ std::vector<double> GeometricDet::computeLegacyShapeParameters(const cms::DDSoli
   // Box
   if (mySolidShape == cms::DDSolidShape::ddbox) {
     const dd4hep::Box& myBox = dd4hep::Box(mySolid);
-    myOldDDShapeParameters = {(myBox.x()) / dd4hep::mm,
-                              (myBox.y()) / dd4hep::mm,
-                              (myBox.z()) / dd4hep::mm};
+    myOldDDShapeParameters = {(myBox.x()) / dd4hep::mm, (myBox.y()) / dd4hep::mm, (myBox.z()) / dd4hep::mm};
   }
 
   // Trapezoid
@@ -292,10 +290,10 @@ std::vector<double> GeometricDet::computeLegacyShapeParameters(const cms::DDSoli
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetTheta())),
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetPhi())),
                               (myTrap->GetH1()) / dd4hep::mm,
-                              (myTrap->GetBl1())/ dd4hep::mm,
-                              (myTrap->GetTl1())/ dd4hep::mm,
+                              (myTrap->GetBl1()) / dd4hep::mm,
+                              (myTrap->GetTl1()) / dd4hep::mm,
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetAlpha1())),
-                              (myTrap->GetH2())  / dd4hep::mm,
+                              (myTrap->GetH2()) / dd4hep::mm,
                               (myTrap->GetBl2()) / dd4hep::mm,
                               (myTrap->GetTl2()) / dd4hep::mm,
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetAlpha2()))};
@@ -305,7 +303,7 @@ std::vector<double> GeometricDet::computeLegacyShapeParameters(const cms::DDSoli
   else if (mySolidShape == cms::DDSolidShape::ddtubs) {
     const dd4hep::Tube& myTube = dd4hep::Tube(mySolid);
     myOldDDShapeParameters = {
-        (myTube->GetDz())   / dd4hep::mm,
+        (myTube->GetDz()) / dd4hep::mm,
         (myTube->GetRmin()) / dd4hep::mm,
         (myTube->GetRmax()) / dd4hep::mm,
         static_cast<double>(fmod(angle_units::operators::convertDegToRad(myTube->GetPhi1()), 2. * M_PI) - 2. * M_PI),

--- a/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
+++ b/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
@@ -1,3 +1,5 @@
+#include <DD4hep/DD4hepUnits.h>
+
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerNumberingBuilder/interface/TrackerShapeToBounds.h"
@@ -99,7 +101,7 @@ GeometricDet::GeometricDet(cms::DDFilteredView* fv, GeometricEnumType type)
     : ddname_(dd4hep::dd::noNamespace(fv->name())),
       type_(type),
       ddd_(fv->navPos()),  // To remove after DetExtra is removed (not used)
-      trans_(geant_units::operators::convertCmToMm(fv->translation())),
+      trans_((fv->translation()) / dd4hep::mm),
       rho_(trans_.Rho()),
       phi_(trans_.Phi()),
       rot_(fv->rotation()),
@@ -278,24 +280,24 @@ std::vector<double> GeometricDet::computeLegacyShapeParameters(const cms::DDSoli
   // Box
   if (mySolidShape == cms::DDSolidShape::ddbox) {
     const dd4hep::Box& myBox = dd4hep::Box(mySolid);
-    myOldDDShapeParameters = {geant_units::operators::convertCmToMm(myBox.x()),
-                              geant_units::operators::convertCmToMm(myBox.y()),
-                              geant_units::operators::convertCmToMm(myBox.z())};
+    myOldDDShapeParameters = {(myBox.x()) / dd4hep::mm,
+                              (myBox.y()) / dd4hep::mm,
+                              (myBox.z()) / dd4hep::mm};
   }
 
   // Trapezoid
   else if (mySolidShape == cms::DDSolidShape::ddtrap) {
     const dd4hep::Trap& myTrap = dd4hep::Trap(mySolid);
-    myOldDDShapeParameters = {geant_units::operators::convertCmToMm(myTrap->GetDZ()),
+    myOldDDShapeParameters = {(myTrap->GetDZ()) / dd4hep::mm,
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetTheta())),
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetPhi())),
-                              geant_units::operators::convertCmToMm(myTrap->GetH1()),
-                              geant_units::operators::convertCmToMm(myTrap->GetBl1()),
-                              geant_units::operators::convertCmToMm(myTrap->GetTl1()),
+                              (myTrap->GetH1()) / dd4hep::mm,
+                              (myTrap->GetBl1())/ dd4hep::mm,
+                              (myTrap->GetTl1())/ dd4hep::mm,
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetAlpha1())),
-                              geant_units::operators::convertCmToMm(myTrap->GetH2()),
-                              geant_units::operators::convertCmToMm(myTrap->GetBl2()),
-                              geant_units::operators::convertCmToMm(myTrap->GetTl2()),
+                              (myTrap->GetH2())  / dd4hep::mm,
+                              (myTrap->GetBl2()) / dd4hep::mm,
+                              (myTrap->GetTl2()) / dd4hep::mm,
                               static_cast<double>(angle_units::operators::convertDegToRad(myTrap->GetAlpha2()))};
   }
 
@@ -303,9 +305,9 @@ std::vector<double> GeometricDet::computeLegacyShapeParameters(const cms::DDSoli
   else if (mySolidShape == cms::DDSolidShape::ddtubs) {
     const dd4hep::Tube& myTube = dd4hep::Tube(mySolid);
     myOldDDShapeParameters = {
-        geant_units::operators::convertCmToMm(myTube->GetDz()),
-        geant_units::operators::convertCmToMm(myTube->GetRmin()),
-        geant_units::operators::convertCmToMm(myTube->GetRmax()),
+        (myTube->GetDz())   / dd4hep::mm,
+        (myTube->GetRmin()) / dd4hep::mm,
+        (myTube->GetRmax()) / dd4hep::mm,
         static_cast<double>(fmod(angle_units::operators::convertDegToRad(myTube->GetPhi1()), 2. * M_PI) - 2. * M_PI),
         static_cast<double>(angle_units::operators::convertDegToRad(myTube->GetPhi2() - myTube->GetPhi1()))};
   }


### PR DESCRIPTION
#### PR description:

DD4hep will transition to use geant4 units

#### PR validation:

`convertCmToMm` [currently](https://cmssdt.cern.ch/lxr/source/DataFormats/Math/interface/GeantUnits.h#0068) multiplies its input by 10. and the current value of `dd4hep::mm` is `0.1` therefore ` x / dd4hep::mm == convertCmToMm(x)`.

FYI: @cvuosalo 