### PR TITLE
[HGCal][bugfix][backport 11_1_X] fix NaN values in LeafCandidate rapidity 

### DIFF
--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -285,7 +285,8 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   }
 
   // Neutral Hadrons
-  constexpr float mpion2 = 0.13957f * 0.13957f;
+  constexpr float mpion = 0.13957f;
+  constexpr float mpion2 = mpion * mpion;
   for (unsigned i = 0; i < trackstersHAD.size(); ++i) {
     auto mergedIdx = indexInMergedCollHAD[i];
     usedTrackstersMerged[mergedIdx] = true;
@@ -500,8 +501,8 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
       tmpCandidate.setPdgId(211 * track.charge());
       float energy = std::sqrt(track.pt() * track.pt() + mpion2);
       tmpCandidate.setRawEnergy(energy);
-      math::XYZTLorentzVector p4(track.momentum().x(), track.momentum().y(), track.momentum().z(), energy);
-      tmpCandidate.setP4(p4);
+      math::PtEtaPhiMLorentzVector p4Polar(track.pt(), track.eta(), track.phi(), mpion);
+      tmpCandidate.setP4(p4Polar);
       resultCandidates->push_back(tmpCandidate);
       usedSeeds[s.index] = true;
     }
@@ -521,8 +522,8 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
       tmpCandidate.setPdgId(211 * track.charge());
       float energy = std::sqrt(track.pt() * track.pt() + mpion2);
       tmpCandidate.setRawEnergy(energy);
-      math::XYZTLorentzVector p4(track.momentum().x(), track.momentum().y(), track.momentum().z(), energy);
-      tmpCandidate.setP4(p4);
+      math::PtEtaPhiMLorentzVector p4Polar(track.pt(), track.eta(), track.phi(), mpion);
+      tmpCandidate.setP4(p4Polar);
       resultCandidates->push_back(tmpCandidate);
       usedSeeds[i] = true;
     }

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -285,7 +285,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
   }
 
   // Neutral Hadrons
-  constexpr float mpion = 0.13957f;
+  constexpr double mpion = 0.13957;
   constexpr float mpion2 = mpion * mpion;
   for (unsigned i = 0; i < trackstersHAD.size(); ++i) {
     auto mergedIdx = indexInMergedCollHAD[i];

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -499,7 +499,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
       tmpCandidate.setCharge(track.charge());
       tmpCandidate.setTrackPtr(edm::Ptr<reco::Track>(track_h, s.index));
       tmpCandidate.setPdgId(211 * track.charge());
-      float energy = std::sqrt(track.pt() * track.pt() + mpion2);
+      float energy = std::sqrt(track.p() * track.p() + mpion2);
       tmpCandidate.setRawEnergy(energy);
       math::PtEtaPhiMLorentzVector p4Polar(track.pt(), track.eta(), track.phi(), mpion);
       tmpCandidate.setP4(p4Polar);
@@ -520,7 +520,7 @@ void TrackstersMergeProducer::produce(edm::Event &evt, const edm::EventSetup &es
       tmpCandidate.setCharge(track.charge());
       tmpCandidate.setTrackPtr(edm::Ptr<reco::Track>(track_h, i));
       tmpCandidate.setPdgId(211 * track.charge());
-      float energy = std::sqrt(track.pt() * track.pt() + mpion2);
+      float energy = std::sqrt(track.p() * track.p() + mpion2);
       tmpCandidate.setRawEnergy(energy);
       math::PtEtaPhiMLorentzVector p4Polar(track.pt(), track.eta(), track.phi(), mpion);
       tmpCandidate.setP4(p4Polar);


### PR DESCRIPTION
#### PR description:

This PR fixes NaN values in the rapidity of LeafCandidates when charged hadrons are created from empty tracksters.
#### PR validation:

Tested in 23234.0 with the injection of TICL in PF --customise RecoHGCal/TICL/iterativeTICL_cff.injectTICLintoPF

@rovere @missirol @hatakeyamak @bendavid @hqucms 

backport of #32524