### PR TITLE
Update HLT subtables after the migration to EOS

### DIFF
--- a/HLTrigger/Configuration/tables/subtables.sh
+++ b/HLTrigger/Configuration/tables/subtables.sh
@@ -55,7 +55,7 @@ function makeCreateConfig() {
   workDir="$baseDir"
 
   # try to read the .jar files from AFS, or download them
-  if checkJars "$baseDir" $jars; then
+  if checkJars "$baseDir" $JARS; then
     # read the .jar fles from AFS
     workDir="$baseDir"
   else
@@ -75,7 +75,7 @@ function makeCreateConfig() {
       fi
       # download to a temporay file and use an atomic move (in case an other istance is downloading the same file
       local TMPJAR=$(mktemp -p "$workDir" .${JAR}.XXXXXXXXXX)
-      curl -s "$baseUrl/$JAR" -o "$TMPJAR"
+      curl -s -L "$baseUrl/$JAR" -o "$TMPJAR"
       mv -n "$TMPJAR" "$workDir/$JAR"
       rm -f "$TMPJAR"
     done


### PR DESCRIPTION
#### PR description:

Update the ConfDB subtables creation script following the migration of the repository from AFS to EOS:
  - fix a bug that prevented using the JAR files in-place;
  - update the curl command to follow redirects when downloading the JAR files over the web.

#### PR validation:

Creation of ConfDB subtables works again.