### PR TITLE
Use correct L1TMuonEndCapParams tag for 2017, 2018, Run 3 and Phase 2 MC

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -49,39 +49,39 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '113X_mc2017_design_v1',
+    'phase1_2017_design'       :  '113X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v1',
+    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '113X_upgrade2018_design_v1',
+    'phase1_2018_design'       :  '113X_upgrade2018_design_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v1',
+    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v1',
+    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v1',
+    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v1',
+    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v1', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v1', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v1',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v1',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v1', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v1', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '113X_mcRun4_realistic_v1'
+    'phase2_realistic'         : '113X_mcRun4_realistic_v2'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

Since PR #29767, which was merged in the 11_1_X series, the EMTF emulator has been configured using the global tag. However, the tags contained in the 2017, 2018, Run 3 or Phase-2 MC specified the incorrect firmware version. This PR updates the tags for `L1TMuonEndCapParamsRcd` as follows:

- 2017: `L1TMuonEndCapParams_Stage2v1`
- 2018, Run 3 and Phase 2: `L1TMuonEndCapParams_Stage2v3_2018_HI_mc`

In particular, despite the "HI" in the 2018 MC string, this is indeed the correct tag for pp collisions as well.

More detail can be found at https://indico.cern.ch/event/983008/#41-l1t-emtf-tag-for-run3-mc-gt.

The GT diffs are as follows:

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_design_v1/113X_mc2017_design_v2

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_realistic_v1/113X_mc2017_realistic_v2

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_deco_v1/113X_mc2017cosmics_realistic_deco_v2

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_peak_v1/113X_mc2017cosmics_realistic_peak_v2

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_design_v1/113X_upgrade2018_design_v2

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_v1/113X_upgrade2018_realistic_v2

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HI_v1/113X_upgrade2018_realistic_HI_v2

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HEfail_v1/113X_upgrade2018_realistic_HEfail_v2

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_deco_v1/113X_upgrade2018cosmics_realistic_deco_v2

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_peak_v1/113X_upgrade2018cosmics_realistic_peak_v2

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_design_v1/113X_mcRun3_2021_design_v2

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_v1/113X_mcRun3_2021_realistic_v2

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021cosmics_realistic_deco_v1/113X_mcRun3_2021cosmics_realistic_deco_v3

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_HI_v1/113X_mcRun3_2021_realistic_HI_v2

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2023_realistic_v1/113X_mcRun3_2023_realistic_v2

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2024_realistic_v1/113X_mcRun3_2024_realistic_v2

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun4_realistic_v1/113X_mcRun4_realistic_v2

#### PR validation:

L1T experts have confirmed that this is the tag contains the correct firmware version. In addition, the following technical tests were performed:

`addOnTests.py -j 8`
`runTheMatrix.py -l limited,10424.0,7.21,11224.0,11024.2,7.4,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 11_1_X and 11_2_X.