### PR TITLE
Improve DD4hep workflow perf, step 1: All paths from SpecPar blocks with same name are stacked together

### DIFF
--- a/SimTracker/TrackerMaterialAnalysis/data/dd4hep_trackingMaterialGroups_ForPhaseII.xml
+++ b/SimTracker/TrackerMaterialAnalysis/data/dd4hep_trackingMaterialGroups_ForPhaseII.xml
@@ -9,7 +9,7 @@
 
   <SpecParSection label="spec-pars2.xml">
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer1">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer1">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule1Layer1/pixel:BModule1Layer1InnerPixelwafer/pixel:BModule1Layer1InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule2Layer1/pixel:BModule2Layer1InnerPixelwafer/pixel:BModule2Layer1InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule3Layer1/pixel:BModule3Layer1InnerPixelwafer/pixel:BModule3Layer1InnerPixelActive"/>
@@ -23,7 +23,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer1" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer2">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer2">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule1Layer2/pixel:BModule1Layer2InnerPixelwafer/pixel:BModule1Layer2InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule2Layer2/pixel:BModule2Layer2InnerPixelwafer/pixel:BModule2Layer2InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule3Layer2/pixel:BModule3Layer2InnerPixelwafer/pixel:BModule3Layer2InnerPixelActive"/>
@@ -37,7 +37,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer2" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer3">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer3">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule1Layer3/pixel:BModule1Layer3InnerPixelwafer/pixel:BModule1Layer3InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule2Layer3/pixel:BModule2Layer3InnerPixelwafer/pixel:BModule2Layer3InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule3Layer3/pixel:BModule3Layer3InnerPixelwafer/pixel:BModule3Layer3InnerPixelActive"/>
@@ -51,7 +51,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer3" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer4">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer4">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule1Layer4/pixel:BModule1Layer4InnerPixelwafer/pixel:BModule1Layer4InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule2Layer4/pixel:BModule2Layer4InnerPixelwafer/pixel:BModule2Layer4InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule3Layer4/pixel:BModule3Layer4InnerPixelwafer/pixel:BModule3Layer4InnerPixelActive"/>
@@ -65,7 +65,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer4" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk1">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk1">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring1Disc1/pixel:EModule1Disc1/pixel:EModule1Disc1InnerPixelwafer/pixel:EModule1Disc1InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring2Disc1/pixel:EModule2Disc1/pixel:EModule2Disc1InnerPixelwafer/pixel:EModule2Disc1InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring3Disc1/pixel:EModule3Disc1/pixel:EModule3Disc1InnerPixelwafer/pixel:EModule3Disc1InnerPixelActive"/>
@@ -73,7 +73,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk1" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk2">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk2">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring1Disc2/pixel:EModule1Disc2/pixel:EModule1Disc2InnerPixelwafer/pixel:EModule1Disc2InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring2Disc2/pixel:EModule2Disc2/pixel:EModule2Disc2InnerPixelwafer/pixel:EModule2Disc2InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring3Disc2/pixel:EModule3Disc2/pixel:EModule3Disc2InnerPixelwafer/pixel:EModule3Disc2InnerPixelActive"/>
@@ -81,7 +81,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk2" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk3">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk3">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring1Disc3/pixel:EModule1Disc3/pixel:EModule1Disc3InnerPixelwafer/pixel:EModule1Disc3InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring2Disc3/pixel:EModule2Disc3/pixel:EModule2Disc3InnerPixelwafer/pixel:EModule2Disc3InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring3Disc3/pixel:EModule3Disc3/pixel:EModule3Disc3InnerPixelwafer/pixel:EModule3Disc3InnerPixelActive"/>
@@ -89,7 +89,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk3" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk4">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk4">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring1Disc4/pixel:EModule1Disc4/pixel:EModule1Disc4InnerPixelwafer/pixel:EModule1Disc4InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring2Disc4/pixel:EModule2Disc4/pixel:EModule2Disc4InnerPixelwafer/pixel:EModule2Disc4InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring3Disc4/pixel:EModule3Disc4/pixel:EModule3Disc4InnerPixelwafer/pixel:EModule3Disc4InnerPixelActive"/>
@@ -97,7 +97,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk4" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk5">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk5">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring1Disc5/pixel:EModule1Disc5/pixel:EModule1Disc5InnerPixelwafer/pixel:EModule1Disc5InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring2Disc5/pixel:EModule2Disc5/pixel:EModule2Disc5InnerPixelwafer/pixel:EModule2Disc5InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring3Disc5/pixel:EModule3Disc5/pixel:EModule3Disc5InnerPixelwafer/pixel:EModule3Disc5InnerPixelActive"/>
@@ -105,7 +105,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk5" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk6">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk6">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring1Disc6/pixel:EModule1Disc6/pixel:EModule1Disc6InnerPixelwafer/pixel:EModule1Disc6InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring2Disc6/pixel:EModule2Disc6/pixel:EModule2Disc6InnerPixelwafer/pixel:EModule2Disc6InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring3Disc6/pixel:EModule3Disc6/pixel:EModule3Disc6InnerPixelwafer/pixel:EModule3Disc6InnerPixelActive"/>
@@ -113,7 +113,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk6" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk7">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk7">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring1Disc7/pixel:EModule1Disc7/pixel:EModule1Disc7InnerPixelwafer/pixel:EModule1Disc7InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring2Disc7/pixel:EModule2Disc7/pixel:EModule2Disc7InnerPixelwafer/pixel:EModule2Disc7InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring3Disc7/pixel:EModule3Disc7/pixel:EModule3Disc7InnerPixelwafer/pixel:EModule3Disc7InnerPixelActive"/>
@@ -121,7 +121,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk7" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk8">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk8">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring1Disc8/pixel:EModule1Disc8/pixel:EModule1Disc8InnerPixelwafer/pixel:EModule1Disc8InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring2Disc8/pixel:EModule2Disc8/pixel:EModule2Disc8InnerPixelwafer/pixel:EModule2Disc8InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring3Disc8/pixel:EModule3Disc8/pixel:EModule3Disc8InnerPixelwafer/pixel:EModule3Disc8InnerPixelActive"/>
@@ -129,7 +129,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk8" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk9">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk9">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring1Disc9/pixel:EModule1Disc9/pixel:EModule1Disc9InnerPixelwafer/pixel:EModule1Disc9InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring2Disc9/pixel:EModule2Disc9/pixel:EModule2Disc9InnerPixelwafer/pixel:EModule2Disc9InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring3Disc9/pixel:EModule3Disc9/pixel:EModule3Disc9InnerPixelwafer/pixel:EModule3Disc9InnerPixelActive"/>
@@ -138,7 +138,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk9" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk10">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk10">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring1Disc10/pixel:EModule1Disc10/pixel:EModule1Disc10InnerPixelwafer/pixel:EModule1Disc10InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring2Disc10/pixel:EModule2Disc10/pixel:EModule2Disc10InnerPixelwafer/pixel:EModule2Disc10InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring3Disc10/pixel:EModule3Disc10/pixel:EModule3Disc10InnerPixelwafer/pixel:EModule3Disc10InnerPixelActive"/>
@@ -147,7 +147,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk10" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk11">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk11">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring1Disc11/pixel:EModule1Disc11/pixel:EModule1Disc11InnerPixelwafer/pixel:EModule1Disc11InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring2Disc11/pixel:EModule2Disc11/pixel:EModule2Disc11InnerPixelwafer/pixel:EModule2Disc11InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring3Disc11/pixel:EModule3Disc11/pixel:EModule3Disc11InnerPixelwafer/pixel:EModule3Disc11InnerPixelActive"/>
@@ -156,7 +156,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk11" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk12">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk12">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring1Disc12/pixel:EModule1Disc12/pixel:EModule1Disc12InnerPixelwafer/pixel:EModule1Disc12InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring2Disc12/pixel:EModule2Disc12/pixel:EModule2Disc12InnerPixelwafer/pixel:EModule2Disc12InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring3Disc12/pixel:EModule3Disc12/pixel:EModule3Disc12InnerPixelwafer/pixel:EModule3Disc12InnerPixelActive"/>
@@ -166,7 +166,7 @@
     </SpecPar>
 
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer1">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer1">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Lowerwafer/BModule1Layer1LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Upperwafer/BModule1Layer1UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule2Layer1/BModule2Layer1Lowerwafer/BModule2Layer1LowerPSMacroPixelactive"/>
@@ -226,7 +226,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer1" />      
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer2">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer2">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Lowerwafer/BModule1Layer2LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Upperwafer/BModule1Layer2UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule2Layer2/BModule2Layer2Lowerwafer/BModule2Layer2LowerPSMacroPixelactive"/>
@@ -290,7 +290,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer2" />            
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer3">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer3">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Lowerwafer/BModule1Layer3LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Upperwafer/BModule1Layer3UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule2Layer3/BModule2Layer3Lowerwafer/BModule2Layer3LowerPSMacroPixelactive"/>
@@ -358,7 +358,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer3" />            
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer4">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer4">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Lowerwafer/BModule1Layer4Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Upperwafer/BModule1Layer4Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule2Layer4/BModule2Layer4Lowerwafer/BModule2Layer4Lower2Sactive"/>
@@ -386,7 +386,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer4" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer5">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer5">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Lowerwafer/BModule1Layer5Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Upperwafer/BModule1Layer5Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule2Layer5/BModule2Layer5Lowerwafer/BModule2Layer5Lower2Sactive"/>
@@ -414,7 +414,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer5" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer6">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer6">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Lowerwafer/BModule1Layer6Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Upperwafer/BModule1Layer6Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule2Layer6/BModule2Layer6Lowerwafer/BModule2Layer6Lower2Sactive"/>
@@ -442,7 +442,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer6" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk1">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk1">
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Lowerwafer/EModule1Disc1LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Upperwafer/EModule1Disc1UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring2Disc1/tracker:EModule2Disc1/EModule2Disc1Lowerwafer/EModule2Disc1LowerPSMacroPixelactive"/>
@@ -476,7 +476,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk1" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk2">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk2">
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Lowerwafer/EModule1Disc2LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Upperwafer/EModule1Disc2UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring2Disc2/tracker:EModule2Disc2/EModule2Disc2Lowerwafer/EModule2Disc2LowerPSMacroPixelactive"/>
@@ -510,7 +510,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk2" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk3">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk3">
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Lowerwafer/EModule4Disc3LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Upperwafer/EModule4Disc3UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring5Disc3/tracker:EModule5Disc3/EModule5Disc3Lowerwafer/EModule5Disc3LowerPSMacroPixelactive"/>
@@ -538,7 +538,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk3" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk4">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk4">
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Lowerwafer/EModule4Disc4LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Upperwafer/EModule4Disc4UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring5Disc4/tracker:EModule5Disc4/EModule5Disc4Lowerwafer/EModule5Disc4LowerPSMacroPixelactive"/>
@@ -566,7 +566,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk4" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk5">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk5">
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Lowerwafer/EModule4Disc5LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Upperwafer/EModule4Disc5UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring5Disc5/tracker:EModule5Disc5/EModule5Disc5Lowerwafer/EModule5Disc5LowerPSMacroPixelactive"/>

--- a/SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseI.xml
+++ b/SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseI.xml
@@ -2,12 +2,12 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
   <SpecParSection label="spec-pars2.xml">
 
-    <SpecPar name="TrackerRecMaterialPixelBarrelLayer0_External">
+    <SpecPar name="TrackingMaterialGroupPixelBarrelLayer0_External">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullPlus[4]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullMinus[1]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer0_External" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelBarrelLayer0">
+    <SpecPar name="TrackingMaterialGroupPixelBarrelLayer0">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullPlus[1]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullPlus[2]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullPlus[3]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
@@ -16,12 +16,12 @@
       <PartSelector path="//PixelBarrel/PixelBarrelLayer0/PixelBarrelLadderFull0/pixbarladderfull0:PixelBarrelModuleBoxFull/pixbarladderfull0:PixelBarrelModuleFullMinus[4]/pixbarladderfull0:PixelBarrelSensorFull/PixelBarrelActiveFull0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer0" /></SpecPar>
 
-   <SpecPar name="TrackerRecMaterialPixelBarrelLayer1_External">
+   <SpecPar name="TrackingMaterialGroupPixelBarrelLayer1_External">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullPlus[4]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullMinus[1]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer1_External" /></SpecPar>
 
-   <SpecPar name="TrackerRecMaterialPixelBarrelLayer1">
+   <SpecPar name="TrackingMaterialGroupPixelBarrelLayer1">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullPlus[1]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullPlus[2]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullPlus[3]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
@@ -30,12 +30,12 @@
       <PartSelector path="//PixelBarrel/PixelBarrelLayer1/PixelBarrelLadderFull1/pixbarladderfull1:PixelBarrelModuleBoxFull/pixbarladderfull1:PixelBarrelModuleFullMinus[4]/pixbarladderfull1:PixelBarrelSensorFull/PixelBarrelActiveFull1" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer1" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelBarrelLayer2_External">
+    <SpecPar name="TrackingMaterialGroupPixelBarrelLayer2_External">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullPlus[4]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullMinus[1]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer2_External" /></SpecPar>
 
-   <SpecPar name="TrackerRecMaterialPixelBarrelLayer2">
+   <SpecPar name="TrackingMaterialGroupPixelBarrelLayer2">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullPlus[1]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullPlus[2]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullPlus[3]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
@@ -44,12 +44,12 @@
       <PartSelector path="//PixelBarrel/PixelBarrelLayer2/PixelBarrelLadderFull2/pixbarladderfull2:PixelBarrelModuleBoxFull/pixbarladderfull2:PixelBarrelModuleFullMinus[4]/pixbarladderfull2:PixelBarrelSensorFull/PixelBarrelActiveFull2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer2" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelBarrelLayer3_External">
+    <SpecPar name="TrackingMaterialGroupPixelBarrelLayer3_External">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer3/PixelBarrelLadderFull3/pixbarladderfull3:PixelBarrelModuleBoxFull/pixbarladderfull3:PixelBarrelModuleFullPlus[4]/pixbarladderfull3:PixelBarrelSensorFull/PixelBarrelActiveFull3" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer3/PixelBarrelLadderFull3/pixbarladderfull3:PixelBarrelModuleBoxFull/pixbarladderfull3:PixelBarrelModuleFullMinus[1]/pixbarladderfull3:PixelBarrelSensorFull/PixelBarrelActiveFull3" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer3_External" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelBarrelLayer3">
+    <SpecPar name="TrackingMaterialGroupPixelBarrelLayer3">
       <PartSelector path="//PixelBarrel/PixelBarrelLayer3/PixelBarrelLadderFull3/pixbarladderfull3:PixelBarrelModuleBoxFull/pixbarladderfull3:PixelBarrelModuleFullPlus[1]/pixbarladderfull3:PixelBarrelSensorFull/PixelBarrelActiveFull3" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer3/PixelBarrelLadderFull3/pixbarladderfull3:PixelBarrelModuleBoxFull/pixbarladderfull3:PixelBarrelModuleFullPlus[2]/pixbarladderfull3:PixelBarrelSensorFull/PixelBarrelActiveFull3" />
       <PartSelector path="//PixelBarrel/PixelBarrelLayer3/PixelBarrelLadderFull3/pixbarladderfull3:PixelBarrelModuleBoxFull/pixbarladderfull3:PixelBarrelModuleFullPlus[3]/pixbarladderfull3:PixelBarrelSensorFull/PixelBarrelActiveFull3" />
@@ -59,7 +59,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelBarrelLayer3" /></SpecPar>
 
 
-    <SpecPar name="TrackerRecMaterialTIBLayer0_Z0">
+    <SpecPar name="TrackingMaterialGroupTIBLayer0_Z0">
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoMin1/TIBModule0B[3]/TIBWaferRphi0/TIBActiveRphi0" />
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoMin1/TIBModule0B[3]/TIBWaferSter0/TIBActiveSter0" />
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoPls1/TIBModule0B[1]/TIBWaferRphi0/TIBActiveRphi0" />
@@ -70,7 +70,7 @@
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Up/TIBString0Up1/TIBString0UpPls1/TIBModule0A[1]/TIBWaferSter0/TIBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer0_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer0_Z20">
+    <SpecPar name="TrackingMaterialGroupTIBLayer0_Z20">
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoMin1/TIBModule0B[1]/TIBWaferRphi0/TIBActiveRphi0" />
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoMin1/TIBModule0B[1]/TIBWaferSter0/TIBActiveSter0" />
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Down/TIBString0Lo1/TIBString0LoMin1/TIBModule0B[2]/TIBWaferRphi0/TIBActiveRphi0" />
@@ -89,7 +89,7 @@
       <PartSelector path="//Tracker/TIB/TIBLayer0/TIBLayer0Up/TIBString0Up1/TIBString0UpPls1/TIBModule0A[3]/TIBWaferSter0/TIBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer0_Z20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer1_Z0">
+    <SpecPar name="TrackingMaterialGroupTIBLayer1_Z0">
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoMin1/TIBModule0A[3]/TIBWaferRphi0/TIBActiveRphi0" />
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoMin1/TIBModule0A[3]/TIBWaferSter0/TIBActiveSter0" />
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoPls1/TIBModule0A[1]/TIBWaferRphi0/TIBActiveRphi0" />
@@ -102,7 +102,7 @@
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Up/TIBString1Up1/TIBString1UpPls1/TIBModule0B[1]/TIBWaferSter0/TIBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer1_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer1_Z30">
+    <SpecPar name="TrackingMaterialGroupTIBLayer1_Z30">
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoMin1/TIBModule0A[1]/TIBWaferRphi0/TIBActiveRphi0" />
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoMin1/TIBModule0A[1]/TIBWaferSter0/TIBActiveSter0" />
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Down/TIBString1Lo1/TIBString1LoMin1/TIBModule0A[2]/TIBWaferRphi0/TIBActiveRphi0" />
@@ -119,7 +119,7 @@
       <PartSelector path="//Tracker/TIB/TIBLayer1/TIBLayer1Up/TIBString1Up1/TIBString1UpPls1/TIBModule0B[3]/TIBWaferSter0/TIBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer1_Z30" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer2_Z0">
+    <SpecPar name="TrackingMaterialGroupTIBLayer2_Z0">
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Down/TIBString2Lo1/TIBString2LoMin1/TIBModule2[2]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Down/TIBString2Lo1/TIBString2LoMin1/TIBModule2[3]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Down/TIBString2Lo1/TIBString2LoPls1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
@@ -130,14 +130,14 @@
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Up/TIBString2Up1/TIBString2UpPls1/TIBModule2[2]/TIBWaferRphi2/TIBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer2_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer2_Z40">
+    <SpecPar name="TrackingMaterialGroupTIBLayer2_Z40">
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Down/TIBString2Lo1/TIBString2LoMin1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Down/TIBString2Lo1/TIBString2LoPls1/TIBModule2[3]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Up/TIBString2Up1/TIBString2UpMin1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer2/TIBLayer2Up/TIBString2Up1/TIBString2UpPls1/TIBModule2[3]/TIBWaferRphi2/TIBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer2_Z40" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer3_Z0">
+    <SpecPar name="TrackingMaterialGroupTIBLayer3_Z0">
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Down/TIBString3Lo1/TIBString3LoMin1/TIBModule2[2]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Down/TIBString3Lo1/TIBString3LoMin1/TIBModule2[3]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Down/TIBString3Lo1/TIBString3LoPls1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
@@ -149,20 +149,20 @@
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Up/TIBString3Up1/TIBString3UpPls1/TIBModule2[2]/TIBWaferRphi2/TIBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer3_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIBLayer3_Z50">
+    <SpecPar name="TrackingMaterialGroupTIBLayer3_Z50">
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Down/TIBString3Lo1/TIBString3LoMin1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Up/TIBString3Up1/TIBString3UpMin1/TIBModule2[1]/TIBWaferRphi2/TIBActiveRphi2" />
       <PartSelector path="//Tracker/TIB/TIBLayer3/TIBLayer3Up/TIBString3Up1/TIBString3UpPls1/TIBModule2[3]/TIBWaferRphi2/TIBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIBLayer3_Z50" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer0_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer0_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[6]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[6]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0H/TOBRodCentral0H/TOBModule0[1]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0H/TOBRodCentral0H/TOBModule0[1]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer0_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer0_Z20">
+    <SpecPar name="TrackingMaterialGroupTOBLayer0_Z20">
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[3]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[3]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[4]/TOBWaferRphi0/TOBActiveRphi0" />
@@ -177,7 +177,7 @@
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0H/TOBRodCentral0H/TOBModule0[4]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer0_Z20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer0_Z70">
+    <SpecPar name="TrackingMaterialGroupTOBLayer0_Z70">
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[1]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[1]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0L/TOBRodCentral0L/TOBModule0[2]/TOBWaferRphi0/TOBActiveRphi0" />
@@ -188,14 +188,14 @@
       <PartSelector path="//Tracker/TOB/TOBLayer0/TOBRod0/TOBRod0H/TOBRodCentral0H/TOBModule0[6]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer0_Z70" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer1_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer1_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[6]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[6]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1H/TOBRodCentral1H/TOBModule0[1]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1H/TOBRodCentral1H/TOBModule0[1]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer1_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer1_Z20">
+    <SpecPar name="TrackingMaterialGroupTOBLayer1_Z20">
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[3]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[3]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[4]/TOBWaferRphi0/TOBActiveRphi0" />
@@ -210,7 +210,7 @@
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1H/TOBRodCentral1H/TOBModule0[4]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer1_Z20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer1_Z80">
+    <SpecPar name="TrackingMaterialGroupTOBLayer1_Z80">
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[1]/TOBWaferRphi0/TOBActiveRphi0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[1]/TOBWaferSter0/TOBActiveSter0" />
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1L/TOBRodCentral1L/TOBModule0[2]/TOBWaferRphi0/TOBActiveRphi0" />
@@ -221,12 +221,12 @@
       <PartSelector path="//Tracker/TOB/TOBLayer1/TOBRod1/TOBRod1H/TOBRodCentral1H/TOBModule0[6]/TOBWaferSter0/TOBActiveSter0" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer1_Z80" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer2_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer2_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[6]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2H/TOBRodCentral2H/TOBModule2[1]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer2_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer2_Z25">
+    <SpecPar name="TrackingMaterialGroupTOBLayer2_Z25">
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[3]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[4]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[5]/TOBWaferRphi2/TOBActiveRphi2" />
@@ -235,19 +235,19 @@
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2H/TOBRodCentral2H/TOBModule2[4]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer2_Z25" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer2_Z80">
+    <SpecPar name="TrackingMaterialGroupTOBLayer2_Z80">
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[1]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2L/TOBRodCentral2L/TOBModule2[2]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2H/TOBRodCentral2H/TOBModule2[5]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer2/TOBRod2/TOBRod2H/TOBRodCentral2H/TOBModule2[6]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer2_Z80" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer3_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer3_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[6]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3H/TOBRodCentral3H/TOBModule2[1]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer3_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer3_Z25">
+    <SpecPar name="TrackingMaterialGroupTOBLayer3_Z25">
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[3]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[4]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[5]/TOBWaferRphi2/TOBActiveRphi2" />
@@ -256,19 +256,19 @@
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3H/TOBRodCentral3H/TOBModule2[4]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer3_Z25" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer3_Z80">
+    <SpecPar name="TrackingMaterialGroupTOBLayer3_Z80">
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[1]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3L/TOBRodCentral3L/TOBModule2[2]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3H/TOBRodCentral3H/TOBModule2[5]/TOBWaferRphi2/TOBActiveRphi2" />
       <PartSelector path="//Tracker/TOB/TOBLayer3/TOBRod3/TOBRod3H/TOBRodCentral3H/TOBModule2[6]/TOBWaferRphi2/TOBActiveRphi2" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer3_Z80" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer4_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer4_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[6]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4H/TOBRodCentral4H/TOBModule4[1]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer4_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer4_Z25">
+    <SpecPar name="TrackingMaterialGroupTOBLayer4_Z25">
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[3]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[4]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[5]/TOBWaferRphi4/TOBActiveRphi4" />
@@ -277,19 +277,19 @@
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4H/TOBRodCentral4H/TOBModule4[4]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer4_Z25" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer4_Z80">
+    <SpecPar name="TrackingMaterialGroupTOBLayer4_Z80">
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[1]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4L/TOBRodCentral4L/TOBModule4[2]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4H/TOBRodCentral4H/TOBModule4[5]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer4/TOBRod4/TOBRod4H/TOBRodCentral4H/TOBModule4[6]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer4_Z80" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer5_Z0">
+    <SpecPar name="TrackingMaterialGroupTOBLayer5_Z0">
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[6]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5H/TOBRodCentral5H/TOBModule4[1]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer5_Z0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer5_Z25">
+    <SpecPar name="TrackingMaterialGroupTOBLayer5_Z25">
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[3]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[4]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[5]/TOBWaferRphi4/TOBActiveRphi4" />
@@ -298,14 +298,14 @@
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5H/TOBRodCentral5H/TOBModule4[4]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer5_Z25" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTOBLayer5_Z80">
+    <SpecPar name="TrackingMaterialGroupTOBLayer5_Z80">
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[1]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5L/TOBRodCentral5L/TOBModule4[2]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5H/TOBRodCentral5H/TOBModule4[5]/TOBWaferRphi4/TOBActiveRphi4" />
       <PartSelector path="//Tracker/TOB/TOBLayer5/TOBRod5/TOBRod5H/TOBRodCentral5H/TOBModule4[6]/TOBWaferRphi4/TOBActiveRphi4" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTOBLayer5_Z80" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk1Fw_Inner">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk1Fw_Inner">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[1]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -352,7 +352,7 @@
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[21]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk1Fw_Inner" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk1Fw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk1Fw_Outer">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[23]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -423,7 +423,7 @@
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[1]/pixfwdblade.*Zplus:PixelForwardBlade[55]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk1Fw_Outer" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk2Fw_Inner">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk2Fw_Inner">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[1]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -470,7 +470,7 @@
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[21]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk2Fw_Inner" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk2Fw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk2Fw_Outer">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[2]/pixfwdblade.*Zplus:PixelForwardBlade[23]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -542,7 +542,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk2Fw_Outer" /></SpecPar>
 
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk3Fw_Inner">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk3Fw_Inner">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[0]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[1]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -589,7 +589,7 @@
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[21]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk3Fw_Inner" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk3Fw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk3Fw_Outer">
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[22]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[23]/pixfwdblade.*Zplus:PixelForwardModule[1]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
@@ -660,7 +660,7 @@
       <PartSelector path="//Tracker/PixelForwardZplus/PixelForwardDiskZplus[3]/pixfwdblade.*Zplus:PixelForwardBlade[55]/pixfwdblade.*Zplus:PixelForwardModule[2]/pixfwdblade.*Zplus:PixelForwardWafer/pixfwdblade.*Zplus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk3Fw_Outer" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk1Bw_Inner">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk1Bw_Inner">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[1]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -707,7 +707,7 @@
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[21]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk1Bw_Inner" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk1Bw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk1Bw_Outer">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[23]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -778,7 +778,7 @@
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[1]/pixfwdblade.*Zminus:PixelForwardBlade[55]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk1Bw_Outer" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk2Bw_Inner">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk2Bw_Inner">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[1]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -825,7 +825,7 @@
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[21]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk2Bw_Inner" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk2Bw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk2Bw_Outer">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[2]/pixfwdblade.*Zminus:PixelForwardBlade[23]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -897,7 +897,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk2Bw_Outer" /></SpecPar>
 
 
-     <SpecPar name="TrackerRecMaterialPixelEndcapDisk3Bw_Inner">
+     <SpecPar name="TrackingMaterialGroupPixelEndcapDisk3Bw_Inner">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[0]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[1]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -945,7 +945,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk3Bw_Inner" /></SpecPar>
 
 
-    <SpecPar name="TrackerRecMaterialPixelEndcapDisk3Bw_Outer">
+    <SpecPar name="TrackingMaterialGroupPixelEndcapDisk3Bw_Outer">
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[22]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[23]/pixfwdblade.*Zminus:PixelForwardModule[1]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
@@ -1016,7 +1016,7 @@
       <PartSelector path="//Tracker/PixelForwardZminus/PixelForwardDiskZminus[3]/pixfwdblade.*Zminus:PixelForwardBlade[55]/pixfwdblade.*Zminus:PixelForwardModule[2]/pixfwdblade.*Zminus:PixelForwardWafer/pixfwdblade.*Zminus:PixelForwardSensor" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPixelEndcapDisk3Bw_Outer" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk1_R0">
+    <SpecPar name="TrackingMaterialGroupTIDDisk1_R0">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing0F/TIDModule0L/TIDModule0RphiWafer/TIDModule0RphiActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing0F/TIDModule0L/TIDModule0StereoWafer/TIDModule0StereoActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing0F/TIDModule0R/TIDModule0RphiWafer/TIDModule0RphiActive" />
@@ -1027,7 +1027,7 @@
       <PartSelector path="//Tracker/TIDB/TIDWheelB[1]/TIDRing0B/TIDModule0R/TIDModule0StereoWafer/TIDModule0StereoActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk1_R0" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk1_R30">
+    <SpecPar name="TrackingMaterialGroupTIDDisk1_R30">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing1F/TIDModule1L/TIDModule1RphiWafer/TIDModule1RphiActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing1F/TIDModule1L/TIDModule1StereoWafer/TIDModule1StereoActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[1]/TIDRing1F/TIDModule1R/TIDModule1RphiWafer/TIDModule1RphiActive" />
@@ -1040,7 +1040,7 @@
       <PartSelector path="//Tracker/TIDB/TIDWheelB[1]/TIDRing2/TIDModule2/TIDModule2RphiWafer/TIDModule2RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk1_R30" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk2_R25">
+    <SpecPar name="TrackingMaterialGroupTIDDisk2_R25">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing0F/TIDModule0L/TIDModule0RphiWafer/TIDModule0RphiActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing0F/TIDModule0L/TIDModule0StereoWafer/TIDModule0StereoActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing0F/TIDModule0R/TIDModule0RphiWafer/TIDModule0RphiActive" />
@@ -1051,7 +1051,7 @@
       <PartSelector path="//Tracker/TIDB/TIDWheelB[2]/TIDRing0B/TIDModule0R/TIDModule0StereoWafer/TIDModule0StereoActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk2_R25" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk2_R30">
+    <SpecPar name="TrackingMaterialGroupTIDDisk2_R30">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing1F/TIDModule1L/TIDModule1RphiWafer/TIDModule1RphiActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing1F/TIDModule1L/TIDModule1StereoWafer/TIDModule1StereoActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing1F/TIDModule1R/TIDModule1RphiWafer/TIDModule1RphiActive" />
@@ -1062,12 +1062,12 @@
       <PartSelector path="//Tracker/TIDB/TIDWheelB[2]/TIDRing1B/TIDModule1R/TIDModule1StereoWafer/TIDModule1StereoActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk2_R30" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk2_R40">
+    <SpecPar name="TrackingMaterialGroupTIDDisk2_R40">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[2]/TIDRing2/TIDModule2/TIDModule2RphiWafer/TIDModule2RphiActive" />
       <PartSelector path="//Tracker/TIDB/TIDWheelB[2]/TIDRing2/TIDModule2/TIDModule2RphiWafer/TIDModule2RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk2_R40" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTIDDisk3_R24">
+    <SpecPar name="TrackingMaterialGroupTIDDisk3_R24">
       <PartSelector path="//Tracker/TIDF/TIDWheelF[3]/TIDRing0F/TIDModule0L/TIDModule0RphiWafer/TIDModule0RphiActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[3]/TIDRing0F/TIDModule0L/TIDModule0StereoWafer/TIDModule0StereoActive" />
       <PartSelector path="//Tracker/TIDF/TIDWheelF[3]/TIDRing0F/TIDModule0R/TIDModule0RphiWafer/TIDModule0RphiActive" />
@@ -1088,7 +1088,7 @@
       <PartSelector path="//Tracker/TIDB/TIDWheelB[3]/TIDRing2/TIDModule2/TIDModule2RphiWafer/TIDModule2RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTIDDisk3_R24" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk0_R20">
+    <SpecPar name="TrackingMaterialGroupTECDisk0_R20">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0RphiWafer/TECModule0RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0StereoWafer/TECModule0StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
@@ -1099,17 +1099,17 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0B/TECRing1B/TECModule1/TECModule1StereoWafer/TECModule1StereoActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk0_R20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk0_R40">
+    <SpecPar name="TrackingMaterialGroupTECDisk0_R40">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0B/TECRing2B/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk0_R40" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk0_R50">
+    <SpecPar name="TrackingMaterialGroupTECDisk0_R50">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing3F/TECModule3/TECModule3RphiWafer/TECModule3RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0B/TECRing3B/TECModule3/TECModule3RphiWafer/TECModule3RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk0_R50" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk0_R60">
+    <SpecPar name="TrackingMaterialGroupTECDisk0_R60">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing4F/TECModule4/TECModule4RphiWafer/TECModule4RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing4F/TECModule4/TECModule4StereoWafer/TECModule4StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing5F/TECModule5/TECModule5RphiWafer/TECModule5RphiActive" />
@@ -1118,12 +1118,12 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0B/TECRing5B/TECModule5/TECModule5RphiWafer/TECModule5RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk0_R60" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk0_R90">
+    <SpecPar name="TrackingMaterialGroupTECDisk0_R90">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0F/TECRing6F/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[0]/TECPetalCont0B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk0_R90" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk1_R20">
+    <SpecPar name="TrackingMaterialGroupTECDisk1_R20">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[1]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0RphiWafer/TECModule0RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[1]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0StereoWafer/TECModule0StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[1]/TECPetalCont0F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
@@ -1146,7 +1146,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[1]/TECPetalCont0B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk1_R20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk2_R20">
+    <SpecPar name="TrackingMaterialGroupTECDisk2_R20">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[2]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0RphiWafer/TECModule0RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[2]/TECPetalCont0F/TECRing0F/TECModule0/TECModule0StereoWafer/TECModule0StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[2]/TECPetalCont0F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
@@ -1169,7 +1169,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelA[2]/TECPetalCont0B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk2_R20" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk3">
+    <SpecPar name="TrackingMaterialGroupTECDisk3">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[3]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[3]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1StereoWafer/TECModule1StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[3]/TECPetalCont3F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
@@ -1188,7 +1188,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[3]/TECPetalCont3B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk3" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk4_R33">
+    <SpecPar name="TrackingMaterialGroupTECDisk4_R33">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[4]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[4]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1StereoWafer/TECModule1StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[4]/TECPetalCont3F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
@@ -1207,7 +1207,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelB[4]/TECPetalCont3B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk4_R33" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk5_R33">
+    <SpecPar name="TrackingMaterialGroupTECDisk5_R33">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheel6[5]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1RphiWafer/TECModule1RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheel6[5]/TECPetalCont3F/TECRing1F/TECModule1/TECModule1StereoWafer/TECModule1StereoActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheel6[5]/TECPetalCont3F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
@@ -1226,7 +1226,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheel6[5]/TECPetalCont3B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk5_R33" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk6">
+    <SpecPar name="TrackingMaterialGroupTECDisk6">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[6]/TECPetalCont6F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[6]/TECPetalCont6F/TECRing3F/TECModule3/TECModule3RphiWafer/TECModule3RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[6]/TECPetalCont6F/TECRing4F/TECModule4/TECModule4RphiWafer/TECModule4RphiActive" />
@@ -1241,7 +1241,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[6]/TECPetalCont6B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk6" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk7_R40">
+    <SpecPar name="TrackingMaterialGroupTECDisk7_R40">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[7]/TECPetalCont6F/TECRing2F/TECModule2/TECModule2RphiWafer/TECModule2RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[7]/TECPetalCont6F/TECRing3F/TECModule3/TECModule3RphiWafer/TECModule3RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[7]/TECPetalCont6F/TECRing4F/TECModule4/TECModule4RphiWafer/TECModule4RphiActive" />
@@ -1256,7 +1256,7 @@
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelC[7]/TECPetalCont6B/TECRing6B/TECModule6/TECModule6RphiWafer/TECModule6RphiActive" />
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialTECDisk7_R40" /></SpecPar>
 
-    <SpecPar name="TrackerRecMaterialTECDisk8">
+    <SpecPar name="TrackingMaterialGroupTECDisk8">
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelD[8]/TECPetalCont8F/TECRing3F/TECModule3/TECModule3RphiWafer/TECModule3RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelD[8]/TECPetalCont8F/TECRing4F/TECModule4/TECModule4RphiWafer/TECModule4RphiActive" />
       <PartSelector path="//Tracker/TEC/TECWheels/TECWheelD[8]/TECPetalCont8F/TECRing4F/TECModule4/TECModule4StereoWafer/TECModule4StereoActive" />

--- a/SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseII.xml
+++ b/SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseII.xml
@@ -2,7 +2,7 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
   <SpecParSection label="spec-pars2.xml">
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer1">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer1">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule1Layer1/pixel:BModule1Layer1InnerPixelwafer/pixel:BModule1Layer1InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule2Layer1/pixel:BModule2Layer1InnerPixelwafer/pixel:BModule2Layer1InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer1/pixel:RodUnflipped1/pixel:BModule3Layer1/pixel:BModule3Layer1InnerPixelwafer/pixel:BModule3Layer1InnerPixelActive"/>
@@ -16,7 +16,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer1" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer2">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer2">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule1Layer2/pixel:BModule1Layer2InnerPixelwafer/pixel:BModule1Layer2InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule2Layer2/pixel:BModule2Layer2InnerPixelwafer/pixel:BModule2Layer2InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer2/pixel:RodUnflipped2/pixel:BModule3Layer2/pixel:BModule3Layer2InnerPixelwafer/pixel:BModule3Layer2InnerPixelActive"/>
@@ -30,7 +30,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer2" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer3">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer3">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule1Layer3/pixel:BModule1Layer3InnerPixelwafer/pixel:BModule1Layer3InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule2Layer3/pixel:BModule2Layer3InnerPixelwafer/pixel:BModule2Layer3InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer3/pixel:RodUnflipped3/pixel:BModule3Layer3/pixel:BModule3Layer3InnerPixelwafer/pixel:BModule3Layer3InnerPixelActive"/>
@@ -44,7 +44,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer3" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelBarrelLayer4">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelBarrelLayer4">
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule1Layer4/pixel:BModule1Layer4InnerPixelwafer/pixel:BModule1Layer4InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule2Layer4/pixel:BModule2Layer4InnerPixelwafer/pixel:BModule2Layer4InnerPixelActive"/>
       <PartSelector path="//pixbar:Phase2PixelBarrel/pixel:Layer4/pixel:RodUnflipped4/pixel:BModule3Layer4/pixel:BModule3Layer4InnerPixelwafer/pixel:BModule3Layer4InnerPixelActive"/>
@@ -58,7 +58,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelBarrelLayer4" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk1">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk1">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring1Disc1/pixel:EModule1Disc1/pixel:EModule1Disc1InnerPixelwafer/pixel:EModule1Disc1InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring2Disc1/pixel:EModule2Disc1/pixel:EModule2Disc1InnerPixelwafer/pixel:EModule2Disc1InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc1/pixel:Ring3Disc1/pixel:EModule3Disc1/pixel:EModule3Disc1InnerPixelwafer/pixel:EModule3Disc1InnerPixelActive"/>
@@ -66,7 +66,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk1" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk2">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk2">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring1Disc2/pixel:EModule1Disc2/pixel:EModule1Disc2InnerPixelwafer/pixel:EModule1Disc2InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring2Disc2/pixel:EModule2Disc2/pixel:EModule2Disc2InnerPixelwafer/pixel:EModule2Disc2InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc2/pixel:Ring3Disc2/pixel:EModule3Disc2/pixel:EModule3Disc2InnerPixelwafer/pixel:EModule3Disc2InnerPixelActive"/>
@@ -74,7 +74,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk2" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk3">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk3">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring1Disc3/pixel:EModule1Disc3/pixel:EModule1Disc3InnerPixelwafer/pixel:EModule1Disc3InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring2Disc3/pixel:EModule2Disc3/pixel:EModule2Disc3InnerPixelwafer/pixel:EModule2Disc3InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc3/pixel:Ring3Disc3/pixel:EModule3Disc3/pixel:EModule3Disc3InnerPixelwafer/pixel:EModule3Disc3InnerPixelActive"/>
@@ -82,7 +82,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk3" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk4">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk4">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring1Disc4/pixel:EModule1Disc4/pixel:EModule1Disc4InnerPixelwafer/pixel:EModule1Disc4InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring2Disc4/pixel:EModule2Disc4/pixel:EModule2Disc4InnerPixelwafer/pixel:EModule2Disc4InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc4/pixel:Ring3Disc4/pixel:EModule3Disc4/pixel:EModule3Disc4InnerPixelwafer/pixel:EModule3Disc4InnerPixelActive"/>
@@ -90,7 +90,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk4" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk5">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk5">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring1Disc5/pixel:EModule1Disc5/pixel:EModule1Disc5InnerPixelwafer/pixel:EModule1Disc5InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring2Disc5/pixel:EModule2Disc5/pixel:EModule2Disc5InnerPixelwafer/pixel:EModule2Disc5InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc5/pixel:Ring3Disc5/pixel:EModule3Disc5/pixel:EModule3Disc5InnerPixelwafer/pixel:EModule3Disc5InnerPixelActive"/>
@@ -98,7 +98,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk5" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk6">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk6">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring1Disc6/pixel:EModule1Disc6/pixel:EModule1Disc6InnerPixelwafer/pixel:EModule1Disc6InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring2Disc6/pixel:EModule2Disc6/pixel:EModule2Disc6InnerPixelwafer/pixel:EModule2Disc6InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc6/pixel:Ring3Disc6/pixel:EModule3Disc6/pixel:EModule3Disc6InnerPixelwafer/pixel:EModule3Disc6InnerPixelActive"/>
@@ -106,7 +106,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk6" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk7">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk7">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring1Disc7/pixel:EModule1Disc7/pixel:EModule1Disc7InnerPixelwafer/pixel:EModule1Disc7InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring2Disc7/pixel:EModule2Disc7/pixel:EModule2Disc7InnerPixelwafer/pixel:EModule2Disc7InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc7/pixel:Ring3Disc7/pixel:EModule3Disc7/pixel:EModule3Disc7InnerPixelwafer/pixel:EModule3Disc7InnerPixelActive"/>
@@ -114,7 +114,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk7" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk8">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk8">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring1Disc8/pixel:EModule1Disc8/pixel:EModule1Disc8InnerPixelwafer/pixel:EModule1Disc8InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring2Disc8/pixel:EModule2Disc8/pixel:EModule2Disc8InnerPixelwafer/pixel:EModule2Disc8InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc8/pixel:Ring3Disc8/pixel:EModule3Disc8/pixel:EModule3Disc8InnerPixelwafer/pixel:EModule3Disc8InnerPixelActive"/>
@@ -122,7 +122,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk8" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk9">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk9">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring1Disc9/pixel:EModule1Disc9/pixel:EModule1Disc9InnerPixelwafer/pixel:EModule1Disc9InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring2Disc9/pixel:EModule2Disc9/pixel:EModule2Disc9InnerPixelwafer/pixel:EModule2Disc9InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc9/pixel:Ring3Disc9/pixel:EModule3Disc9/pixel:EModule3Disc9InnerPixelwafer/pixel:EModule3Disc9InnerPixelActive"/>
@@ -131,7 +131,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk9" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk10">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk10">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring1Disc10/pixel:EModule1Disc10/pixel:EModule1Disc10InnerPixelwafer/pixel:EModule1Disc10InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring2Disc10/pixel:EModule2Disc10/pixel:EModule2Disc10InnerPixelwafer/pixel:EModule2Disc10InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc10/pixel:Ring3Disc10/pixel:EModule3Disc10/pixel:EModule3Disc10InnerPixelwafer/pixel:EModule3Disc10InnerPixelActive"/>
@@ -140,7 +140,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk10" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk11">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk11">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring1Disc11/pixel:EModule1Disc11/pixel:EModule1Disc11InnerPixelwafer/pixel:EModule1Disc11InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring2Disc11/pixel:EModule2Disc11/pixel:EModule2Disc11InnerPixelwafer/pixel:EModule2Disc11InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc11/pixel:Ring3Disc11/pixel:EModule3Disc11/pixel:EModule3Disc11InnerPixelwafer/pixel:EModule3Disc11InnerPixelActive"/>
@@ -149,7 +149,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2PixelForwardDisk11" />
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2PixelForwardDisk12">
+    <SpecPar name="TrackingMaterialGroupPhase2PixelForwardDisk12">
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring1Disc12/pixel:EModule1Disc12/pixel:EModule1Disc12InnerPixelwafer/pixel:EModule1Disc12InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring2Disc12/pixel:EModule2Disc12/pixel:EModule2Disc12InnerPixelwafer/pixel:EModule2Disc12InnerPixelActive"/>
       <PartSelector path="//pixfwd:Phase2PixelEndcap/pixel:Disc12/pixel:Ring3Disc12/pixel:EModule3Disc12/pixel:EModule3Disc12InnerPixelwafer/pixel:EModule3Disc12InnerPixelActive"/>
@@ -159,7 +159,7 @@
     </SpecPar>
 
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer1">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer1">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Lowerwafer/BModule1Layer1LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule1Layer1/BModule1Layer1Upperwafer/BModule1Layer1UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer1/tracker:Rod1/tracker:BModule2Layer1/BModule2Layer1Lowerwafer/BModule2Layer1LowerPSMacroPixelactive"/>
@@ -219,7 +219,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer1" />      
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer2">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer2">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Lowerwafer/BModule1Layer2LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule1Layer2/BModule1Layer2Upperwafer/BModule1Layer2UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer2/tracker:Rod2/tracker:BModule2Layer2/BModule2Layer2Lowerwafer/BModule2Layer2LowerPSMacroPixelactive"/>
@@ -283,7 +283,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer2" />            
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer3">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer3">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Lowerwafer/BModule1Layer3LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule1Layer3/BModule1Layer3Upperwafer/BModule1Layer3UpperPSStripactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer3/tracker:Rod3/tracker:BModule2Layer3/BModule2Layer3Lowerwafer/BModule2Layer3LowerPSMacroPixelactive"/>
@@ -351,7 +351,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer3" />            
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer4">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer4">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Lowerwafer/BModule1Layer4Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule1Layer4/BModule1Layer4Upperwafer/BModule1Layer4Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer4/tracker:Rod4/tracker:BModule2Layer4/BModule2Layer4Lowerwafer/BModule2Layer4Lower2Sactive"/>
@@ -379,7 +379,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer4" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer5">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer5">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Lowerwafer/BModule1Layer5Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule1Layer5/BModule1Layer5Upperwafer/BModule1Layer5Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer5/tracker:Rod5/tracker:BModule2Layer5/BModule2Layer5Lowerwafer/BModule2Layer5Lower2Sactive"/>
@@ -407,7 +407,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer5" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTBarrelLayer6">
+    <SpecPar name="TrackingMaterialGroupPhase2OTBarrelLayer6">
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Lowerwafer/BModule1Layer6Lower2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule1Layer6/BModule1Layer6Upperwafer/BModule1Layer6Upper2Sactive"/>
       <PartSelector path="//Phase2OTBarrel/tracker:Layer6/tracker:Rod6/tracker:BModule2Layer6/BModule2Layer6Lowerwafer/BModule2Layer6Lower2Sactive"/>
@@ -435,7 +435,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTBarrelLayer6" />                  
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk1">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk1">
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Lowerwafer/EModule1Disc1LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring1Disc1/tracker:EModule1Disc1/EModule1Disc1Upperwafer/EModule1Disc1UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc1/tracker:Ring2Disc1/tracker:EModule2Disc1/EModule2Disc1Lowerwafer/EModule2Disc1LowerPSMacroPixelactive"/>
@@ -469,7 +469,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk1" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk2">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk2">
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Lowerwafer/EModule1Disc2LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring1Disc2/tracker:EModule1Disc2/EModule1Disc2Upperwafer/EModule1Disc2UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc2/tracker:Ring2Disc2/tracker:EModule2Disc2/EModule2Disc2Lowerwafer/EModule2Disc2LowerPSMacroPixelactive"/>
@@ -503,7 +503,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk2" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk3">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk3">
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Lowerwafer/EModule4Disc3LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring4Disc3/tracker:EModule4Disc3/EModule4Disc3Upperwafer/EModule4Disc3UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc3/tracker:Ring5Disc3/tracker:EModule5Disc3/EModule5Disc3Lowerwafer/EModule5Disc3LowerPSMacroPixelactive"/>
@@ -531,7 +531,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk3" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk4">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk4">
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Lowerwafer/EModule4Disc4LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring4Disc4/tracker:EModule4Disc4/EModule4Disc4Upperwafer/EModule4Disc4UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc4/tracker:Ring5Disc4/tracker:EModule5Disc4/EModule5Disc4Lowerwafer/EModule5Disc4LowerPSMacroPixelactive"/>
@@ -559,7 +559,7 @@
       <Parameter name="TrackingMaterialGroup" value="TrackerRecMaterialPhase2OTForwardDisk4" />                        
     </SpecPar>
 
-    <SpecPar name="TrackerRecMaterialPhase2OTForwardDisk5">
+    <SpecPar name="TrackingMaterialGroupPhase2OTForwardDisk5">
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Lowerwafer/EModule4Disc5LowerPSMacroPixelactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring4Disc5/tracker:EModule4Disc5/EModule4Disc5Upperwafer/EModule4Disc5UpperPSStripactive"/>
       <PartSelector path="//Phase2OTForward/tracker:Disc5/tracker:Ring5Disc5/tracker:EModule5Disc5/EModule5Disc5Lowerwafer/EModule5Disc5LowerPSMacroPixelactive"/>


### PR DESCRIPTION
**Summary: Reduce number of unnecessary calls to regex comparisons, by simply _renaming_ SpecPar blocks (magic).**

At XML parsing stage, https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc#L974 : all the paths of different SpecPar blocks, with the same block name, are gathered.

It occurs that **many different XMLs use SpecPar sections with the same name, to define different parameters.**
This has several occurrences, mentioned in [1].

**This results, when doing a lookup for a specific parameter from XML, in looping over paths which are not of interest (because these paths are not associated with this parameter anyway).**

For example: when looking for TrackerRadLength, all paths in Geometry/TrackerRecoData/data/PhaseI/trackerRecoMaterial.xml (expected) **and SimTracker/TrackerMaterialAnalysis/data/trackingMaterialGroups_ForPhaseI.xml (not expected)** are looked up. Indeed, the SpecPar blocks in these different XMLs have the same name.

A fix could be to simply add namespace at https://github.com/cms-sw/cmssw/blob/master/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc#L974 , to directly distinguish the different SpecPar blocks. But this results in longer strings (negligible effect in that case), and more importantly, to potential regressions.

A simple fix is to just rename the SpecPar blocks defining different parameters, so that their paths end up stored in different vectors.
This leads to a big perf improvement: x1.4 speedup of overall step1 initialization (XML parsing and geo construction, up to event generator start) on DD4hep workflow on my local.

NB: This is reducing the 'number of calls'.
In a subsequent PR, I propose to remove all regex from trackerRecoMaterial.xml  and trackingMaterialGroups_ForPhaseI.xml (this also has an effect on perf, even if less consequent).

NB 2: Why has trackingMaterialGroups_ForPhaseI.xml been (recently) included in the geometry scenarios? Is it really needed?

NB 3: Why is there a duplicated XML file for DD4hep (SimTracker/TrackerMaterialAnalysis/data/dd4hep_trackingMaterialGroups_ForPhaseII.xml) ?


[1] XMLs where this situation occurs:
- zdcsens.xml and zdcProdCuts.xml (blocks named zdc)
- hcalRecNumbering.xml,HcalProdCuts.xml, hcalSimNumbering.xml, and hcalsenspmf.wml (blocks named hcal)
- All blocks in trackerRecoMaterial.xml and trackingMaterialGroups_ForPhaseI.xml
Since trackingMaterialGroups_ForPhaseI.xm paths are very heavy, this is where the effect is the biggest, though this issue also appears for Zdc and Hcal.

@ianna @civanch  @cvuosalo