### PR TITLE
Better destructor behavior for SiPixelTemplateStore

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplate.h
@@ -207,29 +207,20 @@ struct SiPixelTemplateHeader {  //!< template header structure
 struct SiPixelTemplateStore {  //!< template storage structure
   SiPixelTemplateHeader head;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST
-  float cotbetaY[TEMP_ENTRY_SIZEY];
-  float cotbetaX[TEMP_ENTRY_SIZEX_B];
-  float cotalphaX[TEMP_ENTRY_SIZEX_A];
+  std::array<float, TEMP_ENTRY_SIZEY> cotbetaY;
+  std::array<float, TEMP_ENTRY_SIZEX_B> cotbetaX;
+  std::array<float, TEMP_ENTRY_SIZEX_A> cotalphaX;
   //!< 60 y templates spanning cluster lengths from 0px to +18px
   SiPixelTemplateEntry enty[TEMP_ENTRY_SIZEY];
   //!< 60 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 60 slices
   SiPixelTemplateEntry entx[TEMP_ENTRY_SIZEX_B][TEMP_ENTRY_SIZEX_A];
-  void destroy(){};
 #else
-  float* cotbetaY = nullptr;
-  float* cotbetaX = nullptr;
-  float* cotalphaX = nullptr;
+  std::vector<float> cotbetaY;
+  std::vector<float> cotbetaX;
+  std::vector<float> cotalphaX;
   boost::multi_array<SiPixelTemplateEntry, 1> enty;  //!< use 1d entry to store [60] entries
   //!< use 2d entry to store [60][60] entries
   boost::multi_array<SiPixelTemplateEntry, 2> entx;
-  void destroy() {  // deletes arrays created by pushfile method of SiPixelTemplate
-    if (cotbetaY != nullptr)
-      delete[] cotbetaY;
-    if (cotbetaX != nullptr)
-      delete[] cotbetaX;
-    if (cotalphaX != nullptr)
-      delete[] cotalphaX;
-  }
 #endif
 };
 

--- a/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
+++ b/CondFormats/SiPixelTransient/src/SiPixelTemplate.cc
@@ -235,9 +235,9 @@ bool SiPixelTemplate::pushfile(int filenum, std::vector<SiPixelTemplateStore>& p
 
     // next, layout the 1-d/2-d structures needed to store template
 
-    theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
-    theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
-    theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
+    theCurrentTemp.cotbetaY = std::vector<float>(theCurrentTemp.head.NTy);
+    theCurrentTemp.cotbetaX = std::vector<float>(theCurrentTemp.head.NTyx);
+    theCurrentTemp.cotalphaX = std::vector<float>(theCurrentTemp.head.NTxx);
 
     theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
 
@@ -814,9 +814,9 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject, std::vec
 #ifdef SI_PIXEL_TEMPLATE_USE_BOOST
 
     // next, layout the 1-d/2-d structures needed to store template
-    theCurrentTemp.cotbetaY = new float[theCurrentTemp.head.NTy];
-    theCurrentTemp.cotbetaX = new float[theCurrentTemp.head.NTyx];
-    theCurrentTemp.cotalphaX = new float[theCurrentTemp.head.NTxx];
+    theCurrentTemp.cotbetaY = std::vector<float>(theCurrentTemp.head.NTy);
+    theCurrentTemp.cotbetaX = std::vector<float>(theCurrentTemp.head.NTyx);
+    theCurrentTemp.cotalphaX = std::vector<float>(theCurrentTemp.head.NTxx);
     theCurrentTemp.enty.resize(boost::extents[theCurrentTemp.head.NTy]);
     theCurrentTemp.entx.resize(boost::extents[theCurrentTemp.head.NTyx][theCurrentTemp.head.NTxx]);
 
@@ -3153,18 +3153,18 @@ int SiPixelTemplate::qbin(int id,
   auto yxratio = 0.f;
 
   {
-    auto j = std::lower_bound(templ.cotbetaX, templ.cotbetaX + Nyx, acotb);
-    if (j == templ.cotbetaX + Nyx) {
+    auto j = std::lower_bound(templ.cotbetaX.begin(), templ.cotbetaX.begin() + Nyx, acotb);
+    if (j == templ.cotbetaX.begin() + Nyx) {
       --j;
       yxratio = 1.f;
-    } else if (j == templ.cotbetaX) {
+    } else if (j == templ.cotbetaX.begin()) {
       ++j;
       yxratio = 0.f;
     } else {
       yxratio = (acotb - (*(j - 1))) / ((*j) - (*(j - 1)));
     }
 
-    iyhigh = j - templ.cotbetaX;
+    iyhigh = j - templ.cotbetaX.begin();
     iylow = iyhigh - 1;
   }
 
@@ -3173,18 +3173,18 @@ int SiPixelTemplate::qbin(int id,
   auto xxratio = 0.f;
 
   {
-    auto j = std::lower_bound(templ.cotalphaX, templ.cotalphaX + Nxx, cota);
-    if (j == templ.cotalphaX + Nxx) {
+    auto j = std::lower_bound(templ.cotalphaX.begin(), templ.cotalphaX.begin() + Nxx, cota);
+    if (j == templ.cotalphaX.begin() + Nxx) {
       --j;
       xxratio = 1.f;
-    } else if (j == templ.cotalphaX) {
+    } else if (j == templ.cotalphaX.begin()) {
       ++j;
       xxratio = 0.f;
     } else {
       xxratio = (cota - (*(j - 1))) / ((*j) - (*(j - 1)));
     }
 
-    ihigh = j - templ.cotalphaX;
+    ihigh = j - templ.cotalphaX.begin();
     ilow = ihigh - 1;
   }
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/TrackingRecHitProducer.cc
@@ -94,11 +94,7 @@ TrackingRecHitProducer::TrackingRecHitProducer(const edm::ParameterSet& config) 
   produces<FastTrackerRecHitRefCollection>("simHit2RecHitMap");
 }
 
-TrackingRecHitProducer::~TrackingRecHitProducer() {
-  //--- Delete the templates. This is safe even if thePixelTemp_ vector is empty.
-  for (auto x : _pixelTempStore)
-    x.destroy();
-}
+TrackingRecHitProducer::~TrackingRecHitProducer() {}
 
 void TrackingRecHitProducer::beginStream(edm::StreamID id) {
   for (auto& algo : _recHitAlgorithms) {

--- a/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/PixelTemplateSmearerBase.cc
@@ -125,11 +125,7 @@ PixelTemplateSmearerBase::PixelTemplateSmearerBase(const std::string& name,
   //    event.  So nothing happens now.
 }
 
-PixelTemplateSmearerBase::~PixelTemplateSmearerBase() {
-  //--- Delete the templates. This is safe even if thePixelTemp_ vector is empty.
-  for (auto x : thePixelTemp_)
-    x.destroy();
-}
+PixelTemplateSmearerBase::~PixelTemplateSmearerBase() {}
 
 //-------------------------------------------------------------------------------
 //   beginRun(); the templates are loaded in TrackingRecHitProducer, and unpacked

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -156,8 +156,6 @@ void PixelCPEClusterRepair::fill2DTemplIDs() {
 //  Clean up.
 //-----------------------------------------------------------------------------
 PixelCPEClusterRepair::~PixelCPEClusterRepair() {
-  for (auto x : thePixelTemp_)
-    x.destroy();
   for (auto x : thePixelTemp2D_)
     x.destroy();
 }

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -94,10 +94,7 @@ PixelCPETemplateReco::PixelCPETemplateReco(edm::ParameterSet const& conf,
 //-----------------------------------------------------------------------------
 //  Clean up.
 //-----------------------------------------------------------------------------
-PixelCPETemplateReco::~PixelCPETemplateReco() {
-  for (auto x : thePixelTemp_)
-    x.destroy();
-}
+PixelCPETemplateReco::~PixelCPETemplateReco() {}
 
 std::unique_ptr<PixelCPEBase::ClusterParam> PixelCPETemplateReco::createClusterParam(const SiPixelCluster& cl) const {
   return std::make_unique<ClusterParamTemplate>(cl);


### PR DESCRIPTION

#### PR description:

No longer needs destroy() as member data properly control their own memory.

#### PR validation:

The code compiles both with and without `#define SI_PIXEL_TEMPLATE_USE_BOOST`