### PR TITLE
Switching MCSmartSingleParticleFilter to use an input tag

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
@@ -55,8 +55,7 @@ private:
 using namespace std;
 
 MCSmartSingleParticleFilter::MCSmartSingleParticleFilter(const edm::ParameterSet& iConfig)
-    : token_(consumes<edm::HepMCProduct>(
-          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
+  : token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator","unsmeared")))),
       betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)) {
   vector<int> defpid;
   defpid.push_back(0);

--- a/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
@@ -55,7 +55,8 @@ private:
 using namespace std;
 
 MCSmartSingleParticleFilter::MCSmartSingleParticleFilter(const edm::ParameterSet& iConfig)
-  : token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator","unsmeared")))),
+    : token_(consumes<edm::HepMCProduct>(
+          iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator", "unsmeared")))),
       betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)) {
   vector<int> defpid;
   defpid.push_back(0);


### PR DESCRIPTION
#### PR description:

This PR changes the MCSmartSingleParticleFilter to use an input tag rather than a string to specify its products. At the same time it now allows us to have a different instance label than "unsmeared"

#### PR validation:

matrix tests run

