### PR TITLE
silence compilation warnings for MahiGPU.cu

### DIFF
--- a/RecoLocalCalo/HcalRecProducers/BuildFile.xml
+++ b/RecoLocalCalo/HcalRecProducers/BuildFile.xml
@@ -22,4 +22,5 @@
 <use name="RecoLocalCalo/HcalRecAlgos"/>
 <use name="SimCalorimetry/CaloSimAlgos"/>
 <use name="SimCalorimetry/HcalSimAlgos"/>
+<flags CXXFLAGS="-Wno-unknown-pragmas" FILE="MahiGPU.cu"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
This should silence the following compilation warnings
```
  DataFormats/CaloRecHit/interface/MultifitComputations.h:77: warning: ignoring #pragma unroll  [-Wunknown-pragmas]
    77 |       for (int i = 1; i < MatrixType1::stride; i++) {
      | 
  DataFormats/CaloRecHit/interface/MultifitComputations.h:203: warning: ignoring #pragma unroll  [-Wunknown-pragmas]
   203 |       for (int icol = 0; icol < NPULSES; icol++) {
```