### PR TITLE
Build GE0 in the Muon Reco Geometry

### DIFF
--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -78,10 +78,6 @@ pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buil
                           << " R1: " << fowardLayer->specificSurface().innerRadius()
                           << " R2: " << fowardLayer->specificSurface().outerRadius();
 
-        cout << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size() << " rings, at Z "
-             << fowardLayer->position().z() << " R1: " << fowardLayer->specificSurface().innerRadius()
-             << " R2: " << fowardLayer->specificSurface().outerRadius() << endl;
-
         int iendcap = (st->region() == 1) ? 0 : 1;
         endcapLayers[iendcap].push_back(fowardLayer);
       }

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -29,7 +29,6 @@ pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buil
 
     // GE0
     int station0 = 0;
-    //int layer0 = 0;
     for (int layer0 = GEMDetId::minLayerId + 1; layer0 <= GEMDetId::maxLayerId0; ++layer0) {
       vector<int> rolls0, rings0, chambers0;
       for (int ring = GEMDetId::minRingId; ring <= GEMDetId::maxRingId; ++ring)
@@ -86,11 +85,10 @@ MuRingForwardLayer* MuonGEMDetLayerGeometryBuilder::buildLayer0(int endcap,
 
       for (std::vector<int>::iterator chamber = chambers.begin(); chamber < chambers.end(); chamber++) {
         GEMDetId gemId(endcap, (*ring), station, layer, (*chamber), (*roll));
-        //GEMDetId gemId(endcap, layer, (*chamber), (*roll));
         const GeomDet* geomDet = geo.idToDet(gemId);
 
         if (geomDet != nullptr) {
-          //bool isInFront = isFront(gemId);
+          //ME0s do not currently have an arrangement of which are front and which are back, going to always return true
           bool isInFront = true;
           if (isInFront) {
             frontDets.push_back(geomDet);

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -41,21 +41,19 @@ pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buil
         ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
         if (ringLayer)
           result[iendcap].push_back(ringLayer);
-      } else {     
+      } else {
         for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId; ++layer) {
           vector<int> rolls, rings, chambers;
           rings.push_back(GEMDetId::minRingId);
-          for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) {
+          for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) 
             chambers.push_back(chamber);
-          }
-          for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) {
+          for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) 
             rolls.push_back(roll);
-          }
           ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
           if (ringLayer)
             result[iendcap].push_back(ringLayer);
         }
-      } 
+      }
     }
   }
   pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -34,28 +34,27 @@ pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buil
         vector<int> rolls, rings, chambers;
         rolls.push_back(GEMDetId::minRollId);
         rings.push_back(GEMDetId::minRingId);
-        for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) {
-          chambers.push_back(chamber);
+        for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId / 2; chamber++) {
           // ME0 is composed of 18 super-chambers
-          if (station == GEMDetId::minStationId0 && chamber == GEMDetId::maxChamberId / 2) break;
+          chambers.push_back(chamber);
         }
         ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
         if (ringLayer)
           result[iendcap].push_back(ringLayer);
       } else {     
-          for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId; ++layer) {
-            vector<int> rolls, rings, chambers;
-            rings.push_back(GEMDetId::minRingId);
-            for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) {
-              chambers.push_back(chamber);
-            }
-            for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) {
-              rolls.push_back(roll);
-            }
-            ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
-            if (ringLayer)
-              result[iendcap].push_back(ringLayer);
+        for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId; ++layer) {
+          vector<int> rolls, rings, chambers;
+          rings.push_back(GEMDetId::minRingId);
+          for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) {
+            chambers.push_back(chamber);
           }
+          for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) {
+            rolls.push_back(roll);
+          }
+          ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
+          if (ringLayer)
+            result[iendcap].push_back(ringLayer);
+        }
       } 
     }
   }

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -2,8 +2,6 @@
 
 #include <DataFormats/MuonDetId/interface/GEMDetId.h>
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
-#include <TrackingTools/DetLayers/interface/ForwardDetLayer.h>
-#include <RecoMuon/DetLayers/interface/MuRingForwardLayer.h>
 #include <RecoMuon/DetLayers/interface/MuRingForwardDoubleLayer.h>
 #include <RecoMuon/DetLayers/interface/MuRodBarrelLayer.h>
 #include <RecoMuon/DetLayers/interface/MuDetRing.h>
@@ -24,111 +22,85 @@ MuonGEMDetLayerGeometryBuilder::~MuonGEMDetLayerGeometryBuilder() {}
 // Builds the forward (first) and backward (second) layers
 // Builds etaPartitions (for rechits)
 pair<vector<DetLayer*>, vector<DetLayer*> > MuonGEMDetLayerGeometryBuilder::buildEndcapLayers(const GEMGeometry& geo) {
-  vector<DetLayer*> result[2];
-  for (int endcap = -1; endcap <= 1; endcap += 2) {
-    int iendcap = (endcap == 1) ? 0 : 1;  // +1: forward, -1: backward
+  vector<DetLayer*> endcapLayers[2];
 
-    for (int station = GEMDetId::minStationId0; station <= GEMDetId::maxStationId; ++station) {
-      for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId0; ++layer) {
-        if (station != GEMDetId::minStationId0 && layer > GEMDetId::maxLayerId)
-          break;
-        vector<int> rolls, rings, chambers;
-        rings.push_back(GEMDetId::minRingId);
-        for (int chamber = GEMDetId::minChamberId + 1; chamber <= GEMDetId::maxChamberId; chamber++) {
-          chambers.push_back(chamber);
-          // ME0 is composed of 18 super-chambers
-          if (station == GEMDetId::minStationId0 && chamber == GEMDetId::maxChamberId / 2)
-            break;
+  for (auto st : geo.stations()) {
+    for (int layer = GEMDetId::minLayerId + 1; layer <= GEMDetId::maxLayerId0; ++layer) {
+      if (st->station() != GEMDetId::minStationId0 && layer > GEMDetId::maxLayerId)
+        break;
+
+      ForwardDetLayer* fowardLayer = nullptr;
+      vector<const ForwardDetRing*> frontRings, backRings;
+
+      for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) {
+        vector<const GeomDet*> frontDets, backDets;
+
+        for (auto sc : st->superChambers()) {
+          auto ch = sc->chamber(layer);
+          if (ch == nullptr)
+            continue;
+
+          auto etaP = ch->etaPartition(roll);
+          if (etaP == nullptr)
+            continue;
+
+          bool isInFront = isFront(etaP->id());
+          if (isInFront) {
+            frontDets.push_back(etaP);
+          } else {
+            backDets.push_back(etaP);
+          }
         }
-        for (int roll = GEMDetId::minRollId + 1; roll <= GEMDetId::maxRollId; ++roll) {
-          rolls.push_back(roll);
-          // ME0 layer consists of 10 etapartitions
-          if (station == GEMDetId::minStationId0 && roll == 10)
-            break;
+
+        if (!frontDets.empty()) {
+          precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
+          frontRings.push_back(new MuDetRing(frontDets));
+          LogTrace(metname) << "New front ring with " << frontDets.size()
+                            << " chambers at z=" << frontRings.back()->position().z();
         }
-        ForwardDetLayer* ringLayer = buildLayer(endcap, rings, station, layer, chambers, rolls, geo);
-        if (ringLayer)
-          result[iendcap].push_back(ringLayer);
+        if (!backDets.empty()) {
+          precomputed_value_sort(backDets.begin(), backDets.end(), geomsort::DetPhi());
+          backRings.push_back(new MuDetRing(backDets));
+          LogTrace(metname) << "New back ring with " << backDets.size()
+                            << " chambers at z=" << backRings.back()->position().z();
+        }
+      }
+
+      if (!backRings.empty() && !frontRings.empty() && st->station() != GEMDetId::minStationId0) {
+        fowardLayer = new MuRingForwardDoubleLayer(frontRings, backRings);
+      } else if (!frontRings.empty() && st->station() == GEMDetId::minStationId0) {
+        fowardLayer = new MuRingForwardLayer(frontRings);
+      }
+
+      if (fowardLayer != nullptr) {
+        LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()
+                          << " rings, at Z " << fowardLayer->position().z()
+                          << " R1: " << fowardLayer->specificSurface().innerRadius()
+                          << " R2: " << fowardLayer->specificSurface().outerRadius();
+
+        cout << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size() << " rings, at Z "
+             << fowardLayer->position().z() << " R1: " << fowardLayer->specificSurface().innerRadius()
+             << " R2: " << fowardLayer->specificSurface().outerRadius() << endl;
+
+        int iendcap = (st->region() == 1) ? 0 : 1;
+        endcapLayers[iendcap].push_back(fowardLayer);
       }
     }
   }
-  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(result[0], result[1]);
+
+  pair<vector<DetLayer*>, vector<DetLayer*> > res_pair(endcapLayers[0], endcapLayers[1]);
   return res_pair;
 }
 
-ForwardDetLayer* MuonGEMDetLayerGeometryBuilder::buildLayer(int endcap,
-                                                            vector<int>& rings,
-                                                            int station,
-                                                            int layer,
-                                                            vector<int>& chambers,
-                                                            vector<int>& rolls,
-                                                            const GEMGeometry& geo) {
-  const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonGEMDetLayerGeometryBuilder";
-  ForwardDetLayer* result = nullptr;
-  vector<const ForwardDetRing*> frontRings, backRings;
-  for (std::vector<int>::iterator ring = rings.begin(); ring != rings.end(); ring++) {
-    for (vector<int>::iterator roll = rolls.begin(); roll != rolls.end(); roll++) {
-      vector<const GeomDet*> frontDets, backDets;
-
-      for (std::vector<int>::iterator chamber = chambers.begin(); chamber < chambers.end(); chamber++) {
-        GEMDetId gemId(endcap, (*ring), station, layer, (*chamber), (*roll));
-
-        const GeomDet* geomDet = geo.idToDet(gemId);
-
-        if (geomDet != nullptr) {
-          // ME0s do not currently have an arrangement of which are front and which are back, going to always return true
-          bool isInFront = (station == GEMDetId::minStationId0) or isFront(gemId);
-          if (isInFront) {
-            frontDets.push_back(geomDet);
-          } else {
-            backDets.push_back(geomDet);
-          }
-          LogTrace(metname) << "get GEM Endcap roll " << gemId << (isInFront ? "front" : "back ")
-                            << " at R=" << geomDet->position().perp() << ", phi=" << geomDet->position().phi()
-                            << ", Z=" << geomDet->position().z();
-        }
-      }
-
-      if (!frontDets.empty()) {
-        precomputed_value_sort(frontDets.begin(), frontDets.end(), geomsort::DetPhi());
-        frontRings.push_back(new MuDetRing(frontDets));
-        LogTrace(metname) << "New front ring with " << frontDets.size()
-                          << " chambers at z=" << frontRings.back()->position().z();
-      }
-      if (!backDets.empty()) {
-        precomputed_value_sort(backDets.begin(), backDets.end(), geomsort::DetPhi());
-        backRings.push_back(new MuDetRing(backDets));
-        LogTrace(metname) << "New back ring with " << backDets.size()
-                          << " chambers at z=" << backRings.back()->position().z();
-      }
-    }
-  }
-
-  // How should they be sorted?
-  //    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractZ<GeometricSearchDet,float>());
-  if (!backRings.empty() && !frontRings.empty() && station != GEMDetId::minStationId0) {
-    result = new MuRingForwardDoubleLayer(frontRings, backRings);
-  } else if (!frontRings.empty() && station == GEMDetId::minStationId0) {
-    result = new MuRingForwardLayer(frontRings);
-  } else {
-    result = nullptr;
-  }
-  if (result != nullptr) {
-    LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()
-                      << " rings, at Z " << result->position().z() << " R1: " << result->specificSurface().innerRadius()
-                      << " R2: " << result->specificSurface().outerRadius();
-  }
-  return result;
-}
-
 bool MuonGEMDetLayerGeometryBuilder::isFront(const GEMDetId& gemId) {
-  bool result = false;
-  int chamber = gemId.chamber();
+  // ME0s do not currently have an arrangement of which are front and which are back, going to always return true
+  if (gemId.station() == GEMDetId::minStationId0)
+    return true;
 
-  if (chamber % 2 == 0)
-    result = !result;
+  if (gemId.chamber() % 2 == 0)
+    return true;
 
-  return result;
+  return false;
 }
 
 MuDetRing* MuonGEMDetLayerGeometryBuilder::makeDetRing(vector<const GeomDet*>& geomDets) {

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.cc
@@ -66,7 +66,6 @@ ForwardDetLayer* MuonGEMDetLayerGeometryBuilder::buildLayer(int endcap,
   const std::string metname = "Muon|RecoMuon|RecoMuonDetLayers|MuonGEMDetLayerGeometryBuilder";
   ForwardDetLayer* result = nullptr;
   vector<const ForwardDetRing*> frontRings, backRings;
-  cout << "Station of GEM is " << station << endl;
   for (std::vector<int>::iterator ring = rings.begin(); ring != rings.end(); ring++) {
     for (vector<int>::iterator roll = rolls.begin(); roll != rolls.end(); roll++) {
       vector<const GeomDet*> frontDets, backDets;
@@ -109,13 +108,10 @@ ForwardDetLayer* MuonGEMDetLayerGeometryBuilder::buildLayer(int endcap,
   //    precomputed_value_sort(muDetRods.begin(), muDetRods.end(), geomsort::ExtractZ<GeometricSearchDet,float>());
   if (!backRings.empty() && !frontRings.empty() && station != GEMDetId::minStationId0) {
     result = new MuRingForwardDoubleLayer(frontRings, backRings);
-    cout << "st - " << station << endl;
   } else if (!frontRings.empty() && station == GEMDetId::minStationId0) {
     result = new MuRingForwardLayer(frontRings);
-    cout << "st 0 " << endl;
   } else {
     result = nullptr;
-    cout << "nullptr" << endl;
   }
   if (result != nullptr) {
     LogTrace(metname) << "New MuRingForwardLayer with " << frontRings.size() << " and " << backRings.size()

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -9,6 +9,7 @@
  */
 
 class DetLayer;
+class MuRingForwardLayer;
 class MuRingForwardDoubleLayer;
 class MuDetRing;
 
@@ -29,6 +30,15 @@ public:
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
 
 private:
+  //static MuRingForwardLayer* buildLayer0(
+  //  int endcap, int layer, std::vector<int>& chambers, std::vector<int>& rolls, const GEMGeometry& geo);
+  static MuRingForwardLayer* buildLayer0(int endcap,
+                                         std::vector<int>& rings,
+                                         int station,
+                                         int layer,
+                                         std::vector<int>& chambers,
+                                         std::vector<int>& rolls,
+                                         const GEMGeometry& geo);
   static MuRingForwardDoubleLayer* buildLayer(int endcap,
                                               std::vector<int>& rings,
                                               int station,

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -9,7 +9,7 @@
  */
 
 class DetLayer;
-class ForwardDetRing;
+class ForwardDetLayer;
 class MuRingForwardLayer;
 class MuRingForwardDoubleLayer;
 class MuDetRing;
@@ -31,13 +31,13 @@ public:
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
 
 private:
-  static std::pair<std::vector<const ForwardDetRing*>, std::vector<const ForwardDetRing*> > getRings(int endcap,
-                                              std::vector<int>& rings,
-                                              int station,
-                                              int layer,
-                                              std::vector<int>& chambers,
-                                              std::vector<int>& rolls,
-                                              const GEMGeometry& geo);
+  static ForwardDetLayer* buildLayer(int endcap,
+                                     std::vector<int>& rings,
+                                     int station,
+                                     int layer,
+                                     std::vector<int>& chambers,
+                                     std::vector<int>& rolls,
+                                     const GEMGeometry& geo);
   static bool isFront(const GEMDetId& gemId);
   static MuDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
 };

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -31,13 +31,6 @@ public:
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
 
 private:
-  static ForwardDetLayer* buildLayer(int endcap,
-                                     std::vector<int>& rings,
-                                     int station,
-                                     int layer,
-                                     std::vector<int>& chambers,
-                                     std::vector<int>& rolls,
-                                     const GEMGeometry& geo);
   static bool isFront(const GEMDetId& gemId);
   static MuDetRing* makeDetRing(std::vector<const GeomDet*>& geomDets);
 };

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -30,8 +30,6 @@ public:
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
 
 private:
-  //static MuRingForwardLayer* buildLayer0(
-  //  int endcap, int layer, std::vector<int>& chambers, std::vector<int>& rolls, const GEMGeometry& geo);
   static MuRingForwardLayer* buildLayer0(int endcap,
                                          std::vector<int>& rings,
                                          int station,

--- a/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
+++ b/RecoMuon/DetLayers/src/MuonGEMDetLayerGeometryBuilder.h
@@ -9,6 +9,7 @@
  */
 
 class DetLayer;
+class ForwardDetRing;
 class MuRingForwardLayer;
 class MuRingForwardDoubleLayer;
 class MuDetRing;
@@ -30,14 +31,7 @@ public:
   static std::pair<std::vector<DetLayer*>, std::vector<DetLayer*> > buildEndcapLayers(const GEMGeometry& geo);
 
 private:
-  static MuRingForwardLayer* buildLayer0(int endcap,
-                                         std::vector<int>& rings,
-                                         int station,
-                                         int layer,
-                                         std::vector<int>& chambers,
-                                         std::vector<int>& rolls,
-                                         const GEMGeometry& geo);
-  static MuRingForwardDoubleLayer* buildLayer(int endcap,
+  static std::pair<std::vector<const ForwardDetRing*>, std::vector<const ForwardDetRing*> > getRings(int endcap,
                                               std::vector<int>& rings,
                                               int station,
                                               int layer,


### PR DESCRIPTION
#### PR description:

I copied the ME0 layer builders into MuonGEMDetLayerGeometryBuilder.cc, so that GE0 can be used by the muon reconstruction.
([https://indico.cern.ch/event/982928/contributions/4139669/attachments/2158615/3649556/Dec%208th%202020_ME0toGE0_Seulgi%20Kim.pdf](url))

@jshlee @watson-ij 

#### PR validation:

I ran the matrix 30621.0 for D66 (ME0) and 31021.0 for D67 (GE0) both of which finished without failure. For D66, this change didn't affect the muon reconstruction. In D67, we now see that gem rechits from GE0 are used by muons.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
