### PR TITLE
Use WaitingTaskHolder for function arguments

### DIFF
--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -9,6 +9,7 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/ProductProvenance.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
@@ -25,7 +26,6 @@ ProductProvenanceRetriever: Manages the per event/lumi/run per product provenanc
 
 namespace edm {
   class ProvenanceReaderBase;
-  class WaitingTask;
   class ModuleCallingContext;
   class ProductRegistry;
 
@@ -47,7 +47,7 @@ namespace edm {
     ProvenanceReaderBase() {}
     virtual ~ProvenanceReaderBase();
     virtual std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const = 0;
-    virtual void readProvenanceAsync(WaitingTask* task,
+    virtual void readProvenanceAsync(WaitingTaskHolder task,
                                      ModuleCallingContext const* moduleCallingContext,
                                      unsigned int transitionIndex,
                                      std::atomic<const std::set<ProductProvenance>*>& writeTo) const = 0;
@@ -77,7 +77,7 @@ namespace edm {
 
     void reset();
 
-    void readProvenanceAsync(WaitingTask* task, ModuleCallingContext const* moduleCallingContext) const;
+    void readProvenanceAsync(WaitingTaskHolder task, ModuleCallingContext const* moduleCallingContext) const;
 
     void update(edm::ProductRegistry const&);
 

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -73,7 +73,7 @@ namespace edm {
     setupEntryInfoSet(iReg);
   }
 
-  void ProductProvenanceRetriever::readProvenanceAsync(WaitingTask* task,
+  void ProductProvenanceRetriever::readProvenanceAsync(WaitingTaskHolder task,
                                                        ModuleCallingContext const* moduleCallingContext) const {
     if (provenanceReader_ and nullptr == readEntryInfoSet_.load()) {
       provenanceReader_->readProvenanceAsync(task, moduleCallingContext, transitionIndex_, readEntryInfoSet_);
@@ -128,12 +128,10 @@ namespace edm {
                          entryInfoSet_.end(),
                          entryInfo.branchID(),
                          [](auto const& iEntry, edm::BranchID const& iValue) { return iEntry.branchID() < iValue; });
-    if
-      UNLIKELY(itFound == entryInfoSet_.end() or itFound->branchID() != entryInfo.branchID()) {
-        throw edm::Exception(edm::errors::LogicError)
-            << "ProductProvenanceRetriever::insertIntoSet passed a BranchID " << entryInfo.branchID().id()
-            << " that has not been pre-registered";
-      }
+    if UNLIKELY (itFound == entryInfoSet_.end() or itFound->branchID() != entryInfo.branchID()) {
+      throw edm::Exception(edm::errors::LogicError) << "ProductProvenanceRetriever::insertIntoSet passed a BranchID "
+                                                    << entryInfo.branchID().id() << " that has not been pre-registered";
+    }
     itFound->threadsafe_set(entryInfo.moveParentageID());
   }
 

--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -29,6 +29,8 @@
 namespace edm {
   class WaitingTaskHolder {
   public:
+    friend class WaitingTaskList;
+
     WaitingTaskHolder() : m_task(nullptr) {}
 
     explicit WaitingTaskHolder(edm::WaitingTask* iTask) : m_task(iTask) { m_task->increment_ref_count(); }
@@ -88,6 +90,11 @@ namespace edm {
     }
 
   private:
+    WaitingTask* release_no_decrement() noexcept {
+      auto t = m_task;
+      m_task = nullptr;
+      return t;
+    }
     // ---------- member data --------------------------------
     WaitingTask* m_task;
   };

--- a/FWCore/Concurrency/interface/WaitingTaskList.h
+++ b/FWCore/Concurrency/interface/WaitingTaskList.h
@@ -75,13 +75,12 @@
 
 // user include files
 #include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 // forward declarations
 
 namespace edm {
-  class WaitingTaskHolder;
-
   class EmptyWaitingTask : public WaitingTask {
   public:
     EmptyWaitingTask() = default;

--- a/FWCore/Concurrency/interface/WaitingTaskList.h
+++ b/FWCore/Concurrency/interface/WaitingTaskList.h
@@ -80,6 +80,8 @@
 // forward declarations
 
 namespace edm {
+  class WaitingTaskHolder;
+
   class EmptyWaitingTask : public WaitingTask {
   public:
     EmptyWaitingTask() = default;
@@ -126,6 +128,11 @@ namespace edm {
        * Calls to add() and doneWaiting() can safely be done concurrently.
        */
     void add(WaitingTask*);
+
+    ///Adds task to the waiting list
+    /**Calls to add() and doneWaiting() can safely be done concurrently.
+      */
+    void add(WaitingTaskHolder);
 
     ///Signals that the resource is now available and tasks should be spawned
     /**The owner of the resource calls this function to allow the waiting tasks to

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/hardware_pause.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
@@ -85,6 +86,39 @@ WaitingTaskList::WaitNode* WaitingTaskList::createNode(WaitingTask* iTask) {
   returnValue->m_next.store(returnValue, std::memory_order_relaxed);
 
   return returnValue;
+}
+
+void WaitingTaskList::add(WaitingTaskHolder iTask) {
+  if (!m_waiting) {
+    if (m_exceptionPtr) {
+      iTask.doneWaiting(m_exceptionPtr);
+    }
+  } else {
+    auto task = iTask.release_no_decrement();
+    WaitNode* newHead = createNode(task);
+    //This exchange is sequentially consistent thereby
+    // ensuring ordering between it and setNextNode
+    WaitNode* oldHead = m_head.exchange(newHead);
+    newHead->setNextNode(oldHead);
+
+    //For the case where oldHead != nullptr,
+    // even if 'm_waiting' changed, we don't
+    // have to recheck since we beat 'announce()' in
+    // the ordering of 'm_head.exchange' call so iTask
+    // is guaranteed to be in the link list
+
+    if (nullptr == oldHead) {
+      newHead->setNextNode(0);
+      if (!m_waiting) {
+        //if finished waiting right before we did the
+        // exchange our task will not be spawned. Also,
+        // additional threads may be calling add() and swapping
+        // heads and linking us to the new head.
+        // It is safe to call announce from multiple threads
+        announce();
+      }
+    }
+  }
 }
 
 void WaitingTaskList::add(WaitingTask* iTask) {

--- a/FWCore/Concurrency/src/WaitingTaskList.cc
+++ b/FWCore/Concurrency/src/WaitingTaskList.cc
@@ -108,7 +108,7 @@ void WaitingTaskList::add(WaitingTaskHolder iTask) {
     // is guaranteed to be in the link list
 
     if (nullptr == oldHead) {
-      newHead->setNextNode(0);
+      newHead->setNextNode(nullptr);
       if (!m_waiting) {
         //if finished waiting right before we did the
         // exchange our task will not be spawned. Also,

--- a/FWCore/Framework/interface/Callback.h
+++ b/FWCore/Framework/interface/Callback.h
@@ -66,7 +66,7 @@ namespace edm {
       Callback(const Callback&) = delete;
       const Callback& operator=(const Callback&) = delete;
 
-      void prefetchAsync(WaitingTask* iTask,
+      void prefetchAsync(WaitingTaskHolder iTask,
                          EventSetupRecordImpl const* iRecord,
                          EventSetupImpl const* iEventSetupImpl,
                          ServiceToken const& token) {
@@ -88,20 +88,21 @@ namespace edm {
                         [this, iRecord, iEventSetupImpl, token](std::exception_ptr const* iExcept) {
                           runProducerAsync(iExcept, iRecord, iEventSetupImpl, token);
                         });
-                    prefetchNeededDataAsync(runTask, iEventSetupImpl, &((*postMayGetProxies_).front()), token);
+                    prefetchNeededDataAsync(
+                        WaitingTaskHolder(runTask), iEventSetupImpl, &((*postMayGetProxies_).front()), token);
                   } else {
                     runProducerAsync(iExcept, iRecord, iEventSetupImpl, token);
                   }
                 });
 
             //Get everything we can before knowing about the mayGets
-            prefetchNeededDataAsync(mayGetTask, iEventSetupImpl, getTokenIndices(), token);
+            prefetchNeededDataAsync(WaitingTaskHolder(mayGetTask), iEventSetupImpl, getTokenIndices(), token);
           } else {
             auto task = edm::make_waiting_task(
                 tbb::task::allocate_root(), [this, iRecord, iEventSetupImpl, token](std::exception_ptr const* iExcept) {
                   runProducerAsync(iExcept, iRecord, iEventSetupImpl, token);
                 });
-            prefetchNeededDataAsync(task, iEventSetupImpl, getTokenIndices(), token);
+            prefetchNeededDataAsync(WaitingTaskHolder(task), iEventSetupImpl, getTokenIndices(), token);
           }
         }
       }
@@ -135,7 +136,7 @@ namespace edm {
       ESProxyIndex const* getTokenIndices() const { return producer_->getTokenIndices(id_); }
 
     private:
-      void prefetchNeededDataAsync(WaitingTask* task,
+      void prefetchNeededDataAsync(WaitingTaskHolder task,
                                    EventSetupImpl const* iImpl,
                                    ESProxyIndex const* proxies,
                                    edm::ServiceToken const& token) const {

--- a/FWCore/Framework/interface/CallbackProxy.h
+++ b/FWCore/Framework/interface/CallbackProxy.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include "FWCore/Framework/interface/produce_helpers.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
@@ -53,7 +54,7 @@ namespace edm::eventsetup {
       callback_->holdOntoPointer(dummy);
     }
 
-    void prefetchAsyncImpl(WaitingTask* iWaitTask,
+    void prefetchAsyncImpl(WaitingTaskHolder iWaitTask,
                            const EventSetupRecordImpl& iRecord,
                            const DataKey&,
                            EventSetupImpl const* iEventSetupImpl,

--- a/FWCore/Framework/interface/DataProxy.h
+++ b/FWCore/Framework/interface/DataProxy.h
@@ -25,12 +25,12 @@
 
 // user include files
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 namespace edm {
   class ActivityRegistry;
   class EventSetupImpl;
-  class WaitingTask;
   class ServiceToken;
 
   namespace eventsetup {
@@ -48,8 +48,11 @@ namespace edm {
       // ---------- const member functions ---------------------
       bool cacheIsValid() const { return cacheIsValid_.load(std::memory_order_acquire); }
 
-      void prefetchAsync(
-          WaitingTask*, EventSetupRecordImpl const&, DataKey const&, EventSetupImpl const*, ServiceToken const&) const;
+      void prefetchAsync(WaitingTaskHolder,
+                         EventSetupRecordImpl const&,
+                         DataKey const&,
+                         EventSetupImpl const*,
+                         ServiceToken const&) const;
 
       void const* get(EventSetupRecordImpl const&,
                       DataKey const&,
@@ -80,7 +83,7 @@ namespace edm {
           the pointer must be a pointer to that base class interface and not a pointer to an inheriting class
           instance.
           */
-      virtual void prefetchAsyncImpl(WaitingTask*,
+      virtual void prefetchAsyncImpl(WaitingTaskHolder,
                                      EventSetupRecordImpl const&,
                                      DataKey const& iKey,
                                      EventSetupImpl const*,

--- a/FWCore/Framework/interface/DataProxyTemplate.h
+++ b/FWCore/Framework/interface/DataProxyTemplate.h
@@ -35,6 +35,7 @@
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include <cassert>
 #include <limits>
 #include <atomic>
@@ -55,7 +56,7 @@ namespace edm {
 
       DataProxyTemplate() {}
 
-      void prefetchAsyncImpl(WaitingTask* iTask,
+      void prefetchAsyncImpl(WaitingTaskHolder iTask,
                              const EventSetupRecordImpl& iRecord,
                              const DataKey& iKey,
                              EventSetupImpl const* iEventSetupImpl,

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Concurrency/interface/SerialTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <string>
 
@@ -18,7 +19,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -60,7 +60,7 @@ namespace edm {
   private:
     bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by Worker but not something supported
-    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
+    void preActionBeforeRunEventAsync(WaitingTaskHolder, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -16,6 +16,7 @@ These products should be informational products about the filter decision.
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
@@ -33,7 +34,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
@@ -67,7 +67,7 @@ namespace edm {
   private:
     bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
+    void preActionBeforeRunEventAsync(WaitingTaskHolder, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -15,6 +15,7 @@ EDProducts into an Event.
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <string>
 #include <vector>
@@ -25,7 +26,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -63,7 +63,7 @@ namespace edm {
   private:
     bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
     //Needed by WorkerT but not supported
-    void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {}
+    void preActionBeforeRunEventAsync(WaitingTaskHolder, ModuleCallingContext const&, Principal const&) const {}
 
     void doPreallocate(PreallocationConfiguration const&) {}
     void doBeginJob();

--- a/FWCore/Framework/interface/ESSourceDataProxyBase.h
+++ b/FWCore/Framework/interface/ESSourceDataProxyBase.h
@@ -54,7 +54,7 @@ namespace edm::eventsetup {
     virtual void prefetch(edm::eventsetup::DataKey const& iKey, EventSetupRecordDetails) = 0;
 
   private:
-    void prefetchAsyncImpl(edm::WaitingTask* iTask,
+    void prefetchAsyncImpl(edm::WaitingTaskHolder iTask,
                            edm::eventsetup::EventSetupRecordImpl const&,
                            edm::eventsetup::DataKey const& iKey,
                            edm::EventSetupImpl const*,

--- a/FWCore/Framework/interface/EventSetupRecordImpl.h
+++ b/FWCore/Framework/interface/EventSetupRecordImpl.h
@@ -40,6 +40,7 @@ through the 'validityInterval' method.
 #include "FWCore/Framework/interface/NoProxyException.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Utilities/interface/ESInputTag.h"
@@ -57,7 +58,6 @@ through the 'validityInterval' method.
 // forward declarations
 namespace cms {
   class Exception;
-  class WaitingTask;
 }  // namespace cms
 
 namespace edm {
@@ -66,7 +66,6 @@ namespace edm {
   class ESHandleExceptionFactory;
   class ESInputTag;
   class EventSetupImpl;
-  class WaitingTask;
   class ServiceToken;
 
   namespace eventsetup {
@@ -86,7 +85,10 @@ namespace edm {
       ValidityInterval validityInterval() const;
 
       ///prefetch the data to setup for subsequent calls to getImplementation
-      void prefetchAsync(WaitingTask* iTask, ESProxyIndex iProxyIndex, EventSetupImpl const*, ServiceToken const&) const;
+      void prefetchAsync(WaitingTaskHolder iTask,
+                         ESProxyIndex iProxyIndex,
+                         EventSetupImpl const*,
+                         ServiceToken const&) const;
 
       /**returns true only if someone has already requested data for this key
           and the data was retrieved

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -26,6 +26,7 @@ pointer to a ProductResolver, when queried.
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProductResolverBase.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
@@ -47,7 +48,6 @@ namespace edm {
   class EDConsumerBase;
   class SharedResourcesAcquirer;
   class InputProductResolver;
-  class WaitingTask;
   class UnscheduledConfigurator;
 
   struct FilledProductPtr {
@@ -126,7 +126,7 @@ namespace edm {
                            SharedResourcesAcquirer* sra,
                            ModuleCallingContext const* mcc) const;
 
-    void prefetchAsync(WaitingTask* waitTask,
+    void prefetchAsync(WaitingTaskHolder waitTask,
                        ProductResolverIndex index,
                        bool skipCurrentProcess,
                        ServiceToken const& token,

--- a/FWCore/Framework/interface/ProductResolverBase.h
+++ b/FWCore/Framework/interface/ProductResolverBase.h
@@ -13,6 +13,7 @@ ProductResolver: Class to handle access to a WrapperBase and its related informa
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/Provenance.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/ProductResolverIndex.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
@@ -28,7 +29,6 @@ namespace edm {
   class SharedResourcesAcquirer;
   class Principal;
   class UnscheduledConfigurator;
-  class WaitingTask;
   class ServiceToken;
 
   class ProductResolverBase {
@@ -66,7 +66,7 @@ namespace edm {
 
     /** oDataFetchedIsValid is allowed to be nullptr in which case no value will be assigned
      */
-    void prefetchAsync(WaitingTask* waitTask,
+    void prefetchAsync(WaitingTaskHolder waitTask,
                        Principal const& principal,
                        bool skipCurrentProcess,
                        ServiceToken const& token,
@@ -176,7 +176,7 @@ namespace edm {
                                        bool skipCurrentProcess,
                                        SharedResourcesAcquirer* sra,
                                        ModuleCallingContext const* mcc) const = 0;
-    virtual void prefetchAsync_(WaitingTask* waitTask,
+    virtual void prefetchAsync_(WaitingTaskHolder waitTask,
                                 Principal const& principal,
                                 bool skipCurrentProcess,
                                 ServiceToken const& token,

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -20,6 +20,7 @@
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/UnscheduledAuxiliary.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
@@ -66,7 +67,7 @@ namespace edm {
     const_iterator end() const { return unscheduledWorkers_.end(); }
 
     template <typename T, typename U>
-    void runNowAsync(WaitingTask* task,
+    void runNowAsync(WaitingTaskHolder task,
                      typename T::TransitionInfoType const& info,
                      ServiceToken const& token,
                      StreamID streamID,
@@ -88,7 +89,7 @@ namespace edm {
     }
 
     template <typename T>
-    void runAccumulatorsAsync(WaitingTask* task,
+    void runAccumulatorsAsync(WaitingTaskHolder task,
                               typename T::TransitionInfoType const& info,
                               ServiceToken const& token,
                               StreamID streamID,

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -117,8 +117,12 @@ namespace edm {
 
     auto waitTask = make_empty_waiting_task();
     waitTask->increment_ref_count();
-    processOneOccurrenceAsync<T, U>(
-        waitTask.get(), info, ServiceRegistry::instance().presentToken(), streamID, topContext, context);
+    processOneOccurrenceAsync<T, U>(WaitingTaskHolder(waitTask.get()),
+                                    info,
+                                    ServiceRegistry::instance().presentToken(),
+                                    streamID,
+                                    topContext,
+                                    context);
     waitTask->wait_for_all();
     if (waitTask->exceptionPtr() != nullptr) {
       try {

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -147,7 +147,7 @@ namespace edm {
                                                 typename T::Context const* topContext,
                                                 U const* context) {
     //make sure the unscheduled items see this run or lumi transition
-    unscheduled_.runNowAsync<T, U>(task, info, token, streamID, topContext, context);
+    unscheduled_.runNowAsync<T, U>(std::move(task), info, token, streamID, topContext, context);
   }
 
   template <typename T>
@@ -157,7 +157,7 @@ namespace edm {
                                                StreamID streamID,
                                                ParentContext const& parentContext,
                                                typename T::Context const* context) {
-    unscheduled_.runAccumulatorsAsync<T>(task, info, token, streamID, parentContext, context);
+    unscheduled_.runAccumulatorsAsync<T>(std::move(task), info, token, streamID, parentContext, context);
   }
 }  // namespace edm
 

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/get_underlying_safe.h"
@@ -59,7 +60,7 @@ namespace edm {
                               U const* context,
                               bool cleaningUpAfterException = false);
     template <typename T, typename U>
-    void processOneOccurrenceAsync(WaitingTask*,
+    void processOneOccurrenceAsync(WaitingTaskHolder,
                                    typename T::TransitionInfoType&,
                                    ServiceToken const&,
                                    StreamID,
@@ -67,7 +68,7 @@ namespace edm {
                                    U const* context);
 
     template <typename T>
-    void processAccumulatorsAsync(WaitingTask*,
+    void processAccumulatorsAsync(WaitingTaskHolder,
                                   typename T::TransitionInfoType const&,
                                   ServiceToken const&,
                                   StreamID,
@@ -135,7 +136,7 @@ namespace edm {
   }
 
   template <typename T, typename U>
-  void WorkerManager::processOneOccurrenceAsync(WaitingTask* task,
+  void WorkerManager::processOneOccurrenceAsync(WaitingTaskHolder task,
                                                 typename T::TransitionInfoType& info,
                                                 ServiceToken const& token,
                                                 StreamID streamID,
@@ -146,7 +147,7 @@ namespace edm {
   }
 
   template <typename T>
-  void WorkerManager::processAccumulatorsAsync(WaitingTask* task,
+  void WorkerManager::processAccumulatorsAsync(WaitingTaskHolder task,
                                                typename T::TransitionInfoType const& info,
                                                ServiceToken const& token,
                                                StreamID streamID,

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -23,6 +23,7 @@
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
@@ -34,7 +35,6 @@ namespace edm {
   class StreamID;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -75,8 +75,9 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -36,7 +37,6 @@ namespace edm {
   class StreamID;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
   class WaitingTaskWithArenaHolder;
 
   namespace maker {
@@ -78,7 +78,7 @@ namespace edm {
                      ModuleCallingContext const*,
                      WaitingTaskWithArenaHolder&);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -37,7 +38,6 @@ namespace edm {
   class GlobalSchedule;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
   class WaitingTaskWithArenaHolder;
 
   namespace maker {
@@ -111,7 +111,7 @@ namespace edm {
 
       virtual void produce(StreamID, Event&, EventSetup const&) const = 0;
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/global/OutputModuleBase.h
+++ b/FWCore/Framework/interface/global/OutputModuleBase.h
@@ -39,6 +39,7 @@
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
@@ -49,7 +50,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   template <typename T>
   class OutputModuleCommunicatorT;
@@ -129,7 +129,7 @@ namespace edm {
 
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/limited/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/limited/EDAnalyzerBase.h
@@ -26,6 +26,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -35,7 +36,6 @@ namespace edm {
   class StreamID;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -80,7 +80,7 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/limited/EDFilterBase.h
+++ b/FWCore/Framework/interface/limited/EDFilterBase.h
@@ -28,6 +28,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -37,7 +38,6 @@ namespace edm {
   class StreamID;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -78,8 +78,9 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
       void doBeginJob();

--- a/FWCore/Framework/interface/limited/EDProducerBase.h
+++ b/FWCore/Framework/interface/limited/EDProducerBase.h
@@ -28,6 +28,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -38,7 +39,6 @@ namespace edm {
   class GlobalSchedule;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -111,7 +111,7 @@ namespace edm {
 
       virtual void produce(StreamID, Event&, EventSetup const&) const = 0;
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                     ModuleCallingContext const& iModuleCallingContext,
                                                     Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/limited/OutputModuleBase.h
+++ b/FWCore/Framework/interface/limited/OutputModuleBase.h
@@ -41,6 +41,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 #include "FWCore/Concurrency/interface/LimitedTaskQueue.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 namespace edm {
@@ -50,7 +51,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   template <typename T>
   class OutputModuleCommunicatorT;
@@ -133,8 +133,9 @@ namespace edm {
 
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doBeginProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}
       void doAccessInputProcessBlock(ProcessBlockPrincipal const&, ModuleCallingContext const*) {}

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 namespace edm {
@@ -34,7 +35,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -76,8 +76,9 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 namespace edm {
@@ -35,7 +36,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -75,8 +75,9 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 namespace edm {
@@ -35,7 +36,6 @@ namespace edm {
   class PreallocationConfiguration;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -75,8 +75,9 @@ namespace edm {
     private:
       bool doEvent(EventTransitionInfo const&, ActivityRegistry*, ModuleCallingContext const*);
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       void doPreallocate(PreallocationConfiguration const&);
       virtual void preallocLumis(unsigned int);

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -41,6 +41,7 @@
 #include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/propagate_const.h"
 
 // forward declarations
@@ -52,7 +53,6 @@ namespace edm {
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
   class SubProcessParentageHelper;
-  class WaitingTask;
 
   template <typename T>
   class OutputModuleCommunicatorT;
@@ -235,7 +235,7 @@ namespace edm {
       virtual bool shouldWeCloseFile() const { return false; }
 
       virtual void write(EventForOutput const&) = 0;
-      virtual void preActionBeforeRunEventAsync(WaitingTask* iTask,
+      virtual void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                 ModuleCallingContext const& iModuleCallingContext,
                                                 Principal const& iPrincipal) const {}
 

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -30,6 +30,7 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 #include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -47,7 +48,6 @@ namespace edm {
   class ProductResolverIndexAndSkipBit;
   class ActivityRegistry;
   class ThinnedAssociationsHelper;
-  class WaitingTask;
 
   namespace maker {
     template <typename T>
@@ -128,8 +128,9 @@ namespace edm {
       virtual void preallocLumis(unsigned int) {}
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
 
       virtual void setupStreamModules() = 0;
       virtual void doBeginJob() = 0;

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -35,7 +36,6 @@ namespace edm {
 
   class ModuleCallingContext;
   class ActivityRegistry;
-  class WaitingTask;
   class WaitingTaskWithArenaHolder;
 
   namespace maker {
@@ -76,8 +76,9 @@ namespace edm {
                      WaitingTaskWithArenaHolder&);
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
     };
   }  // namespace stream
 }  // namespace edm

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -35,7 +36,6 @@ namespace edm {
 
   class ModuleCallingContext;
   class ActivityRegistry;
-  class WaitingTask;
   class WaitingTaskWithArenaHolder;
 
   namespace maker {
@@ -76,8 +76,9 @@ namespace edm {
                      WaitingTaskWithArenaHolder&);
 
       //For now this is a placeholder
-      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTask*, ModuleCallingContext const&, Principal const&) const {
-      }
+      /*virtual*/ void preActionBeforeRunEventAsync(WaitingTaskHolder,
+                                                    ModuleCallingContext const&,
+                                                    Principal const&) const {}
     };
   }  // namespace stream
 }  // namespace edm

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -103,7 +103,7 @@ namespace edm {
         auto waitTaskPtr = waitTask.get();
         auto token = ServiceRegistry::instance().presentToken();
         edm::esTaskArena().execute([this, waitTaskPtr, &iRecord, &iKey, iEventSetupImpl, token]() {
-          { prefetchAsync(WaitingTaskHolder(waitTaskPtr), iRecord, iKey, iEventSetupImpl, token); }
+          prefetchAsync(WaitingTaskHolder(waitTaskPtr), iRecord, iKey, iEventSetupImpl, token);
           waitTaskPtr->decrement_ref_count();
           waitTaskPtr->wait_for_all();
         });

--- a/FWCore/Framework/src/DataProxy.cc
+++ b/FWCore/Framework/src/DataProxy.cc
@@ -21,6 +21,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include "FWCore/Framework/src/esTaskArenas.h"
 namespace edm {
@@ -61,7 +62,7 @@ namespace edm {
 
     }  // namespace
 
-    void DataProxy::prefetchAsync(WaitingTask* iTask,
+    void DataProxy::prefetchAsync(WaitingTaskHolder iTask,
                                   EventSetupRecordImpl const& iRecord,
                                   DataKey const& iKey,
                                   EventSetupImpl const* iEventSetupImpl,
@@ -102,7 +103,7 @@ namespace edm {
         auto waitTaskPtr = waitTask.get();
         auto token = ServiceRegistry::instance().presentToken();
         edm::esTaskArena().execute([this, waitTaskPtr, &iRecord, &iKey, iEventSetupImpl, token]() {
-          prefetchAsync(waitTaskPtr, iRecord, iKey, iEventSetupImpl, token);
+          { prefetchAsync(WaitingTaskHolder(waitTaskPtr), iRecord, iKey, iEventSetupImpl, token); }
           waitTaskPtr->decrement_ref_count();
           waitTaskPtr->wait_for_all();
         });

--- a/FWCore/Framework/src/ESSourceDataProxyBase.cc
+++ b/FWCore/Framework/src/ESSourceDataProxyBase.cc
@@ -20,7 +20,7 @@
 // member functions
 //
 
-void edm::eventsetup::ESSourceDataProxyBase::prefetchAsyncImpl(edm::WaitingTask* iTask,
+void edm::eventsetup::ESSourceDataProxyBase::prefetchAsyncImpl(edm::WaitingTaskHolder iTask,
                                                                edm::eventsetup::EventSetupRecordImpl const& iRecord,
                                                                edm::eventsetup::DataKey const& iKey,
                                                                edm::EventSetupImpl const*,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1062,7 +1062,7 @@ namespace edm {
       using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
 
       RunTransitionInfo transitionInfo(runPrincipal, es);
-      beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(),
+      beginStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()),
                                           *schedule_,
                                           preallocations_.numberOfStreams(),
                                           transitionInfo,

--- a/FWCore/Framework/src/EventSetupRecordImpl.cc
+++ b/FWCore/Framework/src/EventSetupRecordImpl.cc
@@ -19,6 +19,7 @@
 #include "FWCore/Framework/interface/DataProxy.h"
 #include "FWCore/Framework/interface/ComponentDescription.h"
 
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -257,7 +258,7 @@ namespace edm {
       return proxies_[std::distance(keysForProxies_.begin(), lb)].get();
     }
 
-    void EventSetupRecordImpl::prefetchAsync(WaitingTask* iTask,
+    void EventSetupRecordImpl::prefetchAsync(WaitingTaskHolder iTask,
                                              ESProxyIndex iProxyIndex,
                                              EventSetupImpl const* iEventSetupImpl,
                                              ServiceToken const& iToken) const {

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -225,7 +225,7 @@ namespace edm {
       auto& aw = workerManager.allWorkers();
       for (Worker* worker : boost::adaptors::reverse(aw)) {
         worker->doWorkAsync<T>(
-            doneTask, transitionInfo, token, StreamID::invalidStreamID(), parentContext, globalContext.get());
+            holdForLoop, transitionInfo, token, StreamID::invalidStreamID(), parentContext, globalContext.get());
       }
     } catch (...) {
       iHolder.doneWaiting(std::current_exception());

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -215,7 +215,7 @@ namespace edm {
     pathStatusInserterWorker_ = pathStatusInserterWorker;
   }
 
-  void Path::processOneOccurrenceAsync(WaitingTask* iTask,
+  void Path::processOneOccurrenceAsync(WaitingTaskHolder iTask,
                                        EventTransitionInfo const& iInfo,
                                        ServiceToken const& iToken,
                                        StreamID const& iStreamID,
@@ -362,7 +362,7 @@ namespace edm {
             this->workerFinished(iException, lastModuleIndex, info, token, iID, iContext);
           });
       workers_[lastModuleIndex].runWorkerAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-          nextTask, iInfo, iToken, iID, iContext);
+          WaitingTaskHolder(nextTask), iInfo, iToken, iID, iContext);
     }
   }
 

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -16,6 +16,7 @@
 #include "DataFormats/Common/interface/HLTenums.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -36,7 +37,6 @@ namespace edm {
   class EarlyDeleteHelper;
   class StreamContext;
   class StreamID;
-  class WaitingTask;
 
   class Path {
   public:
@@ -61,14 +61,14 @@ namespace edm {
     Path& operator=(Path const&) = delete;
 
     template <typename T>
-    void runAllModulesAsync(WaitingTask*,
+    void runAllModulesAsync(WaitingTaskHolder,
                             typename T::TransitionInfoType const&,
                             ServiceToken const&,
                             StreamID const&,
                             typename T::Context const*);
 
     void processOneOccurrenceAsync(
-        WaitingTask*, EventTransitionInfo const&, ServiceToken const&, StreamID const&, StreamContext const*);
+        WaitingTaskHolder, EventTransitionInfo const&, ServiceToken const&, StreamID const&, StreamContext const*);
 
     int bitPosition() const { return bitpos_; }
     std::string const& name() const { return pathContext_.pathName(); }
@@ -183,7 +183,7 @@ namespace edm {
   }  // namespace
 
   template <typename T>
-  void Path::runAllModulesAsync(WaitingTask* task,
+  void Path::runAllModulesAsync(WaitingTaskHolder task,
                                 typename T::TransitionInfoType const& info,
                                 ServiceToken const& token,
                                 StreamID const& streamID,

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -623,7 +623,7 @@ namespace edm {
     return BasicHandle(productData->wrapper(), &(productData->provenance()));
   }
 
-  void Principal::prefetchAsync(WaitingTask* task,
+  void Principal::prefetchAsync(WaitingTaskHolder task,
                                 ProductResolverIndex index,
                                 bool skipCurrentProcess,
                                 ServiceToken const& token,

--- a/FWCore/Framework/src/ProductResolvers.h
+++ b/FWCore/Framework/src/ProductResolvers.h
@@ -17,6 +17,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/thread_safety_macros.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <memory>
 #include <atomic>
@@ -115,7 +116,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -163,7 +164,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -191,7 +192,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -225,7 +226,7 @@ namespace edm {
                                ModuleCallingContext const* mcc) const override {
       return realProduct_.resolveProduct(principal, skipCurrentProcess, sra, mcc);
     }
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -324,7 +325,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -355,7 +356,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const final;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -385,7 +386,7 @@ namespace edm {
       skipCurrentProcess = false;
       return realProduct_->resolveProduct(*parentPrincipal_, skipCurrentProcess, sra, mcc);
     }
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -459,7 +460,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,
@@ -517,7 +518,7 @@ namespace edm {
                                bool skipCurrentProcess,
                                SharedResourcesAcquirer* sra,
                                ModuleCallingContext const* mcc) const override;
-    void prefetchAsync_(WaitingTask* waitTask,
+    void prefetchAsync_(WaitingTaskHolder waitTask,
                         Principal const& principal,
                         bool skipCurrentProcess,
                         ServiceToken const& token,

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -647,17 +647,18 @@ namespace edm {
       WaitingTaskHolder taskHolder(pathsDone);
 
       //start end paths first so on single threaded the paths will run first
+      WaitingTaskHolder hAllPathsDone(allPathsDone);
       for (auto it = end_paths_.rbegin(), itEnd = end_paths_.rend(); it != itEnd; ++it) {
-        it->processOneOccurrenceAsync(allPathsDone, info, serviceToken, streamID_, &streamContext_);
+        it->processOneOccurrenceAsync(hAllPathsDone, info, serviceToken, streamID_, &streamContext_);
       }
 
       for (auto it = trig_paths_.rbegin(), itEnd = trig_paths_.rend(); it != itEnd; ++it) {
-        it->processOneOccurrenceAsync(pathsDone, info, serviceToken, streamID_, &streamContext_);
+        it->processOneOccurrenceAsync(taskHolder, info, serviceToken, streamID_, &streamContext_);
       }
 
       ParentContext parentContext(&streamContext_);
       workerManager_.processAccumulatorsAsync<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>>(
-          allPathsDone, info, serviceToken, streamID_, parentContext, &streamContext_);
+          hAllPathsDone, info, serviceToken, streamID_, parentContext, &streamContext_);
     } catch (...) {
       iTask.doneWaiting(std::current_exception());
     }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -421,31 +421,29 @@ namespace edm {
           iHolder.doneWaiting(excpt);
         });
 
-    auto task =
-        make_functor_task(tbb::task::allocate_root(),
-                          [this, doneTask, h = WaitingTaskHolder(doneTask), info = transitionInfo, token]() mutable {
-                            ServiceRegistry::Operate op(token);
-                            // Caught exception is propagated via WaitingTaskHolder
-                            CMS_SA_ALLOW try {
-                              T::preScheduleSignal(actReg_.get(), &streamContext_);
+    auto task = make_functor_task(
+        tbb::task::allocate_root(), [this, h = WaitingTaskHolder(doneTask), info = transitionInfo, token]() mutable {
+          ServiceRegistry::Operate op(token);
+          // Caught exception is propagated via WaitingTaskHolder
+          CMS_SA_ALLOW try {
+            T::preScheduleSignal(actReg_.get(), &streamContext_);
 
-                              workerManager_.resetAll();
-                            } catch (...) {
-                              h.doneWaiting(std::current_exception());
-                              return;
-                            }
+            workerManager_.resetAll();
+          } catch (...) {
+            h.doneWaiting(std::current_exception());
+            return;
+          }
 
-                            for (auto& p : end_paths_) {
-                              p.runAllModulesAsync<T>(doneTask, info, token, streamID_, &streamContext_);
-                            }
+          for (auto& p : end_paths_) {
+            p.runAllModulesAsync<T>(h, info, token, streamID_, &streamContext_);
+          }
 
-                            for (auto& p : trig_paths_) {
-                              p.runAllModulesAsync<T>(doneTask, info, token, streamID_, &streamContext_);
-                            }
+          for (auto& p : trig_paths_) {
+            p.runAllModulesAsync<T>(h, info, token, streamID_, &streamContext_);
+          }
 
-                            workerManager_.processOneOccurrenceAsync<T>(
-                                doneTask, info, token, streamID_, &streamContext_, &streamContext_);
-                          });
+          workerManager_.processOneOccurrenceAsync<T>(h, info, token, streamID_, &streamContext_, &streamContext_);
+        });
 
     if (streamID_.value() == 0) {
       //Enqueueing will start another thread if there is only

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -30,6 +30,7 @@ the worker is reset().
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/interface/ProductResolverIndexAndSkipBit.h"
 #include "FWCore/Concurrency/interface/WaitingTask.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -149,7 +150,7 @@ namespace edm {
     }
 
     template <typename T>
-    void doWorkAsync(WaitingTask*,
+    void doWorkAsync(WaitingTaskHolder,
                      typename T::TransitionInfoType const&,
                      ServiceToken const&,
                      StreamID,
@@ -157,7 +158,7 @@ namespace edm {
                      typename T::Context const*);
 
     template <typename T>
-    void doWorkNoPrefetchingAsync(WaitingTask*,
+    void doWorkNoPrefetchingAsync(WaitingTaskHolder,
                                   typename T::TransitionInfoType const&,
                                   ServiceToken const&,
                                   StreamID,
@@ -170,7 +171,7 @@ namespace edm {
                                          ParentContext const&,
                                          typename T::Context const*);
 
-    void callWhenDoneAsync(WaitingTask* task) { waitingTasks_.add(task); }
+    void callWhenDoneAsync(WaitingTaskHolder task) { waitingTasks_.add(std::move(task)); }
     void skipOnPath(EventPrincipal const& iEvent);
     void beginJob();
     void endJob();
@@ -294,7 +295,7 @@ namespace edm {
     virtual std::vector<ESRecordIndex> const& esRecordsToGetFrom(Transition) const = 0;
     virtual std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const = 0;
 
-    virtual void preActionBeforeRunEventAsync(WaitingTask* iTask,
+    virtual void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                               ModuleCallingContext const& moduleCallingContext,
                                               Principal const& iPrincipal) const = 0;
 
@@ -338,11 +339,14 @@ namespace edm {
     }
 
     template <typename T>
-    void prefetchAsync(
-        WaitingTask*, ServiceToken const&, ParentContext const&, typename T::TransitionInfoType const&, Transition);
+    void prefetchAsync(WaitingTaskHolder,
+                       ServiceToken const&,
+                       ParentContext const&,
+                       typename T::TransitionInfoType const&,
+                       Transition);
 
-    void esPrefetchAsync(WaitingTask*, EventSetupImpl const&, Transition, ServiceToken const&);
-    void edPrefetchAsync(WaitingTask*, ServiceToken const&, Principal const&) const;
+    void esPrefetchAsync(WaitingTaskHolder, EventSetupImpl const&, Transition, ServiceToken const&);
+    void edPrefetchAsync(WaitingTaskHolder, ServiceToken const&, Principal const&) const;
 
     bool needsESPrefetching(Transition iTrans) const noexcept {
       return iTrans < edm::Transition::NumberOfEventSetupTransitions ? not esItemsToGetFrom(iTrans).empty() : false;
@@ -624,7 +628,7 @@ namespace edm {
         return iWorker->implDo(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   EventTransitionInfo const& info,
                                   Transition transition) {
@@ -651,7 +655,7 @@ namespace edm {
         return iWorker->implDoBegin(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   RunTransitionInfo const& info,
                                   Transition transition) {
@@ -676,7 +680,7 @@ namespace edm {
         return iWorker->implDoStreamBegin(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   RunTransitionInfo const& info,
                                   Transition transition) {
@@ -701,7 +705,7 @@ namespace edm {
         return iWorker->implDoEnd(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   RunTransitionInfo const& info,
                                   Transition transition) {
@@ -726,7 +730,7 @@ namespace edm {
         return iWorker->implDoStreamEnd(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   RunTransitionInfo const& info,
                                   Transition transition) {
@@ -752,7 +756,7 @@ namespace edm {
         return iWorker->implDoBegin(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   LumiTransitionInfo const& info,
                                   Transition transition) {
@@ -777,7 +781,7 @@ namespace edm {
         return iWorker->implDoStreamBegin(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   LumiTransitionInfo const& info,
                                   Transition transition) {
@@ -803,7 +807,7 @@ namespace edm {
         return iWorker->implDoEnd(info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   LumiTransitionInfo const& info,
                                   Transition transition) {
@@ -828,7 +832,7 @@ namespace edm {
         return iWorker->implDoStreamEnd(id, info, mcc);
       }
       static void esPrefetchAsync(Worker* worker,
-                                  WaitingTask* waitingTask,
+                                  WaitingTaskHolder waitingTask,
                                   ServiceToken const& token,
                                   LumiTransitionInfo const& info,
                                   Transition transition) {
@@ -852,8 +856,8 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoBeginProcessBlock(info.principal(), mcc);
       }
-      static constexpr void esPrefetchAsync(
-          Worker*, WaitingTask*, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
+      static void esPrefetchAsync(
+          Worker*, WaitingTaskHolder, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
       static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsProcessBlocks(); }
       static bool needToRunSelection(Worker const* iWorker) { return false; }
       static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
@@ -872,8 +876,8 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoAccessInputProcessBlock(info.principal(), mcc);
       }
-      static constexpr void esPrefetchAsync(
-          Worker*, WaitingTask*, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
+      static void esPrefetchAsync(
+          Worker*, WaitingTaskHolder, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
       static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsInputProcessBlocks(); }
       static bool needToRunSelection(Worker const* iWorker) { return false; }
       static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
@@ -892,8 +896,8 @@ namespace edm {
         ModuleSignalSentry<Arg> cpp(actReg, context, mcc);
         return iWorker->implDoEndProcessBlock(info.principal(), mcc);
       }
-      static constexpr void esPrefetchAsync(
-          Worker*, WaitingTask*, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
+      static void esPrefetchAsync(
+          Worker*, WaitingTaskHolder, ServiceToken const&, ProcessBlockTransitionInfo const&, Transition) {}
       static bool wantsTransition(Worker const* iWorker) { return iWorker->wantsProcessBlocks(); }
       static bool needToRunSelection(Worker const* iWorker) { return false; }
       static SerialTaskQueue* pauseGlobalQueue(Worker* iWorker) { return nullptr; }
@@ -902,7 +906,7 @@ namespace edm {
   }  // namespace workerhelper
 
   template <typename T>
-  void Worker::prefetchAsync(WaitingTask* iTask,
+  void Worker::prefetchAsync(WaitingTaskHolder iTask,
                              ServiceToken const& token,
                              ParentContext const& parentContext,
                              typename T::TransitionInfoType const& transitionInfo,
@@ -915,24 +919,16 @@ namespace edm {
       actReg_->preModuleEventPrefetchingSignal_.emit(*moduleCallingContext_.getStreamContext(), moduleCallingContext_);
     }
 
-    //Need to be sure the ref count isn't set to 0 immediately
-    iTask->increment_ref_count();
-
     workerhelper::CallImpl<T>::esPrefetchAsync(this, iTask, token, transitionInfo, iTransition);
     edPrefetchAsync(iTask, token, principal);
 
     if (principal.branchType() == InEvent) {
       preActionBeforeRunEventAsync(iTask, moduleCallingContext_, principal);
     }
-
-    if (0 == iTask->decrement_ref_count()) {
-      //if everything finishes before we leave this routine, we need to launch the task
-      tbb::task::spawn(*iTask);
-    }
   }
 
   template <typename T>
-  void Worker::doWorkAsync(WaitingTask* task,
+  void Worker::doWorkAsync(WaitingTaskHolder task,
                            typename T::TransitionInfoType const& transitionInfo,
                            ServiceToken const& token,
                            StreamID streamID,
@@ -984,9 +980,12 @@ namespace edm {
         auto ownRunTask = std::make_shared<DestroyTask>(runTask);
         auto selectionTask = make_waiting_task(
             tbb::task::allocate_root(),
-            [ownRunTask, parentContext, info = transitionInfo, token, this](std::exception_ptr const*) mutable {
-              ServiceRegistry::Operate guard(token);
-              prefetchAsync<T>(ownRunTask->release(), token, parentContext, info, T::transition_);
+            [ownRunTask, parentContext, info = transitionInfo, token, this](std::exception_ptr const* iExcept) mutable {
+              //NOTE: a non null value of iExcept means the selection succeeded
+              if (!iExcept) {
+                ServiceRegistry::Operate guard(token);
+                prefetchAsync<T>(WaitingTaskHolder(ownRunTask->release()), token, parentContext, info, T::transition_);
+              }
             });
         prePrefetchSelectionAsync(selectionTask, token, streamID, &transitionInfo.principal());
       } else {
@@ -1000,7 +999,7 @@ namespace edm {
                 AcquireTask<T>(this, transitionInfo, token, parentContext, std::move(runTaskHolder));
           }
         }
-        prefetchAsync<T>(moduleTask, token, parentContext, transitionInfo, T::transition_);
+        prefetchAsync<T>(WaitingTaskHolder(moduleTask), token, parentContext, transitionInfo, T::transition_);
       }
     }
   }
@@ -1032,7 +1031,7 @@ namespace edm {
   }
 
   template <typename T>
-  void Worker::doWorkNoPrefetchingAsync(WaitingTask* task,
+  void Worker::doWorkNoPrefetchingAsync(WaitingTaskHolder task,
                                         typename T::TransitionInfoType const& transitionInfo,
                                         ServiceToken const& serviceToken,
                                         StreamID streamID,
@@ -1076,7 +1075,8 @@ namespace edm {
                 }
               }
             });
-        esPrefetchAsync(afterPrefetch, transitionInfo.eventSetupImpl(), T::transition_, serviceToken);
+        esPrefetchAsync(
+            WaitingTaskHolder(afterPrefetch), transitionInfo.eventSetupImpl(), T::transition_, serviceToken);
       } else {
         if (auto queue = this->serializeRunModule()) {
           queue.push(toDo);
@@ -1167,8 +1167,11 @@ namespace edm {
         //set count to 2 since wait_for_all requires value to not go to 0
         waitTask->set_ref_count(2);
 
-        prefetchAsync<T>(
-            waitTask.get(), ServiceRegistry::instance().presentToken(), parentContext, transitionInfo, T::transition_);
+        prefetchAsync<T>(WaitingTaskHolder(waitTask.get()),
+                         ServiceRegistry::instance().presentToken(),
+                         parentContext,
+                         transitionInfo,
+                         T::transition_);
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
       }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -980,12 +980,9 @@ namespace edm {
         auto ownRunTask = std::make_shared<DestroyTask>(runTask);
         auto selectionTask = make_waiting_task(
             tbb::task::allocate_root(),
-            [ownRunTask, parentContext, info = transitionInfo, token, this](std::exception_ptr const* iExcept) mutable {
-              //NOTE: a non null value of iExcept means the selection succeeded
-              if (!iExcept) {
-                ServiceRegistry::Operate guard(token);
-                prefetchAsync<T>(WaitingTaskHolder(ownRunTask->release()), token, parentContext, info, T::transition_);
-              }
+            [ownRunTask, parentContext, info = transitionInfo, token, this](std::exception_ptr const*) mutable {
+              ServiceRegistry::Operate guard(token);
+              prefetchAsync<T>(WaitingTaskHolder(ownRunTask->release()), token, parentContext, info, T::transition_);
             });
         prePrefetchSelectionAsync(selectionTask, token, streamID, &transitionInfo.principal());
       } else {

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -12,6 +12,7 @@
 */
 
 #include "FWCore/Framework/src/Worker.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 
@@ -19,7 +20,6 @@ namespace edm {
 
   class PathContext;
   class StreamID;
-  class WaitingTask;
   class ServiceToken;
 
   class WorkerInPath {
@@ -29,8 +29,11 @@ namespace edm {
     WorkerInPath(Worker*, FilterAction theAction, unsigned int placeInPath, bool runConcurrently);
 
     template <typename T>
-    void runWorkerAsync(
-        WaitingTask*, typename T::TransitionInfoType const&, ServiceToken const&, StreamID, typename T::Context const*);
+    void runWorkerAsync(WaitingTaskHolder,
+                        typename T::TransitionInfoType const&,
+                        ServiceToken const&,
+                        StreamID,
+                        typename T::Context const*);
 
     bool checkResultsOfRunWorker(bool wasEvent);
 
@@ -101,7 +104,7 @@ namespace edm {
   }
 
   template <typename T>
-  void WorkerInPath::runWorkerAsync(WaitingTask* iTask,
+  void WorkerInPath::runWorkerAsync(WaitingTaskHolder iTask,
                                     typename T::TransitionInfoType const& info,
                                     ServiceToken const& token,
                                     StreamID streamID,

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -145,7 +145,7 @@ namespace edm {
 
     std::vector<ProductResolverIndex> const& itemsShouldPutInEvent() const override;
 
-    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+    void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                       ModuleCallingContext const& iModuleCallingContext,
                                       Principal const& iPrincipal) const override {
       module_->preActionBeforeRunEventAsync(iTask, iModuleCallingContext, iPrincipal);

--- a/FWCore/Framework/src/streamTransitionAsync.h
+++ b/FWCore/Framework/src/streamTransitionAsync.h
@@ -93,15 +93,14 @@ namespace edm {
   }
 
   template <typename Traits>
-  void beginStreamsTransitionAsync(WaitingTask* iWait,
+  void beginStreamsTransitionAsync(WaitingTaskHolder iWait,
                                    Schedule& iSchedule,
                                    unsigned int iNStreams,
                                    typename Traits::TransitionInfoType& transitionInfo,
                                    ServiceToken const& token,
                                    std::vector<SubProcess>& iSubProcesses) {
-    WaitingTaskHolder holdUntilAllStreamsCalled(iWait);
-    for (unsigned int i = 0; i < iNStreams; ++i) {
-      beginStreamTransitionAsync<Traits>(WaitingTaskHolder(iWait), iSchedule, i, transitionInfo, token, iSubProcesses);
+    const for (unsigned int& i = 0; i < iNStreams; ++i) {
+      beginStreamTransitionAsync<Traits>(iWait, iSchedule, i, transitionInfo, token, iSubProcesses);
     }
   }
 

--- a/FWCore/Framework/src/streamTransitionAsync.h
+++ b/FWCore/Framework/src/streamTransitionAsync.h
@@ -99,7 +99,7 @@ namespace edm {
                                    typename Traits::TransitionInfoType& transitionInfo,
                                    ServiceToken const& token,
                                    std::vector<SubProcess>& iSubProcesses) {
-    const for (unsigned int& i = 0; i < iNStreams; ++i) {
+    for (unsigned int i = 0; i < iNStreams; ++i) {
       beginStreamTransitionAsync<Traits>(iWait, iSchedule, i, transitionInfo, token, iSubProcesses);
     }
   }

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/Callback.h"
 #include "FWCore/Framework/interface/ESProducts.h"
 #include "FWCore/Concurrency/interface/ThreadsController.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 #include <memory>
 #include <cassert>
@@ -102,7 +103,7 @@ namespace {
   void call(CALLBACK& iCallback) {
     auto waitTask = edm::make_empty_waiting_task();
     waitTask->set_ref_count(1);
-    iCallback.prefetchAsync(waitTask.get(), nullptr, nullptr, edm::ServiceToken{});
+    iCallback.prefetchAsync(edm::WaitingTaskHolder(waitTask.get()), nullptr, nullptr, edm::ServiceToken{});
     waitTask->wait_for_all();
   }
 }  // namespace

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -755,7 +755,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {
@@ -781,7 +781,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(edm::WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -453,7 +453,7 @@ namespace {
 
     class TestProxy : public DataProxy {
     public:
-      void prefetchAsyncImpl(edm::WaitingTask*,
+      void prefetchAsyncImpl(edm::WaitingTaskHolder,
                              EventSetupRecordImpl const&,
                              DataKey const&,
                              edm::EventSetupImpl const*,

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -577,7 +577,7 @@ namespace {
         if (rec) {
           auto waitTask = edm::make_empty_waiting_task();
           waitTask->set_ref_count(2);
-          rec->prefetchAsync(waitTask.get(), proxies[i], &iImpl, edm::ServiceToken{});
+          rec->prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], &iImpl, edm::ServiceToken{});
           waitTask->decrement_ref_count();
           waitTask->wait_for_all();
           if (waitTask->exceptionPtr()) {

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -254,7 +254,7 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        iRec.prefetchAsync(waitTask.get(), proxies[i], nullptr, edm::ServiceToken{});
+        iRec.prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{});
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
         if (waitTask->exceptionPtr()) {
@@ -275,7 +275,7 @@ namespace {
       for (size_t i = 0; i != proxies.size(); ++i) {
         auto waitTask = edm::make_empty_waiting_task();
         waitTask->set_ref_count(2);
-        iRec.prefetchAsync(waitTask.get(), proxies[i], nullptr, edm::ServiceToken{});
+        iRec.prefetchAsync(WaitingTaskHolder(waitTask.get()), proxies[i], nullptr, edm::ServiceToken{});
         waitTask->decrement_ref_count();
         waitTask->wait_for_all();
         if (waitTask->exceptionPtr()) {

--- a/FWCore/TestProcessor/interface/TestDataProxy.h
+++ b/FWCore/TestProcessor/interface/TestDataProxy.h
@@ -23,6 +23,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/DataProxy.h"
+#include "FWCore/Concurrency/interface/WaitingTaskHolder.h"
 
 // forward declarations
 
@@ -36,7 +37,7 @@ namespace edm {
 
       void setData(std::unique_ptr<T> iData) { data_ = std::move(iData); }
 
-      void prefetchAsyncImpl(WaitingTask*,
+      void prefetchAsyncImpl(WaitingTaskHolder,
                              eventsetup::EventSetupRecordImpl const&,
                              eventsetup::DataKey const&,
                              EventSetupImpl const*,

--- a/FWCore/TestProcessor/src/TestProcessor.cc
+++ b/FWCore/TestProcessor/src/TestProcessor.cc
@@ -470,7 +470,7 @@ namespace edm {
         streamLoopWaitTask->increment_ref_count();
 
         using Traits = OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>;
-        beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(),
+        beginStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()),
                                             *schedule_,
                                             preallocations_.numberOfStreams(),
                                             transitionInfo,
@@ -520,7 +520,7 @@ namespace edm {
 
         using Traits = OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>;
 
-        beginStreamsTransitionAsync<Traits>(streamLoopWaitTask.get(),
+        beginStreamsTransitionAsync<Traits>(WaitingTaskHolder(streamLoopWaitTask.get()),
                                             *schedule_,
                                             preallocations_.numberOfStreams(),
                                             transitionInfo,

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1883,7 +1883,7 @@ namespace edm {
     std::set<ProductProvenance> readProvenance(unsigned int) const override;
 
   private:
-    void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTaskHolder task,
                              ModuleCallingContext const* moduleCallingContext,
                              unsigned int transitionIndex,
                              std::atomic<const std::set<ProductProvenance>*>& writeTo) const override;
@@ -1917,7 +1917,7 @@ namespace edm {
     template <typename R>
     void readProvenanceAsyncImpl(R const* iThis,
                                  SerialTaskQueueChain& chain,
-                                 WaitingTask* task,
+                                 WaitingTaskHolder task,
                                  unsigned int transitionIndex,
                                  std::atomic<const std::set<ProductProvenance>*>& writeTo,
                                  ModuleCallingContext const* iContext,
@@ -1970,7 +1970,7 @@ namespace edm {
     }
   }  // namespace
 
-  void ReducedProvenanceReader::readProvenanceAsync(WaitingTask* task,
+  void ReducedProvenanceReader::readProvenanceAsync(WaitingTaskHolder task,
                                                     ModuleCallingContext const* moduleCallingContext,
                                                     unsigned int transitionIndex,
                                                     std::atomic<const std::set<ProductProvenance>*>& writeTo) const {
@@ -2021,7 +2021,7 @@ namespace edm {
     std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
 
   private:
-    void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTaskHolder task,
                              ModuleCallingContext const* moduleCallingContext,
                              unsigned int transitionIndex,
                              std::atomic<const std::set<ProductProvenance>*>& writeTo) const override;
@@ -2044,7 +2044,7 @@ namespace edm {
         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
         acquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first) {}
 
-  void FullProvenanceReader::readProvenanceAsync(WaitingTask* task,
+  void FullProvenanceReader::readProvenanceAsync(WaitingTaskHolder task,
                                                  ModuleCallingContext const* moduleCallingContext,
                                                  unsigned int transitionIndex,
                                                  std::atomic<const std::set<ProductProvenance>*>& writeTo) const {
@@ -2087,7 +2087,7 @@ namespace edm {
     std::set<ProductProvenance> readProvenance(unsigned int transitionIndex) const override;
 
   private:
-    void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTaskHolder task,
                              ModuleCallingContext const* moduleCallingContext,
                              unsigned int transitionIndex,
                              std::atomic<const std::set<ProductProvenance>*>& writeTo) const override;
@@ -2114,7 +2114,7 @@ namespace edm {
         mutex_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().second),
         acquirer_(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader().first) {}
 
-  void OldProvenanceReader::readProvenanceAsync(WaitingTask* task,
+  void OldProvenanceReader::readProvenanceAsync(WaitingTaskHolder task,
                                                 ModuleCallingContext const* moduleCallingContext,
                                                 unsigned int transitionIndex,
                                                 std::atomic<const std::set<ProductProvenance>*>& writeTo) const {
@@ -2156,7 +2156,7 @@ namespace edm {
 
   private:
     std::set<ProductProvenance> readProvenance(unsigned int) const override;
-    void readProvenanceAsync(WaitingTask* task,
+    void readProvenanceAsync(WaitingTaskHolder task,
                              ModuleCallingContext const* moduleCallingContext,
                              unsigned int transitionIndex,
                              std::atomic<const std::set<ProductProvenance>*>& writeTo) const override;
@@ -2168,7 +2168,7 @@ namespace edm {
     // Not providing parentage!!!
     return std::set<ProductProvenance>{};
   }
-  void DummyProvenanceReader::readProvenanceAsync(WaitingTask* task,
+  void DummyProvenanceReader::readProvenanceAsync(WaitingTaskHolder task,
                                                   ModuleCallingContext const* moduleCallingContext,
                                                   unsigned int transitionIndex,
                                                   std::atomic<const std::set<ProductProvenance>*>& writeTo) const {

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -143,7 +143,7 @@ namespace edm {
     virtual void doExtrasAfterCloseFile();
 
   private:
-    void preActionBeforeRunEventAsync(WaitingTask* iTask,
+    void preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                       ModuleCallingContext const& iModuleCallingContext,
                                       Principal const& iPrincipal) const override;
 

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -392,7 +392,7 @@ namespace edm {
     }
   }
 
-  void PoolOutputModule::preActionBeforeRunEventAsync(WaitingTask* iTask,
+  void PoolOutputModule::preActionBeforeRunEventAsync(WaitingTaskHolder iTask,
                                                       ModuleCallingContext const& iModuleCallingContext,
                                                       Principal const& iPrincipal) const {
     if (DropAll != dropMetaData_) {


### PR DESCRIPTION
#### PR description:

- Switched from WaitingTask* to WaitingTaskHolder in framework APIs. 
- This increases thread safety (by avoiding accidental starvation if a task is not run) and will make it easier to transition away from the deprecated TBB APIs.

#### PR validation:

The code compiles and all framework related unit tests pass.
