### PR TITLE
Introduce extend flag in HGCal validation

### DIFF
--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -1679,13 +1679,13 @@ hgcalLayerClustersPlotter = Plotter()
 layerClustersLabel = 'Layer Clusters'
 
 lc_general = [
-  # [A] calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
+  # calculated "energy density" for cells in a) 120um, b) 200um, c) 300um, d) scint
   # (one entry per rechit, in the appropriate histo)
   _cellsenedens_thick,
-  # [B] number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
+  # number of layer clusters per event in a) 120um, b) 200um, c) 300um, d) scint
   # (one entry per event in each of the four histos)
   _totclusternum_thick,
-  # [G] Miscellaneous plots:
+  # Miscellaneous plots:
   # longdepthbarycentre: The longitudinal depth barycentre. One entry per event.
   # mixedhitscluster: Number of clusters per event with hits in different thicknesses.
   # num_reco_cluster_eta: Number of reco clusters vs eta
@@ -1693,15 +1693,15 @@ lc_general = [
   _energyclustered,
   _mixedhitsclusters,
   _longdepthbarycentre,
-  # [H] SelectedCaloParticles plots
+  # SelectedCaloParticles plots
   _SelectedCaloParticles,
 ]
 lc_zminus = [
-  # [C] number of layer clusters per layer (one entry per event in each histo)
+  # number of layer clusters per layer (one entry per event in each histo)
   _totclusternum_layer_EE_zminus,
   _totclusternum_layer_FH_zminus,
   _totclusternum_layer_BH_zminus,
-  # [D] For each layer cluster:
+  # For each layer cluster:
   # number of cells in layer cluster, by layer - separate histos in each layer for 120um Si, 200/300um Si, Scint
   # NB: not all combinations exist; e.g. no 120um Si in layers with scint.
   # (One entry in the appropriate histo per layer cluster).
@@ -1717,7 +1717,43 @@ lc_zminus = [
   _cellsnum_perthick_perlayer_scint_EE_zminus,
   _cellsnum_perthick_perlayer_scint_FH_zminus,
   _cellsnum_perthick_perlayer_scint_BH_zminus,
-  # [E] For each layer cluster:
+  # Looking at the fraction of true energy that has been clustered; by layer and overall
+  _energyclustered_perlayer_EE_zminus,
+  _energyclustered_perlayer_FH_zminus,
+  _energyclustered_perlayer_BH_zminus,
+  # Score of CaloParticles wrt Layer Clusters
+  _score_caloparticle_to_layerclusters_zminus,
+  # Score of LayerClusters wrt CaloParticles
+  _score_layercluster_to_caloparticles_zminus,
+  # Shared Energy between CaloParticle and LayerClusters
+  _sharedEnergy_caloparticle_to_layercluster_zminus,
+  # Shared Energy between LayerClusters and CaloParticle
+  _sharedEnergy_layercluster_to_caloparticle_zminus,
+  # Cell Association per Layer
+  _cell_association_table_zminus,
+  # Efficiency Plots
+  _efficiencies_zminus,
+  _efficiencies_zminus_eta,
+  _efficiencies_zminus_phi,
+  # Duplicate Plots
+  _duplicates_zminus,
+  _duplicates_zminus_eta,
+  _duplicates_zminus_phi,
+  # Fake Rate Plots
+  _fakes_zminus,
+  _fakes_zminus_eta,
+  _fakes_zminus_phi,
+  # Merge Rate Plots
+  _merges_zminus,
+  _merges_zminus_eta,
+  _merges_zminus_phi,
+  # Energy vs Score 2D plots CP to LC
+  _energyscore_cp2lc_zminus,
+  # Energy vs Score 2D plots LC to CP
+  _energyscore_lc2cp_zminus
+]
+lc_zminus_extended = [
+  # For each layer cluster:
   # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
   # separate histos in each layer for 120um Si, 200/300um Si, Scint
   # NB: not all combinations exist; e.g. no 120um Si in layers with scint.
@@ -1794,40 +1830,6 @@ lc_zminus = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zminus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zminus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zminus,
-  # [F] Looking at the fraction of true energy that has been clustered; by layer and overall
-  _energyclustered_perlayer_EE_zminus,
-  _energyclustered_perlayer_FH_zminus,
-  _energyclustered_perlayer_BH_zminus,
-  # [I] Score of CaloParticles wrt Layer Clusters
-  _score_caloparticle_to_layerclusters_zminus,
-  # [J] Score of LayerClusters wrt CaloParticles
-  _score_layercluster_to_caloparticles_zminus,
-  # [K] Shared Energy between CaloParticle and LayerClusters
-  _sharedEnergy_caloparticle_to_layercluster_zminus,
-  # [K2] Shared Energy between LayerClusters and CaloParticle
-  _sharedEnergy_layercluster_to_caloparticle_zminus,
-  # [L] Cell Association per Layer
-  _cell_association_table_zminus,
-  # [M] Efficiency Plots
-  _efficiencies_zminus,
-  _efficiencies_zminus_eta,
-  _efficiencies_zminus_phi,
-  # [L] Duplicate Plots
-  _duplicates_zminus,
-  _duplicates_zminus_eta,
-  _duplicates_zminus_phi,
-  # [M] Fake Rate Plots
-  _fakes_zminus,
-  _fakes_zminus_eta,
-  _fakes_zminus_phi,
-  # [N] Merge Rate Plots
-  _merges_zminus,
-  _merges_zminus_eta,
-  _merges_zminus_phi,
-  # [O] Energy vs Score 2D plots CP to LC
-  _energyscore_cp2lc_zminus,
-  # [P] Energy vs Score 2D plots LC to CP
-  _energyscore_lc2cp_zminus
 ]
 lc_zplus = [
   # number of layer clusters per layer (one entry per event in each histo)
@@ -1847,6 +1849,40 @@ lc_zplus = [
   _cellsnum_perthick_perlayer_scint_EE_zplus,
   _cellsnum_perthick_perlayer_scint_FH_zplus,
   _cellsnum_perthick_perlayer_scint_BH_zplus,
+  # Looking at the fraction of true energy that has been clustered; by layer and overall
+  _energyclustered_perlayer_EE_zplus,
+  _energyclustered_perlayer_FH_zplus,
+  _energyclustered_perlayer_BH_zplus,
+  # Score of CaloParticles wrt Layer Clusters
+  _score_caloparticle_to_layerclusters_zplus,
+  # Score of LayerClusters wrt CaloParticles
+  _score_layercluster_to_caloparticles_zplus,
+  # Shared Energy between CaloParticle and LayerClusters
+  _sharedEnergy_caloparticle_to_layercluster_zplus,
+  # Shared Energy between LayerClusters and CaloParticle
+  _sharedEnergy_layercluster_to_caloparticle_zplus,
+  # Cell Association per Layer
+  _cell_association_table_zplus,
+  # Efficiency Plots
+  _efficiencies_zplus,
+  _efficiencies_zplus_eta,
+  _efficiencies_zplus_phi,
+  # Duplicate Plots
+  _duplicates_zplus,
+  _duplicates_zplus_eta,
+  _duplicates_zplus_phi,
+  # Fake Rate Plots
+  _fakes_zplus,
+  _fakes_zplus_eta,
+  _fakes_zplus_phi,
+  # Merge Rate Plots
+  _merges_zplus,
+  _merges_zplus_eta,
+  _merges_zplus_phi,
+  _energyscore_cp2lc_zplus,
+  _energyscore_lc2cp_zplus
+]
+lc_zplus_extended = [
   # distance of cells from a) seed cell, b) max cell; and c), d): same with entries weighted by cell energy
   _distancetomaxcell_perthickperlayer_120_EE_zplus,
   _distancetomaxcell_perthickperlayer_120_FH_zplus,
@@ -1920,45 +1956,19 @@ lc_zplus = [
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_EE_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_FH_zplus,
   _distancebetseedandmaxcellvsclusterenergy_perthickperlayer_scint_BH_zplus,
-  # Looking at the fraction of true energy that has been clustered; by layer and overall
-  _energyclustered_perlayer_EE_zplus,
-  _energyclustered_perlayer_FH_zplus,
-  _energyclustered_perlayer_BH_zplus,
-  # Score of CaloParticles wrt Layer Clusters
-  _score_caloparticle_to_layerclusters_zplus,
-  # Score of LayerClusters wrt CaloParticles
-  _score_layercluster_to_caloparticles_zplus,
-  # Shared Energy between CaloParticle and LayerClusters
-  _sharedEnergy_caloparticle_to_layercluster_zplus,
-  # Shared Energy between LayerClusters and CaloParticle
-  _sharedEnergy_layercluster_to_caloparticle_zplus,
-  # Cell Association per Layer
-  _cell_association_table_zplus,
-  # Efficiency Plots
-  _efficiencies_zplus,
-  _efficiencies_zplus_eta,
-  _efficiencies_zplus_phi,
-  # Duplicate Plots
-  _duplicates_zplus,
-  _duplicates_zplus_eta,
-  _duplicates_zplus_phi,
-  # Fake Rate Plots
-  _fakes_zplus,
-  _fakes_zplus_eta,
-  _fakes_zplus_phi,
-  # Merge Rate Plots
-  _merges_zplus,
-  _merges_zplus_eta,
-  _merges_zplus_phi,
-  _energyscore_cp2lc_zplus,
-  _energyscore_lc2cp_zplus
 ]
 
-def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel):
+def append_hgcalLayerClustersPlots(collection = "hgcalLayerClusters", name_collection = layerClustersLabel, extended = False):
+  print('extended : ',extended)
   regions = ["General", "zminus", "zplus"]
-  setPlots = [lc_general, lc_zminus, lc_zplus]
+  plots_lc_zminus  = lc_zminus
+  plots_lc_zplus   = lc_zplus 
+  plots_lc_general = lc_general
+  if extended :
+    plots_lc_zminus = lc_zminus + lc_zminus_extended
+    plots_lc_zplus = lc_zplus + lc_zplus_extended
+  setPlots = [plots_lc_general, plots_lc_zminus, plots_lc_zplus]
   for reg, setPlot in zip(regions, setPlots):
-    print(_hgcalFolders(collection))
     hgcalLayerClustersPlotter.append(collection+"_"+reg, [
                 _hgcalFolders(collection)
                 ], PlotFolder(

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -28,12 +28,15 @@ collection_choices.extend([multiclustersGeneralLabel]+[trackstersGeneralLabel]+[
 def main(opts):
 
     drawArgs={}
+    extendedFlag = False
     if opts.no_ratio:
         drawArgs["ratio"] = False
     if opts.separate:
         drawArgs["separate"] = True
     if opts.png:
         drawArgs["saveFormat"] = ".png"
+    if opts.extended:
+        extendedFlag = True
     if opts.verbose:
         plotting.verbose = True
 
@@ -47,7 +50,7 @@ def main(opts):
 
     if opts.collection==layerClustersGeneralLabel:
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters")
+	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
         val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
     elif opts.collection == multiclustersGeneralLabel:
         hgcmulticlus = [hgcalPlots.hgcalMultiClustersPlotter]
@@ -101,7 +104,7 @@ def main(opts):
 
  	#layer clusters 
 	hgclayclus = [hgcalPlots.hgcalLayerClustersPlotter]
-	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters")
+	hgcalPlots.append_hgcalLayerClustersPlots("hgcalLayerClusters", "Layer Clusters", extendedFlag)
 	val.doPlots(hgclayclus, plotterDrawArgs=drawArgs)
 
         #multiclusters
@@ -140,10 +143,12 @@ if __name__ == "__main__":
                         help="Sample name for HTML page generation (default 'Sample')")
     parser.add_argument("--html-validation-name", type=str, default=["",""], nargs="+",
                         help="Validation name for HTML page generation (enters to <title> element) (default '')")
-    parser.add_argument("--verbose", action="store_true", default = False,
-                        help="Be verbose")
     parser.add_argument("--collection", choices=collection_choices, default=layerClustersGeneralLabel,
                         help="Choose output plots collections among possible choices")    
+    parser.add_argument("--extended", action="store_true", default = False,
+                        help="Include extended set of plots (e.g. bunch of distributions; default off)")
+    parser.add_argument("--verbose", action="store_true", default = False,
+                        help="Be verbose")
 
     opts = parser.parse_args()
 


### PR DESCRIPTION
#### PR description:

- Introducing `extended` flag in order to reduce the number of plots produced automatically in the HGCal validation.
- For a simple validation of two samples, the amount of files produced when the `--separate` option is included is 10269 for a total of  ~500Mb. Here follow a more detail description on which category produced more plots
![num_files_beforePR](https://user-images.githubusercontent.com/5331004/102370287-3118a680-3fbd-11eb-8d0f-7bb321c043d0.png)
- This PR brings the total number of files down to 7005 for a total of ~350Mb.
![num_files_afterPR](https://user-images.githubusercontent.com/5331004/102370281-2f4ee300-3fbd-11eb-8ef6-7526f70b475f.png)
This corresponds at about a 30% reduction.
- The set of plots that are excluded from the default selection were agreed with @apsallid as plots that are not needed for each single release validation.

#### PR validation:

- This PR should not impact any workflow.



