### PR TITLE
[DD4hep] Ensure DDCMS test results stay same with DD4hep units change

### DIFF
--- a/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
+++ b/DetectorDescription/DDCMS/plugins/dd4hep/DDDefinitions2Objects.cc
@@ -1251,8 +1251,8 @@ void Converter<DDLSphere>::operator()(xml_h element) const {
            "DD4CMS",
            "+   Sphere:   r_inner=%8.3f [cm] r_outer=%8.3f [cm]"
            " startPhi=%8.3f [rad] deltaPhi=%8.3f startTheta=%8.3f delteTheta=%8.3f [rad]",
-           rinner,
-           router,
+           rinner / dd4hep::cm,
+           router / dd4hep::cm,
            startPhi,
            deltaPhi,
            startTheta,
@@ -1281,9 +1281,9 @@ void Converter<DDLTorus>::operator()(xml_h element) const {
            "DD4CMS",
            "+   Torus:    r=%10.3f [cm] r_inner=%10.3f [cm] r_outer=%10.3f [cm]"
            " startPhi=%10.3f [rad] deltaPhi=%10.3f [rad]",
-           r,
-           rinner,
-           router,
+           r / dd4hep::cm,
+           rinner / dd4hep::cm,
+           router / dd4hep::cm,
            startPhi,
            deltaPhi);
 
@@ -1311,12 +1311,12 @@ void Converter<DDLPseudoTrap>::operator()(xml_h element) const {
   printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
            "DD4CMS",
            "+   Pseudotrap:  dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2=%.3f dy2=%.3f radius:%.3f atMinusZ:%s",
-           dz,
-           dx1,
-           dy1,
-           dx2,
-           dy2,
-           r,
+           dz / dd4hep::cm,
+           dx1 / dd4hep::cm,
+           dy1 / dd4hep::cm,
+           dx2 / dd4hep::cm,
+           dy2 / dd4hep::cm,
+           r / dd4hep::cm,
            yes_no(atMinusZ));
 
 #endif
@@ -1348,15 +1348,15 @@ void Converter<DDLTrapezoid>::operator()(xml_h element) const {
            "DD4CMS",
            "+   Trapezoid:  dz=%10.3f [cm] alp1:%.3f bl1=%.3f tl1=%.3f alp2=%.3f bl2=%.3f tl2=%.3f h2=%.3f phi=%.3f "
            "theta=%.3f",
-           dz,
+           dz / dd4hep::cm,
            alp1,
-           bl1,
-           tl1,
-           h1,
+           bl1 / dd4hep::cm,
+           tl1 / dd4hep::cm,
+           h1 / dd4hep::cm,
            alp2,
-           bl2,
-           tl2,
-           h2,
+           bl2 / dd4hep::cm,
+           tl2 / dd4hep::cm,
+           h2 / dd4hep::cm,
            phi,
            theta);
 
@@ -1382,11 +1382,11 @@ void Converter<DDLTrd1>::operator()(xml_h element) const {
     printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
              "DD4CMS",
              "+   Trd1:       dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2:%.3f dy2:%.3f",
-             dz,
-             dx1,
-             dy1,
-             dx2,
-             dy2);
+             dz / dd4hep::cm,
+             dx1 / dd4hep::cm,
+             dy1 / dd4hep::cm,
+             dx2 / dd4hep::cm,
+             dy2 / dd4hep::cm);
 
 #endif
 
@@ -1397,11 +1397,11 @@ void Converter<DDLTrd1>::operator()(xml_h element) const {
     printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
              "DD4CMS",
              "+   Trd1(which is actually Trd2):       dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2:%.3f dy2:%.3f",
-             dz,
-             dx1,
-             dy1,
-             dx2,
-             dy2);
+             dz / dd4hep::cm,
+             dx1 / dd4hep::cm,
+             dy1 / dd4hep::cm,
+             dx2 / dd4hep::cm,
+             dy2 / dd4hep::cm);
 
 #endif
 
@@ -1426,11 +1426,11 @@ void Converter<DDLTrd2>::operator()(xml_h element) const {
   printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
            "DD4CMS",
            "+   Trd1:       dz=%8.3f [cm] dx1:%.3f dy1:%.3f dx2:%.3f dy2:%.3f",
-           dz,
-           dx1,
-           dy1,
-           dx2,
-           dy2);
+           dz / dd4hep::cm,
+           dx1 / dd4hep::cm,
+           dy1 / dd4hep::cm,
+           dx2 / dd4hep::cm,
+           dy2 / dd4hep::cm);
 
 #endif
 
@@ -1455,9 +1455,9 @@ void Converter<DDLTubs>::operator()(xml_h element) const {
            "DD4CMS",
            "+   Tubs:     dz=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
            " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]",
-           dz,
-           rmin,
-           rmax,
+           dz / dd4hep::cm,
+           rmin / dd4hep::cm,
+           rmax / dd4hep::cm,
            startPhi,
            deltaPhi);
 
@@ -1490,9 +1490,9 @@ void Converter<DDLCutTubs>::operator()(xml_h element) const {
            "DD4CMS",
            "+   CutTube:  dz=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
            " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]...",
-           dz,
-           rmin,
-           rmax,
+           dz / dd4hep::cm,
+           rmin / dd4hep::cm,
+           rmax / dd4hep::cm,
            startPhi,
            deltaPhi);
 
@@ -1522,13 +1522,13 @@ void Converter<DDLTruncTubs>::operator()(xml_h element) const {
            "DD4CMS",
            "+   TruncTube:zHalf=%8.3f [cm] rmin=%8.3f [cm] rmax=%8.3f [cm]"
            " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad] atStart=%8.3f [cm] atDelta=%8.3f [cm] inside:%s",
-           zhalf,
-           rmin,
-           rmax,
+           zhalf / dd4hep::cm,
+           rmin / dd4hep::cm,
+           rmax / dd4hep::cm,
            startPhi,
            deltaPhi,
-           cutAtStart,
-           cutAtDelta,
+           cutAtStart / dd4hep::cm,
+           cutAtDelta / dd4hep::cm,
            yes_no(cutInside));
 
 #endif
@@ -1551,9 +1551,9 @@ void Converter<DDLEllipticalTube>::operator()(xml_h element) const {
   printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
            "DD4CMS",
            "+   EllipticalTube xSemiAxis=%8.3f [cm] ySemiAxis=%8.3f [cm] zHeight=%8.3f [cm]",
-           dx,
-           dy,
-           dz);
+           dx / dd4hep::cm,
+           dy / dd4hep::cm,
+           dz / dd4hep::cm);
 
 #endif
 
@@ -1583,11 +1583,11 @@ void Converter<DDLCone>::operator()(xml_h element) const {
            " rmin1=%8.3f [cm] rmax1=%8.3f [cm]"
            " rmin2=%8.3f [cm] rmax2=%8.3f [cm]"
            " startPhi=%8.3f [rad] deltaPhi=%8.3f [rad]",
-           dz,
-           rmin1,
-           rmax1,
-           rmin2,
-           rmax2,
+           dz / dd4hep::cm,
+           rmin1 / dd4hep::cm,
+           rmax1 / dd4hep::cm,
+           rmin2 / dd4hep::cm,
+           rmax2 / dd4hep::cm,
            startPhi,
            deltaPhi);
 
@@ -1630,9 +1630,9 @@ void Converter<DDLBox>::operator()(xml_h element) const {
   printout(ns.context()->debug_shapes ? ALWAYS : DEBUG,
            "DD4CMS",
            "+   Box:      dx=%10.3f [cm] dy=%10.3f [cm] dz=%10.3f [cm]",
-           dx,
-           dy,
-           dz);
+           dx / dd4hep::cm,
+           dy / dd4hep::cm,
+           dz / dd4hep::cm);
 
 #endif
 

--- a/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
+++ b/DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "Geometry/Records/interface/DDSpecParRegistryRcd.h"
+
 #include <DD4hep/SpecParRegistry.h>
 
 #include <iostream>
@@ -11,12 +12,6 @@
 using namespace std;
 using namespace cms;
 using namespace edm;
-
-#ifdef HAVE_GEANT4_UNITS
-#define MM_2_CM 1.0
-#else
-#define MM_2_CM 0.1
-#endif
 
 class DDTestSpecParsFilter : public one::EDAnalyzer<> {
 public:
@@ -71,7 +66,7 @@ void DDTestSpecParsFilter::analyze(const Event&, const EventSetup& iEventSetup) 
       for (const auto& kl : t.second->numpars) {
         log << kl.first << " = ";
         for (const auto& kil : kl.second) {
-          log << kil / MM_2_CM << " ";
+          log << kil << " ";
         }
         log << "\n ";
       }

--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -94,7 +94,8 @@ void testDDFilteredView::checkFilteredView() {
   cout << "Get attl from hf as double values:\n";
   vector<double> attl = fview.get<vector<double>>("hf", "attl");
   int count(0);
-  for (auto const& i : attl) {
+  for (double i : attl) {
+    i *= dd4hep::cm;  // Convert DD4hep units to /cm
     std::cout << "attl " << i << " == " << refdattl_[count] << "\n";
     CPPUNIT_ASSERT(abs(i - refdattl_[count]) < 10e-6);
     count++;
@@ -103,7 +104,8 @@ void testDDFilteredView::checkFilteredView() {
   std::cout << "Get LongFL from hf as double values:\n";
   count = 0;
   std::vector<double> LongFL = fview.get<std::vector<double>>("hf", "LongFL");
-  for (auto const& i : LongFL) {
+  for (double i : LongFL) {
+    i /= dd4hep::cm;  // Convert DD4hep units to cm
     std::cout << "LongFL " << i << " == " << refdLongFL_[count] << "\n";
     CPPUNIT_ASSERT(abs(i - refdLongFL_[count]) < 10e-2);
     count++;

--- a/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDSolid.cppunit.cc
@@ -54,12 +54,12 @@ void testDDSolid::checkDDSolid() {
       if (dd4hep::isA<dd4hep::ConeSegment>(dd4hep::Solid(solidA))) {
         cout << " is a ConeSegment:\n";
         for (auto const& i : solidA.dimensions())
-          cout << i << ", ";
+          cout << i / dd4hep::cm << " cm, ";
       }
       cout << "\n";
       DDSolid a(solidA);
       for (auto const& i : a.parameters())
-        cout << i << ", ";
+        cout << i / dd4hep::cm << " cm, ";
       cout << "\n";
 
       auto solidB = solid.solidB();
@@ -67,12 +67,12 @@ void testDDSolid::checkDDSolid() {
       if (dd4hep::isA<dd4hep::ConeSegment>(dd4hep::Solid(solidB))) {
         cout << " is a ConeSegment:\n";
         for (auto const& i : solidB.dimensions())
-          cout << i << ", ";
+          cout << i / dd4hep::cm << " cm, ";
       }
       cout << "\n";
       DDSolid b(solidB);
       for (auto const& i : b.parameters())
-        cout << i << ", ";
+        cout << i / dd4hep::cm << " cm, ";
       cout << "\n";
     }
   }


### PR DESCRIPTION
This PR ensures that DDCMS unit test results and debug output will remain consistent when the DD4hep units are changed. Consistent test results will be one way to validate that the DD4hep units change is working correctly.

The test from `DetectorDescription/DDCMS/plugins/test/DDTestSpecParsFilter.cc` outputs `TrackerXi` and `TrackerRadLength`. These values are defined in XML as plain numbers without units. Thus, it is not necessary to convert their units, and so the unit conversion in the output of these two values is removed by this PR.

#### PR validation:

The unit test results and debug output from these files was checked before and after the PR. They are the same, except for the above-mentioned removal of conversion of `TrackerXi` and `TrackerRadLength` and for the addition (for clarity) of "cm" in the output of the `DDSolid` units test.

The decision of whether to backport this PR to 11_2 will be made later.
