### PR TITLE
EcalClusterEnergyUncertaintyElectronSpecific to free function

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -176,7 +176,6 @@ public:
                   const ElectronHcalHelper::Configuration& hcalCfg,
                   const IsolationConfiguration&,
                   const EcalRecHitsConfiguration&,
-                  std::unique_ptr<EcalClusterFunctionBaseClass>&& superClusterErrorFunction,
                   std::unique_ptr<EcalClusterFunctionBaseClass>&& crackCorrectionFunction,
                   const RegressionHelper::Configuration& regCfg,
                   const edm::ParameterSet& tkIsol03Cfg,
@@ -251,7 +250,6 @@ private:
 
   // additional configuration and helpers
   ElectronHcalHelper hcalHelper_;
-  std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction_;
   std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
   RegressionHelper regHelper_;
 };

--- a/RecoEgamma/EgammaElectronAlgos/interface/ecalClusterEnergyUncertaintyElectronSpecific.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ecalClusterEnergyUncertaintyElectronSpecific.h
@@ -1,0 +1,25 @@
+#ifndef RecoEgamma_EgammaElectronAlgos_ecalClusterEnergyUncertaintyElectronSpecific_h
+#define RecoEgamma_EgammaElectronAlgos_ecalClusterEnergyUncertaintyElectronSpecific_h
+
+/** ecalClusterEnergyUncertaintyElectronSpecific
+  *  Function that provides uncertainty on supercluster energy measurement
+  *  Available numbers: total effective uncertainty (in GeV)
+  *                     assymetric uncertainties (positive and negative)
+  *
+  *  $Id: ecalClusterEnergyUncertaintyElectronSpecific.h
+  *  $Date:
+  *  $Revision:
+  *  \author Nicolas Chanon, December 2011
+  */
+
+namespace reco {
+  class SuperCluster;
+}
+
+namespace egamma {
+
+  float ecalClusterEnergyUncertaintyElectronSpecific(reco::SuperCluster const& superCluster);
+
+}
+
+#endif

--- a/RecoEgamma/EgammaElectronAlgos/src/ecalClusterEnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ecalClusterEnergyUncertaintyElectronSpecific.cc
@@ -1,39 +1,7 @@
-/** \class EcalClusterEnergyUncertainty
-  *  Function that provides uncertainty on supercluster energy measurement
-  *  Available numbers: total effective uncertainty (in GeV)
-  *                     assymetric uncertainties (positive and negative)
-  *
-  *  $Id: EcalClusterEnergyUncertainty.h
-  *  $Date:
-  *  $Revision:
-  *  \author Nicolas Chanon, December 2011
-  */
+#include "RecoEgamma/EgammaElectronAlgos/interface/ecalClusterEnergyUncertaintyElectronSpecific.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterEnergyUncertaintyParameters.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-class EcalClusterEnergyUncertaintyObjectSpecific : public EcalClusterFunctionBaseClass {
-public:
-  EcalClusterEnergyUncertaintyObjectSpecific(const edm::ParameterSet &){};
-
-  // check initialization
-  void checkInit() const {}
-
-  // compute the correction
-  float getValue(const reco::SuperCluster &, const int mode) const override;
-  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override { return 0.; };
-
-  // set parameters
-  void init(const edm::EventSetup &es) override {}
-};
-
-float EcalClusterEnergyUncertaintyObjectSpecific::getValue(const reco::SuperCluster &superCluster,
-                                                           const int mode) const {
-  checkInit();
-
-  // mode  = 0 returns electron energy uncertainty
-
+float egamma::ecalClusterEnergyUncertaintyElectronSpecific(reco::SuperCluster const& superCluster) {
   float en = superCluster.energy();
   float eta = fabs(superCluster.eta());
   float et = en / cosh(eta);
@@ -273,8 +241,3 @@ float EcalClusterEnergyUncertaintyObjectSpecific::getValue(const reco::SuperClus
 
   return (uncertainty * en);
 }
-
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory,
-                  EcalClusterEnergyUncertaintyObjectSpecific,
-                  "EcalClusterEnergyUncertaintyObjectSpecific");

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -212,7 +212,6 @@ void GsfElectronProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   }
 
   // Corrections
-  desc.add<std::string>("superClusterErrorFunction", "EcalClusterEnergyUncertaintyObjectSpecific");
   desc.add<std::string>("crackCorrectionFunction", "EcalClusterCrackCorrection");
 
   desc.add<bool>("ecalWeightsFromDB", true);
@@ -375,7 +374,6 @@ GsfElectronProducer::GsfElectronProducer(const edm::ParameterSet& cfg, const Gsf
       hcalCfg_,
       isoCfg,
       recHitsCfg,
-      EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("superClusterErrorFunction"), cfg),
       EcalClusterFunctionFactory::get()->create(cfg.getParameter<std::string>("crackCorrectionFunction"), cfg),
       regressionCfg,
       cfg.getParameter<edm::ParameterSet>("trkIsol03Cfg"),


### PR DESCRIPTION
#### PR description:

After https://github.com/cms-sw/cmssw/pull/32424, the ES consumes migration of RecoEgamma plugins is still on my radar. On thing that makes the migration complicated is this factory pattern with functions inheriting from the `EcalClusterFunctionBaseClass`.

But before thinking of a solution for these ECAL cluster functions, maybe this this is a good opportunity to think about where this factory pattern is really needed to reduce the complexity of the migration a bit.

I spotted the `EcalClusterEnergyUncertaintyElectronSpecific` function, which is only used once for the electrons and therefore a good candidate for conversion into a free function in RecoEgamma/EgammaElectronAlgos.


#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.