### PR TITLE
MTD geometry: make dd4hep test independent on dd4hep length unit change

### DIFF
--- a/Geometry/MTDCommonData/test/BuildFile.xml
+++ b/Geometry/MTDCommonData/test/BuildFile.xml
@@ -20,6 +20,7 @@
   <use name="Geometry/MTDCommonData"/>
   <use name="Geometry/Records"/>
   <use name="rootcling"/>
+  <use name="dd4hep"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -31,6 +31,7 @@
 
 #include "DataFormats/Math/interface/GeantUnits.h"
 #include "DataFormats/Math/interface/Rounding.h"
+#include <DD4hep/DD4hepUnits.h>
 
 //#define EDM_ML_DEBUG
 
@@ -63,7 +64,6 @@ private:
 using DD3Vector = ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>>;
 using angle_units::operators::convertRadToDeg;
 using cms_rounding::roundIfNear0;
-using geant_units::operators::convertCmToMm;
 
 DD4hep_TestMTDIdealGeometry::DD4hep_TestMTDIdealGeometry(const edm::ParameterSet& iConfig)
     : tag_(iConfig.getParameter<edm::ESInputTag>("DDDetector")),
@@ -259,13 +259,13 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
         }
         dd4hep::Box mySens(fv.solid());
         spos << "Solid shape name: " << DDSolidShapesName::name(fv.legacyShape(fv.shape())) << "\n";
-        spos << "Box dimensions: " << fround(convertCmToMm(mySens.x())) << " " << fround(convertCmToMm(mySens.y()))
-             << " " << fround(convertCmToMm(mySens.z())) << "\n";
+        spos << "Box dimensions: " << fround(mySens.x()/dd4hep::mm) << " " << fround(mySens.y()/dd4hep::mm)
+             << " " << fround(mySens.z()/dd4hep::mm) << "\n";
 
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
-        spos << "Translation vector components: " << fround(convertCmToMm(fv.translation().x())) << " "
-             << fround(convertCmToMm(fv.translation().y())) << " " << fround(convertCmToMm(fv.translation().z())) << " "
+        spos << "Translation vector components: " << fround(fv.translation().x()/dd4hep::mm) << " "
+             << fround(fv.translation().y()/dd4hep::mm) << " " << fround(fv.translation().z()/dd4hep::mm) << " "
              << "\n";
         spos << "Rotation matrix components: " << fround(x.X()) << " " << fround(x.Y()) << " " << fround(x.Z()) << " "
              << fround(y.X()) << " " << fround(y.Y()) << " " << fround(y.Z()) << " " << fround(z.X()) << " "
@@ -280,23 +280,23 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
             std::sqrt(std::pow(zeroGlobal.X() - cn1Global.X(), 2) + std::pow(zeroGlobal.Y() - cn1Global.Y(), 2) +
                       std::pow(zeroGlobal.Z() - cn1Global.Z(), 2));
 
-        spos << "Center global   = " << fround(convertCmToMm(zeroGlobal.X())) << fround(convertCmToMm(zeroGlobal.Y()))
-             << fround(convertCmToMm(zeroGlobal.Z())) << " r = " << fround(convertCmToMm(zeroGlobal.Rho()))
+        spos << "Center global   = " << fround(zeroGlobal.X()/dd4hep::mm) << fround(zeroGlobal.Y()/dd4hep::mm)
+             << fround(zeroGlobal.Z()/dd4hep::mm) << " r = " << fround(zeroGlobal.Rho()/dd4hep::mm)
              << " phi = " << fround(convertRadToDeg(zeroGlobal.Phi())) << "\n";
 
-        spos << "Corner 1 local  = " << fround(convertCmToMm(cn1Local.X())) << fround(convertCmToMm(cn1Local.Y()))
-             << fround(convertCmToMm(cn1Local.Z())) << " DeltaR = " << fround(convertCmToMm(distLocal)) << "\n";
+        spos << "Corner 1 local  = " << fround(cn1Local.X()/dd4hep::mm) << fround(cn1Local.Y()/dd4hep::mm)
+             << fround(cn1Local.Z()/dd4hep::mm) << " DeltaR = " << fround(distLocal/dd4hep::mm) << "\n";
 
-        spos << "Corner 1 global = " << fround(convertCmToMm(cn1Global.X())) << fround(convertCmToMm(cn1Global.Y()))
-             << fround(convertCmToMm(cn1Global.Z())) << " DeltaR = " << fround(convertCmToMm(distGlobal)) << "\n";
+        spos << "Corner 1 global = " << fround(cn1Global.X()/dd4hep::mm) << fround(cn1Global.Y()/dd4hep::mm)
+             << fround(cn1Global.Z()/dd4hep::mm) << " DeltaR = " << fround(distGlobal/dd4hep::mm) << "\n";
 
         spos << "\n";
-        if (std::fabs(convertCmToMm(distGlobal - distLocal)) > 1.e-6) {
+        if (std::fabs(distGlobal - distLocal)/dd4hep::mm > 1.e-6) {
           spos << "DIFFERENCE IN DISTANCE \n";
         }
-        sunitt << fround(convertCmToMm(zeroGlobal.X())) << fround(convertCmToMm(zeroGlobal.Y()))
-               << fround(convertCmToMm(zeroGlobal.Z())) << fround(convertCmToMm(cn1Global.X()))
-               << fround(convertCmToMm(cn1Global.Y())) << fround(convertCmToMm(cn1Global.Z()));
+        sunitt << fround(zeroGlobal.X()/dd4hep::mm) << fround(zeroGlobal.Y()/dd4hep::mm)
+               << fround(zeroGlobal.Z()/dd4hep::mm) << fround(cn1Global.X()/dd4hep::mm)
+               << fround(cn1Global.Y()/dd4hep::mm) << fround(cn1Global.Z()/dd4hep::mm);
         edm::LogInfo("DD4hep_TestMTDPosition") << spos.str();
 
         edm::LogVerbatim("MTDUnitTest") << sunitt.str();

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -259,13 +259,13 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
         }
         dd4hep::Box mySens(fv.solid());
         spos << "Solid shape name: " << DDSolidShapesName::name(fv.legacyShape(fv.shape())) << "\n";
-        spos << "Box dimensions: " << fround(mySens.x()/dd4hep::mm) << " " << fround(mySens.y()/dd4hep::mm)
-             << " " << fround(mySens.z()/dd4hep::mm) << "\n";
+        spos << "Box dimensions: " << fround(mySens.x() / dd4hep::mm) << " " << fround(mySens.y() / dd4hep::mm) << " "
+             << fround(mySens.z() / dd4hep::mm) << "\n";
 
         DD3Vector x, y, z;
         fv.rotation().GetComponents(x, y, z);
-        spos << "Translation vector components: " << fround(fv.translation().x()/dd4hep::mm) << " "
-             << fround(fv.translation().y()/dd4hep::mm) << " " << fround(fv.translation().z()/dd4hep::mm) << " "
+        spos << "Translation vector components: " << fround(fv.translation().x() / dd4hep::mm) << " "
+             << fround(fv.translation().y() / dd4hep::mm) << " " << fround(fv.translation().z() / dd4hep::mm) << " "
              << "\n";
         spos << "Rotation matrix components: " << fround(x.X()) << " " << fround(x.Y()) << " " << fround(x.Z()) << " "
              << fround(y.X()) << " " << fround(y.Y()) << " " << fround(y.Z()) << " " << fround(z.X()) << " "
@@ -280,23 +280,23 @@ void DD4hep_TestMTDIdealGeometry::analyze(const edm::Event& iEvent, const edm::E
             std::sqrt(std::pow(zeroGlobal.X() - cn1Global.X(), 2) + std::pow(zeroGlobal.Y() - cn1Global.Y(), 2) +
                       std::pow(zeroGlobal.Z() - cn1Global.Z(), 2));
 
-        spos << "Center global   = " << fround(zeroGlobal.X()/dd4hep::mm) << fround(zeroGlobal.Y()/dd4hep::mm)
-             << fround(zeroGlobal.Z()/dd4hep::mm) << " r = " << fround(zeroGlobal.Rho()/dd4hep::mm)
+        spos << "Center global   = " << fround(zeroGlobal.X() / dd4hep::mm) << fround(zeroGlobal.Y() / dd4hep::mm)
+             << fround(zeroGlobal.Z() / dd4hep::mm) << " r = " << fround(zeroGlobal.Rho() / dd4hep::mm)
              << " phi = " << fround(convertRadToDeg(zeroGlobal.Phi())) << "\n";
 
-        spos << "Corner 1 local  = " << fround(cn1Local.X()/dd4hep::mm) << fround(cn1Local.Y()/dd4hep::mm)
-             << fround(cn1Local.Z()/dd4hep::mm) << " DeltaR = " << fround(distLocal/dd4hep::mm) << "\n";
+        spos << "Corner 1 local  = " << fround(cn1Local.X() / dd4hep::mm) << fround(cn1Local.Y() / dd4hep::mm)
+             << fround(cn1Local.Z() / dd4hep::mm) << " DeltaR = " << fround(distLocal / dd4hep::mm) << "\n";
 
-        spos << "Corner 1 global = " << fround(cn1Global.X()/dd4hep::mm) << fround(cn1Global.Y()/dd4hep::mm)
-             << fround(cn1Global.Z()/dd4hep::mm) << " DeltaR = " << fround(distGlobal/dd4hep::mm) << "\n";
+        spos << "Corner 1 global = " << fround(cn1Global.X() / dd4hep::mm) << fround(cn1Global.Y() / dd4hep::mm)
+             << fround(cn1Global.Z() / dd4hep::mm) << " DeltaR = " << fround(distGlobal / dd4hep::mm) << "\n";
 
         spos << "\n";
-        if (std::fabs(distGlobal - distLocal)/dd4hep::mm > 1.e-6) {
+        if (std::fabs(distGlobal - distLocal) / dd4hep::mm > 1.e-6) {
           spos << "DIFFERENCE IN DISTANCE \n";
         }
-        sunitt << fround(zeroGlobal.X()/dd4hep::mm) << fround(zeroGlobal.Y()/dd4hep::mm)
-               << fround(zeroGlobal.Z()/dd4hep::mm) << fround(cn1Global.X()/dd4hep::mm)
-               << fround(cn1Global.Y()/dd4hep::mm) << fround(cn1Global.Z()/dd4hep::mm);
+        sunitt << fround(zeroGlobal.X() / dd4hep::mm) << fround(zeroGlobal.Y() / dd4hep::mm)
+               << fround(zeroGlobal.Z() / dd4hep::mm) << fround(cn1Global.X() / dd4hep::mm)
+               << fround(cn1Global.Y() / dd4hep::mm) << fround(cn1Global.Z() / dd4hep::mm);
         edm::LogInfo("DD4hep_TestMTDPosition") << spos.str();
 
         edm::LogVerbatim("MTDUnitTest") << sunitt.str();

--- a/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
+++ b/Geometry/MTDCommonData/test/DD4hep_TestMTDIdealGeometry.cc
@@ -29,7 +29,7 @@
 #include "DataFormats/ForwardDetId/interface/BTLDetId.h"
 #include "DataFormats/ForwardDetId/interface/ETLDetId.h"
 
-#include "DataFormats/Math/interface/GeantUnits.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "DataFormats/Math/interface/Rounding.h"
 #include <DD4hep/DD4hepUnits.h>
 


### PR DESCRIPTION
#### PR description:

This PR replaces ```convertCmToMm``` with ```/dd4hep::mm``` in order to make the dd4hep MTD ideal geometry test code insensitive to changes in the DD4hep baseline unit of measurements for length, as done for many other subsystems. #32488 takes care of the RECO level geometry update.

#### PR validation:

The unit test shows an identical description for both DDD and DD4hep.