### PR TITLE
HGCal ID variables

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
+++ b/RecoEgamma/EgammaHLTProducers/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="Geometry/CaloGeometry"/>
 <use name="RecoEcal/EgammaCoreTools"/>
 <use name="RecoEgamma/EgammaIsolationAlgos"/>
+<use name="RecoEgamma/EgammaTools"/>
 <use name="MagneticField/Engine"/>
 <use name="MagneticField/Records"/>
 <use name="DataFormats/DetId"/>

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -1,0 +1,139 @@
+
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+
+#include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
+#include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
+
+class EgammaHLTHGCalIDVarProducer : public edm::stream::EDProducer<> {
+public:
+  explicit EgammaHLTHGCalIDVarProducer(const edm::ParameterSet&);
+  ~EgammaHLTHGCalIDVarProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  class PCAAssocMap {
+  public:
+    PCAAssocMap(double HGCalShowerShapeHelper::ShowerWidths::*var, const std::string& name) : var_(var), name_(name) {}
+
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap>& initMap(
+        const edm::Handle<reco::RecoEcalCandidateCollection>& candHandle) {
+      assocMap_ = std::make_unique<reco::RecoEcalCandidateIsolationMap>(candHandle);
+      return assocMap_;
+    }
+
+    void insert(reco::RecoEcalCandidateRef& ref, const HGCalShowerShapeHelper::ShowerWidths& showerWidths) {
+      assocMap_->insert(ref, showerWidths.*var_);
+    }
+
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap>& operator()() { return assocMap_; }
+    const std::string& name() const { return name_; }
+
+  private:
+    double HGCalShowerShapeHelper::ShowerWidths::*var_;
+    std::string name_;
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> assocMap_;
+  };
+
+private:
+  // ----------member data ---------------------------
+  float rCylinder_;
+  float hOverECone_;
+  std::vector<PCAAssocMap> pcaAssocMaps_;
+  const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> recoEcalCandidateToken_;
+  const edm::EDGetTokenT<reco::PFRecHitCollection> hgcalRecHitToken_;
+  const edm::EDGetTokenT<reco::CaloClusterCollection> layerClusterToken_;
+};
+
+EgammaHLTHGCalIDVarProducer::EgammaHLTHGCalIDVarProducer(const edm::ParameterSet& config)
+    : rCylinder_(config.getParameter<double>("rCylinder")),
+      hOverECone_(config.getParameter<double>("hOverECone")),
+      recoEcalCandidateToken_(
+          consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
+      hgcalRecHitToken_(consumes<reco::PFRecHitCollection>(config.getParameter<edm::InputTag>("hgcalRecHits"))),
+      layerClusterToken_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusters"))) {
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2xx, "sigma2xx"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2yy, "sigma2yy"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2zz, "sigma2zz"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2xy, "sigma2xy"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2yz, "sigma2yz"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2zx, "sigma2zx"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2uu, "sigma2uu"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2vv, "sigma2vv"));
+  pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2ww, "sigma2ww"));
+
+  produces<reco::RecoEcalCandidateIsolationMap>("rVar");
+  produces<reco::RecoEcalCandidateIsolationMap>("hForHOverE");
+  for (auto& var : pcaAssocMaps_) {
+    produces<reco::RecoEcalCandidateIsolationMap>(var.name());
+  }
+}
+
+EgammaHLTHGCalIDVarProducer::~EgammaHLTHGCalIDVarProducer() {}
+
+void EgammaHLTHGCalIDVarProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("recoEcalCandidateProducer", edm::InputTag("hltL1SeededRecoEcalCandidate"));
+  desc.add<edm::InputTag>("hgcalRecHits", edm::InputTag("hgcalRecHits"));
+  desc.add<edm::InputTag>("layerClusters", edm::InputTag("layerClusters"));
+  desc.add<double>("rCylinder", 2.8);
+  desc.add<double>("hOverECone", 0.15);
+  descriptions.add(("hltEgammaHLTHGCalIDVarProducer"), desc);
+}
+
+void EgammaHLTHGCalIDVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto recoEcalCandHandle = iEvent.getHandle(recoEcalCandidateToken_);
+  auto hgcalRecHitHandle = iEvent.getHandle(hgcalRecHitToken_);
+  auto layerClustersHandle = iEvent.getHandle(layerClusterToken_);
+
+  HGCalShowerShapeHelper ssCalc;
+  ssCalc.initPerEvent(iSetup, *hgcalRecHitHandle);
+
+  auto rVarMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  auto hForHoverEMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(recoEcalCandHandle);
+  for (auto& pcaMap : pcaAssocMaps_) {
+    pcaMap.initMap(recoEcalCandHandle);
+  }
+
+  for (size_t candNr = 0; candNr < recoEcalCandHandle->size(); candNr++) {
+    reco::RecoEcalCandidateRef candRef(recoEcalCandHandle, candNr);
+    ssCalc.initPerObject(candRef->superCluster()->hitsAndFractions());
+    rVarMap->insert(candRef, ssCalc.getRvar(rCylinder_, candRef->superCluster()->energy()));
+
+    float hForHoverE = HGCalClusterTools::hadEnergyInCone(
+        candRef->superCluster()->eta(), candRef->superCluster()->phi(), *layerClustersHandle, 0., hOverECone_, 0., 0.);
+    hForHoverEMap->insert(candRef, hForHoverE);
+    auto pcaWidths = ssCalc.getPCAWidths(rCylinder_);
+    for (auto& pcaMap : pcaAssocMaps_) {
+      pcaMap.insert(candRef, pcaWidths);
+    }
+  }
+  iEvent.put(std::move(rVarMap), "rVar");
+  iEvent.put(std::move(hForHoverEMap), "hForHOverE");
+  for (auto& pcaMap : pcaAssocMaps_) {
+    iEvent.put(std::move(pcaMap()), pcaMap.name());
+  }
+}
+
+DEFINE_FWK_MODULE(EgammaHLTHGCalIDVarProducer);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -5,23 +5,17 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
-
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
-
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-
 #include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 #include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -31,17 +31,15 @@ public:
   public:
     PCAAssocMap(double HGCalShowerShapeHelper::ShowerWidths::*var, const std::string& name) : var_(var), name_(name) {}
 
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap>& initMap(
-        const edm::Handle<reco::RecoEcalCandidateCollection>& candHandle) {
+    void initMap(const edm::Handle<reco::RecoEcalCandidateCollection>& candHandle) {
       assocMap_ = std::make_unique<reco::RecoEcalCandidateIsolationMap>(candHandle);
-      return assocMap_;
     }
 
     void insert(reco::RecoEcalCandidateRef& ref, const HGCalShowerShapeHelper::ShowerWidths& showerWidths) {
       assocMap_->insert(ref, showerWidths.*var_);
     }
 
-    std::unique_ptr<reco::RecoEcalCandidateIsolationMap>& operator()() { return assocMap_; }
+    std::unique_ptr<reco::RecoEcalCandidateIsolationMap> releaseMap() { return std::move(assocMap_); }
     const std::string& name() const { return name_; }
 
   private:
@@ -126,7 +124,7 @@ void EgammaHLTHGCalIDVarProducer::produce(edm::Event& iEvent, const edm::EventSe
   iEvent.put(std::move(rVarMap), "rVar");
   iEvent.put(std::move(hForHoverEMap), "hForHOverE");
   for (auto& pcaMap : pcaAssocMaps_) {
-    iEvent.put(std::move(pcaMap()), pcaMap.name());
+    iEvent.put(pcaMap.releaseMap(), pcaMap.name());
   }
 }
 

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTHGCalIDVarProducer.cc
@@ -64,8 +64,7 @@ EgammaHLTHGCalIDVarProducer::EgammaHLTHGCalIDVarProducer(const edm::ParameterSet
           consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("recoEcalCandidateProducer"))),
       hgcalRecHitToken_(consumes<reco::PFRecHitCollection>(config.getParameter<edm::InputTag>("hgcalRecHits"))),
       layerClusterToken_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusters"))),
-      ssCalc_(consumesCollector())
-{
+      ssCalc_(consumesCollector()) {
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2xx, "sigma2xx"));
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2yy, "sigma2yy"));
   pcaAssocMaps_.emplace_back(PCAAssocMap(&HGCalShowerShapeHelper::ShowerWidths::sigma2zz, "sigma2zz"));

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
@@ -1,0 +1,187 @@
+#include <iostream>
+#include <vector>
+#include <memory>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateIsolation.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+
+#include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
+
+
+template <typename T1>
+class HLTHGCalLayerClusterIsolationProducer : public edm::stream::EDProducer<> {
+  typedef std::vector<T1> T1Collection;
+  typedef edm::Ref<T1Collection> T1Ref;
+  typedef edm::AssociationMap<edm::OneToValue<std::vector<T1>, float>> T1IsolationMap;
+
+public:
+  explicit HLTHGCalLayerClusterIsolationProducer(const edm::ParameterSet&);
+  ~HLTHGCalLayerClusterIsolationProducer() override;
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  edm::EDGetTokenT<T1Collection> recoCandidateProducer_;
+  const edm::EDGetTokenT<reco::CaloClusterCollection> layerClusterProducer_;
+  const edm::EDGetTokenT<double> rhoProducer_;
+
+  const double drMax_;
+  const double drVetoEM_;
+  const double drVetoHad_;
+  const double minEnergyEM_;
+  const double minEnergyHad_;
+  const double minEtEM_;
+  const double minEtHad_;
+  const bool useEt_;
+  const bool doRhoCorrection_;
+  const double rhoMax_;
+  const double rhoScale_;
+  const std::vector<double> effectiveAreas_;
+};
+
+template <typename T1>
+HLTHGCalLayerClusterIsolationProducer<T1>::HLTHGCalLayerClusterIsolationProducer(const edm::ParameterSet& config)
+    : layerClusterProducer_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusterProducer"))),
+      rhoProducer_(consumes<double>(config.getParameter<edm::InputTag>("rhoProducer"))),
+      drMax_(config.getParameter<double>("drMax")),
+      drVetoEM_(config.getParameter<double>("drVetoEM")),
+      drVetoHad_(config.getParameter<double>("drVetoHad")),
+      minEnergyEM_(config.getParameter<double>("minEnergyEM")),
+      minEnergyHad_(config.getParameter<double>("minEnergyHad")),
+      minEtEM_(config.getParameter<double>("minEtEM")),
+      minEtHad_(config.getParameter<double>("minEtHad")),
+      useEt_(config.getParameter<bool>("useEt")),
+      doRhoCorrection_(config.getParameter<bool>("doRhoCorrection")),
+      rhoMax_(config.getParameter<double>("rhoMax")),
+      rhoScale_(config.getParameter<double>("rhoScale")),
+      effectiveAreas_(config.getParameter<std::vector<double>>("effectiveAreas")) {
+  if (doRhoCorrection_) {
+    if (effectiveAreas_.size() != 2)
+      throw cms::Exception("IncompatibleVects") << "effectiveAreas should have two elements for em and had components. \n";
+  }
+
+  std::string recoCandidateProducerName = "recoCandidateProducer";
+  if ((typeid(HLTHGCalLayerClusterIsolationProducer<T1>) ==
+       typeid(HLTHGCalLayerClusterIsolationProducer<reco::RecoEcalCandidate>)))
+    recoCandidateProducerName = "recoEcalCandidateProducer";
+
+  recoCandidateProducer_ = consumes<T1Collection>(config.getParameter<edm::InputTag>(recoCandidateProducerName));
+  produces<T1IsolationMap>();
+}
+
+template <typename T1>
+HLTHGCalLayerClusterIsolationProducer<T1>::~HLTHGCalLayerClusterIsolationProducer() {}
+
+template <typename T1>
+void HLTHGCalLayerClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  std::string recoCandidateProducerName = "recoCandidateProducer";
+  if ((typeid(HLTHGCalLayerClusterIsolationProducer<T1>) ==
+       typeid(HLTHGCalLayerClusterIsolationProducer<reco::RecoEcalCandidate>)))
+    recoCandidateProducerName = "recoEcalCandidateProducer";
+
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>(recoCandidateProducerName, edm::InputTag("hltL1SeededRecoEcalCandidatePF"));
+  desc.add<edm::InputTag>("layerClusterProducer", edm::InputTag("hltParticleFlowClusterECAL"));
+  desc.add<edm::InputTag>("rhoProducer", edm::InputTag("fixedGridRhoFastjetAllCalo"));
+  desc.add<bool>("doRhoCorrection", false);
+  desc.add<bool>("useEt", false);
+  desc.add<double>("rhoMax", 9.9999999E7);
+  desc.add<double>("rhoScale", 1.0);
+  desc.add<double>("drMax", 0.3);
+  desc.add<double>("drVetoEM", 0.0);
+  desc.add<double>("drVetoHad", 0.0);
+  desc.add<double>("minEnergyEM", 0.0);
+  desc.add<double>("minEnergyHad", 0.0);
+  desc.add<double>("minEtEM", 0.0);
+  desc.add<double>("minEtHad", 0.0);
+  desc.add<std::vector<double>>("effectiveAreas", {0.0, 0.0});  // for em and had components
+  descriptions.add(defaultModuleLabel<HLTHGCalLayerClusterIsolationProducer<T1>>(), desc);
+}
+
+template <typename T1>
+void HLTHGCalLayerClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const edm::EventSetup&) {
+  edm::Handle<double> rhoHandle;
+  double rho = 0.0;
+  if (doRhoCorrection_) {
+    iEvent.getByToken(rhoProducer_, rhoHandle);
+    rho = *(rhoHandle.product());
+  }
+
+  if (rho > rhoMax_)
+    rho = rhoMax_;
+
+  rho = rho * rhoScale_;
+
+  edm::Handle<T1Collection> recoCandHandle;
+  edm::Handle<reco::CaloClusterCollection> clusterHandle;
+
+  iEvent.getByToken(recoCandidateProducer_, recoCandHandle);
+  iEvent.getByToken(layerClusterProducer_, clusterHandle);
+
+  const std::vector<reco::CaloCluster> layerClusters = *(clusterHandle.product());
+
+  T1IsolationMap recoCandMap(recoCandHandle);
+
+  for (unsigned int iReco = 0; iReco < recoCandHandle->size(); iReco++) {
+    T1Ref candRef(recoCandHandle, iReco);
+
+    float sum_em = HGCalClusterTools::emEnergyInCone(candRef->eta(), candRef->phi(),
+                                                     layerClusters,
+                                                     drVetoEM_, drMax_,
+                                                     minEtEM_, minEnergyEM_,
+                                                     useEt_ ? HGCalClusterTools::EType::ET :
+                                                              HGCalClusterTools::EType::ENERGY );
+
+    float sum_had = HGCalClusterTools::hadEnergyInCone(candRef->eta(), candRef->phi(),
+                                                       layerClusters,
+                                                       drVetoHad_, drMax_,
+                                                       minEtHad_, minEnergyHad_,
+                                                       useEt_ ? HGCalClusterTools::EType::ET :
+                                                                HGCalClusterTools::EType::ENERGY );
+
+    if (doRhoCorrection_) {
+      sum_em = sum_em - rho * effectiveAreas_.at(0);
+      sum_had = sum_had - rho * effectiveAreas_.at(1);
+    }
+
+    float sum = sum_em + sum_had;
+
+    recoCandMap.insert(candRef, sum);
+  }
+
+  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMap));
+}
+
+typedef HLTHGCalLayerClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTHGCalLayerClusterIsolationProducer;
+typedef HLTHGCalLayerClusterIsolationProducer<reco::RecoChargedCandidate> MuonHLTHGCalLayerClusterIsolationProducer;
+
+DEFINE_FWK_MODULE(EgammaHLTHGCalLayerClusterIsolationProducer);
+DEFINE_FWK_MODULE(MuonHLTHGCalLayerClusterIsolationProducer);

--- a/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/HLTHGCalLayerClusterIsolationProducer.cc
@@ -34,7 +34,6 @@
 
 #include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
 
-
 template <typename T1>
 class HLTHGCalLayerClusterIsolationProducer : public edm::stream::EDProducer<> {
   typedef std::vector<T1> T1Collection;
@@ -69,7 +68,8 @@ private:
 
 template <typename T1>
 HLTHGCalLayerClusterIsolationProducer<T1>::HLTHGCalLayerClusterIsolationProducer(const edm::ParameterSet& config)
-    : layerClusterProducer_(consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusterProducer"))),
+    : layerClusterProducer_(
+          consumes<reco::CaloClusterCollection>(config.getParameter<edm::InputTag>("layerClusterProducer"))),
       rhoProducer_(consumes<double>(config.getParameter<edm::InputTag>("rhoProducer"))),
       drMax_(config.getParameter<double>("drMax")),
       drVetoEM_(config.getParameter<double>("drVetoEM")),
@@ -85,7 +85,8 @@ HLTHGCalLayerClusterIsolationProducer<T1>::HLTHGCalLayerClusterIsolationProducer
       effectiveAreas_(config.getParameter<std::vector<double>>("effectiveAreas")) {
   if (doRhoCorrection_) {
     if (effectiveAreas_.size() != 2)
-      throw cms::Exception("IncompatibleVects") << "effectiveAreas should have two elements for em and had components. \n";
+      throw cms::Exception("IncompatibleVects")
+          << "effectiveAreas should have two elements for em and had components. \n";
   }
 
   std::string recoCandidateProducerName = "recoCandidateProducer";
@@ -134,7 +135,7 @@ void HLTHGCalLayerClusterIsolationProducer<T1>::produce(edm::Event& iEvent, cons
     rho = *(rhoHandle.product());
   }
 
-  rho = std::min(rho,rhoMax_);
+  rho = std::min(rho, rhoMax_);
   rho = rho * rhoScale_;
 
   edm::Handle<T1Collection> recoCandHandle;
@@ -152,19 +153,25 @@ void HLTHGCalLayerClusterIsolationProducer<T1>::produce(edm::Event& iEvent, cons
   for (unsigned int iReco = 0; iReco < recoCandHandle->size(); iReco++) {
     T1Ref candRef(recoCandHandle, iReco);
 
-    float sumEm = HGCalClusterTools::emEnergyInCone(candRef->eta(), candRef->phi(),
-						    layerClusters,
-						    drVetoEM_, drMax_,
-						    minEtEM_, minEnergyEM_,
-						    useEt_ ? HGCalClusterTools::EType::ET :
-						    HGCalClusterTools::EType::ENERGY );
+    float sumEm =
+        HGCalClusterTools::emEnergyInCone(candRef->eta(),
+                                          candRef->phi(),
+                                          layerClusters,
+                                          drVetoEM_,
+                                          drMax_,
+                                          minEtEM_,
+                                          minEnergyEM_,
+                                          useEt_ ? HGCalClusterTools::EType::ET : HGCalClusterTools::EType::ENERGY);
 
-    float sumHad = HGCalClusterTools::hadEnergyInCone(candRef->eta(), candRef->phi(),
-						      layerClusters,
-						      drVetoHad_, drMax_,
-						      minEtHad_, minEnergyHad_,
-						      useEt_ ? HGCalClusterTools::EType::ET :
-						      HGCalClusterTools::EType::ENERGY );
+    float sumHad =
+        HGCalClusterTools::hadEnergyInCone(candRef->eta(),
+                                           candRef->phi(),
+                                           layerClusters,
+                                           drVetoHad_,
+                                           drMax_,
+                                           minEtHad_,
+                                           minEnergyHad_,
+                                           useEt_ ? HGCalClusterTools::EType::ET : HGCalClusterTools::EType::ENERGY);
 
     if (doRhoCorrection_) {
       sumEm = sumEm - rho * effectiveAreas_.at(0);
@@ -179,8 +186,8 @@ void HLTHGCalLayerClusterIsolationProducer<T1>::produce(edm::Event& iEvent, cons
   }
 
   iEvent.put(std::make_unique<T1IsolationMap>(recoCandMap));
-  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMapEm),"em");
-  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMapHad),"had");
+  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMapEm), "em");
+  iEvent.put(std::make_unique<T1IsolationMap>(recoCandMapHad), "had");
 }
 
 typedef HLTHGCalLayerClusterIsolationProducer<reco::RecoEcalCandidate> EgammaHLTHGCalLayerClusterIsolationProducer;

--- a/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
+++ b/RecoEgamma/EgammaHLTProducers/python/HLTEgPhaseIITestSequence_cff.py
@@ -1,0 +1,2656 @@
+import FWCore.ParameterSet.Config as cms
+
+#this is solely to meet reco convenor requirements and does not necessarily represent the E/gamma Phase-II HLT
+#it is not supported by the TSG
+
+hltBunchSpacingProducer = cms.EDProducer("BunchSpacingProducer")
+
+
+hltEcalBarrelClusterFastTimer = cms.EDProducer("EcalBarrelClusterFastTimer",
+    ebClusters = cms.InputTag("hltParticleFlowClusterECALUncorrectedUnseeded"),
+    ebTimeHits = cms.InputTag("hltEcalDetailedTimeRecHit","EcalRecHitsEB"),
+    ecalDepth = cms.double(7.0),
+    minEnergyToConsider = cms.double(0.0),
+    minFractionToConsider = cms.double(0.1),
+    resolutionModels = cms.VPSet(cms.PSet(
+        modelName = cms.string('PerfectResolutionModel')
+    )),
+    timedVertices = cms.InputTag("offlinePrimaryVertices4D")
+)
+
+
+hltEcalDetIdToBeRecovered = cms.EDProducer("EcalDetIdToBeRecoveredProducer",
+    ebDetIdToBeRecovered = cms.string('ebDetId'),
+    ebFEToBeRecovered = cms.string('ebFE'),
+    ebIntegrityChIdErrors = cms.InputTag("hltEcalDigis","EcalIntegrityChIdErrors"),
+    ebIntegrityGainErrors = cms.InputTag("hltEcalDigis","EcalIntegrityGainErrors"),
+    ebIntegrityGainSwitchErrors = cms.InputTag("hltEcalDigis","EcalIntegrityGainSwitchErrors"),
+    ebSrFlagCollection = cms.InputTag("hltEcalDigis"),
+    eeDetIdToBeRecovered = cms.string('eeDetId'),
+    eeFEToBeRecovered = cms.string('eeFE'),
+    eeIntegrityChIdErrors = cms.InputTag("hltEcalDigis","EcalIntegrityChIdErrors"),
+    eeIntegrityGainErrors = cms.InputTag("hltEcalDigis","EcalIntegrityGainErrors"),
+    eeIntegrityGainSwitchErrors = cms.InputTag("hltEcalDigis","EcalIntegrityGainSwitchErrors"),
+    eeSrFlagCollection = cms.InputTag("hltEcalDigis"),
+    integrityBlockSizeErrors = cms.InputTag("hltEcalDigis","EcalIntegrityBlockSizeErrors"),
+    integrityTTIdErrors = cms.InputTag("hltEcalDigis","EcalIntegrityTTIdErrors")
+)
+
+
+hltEcalDetailedTimeRecHit = cms.EDProducer("EcalDetailedTimeRecHitProducer",
+    EBDetailedTimeRecHitCollection = cms.string('EcalRecHitsEB'),
+    EBRecHitCollection = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+    EBTimeDigiCollection = cms.InputTag("mix","EBTimeDigi"),
+    EBTimeLayer = cms.int32(7),
+    EEDetailedTimeRecHitCollection = cms.string('EcalRecHitsEE'),
+    EERecHitCollection = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+    EETimeDigiCollection = cms.InputTag("mix","EETimeDigi"),
+    EETimeLayer = cms.int32(3),
+    correctForVertexZPosition = cms.bool(False),
+    recoVertex = cms.InputTag("offlinePrimaryVerticesWithBS"),
+    simVertex = cms.InputTag("g4SimHits"),
+    useMCTruthVertex = cms.bool(False)
+)
+
+
+hltEcalDigis = cms.EDProducer("EcalRawToDigi",
+    DoRegional = cms.bool(False),
+    FEDs = cms.vint32(
+        601, 602, 603, 604, 605, 
+        606, 607, 608, 609, 610, 
+        611, 612, 613, 614, 615, 
+        616, 617, 618, 619, 620, 
+        621, 622, 623, 624, 625, 
+        626, 627, 628, 629, 630, 
+        631, 632, 633, 634, 635, 
+        636, 637, 638, 639, 640, 
+        641, 642, 643, 644, 645, 
+        646, 647, 648, 649, 650, 
+        651, 652, 653, 654
+    ),
+    FedLabel = cms.InputTag("listfeds"),
+    InputLabel = cms.InputTag("rawDataCollector"),
+    eventPut = cms.bool(True),
+    feIdCheck = cms.bool(True),
+    feUnpacking = cms.bool(True),
+    forceToKeepFRData = cms.bool(False),
+    headerUnpacking = cms.bool(True),
+    memUnpacking = cms.bool(True),
+    mightGet = cms.optional.untracked.vstring,
+    numbTriggerTSamples = cms.int32(1),
+    numbXtalTSamples = cms.int32(10),
+    orderedDCCIdList = cms.vint32(
+        1, 2, 3, 4, 5, 
+        6, 7, 8, 9, 10, 
+        11, 12, 13, 14, 15, 
+        16, 17, 18, 19, 20, 
+        21, 22, 23, 24, 25, 
+        26, 27, 28, 29, 30, 
+        31, 32, 33, 34, 35, 
+        36, 37, 38, 39, 40, 
+        41, 42, 43, 44, 45, 
+        46, 47, 48, 49, 50, 
+        51, 52, 53, 54
+    ),
+    orderedFedList = cms.vint32(
+        601, 602, 603, 604, 605, 
+        606, 607, 608, 609, 610, 
+        611, 612, 613, 614, 615, 
+        616, 617, 618, 619, 620, 
+        621, 622, 623, 624, 625, 
+        626, 627, 628, 629, 630, 
+        631, 632, 633, 634, 635, 
+        636, 637, 638, 639, 640, 
+        641, 642, 643, 644, 645, 
+        646, 647, 648, 649, 650, 
+        651, 652, 653, 654
+    ),
+    silentMode = cms.untracked.bool(True),
+    srpUnpacking = cms.bool(True),
+    syncCheck = cms.bool(True),
+    tccUnpacking = cms.bool(True)
+)
+
+
+hltEcalPreshowerDigis = cms.EDProducer("ESRawToDigi",
+    ESdigiCollection = cms.string(''),
+    InstanceES = cms.string(''),
+    LookupTable = cms.FileInPath('EventFilter/ESDigiToRaw/data/ES_lookup_table.dat'),
+    debugMode = cms.untracked.bool(False),
+    mightGet = cms.optional.untracked.vstring,
+    sourceTag = cms.InputTag("rawDataCollector")
+)
+
+
+hltEcalPreshowerRecHit = cms.EDProducer("ESRecHitProducer",
+    ESRecoAlgo = cms.int32(0),
+    ESdigiCollection = cms.InputTag("hltEcalPreshowerDigis"),
+    ESrechitCollection = cms.string('EcalRecHitsES'),
+    algo = cms.string('ESRecHitWorker')
+)
+
+
+hltEcalRecHit = cms.EDProducer("EcalRecHitProducer",
+    ChannelStatusToBeExcluded = cms.vstring(
+        'kDAC', 
+        'kNoisy', 
+        'kNNoisy', 
+        'kFixedG6', 
+        'kFixedG1', 
+        'kFixedG0', 
+        'kNonRespondingIsolated', 
+        'kDeadVFE', 
+        'kDeadFE', 
+        'kNoDataNoTP'
+    ),
+    EBLaserMAX = cms.double(3.0),
+    EBLaserMIN = cms.double(0.5),
+    EBrechitCollection = cms.string('EcalRecHitsEB'),
+    EBuncalibRecHitCollection = cms.InputTag("hltEcalUncalibRecHit","EcalUncalibRecHitsEB"),
+    EELaserMAX = cms.double(8.0),
+    EELaserMIN = cms.double(0.5),
+    EErechitCollection = cms.string('EcalRecHitsEE'),
+    EEuncalibRecHitCollection = cms.InputTag("hltEcalUncalibRecHit","EcalUncalibRecHitsEE"),
+    algo = cms.string('EcalRecHitWorkerSimple'),
+    algoRecover = cms.string('EcalRecHitWorkerRecover'),
+    bdtWeightFileCracks = cms.FileInPath('RecoLocalCalo/EcalDeadChannelRecoveryAlgos/data/BDTWeights/bdtgAllRH_8GT700MeV_onlyCracks_ZskimData2017_v1.xml'),
+    bdtWeightFileNoCracks = cms.FileInPath('RecoLocalCalo/EcalDeadChannelRecoveryAlgos/data/BDTWeights/bdtgAllRH_8GT700MeV_noCracks_ZskimData2017_v1.xml'),
+    cleaningConfig = cms.PSet(
+        cThreshold_barrel = cms.double(4),
+        cThreshold_double = cms.double(10),
+        cThreshold_endcap = cms.double(15),
+        e4e1Threshold_barrel = cms.double(0.08),
+        e4e1Threshold_endcap = cms.double(0.3),
+        e4e1_a_barrel = cms.double(0.02),
+        e4e1_a_endcap = cms.double(0.02),
+        e4e1_b_barrel = cms.double(0.02),
+        e4e1_b_endcap = cms.double(-0.0125),
+        e6e2thresh = cms.double(0.04),
+        ignoreOutOfTimeThresh = cms.double(1000000000.0),
+        tightenCrack_e1_double = cms.double(2),
+        tightenCrack_e1_single = cms.double(1),
+        tightenCrack_e4e1_single = cms.double(2.5),
+        tightenCrack_e6e2_double = cms.double(3)
+    ),
+    dbStatusToBeExcludedEB = cms.vint32(14, 78, 142),
+    dbStatusToBeExcludedEE = cms.vint32(14, 78, 142),
+    ebDetIdToBeRecovered = cms.InputTag("hltEcalDetIdToBeRecovered","ebDetId"),
+    ebFEToBeRecovered = cms.InputTag("hltEcalDetIdToBeRecovered","ebFE"),
+    eeDetIdToBeRecovered = cms.InputTag("hltEcalDetIdToBeRecovered","eeDetId"),
+    eeFEToBeRecovered = cms.InputTag("hltEcalDetIdToBeRecovered","eeFE"),
+    flagsMapDBReco = cms.PSet(
+        kDead = cms.vstring('kNoDataNoTP'),
+        kGood = cms.vstring(
+            'kOk', 
+            'kDAC', 
+            'kNoLaser', 
+            'kNoisy'
+        ),
+        kNeighboursRecovered = cms.vstring(
+            'kFixedG0', 
+            'kNonRespondingIsolated', 
+            'kDeadVFE'
+        ),
+        kNoisy = cms.vstring(
+            'kNNoisy', 
+            'kFixedG6', 
+            'kFixedG1'
+        ),
+        kTowerRecovered = cms.vstring('kDeadFE')
+    ),
+    killDeadChannels = cms.bool(True),
+    laserCorrection = cms.bool(True),
+    logWarningEtThreshold_EB_FE = cms.double(50),
+    logWarningEtThreshold_EE_FE = cms.double(50),
+    recoverEBFE = cms.bool(True),
+    recoverEBIsolatedChannels = cms.bool(False),
+    recoverEBVFE = cms.bool(False),
+    recoverEEFE = cms.bool(True),
+    recoverEEIsolatedChannels = cms.bool(False),
+    recoverEEVFE = cms.bool(False),
+    singleChannelRecoveryMethod = cms.string('BDTG'),
+    singleChannelRecoveryThreshold = cms.double(0.7),
+    skipTimeCalib = cms.bool(False),
+    sum8ChannelRecoveryThreshold = cms.double(0.0),
+    triggerPrimitiveDigiCollection = cms.InputTag("hltEcalDigis","EcalTriggerPrimitives")
+)
+
+
+hltEcalUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
+    EBdigiCollection = cms.InputTag("hltEcalDigis","ebDigis"),
+    EBhitCollection = cms.string('EcalUncalibRecHitsEB'),
+    EEdigiCollection = cms.InputTag("hltEcalDigis","eeDigis"),
+    EEhitCollection = cms.string('EcalUncalibRecHitsEE'),
+    algo = cms.string('EcalUncalibRecHitWorkerMultiFit'),
+    algoPSet = cms.PSet(
+        EBamplitudeFitParameters = cms.vdouble(1.138, 1.652),
+        EBtimeConstantTerm = cms.double(0.6),
+        EBtimeFitLimits_Lower = cms.double(0.2),
+        EBtimeFitLimits_Upper = cms.double(1.4),
+        EBtimeFitParameters = cms.vdouble(
+            -2.015452, 3.130702, -12.3473, 41.88921, -82.83944, 
+            91.01147, -50.35761, 11.05621
+        ),
+        EBtimeNconst = cms.double(28.5),
+        EEamplitudeFitParameters = cms.vdouble(1.89, 1.4),
+        EEtimeConstantTerm = cms.double(1.0),
+        EEtimeFitLimits_Lower = cms.double(0.2),
+        EEtimeFitLimits_Upper = cms.double(1.4),
+        EEtimeFitParameters = cms.vdouble(
+            -2.390548, 3.553628, -17.62341, 67.67538, -133.213, 
+            140.7432, -75.41106, 16.20277
+        ),
+        EEtimeNconst = cms.double(31.8),
+        EcalPulseShapeParameters = cms.PSet(
+            EBCorrNoiseMatrixG01 = cms.vdouble(
+                1.0, 0.73354, 0.64442, 0.58851, 0.55425, 
+                0.53082, 0.51916, 0.51097, 0.50732, 0.50409
+            ),
+            EBCorrNoiseMatrixG06 = cms.vdouble(
+                1.0, 0.70946, 0.58021, 0.49846, 0.45006, 
+                0.41366, 0.39699, 0.38478, 0.37847, 0.37055
+            ),
+            EBCorrNoiseMatrixG12 = cms.vdouble(
+                1.0, 0.71073, 0.55721, 0.46089, 0.40449, 
+                0.35931, 0.33924, 0.32439, 0.31581, 0.30481
+            ),
+            EBPulseShapeCovariance = cms.vdouble(
+                3.001e-06, 1.233e-05, 0.0, -4.416e-06, -4.571e-06, 
+                -3.614e-06, -2.636e-06, -1.286e-06, -8.41e-07, -5.296e-07, 
+                0.0, 0.0, 1.233e-05, 6.154e-05, 0.0, 
+                -2.2e-05, -2.309e-05, -1.838e-05, -1.373e-05, -7.334e-06, 
+                -5.088e-06, -3.745e-06, -2.428e-06, 0.0, 0.0, 
+                0.0, 0.0, 0.0, 0.0, 0.0, 
+                0.0, 0.0, 0.0, 0.0, 0.0, 
+                0.0, -4.416e-06, -2.2e-05, 0.0, 8.319e-06, 
+                8.545e-06, 6.792e-06, 5.059e-06, 2.678e-06, 1.816e-06, 
+                1.223e-06, 8.245e-07, 5.589e-07, -4.571e-06, -2.309e-05, 
+                0.0, 8.545e-06, 9.182e-06, 7.219e-06, 5.388e-06, 
+                2.853e-06, 1.944e-06, 1.324e-06, 9.083e-07, 6.335e-07, 
+                -3.614e-06, -1.838e-05, 0.0, 6.792e-06, 7.219e-06, 
+                6.016e-06, 4.437e-06, 2.385e-06, 1.636e-06, 1.118e-06, 
+                7.754e-07, 5.556e-07, -2.636e-06, -1.373e-05, 0.0, 
+                5.059e-06, 5.388e-06, 4.437e-06, 3.602e-06, 1.917e-06, 
+                1.322e-06, 9.079e-07, 6.529e-07, 4.752e-07, -1.286e-06, 
+                -7.334e-06, 0.0, 2.678e-06, 2.853e-06, 2.385e-06, 
+                1.917e-06, 1.375e-06, 9.1e-07, 6.455e-07, 4.693e-07, 
+                3.657e-07, -8.41e-07, -5.088e-06, 0.0, 1.816e-06, 
+                1.944e-06, 1.636e-06, 1.322e-06, 9.1e-07, 9.115e-07, 
+                6.062e-07, 4.436e-07, 3.422e-07, -5.296e-07, -3.745e-06, 
+                0.0, 1.223e-06, 1.324e-06, 1.118e-06, 9.079e-07, 
+                6.455e-07, 6.062e-07, 7.217e-07, 4.862e-07, 3.768e-07, 
+                0.0, -2.428e-06, 0.0, 8.245e-07, 9.083e-07, 
+                7.754e-07, 6.529e-07, 4.693e-07, 4.436e-07, 4.862e-07, 
+                6.509e-07, 4.418e-07, 0.0, 0.0, 0.0, 
+                5.589e-07, 6.335e-07, 5.556e-07, 4.752e-07, 3.657e-07, 
+                3.422e-07, 3.768e-07, 4.418e-07, 6.142e-07
+            ),
+            EBPulseShapeTemplate = cms.vdouble(
+                0.0113979, 0.758151, 1.0, 0.887744, 0.673548, 
+                0.474332, 0.319561, 0.215144, 0.147464, 0.101087, 
+                0.0693181, 0.0475044
+            ),
+            EBdigiCollection = cms.string(''),
+            EECorrNoiseMatrixG01 = cms.vdouble(
+                1.0, 0.72698, 0.62048, 0.55691, 0.51848, 
+                0.49147, 0.47813, 0.47007, 0.46621, 0.46265
+            ),
+            EECorrNoiseMatrixG06 = cms.vdouble(
+                1.0, 0.71217, 0.47464, 0.34056, 0.26282, 
+                0.20287, 0.17734, 0.16256, 0.15618, 0.14443
+            ),
+            EECorrNoiseMatrixG12 = cms.vdouble(
+                1.0, 0.71373, 0.44825, 0.30152, 0.21609, 
+                0.14786, 0.11772, 0.10165, 0.09465, 0.08098
+            ),
+            EEPulseShapeCovariance = cms.vdouble(
+                3.941e-05, 3.333e-05, 0.0, -1.449e-05, -1.661e-05, 
+                -1.424e-05, -1.183e-05, -6.842e-06, -4.915e-06, -3.411e-06, 
+                0.0, 0.0, 3.333e-05, 2.862e-05, 0.0, 
+                -1.244e-05, -1.431e-05, -1.233e-05, -1.032e-05, -5.883e-06, 
+                -4.154e-06, -2.902e-06, -2.128e-06, 0.0, 0.0, 
+                0.0, 0.0, 0.0, 0.0, 0.0, 
+                0.0, 0.0, 0.0, 0.0, 0.0, 
+                0.0, -1.449e-05, -1.244e-05, 0.0, 5.84e-06, 
+                6.649e-06, 5.72e-06, 4.812e-06, 2.708e-06, 1.869e-06, 
+                1.33e-06, 9.186e-07, 6.446e-07, -1.661e-05, -1.431e-05, 
+                0.0, 6.649e-06, 7.966e-06, 6.898e-06, 5.794e-06, 
+                3.157e-06, 2.184e-06, 1.567e-06, 1.084e-06, 7.575e-07, 
+                -1.424e-05, -1.233e-05, 0.0, 5.72e-06, 6.898e-06, 
+                6.341e-06, 5.347e-06, 2.859e-06, 1.991e-06, 1.431e-06, 
+                9.839e-07, 6.886e-07, -1.183e-05, -1.032e-05, 0.0, 
+                4.812e-06, 5.794e-06, 5.347e-06, 4.854e-06, 2.628e-06, 
+                1.809e-06, 1.289e-06, 9.02e-07, 6.146e-07, -6.842e-06, 
+                -5.883e-06, 0.0, 2.708e-06, 3.157e-06, 2.859e-06, 
+                2.628e-06, 1.863e-06, 1.296e-06, 8.882e-07, 6.108e-07, 
+                4.283e-07, -4.915e-06, -4.154e-06, 0.0, 1.869e-06, 
+                2.184e-06, 1.991e-06, 1.809e-06, 1.296e-06, 1.217e-06, 
+                8.669e-07, 5.751e-07, 3.882e-07, -3.411e-06, -2.902e-06, 
+                0.0, 1.33e-06, 1.567e-06, 1.431e-06, 1.289e-06, 
+                8.882e-07, 8.669e-07, 9.522e-07, 6.717e-07, 4.293e-07, 
+                0.0, -2.128e-06, 0.0, 9.186e-07, 1.084e-06, 
+                9.839e-07, 9.02e-07, 6.108e-07, 5.751e-07, 6.717e-07, 
+                7.911e-07, 5.493e-07, 0.0, 0.0, 0.0, 
+                6.446e-07, 7.575e-07, 6.886e-07, 6.146e-07, 4.283e-07, 
+                3.882e-07, 4.293e-07, 5.493e-07, 7.027e-07
+            ),
+            EEPulseShapeTemplate = cms.vdouble(
+                0.116442, 0.756246, 1.0, 0.897182, 0.686831, 
+                0.491506, 0.344111, 0.245731, 0.174115, 0.123361, 
+                0.0874288, 0.061957
+            ),
+            EEdigiCollection = cms.string(''),
+            ESdigiCollection = cms.string(''),
+            EcalPreMixStage1 = cms.bool(False),
+            EcalPreMixStage2 = cms.bool(False),
+            UseLCcorrection = cms.untracked.bool(True)
+        ),
+        activeBXs = cms.vint32(
+            -5, -4, -3, -2, -1, 
+            0, 1, 2, 3, 4
+        ),
+        addPedestalUncertaintyEB = cms.double(0.0),
+        addPedestalUncertaintyEE = cms.double(0.0),
+        ampErrorCalculation = cms.bool(True),
+        amplitudeThresholdEB = cms.double(10),
+        amplitudeThresholdEE = cms.double(10),
+        chi2ThreshEB_ = cms.double(65.0),
+        chi2ThreshEE_ = cms.double(50.0),
+        doPrefitEB = cms.bool(False),
+        doPrefitEE = cms.bool(False),
+        dynamicPedestalsEB = cms.bool(False),
+        dynamicPedestalsEE = cms.bool(False),
+        ebPulseShape = cms.vdouble(
+            5.2e-05, -5.26e-05, 6.66e-05, 0.1168, 0.7575, 
+            1.0, 0.8876, 0.6732, 0.4741, 0.3194
+        ),
+        ebSpikeThreshold = cms.double(1.042),
+        eePulseShape = cms.vdouble(
+            5.2e-05, -5.26e-05, 6.66e-05, 0.1168, 0.7575, 
+            1.0, 0.8876, 0.6732, 0.4741, 0.3194
+        ),
+        gainSwitchUseMaxSampleEB = cms.bool(True),
+        gainSwitchUseMaxSampleEE = cms.bool(False),
+        kPoorRecoFlagEB = cms.bool(True),
+        kPoorRecoFlagEE = cms.bool(False),
+        mitigateBadSamplesEB = cms.bool(False),
+        mitigateBadSamplesEE = cms.bool(False),
+        outOfTimeThresholdGain12mEB = cms.double(5),
+        outOfTimeThresholdGain12mEE = cms.double(1000),
+        outOfTimeThresholdGain12pEB = cms.double(5),
+        outOfTimeThresholdGain12pEE = cms.double(1000),
+        outOfTimeThresholdGain61mEB = cms.double(5),
+        outOfTimeThresholdGain61mEE = cms.double(1000),
+        outOfTimeThresholdGain61pEB = cms.double(5),
+        outOfTimeThresholdGain61pEE = cms.double(1000),
+        prefitMaxChiSqEB = cms.double(25.0),
+        prefitMaxChiSqEE = cms.double(10.0),
+        selectiveBadSampleCriteriaEB = cms.bool(False),
+        selectiveBadSampleCriteriaEE = cms.bool(False),
+        simplifiedNoiseModelForGainSwitch = cms.bool(True),
+        timealgo = cms.string('RatioMethod'),
+        useLumiInfoRunHeader = cms.bool(True)
+    )
+)
+
+
+hltEgammaBestGsfTrackVarsUnseeded = cms.EDProducer("EgammaHLTGsfTrackVarProducer",
+    beamSpotProducer = cms.InputTag("hltOnlineBeamSpot"),
+    inputCollection = cms.InputTag("hltEgammaGsfElectronsUnseeded"),
+    lowerTrackNrToRemoveCut = cms.int32(-1),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    upperTrackNrToRemoveCut = cms.int32(9999),
+    useDefaultValuesForBarrel = cms.bool(False),
+    useDefaultValuesForEndcap = cms.bool(False)
+)
+
+
+hltEgammaCandidatesUnseeded = cms.EDProducer("EgammaHLTRecoEcalCandidateProducers",
+    recoEcalCandidateCollection = cms.string(''),
+    scHybridBarrelProducer = cms.InputTag("hltParticleFlowSuperClusterECALUnseeded","hltParticleFlowSuperClusterECALBarrel"),
+    scIslandEndcapProducer = cms.InputTag("hltParticleFlowSuperClusterHGCalFromTICL")
+)
+
+
+hltEgammaCkfTrackCandidatesForGSFUnseeded = cms.EDProducer("CkfTrackCandidateMaker",
+    MeasurementTrackerEvent = cms.InputTag("hltMeasurementTrackerEvent"),
+    NavigationSchool = cms.string('SimpleNavigationSchool'),
+    RedundantSeedCleaner = cms.string('CachingSeedCleanerBySharedInput'),
+    SimpleMagneticField = cms.string(''),
+    TrajectoryBuilder = cms.string(''),
+    TrajectoryBuilderPSet = cms.PSet(
+        refToPSet_ = cms.string('HLTPSetTrajectoryBuilderForGsfElectrons')
+    ),
+    TrajectoryCleaner = cms.string('hltESPTrajectoryCleanerBySharedHits'),
+    TransientInitialStateEstimatorParameters = cms.PSet(
+        numberMeasurementsForFit = cms.int32(4),
+        propagatorAlongTISE = cms.string('PropagatorWithMaterial'),
+        propagatorOppositeTISE = cms.string('PropagatorWithMaterialOpposite')
+    ),
+    cleanTrajectoryAfterInOut = cms.bool(True),
+    doSeedingRegionRebuilding = cms.bool(True),
+    maxNSeeds = cms.uint32(1000000),
+    maxSeedsBeforeCleaning = cms.uint32(1000),
+    reverseTrajectories = cms.bool(False),
+    src = cms.InputTag("hltEgammaElectronPixelSeedsUnseeded"),
+    useHitsSplitting = cms.bool(True)
+)
+
+hltEgammaElectronPixelSeedsUnseeded = cms.EDProducer("ElectronNHitSeedProducer",
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+    initialSeeds = cms.InputTag("hltElePixelSeedsCombinedUnseeded"),
+    matcherConfig = cms.PSet(
+        detLayerGeom = cms.ESInputTag("","GlobalDetLayerGeometry"),
+        enableHitSkipping = cms.bool(True),
+        matchingCuts = cms.VPSet(
+            cms.PSet(
+                dPhiMaxHighEt = cms.vdouble(0.05),
+                dPhiMaxHighEtThres = cms.vdouble(20.0),
+                dPhiMaxLowEtGrad = cms.vdouble(-0.002),
+                dRZMaxHighEt = cms.vdouble(9999.0),
+                dRZMaxHighEtThres = cms.vdouble(0.0),
+                dRZMaxLowEtGrad = cms.vdouble(0.0),
+                version = cms.int32(2)
+            ), 
+            cms.PSet(
+                dPhiMaxHighEt = cms.vdouble(0.003),
+                dPhiMaxHighEtThres = cms.vdouble(0.0),
+                dPhiMaxLowEtGrad = cms.vdouble(0.0),
+                dRZMaxHighEt = cms.vdouble(0.05),
+                dRZMaxHighEtThres = cms.vdouble(30.0),
+                dRZMaxLowEtGrad = cms.vdouble(-0.002),
+                etaBins = cms.vdouble(),
+                version = cms.int32(2)
+            ), 
+            cms.PSet(
+                dPhiMaxHighEt = cms.vdouble(0.003),
+                dPhiMaxHighEtThres = cms.vdouble(0.0),
+                dPhiMaxLowEtGrad = cms.vdouble(0.0),
+                dRZMaxHighEt = cms.vdouble(0.05),
+                dRZMaxHighEtThres = cms.vdouble(30.0),
+                dRZMaxLowEtGrad = cms.vdouble(-0.002),
+                etaBins = cms.vdouble(),
+                version = cms.int32(2)
+            )
+        ),
+        minNrHits = cms.vuint32(2, 3),
+        minNrHitsValidLayerBins = cms.vint32(4),
+        navSchool = cms.ESInputTag("","SimpleNavigationSchool"),
+        requireExactMatchCount = cms.bool(False),
+        useParamMagFieldIfDefined = cms.bool(True),
+        useRecoVertex = cms.bool(False)
+    ),
+    measTkEvt = cms.InputTag("hltMeasurementTrackerEvent"),
+    superClusters = cms.VInputTag("hltEgammaSuperClustersToPixelMatchUnseeded"),
+    vertices = cms.InputTag("")
+)
+
+
+hltEgammaGsfElectronsUnseeded = cms.EDProducer("EgammaHLTPixelMatchElectronProducers",
+    BSProducer = cms.InputTag("hltOnlineBeamSpot"),
+    GsfTrackProducer = cms.InputTag("hltEgammaGsfTracksUnseeded"),
+    TrackProducer = cms.InputTag(""),
+    UseGsfTracks = cms.bool(True)
+)
+
+
+hltEgammaGsfTrackVarsUnseeded = cms.EDProducer("EgammaHLTGsfTrackVarProducer",
+    beamSpotProducer = cms.InputTag("hltOnlineBeamSpot"),
+    inputCollection = cms.InputTag("hltEgammaGsfTracksUnseeded"),
+    lowerTrackNrToRemoveCut = cms.int32(-1),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    upperTrackNrToRemoveCut = cms.int32(9999),
+    useDefaultValuesForBarrel = cms.bool(False),
+    useDefaultValuesForEndcap = cms.bool(False)
+)
+
+
+hltEgammaGsfTracksUnseeded = cms.EDProducer("GsfTrackProducer",
+    AlgorithmName = cms.string('gsf'),
+    Fitter = cms.string('GsfElectronFittingSmoother'),
+    GeometricInnerState = cms.bool(False),
+    MeasurementTracker = cms.string(''),
+    MeasurementTrackerEvent = cms.InputTag("hltMeasurementTrackerEvent"),
+    NavigationSchool = cms.string('SimpleNavigationSchool'),
+    Propagator = cms.string('fwdGsfElectronPropagator'),
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    TrajectoryInEvent = cms.bool(False),
+    beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+    producer = cms.string(''),
+    src = cms.InputTag("hltEgammaCkfTrackCandidatesForGSFUnseeded"),
+    useHitsSplitting = cms.bool(False)
+)
+
+
+hltEgammaHoverEUnseeded = cms.EDProducer("EgammaHLTBcHcalIsolationProducersRegional",
+    absEtaLowEdges = cms.vdouble(0.0, 1.479),
+    caloTowerProducer = cms.InputTag("hltTowerMakerForAll"),
+    depth = cms.int32(-1),
+    doEtSum = cms.bool(False),
+    doRhoCorrection = cms.bool(False),
+    effectiveAreas = cms.vdouble(0.105, 0.17),
+    etMin = cms.double(0.0),
+    innerCone = cms.double(0.0),
+    outerCone = cms.double(0.14),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    rhoMax = cms.double(99999999.0),
+    rhoProducer = cms.InputTag("hltFixedGridRhoFastjetAllCaloForMuons"),
+    rhoScale = cms.double(1.0),
+    useSingleTower = cms.bool(False)
+)
+
+
+hltEgammaPixelMatchVarsUnseeded = cms.EDProducer("EgammaHLTPixelMatchVarProducer",
+    dPhi1SParams = cms.PSet(
+        bins = cms.VPSet(
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00112, 0.000752, -0.00122, 0.00109),
+                funcType = cms.string('TF1:=pol3'),
+                xMax = cms.double(1.5),
+                xMin = cms.double(0.0),
+                yMax = cms.int32(1),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00222, 0.000196, -0.000203, 0.000447),
+                funcType = cms.string('TF1:=pol3'),
+                xMax = cms.double(1.5),
+                xMin = cms.double(0.0),
+                yMax = cms.int32(2),
+                yMin = cms.int32(2)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00236, 0.000691, 0.000199, 0.000416),
+                funcType = cms.string('TF1:=pol3'),
+                xMax = cms.double(1.5),
+                xMin = cms.double(0.0),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(3)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00823, -0.0029),
+                funcType = cms.string('TF1:=pol1'),
+                xMax = cms.double(2.0),
+                xMin = cms.double(1.5),
+                yMax = cms.int32(1),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00282),
+                funcType = cms.string('TF1:=pol0'),
+                xMax = cms.double(3.0),
+                xMin = cms.double(2.0),
+                yMax = cms.int32(1),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.010838, -0.00345),
+                funcType = cms.string('TF1:=pol1'),
+                xMax = cms.double(2.0),
+                xMin = cms.double(1.5),
+                yMax = cms.int32(2),
+                yMin = cms.int32(2)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.0043),
+                funcType = cms.string('TF1:=pol0'),
+                xMax = cms.double(3.0),
+                xMin = cms.double(2.0),
+                yMax = cms.int32(2),
+                yMin = cms.int32(2)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.0208, -0.0125, 0.00231),
+                funcType = cms.string('TF1:=pol2'),
+                xMax = cms.double(3.0),
+                xMin = cms.double(1.5),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(3)
+            )
+        )
+    ),
+    dPhi2SParams = cms.PSet(
+        bins = cms.VPSet(
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00013),
+                funcType = cms.string('TF1:=pol0'),
+                xMax = cms.double(1.6),
+                xMin = cms.double(0.0),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00045, -0.000199),
+                funcType = cms.string('TF1:=pol1'),
+                xMax = cms.double(1.9),
+                xMin = cms.double(1.5),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(7.94e-05),
+                funcType = cms.string('TF1:=pol0'),
+                xMax = cms.double(3.0),
+                xMin = cms.double(1.9),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(1)
+            )
+        )
+    ),
+    dRZ2SParams = cms.PSet(
+        bins = cms.VPSet(
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.00299, 0.000299, -4.13e-06, 0.00191),
+                funcType = cms.string('TF1:=pol3'),
+                xMax = cms.double(1.5),
+                xMin = cms.double(0.0),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(1)
+            ), 
+            cms.PSet(
+                binType = cms.string('AbsEtaClus'),
+                funcParams = cms.vdouble(0.248, -0.329, 0.148, -0.0222),
+                funcType = cms.string('TF1:=pol3'),
+                xMax = cms.double(3.0),
+                xMin = cms.double(1.5),
+                yMax = cms.int32(99999),
+                yMin = cms.int32(1)
+            )
+        )
+    ),
+    pixelSeedsProducer = cms.InputTag("hltEgammaElectronPixelSeedsUnseeded"),
+    productsToWrite = cms.int32(0),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded")
+)
+
+
+hltEgammaSuperClustersToPixelMatchUnseeded = cms.EDProducer("EgammaHLTFilteredSuperClusterProducer",
+    cands = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    cuts = cms.VPSet(cms.PSet(
+        barrelCut = cms.PSet(
+            cutOverE = cms.double(0.2),
+            useEt = cms.bool(False)
+        ),
+        endcapCut = cms.PSet(
+            cutOverE = cms.double(0.2),
+            useEt = cms.bool(False)
+        ),
+        var = cms.InputTag("hltEgammaHoverEUnseeded")
+    ))
+)
+
+
+hltElePixelHitDoubletsForTripletsUnseeded = cms.EDProducer("HitPairEDProducer",
+    clusterCheck = cms.InputTag(""),
+    layerPairs = cms.vuint32(0, 1),
+    maxElement = cms.uint32(0),
+    maxElementTotal = cms.uint32(50000000),
+    produceIntermediateHitDoublets = cms.bool(True),
+    produceSeedingHitSets = cms.bool(True),
+    seedingLayers = cms.InputTag("hltPixelLayerTriplets"),
+    trackingRegions = cms.InputTag("hltEleSeedsTrackingRegionsUnseeded"),
+    trackingRegionsSeedingLayers = cms.InputTag("")
+)
+
+
+hltElePixelHitDoubletsUnseeded = cms.EDProducer("HitPairEDProducer",
+    clusterCheck = cms.InputTag(""),
+    layerPairs = cms.vuint32(0),
+    maxElement = cms.uint32(0),
+    maxElementTotal = cms.uint32(50000000),
+    produceIntermediateHitDoublets = cms.bool(True),
+    produceSeedingHitSets = cms.bool(True),
+    seedingLayers = cms.InputTag("hltPixelLayerPairs"),
+    trackingRegions = cms.InputTag("hltEleSeedsTrackingRegionsUnseeded"),
+    trackingRegionsSeedingLayers = cms.InputTag("")
+)
+
+
+hltElePixelHitTripletsClusterRemoverUnseeded = cms.EDProducer("SeedClusterRemoverPhase2",
+    phase2OTClusters = cms.InputTag("hltSiPhase2Clusters"),
+    pixelClusters = cms.InputTag("hltSiPixelClusters"),
+    trajectories = cms.InputTag("hltElePixelSeedsTripletsUnseeded")
+)
+
+
+hltElePixelHitTripletsUnseeded = cms.EDProducer("CAHitTripletEDProducer",
+    CAHardPtCut = cms.double(0.3),
+    CAPhiCut = cms.double(0.1),
+    CAThetaCut = cms.double(0.004),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('none')
+    ),
+    doublets = cms.InputTag("hltElePixelHitDoubletsForTripletsUnseeded"),
+    extraHitRPhitolerance = cms.double(0.032),
+    maxChi2 = cms.PSet(
+        enabled = cms.bool(True),
+        pt1 = cms.double(0.8),
+        pt2 = cms.double(8.0),
+        value1 = cms.double(100.0),
+        value2 = cms.double(6.0)
+    ),
+    useBendingCorrection = cms.bool(True)
+)
+
+
+hltElePixelSeedsCombinedUnseeded = cms.EDProducer("SeedCombiner",
+    seedCollections = cms.VInputTag("hltElePixelSeedsDoubletsUnseeded", "hltElePixelSeedsTripletsUnseeded")
+)
+
+
+hltElePixelSeedsDoubletsUnseeded = cms.EDProducer("SeedCreatorFromRegionConsecutiveHitsEDProducer",
+    MinOneOverPtError = cms.double(1.0),
+    OriginTransverseErrorMultiplier = cms.double(1.0),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('none')
+    ),
+    SeedMomentumForBOFF = cms.double(5.0),
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    forceKinematicWithRegionDirection = cms.bool(False),
+    magneticField = cms.string('ParabolicMf'),
+    propagator = cms.string('PropagatorWithMaterialParabolicMf'),
+    seedingHitSets = cms.InputTag("hltElePixelHitDoubletsUnseeded")
+)
+
+
+hltElePixelSeedsTripletsUnseeded = cms.EDProducer("SeedCreatorFromRegionConsecutiveHitsEDProducer",
+    MinOneOverPtError = cms.double(1.0),
+    OriginTransverseErrorMultiplier = cms.double(1.0),
+    SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('none')
+    ),
+    SeedMomentumForBOFF = cms.double(5.0),
+    TTRHBuilder = cms.string('WithTrackAngle'),
+    forceKinematicWithRegionDirection = cms.bool(False),
+    magneticField = cms.string('ParabolicMf'),
+    propagator = cms.string('PropagatorWithMaterialParabolicMf'),
+    seedingHitSets = cms.InputTag("hltElePixelHitTripletsUnseeded")
+)
+
+
+hltEleSeedsTrackingRegionsUnseeded = cms.EDProducer("TrackingRegionsFromSuperClustersEDProducer",
+    RegionPSet = cms.PSet(
+        beamSpot = cms.InputTag("hltOnlineBeamSpot"),
+        defaultZ = cms.double(0.0),
+        deltaEtaRegion = cms.double(0.1),
+        deltaPhiRegion = cms.double(0.4),
+        measurementTrackerEvent = cms.InputTag(""),
+        minBSDeltaZ = cms.double(0.0),
+        nrSigmaForBSDeltaZ = cms.double(4.0),
+        originHalfLength = cms.double(12.5),
+        originRadius = cms.double(0.2),
+        precise = cms.bool(True),
+        ptMin = cms.double(1.5),
+        superClusters = cms.VInputTag("hltEgammaSuperClustersToPixelMatchUnseeded"),
+        useZInBeamspot = cms.bool(False),
+        useZInVertex = cms.bool(False),
+        vertices = cms.InputTag(""),
+        whereToUseMeasTracker = cms.string('kNever')
+    )
+)
+
+
+hltFilteredLayerClustersEM = cms.EDProducer("FilteredLayerClustersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("hltHgcalLayerClusters","InitialLayerClustersMask"),
+    algo_number = cms.int32(8),
+    clusterFilter = cms.string('ClusterFilterByAlgoAndSizeAndLayerRange'),
+    iteration_label = cms.string('EM'),
+    max_cluster_size = cms.int32(9999),
+    max_layerId = cms.int32(30),
+    mightGet = cms.optional.untracked.vstring,
+    min_cluster_size = cms.int32(3),
+    min_layerId = cms.int32(0)
+)
+
+
+hltFilteredLayerClustersHAD = cms.EDProducer("FilteredLayerClustersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("hltTiclTrackstersEM"),
+    algo_number = cms.int32(8),
+    clusterFilter = cms.string('ClusterFilterByAlgoAndSize'),
+    iteration_label = cms.string('HAD'),
+    max_cluster_size = cms.int32(9999),
+    max_layerId = cms.int32(9999),
+    mightGet = cms.optional.untracked.vstring,
+    min_cluster_size = cms.int32(3),
+    min_layerId = cms.int32(0)
+)
+
+
+hltFilteredLayerClustersTrk = cms.EDProducer("FilteredLayerClustersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("hltTiclTrackstersEM"),
+    algo_number = cms.int32(8),
+    clusterFilter = cms.string('ClusterFilterByAlgoAndSize'),
+    iteration_label = cms.string('Trk'),
+    max_cluster_size = cms.int32(9999),
+    max_layerId = cms.int32(9999),
+    mightGet = cms.optional.untracked.vstring,
+    min_cluster_size = cms.int32(3),
+    min_layerId = cms.int32(0)
+)
+
+
+hltFilteredLayerClustersTrkEM = cms.EDProducer("FilteredLayerClustersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    LayerClustersInputMask = cms.InputTag("hltHgcalLayerClusters","InitialLayerClustersMask"),
+    algo_number = cms.int32(8),
+    clusterFilter = cms.string('ClusterFilterByAlgoAndSizeAndLayerRange'),
+    iteration_label = cms.string('TrkEM'),
+    max_cluster_size = cms.int32(9999),
+    max_layerId = cms.int32(30),
+    mightGet = cms.optional.untracked.vstring,
+    min_cluster_size = cms.int32(3),
+    min_layerId = cms.int32(0)
+)
+
+
+hltFixedGridRhoFastjetAllCaloForMuons = cms.EDProducer("FixedGridRhoProducerFastjet",
+    gridSpacing = cms.double(0.55),
+    maxRapidity = cms.double(2.5),
+    pfCandidatesTag = cms.InputTag("hltTowerMakerForAll")
+)
+
+
+hltHGCalRecHit = cms.EDProducer("HGCalRecHitProducer",
+    HGCEE_cce = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_chargeCollectionEfficiencies')
+    ),
+    HGCEE_fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+    HGCEE_isSiFE = cms.bool(True),
+    HGCEE_keV2DIGI = cms.double(0.044259),
+    HGCEE_noise_fC = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_noise_fC')
+    ),
+    HGCEErechitCollection = cms.string('HGCEERecHits'),
+    HGCEEuncalibRecHitCollection = cms.InputTag("hltHGCalUncalibRecHit","HGCEEUncalibRecHits"),
+    HGCHEB_isSiFE = cms.bool(True),
+    HGCHEB_keV2DIGI = cms.double(0.00148148148148),
+    HGCHEB_noise_MIP = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_noise_heback')
+    ),
+    HGCHEBrechitCollection = cms.string('HGCHEBRecHits'),
+    HGCHEBuncalibRecHitCollection = cms.InputTag("hltHGCalUncalibRecHit","HGCHEBUncalibRecHits"),
+    HGCHEF_cce = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_chargeCollectionEfficiencies')
+    ),
+    HGCHEF_fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+    HGCHEF_isSiFE = cms.bool(True),
+    HGCHEF_keV2DIGI = cms.double(0.044259),
+    HGCHEF_noise_fC = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_noise_fC')
+    ),
+    HGCHEFrechitCollection = cms.string('HGCHEFRecHits'),
+    HGCHEFuncalibRecHitCollection = cms.InputTag("hltHGCalUncalibRecHit","HGCHEFUncalibRecHits"),
+    HGCHFNose_cce = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_chargeCollectionEfficiencies')
+    ),
+    HGCHFNose_fCPerMIP = cms.vdouble(1.25, 2.57, 3.88),
+    HGCHFNose_isSiFE = cms.bool(False),
+    HGCHFNose_keV2DIGI = cms.double(0.044259),
+    HGCHFNose_noise_fC = cms.PSet(
+        refToPSet_ = cms.string('HGCAL_noise_fC')
+    ),
+    HGCHFNoserechitCollection = cms.string('HGCHFNoseRecHits'),
+    HGCHFNoseuncalibRecHitCollection = cms.InputTag("hltHGCalUncalibRecHit","HGCHFNoseUncalibRecHits"),
+    algo = cms.string('HGCalRecHitWorkerSimple'),
+    constSiPar = cms.double(0.02),
+    deltasi_index_regemfac = cms.int32(3),
+    layerNoseWeights = cms.vdouble(
+        0.0, 39.500245, 39.756638, 39.756638, 39.756638, 
+        39.756638, 66.020266, 92.283895, 92.283895
+    ),
+    layerWeights = cms.vdouble(
+        0.0, 8.894541, 10.937907, 10.937907, 10.937907, 
+        10.937907, 10.937907, 10.937907, 10.937907, 10.937907, 
+        10.932882, 10.932882, 10.937907, 10.937907, 10.938169, 
+        10.938169, 10.938169, 10.938169, 10.938169, 10.938169, 
+        10.938169, 10.938169, 10.938169, 10.938169, 10.938169, 
+        10.938169, 10.938169, 10.938169, 32.332097, 51.574301, 
+        51.444192, 51.444192, 51.444192, 51.444192, 51.444192, 
+        51.444192, 51.444192, 51.444192, 51.444192, 51.444192, 
+        69.513118, 87.582044, 87.582044, 87.582044, 87.582044, 
+        87.582044, 87.214571, 86.888309, 86.92952, 86.92952, 
+        86.92952
+    ),
+    maxValSiPar = cms.double(10000.0),
+    minValSiPar = cms.double(10.0),
+    noiseSiPar = cms.double(5.5),
+    rangeMask = cms.uint32(4294442496),
+    rangeMatch = cms.uint32(1161838592),
+    sciThicknessCorrection = cms.double(0.9),
+    thicknessCorrection = cms.vdouble(
+        0.77, 0.77, 0.77, 0.84, 0.84, 
+        0.84
+    ),
+    thicknessNoseCorrection = cms.vdouble(1.132, 1.092, 1.084)
+)
+
+
+hltHGCalUncalibRecHit = cms.EDProducer("HGCalUncalibRecHitProducer",
+    HGCEEConfig = cms.PSet(
+        adcNbits = cms.uint32(10),
+        adcSaturation = cms.double(100),
+        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        isSiFE = cms.bool(True),
+        tdcNbits = cms.uint32(12),
+        tdcOnset = cms.double(60),
+        tdcSaturation = cms.double(10000),
+        toaLSB_ns = cms.double(0.0244)
+    ),
+    HGCEEdigiCollection = cms.InputTag("hltHgcalDigis","EE"),
+    HGCEEhitCollection = cms.string('HGCEEUncalibRecHits'),
+    HGCHEBConfig = cms.PSet(
+        adcNbits = cms.uint32(10),
+        adcSaturation = cms.double(68.75),
+        fCPerMIP = cms.vdouble(1.0, 1.0, 1.0),
+        isSiFE = cms.bool(True),
+        tdcNbits = cms.uint32(12),
+        tdcOnset = cms.double(55),
+        tdcSaturation = cms.double(1000),
+        toaLSB_ns = cms.double(0.0244)
+    ),
+    HGCHEBdigiCollection = cms.InputTag("hltHgcalDigis","HEback"),
+    HGCHEBhitCollection = cms.string('HGCHEBUncalibRecHits'),
+    HGCHEFConfig = cms.PSet(
+        adcNbits = cms.uint32(10),
+        adcSaturation = cms.double(100),
+        fCPerMIP = cms.vdouble(2.06, 3.43, 5.15),
+        isSiFE = cms.bool(True),
+        tdcNbits = cms.uint32(12),
+        tdcOnset = cms.double(60),
+        tdcSaturation = cms.double(10000),
+        toaLSB_ns = cms.double(0.0244)
+    ),
+    HGCHEFdigiCollection = cms.InputTag("hltHgcalDigis","HEfront"),
+    HGCHEFhitCollection = cms.string('HGCHEFUncalibRecHits'),
+    HGCHFNoseConfig = cms.PSet(
+        adcNbits = cms.uint32(10),
+        adcSaturation = cms.double(100),
+        fCPerMIP = cms.vdouble(1.25, 2.57, 3.88),
+        isSiFE = cms.bool(False),
+        tdcNbits = cms.uint32(12),
+        tdcOnset = cms.double(60),
+        tdcSaturation = cms.double(10000),
+        toaLSB_ns = cms.double(0.0244)
+    ),
+    HGCHFNosedigiCollection = cms.InputTag("hfnoseDigis","HFNose"),
+    HGCHFNosehitCollection = cms.string('HGCHFNoseUncalibRecHits'),
+    algo = cms.string('HGCalUncalibRecHitWorkerWeights')
+)
+
+
+hltHbhereco = cms.EDProducer("HBHEPhase1Reconstructor",
+    algoConfigClass = cms.string(''),
+    algorithm = cms.PSet(
+        Class = cms.string('SimpleHBHEPhase1Algo'),
+        activeBXs = cms.vint32(
+            -3, -2, -1, 0, 1, 
+            2, 3, 4
+        ),
+        applyLegacyHBMCorrection = cms.bool(False),
+        applyPedConstraint = cms.bool(True),
+        applyPulseJitter = cms.bool(False),
+        applyTimeConstraint = cms.bool(True),
+        applyTimeSlew = cms.bool(True),
+        applyTimeSlewM3 = cms.bool(True),
+        calculateArrivalTime = cms.bool(True),
+        chiSqSwitch = cms.double(15.0),
+        correctForPhaseContainment = cms.bool(True),
+        correctionPhaseNS = cms.double(6.0),
+        deltaChiSqThresh = cms.double(0.001),
+        dynamicPed = cms.bool(False),
+        firstSampleShift = cms.int32(0),
+        fitTimes = cms.int32(1),
+        meanPed = cms.double(0.0),
+        meanTime = cms.double(0.0),
+        nMaxItersMin = cms.int32(500),
+        nMaxItersNNLS = cms.int32(500),
+        nnlsThresh = cms.double(1e-11),
+        pulseJitter = cms.double(1.0),
+        respCorrM3 = cms.double(1.0),
+        samplesToAdd = cms.int32(2),
+        tdcTimeShift = cms.double(0.0),
+        timeMax = cms.double(12.5),
+        timeMin = cms.double(-12.5),
+        timeSigmaHPD = cms.double(5.0),
+        timeSigmaSiPM = cms.double(2.5),
+        timeSlewParsType = cms.int32(3),
+        ts4Max = cms.vdouble(100.0, 20000.0, 30000.0),
+        ts4Min = cms.double(0.0),
+        ts4Thresh = cms.double(0.0),
+        ts4chi2 = cms.vdouble(15.0, 15.0),
+        useM2 = cms.bool(False),
+        useM3 = cms.bool(True),
+        useMahi = cms.bool(True)
+    ),
+    digiLabelQIE11 = cms.InputTag("hltHcalDigis"),
+    digiLabelQIE8 = cms.InputTag("hltHcalDigis"),
+    dropZSmarkedPassed = cms.bool(True),
+    flagParametersQIE11 = cms.PSet(
+
+    ),
+    flagParametersQIE8 = cms.PSet(
+        hitEnergyMinimum = cms.double(1.0),
+        hitMultiplicityThreshold = cms.int32(17),
+        nominalPedestal = cms.double(3.0),
+        pulseShapeParameterSets = cms.VPSet(
+            cms.PSet(
+                pulseShapeParameters = cms.vdouble(
+                    0.0, 100.0, -50.0, 0.0, -15.0, 
+                    0.15
+                )
+            ), 
+            cms.PSet(
+                pulseShapeParameters = cms.vdouble(
+                    100.0, 2000.0, -50.0, 0.0, -5.0, 
+                    0.05
+                )
+            ), 
+            cms.PSet(
+                pulseShapeParameters = cms.vdouble(
+                    2000.0, 1000000.0, -50.0, 0.0, 95.0, 
+                    0.0
+                )
+            ), 
+            cms.PSet(
+                pulseShapeParameters = cms.vdouble(
+                    -1000000.0, 1000000.0, 45.0, 0.1, 1000000.0, 
+                    0.0
+                )
+            )
+        )
+    ),
+    makeRecHits = cms.bool(True),
+    processQIE11 = cms.bool(True),
+    processQIE8 = cms.bool(True),
+    pulseShapeParametersQIE11 = cms.PSet(
+
+    ),
+    pulseShapeParametersQIE8 = cms.PSet(
+        LeftSlopeCut = cms.vdouble(5.0, 2.55, 2.55),
+        LeftSlopeThreshold = cms.vdouble(250.0, 500.0, 100000.0),
+        LinearCut = cms.vdouble(-3.0, -0.054, -0.054),
+        LinearThreshold = cms.vdouble(20.0, 100.0, 100000.0),
+        MinimumChargeThreshold = cms.double(20.0),
+        MinimumTS4TS5Threshold = cms.double(100.0),
+        R45MinusOneRange = cms.double(0.2),
+        R45PlusOneRange = cms.double(0.2),
+        RMS8MaxCut = cms.vdouble(-13.5, -11.5, -11.5),
+        RMS8MaxThreshold = cms.vdouble(20.0, 100.0, 100000.0),
+        RightSlopeCut = cms.vdouble(5.0, 4.15, 4.15),
+        RightSlopeSmallCut = cms.vdouble(1.08, 1.16, 1.16),
+        RightSlopeSmallThreshold = cms.vdouble(150.0, 200.0, 100000.0),
+        RightSlopeThreshold = cms.vdouble(250.0, 400.0, 100000.0),
+        TS3TS4ChargeThreshold = cms.double(70.0),
+        TS3TS4UpperChargeThreshold = cms.double(20.0),
+        TS4TS5ChargeThreshold = cms.double(70.0),
+        TS4TS5LowerCut = cms.vdouble(
+            -1.0, -0.7, -0.5, -0.4, -0.3, 
+            0.1
+        ),
+        TS4TS5LowerThreshold = cms.vdouble(
+            100.0, 120.0, 160.0, 200.0, 300.0, 
+            500.0
+        ),
+        TS4TS5UpperCut = cms.vdouble(1.0, 0.8, 0.75, 0.72),
+        TS4TS5UpperThreshold = cms.vdouble(70.0, 90.0, 100.0, 400.0),
+        TS5TS6ChargeThreshold = cms.double(70.0),
+        TS5TS6UpperChargeThreshold = cms.double(20.0),
+        TriangleIgnoreSlow = cms.bool(False),
+        TrianglePeakTS = cms.uint32(10000),
+        UseDualFit = cms.bool(True)
+    ),
+    recoParamsFromDB = cms.bool(True),
+    saveDroppedInfos = cms.bool(False),
+    saveEffectivePedestal = cms.bool(True),
+    saveInfos = cms.bool(False),
+    setLegacyFlagsQIE11 = cms.bool(False),
+    setLegacyFlagsQIE8 = cms.bool(True),
+    setNegativeFlagsQIE11 = cms.bool(False),
+    setNegativeFlagsQIE8 = cms.bool(True),
+    setNoiseFlagsQIE11 = cms.bool(False),
+    setNoiseFlagsQIE8 = cms.bool(True),
+    setPulseShapeFlagsQIE11 = cms.bool(False),
+    setPulseShapeFlagsQIE8 = cms.bool(True),
+    sipmQNTStoSum = cms.int32(3),
+    sipmQTSShift = cms.int32(0),
+    tsFromDB = cms.bool(False),
+    use8ts = cms.bool(True)
+)
+
+
+hltHcalDigis = cms.EDProducer("HcalRawToDigi",
+    ComplainEmptyData = cms.untracked.bool(False),
+    ElectronicsMap = cms.string(''),
+    ExpectedOrbitMessageTime = cms.untracked.int32(-1),
+    FEDs = cms.untracked.vint32(),
+    FilterDataQuality = cms.bool(True),
+    HcalFirstFED = cms.untracked.int32(700),
+    InputLabel = cms.InputTag("rawDataCollector"),
+    UnpackCalib = cms.untracked.bool(True),
+    UnpackTTP = cms.untracked.bool(True),
+    UnpackUMNio = cms.untracked.bool(True),
+    UnpackZDC = cms.untracked.bool(True),
+    UnpackerMode = cms.untracked.int32(0),
+    firstSample = cms.int32(0),
+    lastSample = cms.int32(9),
+    mightGet = cms.optional.untracked.vstring,
+    saveQIE10DataNSamples = cms.untracked.vint32(),
+    saveQIE10DataTags = cms.untracked.vstring(),
+    saveQIE11DataNSamples = cms.untracked.vint32(),
+    saveQIE11DataTags = cms.untracked.vstring(),
+    silent = cms.untracked.bool(True)
+)
+
+
+hltHfprereco = cms.EDProducer("HFPreReconstructor",
+    digiLabel = cms.InputTag("hltHcalDigis"),
+    dropZSmarkedPassed = cms.bool(True),
+    forceSOI = cms.int32(-1),
+    soiShift = cms.int32(0),
+    sumAllTimeSlices = cms.bool(False),
+    tsFromDB = cms.bool(False)
+)
+
+
+hltHfreco = cms.EDProducer("HFPhase1Reconstructor",
+    HFStripFilter = cms.PSet(
+        gap = cms.int32(2),
+        lstrips = cms.int32(2),
+        maxStripTime = cms.double(10.0),
+        maxThreshold = cms.double(100.0),
+        seedHitIetaMax = cms.int32(35),
+        stripThreshold = cms.double(40.0),
+        timeMax = cms.double(6.0),
+        verboseLevel = cms.untracked.int32(10),
+        wedgeCut = cms.double(0.05)
+    ),
+    PETstat = cms.PSet(
+        HcalAcceptSeverityLevel = cms.int32(9),
+        longETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        longEnergyParams = cms.vdouble(
+            43.5, 45.7, 48.32, 51.36, 54.82, 
+            58.7, 63.0, 67.72, 72.86, 78.42, 
+            84.4, 90.8, 97.62
+        ),
+        long_R = cms.vdouble(0.98),
+        long_R_29 = cms.vdouble(0.8),
+        shortETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        shortEnergyParams = cms.vdouble(
+            35.1773, 35.37, 35.7933, 36.4472, 37.3317, 
+            38.4468, 39.7925, 41.3688, 43.1757, 45.2132, 
+            47.4813, 49.98, 52.7093
+        ),
+        short_R = cms.vdouble(0.8),
+        short_R_29 = cms.vdouble(0.8)
+    ),
+    S8S1stat = cms.PSet(
+        HcalAcceptSeverityLevel = cms.int32(9),
+        isS8S1 = cms.bool(True),
+        longETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        longEnergyParams = cms.vdouble(
+            40.0, 100.0, 100.0, 100.0, 100.0, 
+            100.0, 100.0, 100.0, 100.0, 100.0, 
+            100.0, 100.0, 100.0
+        ),
+        long_optimumSlope = cms.vdouble(
+            0.3, 0.1, 0.1, 0.1, 0.1, 
+            0.1, 0.1, 0.1, 0.1, 0.1, 
+            0.1, 0.1, 0.1
+        ),
+        shortETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        shortEnergyParams = cms.vdouble(
+            40.0, 100.0, 100.0, 100.0, 100.0, 
+            100.0, 100.0, 100.0, 100.0, 100.0, 
+            100.0, 100.0, 100.0
+        ),
+        short_optimumSlope = cms.vdouble(
+            0.3, 0.1, 0.1, 0.1, 0.1, 
+            0.1, 0.1, 0.1, 0.1, 0.1, 
+            0.1, 0.1, 0.1
+        )
+    ),
+    S9S1stat = cms.PSet(
+        HcalAcceptSeverityLevel = cms.int32(9),
+        isS8S1 = cms.bool(False),
+        longETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        longEnergyParams = cms.vdouble(
+            43.5, 45.7, 48.32, 51.36, 54.82, 
+            58.7, 63.0, 67.72, 72.86, 78.42, 
+            84.4, 90.8, 97.62
+        ),
+        long_optimumSlope = cms.vdouble(
+            -99999.0, 0.0164905, 0.0238698, 0.0321383, 0.041296, 
+            0.0513428, 0.0622789, 0.0741041, 0.0868186, 0.100422, 
+            0.135313, 0.136289, 0.0589927
+        ),
+        shortETParams = cms.vdouble(
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0, 0.0, 0.0, 
+            0.0, 0.0, 0.0
+        ),
+        shortEnergyParams = cms.vdouble(
+            35.1773, 35.37, 35.7933, 36.4472, 37.3317, 
+            38.4468, 39.7925, 41.3688, 43.1757, 45.2132, 
+            47.4813, 49.98, 52.7093
+        ),
+        short_optimumSlope = cms.vdouble(
+            -99999.0, 0.0164905, 0.0238698, 0.0321383, 0.041296, 
+            0.0513428, 0.0622789, 0.0741041, 0.0868186, 0.100422, 
+            0.135313, 0.136289, 0.0589927
+        )
+    ),
+    algoConfigClass = cms.string('HFPhase1PMTParams'),
+    algorithm = cms.PSet(
+        Class = cms.string('HFFlexibleTimeCheck'),
+        energyWeights = cms.vdouble(
+            1.0, 1.0, 1.0, 0.0, 1.0, 
+            0.0, 2.0, 0.0, 2.0, 0.0, 
+            2.0, 0.0, 1.0, 0.0, 0.0, 
+            1.0, 0.0, 1.0, 0.0, 2.0, 
+            0.0, 2.0, 0.0, 2.0, 0.0, 
+            1.0
+        ),
+        rejectAllFailures = cms.bool(True),
+        soiPhase = cms.uint32(1),
+        tfallIfNoTDC = cms.double(-101.0),
+        timeShift = cms.double(0.0),
+        tlimits = cms.vdouble(-1000.0, 1000.0, -1000.0, 1000.0),
+        triseIfNoTDC = cms.double(-100.0)
+    ),
+    checkChannelQualityForDepth3and4 = cms.bool(False),
+    inputLabel = cms.InputTag("hltHfprereco"),
+    runHFStripFilter = cms.bool(False),
+    setNoiseFlags = cms.bool(True),
+    useChannelQualityFromDB = cms.bool(False)
+)
+
+
+hltHgcalDigis = cms.EDProducer("HGCalRawToDigiFake",
+    bhDigis = cms.InputTag("simHGCalUnsuppressedDigis","HEback"),
+    eeDigis = cms.InputTag("simHGCalUnsuppressedDigis","EE"),
+    fhDigis = cms.InputTag("simHGCalUnsuppressedDigis","HEfront"),
+    mightGet = cms.optional.untracked.vstring
+)
+
+
+hltHgcalLayerClusters = cms.EDProducer("HGCalLayerClusterProducer",
+    HFNoseInput = cms.InputTag("hltHGCalRecHit","HGCHFNoseRecHits"),
+    HGCBHInput = cms.InputTag("hltHGCalRecHit","HGCHEBRecHits"),
+    HGCEEInput = cms.InputTag("hltHGCalRecHit","HGCEERecHits"),
+    HGCFHInput = cms.InputTag("hltHGCalRecHit","HGCHEFRecHits"),
+    detector = cms.string('all'),
+    doSharing = cms.bool(False),
+    mightGet = cms.optional.untracked.vstring,
+    nHitsTime = cms.uint32(3),
+    plugin = cms.PSet(
+        dEdXweights = cms.vdouble(
+            0.0, 8.894541, 10.937907, 10.937907, 10.937907, 
+            10.937907, 10.937907, 10.937907, 10.937907, 10.937907, 
+            10.932882, 10.932882, 10.937907, 10.937907, 10.938169, 
+            10.938169, 10.938169, 10.938169, 10.938169, 10.938169, 
+            10.938169, 10.938169, 10.938169, 10.938169, 10.938169, 
+            10.938169, 10.938169, 10.938169, 32.332097, 51.574301, 
+            51.444192, 51.444192, 51.444192, 51.444192, 51.444192, 
+            51.444192, 51.444192, 51.444192, 51.444192, 51.444192, 
+            69.513118, 87.582044, 87.582044, 87.582044, 87.582044, 
+            87.582044, 87.214571, 86.888309, 86.92952, 86.92952, 
+            86.92952
+        ),
+        deltac = cms.vdouble(1.3, 1.3, 5, 0.0315),
+        deltasi_index_regemfac = cms.int32(3),
+        dependSensor = cms.bool(True),
+        ecut = cms.double(3),
+        fcPerEle = cms.double(0.00016020506),
+        fcPerMip = cms.vdouble(
+            2.06, 3.43, 5.15, 2.06, 3.43, 
+            5.15
+        ),
+        kappa = cms.double(9),
+        maxNumberOfThickIndices = cms.uint32(6),
+        noiseMip = cms.PSet(
+            refToPSet_ = cms.string('HGCAL_noise_heback')
+        ),
+        noises = cms.vdouble(
+            2000.0, 2400.0, 2000.0, 2000.0, 2400.0, 
+            2000.0
+        ),
+        positionDeltaRho2 = cms.double(1.69),
+        sciThicknessCorrection = cms.double(0.9),
+        thicknessCorrection = cms.vdouble(
+            0.77, 0.77, 0.77, 0.84, 0.84, 
+            0.84
+        ),
+        thresholdW0 = cms.vdouble(2.9, 2.9, 2.9),
+        type = cms.string('CLUE'),
+        use2x2 = cms.bool(True),
+        verbosity = cms.untracked.uint32(3)
+    ),
+    timeClname = cms.string('timeLayerCluster'),
+    timeOffset = cms.double(5)
+)
+
+
+hltHoreco = cms.EDProducer("HcalHitReconstructor",
+    HFInWindowStat = cms.PSet(
+
+    ),
+    PETstat = cms.PSet(
+
+    ),
+    S8S1stat = cms.PSet(
+
+    ),
+    S9S1stat = cms.PSet(
+
+    ),
+    Subdetector = cms.string('HO'),
+    correctForPhaseContainment = cms.bool(True),
+    correctForTimeslew = cms.bool(True),
+    correctTiming = cms.bool(False),
+    correctionPhaseNS = cms.double(13.0),
+    dataOOTCorrectionCategory = cms.string('Data'),
+    dataOOTCorrectionName = cms.string(''),
+    digiLabel = cms.InputTag("hltHcalDigis"),
+    digiTimeFromDB = cms.bool(True),
+    digistat = cms.PSet(
+
+    ),
+    dropZSmarkedPassed = cms.bool(True),
+    firstAuxTS = cms.int32(4),
+    firstSample = cms.int32(4),
+    hfTimingTrustParameters = cms.PSet(
+
+    ),
+    mcOOTCorrectionCategory = cms.string('MC'),
+    mcOOTCorrectionName = cms.string(''),
+    recoParamsFromDB = cms.bool(True),
+    samplesToAdd = cms.int32(4),
+    saturationParameters = cms.PSet(
+        maxADCvalue = cms.int32(127)
+    ),
+    setHSCPFlags = cms.bool(False),
+    setNegativeFlags = cms.bool(False),
+    setNoiseFlags = cms.bool(False),
+    setPulseShapeFlags = cms.bool(False),
+    setSaturationFlags = cms.bool(False),
+    setTimingTrustFlags = cms.bool(False),
+    tsFromDB = cms.bool(True),
+    useLeakCorrection = cms.bool(False)
+)
+
+
+hltMeasurementTrackerEvent = cms.EDProducer("MeasurementTrackerEventProducer",
+    Phase2TrackerCluster1DProducer = cms.string('hltSiPhase2Clusters'),
+    badPixelFEDChannelCollectionLabels = cms.VInputTag("hltSiPixelDigis"),
+    inactivePixelDetectorLabels = cms.VInputTag(),
+    inactiveStripDetectorLabels = cms.VInputTag("hltSiStripDigis"),
+    measurementTracker = cms.string(''),
+    mightGet = cms.optional.untracked.vstring,
+    pixelCablingMapLabel = cms.string(''),
+    pixelClusterProducer = cms.string('hltSiPixelClusters'),
+    skipClusters = cms.InputTag(""),
+    stripClusterProducer = cms.string(''),
+    switchOffPixelsIfEmpty = cms.bool(True)
+)
+
+
+hltOfflineBeamSpot = cms.EDProducer("BeamSpotProducer")
+
+
+hltParticleFlowClusterECALUncorrectedUnseeded = cms.EDProducer("PFClusterProducer",
+    energyCorrector = cms.PSet(
+
+    ),
+    initialClusteringStep = cms.PSet(
+        algoName = cms.string('Basic2DGenericTopoClusterizer'),
+        thresholdsByDetector = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('ECAL_BARREL'),
+                gatheringThreshold = cms.double(0.175),
+                gatheringThresholdPt = cms.double(0.0)
+            ), 
+            cms.PSet(
+                detector = cms.string('ECAL_ENDCAP'),
+                gatheringThreshold = cms.double(0.3),
+                gatheringThresholdPt = cms.double(0.0)
+            )
+        ),
+        useCornerCells = cms.bool(True)
+    ),
+    pfClusterBuilder = cms.PSet(
+        algoName = cms.string('Basic2DGenericPFlowClusterizer'),
+        allCellsPositionCalc = cms.PSet(
+            algoName = cms.string('Basic2DGenericPFlowPositionCalc'),
+            logWeightDenominator = cms.double(0.08),
+            minAllowedNormalization = cms.double(1e-09),
+            minFractionInCalc = cms.double(1e-09),
+            posCalcNCrystals = cms.int32(-1),
+            timeResolutionCalcBarrel = cms.PSet(
+                constantTerm = cms.double(0.428192),
+                constantTermLowE = cms.double(0.0),
+                corrTermLowE = cms.double(0.0510871),
+                noiseTerm = cms.double(1.10889),
+                noiseTermLowE = cms.double(1.31883),
+                threshHighE = cms.double(5.0),
+                threshLowE = cms.double(0.5)
+            ),
+            timeResolutionCalcEndcap = cms.PSet(
+                constantTerm = cms.double(0.0),
+                constantTermLowE = cms.double(0.0),
+                corrTermLowE = cms.double(0.0),
+                noiseTerm = cms.double(5.72489999999),
+                noiseTermLowE = cms.double(6.92683000001),
+                threshHighE = cms.double(10.0),
+                threshLowE = cms.double(1.0)
+            )
+        ),
+        excludeOtherSeeds = cms.bool(True),
+        maxIterations = cms.uint32(50),
+        minFracTot = cms.double(1e-20),
+        minFractionToKeep = cms.double(1e-07),
+        positionCalc = cms.PSet(
+            algoName = cms.string('Basic2DGenericPFlowPositionCalc'),
+            logWeightDenominator = cms.double(0.08),
+            minAllowedNormalization = cms.double(1e-09),
+            minFractionInCalc = cms.double(1e-09),
+            posCalcNCrystals = cms.int32(9),
+            timeResolutionCalcBarrel = cms.PSet(
+                constantTerm = cms.double(0.428192),
+                constantTermLowE = cms.double(0.0),
+                corrTermLowE = cms.double(0.0510871),
+                noiseTerm = cms.double(1.10889),
+                noiseTermLowE = cms.double(1.31883),
+                threshHighE = cms.double(5.0),
+                threshLowE = cms.double(0.5)
+            ),
+            timeResolutionCalcEndcap = cms.PSet(
+                constantTerm = cms.double(0.0),
+                constantTermLowE = cms.double(0.0),
+                corrTermLowE = cms.double(0.0),
+                noiseTerm = cms.double(5.72489999999),
+                noiseTermLowE = cms.double(6.92683000001),
+                threshHighE = cms.double(10.0),
+                threshLowE = cms.double(1.0)
+            )
+        ),
+        positionCalcForConvergence = cms.PSet(
+            T0_EB = cms.double(7.4),
+            T0_EE = cms.double(3.1),
+            T0_ES = cms.double(1.2),
+            W0 = cms.double(4.2),
+            X0 = cms.double(0.89),
+            algoName = cms.string('ECAL2DPositionCalcWithDepthCorr'),
+            minAllowedNormalization = cms.double(0.0),
+            minFractionInCalc = cms.double(0.0)
+        ),
+        recHitEnergyNorms = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('ECAL_BARREL'),
+                recHitEnergyNorm = cms.double(0.08)
+            ), 
+            cms.PSet(
+                detector = cms.string('ECAL_ENDCAP'),
+                recHitEnergyNorm = cms.double(0.3)
+            )
+        ),
+        showerSigma = cms.double(1.5),
+        stoppingTolerance = cms.double(1e-08)
+    ),
+    positionReCalc = cms.PSet(
+        T0_EB = cms.double(7.4),
+        T0_EE = cms.double(3.1),
+        T0_ES = cms.double(1.2),
+        W0 = cms.double(4.2),
+        X0 = cms.double(0.89),
+        algoName = cms.string('ECAL2DPositionCalcWithDepthCorr'),
+        minAllowedNormalization = cms.double(0.0),
+        minFractionInCalc = cms.double(0.0)
+    ),
+    recHitCleaners = cms.VPSet(),
+    recHitsSource = cms.InputTag("hltParticleFlowRecHitECALUnseeded"),
+    seedCleaners = cms.VPSet(cms.PSet(
+        RecHitFlagsToBeExcluded = cms.vstring(),
+        algoName = cms.string('FlagsCleanerECAL')
+    )),
+    seedFinder = cms.PSet(
+        algoName = cms.string('LocalMaximumSeedFinder'),
+        nNeighbours = cms.int32(8),
+        thresholdsByDetector = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('ECAL_ENDCAP'),
+                seedingThreshold = cms.double(0.6),
+                seedingThresholdPt = cms.double(0.15)
+            ), 
+            cms.PSet(
+                detector = cms.string('ECAL_BARREL'),
+                seedingThreshold = cms.double(0.4375),
+                seedingThresholdPt = cms.double(0.0)
+            )
+        )
+    )
+)
+
+
+hltParticleFlowClusterECALUnseeded = cms.EDProducer("CorrectedECALPFClusterProducer",
+    energyCorrector = cms.PSet(
+        applyCrackCorrections = cms.bool(False),
+        applyMVACorrections = cms.bool(True),
+        autoDetectBunchSpacing = cms.bool(True),
+        bunchSpacing = cms.int32(25),
+        ebSrFlagLabel = cms.InputTag("hltEcalDigis"),
+        eeSrFlagLabel = cms.InputTag("hltEcalDigis"),
+        maxPtForMVAEvaluation = cms.double(300.0),
+        recHitsEBLabel = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+        recHitsEELabel = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+        setEnergyUncertainty = cms.bool(False),
+        srfAwareCorrection = cms.bool(True)
+    ),
+    inputECAL = cms.InputTag("hltParticleFlowTimeAssignerECALUnseeded"),
+    inputPS = cms.InputTag("hltParticleFlowClusterPSUnseeded"),
+    mightGet = cms.optional.untracked.vstring,
+    minimumPSEnergy = cms.double(0)
+)
+
+
+hltParticleFlowClusterHGCalFromTICL = cms.EDProducer("PFClusterProducer",
+    energyCorrector = cms.PSet(
+
+    ),
+    initialClusteringStep = cms.PSet(
+        algoName = cms.string('PFClusterFromHGCalMultiCluster'),
+        clusterSrc = cms.InputTag("hltTiclMultiClustersFromTrackstersMerge"),
+        filterByTracksterPID = cms.bool(False),
+        filter_on_categories = cms.vint32(0, 1),
+        pid_threshold = cms.double(0.8),
+        thresholdsByDetector = cms.VPSet(),
+        tracksterSrc = cms.InputTag("hltTiclTrackstersEM")
+    ),
+    pfClusterBuilder = cms.PSet(
+
+    ),
+    positionReCalc = cms.PSet(
+        algoName = cms.string('Cluster3DPCACalculator'),
+        minFractionInCalc = cms.double(1e-09),
+        updateTiming = cms.bool(False)
+    ),
+    recHitCleaners = cms.VPSet(),
+    recHitsSource = cms.InputTag("hltParticleFlowRecHitHGC"),
+    seedCleaners = cms.VPSet(),
+    seedFinder = cms.PSet(
+        algoName = cms.string('PassThruSeedFinder'),
+        nNeighbours = cms.int32(8),
+        thresholdsByDetector = cms.VPSet()
+    )
+)
+
+
+hltParticleFlowClusterHGCalFromTICLHAD = cms.EDProducer("PFClusterProducer",
+    energyCorrector = cms.PSet(
+
+    ),
+    initialClusteringStep = cms.PSet(
+        algoName = cms.string('PFClusterFromHGCalMultiCluster'),
+        clusterSrc = cms.InputTag("hltTiclMultiClustersFromTrackstersHAD"),
+        filterByTracksterPID = cms.bool(False),
+        filter_on_categories = cms.vint32(0, 1),
+        pid_threshold = cms.double(0.8),
+        thresholdsByDetector = cms.VPSet(),
+        tracksterSrc = cms.InputTag("hltTiclTrackstersHAD")
+    ),
+    pfClusterBuilder = cms.PSet(
+
+    ),
+    positionReCalc = cms.PSet(
+        algoName = cms.string('Cluster3DPCACalculator'),
+        minFractionInCalc = cms.double(1e-09),
+        updateTiming = cms.bool(False)
+    ),
+    recHitCleaners = cms.VPSet(),
+    recHitsSource = cms.InputTag("hltParticleFlowRecHitHGC"),
+    seedCleaners = cms.VPSet(),
+    seedFinder = cms.PSet(
+        algoName = cms.string('PassThruSeedFinder'),
+        nNeighbours = cms.int32(8),
+        thresholdsByDetector = cms.VPSet()
+    )
+)
+
+
+hltParticleFlowClusterPSUnseeded = cms.EDProducer("PFClusterProducer",
+    energyCorrector = cms.PSet(
+
+    ),
+    initialClusteringStep = cms.PSet(
+        algoName = cms.string('Basic2DGenericTopoClusterizer'),
+        thresholdsByDetector = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('PS1'),
+                gatheringThreshold = cms.double(6e-05),
+                gatheringThresholdPt = cms.double(0.0)
+            ), 
+            cms.PSet(
+                detector = cms.string('PS2'),
+                gatheringThreshold = cms.double(6e-05),
+                gatheringThresholdPt = cms.double(0.0)
+            )
+        ),
+        useCornerCells = cms.bool(False)
+    ),
+    pfClusterBuilder = cms.PSet(
+        algoName = cms.string('Basic2DGenericPFlowClusterizer'),
+        excludeOtherSeeds = cms.bool(True),
+        maxIterations = cms.uint32(50),
+        minFracTot = cms.double(1e-20),
+        minFractionToKeep = cms.double(1e-07),
+        positionCalc = cms.PSet(
+            algoName = cms.string('Basic2DGenericPFlowPositionCalc'),
+            logWeightDenominator = cms.double(6e-05),
+            minAllowedNormalization = cms.double(1e-09),
+            minFractionInCalc = cms.double(1e-09),
+            posCalcNCrystals = cms.int32(-1)
+        ),
+        recHitEnergyNorms = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('PS1'),
+                recHitEnergyNorm = cms.double(6e-05)
+            ), 
+            cms.PSet(
+                detector = cms.string('PS2'),
+                recHitEnergyNorm = cms.double(6e-05)
+            )
+        ),
+        showerSigma = cms.double(0.3),
+        stoppingTolerance = cms.double(1e-08)
+    ),
+    positionReCalc = cms.PSet(
+
+    ),
+    recHitCleaners = cms.VPSet(),
+    recHitsSource = cms.InputTag("hltParticleFlowRecHitPSUnseeded"),
+    seedCleaners = cms.VPSet(),
+    seedFinder = cms.PSet(
+        algoName = cms.string('LocalMaximumSeedFinder'),
+        nNeighbours = cms.int32(4),
+        thresholdsByDetector = cms.VPSet(
+            cms.PSet(
+                detector = cms.string('PS1'),
+                seedingThreshold = cms.double(0.00012),
+                seedingThresholdPt = cms.double(0.0)
+            ), 
+            cms.PSet(
+                detector = cms.string('PS2'),
+                seedingThreshold = cms.double(0.00012),
+                seedingThresholdPt = cms.double(0.0)
+            )
+        )
+    )
+)
+
+
+hltParticleFlowRecHitECALUnseeded = cms.EDProducer("PFRecHitProducer",
+    navigator = cms.PSet(
+        barrel = cms.PSet(
+
+        ),
+        endcap = cms.PSet(
+
+        ),
+        name = cms.string('PFRecHitECALNavigator')
+    ),
+    producers = cms.VPSet(
+        cms.PSet(
+            name = cms.string('PFEBRecHitCreator'),
+            qualityTests = cms.VPSet(
+                cms.PSet(
+                    applySelectionsToAllCrystals = cms.bool(True),
+                    name = cms.string('PFRecHitQTestDBThreshold')
+                ), 
+                cms.PSet(
+                    cleaningThreshold = cms.double(2.0),
+                    name = cms.string('PFRecHitQTestECAL'),
+                    skipTTRecoveredHits = cms.bool(True),
+                    timingCleaning = cms.bool(True),
+                    topologicalCleaning = cms.bool(True)
+                )
+            ),
+            srFlags = cms.InputTag(""),
+            src = cms.InputTag("hltEcalRecHit","EcalRecHitsEB")
+        ), 
+        cms.PSet(
+            name = cms.string('PFEERecHitCreator'),
+            qualityTests = cms.VPSet(
+                cms.PSet(
+                    applySelectionsToAllCrystals = cms.bool(True),
+                    name = cms.string('PFRecHitQTestDBThreshold')
+                ), 
+                cms.PSet(
+                    cleaningThreshold = cms.double(2.0),
+                    name = cms.string('PFRecHitQTestECAL'),
+                    skipTTRecoveredHits = cms.bool(True),
+                    timingCleaning = cms.bool(True),
+                    topologicalCleaning = cms.bool(True)
+                )
+            ),
+            srFlags = cms.InputTag(""),
+            src = cms.InputTag("hltEcalRecHit","EcalRecHitsEE")
+        )
+    )
+)
+
+
+hltParticleFlowRecHitHGC = cms.EDProducer("PFRecHitProducer",
+    navigator = cms.PSet(
+        hgcee = cms.PSet(
+            name = cms.string('PFRecHitHGCEENavigator'),
+            topologySource = cms.string('HGCalEESensitive')
+        ),
+        hgcheb = cms.PSet(
+            name = cms.string('PFRecHitHGCHENavigator'),
+            topologySource = cms.string('HGCalHEScintillatorSensitive')
+        ),
+        hgchef = cms.PSet(
+            name = cms.string('PFRecHitHGCHENavigator'),
+            topologySource = cms.string('HGCalHESiliconSensitive')
+        ),
+        name = cms.string('PFRecHitHGCNavigator')
+    ),
+    producers = cms.VPSet(
+        cms.PSet(
+            geometryInstance = cms.string('HGCalEESensitive'),
+            name = cms.string('PFHGCalEERecHitCreator'),
+            qualityTests = cms.VPSet(cms.PSet(
+                name = cms.string('PFRecHitQTestHGCalThresholdSNR'),
+                thresholdSNR = cms.double(5.0)
+            )),
+            src = cms.InputTag("hltHGCalRecHit","HGCEERecHits")
+        ), 
+        cms.PSet(
+            geometryInstance = cms.string('HGCalHESiliconSensitive'),
+            name = cms.string('PFHGCalHSiRecHitCreator'),
+            qualityTests = cms.VPSet(cms.PSet(
+                name = cms.string('PFRecHitQTestHGCalThresholdSNR'),
+                thresholdSNR = cms.double(5.0)
+            )),
+            src = cms.InputTag("hltHGCalRecHit","HGCHEFRecHits")
+        ), 
+        cms.PSet(
+            geometryInstance = cms.string(''),
+            name = cms.string('PFHGCalHScRecHitCreator'),
+            qualityTests = cms.VPSet(cms.PSet(
+                name = cms.string('PFRecHitQTestHGCalThresholdSNR'),
+                thresholdSNR = cms.double(5.0)
+            )),
+            src = cms.InputTag("hltHGCalRecHit","HGCHEBRecHits")
+        )
+    )
+)
+
+
+hltParticleFlowRecHitPSUnseeded = cms.EDProducer("PFRecHitProducer",
+    navigator = cms.PSet(
+        name = cms.string('PFRecHitPreshowerNavigator')
+    ),
+    producers = cms.VPSet(cms.PSet(
+        name = cms.string('PFPSRecHitCreator'),
+        qualityTests = cms.VPSet(
+            cms.PSet(
+                name = cms.string('PFRecHitQTestThreshold'),
+                threshold = cms.double(0.0)
+            ), 
+            cms.PSet(
+                cleaningThreshold = cms.double(0.0),
+                name = cms.string('PFRecHitQTestES'),
+                topologicalCleaning = cms.bool(True)
+            )
+        ),
+        src = cms.InputTag("hltEcalPreshowerRecHit","EcalRecHitsES")
+    ))
+)
+
+
+hltParticleFlowSuperClusterECALUnseeded = cms.EDProducer("PFECALSuperClusterProducer",
+    BeamSpot = cms.InputTag("hltOnlineBeamSpot"),
+    ClusteringType = cms.string('Mustache'),
+    ESAssociation = cms.InputTag("hltParticleFlowClusterECALUnseeded"),
+    EnergyWeight = cms.string('Raw'),
+    PFBasicClusterCollectionBarrel = cms.string('hltParticleFlowBasicClusterECALBarrel'),
+    PFBasicClusterCollectionEndcap = cms.string('hltParticleFlowBasicClusterECALEndcap'),
+    PFBasicClusterCollectionPreshower = cms.string('hltParticleFlowBasicClusterECALPreshower'),
+    PFClusters = cms.InputTag("hltParticleFlowClusterECALUnseeded"),
+    PFSuperClusterCollectionBarrel = cms.string('hltParticleFlowSuperClusterECALBarrel'),
+    PFSuperClusterCollectionEndcap = cms.string('hltParticleFlowSuperClusterECALEndcap'),
+    PFSuperClusterCollectionEndcapWithPreshower = cms.string('hltParticleFlowSuperClusterECALEndcapWithPreshower'),
+    applyCrackCorrections = cms.bool(False),
+    barrelRecHits = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+    doSatelliteClusterMerge = cms.bool(False),
+    dropUnseedable = cms.bool(False),
+    endcapRecHits = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+    etawidth_SuperClusterBarrel = cms.double(0.04),
+    etawidth_SuperClusterEndcap = cms.double(0.04),
+    isOOTCollection = cms.bool(False),
+    phiwidth_SuperClusterBarrel = cms.double(0.6),
+    phiwidth_SuperClusterEndcap = cms.double(0.6),
+    regressionConfig = cms.PSet(
+        ecalRecHitsEB = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+        ecalRecHitsEE = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+        isHLT = cms.bool(True),
+        regressionKeyEB = cms.string('pfscecal_EBCorrection_online'),
+        regressionKeyEE = cms.string('pfscecal_EECorrection_online'),
+        uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_online'),
+        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_online')
+    ),
+    satelliteClusterSeedThreshold = cms.double(50.0),
+    satelliteMajorityFraction = cms.double(0.5),
+    seedThresholdIsET = cms.bool(True),
+    thresh_PFClusterBarrel = cms.double(0.5),
+    thresh_PFClusterES = cms.double(0.5),
+    thresh_PFClusterEndcap = cms.double(0.5),
+    thresh_PFClusterSeedBarrel = cms.double(1.0),
+    thresh_PFClusterSeedEndcap = cms.double(1.0),
+    thresh_SCEt = cms.double(4.0),
+    useDynamicDPhiWindow = cms.bool(True),
+    useRegression = cms.bool(True),
+    use_preshower = cms.bool(True),
+    verbose = cms.untracked.bool(False)
+)
+
+
+hltParticleFlowSuperClusterHGCalFromTICL = cms.EDProducer("PFECALSuperClusterProducer",
+    BeamSpot = cms.InputTag("hltOfflineBeamSpot"),
+    ClusteringType = cms.string('Mustache'),
+    ESAssociation = cms.InputTag("hltParticleFlowClusterECALUnseeded"),
+    EnergyWeight = cms.string('Raw'),
+    PFBasicClusterCollectionBarrel = cms.string('particleFlowBasicClusterECALBarrel'),
+    PFBasicClusterCollectionEndcap = cms.string(''),
+    PFBasicClusterCollectionPreshower = cms.string('particleFlowBasicClusterECALPreshower'),
+    PFClusters = cms.InputTag("hltParticleFlowClusterHGCalFromTICL"),
+    PFSuperClusterCollectionBarrel = cms.string('particleFlowSuperClusterECALBarrel'),
+    PFSuperClusterCollectionEndcap = cms.string(''),
+    PFSuperClusterCollectionEndcapWithPreshower = cms.string(''),
+    applyCrackCorrections = cms.bool(False),
+    barrelRecHits = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+    doSatelliteClusterMerge = cms.bool(False),
+    dropUnseedable = cms.bool(True),
+    endcapRecHits = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+    etawidth_SuperClusterBarrel = cms.double(0.04),
+    etawidth_SuperClusterEndcap = cms.double(0.04),
+    isOOTCollection = cms.bool(False),
+    mightGet = cms.optional.untracked.vstring,
+    phiwidth_SuperClusterBarrel = cms.double(0.6),
+    phiwidth_SuperClusterEndcap = cms.double(0.6),
+    regressionConfig = cms.PSet(
+        applySigmaIetaIphiBug = cms.bool(False),
+        eRecHitThreshold = cms.double(1),
+        ecalRecHitsEB = cms.InputTag("hltEcalRecHit","EcalRecHitsEB"),
+        ecalRecHitsEE = cms.InputTag("hltEcalRecHit","EcalRecHitsEE"),
+        isHLT = cms.bool(False),
+        regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v2'),
+        regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v2'),
+        uncertaintyKeyEB = cms.string('pfscecal_EBUncertainty_offline_v2'),
+        uncertaintyKeyEE = cms.string('pfscecal_EEUncertainty_offline_v2'),
+        vertexCollection = cms.InputTag("")
+    ),
+    satelliteClusterSeedThreshold = cms.double(50),
+    satelliteMajorityFraction = cms.double(0.5),
+    seedThresholdIsET = cms.bool(True),
+    thresh_PFClusterBarrel = cms.double(0),
+    thresh_PFClusterES = cms.double(0),
+    thresh_PFClusterEndcap = cms.double(0.15),
+    thresh_PFClusterSeedBarrel = cms.double(1),
+    thresh_PFClusterSeedEndcap = cms.double(1),
+    thresh_SCEt = cms.double(4),
+    useDynamicDPhiWindow = cms.bool(True),
+    useRegression = cms.bool(False),
+    use_preshower = cms.bool(False),
+    verbose = cms.untracked.bool(False)
+)
+
+
+hltParticleFlowTimeAssignerECALUnseeded = cms.EDProducer("PFClusterTimeAssigner",
+    mightGet = cms.optional.untracked.vstring,
+    src = cms.InputTag("hltParticleFlowClusterECALUncorrectedUnseeded"),
+    timeResoSrc = cms.InputTag("hltEcalBarrelClusterFastTimer","PerfectResolutionModelResolution"),
+    timeSrc = cms.InputTag("hltEcalBarrelClusterFastTimer","PerfectResolutionModel")
+)
+
+
+hltPixelLayerPairs = cms.EDProducer("SeedingLayersEDProducer",
+    BPix = cms.PSet(
+        HitProducer = cms.string('hltSiPixelRecHits'),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
+        skipClusters = cms.InputTag("hltElePixelHitTripletsClusterRemoverUnseeded")
+    ),
+    FPix = cms.PSet(
+        HitProducer = cms.string('hltSiPixelRecHits'),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
+        skipClusters = cms.InputTag("hltElePixelHitTripletsClusterRemoverUnseeded")
+    ),
+    MTEC = cms.PSet(
+
+    ),
+    MTIB = cms.PSet(
+
+    ),
+    MTID = cms.PSet(
+
+    ),
+    MTOB = cms.PSet(
+
+    ),
+    TEC = cms.PSet(
+
+    ),
+    TIB = cms.PSet(
+
+    ),
+    TID = cms.PSet(
+
+    ),
+    TOB = cms.PSet(
+
+    ),
+    layerList = cms.vstring(
+        'BPix1+BPix2', 
+        'BPix1+BPix3', 
+        'BPix1+BPix4', 
+        'BPix2+BPix3', 
+        'BPix2+BPix4', 
+        'BPix3+BPix4', 
+        'FPix1_pos+FPix2_pos', 
+        'FPix1_pos+FPix3_pos', 
+        'FPix2_pos+FPix3_pos', 
+        'BPix1+FPix1_pos', 
+        'BPix1+FPix2_pos', 
+        'BPix1+FPix3_pos', 
+        'BPix2+FPix1_pos', 
+        'BPix2+FPix2_pos', 
+        'BPix2+FPix3_pos', 
+        'BPix3+FPix1_pos', 
+        'BPix3+FPix2_pos', 
+        'BPix3+FPix3_pos', 
+        'BPix4+FPix1_pos', 
+        'BPix4+FPix2_pos', 
+        'BPix4+FPix3_pos', 
+        'FPix1_neg+FPix2_neg', 
+        'FPix1_neg+FPix3_neg', 
+        'FPix2_neg+FPix3_neg', 
+        'BPix1+FPix1_neg', 
+        'BPix1+FPix2_neg', 
+        'BPix1+FPix3_neg', 
+        'BPix2+FPix1_neg', 
+        'BPix2+FPix2_neg', 
+        'BPix2+FPix3_neg', 
+        'BPix3+FPix1_neg', 
+        'BPix3+FPix2_neg', 
+        'BPix3+FPix3_neg', 
+        'BPix4+FPix1_neg', 
+        'BPix4+FPix2_neg', 
+        'BPix4+FPix3_neg'
+    )
+)
+
+
+hltPixelLayerTriplets = cms.EDProducer("SeedingLayersEDProducer",
+    BPix = cms.PSet(
+        HitProducer = cms.string('hltSiPixelRecHits'),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets')
+    ),
+    FPix = cms.PSet(
+        HitProducer = cms.string('hltSiPixelRecHits'),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets')
+    ),
+    MTEC = cms.PSet(
+
+    ),
+    MTIB = cms.PSet(
+
+    ),
+    MTID = cms.PSet(
+
+    ),
+    MTOB = cms.PSet(
+
+    ),
+    TEC = cms.PSet(
+
+    ),
+    TIB = cms.PSet(
+
+    ),
+    TID = cms.PSet(
+
+    ),
+    TOB = cms.PSet(
+
+    ),
+    layerList = cms.vstring(
+        'BPix1+BPix2+BPix3', 
+        'BPix2+BPix3+BPix4', 
+        'BPix1+BPix3+BPix4', 
+        'BPix1+BPix2+BPix4', 
+        'BPix2+BPix3+FPix1_pos', 
+        'BPix2+BPix3+FPix1_neg', 
+        'BPix1+BPix2+FPix1_pos', 
+        'BPix1+BPix2+FPix1_neg', 
+        'BPix2+FPix1_pos+FPix2_pos', 
+        'BPix2+FPix1_neg+FPix2_neg', 
+        'BPix1+FPix1_pos+FPix2_pos', 
+        'BPix1+FPix1_neg+FPix2_neg', 
+        'FPix1_pos+FPix2_pos+FPix3_pos', 
+        'FPix1_neg+FPix2_neg+FPix3_neg', 
+        'BPix1+BPix3+FPix1_pos', 
+        'BPix1+BPix2+FPix2_pos', 
+        'BPix1+BPix3+FPix1_neg', 
+        'BPix1+BPix2+FPix2_neg', 
+        'BPix1+FPix2_neg+FPix3_neg', 
+        'BPix1+FPix1_neg+FPix3_neg', 
+        'BPix1+FPix2_pos+FPix3_pos', 
+        'BPix1+FPix1_pos+FPix3_pos'
+    )
+)
+
+
+hltSiPhase2Clusters = cms.EDProducer("Phase2TrackerClusterizer",
+    maxClusterSize = cms.uint32(0),
+    maxNumberClusters = cms.uint32(0),
+    src = cms.InputTag("mix","Tracker")
+)
+
+
+hltSiPixelClusters = cms.EDProducer("SiPixelClusterProducer",
+    ChannelThreshold = cms.int32(1000),
+    ClusterMode = cms.string('PixelThresholdClusterizer'),
+    ClusterThreshold = cms.int32(4000),
+    ClusterThreshold_L1 = cms.int32(4000),
+    ElectronPerADCGain = cms.double(600.0),
+    MissCalibrate = cms.bool(False),
+    Phase2Calibration = cms.bool(True),
+    Phase2DigiBaseline = cms.double(1200),
+    Phase2KinkADC = cms.int32(8),
+    Phase2ReadoutMode = cms.int32(-1),
+    SeedThreshold = cms.int32(1000),
+    SplitClusters = cms.bool(False),
+    VCaltoElectronGain = cms.int32(1),
+    VCaltoElectronGain_L1 = cms.int32(1),
+    VCaltoElectronOffset = cms.int32(0),
+    VCaltoElectronOffset_L1 = cms.int32(0),
+    maxNumberOfClusters = cms.int32(-1),
+    mightGet = cms.optional.untracked.vstring,
+    payloadType = cms.string('Offline'),
+    src = cms.InputTag("simSiPixelDigis","Pixel")
+)
+
+
+hltSiPixelRecHits = cms.EDProducer("SiPixelRecHitConverter",
+    CPE = cms.string('PixelCPEGeneric'),
+    VerboseLevel = cms.untracked.int32(0),
+    src = cms.InputTag("hltSiPixelClusters")
+)
+
+
+hltSiStripDigis = cms.EDProducer("SiStripRawToDigiModule",
+    AppendedBytes = cms.int32(0),
+    DoAPVEmulatorCheck = cms.bool(False),
+    DoAllCorruptBufferChecks = cms.bool(False),
+    ErrorThreshold = cms.uint32(7174),
+    LegacyUnpacker = cms.bool(False),
+    MarkModulesOnMissingFeds = cms.bool(True),
+    ProductLabel = cms.InputTag("rawDataCollector"),
+    TriggerFedId = cms.int32(0),
+    UnpackBadChannels = cms.bool(False),
+    UnpackCommonModeValues = cms.bool(False),
+    UseDaqRegister = cms.bool(False),
+    UseFedKey = cms.bool(False)
+)
+
+
+hltTiclLayerTileProducer = cms.EDProducer("TICLLayerTileProducer",
+    detector = cms.string('HGCAL'),
+    layer_HFNose_clusters = cms.InputTag("hgcalLayerClustersHFNose"),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    mightGet = cms.optional.untracked.vstring
+)
+
+
+hltTiclMultiClustersFromTrackstersHAD = cms.EDProducer("MultiClustersFromTrackstersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    Tracksters = cms.InputTag("hltTiclTrackstersHAD"),
+    mightGet = cms.optional.untracked.vstring,
+    verbosity = cms.untracked.uint32(3)
+)
+
+
+hltTiclMultiClustersFromTrackstersMerge = cms.EDProducer("MultiClustersFromTrackstersProducer",
+    LayerClusters = cms.InputTag("hltHgcalLayerClusters"),
+    Tracksters = cms.InputTag("hltTiclTrackstersEM"),
+    mightGet = cms.optional.untracked.vstring,
+    verbosity = cms.untracked.uint32(3)
+)
+
+
+hltTiclSeedingGlobal = cms.EDProducer("TICLSeedingRegionProducer",
+    algoId = cms.int32(2),
+    algo_verbosity = cms.int32(0),
+    cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
+    mightGet = cms.optional.untracked.vstring,
+    propagator = cms.string('PropagatorWithMaterial'),
+    tracks = cms.InputTag("generalTracks")
+)
+
+
+hltTiclSeedingTrk = cms.EDProducer("TICLSeedingRegionProducer",
+    algoId = cms.int32(1),
+    algo_verbosity = cms.int32(0),
+    cutTk = cms.string('1.48 < abs(eta) < 3.0 && pt > 1. && quality("highPurity") && hitPattern().numberOfLostHits("MISSING_OUTER_HITS") < 5'),
+    mightGet = cms.optional.untracked.vstring,
+    propagator = cms.string('PropagatorWithMaterial'),
+    tracks = cms.InputTag("generalTracks","","@skipCurrentProcess")
+)
+
+
+hltTiclTrackstersEM = cms.EDProducer("TrackstersProducer",
+    algo_verbosity = cms.int32(0),
+    detector = cms.string('HGCAL'),
+    eid_graph_path = cms.string('RecoHGCal/TICL/data/tf_models/energy_id_v0.pb'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(1),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    energy_em_over_total_threshold = cms.double(0.9),
+    etaLimitIncreaseWindow = cms.double(2.1),
+    filter_on_categories = cms.vint32(0, 1),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersEM","EM"),
+    itername = cms.string('EM'),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    layer_clusters_hfnose_tiles = cms.InputTag("ticlLayerTileHFNose"),
+    layer_clusters_tiles = cms.InputTag("hltTiclLayerTileProducer"),
+    max_delta_time = cms.double(3),
+    max_longitudinal_sigmaPCA = cms.double(10),
+    max_missing_layers_in_trackster = cms.int32(1),
+    max_out_in_hops = cms.int32(1),
+    mightGet = cms.optional.untracked.vstring,
+    min_cos_pointing = cms.double(0.9),
+    min_cos_theta = cms.double(0.97),
+    min_layers_per_trackster = cms.int32(10),
+    oneTracksterPerTrackSeed = cms.bool(False),
+    original_mask = cms.InputTag("hltHgcalLayerClusters","InitialLayerClustersMask"),
+    out_in_dfs = cms.bool(True),
+    pid_threshold = cms.double(0.5),
+    promoteEmptyRegionToTrackster = cms.bool(False),
+    root_doublet_max_distance_from_seed_squared = cms.double(9999),
+    seeding_regions = cms.InputTag("hltTiclSeedingGlobal"),
+    shower_start_max_layer = cms.int32(5),
+    skip_layers = cms.int32(2),
+    time_layerclusters = cms.InputTag("hltHgcalLayerClusters","timeLayerCluster")
+)
+
+
+hltTiclTrackstersHAD = cms.EDProducer("TrackstersProducer",
+    algo_verbosity = cms.int32(0),
+    detector = cms.string('HGCAL'),
+    eid_graph_path = cms.string('RecoHGCal/TICL/data/tf_models/energy_id_v0.pb'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(1),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    energy_em_over_total_threshold = cms.double(-1),
+    etaLimitIncreaseWindow = cms.double(2.1),
+    filter_on_categories = cms.vint32(0),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersHAD","HAD"),
+    itername = cms.string('HADRONIC'),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    layer_clusters_hfnose_tiles = cms.InputTag("ticlLayerTileHFNose"),
+    layer_clusters_tiles = cms.InputTag("hltTiclLayerTileProducer"),
+    max_delta_time = cms.double(-1),
+    max_longitudinal_sigmaPCA = cms.double(9999),
+    max_missing_layers_in_trackster = cms.int32(9999),
+    max_out_in_hops = cms.int32(10),
+    mightGet = cms.optional.untracked.vstring,
+    min_cos_pointing = cms.double(0.819),
+    min_cos_theta = cms.double(0.866),
+    min_layers_per_trackster = cms.int32(12),
+    oneTracksterPerTrackSeed = cms.bool(False),
+    original_mask = cms.InputTag("hltTiclTrackstersEM"),
+    out_in_dfs = cms.bool(True),
+    pid_threshold = cms.double(0),
+    promoteEmptyRegionToTrackster = cms.bool(False),
+    root_doublet_max_distance_from_seed_squared = cms.double(9999),
+    seeding_regions = cms.InputTag("hltTiclSeedingGlobal"),
+    shower_start_max_layer = cms.int32(9999),
+    skip_layers = cms.int32(1),
+    time_layerclusters = cms.InputTag("hltHgcalLayerClusters","timeLayerCluster")
+)
+
+
+hltTiclTrackstersMerge = cms.EDProducer("TrackstersMergeProducer",
+    cosangle_align = cms.double(0.9945),
+    debug = cms.bool(True),
+    e_over_h_threshold = cms.double(1),
+    eid_graph_path = cms.string('RecoHGCal/TICL/data/tf_models/energy_id_v0.pb'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(1),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    eta_bin_window = cms.int32(1),
+    halo_max_distance2 = cms.double(4),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    mightGet = cms.optional.untracked.vstring,
+    optimiseAcrossTracksters = cms.bool(True),
+    phi_bin_window = cms.int32(1),
+    pt_neutral_threshold = cms.double(2),
+    pt_sigma_high = cms.double(2),
+    pt_sigma_low = cms.double(2),
+    resol_calo_offset_em = cms.double(1.5),
+    resol_calo_offset_had = cms.double(1.5),
+    resol_calo_scale_em = cms.double(0.15),
+    resol_calo_scale_had = cms.double(0.15),
+    seedingTrk = cms.InputTag("hltTiclSeedingTrk"),
+    track_max_eta = cms.double(3),
+    track_max_missing_outerhits = cms.int32(5),
+    track_min_eta = cms.double(1.48),
+    track_min_pt = cms.double(1),
+    tracks = cms.InputTag("generalTracks","","@skipCurrentProcess"),
+    trackstersem = cms.InputTag("hltTiclTrackstersEM"),
+    trackstershad = cms.InputTag("hltTiclTrackstersHAD"),
+    tracksterstrk = cms.InputTag(""),
+    tracksterstrkem = cms.InputTag("")
+)
+
+
+hltTiclTrackstersTrk = cms.EDProducer("TrackstersProducer",
+    algo_verbosity = cms.int32(2),
+    detector = cms.string('HGCAL'),
+    eid_graph_path = cms.string('RecoHGCal/TICL/data/tf_models/energy_id_v0.pb'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(1),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    energy_em_over_total_threshold = cms.double(-1),
+    etaLimitIncreaseWindow = cms.double(2.1),
+    filter_on_categories = cms.vint32(2, 4),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersTrk","Trk"),
+    itername = cms.string('TRK'),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    layer_clusters_hfnose_tiles = cms.InputTag("ticlLayerTileHFNose"),
+    layer_clusters_tiles = cms.InputTag("hltTiclLayerTileProducer"),
+    max_delta_time = cms.double(-1.0),
+    max_longitudinal_sigmaPCA = cms.double(9999),
+    max_missing_layers_in_trackster = cms.int32(9999),
+    max_out_in_hops = cms.int32(10),
+    mightGet = cms.optional.untracked.vstring,
+    min_cos_pointing = cms.double(0.798),
+    min_cos_theta = cms.double(0.866),
+    min_layers_per_trackster = cms.int32(10),
+    oneTracksterPerTrackSeed = cms.bool(True),
+    original_mask = cms.InputTag("hltTiclTrackstersEM"),
+    out_in_dfs = cms.bool(True),
+    pid_threshold = cms.double(0),
+    promoteEmptyRegionToTrackster = cms.bool(True),
+    root_doublet_max_distance_from_seed_squared = cms.double(9999),
+    seeding_regions = cms.InputTag("hltTiclSeedingTrk"),
+    shower_start_max_layer = cms.int32(9999),
+    skip_layers = cms.int32(3),
+    time_layerclusters = cms.InputTag("hltHgcalLayerClusters","timeLayerCluster")
+)
+
+
+hltTiclTrackstersTrkEM = cms.EDProducer("TrackstersProducer",
+    algo_verbosity = cms.int32(0),
+    detector = cms.string('HGCAL'),
+    eid_graph_path = cms.string('RecoHGCal/TICL/data/tf_models/energy_id_v0.pb'),
+    eid_input_name = cms.string('input'),
+    eid_min_cluster_energy = cms.double(1),
+    eid_n_clusters = cms.int32(10),
+    eid_n_layers = cms.int32(50),
+    eid_output_name_energy = cms.string('output/regressed_energy'),
+    eid_output_name_id = cms.string('output/id_probabilities'),
+    energy_em_over_total_threshold = cms.double(0.9),
+    etaLimitIncreaseWindow = cms.double(2.1),
+    filter_on_categories = cms.vint32(0, 1),
+    filtered_mask = cms.InputTag("hltFilteredLayerClustersTrkEM","TrkEM"),
+    itername = cms.string('TrkEM'),
+    layer_clusters = cms.InputTag("hltHgcalLayerClusters"),
+    layer_clusters_hfnose_tiles = cms.InputTag("ticlLayerTileHFNose"),
+    layer_clusters_tiles = cms.InputTag("hltTiclLayerTileProducer"),
+    max_delta_time = cms.double(3),
+    max_longitudinal_sigmaPCA = cms.double(10),
+    max_missing_layers_in_trackster = cms.int32(2),
+    max_out_in_hops = cms.int32(1),
+    mightGet = cms.optional.untracked.vstring,
+    min_cos_pointing = cms.double(0.94),
+    min_cos_theta = cms.double(0.97),
+    min_layers_per_trackster = cms.int32(10),
+    oneTracksterPerTrackSeed = cms.bool(False),
+    original_mask = cms.InputTag("hltHgcalLayerClusters","InitialLayerClustersMask"),
+    out_in_dfs = cms.bool(True),
+    pid_threshold = cms.double(0.5),
+    promoteEmptyRegionToTrackster = cms.bool(False),
+    root_doublet_max_distance_from_seed_squared = cms.double(0.0025),
+    seeding_regions = cms.InputTag("hltTiclSeedingTrk"),
+    shower_start_max_layer = cms.int32(5),
+    skip_layers = cms.int32(2),
+    time_layerclusters = cms.InputTag("hltHgcalLayerClusters","timeLayerCluster")
+)
+
+
+hltTowerMakerForAll = cms.EDProducer("CaloTowersCreator",
+    AllowMissingInputs = cms.bool(False),
+    EBGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    EBSumThreshold = cms.double(0.2),
+    EBThreshold = cms.double(0.07),
+    EBWeight = cms.double(1.0),
+    EBWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    EEGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    EESumThreshold = cms.double(0.45),
+    EEThreshold = cms.double(0.3),
+    EEWeight = cms.double(1.0),
+    EEWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    EcalRecHitSeveritiesToBeExcluded = cms.vstring(
+        'kTime', 
+        'kWeird', 
+        'kBad'
+    ),
+    EcalSeveritiesToBeUsedInBadTowers = cms.vstring(),
+    EcutTower = cms.double(-1000.0),
+    HBGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HBThreshold = cms.double(0.3),
+    HBThreshold1 = cms.double(0.1),
+    HBThreshold2 = cms.double(0.2),
+    HBWeight = cms.double(1.0),
+    HBWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HEDGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HEDThreshold = cms.double(0.2),
+    HEDThreshold1 = cms.double(0.1),
+    HEDWeight = cms.double(1.0),
+    HEDWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HESGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HESThreshold = cms.double(0.2),
+    HESThreshold1 = cms.double(0.1),
+    HESWeight = cms.double(1.0),
+    HESWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HF1Grid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HF1Threshold = cms.double(0.5),
+    HF1Weight = cms.double(1.0),
+    HF1Weights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HF2Grid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HF2Threshold = cms.double(0.85),
+    HF2Weight = cms.double(1.0),
+    HF2Weights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HOGrid = cms.vdouble(-1.0, 1.0, 10.0, 100.0, 1000.0),
+    HOThreshold0 = cms.double(1.1),
+    HOThresholdMinus1 = cms.double(3.5),
+    HOThresholdMinus2 = cms.double(3.5),
+    HOThresholdPlus1 = cms.double(3.5),
+    HOThresholdPlus2 = cms.double(3.5),
+    HOWeight = cms.double(1.0),
+    HOWeights = cms.vdouble(1.0, 1.0, 1.0, 1.0, 1.0),
+    HcalAcceptSeverityLevel = cms.uint32(9),
+    HcalAcceptSeverityLevelForRejectedHit = cms.uint32(9999),
+    HcalPhase = cms.int32(1),
+    HcalThreshold = cms.double(-1000.0),
+    MomConstrMethod = cms.int32(1),
+    MomEBDepth = cms.double(0.3),
+    MomEEDepth = cms.double(0.0),
+    MomHBDepth = cms.double(0.2),
+    MomHEDepth = cms.double(0.4),
+    UseEcalRecoveredHits = cms.bool(False),
+    UseEtEBTreshold = cms.bool(False),
+    UseEtEETreshold = cms.bool(False),
+    UseHO = cms.bool(False),
+    UseHcalRecoveredHits = cms.bool(True),
+    UseRejectedHitsOnly = cms.bool(False),
+    UseRejectedRecoveredEcalHits = cms.bool(False),
+    UseRejectedRecoveredHcalHits = cms.bool(True),
+    UseSymEBTreshold = cms.bool(True),
+    UseSymEETreshold = cms.bool(True),
+    ecalInputs = cms.VInputTag("hltEcalRecHit:EcalRecHitsEB", "hltEcalRecHit:EcalRecHitsEE"),
+    hbheInput = cms.InputTag("hltHbhereco"),
+    hfInput = cms.InputTag("hltHfreco"),
+    hoInput = cms.InputTag("hltHoreco"),
+    missingHcalRescaleFactorForEcal = cms.double(0)
+)
+
+
+hltEG5EtUnseededFilter = cms.EDFilter("HLTEgammaEtFilter",
+    etcutEB = cms.double(5.0),
+    etcutEE = cms.double(5.0),
+    inputTag = cms.InputTag("hltEgammaCandidatesWrapperUnseeded"),
+    l1EGCand = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    ncandcut = cms.int32(1),
+    saveTags = cms.bool(True)
+)
+
+
+hltEgammaCandidatesWrapperUnseeded = cms.EDFilter("HLTEgammaTriggerFilterObjectWrapper",
+    candIsolatedTag = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    candNonIsolatedTag = cms.InputTag(""),
+    doIsolated = cms.bool(True),
+    saveTags = cms.bool(True)
+)
+
+
+HLTPFClusteringForEgammaUnseeded = cms.Sequence(hltParticleFlowRecHitECALUnseeded+hltParticleFlowRecHitPSUnseeded+hltParticleFlowClusterPSUnseeded+hltParticleFlowClusterECALUncorrectedUnseeded+hltEcalBarrelClusterFastTimer+hltParticleFlowTimeAssignerECALUnseeded+hltParticleFlowClusterECALUnseeded+hltParticleFlowSuperClusterECALUnseeded)
+
+
+HLTDoLocalPixelSequence = cms.Sequence(hltSiPixelClusters+hltSiPixelRecHits)
+
+
+HLTDoLocalStripSequence = cms.Sequence(hltSiStripDigis+hltSiPhase2Clusters)
+
+
+HLTDoLocalHcalSequence = cms.Sequence(hltHcalDigis+hltHbhereco+hltHfprereco+hltHfreco+hltHoreco)
+
+
+HLTGsfElectronUnseededSequence = cms.Sequence(hltEgammaCkfTrackCandidatesForGSFUnseeded+hltEgammaGsfTracksUnseeded+hltEgammaGsfElectronsUnseeded+hltEgammaGsfTrackVarsUnseeded+hltEgammaBestGsfTrackVarsUnseeded)
+
+
+HLTElePixelMatchUnseededSequence = cms.Sequence(HLTDoLocalPixelSequence+HLTDoLocalStripSequence+hltPixelLayerTriplets+hltEgammaHoverEUnseeded+hltEgammaSuperClustersToPixelMatchUnseeded+hltEleSeedsTrackingRegionsUnseeded+hltElePixelHitDoubletsForTripletsUnseeded+hltElePixelHitTripletsUnseeded+hltElePixelSeedsTripletsUnseeded+hltElePixelHitTripletsClusterRemoverUnseeded+hltPixelLayerPairs+hltElePixelHitDoubletsUnseeded+hltElePixelSeedsDoubletsUnseeded+hltElePixelSeedsCombinedUnseeded+hltMeasurementTrackerEvent+hltEgammaElectronPixelSeedsUnseeded+hltEgammaPixelMatchVarsUnseeded)
+
+
+HLTDoFullUnpackingEgammaEcalSequence = cms.Sequence(hltBunchSpacingProducer+hltEcalDigis+hltEcalPreshowerDigis+hltEcalUncalibRecHit+hltEcalDetIdToBeRecovered+hltEcalRecHit+hltEcalPreshowerRecHit+hltEcalDetailedTimeRecHit)
+
+
+HLTHgcalTiclPFClusteringForEgammaUnseeded = cms.Sequence(hltOfflineBeamSpot+hltHgcalDigis+hltHGCalUncalibRecHit+hltHGCalRecHit+hltParticleFlowRecHitHGC+hltHgcalLayerClusters+hltTiclLayerTileProducer+hltFilteredLayerClustersEM+hltTiclSeedingGlobal+hltTiclTrackstersEM+hltFilteredLayerClustersHAD+hltTiclTrackstersHAD+hltTiclMultiClustersFromTrackstersMerge+hltParticleFlowClusterHGCalFromTICL+hltParticleFlowSuperClusterHGCalFromTICL+hltTiclMultiClustersFromTrackstersHAD+hltParticleFlowClusterHGCalFromTICLHAD)
+
+
+HLTHgcalTiclPFClusteringForEgamma = cms.Sequence(hltOfflineBeamSpot+hltHgcalDigis+hltHGCalUncalibRecHit+hltHGCalRecHit+hltParticleFlowRecHitHGC+hltHgcalLayerClusters+hltTiclLayerTileProducer+hltFilteredLayerClustersEM+hltTiclSeedingGlobal+hltTiclTrackstersEM+hltFilteredLayerClustersHAD+hltTiclTrackstersHAD+hltTiclMultiClustersFromTrackstersMerge+hltParticleFlowClusterHGCalFromTICL+hltParticleFlowSuperClusterHGCalFromTICL+hltTiclMultiClustersFromTrackstersHAD+hltParticleFlowClusterHGCalFromTICLHAD)
+
+
+HLTFastJetForEgamma = cms.Sequence(hltTowerMakerForAll+hltTowerMakerForAll+hltTowerMakerForAll+hltFixedGridRhoFastjetAllCaloForMuons)
+
+hltEgammaHGCALIDVarsUnseeded = cms.EDProducer("EgammaHLTHGCalIDVarProducer",
+    hgcalRecHits = cms.InputTag("particleFlowRecHitHGC"),
+    layerClusters = cms.InputTag("hgcalLayerClusters"),
+    rCylinder = cms.double(2.8),
+    hOverECone = cms.double(0.15),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded")
+)
+hltEgammaHGCALIsolUnseeded = cms.EDProducer("EgammaHLTHGCalLayerClusterIsolationProducer",
+    layerClusterProducer = cms.InputTag("hgcalLayerClusters"),
+    recoEcalCandidateProducer = cms.InputTag("hltEgammaCandidatesUnseeded"),
+    drMax = cms.double(0.3),
+    drVetoEM = cms.double(0.15),
+    drVetoHad = cms.double(0.15),
+    minEnergyEM = cms.double(0.),
+    minEnergyHad = cms.double(0.),
+    minEtEM = cms.double(0.),
+    minEtHad = cms.double(0.),
+    useEt = cms.bool(True),
+    doRhoCorrection = cms.bool(False),
+)
+
+
+HLTEgPhaseIITestSequence = cms.Sequence(hltBunchSpacingProducer+hltEcalDigis+hltEcalPreshowerDigis+hltEcalUncalibRecHit+hltEcalDetIdToBeRecovered+hltEcalRecHit+hltEcalPreshowerRecHit+hltEcalDetailedTimeRecHit+HLTPFClusteringForEgammaUnseeded+hltOfflineBeamSpot+hltHgcalDigis+hltHGCalUncalibRecHit+hltHGCalRecHit+hltParticleFlowRecHitHGC+hltHgcalLayerClusters+hltTiclLayerTileProducer+hltFilteredLayerClustersEM+hltTiclSeedingGlobal+hltTiclTrackstersEM+hltFilteredLayerClustersHAD+hltTiclTrackstersHAD+hltTiclMultiClustersFromTrackstersMerge+hltParticleFlowClusterHGCalFromTICL+hltParticleFlowSuperClusterHGCalFromTICL+hltTiclMultiClustersFromTrackstersHAD+hltParticleFlowClusterHGCalFromTICLHAD+hltEgammaCandidatesUnseeded+hltEgammaCandidatesWrapperUnseeded+hltEG5EtUnseededFilter+HLTDoLocalHcalSequence+HLTFastJetForEgamma+hltEgammaHoverEUnseeded+hltEgammaHGCALIDVarsUnseeded+hltEgammaHGCALIsolUnseeded+hltSiPixelClusters+hltSiPixelRecHits+hltSiStripDigis+hltSiPhase2Clusters+hltPixelLayerTriplets+hltEgammaHoverEUnseeded+hltEgammaSuperClustersToPixelMatchUnseeded+hltEleSeedsTrackingRegionsUnseeded+hltElePixelHitDoubletsForTripletsUnseeded+hltElePixelHitTripletsUnseeded+hltElePixelSeedsTripletsUnseeded+hltElePixelHitTripletsClusterRemoverUnseeded+hltPixelLayerPairs+hltElePixelHitDoubletsUnseeded+hltElePixelSeedsDoubletsUnseeded+hltElePixelSeedsCombinedUnseeded+hltMeasurementTrackerEvent+hltEgammaElectronPixelSeedsUnseeded+hltEgammaPixelMatchVarsUnseeded+HLTGsfElectronUnseededSequence)
+
+
+HLTPSetTrajectoryBuilderForGsfElectrons = cms.PSet(
+    ComponentType = cms.string('CkfTrajectoryBuilder'),
+    MeasurementTrackerName = cms.string('hltESPMeasurementTracker'),
+    TTRHBuilder = cms.string('hltESPTTRHBWithTrackAngle'),
+    alwaysUseInvalidHits = cms.bool(True),
+    estimator = cms.string('hltESPChi2ChargeMeasurementEstimator2000'),
+    intermediateCleaning = cms.bool(False),
+    lostHitPenalty = cms.double(90.0),
+    maxCand = cms.int32(5),
+    propagatorAlong = cms.string('hltESPFwdElectronPropagator'),
+    propagatorOpposite = cms.string('hltESPBwdElectronPropagator'),
+    seedAs5DHit = cms.bool(False),
+    trajectoryFilter = cms.PSet(
+        refToPSet_ = cms.string('HLTPSetTrajectoryFilterForElectrons')
+    ),
+    updator = cms.string('hltESPKFUpdator')
+)
+
+
+
+HLTPSetTrajectoryFilterForElectrons = cms.PSet(
+    ComponentType = cms.string('CkfBaseTrajectoryFilter'),
+    chargeSignificance = cms.double(-1.0),
+    constantValueForLostHitsFractionFilter = cms.double(1.0),
+    extraNumberOfHitsBeforeTheFirstLoop = cms.int32(4),
+    maxCCCLostHits = cms.int32(9999),
+    maxConsecLostHits = cms.int32(1),
+    maxLostHits = cms.int32(1),
+    maxLostHitsFraction = cms.double(999.0),
+    maxNumberOfHits = cms.int32(-1),
+    minGoodStripCharge = cms.PSet(
+        refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone')
+    ),
+    minHitsMinPt = cms.int32(-1),
+    minNumberOfHitsForLoopers = cms.int32(13),
+    minNumberOfHitsPerLoop = cms.int32(4),
+    minPt = cms.double(2.0),
+    minimumNumberOfHits = cms.int32(5),
+    nSigmaMinPt = cms.double(5.0),
+    pixelSeedExtension = cms.bool(False),
+    seedExtension = cms.int32(0),
+    seedPairPenalty = cms.int32(0),
+    strictSeedExtension = cms.bool(False)
+)
+
+HLTSiStripClusterChargeCutNone = cms.PSet(
+    value = cms.double(-1.0)
+)
+hltESPTrajectoryCleanerBySharedHits = cms.ESProducer("TrajectoryCleanerESProducer",
+    ComponentName = cms.string('hltESPTrajectoryCleanerBySharedHits'),
+    ComponentType = cms.string('TrajectoryCleanerBySharedHits'),
+    MissingHitPenalty = cms.double(0.0),
+    ValidHitBonus = cms.double(100.0),
+    allowSharedFirstHit = cms.bool(False),
+    fractionShared = cms.double(0.5)
+)
+hltESPKFUpdator = cms.ESProducer("KFUpdatorESProducer",
+    ComponentName = cms.string('hltESPKFUpdator')
+)
+hltESPBwdElectronPropagator = cms.ESProducer("PropagatorWithMaterialESProducer",
+    ComponentName = cms.string('hltESPBwdElectronPropagator'),
+    Mass = cms.double(0.000511),
+    MaxDPhi = cms.double(1.6),
+    PropagationDirection = cms.string('oppositeToMomentum'),
+    SimpleMagneticField = cms.string(''),
+    ptMin = cms.double(-1.0),
+    useRungeKutta = cms.bool(False)
+)
+
+hltESPFwdElectronPropagator = cms.ESProducer("PropagatorWithMaterialESProducer",
+    ComponentName = cms.string('hltESPFwdElectronPropagator'),
+    Mass = cms.double(0.000511),
+    MaxDPhi = cms.double(1.6),
+    PropagationDirection = cms.string('alongMomentum'),
+    SimpleMagneticField = cms.string(''),
+    ptMin = cms.double(-1.0),
+    useRungeKutta = cms.bool(False)
+)
+
+hltESPGsfTrajectoryFitter = cms.ESProducer("GsfTrajectoryFitterESProducer",
+    ComponentName = cms.string('hltESPGsfTrajectoryFitter'),
+    GeometricalPropagator = cms.string('hltESPAnalyticalPropagator'),
+    MaterialEffectsUpdator = cms.string('hltESPElectronMaterialEffects'),
+    Merger = cms.string('hltESPCloseComponentsMerger5D'),
+    RecoGeometry = cms.string('hltESPGlobalDetLayerGeometry')
+)
+
+hltESPGsfTrajectorySmoother = cms.ESProducer("GsfTrajectorySmootherESProducer",
+    ComponentName = cms.string('hltESPGsfTrajectorySmoother'),
+    ErrorRescaling = cms.double(100.0),
+    GeometricalPropagator = cms.string('hltESPBwdAnalyticalPropagator'),
+    MaterialEffectsUpdator = cms.string('hltESPElectronMaterialEffects'),
+    Merger = cms.string('hltESPCloseComponentsMerger5D'),
+    RecoGeometry = cms.string('hltESPGlobalDetLayerGeometry')
+)
+
+hltESPElectronMaterialEffects = cms.ESProducer("GsfMaterialEffectsESProducer",
+    BetheHeitlerCorrection = cms.int32(2),
+    BetheHeitlerParametrization = cms.string('BetheHeitler_cdfmom_nC6_O5.par'),
+    ComponentName = cms.string('hltESPElectronMaterialEffects'),
+    EnergyLossUpdator = cms.string('GsfBetheHeitlerUpdator'),
+    Mass = cms.double(0.000511),
+    MultipleScatteringUpdator = cms.string('MultipleScatteringUpdator')
+)
+
+hltESPChi2ChargeMeasurementEstimator2000 = cms.ESProducer("Chi2ChargeMeasurementEstimatorESProducer",
+    ComponentName = cms.string('hltESPChi2ChargeMeasurementEstimator2000'),
+    MaxChi2 = cms.double(2000.0),
+    MaxDisplacement = cms.double(100.0),
+    MaxSagitta = cms.double(-1.0),
+    MinPtForHitRecoveryInGluedDet = cms.double(1000000.0),
+    MinimalTolerance = cms.double(10.0),
+    appendToDataLabel = cms.string(''),
+    clusterChargeCut = cms.PSet(
+        refToPSet_ = cms.string('HLTSiStripClusterChargeCutNone')
+    ),
+    nSigma = cms.double(3.0),
+    pTChargeCutThreshold = cms.double(-1.0)
+)
+
+hltTTRBWR = cms.ESProducer("TkTransientTrackingRecHitBuilderESProducer",
+    ComponentName = cms.string('hltESPTTRHBWithTrackAngle'),
+    ComputeCoarseLocalPositionFromDisk = cms.bool(False),
+    Matcher = cms.string('StandardMatcher'),
+    Phase2StripCPE = cms.string('Phase2StripCPE'),
+    PixelCPE = cms.string('PixelCPEGeneric'),
+    StripCPE = cms.string('StripCPEfromTrackAngle')
+)

--- a/RecoEgamma/EgammaTools/interface/HGCalClusterTools.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalClusterTools.h
@@ -1,0 +1,44 @@
+#ifndef RecoEgamma_EgammaTools_HGCalClusterTools_h
+#define RecoEgamma_EgammaTools_HGCalClusterTools_h
+
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include <vector>
+
+class HGCalClusterTools {
+public:
+  enum class EType { ET, ENERGY };
+
+  static float energyInCone(const float eta,
+                            const float phi,
+                            const std::vector<reco::CaloCluster>& layerClusters,
+                            const float minDR,
+                            const float maxDR,
+                            const float minEt,
+                            const float minEnergy,
+                            const std::vector<DetId::Detector>& subDets,
+                            const HGCalClusterTools::EType& eType = EType::ENERGY);
+
+  static float hadEnergyInCone(const float eta,
+                               const float phi,
+                               const std::vector<reco::CaloCluster>& layerClusters,
+                               const float minDR,
+                               const float maxDR,
+                               const float minEt,
+                               const float minEnergy,
+                               const HGCalClusterTools::EType& eType = EType::ENERGY) {
+    return energyInCone(
+        eta, phi, layerClusters, minDR, maxDR, minEt, minEnergy, {DetId::HGCalHSi, DetId::HGCalHSc}, eType);
+  }
+  static float emEnergyInCone(const float eta,
+                              const float phi,
+                              const std::vector<reco::CaloCluster>& layerClusters,
+                              const float minDR,
+                              const float maxDR,
+                              const float minEt,
+                              const float minEnergy,
+                              const HGCalClusterTools::EType& eType = EType::ENERGY) {
+    return energyInCone(eta, phi, layerClusters, minDR, maxDR, minEt, minEnergy, {DetId::HGCalEE}, eType);
+  }
+};
+
+#endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -75,9 +75,13 @@ private:
   std::vector<double> layerEnergies_;
   std::vector<ROOT::Math::XYZVector> layerCentroids_;
 
-  void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &v_recHit);
+  void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits);
 
   void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
+
+public:
+  static constexpr double kLDWaferCellSize_ = 0.698;
+  static constexpr double kHDWaferCellSize_ = 0.465;
 
   void setLayerWiseStuff();
 
@@ -95,21 +99,20 @@ private:
     double sigma2ww;
 
     ShowerWidths() {
-      sigma2xx = 0;
-      sigma2yy = 0;
-      sigma2zz = 0;
+      sigma2xx = 0.0;
+      sigma2yy = 0.0;
+      sigma2zz = 0.0;
 
-      sigma2xy = 0;
-      sigma2yz = 0;
-      sigma2zx = 0;
+      sigma2xy = 0.0;
+      sigma2yz = 0.0;
+      sigma2zx = 0.0;
 
-      sigma2uu = 0;
-      sigma2vv = 0;
-      sigma2ww = 0;
+      sigma2uu = 0.0;
+      sigma2vv = 0.0;
+      sigma2ww = 0.0;
     }
   };
 
-public:
   void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);
 
   void initPerObject(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
@@ -119,13 +122,13 @@ public:
                      int maxLayer = 28,
                      DetId::Detector subDet = DetId::HGCalEE);
 
-  double getCellSize(DetId detId);
+  const double getCellSize(DetId detId);
 
   // Compute Rvar in a cylinder around the layer centroids
-  double getRvar(double cylinderR, double energyNorm, bool useFractions = true, bool useCellSize = true);
+  const double getRvar(double cylinderR, double energyNorm, bool useFractions = true, bool useCellSize = true);
 
   // Compute PCA widths around the layer centroids
-  ShowerWidths getPCAwidths(double cylinderR, bool useFractions = false);
+  const ShowerWidths getPCAWidths(double cylinderR, bool useFractions = false);
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -1,163 +1,131 @@
-# ifndef RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
-# define RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
-
+#ifndef RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
+#define RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
 
 // system include files
 #include <memory>
 
 // user include files
-# include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-# include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-# include "DataFormats/FWLite/interface/ESHandle.h"
-# include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
-# include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-# include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-# include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
-# include "DataFormats/Math/interface/LorentzVector.h"
-# include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-# include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
-# include "DataFormats/TrackReco/interface/Track.h"
-# include "DataFormats/TrackReco/interface/TrackFwd.h"
-# include "FWCore/Framework/interface/Event.h"
-# include "FWCore/Framework/interface/Frameworkfwd.h"
-# include "FWCore/Framework/interface/MakerMacros.h"
-# include "FWCore/Framework/interface/stream/EDProducer.h"
-# include "FWCore/ParameterSet/interface/ParameterSet.h"
-# include "FWCore/Utilities/interface/StreamID.h"
-# include "Geometry/CaloTopology/interface/HGCalTopology.h"
-# include "Geometry/Records/interface/IdealGeometryRecord.h"
-# include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
-# include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/FWLite/interface/ESHandle.h"
+#include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "Geometry/CaloTopology/interface/HGCalTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
-# include <CLHEP/Vector/LorentzVector.h>
+#include <CLHEP/Vector/LorentzVector.h>
 
-# include <algorithm>
-# include <iostream>
-# include <map>
-# include <stdlib.h>
-# include <string>
-# include <type_traits>
-# include <utility>
-# include <vector>
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
-# include <TMatrixD.h>
-# include <TVectorD.h>
+#include <TMatrixD.h>
+#include <TVectorD.h>
 
-# include <Math/Point3D.h>
-# include <Math/Point3Dfwd.h>
+#include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h>
 
+class HGCalShowerShapeHelper {
+private:
+  // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
+  // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
+  // Once intitialized, one can the calculate different variables one after another for a given object.
+  // If a different set of preselections (E, ET, etc.) is required for a given object, then reinitialize using initPerObject(...).
 
+  // In principle should consider the HGCalHSi and HGCalHSc hits (leakage) also.
+  // Can have subdetector dependent thresholds and layer selection.
+  // To be implemented.
 
-class HGCalShowerShapeHelper
-{
-    private :
-    
-    // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
-    // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
-    // Once intitialized, one can the calculate different variables one after another for a given object.
-    // If a different set of preselections (E, ET, etc.) is required for a given object, then reinitialize using initPerObject(...).
-    
-    // In principle should consider the HGCalHSi and HGCalHSc hits (leakage) also.
-    // Can have subdetector dependent thresholds and layer selection.
-    // To be implemented.
-    
-    double minHitE_;
-    double minHitET_;
-    double minHitET2_;
-    int minLayer_;
-    int maxLayer_;
-    int nLayer_;
-    DetId::Detector subDet_;
-    
-    hgcal::RecHitTools recHitTools_;
-    
-    std::unordered_map <uint32_t, const reco::PFRecHit*> pfRecHitPtrMap_;
-    std::vector <std::pair <DetId, float> > hitsAndFracs_;
-    std::vector <double> hitEnergies_;
-    std::vector <double> hitEnergiesWithFracs_;
-    
-    ROOT::Math::XYZVector centroid_;
-    std::vector <double> layerEnergies_;
-    std::vector <ROOT::Math::XYZVector> layerCentroids_;
-    
-    
-    void setPFRecHitPtrMap(
-        const std::vector <reco::PFRecHit> &v_recHit
-    );
-    
-    void setFilteredHitsAndFractions(
-        const std::vector <std::pair <DetId, float> > &hitsAndFracs
-    );
-    
-    void setLayerWiseStuff();
-    
-    
-    struct ShowerWidths
-    {
-        double sigma2xx;
-        double sigma2yy;
-        double sigma2zz;
-        
-        double sigma2xy;
-        double sigma2yz;
-        double sigma2zx;
-        
-        double sigma2uu;
-        double sigma2vv;
-        double sigma2ww;
-        
-        ShowerWidths()
-        {
-            sigma2xx = 0;
-            sigma2yy = 0;
-            sigma2zz = 0;
-            
-            sigma2xy = 0;
-            sigma2yz = 0;
-            sigma2zx = 0;
-            
-            sigma2uu = 0;
-            sigma2vv = 0;
-            sigma2ww = 0;
-        }
-    };
-    
-    
-    public :
-    
-    
-    void initPerEvent(
-        const edm::EventSetup &iSetup,
-        const std::vector <reco::PFRecHit> &recHits
-    );
-    
-    void initPerObject(
-        const std::vector <std::pair <DetId, float> > &hitsAndFracs,
-        double minHitE = 0,
-        double minHitET = 0,
-        int minLayer = 1,
-        int maxLayer = 28,
-        DetId::Detector subDet = DetId::HGCalEE
-    );
-    
-    double getCellSize(
-        DetId detId
-    );
-    
-    // Compute Rvar in a cylinder around the layer centroids
-    double getRvar(
-        double cylinderR,
-        double energyNorm,
-        bool useFractions = true,
-        bool useCellSize = true
-    );
-    
-    // Compute PCA widths around the layer centroids
-    ShowerWidths getPCAwidths(
-        double cylinderR,
-        bool useFractions = false
-    );
+  double minHitE_;
+  double minHitET_;
+  double minHitET2_;
+  int minLayer_;
+  int maxLayer_;
+  int nLayer_;
+  DetId::Detector subDet_;
+
+  hgcal::RecHitTools recHitTools_;
+
+  std::unordered_map<uint32_t, const reco::PFRecHit *> pfRecHitPtrMap_;
+  std::vector<std::pair<DetId, float> > hitsAndFracs_;
+  std::vector<double> hitEnergies_;
+  std::vector<double> hitEnergiesWithFracs_;
+
+  ROOT::Math::XYZVector centroid_;
+  std::vector<double> layerEnergies_;
+  std::vector<ROOT::Math::XYZVector> layerCentroids_;
+
+  void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &v_recHit);
+
+  void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
+
+  void setLayerWiseStuff();
+
+  struct ShowerWidths {
+    double sigma2xx;
+    double sigma2yy;
+    double sigma2zz;
+
+    double sigma2xy;
+    double sigma2yz;
+    double sigma2zx;
+
+    double sigma2uu;
+    double sigma2vv;
+    double sigma2ww;
+
+    ShowerWidths() {
+      sigma2xx = 0;
+      sigma2yy = 0;
+      sigma2zz = 0;
+
+      sigma2xy = 0;
+      sigma2yz = 0;
+      sigma2zx = 0;
+
+      sigma2uu = 0;
+      sigma2vv = 0;
+      sigma2ww = 0;
+    }
+  };
+
+public:
+  void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);
+
+  void initPerObject(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
+                     double minHitE = 0,
+                     double minHitET = 0,
+                     int minLayer = 1,
+                     int maxLayer = 28,
+                     DetId::Detector subDet = DetId::HGCalEE);
+
+  double getCellSize(DetId detId);
+
+  // Compute Rvar in a cylinder around the layer centroids
+  double getRvar(double cylinderR, double energyNorm, bool useFractions = true, bool useCellSize = true);
+
+  // Compute PCA widths around the layer centroids
+  ShowerWidths getPCAwidths(double cylinderR, bool useFractions = false);
 };
 
-
-# endif
+#endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -1,0 +1,163 @@
+# ifndef RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
+# define RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
+
+
+// system include files
+#include <memory>
+
+// user include files
+# include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+# include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+# include "DataFormats/FWLite/interface/ESHandle.h"
+# include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
+# include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+# include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+# include "DataFormats/HGCRecHit/interface/HGCRecHit.h"
+# include "DataFormats/Math/interface/LorentzVector.h"
+# include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+# include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
+# include "DataFormats/TrackReco/interface/Track.h"
+# include "DataFormats/TrackReco/interface/TrackFwd.h"
+# include "FWCore/Framework/interface/Event.h"
+# include "FWCore/Framework/interface/Frameworkfwd.h"
+# include "FWCore/Framework/interface/MakerMacros.h"
+# include "FWCore/Framework/interface/stream/EDProducer.h"
+# include "FWCore/ParameterSet/interface/ParameterSet.h"
+# include "FWCore/Utilities/interface/StreamID.h"
+# include "Geometry/CaloTopology/interface/HGCalTopology.h"
+# include "Geometry/Records/interface/IdealGeometryRecord.h"
+# include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+# include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
+
+# include <CLHEP/Vector/LorentzVector.h>
+
+# include <algorithm>
+# include <iostream>
+# include <map>
+# include <stdlib.h>
+# include <string>
+# include <type_traits>
+# include <utility>
+# include <vector>
+
+# include <TMatrixD.h>
+# include <TVectorD.h>
+
+# include <Math/Point3D.h>
+# include <Math/Point3Dfwd.h>
+
+
+
+class HGCalShowerShapeHelper
+{
+    private :
+    
+    // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
+    // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
+    // Once intitialized, one can the calculate different variables one after another for a given object.
+    // If a different set of preselections (E, ET, etc.) is required for a given object, then reinitialize using initPerObject(...).
+    
+    // In principle should consider the HGCalHSi and HGCalHSc hits (leakage) also.
+    // Can have subdetector dependent thresholds and layer selection.
+    // To be implemented.
+    
+    double minHitE_;
+    double minHitET_;
+    double minHitET2_;
+    int minLayer_;
+    int maxLayer_;
+    int nLayer_;
+    DetId::Detector subDet_;
+    
+    hgcal::RecHitTools recHitTools_;
+    
+    std::unordered_map <uint32_t, const reco::PFRecHit*> pfRecHitPtrMap_;
+    std::vector <std::pair <DetId, float> > hitsAndFracs_;
+    std::vector <double> hitEnergies_;
+    std::vector <double> hitEnergiesWithFracs_;
+    
+    ROOT::Math::XYZVector centroid_;
+    std::vector <double> layerEnergies_;
+    std::vector <ROOT::Math::XYZVector> layerCentroids_;
+    
+    
+    void setPFRecHitPtrMap(
+        const std::vector <reco::PFRecHit> &v_recHit
+    );
+    
+    void setFilteredHitsAndFractions(
+        const std::vector <std::pair <DetId, float> > &hitsAndFracs
+    );
+    
+    void setLayerWiseStuff();
+    
+    
+    struct ShowerWidths
+    {
+        double sigma2xx;
+        double sigma2yy;
+        double sigma2zz;
+        
+        double sigma2xy;
+        double sigma2yz;
+        double sigma2zx;
+        
+        double sigma2uu;
+        double sigma2vv;
+        double sigma2ww;
+        
+        ShowerWidths()
+        {
+            sigma2xx = 0;
+            sigma2yy = 0;
+            sigma2zz = 0;
+            
+            sigma2xy = 0;
+            sigma2yz = 0;
+            sigma2zx = 0;
+            
+            sigma2uu = 0;
+            sigma2vv = 0;
+            sigma2ww = 0;
+        }
+    };
+    
+    
+    public :
+    
+    
+    void initPerEvent(
+        const edm::EventSetup &iSetup,
+        const std::vector <reco::PFRecHit> &recHits
+    );
+    
+    void initPerObject(
+        const std::vector <std::pair <DetId, float> > &hitsAndFracs,
+        double minHitE = 0,
+        double minHitET = 0,
+        int minLayer = 1,
+        int maxLayer = 28,
+        DetId::Detector subDet = DetId::HGCalEE
+    );
+    
+    double getCellSize(
+        DetId detId
+    );
+    
+    // Compute Rvar in a cylinder around the layer centroids
+    double getRvar(
+        double cylinderR,
+        double energyNorm,
+        bool useFractions = true,
+        bool useCellSize = true
+    );
+    
+    // Compute PCA widths around the layer centroids
+    ShowerWidths getPCAwidths(
+        double cylinderR,
+        bool useFractions = false
+    );
+};
+
+
+# endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -98,19 +98,16 @@ public:
     double sigma2vv;
     double sigma2ww;
 
-    ShowerWidths() {
-      sigma2xx = 0.0;
-      sigma2yy = 0.0;
-      sigma2zz = 0.0;
-
-      sigma2xy = 0.0;
-      sigma2yz = 0.0;
-      sigma2zx = 0.0;
-
-      sigma2uu = 0.0;
-      sigma2vv = 0.0;
-      sigma2ww = 0.0;
-    }
+    ShowerWidths()
+        : sigma2xx(0.0),
+          sigma2yy(0.0),
+          sigma2zz(0.0),
+          sigma2xy(0.0),
+          sigma2yz(0.0),
+          sigma2zx(0.0),
+          sigma2uu(0.0),
+          sigma2vv(0.0),
+          sigma2ww(0.0) {}
   };
 
   void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -2,9 +2,24 @@
 #define RecoEgamma_EgammaTools_HGCalShowerShapeHelper_h
 
 // system include files
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
-// user include files
+// external include files
+#include <CLHEP/Vector/LorentzVector.h>
+#include <Math/Point3D.h>
+#include <Math/Point3Dfwd.h>
+#include <TMatrixD.h>
+#include <TVectorD.h>
+
+// CMSSW include files
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/FWLite/interface/ESHandle.h"
@@ -27,23 +42,6 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
-
-#include <CLHEP/Vector/LorentzVector.h>
-
-#include <algorithm>
-#include <cstdlib>
-#include <iostream>
-#include <map>
-#include <string>
-#include <type_traits>
-#include <utility>
-#include <vector>
-
-#include <TMatrixD.h>
-#include <TVectorD.h>
-
-#include <Math/Point3D.h>
-#include <Math/Point3Dfwd.h>
 
 class HGCalShowerShapeHelper {
 private:
@@ -80,8 +78,8 @@ private:
   void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
 
 public:
-  static constexpr double kLDWaferCellSize_ = 0.698;
-  static constexpr double kHDWaferCellSize_ = 0.465;
+  static const double kLDWaferCellSize_;
+  static const double kHDWaferCellSize_;
 
   void setLayerWiseStuff();
 
@@ -116,7 +114,7 @@ public:
                      double minHitE = 0,
                      double minHitET = 0,
                      int minLayer = 1,
-                     int maxLayer = 28,
+                     int maxLayer = -1,
                      DetId::Detector subDet = DetId::HGCalEE);
 
   const double getCellSize(DetId detId);

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -44,7 +44,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
 class HGCalShowerShapeHelper {
-private:
+
   // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
   // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
   // Once intitialized, one can the calculate different variables one after another for a given object.
@@ -53,30 +53,6 @@ private:
   // In principle should consider the HGCalHSi and HGCalHSc hits (leakage) also.
   // Can have subdetector dependent thresholds and layer selection.
   // To be implemented.
-
-  double minHitE_;
-  double minHitET_;
-  double minHitET2_;
-  int minLayer_;
-  int maxLayer_;
-  int nLayer_;
-  DetId::Detector subDet_;
-
-  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
-  hgcal::RecHitTools recHitTools_;
-
-  std::unordered_map<uint32_t, const reco::PFRecHit *> pfRecHitPtrMap_;
-  std::vector<std::pair<DetId, float> > hitsAndFracs_;
-  std::vector<double> hitEnergies_;
-  std::vector<double> hitEnergiesWithFracs_;
-
-  ROOT::Math::XYZVector centroid_;
-  std::vector<double> layerEnergies_;
-  std::vector<ROOT::Math::XYZVector> layerCentroids_;
-
-  void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits);
-
-  void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
 
 public:
   static const double kLDWaferCellSize_;
@@ -109,7 +85,7 @@ public:
           sigma2ww(0.0) {}
   };
 
-  HGCalShowerShapeHelper(edm::ConsumesCollector &sumes);
+  HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes);
 
   void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);
 
@@ -127,6 +103,31 @@ public:
 
   // Compute PCA widths around the layer centroids
   const ShowerWidths getPCAWidths(double cylinderR, bool useFractions = false);
+
+private:
+  void setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits);
+  void setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs);
+
+  double minHitE_;
+  double minHitET_;
+  double minHitET2_;
+  int minLayer_;
+  int maxLayer_;
+  int nLayer_;
+  DetId::Detector subDet_;
+
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+  hgcal::RecHitTools recHitTools_;
+
+  std::unordered_map<uint32_t, const reco::PFRecHit *> pfRecHitPtrMap_;
+  std::vector<std::pair<DetId, float> > hitsAndFracs_;
+  std::vector<double> hitEnergies_;
+  std::vector<double> hitEnergiesWithFracs_;
+
+  ROOT::Math::XYZVector centroid_;
+  std::vector<double> layerEnergies_;
+  std::vector<ROOT::Math::XYZVector> layerCentroids_;
+
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -44,7 +44,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
 class HGCalShowerShapeHelper {
-
   // Good to filter/compute/store this stuff beforehand as they are common to the shower shape variables.
   // No point in filtering, computing layer-wise centroids, etc. for each variable again and again.
   // Once intitialized, one can the calculate different variables one after another for a given object.
@@ -127,7 +126,6 @@ private:
   ROOT::Math::XYZVector centroid_;
   std::vector<double> layerEnergies_;
   std::vector<ROOT::Math::XYZVector> layerCentroids_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
+++ b/RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h
@@ -8,7 +8,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -33,6 +32,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -62,6 +62,7 @@ private:
   int nLayer_;
   DetId::Detector subDet_;
 
+  edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
   hgcal::RecHitTools recHitTools_;
 
   std::unordered_map<uint32_t, const reco::PFRecHit *> pfRecHitPtrMap_;
@@ -81,7 +82,7 @@ public:
   static const double kLDWaferCellSize_;
   static const double kHDWaferCellSize_;
 
-  void setLayerWiseStuff();
+  void setLayerWiseInfo();
 
   struct ShowerWidths {
     double sigma2xx;
@@ -107,6 +108,8 @@ public:
           sigma2vv(0.0),
           sigma2ww(0.0) {}
   };
+
+  HGCalShowerShapeHelper(edm::ConsumesCollector &sumes);
 
   void initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &recHits);
 

--- a/RecoEgamma/EgammaTools/src/HGCalClusterTools.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalClusterTools.cc
@@ -1,0 +1,56 @@
+#include "RecoEgamma/EgammaTools/interface/HGCalClusterTools.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+float HGCalClusterTools::energyInCone(const float eta,
+                                      const float phi,
+                                      const std::vector<reco::CaloCluster>& layerClusters,
+                                      const float minDR,
+                                      const float maxDR,
+                                      const float minEt,
+                                      const float minEnergy,
+                                      const std::vector<DetId::Detector>& subDets,
+                                      const HGCalClusterTools::EType& eType) {
+  float hadValue = 0.;
+
+  const float minDR2 = minDR * minDR;
+  const float maxDR2 = maxDR * maxDR;
+
+  for (auto& clus : layerClusters) {
+    if (clus.energy() < minEnergy) {
+      continue;
+    }
+
+    if (std::find(subDets.begin(), subDets.end(), clus.seed().det()) == subDets.end()) {
+      continue;
+    }
+
+    float clusEt = clus.energy() * std::sin(clus.position().theta());
+    if (clusEt < minEt) {
+      continue;
+    }
+
+    //this is a prefilter on the clusters before we calculuate
+    //the expensive eta() of the cluster
+    float dPhi = reco::deltaPhi(phi, clus.phi());
+    if (dPhi > maxDR) {
+      continue;
+    }
+
+    float dR2 = reco::deltaR2(eta, phi, clus.eta(), clus.phi());
+    if (dR2 < minDR2 || dR2 > maxDR2) {
+      continue;
+    }
+    switch (eType) {
+      case EType::ET:
+        hadValue += clusEt;
+        break;
+      case EType::ENERGY:
+        hadValue += clus.energy();
+        break;
+    }
+  }
+  return hadValue;
+}

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -1,376 +1,310 @@
-# include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
+#include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 
+void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
+  //recHitTools_.getEventSetup(iSetup);
 
-void HGCalShowerShapeHelper::initPerEvent(
-    const edm::EventSetup &iSetup,
-    const std::vector <reco::PFRecHit> &pfRecHits
-)
-{
-    //recHitTools_.getEventSetup(iSetup);
-    
-    edm::ESHandle <CaloGeometry> geom;
-    iSetup.get<CaloGeometryRecord>().get(geom);
-    recHitTools_.setGeometry(*(geom.product()));
-    
-    
-    setPFRecHitPtrMap(pfRecHits);
+  edm::ESHandle<CaloGeometry> geom;
+  iSetup.get<CaloGeometryRecord>().get(geom);
+  recHitTools_.setGeometry(*(geom.product()));
+
+  setPFRecHitPtrMap(pfRecHits);
 }
 
+void HGCalShowerShapeHelper::initPerObject(const std::vector<std::pair<DetId, float> > &hitsAndFracs,
+                                           double minHitE,
+                                           double minHitET,
+                                           int minLayer,
+                                           int maxLayer,
+                                           DetId::Detector subDet) {
+  // Safety checks
+  nLayer_ = maxLayer - minLayer + 1;
+  assert(nLayer_ > 0);
 
-void HGCalShowerShapeHelper::initPerObject(
-    const std::vector <std::pair <DetId, float> > &hitsAndFracs,
-    double minHitE,
-    double minHitET,
-    int minLayer,
-    int maxLayer,
-    DetId::Detector subDet
-)
-{
-    // Safety checks
-    nLayer_ = maxLayer - minLayer + 1;
-    assert(nLayer_ > 0);
-    
-    minHitE_ = minHitE;
-    minHitET_ = minHitET;
-    minHitET2_ = minHitET*minHitET;
-    minLayer_ = minLayer;
-    maxLayer_ = maxLayer;
-    subDet_ = subDet;
-    
-    
-    setFilteredHitsAndFractions(
-        hitsAndFracs
-    );
-    
-    
-    setLayerWiseStuff();
+  minHitE_ = minHitE;
+  minHitET_ = minHitET;
+  minHitET2_ = minHitET * minHitET;
+  minLayer_ = minLayer;
+  maxLayer_ = maxLayer;
+  subDet_ = subDet;
+
+  setFilteredHitsAndFractions(hitsAndFracs);
+
+  setLayerWiseStuff();
 }
 
+void HGCalShowerShapeHelper::setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits) {
+  pfRecHitPtrMap_.clear();
 
-void HGCalShowerShapeHelper::setPFRecHitPtrMap(
-    const std::vector <reco::PFRecHit> &recHits
-)
-{
-    pfRecHitPtrMap_.clear();
-    
-    for(auto &recHit : recHits)
-    {
-        pfRecHitPtrMap_[recHit.detId()] = &recHit;
-    }
+  for (auto &recHit : recHits) {
+    pfRecHitPtrMap_[recHit.detId()] = &recHit;
+  }
 }
 
+void HGCalShowerShapeHelper::setFilteredHitsAndFractions(const std::vector<std::pair<DetId, float> > &hitsAndFracs) {
+  hitsAndFracs_.clear();
+  hitEnergies_.clear();
+  hitEnergiesWithFracs_.clear();
 
-void HGCalShowerShapeHelper::setFilteredHitsAndFractions(
-    const std::vector <std::pair <DetId, float> > &hitsAndFracs
-)
-{
-    hitsAndFracs_.clear();
-    hitEnergies_.clear();
-    hitEnergiesWithFracs_.clear();
-    
-    for(const auto &hnf : hitsAndFracs)
-    {
-        DetId hitId = hnf.first;
-        float hitEfrac = hnf.second;
-        
-        int hitLayer = recHitTools_.getLayer(hitId);
-        
-        if(hitLayer > nLayer_)
-        {
-            continue;
-        }
-        
-        if(hitId.det() != subDet_)
-        {
-            continue;
-        }
-        
-        if(pfRecHitPtrMap_.find(hitId.rawId()) == pfRecHitPtrMap_.end())
-        {
-            continue;
-        }
-        
-        reco::PFRecHit recHit = *pfRecHitPtrMap_[hitId.rawId()];
-        
-        if(recHit.energy() < minHitE_)
-        {
-            continue;
-        }
-        
-        if(recHit.pt2() < minHitET2_)
-        {
-            continue;
-        }
-        
-        // Fill the vectors
-        hitsAndFracs_.push_back(hnf);
-        hitEnergies_.push_back(recHit.energy());
-        hitEnergiesWithFracs_.push_back(recHit.energy()*hitEfrac);
+  for (const auto &hnf : hitsAndFracs) {
+    DetId hitId = hnf.first;
+    float hitEfrac = hnf.second;
+
+    int hitLayer = recHitTools_.getLayer(hitId);
+
+    if (hitLayer > nLayer_) {
+      continue;
     }
+
+    if (hitId.det() != subDet_) {
+      continue;
+    }
+
+    if (pfRecHitPtrMap_.find(hitId.rawId()) == pfRecHitPtrMap_.end()) {
+      continue;
+    }
+
+    reco::PFRecHit recHit = *pfRecHitPtrMap_[hitId.rawId()];
+
+    if (recHit.energy() < minHitE_) {
+      continue;
+    }
+
+    if (recHit.pt2() < minHitET2_) {
+      continue;
+    }
+
+    // Fill the vectors
+    hitsAndFracs_.push_back(hnf);
+    hitEnergies_.push_back(recHit.energy());
+    hitEnergiesWithFracs_.push_back(recHit.energy() * hitEfrac);
+  }
 }
 
+void HGCalShowerShapeHelper::setLayerWiseStuff() {
+  layerEnergies_.clear();
+  layerEnergies_.resize(nLayer_);
 
-void HGCalShowerShapeHelper::setLayerWiseStuff()
-{
-    layerEnergies_.clear();
-    layerEnergies_.resize(nLayer_);
-    
-    layerCentroids_.clear();
-    layerCentroids_.resize(nLayer_);
-    
-    centroid_.SetXYZ(0, 0, 0);
-    
-    int iHit = -1;
-    double totalW = 0;
-    
-    // Compute the centroid per layer
-    for(const auto &hnf : hitsAndFracs_)
-    {
-        iHit++;
-        
-        DetId hitId = hnf.first;
-        
-        double weight = hitEnergies_[iHit];
-        totalW += weight;
-        
-        const auto &hitPos = recHitTools_.getPosition(hitId);
-        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
-        
-        centroid_ += weight * hitXYZ;
-        
-        int hitLayer = recHitTools_.getLayer(hitId) - 1;
-        
-        layerEnergies_[hitLayer] += weight;
-        layerCentroids_[hitLayer] += weight * hitXYZ;
+  layerCentroids_.clear();
+  layerCentroids_.resize(nLayer_);
+
+  centroid_.SetXYZ(0, 0, 0);
+
+  int iHit = -1;
+  double totalW = 0;
+
+  // Compute the centroid per layer
+  for (const auto &hnf : hitsAndFracs_) {
+    iHit++;
+
+    DetId hitId = hnf.first;
+
+    double weight = hitEnergies_[iHit];
+    totalW += weight;
+
+    const auto &hitPos = recHitTools_.getPosition(hitId);
+    ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+
+    centroid_ += weight * hitXYZ;
+
+    int hitLayer = recHitTools_.getLayer(hitId) - 1;
+
+    layerEnergies_[hitLayer] += weight;
+    layerCentroids_[hitLayer] += weight * hitXYZ;
+  }
+
+  int iLayer = -1;
+
+  for (auto &centroid : layerCentroids_) {
+    iLayer++;
+
+    if (layerEnergies_[iLayer]) {
+      centroid /= layerEnergies_[iLayer];
     }
-    
-    int iLayer = -1;
-    
-    for(auto &centroid : layerCentroids_)
-    {
-        iLayer++;
-        
-        if(layerEnergies_[iLayer])
-        {
-            centroid /= layerEnergies_[iLayer];
-        }
-    }
-    
-    if(totalW)
-    {
-        centroid_ /= totalW;
-    }
+  }
+
+  if (totalW) {
+    centroid_ /= totalW;
+  }
 }
 
+double HGCalShowerShapeHelper::getCellSize(DetId detId) {
+  double siThickness = recHitTools_.getSiThickness(detId);
 
-double HGCalShowerShapeHelper::getCellSize(DetId detId)
-{
-    double siThickness = recHitTools_.getSiThickness(detId);
-    
-    // HD wafers
-    if(siThickness < 150)
-    {
-        return 0.465;
-    }
-    
-    // LD wafers
-    else
-    {
-        return 0.698;
-    }
+  // HD wafers
+  if (siThickness < 150) {
+    return 0.465;
+  }
+
+  // LD wafers
+  else {
+    return 0.698;
+  }
 }
 
+double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm, bool useFractions, bool useCellSize) {
+  if (hitsAndFracs_.empty()) {
+    return 0;
+  }
 
-double HGCalShowerShapeHelper::getRvar(
-    double cylinderR,
-    double energyNorm,
-    bool useFractions,
-    bool useCellSize
-)
-{
-    if(hitsAndFracs_.empty())
-    {
-        return 0;
+  assert(energyNorm > 0);
+
+  double cylinderR2 = cylinderR * cylinderR;
+
+  double Rvar = 0;
+
+  std::vector<double>::iterator hitEnergyIter;
+
+  if (useFractions) {
+    hitEnergyIter = hitEnergiesWithFracs_.begin();
+  }
+
+  else {
+    hitEnergyIter = hitEnergies_.begin();
+  }
+
+  hitEnergyIter--;
+
+  for (const auto &hnf : hitsAndFracs_) {
+    hitEnergyIter++;
+
+    DetId hitId = hnf.first;
+
+    int hitLayer = recHitTools_.getLayer(hitId) - 1;
+
+    const auto &hitPos = recHitTools_.getPosition(hitId);
+    ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+
+    auto distXYZ = hitXYZ - layerCentroids_[hitLayer];
+
+    double r2 = distXYZ.x() * distXYZ.x() + distXYZ.y() * distXYZ.y();
+
+    // Including the cell size seems to make the variable less sensitive to the HD/LD transition region
+    if (useCellSize) {
+      if (sqrt(r2) > cylinderR + getCellSize(hitId)) {
+        continue;
+      }
     }
-    
-    assert(energyNorm > 0);
-    
-    double cylinderR2 = cylinderR*cylinderR;
-    
-    double Rvar = 0;
-    
-    std::vector <double>::iterator hitEnergyIter;
-    
-    if(useFractions)
-    {
-        hitEnergyIter = hitEnergiesWithFracs_.begin();
+
+    else {
+      if (r2 > cylinderR2) {
+        continue;
+      }
     }
-    
-    else
-    {
-        hitEnergyIter = hitEnergies_.begin();
-    }
-    
-    hitEnergyIter--;
-    
-    for(const auto &hnf : hitsAndFracs_)
-    {
-        hitEnergyIter++;
-        
-        DetId hitId = hnf.first;
-        
-        int hitLayer = recHitTools_.getLayer(hitId) - 1;
-        
-        const auto &hitPos = recHitTools_.getPosition(hitId);
-        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
-        
-        auto distXYZ = hitXYZ - layerCentroids_[hitLayer];
-        
-        double r2 = distXYZ.x()*distXYZ.x() + distXYZ.y()*distXYZ.y();
-        
-        // Including the cell size seems to make the variable less sensitive to the HD/LD transition region
-        if(useCellSize)
-        {
-            if(sqrt(r2) > cylinderR+getCellSize(hitId))
-            {
-                continue;
-            }
-        }
-        
-        else
-        {
-            if(r2 > cylinderR2)
-            {
-                continue;
-            }
-        }
-        
-        Rvar += *hitEnergyIter;
-    }
-    
-    Rvar /= energyNorm;
-    
-    
-    return Rvar;
+
+    Rvar += *hitEnergyIter;
+  }
+
+  Rvar /= energyNorm;
+
+  return Rvar;
 }
 
+HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAwidths(double cylinderR, bool useFractions) {
+  if (hitsAndFracs_.empty()) {
+    return ShowerWidths();
+  }
 
-HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAwidths(
-    double cylinderR,
-    bool useFractions
-)
-{
-    if(hitsAndFracs_.empty())
-    {
-        return ShowerWidths();
-    }
-    
-    double cylinderR2 = cylinderR*cylinderR;
-    
-    TMatrixD covMat(3, 3);
-    
-    double dxdx = 0;
-    double dydy = 0;
-    double dzdz = 0;
+  double cylinderR2 = cylinderR * cylinderR;
 
-    double dxdy = 0;
-    double dydz = 0;
-    double dzdx = 0;
-    
-    double totalW = 0;
-    
-    std::vector <double>::iterator hitEnergyIter;
-    
-    if(useFractions)
-    {
-        hitEnergyIter = hitEnergiesWithFracs_.begin();
+  TMatrixD covMat(3, 3);
+
+  double dxdx = 0;
+  double dydy = 0;
+  double dzdz = 0;
+
+  double dxdy = 0;
+  double dydz = 0;
+  double dzdx = 0;
+
+  double totalW = 0;
+
+  std::vector<double>::iterator hitEnergyIter;
+
+  if (useFractions) {
+    hitEnergyIter = hitEnergiesWithFracs_.begin();
+  }
+
+  else {
+    hitEnergyIter = hitEnergies_.begin();
+  }
+
+  int nHit = 0;
+
+  hitEnergyIter--;
+
+  for (const auto &hnf : hitsAndFracs_) {
+    hitEnergyIter++;
+
+    DetId hitId = hnf.first;
+
+    const auto &hitPos = recHitTools_.getPosition(hitId);
+    ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+
+    int hitLayer = recHitTools_.getLayer(hitId) - 1;
+
+    ROOT::Math::XYZVector radXYZ = hitXYZ - layerCentroids_[hitLayer];
+
+    double r2 = radXYZ.x() * radXYZ.x() + radXYZ.y() * radXYZ.y();
+
+    if (r2 > cylinderR2) {
+      continue;
     }
-    
-    else
-    {
-        hitEnergyIter = hitEnergies_.begin();
-    }
-    
-    int nHit = 0;
-    
-    hitEnergyIter--;
-    
-    for(const auto &hnf : hitsAndFracs_)
-    {
-        hitEnergyIter++;
-        
-        DetId hitId = hnf.first;
-        
-        const auto &hitPos = recHitTools_.getPosition(hitId);
-        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
-        
-        int hitLayer = recHitTools_.getLayer(hitId) - 1;
-        
-        ROOT::Math::XYZVector radXYZ = hitXYZ - layerCentroids_[hitLayer];
-        
-        double r2 = radXYZ.x()*radXYZ.x() + radXYZ.y()*radXYZ.y();
-        
-        if(r2 > cylinderR2)
-        {
-            continue;
-        }
-        
-        ROOT::Math::XYZVector dXYZ = hitXYZ - centroid_;
-        
-        double weight = *hitEnergyIter;
-        totalW += weight;
-        
-        dxdx += weight * dXYZ.x() * dXYZ.x();
-        dydy += weight * dXYZ.y() * dXYZ.y();
-        dzdz += weight * dXYZ.z() * dXYZ.z();
-        
-        dxdy += weight * dXYZ.x() * dXYZ.y();
-        dydz += weight * dXYZ.y() * dXYZ.z();
-        dzdx += weight * dXYZ.z() * dXYZ.x();
-        
-        nHit++;
-    }
-    
-    if(!totalW || nHit < 2)
-    {
-        return ShowerWidths();
-    }
-    
-    dxdx /= totalW;
-    dydy /= totalW;
-    dzdz /= totalW;
-    
-    dxdy /= totalW;
-    dydz /= totalW;
-    dzdx /= totalW;
-    
-    covMat(0, 0) = dxdx;
-    covMat(1, 1) = dydy;
-    covMat(2, 2) = dzdz;
-    
-    covMat(0, 1) = covMat(1, 0) = dxdy;
-    covMat(0, 2) = covMat(2, 0) = dzdx;
-    covMat(1, 2) = covMat(2, 1) = dydz;
-    
-    // Get eigen values and vectors
-    TVectorD eigVals(3);
-    TMatrixD eigVecMat(3, 3);
-    
-    eigVecMat = covMat.EigenVectors(eigVals);
-    
-    ShowerWidths returnWidths;
-    
-    returnWidths.sigma2xx = dxdx;
-    returnWidths.sigma2yy = dydy;
-    returnWidths.sigma2zz = dzdz;
-    
-    returnWidths.sigma2xy = dxdy;
-    returnWidths.sigma2yz = dydz;
-    returnWidths.sigma2zx = dzdx;
-    
-    returnWidths.sigma2uu = eigVals(1);
-    returnWidths.sigma2vv = eigVals(2);
-    returnWidths.sigma2ww = eigVals(0);
-    
-    return returnWidths;
+
+    ROOT::Math::XYZVector dXYZ = hitXYZ - centroid_;
+
+    double weight = *hitEnergyIter;
+    totalW += weight;
+
+    dxdx += weight * dXYZ.x() * dXYZ.x();
+    dydy += weight * dXYZ.y() * dXYZ.y();
+    dzdz += weight * dXYZ.z() * dXYZ.z();
+
+    dxdy += weight * dXYZ.x() * dXYZ.y();
+    dydz += weight * dXYZ.y() * dXYZ.z();
+    dzdx += weight * dXYZ.z() * dXYZ.x();
+
+    nHit++;
+  }
+
+  if (!totalW || nHit < 2) {
+    return ShowerWidths();
+  }
+
+  dxdx /= totalW;
+  dydy /= totalW;
+  dzdz /= totalW;
+
+  dxdy /= totalW;
+  dydz /= totalW;
+  dzdx /= totalW;
+
+  covMat(0, 0) = dxdx;
+  covMat(1, 1) = dydy;
+  covMat(2, 2) = dzdz;
+
+  covMat(0, 1) = covMat(1, 0) = dxdy;
+  covMat(0, 2) = covMat(2, 0) = dzdx;
+  covMat(1, 2) = covMat(2, 1) = dydz;
+
+  // Get eigen values and vectors
+  TVectorD eigVals(3);
+  TMatrixD eigVecMat(3, 3);
+
+  eigVecMat = covMat.EigenVectors(eigVals);
+
+  ShowerWidths returnWidths;
+
+  returnWidths.sigma2xx = dxdx;
+  returnWidths.sigma2yy = dydy;
+  returnWidths.sigma2zz = dzdz;
+
+  returnWidths.sigma2xy = dxdy;
+  returnWidths.sigma2yz = dydz;
+  returnWidths.sigma2zx = dzdx;
+
+  returnWidths.sigma2uu = eigVals(1);
+  returnWidths.sigma2vv = eigVals(2);
+  returnWidths.sigma2ww = eigVals(0);
+
+  return returnWidths;
 }

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -136,7 +136,10 @@ const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm
     return 0;
   }
 
-  assert(energyNorm > 0);
+  if (energyNorm <= 0) {
+    edm::LogWarning("HGCalShowerShapeHelper")
+        << "Encountered negative or zero energy for HGCal R-variable denomintor: " << energyNorm << std::endl;
+  }
 
   double cylinderR2 = cylinderR * cylinderR;
 

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -1,0 +1,376 @@
+# include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
+
+
+void HGCalShowerShapeHelper::initPerEvent(
+    const edm::EventSetup &iSetup,
+    const std::vector <reco::PFRecHit> &pfRecHits
+)
+{
+    //recHitTools_.getEventSetup(iSetup);
+    
+    edm::ESHandle <CaloGeometry> geom;
+    iSetup.get<CaloGeometryRecord>().get(geom);
+    recHitTools_.setGeometry(*(geom.product()));
+    
+    
+    setPFRecHitPtrMap(pfRecHits);
+}
+
+
+void HGCalShowerShapeHelper::initPerObject(
+    const std::vector <std::pair <DetId, float> > &hitsAndFracs,
+    double minHitE,
+    double minHitET,
+    int minLayer,
+    int maxLayer,
+    DetId::Detector subDet
+)
+{
+    // Safety checks
+    nLayer_ = maxLayer - minLayer + 1;
+    assert(nLayer_ > 0);
+    
+    minHitE_ = minHitE;
+    minHitET_ = minHitET;
+    minHitET2_ = minHitET*minHitET;
+    minLayer_ = minLayer;
+    maxLayer_ = maxLayer;
+    subDet_ = subDet;
+    
+    
+    setFilteredHitsAndFractions(
+        hitsAndFracs
+    );
+    
+    
+    setLayerWiseStuff();
+}
+
+
+void HGCalShowerShapeHelper::setPFRecHitPtrMap(
+    const std::vector <reco::PFRecHit> &recHits
+)
+{
+    pfRecHitPtrMap_.clear();
+    
+    for(auto &recHit : recHits)
+    {
+        pfRecHitPtrMap_[recHit.detId()] = &recHit;
+    }
+}
+
+
+void HGCalShowerShapeHelper::setFilteredHitsAndFractions(
+    const std::vector <std::pair <DetId, float> > &hitsAndFracs
+)
+{
+    hitsAndFracs_.clear();
+    hitEnergies_.clear();
+    hitEnergiesWithFracs_.clear();
+    
+    for(const auto &hnf : hitsAndFracs)
+    {
+        DetId hitId = hnf.first;
+        float hitEfrac = hnf.second;
+        
+        int hitLayer = recHitTools_.getLayer(hitId);
+        
+        if(hitLayer > nLayer_)
+        {
+            continue;
+        }
+        
+        if(hitId.det() != subDet_)
+        {
+            continue;
+        }
+        
+        if(pfRecHitPtrMap_.find(hitId.rawId()) == pfRecHitPtrMap_.end())
+        {
+            continue;
+        }
+        
+        reco::PFRecHit recHit = *pfRecHitPtrMap_[hitId.rawId()];
+        
+        if(recHit.energy() < minHitE_)
+        {
+            continue;
+        }
+        
+        if(recHit.pt2() < minHitET2_)
+        {
+            continue;
+        }
+        
+        // Fill the vectors
+        hitsAndFracs_.push_back(hnf);
+        hitEnergies_.push_back(recHit.energy());
+        hitEnergiesWithFracs_.push_back(recHit.energy()*hitEfrac);
+    }
+}
+
+
+void HGCalShowerShapeHelper::setLayerWiseStuff()
+{
+    layerEnergies_.clear();
+    layerEnergies_.resize(nLayer_);
+    
+    layerCentroids_.clear();
+    layerCentroids_.resize(nLayer_);
+    
+    centroid_.SetXYZ(0, 0, 0);
+    
+    int iHit = -1;
+    double totalW = 0;
+    
+    // Compute the centroid per layer
+    for(const auto &hnf : hitsAndFracs_)
+    {
+        iHit++;
+        
+        DetId hitId = hnf.first;
+        
+        double weight = hitEnergies_[iHit];
+        totalW += weight;
+        
+        const auto &hitPos = recHitTools_.getPosition(hitId);
+        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+        
+        centroid_ += weight * hitXYZ;
+        
+        int hitLayer = recHitTools_.getLayer(hitId) - 1;
+        
+        layerEnergies_[hitLayer] += weight;
+        layerCentroids_[hitLayer] += weight * hitXYZ;
+    }
+    
+    int iLayer = -1;
+    
+    for(auto &centroid : layerCentroids_)
+    {
+        iLayer++;
+        
+        if(layerEnergies_[iLayer])
+        {
+            centroid /= layerEnergies_[iLayer];
+        }
+    }
+    
+    if(totalW)
+    {
+        centroid_ /= totalW;
+    }
+}
+
+
+double HGCalShowerShapeHelper::getCellSize(DetId detId)
+{
+    double siThickness = recHitTools_.getSiThickness(detId);
+    
+    // HD wafers
+    if(siThickness < 150)
+    {
+        return 0.465;
+    }
+    
+    // LD wafers
+    else
+    {
+        return 0.698;
+    }
+}
+
+
+double HGCalShowerShapeHelper::getRvar(
+    double cylinderR,
+    double energyNorm,
+    bool useFractions,
+    bool useCellSize
+)
+{
+    if(hitsAndFracs_.empty())
+    {
+        return 0;
+    }
+    
+    assert(energyNorm > 0);
+    
+    double cylinderR2 = cylinderR*cylinderR;
+    
+    double Rvar = 0;
+    
+    std::vector <double>::iterator hitEnergyIter;
+    
+    if(useFractions)
+    {
+        hitEnergyIter = hitEnergiesWithFracs_.begin();
+    }
+    
+    else
+    {
+        hitEnergyIter = hitEnergies_.begin();
+    }
+    
+    hitEnergyIter--;
+    
+    for(const auto &hnf : hitsAndFracs_)
+    {
+        hitEnergyIter++;
+        
+        DetId hitId = hnf.first;
+        
+        int hitLayer = recHitTools_.getLayer(hitId) - 1;
+        
+        const auto &hitPos = recHitTools_.getPosition(hitId);
+        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+        
+        auto distXYZ = hitXYZ - layerCentroids_[hitLayer];
+        
+        double r2 = distXYZ.x()*distXYZ.x() + distXYZ.y()*distXYZ.y();
+        
+        // Including the cell size seems to make the variable less sensitive to the HD/LD transition region
+        if(useCellSize)
+        {
+            if(sqrt(r2) > cylinderR+getCellSize(hitId))
+            {
+                continue;
+            }
+        }
+        
+        else
+        {
+            if(r2 > cylinderR2)
+            {
+                continue;
+            }
+        }
+        
+        Rvar += *hitEnergyIter;
+    }
+    
+    Rvar /= energyNorm;
+    
+    
+    return Rvar;
+}
+
+
+HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAwidths(
+    double cylinderR,
+    bool useFractions
+)
+{
+    if(hitsAndFracs_.empty())
+    {
+        return ShowerWidths();
+    }
+    
+    double cylinderR2 = cylinderR*cylinderR;
+    
+    TMatrixD covMat(3, 3);
+    
+    double dxdx = 0;
+    double dydy = 0;
+    double dzdz = 0;
+
+    double dxdy = 0;
+    double dydz = 0;
+    double dzdx = 0;
+    
+    double totalW = 0;
+    
+    std::vector <double>::iterator hitEnergyIter;
+    
+    if(useFractions)
+    {
+        hitEnergyIter = hitEnergiesWithFracs_.begin();
+    }
+    
+    else
+    {
+        hitEnergyIter = hitEnergies_.begin();
+    }
+    
+    int nHit = 0;
+    
+    hitEnergyIter--;
+    
+    for(const auto &hnf : hitsAndFracs_)
+    {
+        hitEnergyIter++;
+        
+        DetId hitId = hnf.first;
+        
+        const auto &hitPos = recHitTools_.getPosition(hitId);
+        ROOT::Math::XYZVector hitXYZ(hitPos.x(), hitPos.y(), hitPos.z());
+        
+        int hitLayer = recHitTools_.getLayer(hitId) - 1;
+        
+        ROOT::Math::XYZVector radXYZ = hitXYZ - layerCentroids_[hitLayer];
+        
+        double r2 = radXYZ.x()*radXYZ.x() + radXYZ.y()*radXYZ.y();
+        
+        if(r2 > cylinderR2)
+        {
+            continue;
+        }
+        
+        ROOT::Math::XYZVector dXYZ = hitXYZ - centroid_;
+        
+        double weight = *hitEnergyIter;
+        totalW += weight;
+        
+        dxdx += weight * dXYZ.x() * dXYZ.x();
+        dydy += weight * dXYZ.y() * dXYZ.y();
+        dzdz += weight * dXYZ.z() * dXYZ.z();
+        
+        dxdy += weight * dXYZ.x() * dXYZ.y();
+        dydz += weight * dXYZ.y() * dXYZ.z();
+        dzdx += weight * dXYZ.z() * dXYZ.x();
+        
+        nHit++;
+    }
+    
+    if(!totalW || nHit < 2)
+    {
+        return ShowerWidths();
+    }
+    
+    dxdx /= totalW;
+    dydy /= totalW;
+    dzdz /= totalW;
+    
+    dxdy /= totalW;
+    dydz /= totalW;
+    dzdx /= totalW;
+    
+    covMat(0, 0) = dxdx;
+    covMat(1, 1) = dydy;
+    covMat(2, 2) = dzdz;
+    
+    covMat(0, 1) = covMat(1, 0) = dxdy;
+    covMat(0, 2) = covMat(2, 0) = dzdx;
+    covMat(1, 2) = covMat(2, 1) = dydz;
+    
+    // Get eigen values and vectors
+    TVectorD eigVals(3);
+    TMatrixD eigVecMat(3, 3);
+    
+    eigVecMat = covMat.EigenVectors(eigVals);
+    
+    ShowerWidths returnWidths;
+    
+    returnWidths.sigma2xx = dxdx;
+    returnWidths.sigma2yy = dydy;
+    returnWidths.sigma2zz = dzdz;
+    
+    returnWidths.sigma2xy = dxdy;
+    returnWidths.sigma2yz = dydz;
+    returnWidths.sigma2zx = dzdx;
+    
+    returnWidths.sigma2uu = eigVals(1);
+    returnWidths.sigma2vv = eigVals(2);
+    returnWidths.sigma2ww = eigVals(0);
+    
+    return returnWidths;
+}

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -1,5 +1,8 @@
 #include "RecoEgamma/EgammaTools/interface/HGCalShowerShapeHelper.h"
 
+const double HGCalShowerShapeHelper::kLDWaferCellSize_ = 0.698;
+const double HGCalShowerShapeHelper::kHDWaferCellSize_ = 0.465;
+
 void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
   edm::ESHandle<CaloGeometry> geom;
   iSetup.get<CaloGeometryRecord>().get(geom);
@@ -14,6 +17,8 @@ void HGCalShowerShapeHelper::initPerObject(const std::vector<std::pair<DetId, fl
                                            int minLayer,
                                            int maxLayer,
                                            DetId::Detector subDet) {
+  maxLayer = maxLayer <= 0 ? recHitTools_.lastLayerEE() : maxLayer;
+
   // Safety checks
   nLayer_ = maxLayer - minLayer + 1;
   assert(nLayer_ > 0);
@@ -126,9 +131,7 @@ void HGCalShowerShapeHelper::setLayerWiseStuff() {
 }
 
 const double HGCalShowerShapeHelper::getCellSize(DetId detId) {
-  double siThickness = recHitTools_.getSiThickness(detId);
-
-  return siThickness < 150 ? kHDWaferCellSize_ : kLDWaferCellSize_;
+  return recHitTools_.getSiThickIndex(detId) == 0 ? kHDWaferCellSize_ : kLDWaferCellSize_;
 }
 
 const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm, bool useFractions, bool useCellSize) {

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -146,7 +146,7 @@ const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm
 
   double cylinderR2 = cylinderR * cylinderR;
 
-  double Rvar = 0.0;
+  double rVar = 0.0;
 
   auto hitEnergyIter = useFractions ? hitEnergiesWithFracs_.begin() : hitEnergies_.begin();
 
@@ -177,12 +177,12 @@ const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm
       continue;
     }
 
-    Rvar += *hitEnergyIter;
+    rVar += *hitEnergyIter;
   }
 
-  Rvar /= energyNorm;
+  rVar /= energyNorm;
 
-  return Rvar;
+  return rVar;
 }
 
 const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(double cylinderR, bool useFractions) {

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -3,7 +3,7 @@
 const double HGCalShowerShapeHelper::kLDWaferCellSize_ = 0.698;
 const double HGCalShowerShapeHelper::kHDWaferCellSize_ = 0.465;
 
-HGCalShowerShapeHelper::HGCalShowerShapeHelper(edm::ConsumesCollector &sumes)
+HGCalShowerShapeHelper::HGCalShowerShapeHelper(edm::ConsumesCollector &&sumes)
     : caloGeometryToken_{sumes.esConsumes()} {}
 
 void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -263,6 +263,10 @@ const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(
   covMat(0, 2) = covMat(2, 0) = dzdx;
   covMat(1, 2) = covMat(2, 1) = dydz;
 
+  if (!covMat.Sum()) {
+    return ShowerWidths();
+  }
+
   // Get eigen values and vectors
   TVectorD eigVals(3);
   TMatrixD eigVecMat(3, 3);

--- a/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
+++ b/RecoEgamma/EgammaTools/src/HGCalShowerShapeHelper.cc
@@ -3,11 +3,11 @@
 const double HGCalShowerShapeHelper::kLDWaferCellSize_ = 0.698;
 const double HGCalShowerShapeHelper::kHDWaferCellSize_ = 0.465;
 
-void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
-  edm::ESHandle<CaloGeometry> geom;
-  iSetup.get<CaloGeometryRecord>().get(geom);
-  recHitTools_.setGeometry(*(geom.product()));
+HGCalShowerShapeHelper::HGCalShowerShapeHelper(edm::ConsumesCollector &sumes)
+    : caloGeometryToken_{sumes.esConsumes()} {}
 
+void HGCalShowerShapeHelper::initPerEvent(const edm::EventSetup &iSetup, const std::vector<reco::PFRecHit> &pfRecHits) {
+  recHitTools_.setGeometry(iSetup.getData(caloGeometryToken_));
   setPFRecHitPtrMap(pfRecHits);
 }
 
@@ -32,7 +32,7 @@ void HGCalShowerShapeHelper::initPerObject(const std::vector<std::pair<DetId, fl
 
   setFilteredHitsAndFractions(hitsAndFracs);
 
-  setLayerWiseStuff();
+  setLayerWiseInfo();
 }
 
 void HGCalShowerShapeHelper::setPFRecHitPtrMap(const std::vector<reco::PFRecHit> &recHits) {
@@ -66,7 +66,7 @@ void HGCalShowerShapeHelper::setFilteredHitsAndFractions(const std::vector<std::
       continue;
     }
 
-    reco::PFRecHit recHit = *pfRecHitPtrMap_[hitId.rawId()];
+    const reco::PFRecHit &recHit = *pfRecHitPtrMap_[hitId.rawId()];
 
     if (recHit.energy() < minHitE_) {
       continue;
@@ -83,7 +83,7 @@ void HGCalShowerShapeHelper::setFilteredHitsAndFractions(const std::vector<std::
   }
 }
 
-void HGCalShowerShapeHelper::setLayerWiseStuff() {
+void HGCalShowerShapeHelper::setLayerWiseInfo() {
   layerEnergies_.clear();
   layerEnergies_.resize(nLayer_);
 
@@ -136,17 +136,17 @@ const double HGCalShowerShapeHelper::getCellSize(DetId detId) {
 
 const double HGCalShowerShapeHelper::getRvar(double cylinderR, double energyNorm, bool useFractions, bool useCellSize) {
   if (hitsAndFracs_.empty()) {
-    return 0;
+    return 0.0;
   }
 
-  if (energyNorm <= 0) {
+  if (energyNorm <= 0.0) {
     edm::LogWarning("HGCalShowerShapeHelper")
-        << "Encountered negative or zero energy for HGCal R-variable denomintor: " << energyNorm << std::endl;
+        << "Encountered negative or zero energy for HGCal R-variable denominator: " << energyNorm << std::endl;
   }
 
   double cylinderR2 = cylinderR * cylinderR;
 
-  double Rvar = 0;
+  double Rvar = 0.0;
 
   auto hitEnergyIter = useFractions ? hitEnergiesWithFracs_.begin() : hitEnergies_.begin();
 
@@ -202,7 +202,7 @@ const HGCalShowerShapeHelper::ShowerWidths HGCalShowerShapeHelper::getPCAWidths(
   double dydz = 0.0;
   double dzdx = 0.0;
 
-  double totalW = 0;
+  double totalW = 0.0;
 
   auto hitEnergyIter = useFractions ? hitEnergiesWithFracs_.begin() : hitEnergies_.begin();
 


### PR DESCRIPTION
#### PR description:

This PR adds the following tools/producers for HGCal egamma:
1. HGCalShowerShapeHelper (calculates shower shape variables like shower widths)
2. HGCalClusterTools (calculates isolation quantities using HGCal layer-clusters)
3. HGCalID variable producer (ID variable producer required for egamma HLT)

Backport PR for 11_1_x: #32517 
Backport PR for 11_2_x: #32520

Test config:
```
cmsDriver.py hltTest --python_filename egHLTPhaseIITest_cfg.py --eventcontent AODSIM --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring --step RAW2DIGI,RECO --datatier AODSIM  --conditions auto:phase2_realistic_T15 --geometry Extended2026D49 --nThreads 4 --filein /store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/DoubleElectron_FlatPt-1To100/GEN-SIM-DIGI-RAW-MINIAOD/PU200_111X_mcRun4_realistic_T15_v1-v2/280000/1B09CC5D-FAA3-5442-BE7B-96302835E860.root --era Phase2C9 --no_exec --mc --customise_commands "process.load('RecoEgamma.EgammaHLTProducers.HLTEgPhaseIITestSequence_cff');process.HLT_EgPhaseIITest_v1 = cms.Path(process.HLTEgPhaseIITestSequence);process.schedule.append(process.HLT_EgPhaseIITest_v1);process.AODSIMoutput.outputCommands.extend(['keep recoEcalCandidates*_*_*_*','keep recoRecoEcalCandidatesToValuefloatAssociation_*_*_*'])" -n 12 --processName=RECO2
```

Shower-shape variables studies:
https://indico.cern.ch/event/879938/contributions/4128109/attachments/2153463/3631734/presentation_20201201_EGammaGeneral.pdf#page=31

Isolation variable (using ClusterTools) studies:
https://indico.cern.ch/event/879938/contributions/4124438/attachments/2153449/3631661/CMSweek_Dec2020_EGM_Swagata.pdf#page=4