### PR TITLE
Added "/dd4hep::cm" to the CSCGeometryParsFromDD Class

### DIFF
--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -7,7 +7,7 @@
 // \author Sergio Lo Meo (sergio.lo.meo@cern.ch) following what Ianna Osburne made for DTs (DD4HEP migration)
 //         Created:  Thu, 05 March 2020 
 //         Modified: Thu, 04 June 2020, following what made in PR #30047               
-//   
+//         Modified: Wed, 23 December 2020 
 //         Original author: Tim Cox
 */
 #include "CSCGeometryParsFromDD.h"

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -453,7 +453,7 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
       }
 
       auto wirespacing = fv.get<double>("WireSpacing");
-      wg.wireSpacing = static_cast<double>(wirespacing / dd4hep::cm);
+      wg.wireSpacing = static_cast<double>(wirespacing / dd4hep::mm);
       edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing / dd4hep::cm;
 
       auto alignmentpintofirstwire = fv.get<double>("AlignmentPinToFirstWire");
@@ -477,7 +477,7 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
       wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane / dd4hep::cm);
       edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane / dd4hep::cm;
 
-      uparvals.emplace_back(wg.wireSpacing / dd4hep::mm);
+      uparvals.emplace_back(wg.wireSpacing);
       uparvals.emplace_back(wg.alignmentPinToFirstWire);
       uparvals.emplace_back(wg.numberOfGroups);
       uparvals.emplace_back(wg.narrowWidthOfWirePlane);

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -36,6 +36,8 @@ CSCGeometryParsFromDD::CSCGeometryParsFromDD() : myName("CSCGeometryParsFromDD")
 
 CSCGeometryParsFromDD::~CSCGeometryParsFromDD() {}
 
+//ddd
+
 bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
                                   const MuonGeometryConstants& muonConstants,
                                   RecoIdealGeometry& rig,
@@ -65,6 +67,9 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
   std::vector<double> gtran(3);
   std::vector<double> grmat(9);
   std::vector<double> trm(9);
+
+  edm::LogVerbatim("CSCGeometryParsFromDD") << "(0) CSCGeometryParsFromDD - DDD ";
+
   while (doSubDets) {
     spec = fv.specifics();
     spit = spec.begin();
@@ -90,6 +95,10 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
     int jring = detid.ring();
     int jchamber = detid.chamber();
     int jlayer = detid.layer();
+
+    edm::LogVerbatim("CSCGeometryParsFromDD")
+        << "(1) detId: " << id << " jendcap: " << jendcap << " jstation: " << jstation << " jring: " << jring
+        << " jchamber: " << jchamber << " jlayer: " << jlayer;
 
     // Package up the wire group info as it's decoded
     CSCWireGroupPackage wg;
@@ -137,16 +146,21 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
             }
           } else if (it->second.name() == "WireSpacing") {
             wg.wireSpacing = it->second.doubles()[0];
+            edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing;
           } else if (it->second.name() == "AlignmentPinToFirstWire") {
             wg.alignmentPinToFirstWire = it->second.doubles()[0];
+            edm::LogVerbatim("CSCGeometryParsFromDD") << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire;
           } else if (it->second.name() == "TotNumWireGroups") {
             wg.numberOfGroups = int(it->second.doubles()[0]);
           } else if (it->second.name() == "LengthOfFirstWire") {
             wg.narrowWidthOfWirePlane = it->second.doubles()[0];
+            edm::LogVerbatim("CSCGeometryParsFromDD") << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane;
           } else if (it->second.name() == "LengthOfLastWire") {
             wg.wideWidthOfWirePlane = it->second.doubles()[0];
+            edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane;
           } else if (it->second.name() == "RadialExtentOfWirePlane") {
             wg.lengthOfWirePlane = it->second.doubles()[0];
+            edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane;
           }
         }
       }
@@ -200,6 +214,8 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
     LogTrace(myName) << myName << ": fill fpar...";
     LogTrace(myName) << myName << ": dpars are... " << dpar[4] / cm << ", " << dpar[8] / cm << ", " << dpar[3] / cm
                      << ", " << dpar[0] / cm;
+    edm::LogVerbatim("CSCGeometryParsFromDD") << "(7) dpar[4]: " << dpar[4] / cm << " dpar[8]:  " << dpar[8] / cm
+                                              << " dpar[3]: " << dpar[3] / cm << " dpar[0]: " << dpar[0] / cm;
 
     fpar.emplace_back((dpar[4] / cm));
     fpar.emplace_back((dpar[8] / cm));
@@ -213,6 +229,9 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
     gtran[2] = (float)1.0 * (fv.translation().Z() / cm);
 
     LogTrace(myName) << myName << ": gtran[0]=" << gtran[0] << ", gtran[1]=" << gtran[1] << ", gtran[2]=" << gtran[2];
+
+    edm::LogVerbatim("CSCGeometryParsFromDD")
+        << "(8) gtran[0]: " << gtran[0] << " gtran[1]: " << gtran[1] << " gtran[2]: " << gtran[2];
 
     LogTrace(myName) << myName << ": fill grmat...";
 
@@ -369,6 +388,9 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
   std::vector<double> gtran(3);
   std::vector<double> grmat(9);
   std::vector<double> trm(9);
+
+  edm::LogVerbatim("CSCGeometryParsFromDD") << "(0) CSCGeometryParsFromDD - DD4HEP ";
+
   while (fv.firstChild()) {
     MuonGeometryNumbering mbn(muonConstants);
     CSCNumberingScheme cscnum(muonConstants);
@@ -380,6 +402,10 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
     int jring = detid.ring();
     int jchamber = detid.chamber();
     int jlayer = detid.layer();
+
+    edm::LogVerbatim("CSCGeometryParsFromDD")
+        << "(1) detId: " << id << " jendcap: " << jendcap << " jstation: " << jstation << " jring: " << jring
+        << " jchamber: " << jchamber << " jlayer: " << jlayer;
 
     // Package up the wire group info as it's decoded
     CSCWireGroupPackage wg;
@@ -426,24 +452,31 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
       }
 
       auto wirespacing = fv.get<double>("WireSpacing");
-      wg.wireSpacing = static_cast<double>(wirespacing);
+      wg.wireSpacing = static_cast<double>(wirespacing / dd4hep::cm);
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing / dd4hep::cm;
 
       auto alignmentpintofirstwire = fv.get<double>("AlignmentPinToFirstWire");
-      wg.alignmentPinToFirstWire = static_cast<double>(alignmentpintofirstwire);
+      wg.alignmentPinToFirstWire = static_cast<double>(alignmentpintofirstwire / dd4hep::cm);
+      edm::LogVerbatim("CSCGeometryParsFromDD")
+          << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire / dd4hep::cm;
 
       auto totnumwiregroups = fv.get<double>("TotNumWireGroups");
       wg.numberOfGroups = static_cast<int>(totnumwiregroups);
 
       auto lengthoffirstwire = fv.get<double>("LengthOfFirstWire");
-      wg.narrowWidthOfWirePlane = static_cast<double>(lengthoffirstwire);
+      wg.narrowWidthOfWirePlane = static_cast<double>(lengthoffirstwire / dd4hep::cm);
+      edm::LogVerbatim("CSCGeometryParsFromDD")
+          << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane / dd4hep::cm;
 
       auto lengthoflastwire = fv.get<double>("LengthOfLastWire");
-      wg.wideWidthOfWirePlane = static_cast<double>(lengthoflastwire);
+      wg.wideWidthOfWirePlane = static_cast<double>(lengthoflastwire / dd4hep::cm);
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane / dd4hep::cm;
 
       auto radialextentofwireplane = fv.get<double>("RadialExtentOfWirePlane");
-      wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane);
+      wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane / dd4hep::cm);
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane / dd4hep::cm;
 
-      uparvals.emplace_back((wg.wireSpacing) * 10.0);
+      uparvals.emplace_back(wg.wireSpacing / dd4hep::mm);
       uparvals.emplace_back(wg.alignmentPinToFirstWire);
       uparvals.emplace_back(wg.numberOfGroups);
       uparvals.emplace_back(wg.narrowWidthOfWirePlane);
@@ -477,25 +510,36 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
       std::transform(
           dpar.begin(), dpar.end(), dpar.begin(), [](double i) -> double { return cms_rounding::roundIfNear0(i); });
 
-      fpar.emplace_back((dpar[1]));
-      fpar.emplace_back((dpar[2]));
-      fpar.emplace_back((dpar[3]));
-      fpar.emplace_back((dpar[4]));
+      fpar.emplace_back((dpar[1] / dd4hep::cm));
+      fpar.emplace_back((dpar[2] / dd4hep::cm));
+      fpar.emplace_back((dpar[3] / dd4hep::cm));
+      fpar.emplace_back((dpar[4] / dd4hep::cm));
+      edm::LogVerbatim("CSCGeometryParsFromDD")
+          << "(7) - Subtraction - dpar[1] (ddd dpar[4]): " << dpar[1] / dd4hep::cm
+          << " (ddd dpar[8]):  " << dpar[2] / dd4hep::cm << " dpar[3] (as ddd): " << dpar[3] / dd4hep::cm
+          << " dpar[4] (ddd dpar[0]): " << dpar[4] / dd4hep::cm;
     } else {
       dpar = fv.parameters();
 
       std::transform(
           dpar.begin(), dpar.end(), dpar.begin(), [](double i) -> double { return cms_rounding::roundIfNear0(i); });
 
-      fpar.emplace_back((dpar[0]));
-      fpar.emplace_back((dpar[1]));
-      fpar.emplace_back((dpar[2]));
-      fpar.emplace_back((dpar[3]));
+      fpar.emplace_back((dpar[0] / dd4hep::cm));
+      fpar.emplace_back((dpar[1] / dd4hep::cm));
+      fpar.emplace_back((dpar[2] / dd4hep::cm));
+      fpar.emplace_back((dpar[3] / dd4hep::cm));
+      edm::LogVerbatim("CSCGeometryParsFromDD")
+          << "(7)Bis - Else - dpar[0]: " << dpar[0] / dd4hep::cm << " dpar[1]: " << dpar[1] / dd4hep::cm
+          << " dpar[2]:  " << dpar[2] / dd4hep::cm << " dpar[3]: " << dpar[3] / dd4hep::cm;
     }
 
-    gtran[0] = static_cast<float>(fv.translation().X());
-    gtran[1] = static_cast<float>(fv.translation().Y());
-    gtran[2] = static_cast<float>(fv.translation().Z());
+    gtran[0] = static_cast<float>(fv.translation().X() / dd4hep::cm);
+    gtran[1] = static_cast<float>(fv.translation().Y() / dd4hep::cm);
+    gtran[2] = static_cast<float>(fv.translation().Z() / dd4hep::cm);
+
+    edm::LogVerbatim("CSCGeometryParsFromDD")
+        << "(8) gtran[0]: " << gtran[0] / dd4hep::cm << " gtran[1]: " << gtran[1] / dd4hep::cm
+        << " gtran[2]: " << gtran[2] / dd4hep::cm;
 
     std::transform(
         gtran.begin(), gtran.end(), gtran.begin(), [](double i) -> double { return cms_rounding::roundIfNear0(i); });

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -21,7 +21,6 @@
 #include "Geometry/CSCGeometry/src/CSCWireGroupPackage.h"
 #include "CondFormats/GeometryObjects/interface/CSCRecoDigiParameters.h"
 #include "CondFormats/GeometryObjects/interface/RecoIdealGeometry.h"
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
@@ -31,6 +30,7 @@
 
 using namespace std;
 using namespace cms_units::operators;
+using namespace geant_units::operators;
 
 CSCGeometryParsFromDD::CSCGeometryParsFromDD() : myName("CSCGeometryParsFromDD") {}
 
@@ -212,21 +212,22 @@ bool CSCGeometryParsFromDD::build(const DDCompactView* cview,
 
     LogTrace(myName) << myName << ": noOfAnonParams=" << noOfAnonParams;
     LogTrace(myName) << myName << ": fill fpar...";
-    LogTrace(myName) << myName << ": dpars are... " << dpar[4] / cm << ", " << dpar[8] / cm << ", " << dpar[3] / cm
-                     << ", " << dpar[0] / cm;
-    edm::LogVerbatim("CSCGeometryParsFromDD") << "(7) dpar[4]: " << dpar[4] / cm << " dpar[8]:  " << dpar[8] / cm
-                                              << " dpar[3]: " << dpar[3] / cm << " dpar[0]: " << dpar[0] / cm;
+    LogTrace(myName) << myName << ": dpars are... " << convertMmToCm(dpar[4]) << ", " << convertMmToCm(dpar[8]) << ", "
+                     << convertMmToCm(dpar[3]) << ", " << convertMmToCm(dpar[0]);
+    edm::LogVerbatim("CSCGeometryParsFromDD")
+        << "(7) dpar[4]: " << convertMmToCm(dpar[4]) << " dpar[8]:  " << convertMmToCm(dpar[8])
+        << " dpar[3]: " << convertMmToCm(dpar[3]) << " dpar[0]: " << convertMmToCm(dpar[0]);
 
-    fpar.emplace_back((dpar[4] / cm));
-    fpar.emplace_back((dpar[8] / cm));
-    fpar.emplace_back((dpar[3] / cm));
-    fpar.emplace_back((dpar[0] / cm));
+    fpar.emplace_back(convertMmToCm(dpar[4]));
+    fpar.emplace_back(convertMmToCm(dpar[8]));
+    fpar.emplace_back(convertMmToCm(dpar[3]));
+    fpar.emplace_back(convertMmToCm(dpar[0]));
 
     LogTrace(myName) << myName << ": fill gtran...";
 
-    gtran[0] = (float)1.0 * (fv.translation().X() / cm);
-    gtran[1] = (float)1.0 * (fv.translation().Y() / cm);
-    gtran[2] = (float)1.0 * (fv.translation().Z() / cm);
+    gtran[0] = (float)1.0 * (convertMmToCm(fv.translation().X()));
+    gtran[1] = (float)1.0 * (convertMmToCm(fv.translation().Y()));
+    gtran[2] = (float)1.0 * (convertMmToCm(fv.translation().Z()));
 
     LogTrace(myName) << myName << ": gtran[0]=" << gtran[0] << ", gtran[1]=" << gtran[1] << ", gtran[2]=" << gtran[2];
 
@@ -554,10 +555,7 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
       }
     }
 
-    if (wg.numberOfGroups != 0) {
-      for (size_t i = 0; i < wg.consecutiveGroups.size(); i++) {
-      }
-    } else {
+    if (wg.numberOfGroups == 0) {
       LogTrace(myName) << myName << " wg.numberOfGroups == 0 ";
     }
 

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -454,28 +454,26 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
 
       auto wirespacing = fv.get<double>("WireSpacing");
       wg.wireSpacing = static_cast<double>(wirespacing / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing / dd4hep::mm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing;
 
       auto alignmentpintofirstwire = fv.get<double>("AlignmentPinToFirstWire");
       wg.alignmentPinToFirstWire = static_cast<double>(alignmentpintofirstwire / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD")
-          << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire / dd4hep::mm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire;
 
       auto totnumwiregroups = fv.get<double>("TotNumWireGroups");
       wg.numberOfGroups = static_cast<int>(totnumwiregroups);
 
       auto lengthoffirstwire = fv.get<double>("LengthOfFirstWire");
       wg.narrowWidthOfWirePlane = static_cast<double>(lengthoffirstwire / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD")
-          << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane / dd4hep::mm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane;
 
       auto lengthoflastwire = fv.get<double>("LengthOfLastWire");
       wg.wideWidthOfWirePlane = static_cast<double>(lengthoflastwire / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane / dd4hep::mm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane;
 
       auto radialextentofwireplane = fv.get<double>("RadialExtentOfWirePlane");
       wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane / dd4hep::mm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane;
 
       uparvals.emplace_back(wg.wireSpacing);
       uparvals.emplace_back(wg.alignmentPinToFirstWire);

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -454,28 +454,28 @@ bool CSCGeometryParsFromDD::build(const cms::DDCompactView* cview,
 
       auto wirespacing = fv.get<double>("WireSpacing");
       wg.wireSpacing = static_cast<double>(wirespacing / dd4hep::mm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing / dd4hep::cm;
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(2) wireSpacing: " << wg.wireSpacing / dd4hep::mm;
 
       auto alignmentpintofirstwire = fv.get<double>("AlignmentPinToFirstWire");
-      wg.alignmentPinToFirstWire = static_cast<double>(alignmentpintofirstwire / dd4hep::cm);
+      wg.alignmentPinToFirstWire = static_cast<double>(alignmentpintofirstwire / dd4hep::mm);
       edm::LogVerbatim("CSCGeometryParsFromDD")
-          << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire / dd4hep::cm;
+          << "(3) alignmentPinToFirstWire: " << wg.alignmentPinToFirstWire / dd4hep::mm;
 
       auto totnumwiregroups = fv.get<double>("TotNumWireGroups");
       wg.numberOfGroups = static_cast<int>(totnumwiregroups);
 
       auto lengthoffirstwire = fv.get<double>("LengthOfFirstWire");
-      wg.narrowWidthOfWirePlane = static_cast<double>(lengthoffirstwire / dd4hep::cm);
+      wg.narrowWidthOfWirePlane = static_cast<double>(lengthoffirstwire / dd4hep::mm);
       edm::LogVerbatim("CSCGeometryParsFromDD")
-          << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane / dd4hep::cm;
+          << "(4) narrowWidthOfWirePlane: " << wg.narrowWidthOfWirePlane / dd4hep::mm;
 
       auto lengthoflastwire = fv.get<double>("LengthOfLastWire");
-      wg.wideWidthOfWirePlane = static_cast<double>(lengthoflastwire / dd4hep::cm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane / dd4hep::cm;
+      wg.wideWidthOfWirePlane = static_cast<double>(lengthoflastwire / dd4hep::mm);
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(5) wideWidthOfWirePlane: " << wg.wideWidthOfWirePlane / dd4hep::mm;
 
       auto radialextentofwireplane = fv.get<double>("RadialExtentOfWirePlane");
-      wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane / dd4hep::cm);
-      edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane / dd4hep::cm;
+      wg.lengthOfWirePlane = static_cast<double>(radialextentofwireplane / dd4hep::mm);
+      edm::LogVerbatim("CSCGeometryParsFromDD") << "(6) lengthOfWirePlane: " << wg.lengthOfWirePlane / dd4hep::mm;
 
       uparvals.emplace_back(wg.wireSpacing);
       uparvals.emplace_back(wg.alignmentPinToFirstWire);

--- a/Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDD4hep_cfg.py
+++ b/Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDD4hep_cfg.py
@@ -27,6 +27,17 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
+process.MessageLogger = cms.Service(
+        "MessageLogger",
+  destinations = cms.untracked.vstring(
+                'cout'
+        ),
+        cout = cms.untracked.PSet(
+                threshold = cms.untracked.string('DEBUG')
+        ),
+        debugModules = cms.untracked.vstring('*')
+)
+
 process.cscGeometryDump.verbose = True
 
 process.p = cms.Path(process.cscGeometryDump)

--- a/Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDDD_cfg.py
+++ b/Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDDD_cfg.py
@@ -15,6 +15,7 @@ process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Geometry.CSCGeometryBuilder.cscGeometry_cfi")
 process.load("Geometry.CSCGeometryBuilder.cscGeometryDump_cfi")
 
+
 process.CSCGeometryESModule.applyAlignment = False
 if 'MessageLogger' in process.__dict__:
     process.MessageLogger.Geometry=dict()
@@ -26,6 +27,18 @@ process.source = cms.Source('EmptySource')
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
+
+process.MessageLogger = cms.Service(
+        "MessageLogger",
+  destinations = cms.untracked.vstring(
+                'cout'
+        ),
+        cout = cms.untracked.PSet(
+                threshold = cms.untracked.string('DEBUG')
+        ),
+        debugModules = cms.untracked.vstring('*')
+)
+
 
 process.cscGeometryDump.verbose = True
 

--- a/Geometry/CSCGeometryBuilder/test/python/validateCSCGeometryDD4hep_cfg.py
+++ b/Geometry/CSCGeometryBuilder/test/python/validateCSCGeometryDD4hep_cfg.py
@@ -9,11 +9,17 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-
 process.load('Configuration.StandardSequences.DD4hep_GeometrySim_cff')
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load("Geometry.CSCGeometryBuilder.cscGeometry_cfi")
+
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
 
 process.CSCGeometryESModule.applyAlignment = False
 
@@ -25,7 +31,7 @@ process.CSCGeometryESModule.applyAlignment = False
 #
 process.valid = cms.EDAnalyzer("CSCGeometryValidate",
                                infileName = cms.untracked.string('cmsRecoGeom-2021.root'),
-                               outfileName = cms.untracked.string('validateCSCGeometry.root'),
+                               outfileName = cms.untracked.string('validateCSCGeometryDD4HEP.root'),
                                tolerance = cms.untracked.int32(7)
                                )
 

--- a/Geometry/CSCGeometryBuilder/test/python/validateCSCGeometryDDD_cfg.py
+++ b/Geometry/CSCGeometryBuilder/test/python/validateCSCGeometryDDD_cfg.py
@@ -14,6 +14,13 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
 process.load("Geometry.CSCGeometryBuilder.cscGeometry_cfi")
 
+process.MessageLogger = cms.Service("MessageLogger",
+                                destinations = cms.untracked.vstring('myLog'),
+                                myLog = cms.untracked.PSet(
+                                threshold = cms.untracked.string('INFO'),
+                                )
+                            )
+
 process.CSCGeometryESModule.applyAlignment = False
 
 #
@@ -24,7 +31,7 @@ process.CSCGeometryESModule.applyAlignment = False
 #
 process.valid = cms.EDAnalyzer("CSCGeometryValidate",
                                infileName = cms.untracked.string('cmsRecoGeom-2021.root'),
-                               outfileName = cms.untracked.string('validateCSCGeometry2.root'),
+                               outfileName = cms.untracked.string('validateCSCGeometryDDD.root'),
                                tolerance = cms.untracked.int32(7)
                                )
 


### PR DESCRIPTION
**PR description:**

Added "/ ddhep::cm" to the DD4hep part of the CScGeometryParsFromDD Class in order to simplify a possible future unit transition 

**PR validation:**

1) validation by "cmsRun Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDDD_cfg.py" and "cmsRun Geometry/CSCGeometryBuilder/test/python/dumpCSCGeometryDD4hep_cfg.py". Save the output of each dump script and look at these values:
wireSpacing = 0.25, y1 = -79.9354, narrow_width = 20.13, wide_width = 48.71, length = 150.5, wireAngle = 0.506145, theWireOffset = -69.9131
They have to be the same for DDD and DD4hep.

2) validation by "cmsRun Geometry/CSCGeometryBuilder/test/python/validateCSCGeometryDD4Hep_cfg.py" and "cmsRun Geometry/RPCGeometryBuilder/test/python/validateDTGeometryDDD_cfg.py" 

See attached picture (only one histo for DD4hep)

3) validation by printouts (myLog.log), for both DD & DD4Hep, created by the validation scripts used above (for example please see, below, the parameters check for the Det Id 604017672)

//DDD

(0) CSCGeometryParsFromDD - DDD 
(1) detId: 604017672 jendcap: 1 jstation: 1 jring: 1 jchamber: 1 jlayer: 0
(7) dpar[4]: 15.065 cm dpar[8]:  30.45 cm dpar[3]: 7.35 cm dpar[0]: 81 cm
(8) gtran[0]: 181.5 cm gtran[1]: -3.15941e-13 cm gtran[2]: 616.95 cm

//DD4Hep

(0) CSCGeometryParsFromDD - DD4HEP 
(1) detId: 604017672 jendcap: 1 jstation: 1 jring: 1 jchamber: 1 jlayer: 0
(7) dpar[0]: 15.065 cm dpar[1]: 30.45 cm dpar[2]:  7.35 cm dpar[3]: 81 cm
(8) gtran[0]: 181.5 cm gtran[1]: -4.46384e-14 cm gtran[2]: 616.95 cm

4) validation by "runTheMatrix.py -l 25202.1" :

25202.1_TTbar_13+TTbar_13+DIGIUP15APVSimu_PU25+RECOUP15_PU25+HARVESTUP15_PU25 Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Dec 17 17:44:41 2020-date Thu Dec 17 17:22:02 2020; exit: 0 0 0 0 1 1 1 1 tests passed, 0 0 0 0 failed

**if this PR is a backport please specify the original PR and why you need to backport that PR:**

nothing special

![Schermata 2020-12-17 alle 18 10 42](https://user-images.githubusercontent.com/28751695/102519819-47913180-4093-11eb-9a49-264121634068.png)
