### PR TITLE
[DD4hep] Convert production cuts units using DD4hep-invariant method

### DIFF
--- a/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
@@ -29,12 +29,6 @@ using namespace cms;
 using namespace edm;
 using namespace dd4hep;
 
-#ifdef HAVE_GEANT4_UNITS
-#define MM_2_CM 1.0
-#else
-#define MM_2_CM 0.1
-#endif
-
 namespace {
   bool sortByName(const std::pair<G4LogicalVolume*, const dd4hep::SpecPar*>& p1,
                   const std::pair<G4LogicalVolume*, const dd4hep::SpecPar*>& p2) {
@@ -72,6 +66,7 @@ private:
 DD4hepTestDDDWorld::DD4hepTestDDDWorld(const ParameterSet& iConfig)
     : tag_(iConfig.getParameter<ESInputTag>("DDDetector")), keywordRegion_("CMSCutsRegion") {
   verbosity_ = iConfig.getUntrackedParameter<int>("Verbosity", 1);
+  verbosity_ = 1;
   kernel_ = new G4MTRunManagerKernel();
 }
 
@@ -171,11 +166,11 @@ void DD4hepTestDDDWorld::update() {
     // you must have four of them: e+ e- gamma proton
     //
 
-    // Geant4 expects mm units. DD4hep returns cm, so must convert to mm.
-    double gammacut = it.second->dblValue("ProdCutsForGamma") / MM_2_CM;
-    double electroncut = it.second->dblValue("ProdCutsForElectrons") / MM_2_CM;
-    double positroncut = it.second->dblValue("ProdCutsForPositrons") / MM_2_CM;
-    double protoncut = it.second->dblValue("ProdCutsForProtons") / MM_2_CM;
+    // Geant4 expects mm units. DD4hep may return different units, so convert to mm.
+    double gammacut = it.second->dblValue("ProdCutsForGamma") / dd4hep::mm;
+    double electroncut = it.second->dblValue("ProdCutsForElectrons") / dd4hep::mm;
+    double positroncut = it.second->dblValue("ProdCutsForPositrons") / dd4hep::mm;
+    double protoncut = it.second->dblValue("ProdCutsForProtons") / dd4hep::mm;
     if (protoncut == 0) {
       protoncut = electroncut;
     }

--- a/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/test/plugins/DD4hepTestDDDWorld.cc
@@ -66,7 +66,6 @@ private:
 DD4hepTestDDDWorld::DD4hepTestDDDWorld(const ParameterSet& iConfig)
     : tag_(iConfig.getParameter<ESInputTag>("DDDetector")), keywordRegion_("CMSCutsRegion") {
   verbosity_ = iConfig.getUntrackedParameter<int>("Verbosity", 1);
-  verbosity_ = 1;
   kernel_ = new G4MTRunManagerKernel();
 }
 

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -1,6 +1,5 @@
 #include "SimG4Core/Geometry/interface/DDG4ProductionCuts.h"
 #include "DetectorDescription/Core/interface/DDLogicalPart.h"
-#include "DataFormats/Math/interface/GeantUnits.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -14,14 +13,6 @@
 #include "G4LogicalVolume.hh"
 
 #include <algorithm>
-
-using geant_units::operators::convertCmToMm;
-
-#ifdef HAVE_GEANT4_UNITS
-#define MM_2_CM 1.0
-#else
-#define MM_2_CM 0.1
-#endif
 
 namespace {
   /** helper function to compare parts through their name instead of comparing them
@@ -233,10 +224,10 @@ void DDG4ProductionCuts::setProdCuts(const dd4hep::SpecPar* spec, G4Region* regi
     // search for production cuts
     // you must have four of them: e+ e- gamma proton
     //
-    double gammacut = spec->dblValue("ProdCutsForGamma") / MM_2_CM;
-    double electroncut = spec->dblValue("ProdCutsForElectrons") / MM_2_CM;
-    double positroncut = spec->dblValue("ProdCutsForPositrons") / MM_2_CM;
-    double protoncut = spec->dblValue("ProdCutsForProtons") / MM_2_CM;
+    double gammacut = spec->dblValue("ProdCutsForGamma") / dd4hep::mm;  // Convert from DD4hep units to mm
+    double electroncut = spec->dblValue("ProdCutsForElectrons") / dd4hep::mm;
+    double positroncut = spec->dblValue("ProdCutsForPositrons") / dd4hep::mm;
+    double protoncut = spec->dblValue("ProdCutsForProtons") / dd4hep::mm;
     if (protoncut == 0) {
       protoncut = electroncut;
     }


### PR DESCRIPTION
Production cuts are converted to mm for use in Geant4. This PR changes the method of conversion to the DD4hep method so it will work even when the DD4hep units convention changes.


#### PR validation:

Debug output from ` SimG4Core/DD4hepGeometry/test/python/testG4Regions.py` from before and after the PR changes show that the production cuts are unchanged.

A decision on whether to backport to 11_2 will be made later.