### PR TITLE
SiStrip Payload Inspector: alternative style Tracker Maps and code clean-up

### DIFF
--- a/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
+++ b/CondCore/SiStripPlugins/interface/SiStripPayloadInspectorHelper.h
@@ -837,19 +837,21 @@ namespace SiStripPI {
       } break;
 
       case FIRE: {
-        double stops[NRGBs] = {0.00, 0.20, 0.80, 1.00};
-        double red[NRGBs] = {1.00, 1.00, 1.00, 0.50};
-        double green[NRGBs] = {1.00, 1.00, 0.00, 0.00};
-        double blue[NRGBs] = {0.20, 0.00, 0.00, 0.00};
-        TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+        const int NCOLs = 4;
+        double stops[NCOLs] = {0.00, 0.20, 0.80, 1.00};
+        double red[NCOLs] = {1.00, 1.00, 1.00, 0.50};
+        double green[NCOLs] = {1.00, 1.00, 0.00, 0.00};
+        double blue[NCOLs] = {0.20, 0.00, 0.00, 0.00};
+        TColor::CreateGradientColorTable(NCOLs, stops, red, green, blue, NCont);
       } break;
 
       case ANTIFIRE: {
-        double stops[NRGBs] = {0.00, 0.20, 0.80, 1.00};
-        double red[NRGBs] = {0.50, 1.00, 1.00, 1.00};
-        double green[NRGBs] = {0.00, 0.00, 1.00, 1.00};
-        double blue[NRGBs] = {0.00, 0.00, 0.00, 0.20};
-        TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
+        const int NCOLs = 4;
+        double stops[NCOLs] = {0.00, 0.20, 0.80, 1.00};
+        double red[NCOLs] = {0.50, 1.00, 1.00, 1.00};
+        double green[NCOLs] = {0.00, 0.00, 1.00, 1.00};
+        double blue[NCOLs] = {0.00, 0.00, 0.00, 0.20};
+        TColor::CreateGradientColorTable(NCOLs, stops, red, green, blue, NCont);
       } break;
 
       case LOGREDBLUE: {

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -58,6 +58,7 @@ public:
 
     TGaxis::SetMaxDigits(2);
 
+    // margin of the box
     static constexpr int margin = 5;
     m_trackerMap =
         new TH2Poly("Tracker Map", m_mapTitle.c_str(), minx - margin, maxx + margin, miny - margin, maxy + margin);
@@ -65,7 +66,8 @@ public:
     m_trackerMap->SetOption(m_option);
     m_trackerMap->SetStats(false);
     m_trackerMap->GetZaxis()->SetLabelSize(0.03);
-    m_trackerMap->GetZaxis()->SetTitleOffset(0.7);
+    m_trackerMap->GetZaxis()->SetTitleOffset(0.5);
+    m_trackerMap->GetZaxis()->SetTitleSize(0.05);
     m_trackerMap->GetZaxis()->SetTitle(m_zAxisTitle.c_str());
     m_trackerMap->GetZaxis()->CenterTitle();
 
@@ -82,23 +84,13 @@ public:
 
   //============================================================================
   void drawMap(TCanvas& canvas, std::string option = "") {
+    static constexpr float tmargin_ = 0.08;
+    static constexpr float bmargin_ = 0.02;
+    static constexpr float lmargin_ = 0.02;
+    static constexpr float rmargin_ = 0.08;
+
     canvas.cd();
-    adjustCanvasMargins(canvas.cd(), 0.08, 0.06, 0.01, 0.06);
-
-    /*
-    if(!m_values.empty()){
-
-      m_axmax = *std::max_element(m_values.begin(), m_values.end());
-      m_axmin = *std::min_element(m_values.begin(), m_values.end());
-
-      canvas.cd();
-
-      auto color_bar_axis = new TGaxis(gPad->GetUxmin()-0.01,0.03, gPad->GetUxmax()-0.01, 0.03 , m_axmin, m_axmax ,505, "SDH");
-      color_bar_axis->SetName("color_bar_axis");
-      color_bar_axis->Draw();    
-
-    }
-    */
+    adjustCanvasMargins(canvas.cd(), tmargin_, bmargin_, lmargin_, rmargin_);
 
     canvas.Update();
 
@@ -113,10 +105,8 @@ public:
     TPaletteAxis* palette = (TPaletteAxis*)m_trackerMap->GetListOfFunctions()->FindObject("palette");
     if (palette != nullptr) {
       palette->SetLabelSize(0.02);
-      palette->SetX1NDC(0.95);
-      palette->SetX2NDC(0.96);
-      palette->SetY1NDC(0.05);
-      palette->SetY2NDC(0.95);
+      palette->SetX1NDC(1 - rmargin_);
+      palette->SetX2NDC(1 - rmargin_ + lmargin_);
       gPad->Modified();
       gPad->Update();
     }
@@ -181,30 +171,25 @@ public:
         } else {
           if (i % 2 == 0) {
             x[ix] = static_cast<TObjString*>(array->At(i))->String().Atof();
-
             if (x[ix] < minx) {
               minx = x[ix];
             }
-
             if (x[ix] > maxx) {
               maxx = x[ix];
             }
-
             ++ix;
           } else {
             y[iy] = static_cast<TObjString*>(array->At(i))->String().Atof();
-
             if (y[iy] < miny) {
               miny = y[iy];
             }
             if (y[iy] > maxy) {
               maxy = y[iy];
             }
-
             ++iy;
-          }
-        }
-      }
+          }  // else
+        }    // else
+      }      // loop on entries
 
       if (isPixel) {
         continue;

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -251,11 +251,11 @@ private:
     text_Y.SetTextSize(0.04);
     text_Y.SetTextAlign(11);
     text_Y.SetTextColor(kBlue);
-    text_Y.DrawLatexNDC(x_X2+0.005, y_Y2 - 0.01, y_label);
+    text_Y.DrawLatexNDC(x_X2 + 0.005, y_Y2 - 0.01, y_label);
   }
 
   //============================================================================
-  void adjustCanvasMargins(TVirtualPad* pad, float top, float bottom, float left, float right) {
+  void adjustCanvasMargins(TVirtualPad* pad, const float top, const float bottom, const float left, const float right) {
     if (top > 0) {
       pad->SetTopMargin(top);
     }

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -1,0 +1,199 @@
+#ifndef CONDCORE_SISTRIPPLUGINS_SISTRIPTKMAPS_H
+#define CONDCORE_SISTRIPPLUGINS_SISTRIPTKMAPS_H
+
+// CMSSW includes
+#include "CalibTracker/StandaloneTrackerTopology/interface/StandaloneTrackerTopology.h"
+#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
+#include "DataFormats/SiPixelDetId/interface/PXFDetId.h"
+#include "DataFormats/TrackerCommon/interface/PixelBarrelName.h"
+#include "DataFormats/TrackerCommon/interface/PixelEndcapName.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// ROOT includes
+#include "TPaletteAxis.h"
+#include "TGaxis.h"
+#include "TCanvas.h"
+#include "TColor.h"
+#include "TGraph.h"
+#include "TH1.h"
+#include "TH2.h"
+#include "TLatex.h"
+#include "TH2Poly.h"
+#include "TObjArray.h"
+#include "TObjString.h"
+#include "TProfile2D.h"
+#include "TStyle.h"
+
+// STL includes
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+#include <boost/tokenizer.hpp>
+#include <boost/range/adaptor/indexed.hpp>
+
+#define MYOUT LogDebug("SiStripTkMaps")
+
+/*--------------------------------------------------------------------
+/ Ancillary class to build SiStrip Tracker maps
+/--------------------------------------------------------------------*/
+class SiStripTkMaps {
+public:
+  SiStripTkMaps(const char* option)
+      : m_option{option},
+        m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
+            edm::FileInPath("Geometry/TrackerCommonData/data/PhaseI/trackerParameters.xml").fullPath())} {}
+
+  ~SiStripTkMaps() {}
+
+  //============================================================================
+  void bookMap(const std::string mapTitle,const std::string zAxisTitle) {
+    double minx = 0xFFFFFF, maxx = -0xFFFFFF, miny = 0xFFFFFF, maxy = -0xFFFFFFF;
+    readVertices(minx, maxx, miny, maxy);
+
+    // set the titles
+    m_zAxisTitle=zAxisTitle;
+    m_mapTitle=mapTitle;
+
+    TGaxis::SetMaxDigits(2);
+
+    static constexpr int margin = 5;
+    m_trackerMap =
+        new TH2Poly("Tracker Map", m_mapTitle.c_str(), minx - margin, maxx + margin, miny - margin, maxy + margin);
+    m_trackerMap->SetFloat();
+    m_trackerMap->SetOption(m_option);
+    m_trackerMap->SetStats(false);
+    m_trackerMap->GetZaxis()->SetLabelSize(0.03);
+    m_trackerMap->GetZaxis()->SetTitleOffset(0.7);
+    m_trackerMap->GetZaxis()->SetTitle(m_zAxisTitle.c_str());
+    m_trackerMap->GetZaxis()->CenterTitle();
+
+    for (const auto& pair : m_bins) {
+      m_trackerMap->AddBin(pair.second->Clone());
+    }
+  }
+
+  //============================================================================
+  void fill(long rawid, double val) { m_trackerMap->Fill(TString::Format("%ld", rawid), val); }
+
+  //============================================================================
+  void drawMap(TCanvas& canvas, std::string option = "") {
+    canvas.cd();
+    adjustCanvasMargins(canvas.cd(), 0.07, 0.01, 0.01, 0.10);
+
+    m_trackerMap->SetTitle("");  
+    if (!option.empty()) {
+      m_trackerMap->Draw(option.c_str());
+    } else {
+      m_trackerMap->Draw();
+    }
+
+    canvas.SetFrameLineColor(0);
+
+  }
+
+  //============================================================================
+  TH2Poly* getTheMap() { return m_trackerMap; }
+
+  //============================================================================
+  void setZAxisRange(double xmin, double xmax) { m_trackerMap->GetZaxis()->SetRangeUser(xmin, xmax); }
+
+  //============================================================================
+  void adjustCanvasMargins(TVirtualPad* pad, float top, float bottom, float left, float right) {
+    if (top > 0) {
+      pad->SetTopMargin(top);
+    }
+    if (bottom > 0) {
+      pad->SetBottomMargin(bottom);
+    }
+    if (left > 0) {
+      pad->SetLeftMargin(left);
+    }
+    if (right > 0) {
+      pad->SetRightMargin(right);
+    }
+  }
+
+  //============================================================================
+  void readVertices(double& minx, double& maxx, double& miny, double& maxy) {
+    std::ifstream in;
+
+    in.open(edm::FileInPath("DQM/SiStripMonitorClient/data/Geometry/tracker_map_bare").fullPath().c_str());
+
+    if (!in.good()) {
+      throw cms::Exception("FileError") << "Problem opening corner file!!" << std::endl;
+      return;
+    }
+
+    while (in.good()) {
+      long detid = 0;
+      double x[5], y[5];
+
+      std::string line;
+      std::getline(in, line);
+
+      TString string(line);
+      TObjArray* array = string.Tokenize(" ");
+      int ix{0}, iy{0};
+      bool isPixel{false};
+      for (int i = 0; i < array->GetEntries(); ++i) {
+        if (i == 0) {
+          detid = static_cast<TObjString*>(array->At(i))->String().Atoll();
+
+          // Drop Pixel Data
+          DetId detId(detid);
+          if (detId.subdetId() == PixelSubdetector::PixelBarrel || detId.subdetId() == PixelSubdetector::PixelEndcap) {
+            isPixel = true;
+            break;
+          }
+        } else {
+          if (i % 2 == 0) {
+            x[ix] = static_cast<TObjString*>(array->At(i))->String().Atof();
+
+            if (x[ix] < minx) {
+              minx = x[ix];
+            }
+
+            if (x[ix] > maxx) {
+              maxx = x[ix];
+            }
+
+            ++ix;
+          } else {
+            y[iy] = static_cast<TObjString*>(array->At(i))->String().Atof();
+
+            if (y[iy] < miny) {
+              miny = y[iy];
+            }
+            if (y[iy] > maxy) {
+              maxy = y[iy];
+            }
+
+            ++iy;
+          }
+        }
+      }
+
+      if (isPixel) {
+        continue;
+      }
+
+      m_detIdVector.push_back(detid);
+      m_bins[detid] = std::make_shared<TGraph>(ix, x, y);
+      m_bins[detid]->SetName(TString::Format("%ld", detid));
+      m_bins[detid]->SetTitle(TString::Format("Module ID=%ld", detid));
+    }
+  }
+
+private:
+  Option_t* m_option;
+  std::string m_mapTitle="";
+  std::string m_zAxisTitle="";
+  std::map<long, std::shared_ptr<TGraph> > m_bins;
+  std::vector<unsigned> m_detIdVector;
+  TrackerTopology m_trackerTopo;
+  TH2Poly* m_trackerMap{nullptr};
+};
+
+#endif

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -91,7 +91,6 @@ public:
 
     canvas.cd();
     adjustCanvasMargins(canvas.cd(), tmargin_, bmargin_, lmargin_, rmargin_);
-
     canvas.Update();
 
     m_trackerMap->SetTitle("");
@@ -101,17 +100,79 @@ public:
       m_trackerMap->Draw();
     }
 
+    canvas.SetFrameLineColor(0);
     gPad->Update();
     TPaletteAxis* palette = (TPaletteAxis*)m_trackerMap->GetListOfFunctions()->FindObject("palette");
     if (palette != nullptr) {
       palette->SetLabelSize(0.02);
       palette->SetX1NDC(1 - rmargin_);
       palette->SetX2NDC(1 - rmargin_ + lmargin_);
-      gPad->Modified();
-      gPad->Update();
+    }
+  }
+
+  //============================================================================
+  void dressMap(TCanvas& canv) {
+    static constexpr int wH_ = 3000;
+    static constexpr int hH_ = 850;
+    if (canv.GetWindowHeight() != hH_ && canv.GetWindowWidth() != wH_) {
+      std::cout << "resetting the window size!"
+                << "height is:  " << canv.GetWindowHeight() << "width  is:  " << canv.GetWindowWidth() << std::endl;
+      canv.SetWindowSize(wH_, hH_);
     }
 
-    canvas.SetFrameLineColor(0);
+    std::array<std::string, 12> barrelNames = {
+        {"TIB L2", "TIB L1", "TIB L4", "TIB L3", "TOB L2", "TOB L1", "TOB L4", " TOB L3", "TOB L6", "TOB L5"}};
+    std::array<std::string, 4> endcapNames = {{"TID", "TEC", "TID", "TEC"}};
+    std::array<std::string, 24> disknumbering = {{"+1", "+2", "+3", "+1", "+2", "+3", "+4", "+5",
+                                                  "+6", "+7", "+8", "+9", "-1", "-2", "-3", "-1",
+                                                  "-2", "-3", "-4", "-5", "-6", "-7", "-8", "-9"}};
+
+    static constexpr std::array<float, 12> b_coordx = {
+        {0.1, 0.1, 0.26, 0.26, 0.41, 0.41, 0.56, 0.56, 0.725, 0.725, 0.05, 0.17}};
+    static constexpr std::array<float, 12> b_coordy = {
+        {0.70, 0.45, 0.70, 0.45, 0.70, 0.46, 0.70, 0.46, 0.70, 0.46, 0.85, 0.85}};
+
+    static constexpr std::array<float, 4> e_coordx = {{0.01, 0.21, 0.01, 0.21}};
+    static constexpr std::array<float, 4> e_coordy = {{0.89, 0.89, 0.17, 0.17}};
+
+    static constexpr std::array<float, 24> n_coordx = {{0.01,  0.087, 0.165, 0.227, 0.305, 0.383, 0.461, 0.539,
+                                                        0.616, 0.694, 0.772, 0.850, 0.01,  0.087, 0.165, 0.227,
+                                                        0.305, 0.383, 0.461, 0.539, 0.617, 0.695, 0.773, 0.851}};
+
+    static constexpr std::array<float, 24> n_coordy = {{0.85, 0.85, 0.85, 0.85, 0.85, 0.85, 0.85, 0.85,
+                                                        0.85, 0.85, 0.85, 0.85, 0.13, 0.13, 0.13, 0.13,
+                                                        0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13, 0.13}};
+
+    canv.cd();
+    for (const auto& name : barrelNames | boost::adaptors::indexed(0)) {
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.035);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(b_coordx[name.index()], b_coordy[name.index()], name.value().c_str());
+    }
+
+    for (const auto& name : endcapNames | boost::adaptors::indexed(0)) {
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.05);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(e_coordx[name.index()], e_coordy[name.index()], name.value().c_str());
+    }
+
+    for (const auto& name : disknumbering | boost::adaptors::indexed(0)) {
+      auto ltx = TLatex();
+      ltx.SetTextFont(62);
+      ltx.SetTextSize(0.035);
+      ltx.SetTextAlign(11);
+      ltx.DrawLatexNDC(n_coordx[name.index()], n_coordy[name.index()], name.value().c_str());
+    }
+
+    auto ltx = TLatex();
+    ltx.SetTextFont(62);
+    ltx.SetTextSize(0.045);
+    ltx.SetTextAlign(11);
+    ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.03, m_mapTitle.c_str());
   }
 
   //============================================================================
@@ -195,10 +256,10 @@ public:
         continue;
       }
 
-      m_detIdVector.push_back(detid);
       m_bins[detid] = std::make_shared<TGraph>(ix, x, y);
       m_bins[detid]->SetName(TString::Format("%ld", detid));
       m_bins[detid]->SetTitle(TString::Format("Module ID=%ld", detid));
+      m_detIdVector.push_back(detid);
     }
   }
 

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -10,6 +10,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // ROOT includes
+#include "TArrow.h"
 #include "TPaletteAxis.h"
 #include "TGaxis.h"
 #include "TCanvas.h"
@@ -115,8 +116,6 @@ public:
     static constexpr int wH_ = 3000;
     static constexpr int hH_ = 850;
     if (canv.GetWindowHeight() != hH_ && canv.GetWindowWidth() != wH_) {
-      std::cout << "resetting the window size!"
-                << "height is:  " << canv.GetWindowHeight() << "width  is:  " << canv.GetWindowWidth() << std::endl;
       canv.SetWindowSize(wH_, hH_);
     }
 
@@ -173,6 +172,87 @@ public:
     ltx.SetTextSize(0.045);
     ltx.SetTextAlign(11);
     ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.03, m_mapTitle.c_str());
+
+    // barrel axes
+    float phiX1 = 0.09;
+    float phiX2 = 0.23;
+    float phiY1 = 0.24;
+    float phiY2 = phiY1;
+    auto arrowPhi = TArrow();
+    arrowPhi.SetLineColor(kBlue);
+    arrowPhi.SetLineWidth(2);
+    arrowPhi.SetOption("|>");
+    arrowPhi.SetArrowSize(10);
+    arrowPhi.DrawLineNDC(phiX1, phiY1, phiX2, phiY2);
+    //arrowPhi.SetNDC(kTRUE);
+    //arrowPhi.DrawArrow(0.09,0.25,0.23,0.25,0.1,"|>");
+
+    float zX1 = phiX2;
+    float zX2 = zX1;
+    float zY1 = phiY1;
+    float zY2 = 0.45;
+    auto arrowZ = TArrow();
+    arrowZ.SetLineColor(kBlue);
+    arrowZ.SetLineWidth(2);
+    arrowZ.SetOption("|>");
+    arrowZ.SetArrowSize(10);
+    arrowZ.DrawLineNDC(zX1, zY1, zX2, zY2);
+    //arrowZ.SetNDC(kTRUE);
+    //arrowZ.DrawArrow(0.09,0.25,0.09,0.45,0.1,"|>");
+
+    auto textPhi = TLatex();
+    textPhi.SetTextSize(0.04);
+    textPhi.SetTextAlign(11);
+    textPhi.SetTextColor(kBlue);
+    textPhi.DrawLatexNDC(phiX1 - 0.01, phiY1 + 0.01, "#phi");
+
+    auto textZ = TLatex();
+    textZ.SetTextSize(0.04);
+    textZ.SetTextAlign(11);
+    textZ.SetTextColor(kBlue);
+    textZ.DrawLatexNDC(zX1 + 0.005, zY2, "z");
+
+    // endcap axes
+    float xX1 = 0.85;
+    float xX2 = 0.89;
+    float xY1 = 0.83;
+    float xY2 = xY1;
+    auto arrowX = TArrow();
+    arrowX.SetLineColor(kBlue);
+    arrowX.SetLineWidth(2);
+    arrowX.SetOption("|>");
+    arrowX.SetArrowSize(10);
+    arrowX.DrawLineNDC(xX1, xY1, xX2, xY2);
+    //arrowX.SetNDC(kTRUE);
+    //arrowX.DrawArrow(0.09,0.25,0.23,0.25,0.1,"|>");
+
+    float yX1 = xX2;
+    float yX2 = yX1;
+    float yY1 = xY1;
+    float yY2 = 0.95;
+    auto arrowY = TArrow();
+    arrowY.SetLineColor(kBlue);
+    arrowY.SetLineWidth(2);
+    arrowY.SetOption("|>");
+    arrowY.SetArrowSize(10);
+    arrowY.DrawLineNDC(yX1, yY1, yX2, yY2);
+    //arrowY.SetNDC(kTRUE);
+    //arrowY.DrawArrow(0.09,0.25,0.09,0.45,0.1,"|>");
+
+    auto textX = TLatex();
+    textX.SetTextSize(0.04);
+    textX.SetTextAlign(11);
+    textX.SetTextColor(kBlue);
+    textX.DrawLatexNDC(xX1, xY1 - 0.03, "x");
+
+    auto textY = TLatex();
+    textY.SetTextSize(0.04);
+    textY.SetTextAlign(11);
+    textY.SetTextColor(kBlue);
+    textY.DrawLatexNDC(yX1 - 0.01, yY2, "y");
+
+    canv.Modified();
+    canv.Update();  // make sure it's really (re)drawn
   }
 
   //============================================================================

--- a/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
+++ b/CondCore/SiStripPlugins/interface/SiStripTkMaps.h
@@ -176,7 +176,19 @@ public:
   }
 
   //============================================================================
-  TH2Poly* getTheMap() { return m_trackerMap; }
+  const TH2Poly* getTheMap() { return m_trackerMap; }
+
+  //============================================================================
+  inline const std::string& getTheMapTitle() { return m_mapTitle; }
+
+  //============================================================================
+  inline const std::string& getTheZAxisTitle() { return m_zAxisTitle; }
+
+  //============================================================================
+  inline const std::vector<unsigned int>& getTheFilledIds() { return m_detIdVector; }
+
+  //============================================================================
+  inline const std::vector<double>& getTheFilledValues() { return m_values; }
 
   //============================================================================
   void setZAxisRange(double xmin, double xmax) { m_trackerMap->GetZaxis()->SetRangeUser(xmin, xmax); }
@@ -269,7 +281,7 @@ private:
   std::string m_zAxisTitle = "";
   double m_axmin, m_axmax;
   std::map<long, std::shared_ptr<TGraph> > m_bins;
-  std::vector<unsigned> m_detIdVector;
+  std::vector<unsigned int> m_detIdVector;
   std::vector<double> m_values;
   TrackerTopology m_trackerTopo;
   TH2Poly* m_trackerMap{nullptr};

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -552,9 +552,9 @@ namespace {
   *************************************************/
 
   template <int ntags, IOVMultiplicity nIOVs>
-  class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
+  class SiStripApvGainsRatioTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
-    SiStripApvGainsRatioWithPreviousIOVTrackerMapBase()
+    SiStripApvGainsRatioTrackerMapBase()
         : PlotImage<SiStripApvGain, nIOVs, ntags>("Tracker Map of ratio of SiStripGains with previous IOV") {
       PlotBase::addInputParam("nsigma");
     }
@@ -653,19 +653,17 @@ namespace {
     }
   };
 
-  using SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap =
-      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<1, MULTI_IOV>;
-  using SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags =
-      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<2, SINGLE_IOV>;
+  using SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap = SiStripApvGainsRatioTrackerMapBase<1, MULTI_IOV>;
+  using SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags = SiStripApvGainsRatioTrackerMapBase<2, SINGLE_IOV>;
 
   /************************************************
    TrackerMap of SiStripApvGains (ratio for largest deviation with previous gain per detid)
   *************************************************/
 
   template <int ntags, IOVMultiplicity nIOVs>
-  class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
+  class SiStripApvGainsRatioMaxDeviationTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
-    SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase()
+    SiStripApvGainsRatioMaxDeviationTrackerMapBase()
         : PlotImage<SiStripApvGain, nIOVs, ntags>(
               "Tracker Map of ratio (for largest deviation) of SiStripGains with previous IOV") {
       PlotBase::addInputParam("nsigma");
@@ -677,9 +675,11 @@ namespace {
       auto ip = paramValues.find("nsigma");
       if (ip != paramValues.end()) {
         nsigma = boost::lexical_cast<unsigned int>(ip->second);
-        std::cout << "using custom z-axis saturation: " << nsigma << " sigmas" << std::endl;
+        edm::LogPrint("SiStripApvGain_PayloadInspector")
+            << "using custom z-axis saturation: " << nsigma << " sigmas" << std::endl;
       } else {
-        std::cout << "using default saturation: " << nsigma << " sigmas" << std::endl;
+        edm::LogPrint("SiStripApvGain_PayloadInspector")
+            << "using default saturation: " << nsigma << " sigmas" << std::endl;
       }
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
@@ -786,10 +786,10 @@ namespace {
   };
 
   using SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap =
-      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<1, MULTI_IOV>;
+      SiStripApvGainsRatioMaxDeviationTrackerMapBase<1, MULTI_IOV>;
 
   using SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags =
-      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<2, SINGLE_IOV>;
+      SiStripApvGainsRatioMaxDeviationTrackerMapBase<2, SINGLE_IOV>;
 
   /************************************************
     TrackerMap of SiStripApvGains (maximum gain per detid)

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -45,13 +45,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvGainsValue : public cond::payloadInspector::Histogram1D<SiStripApvGain> {
+  class SiStripApvGainsValue
+      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsValue()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain>(
-              "SiStripApv Gains values", "SiStripApv Gains values", 200, 0.0, 2.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains values", "SiStripApv Gains values", 200, 0.0, 2.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -81,17 +80,17 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvBarrelGainsByLayer : public cond::payloadInspector::Histogram1D<SiStripApvGain> {
+  class SiStripApvBarrelGainsByLayer
+      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvBarrelGainsByLayer()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain>("SiStripApv Gains averages by Barrel layer",
-                                                              "Barrel layer (0-3: TIB), (4-9: TOB)",
-                                                              10,
-                                                              0,
-                                                              10,
-                                                              "average SiStripApv Gain") {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains averages by Barrel layer",
+              "Barrel layer (0-3: TIB), (4-9: TOB)",
+              10,
+              0,
+              10,
+              "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -142,21 +141,20 @@ namespace {
     SiStripApvGains for Tracker Barrel of 1 IOV
   *************************************************/
 
-  class SiStripApvAbsoluteBarrelGainsByLayer : public cond::payloadInspector::Histogram2D<SiStripApvGain> {
+  class SiStripApvAbsoluteBarrelGainsByLayer
+      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvAbsoluteBarrelGainsByLayer()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain>("SiStripApv Gains by Barrel layer",
-                                                              "Barrel layer (0-3: TIB), (4-9: TOB)",
-                                                              10,
-                                                              0,
-                                                              10,
-                                                              "SiStripApv Gain",
-                                                              200,
-                                                              0.0,
-                                                              2.0) {
-      Base::setSingleIov(true);
-    }
-
+        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains by Barrel layer",
+              "Barrel layer (0-3: TIB), (4-9: TOB)",
+              10,
+              0,
+              10,
+              "SiStripApv Gain",
+              200,
+              0.0,
+              2.0) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       for (auto const& iov : tag.iovs) {
@@ -191,17 +189,17 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvEndcapMinusGainsByDisk : public cond::payloadInspector::Histogram1D<SiStripApvGain> {
+  class SiStripApvEndcapMinusGainsByDisk
+      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvEndcapMinusGainsByDisk()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain>("SiStripApv Gains averages by Endcap (minus) disk",
-                                                              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
-                                                              12,
-                                                              0,
-                                                              12,
-                                                              "average SiStripApv Gain") {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains averages by Endcap (minus) disk",
+              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
+              12,
+              0,
+              12,
+              "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -261,17 +259,17 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvEndcapPlusGainsByDisk : public cond::payloadInspector::Histogram1D<SiStripApvGain> {
+  class SiStripApvEndcapPlusGainsByDisk
+      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvEndcapPlusGainsByDisk()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain>("SiStripApv Gains averages by Endcap (plus) disk",
-                                                              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
-                                                              12,
-                                                              0,
-                                                              12,
-                                                              "average SiStripApv Gain") {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains averages by Endcap (plus) disk",
+              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
+              12,
+              0,
+              12,
+              "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -330,20 +328,20 @@ namespace {
     2D histogram of absolute (i.e. not average)
     SiStripApv Gains on the Endcap- for 1 IOV
    ************************************************/
-  class SiStripApvAbsoluteEndcapMinusGainsByDisk : public cond::payloadInspector::Histogram2D<SiStripApvGain> {
+  class SiStripApvAbsoluteEndcapMinusGainsByDisk
+      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvAbsoluteEndcapMinusGainsByDisk()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain>("SiStripApv Gains averages by Endcap (minus) disk",
-                                                              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
-                                                              12,
-                                                              0,
-                                                              12,
-                                                              "SiStripApv Gain",
-                                                              200,
-                                                              0.0,
-                                                              2.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains averages by Endcap (minus) disk",
+              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
+              12,
+              0,
+              12,
+              "SiStripApv Gain",
+              200,
+              0.0,
+              2.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -390,21 +388,20 @@ namespace {
     2D histogram of absolute (i.e. not average)
     SiStripApv Gains on the Endcap+ for 1 IOV
    ************************************************/
-  class SiStripApvAbsoluteEndcapPlusGainsByDisk : public cond::payloadInspector::Histogram2D<SiStripApvGain> {
+  class SiStripApvAbsoluteEndcapPlusGainsByDisk
+      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvAbsoluteEndcapPlusGainsByDisk()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain>("SiStripApv Gains averages by Endcap (plus) disk",
-                                                              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
-                                                              12,
-                                                              0,
-                                                              12,
-                                                              "SiStripApv Gain",
-                                                              200,
-                                                              0.0,
-                                                              2.0) {
-      Base::setSingleIov(true);
-    }
-
+        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripApv Gains averages by Endcap (plus) disk",
+              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
+              12,
+              0,
+              12,
+              "SiStripApv Gain",
+              200,
+              0.0,
+              2.0) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       for (auto const& iov : tag.iovs) {
@@ -449,15 +446,16 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (average gain per detid)
   *************************************************/
-  class SiStripApvGainsAverageTrackerMap : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  class SiStripApvGainsAverageTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsAverageTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of average SiStripGains") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of average SiStripGains") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap = "SiStrip APV Gain average per module (payload : " + std::get<1>(iov) + ")";
@@ -498,15 +496,16 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (module with default)
   *************************************************/
-  class SiStripApvGainsDefaultTrackerMap : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  class SiStripApvGainsDefaultTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsDefaultTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of SiStripGains to default") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStripGains to default") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripApvGains");
@@ -568,14 +567,18 @@ namespace {
     TrackerMap of SiStripApvGains (ratio with previous gain per detid)
   *************************************************/
 
-  class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of ratio of SiStripGains with previous IOV") {
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
+              "Tracker Map of ratio of SiStripGains with previous IOV") {
       cond::payloadInspector::PlotBase::addInputParam("nsigma");
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
+      // determine n. sigmas
       unsigned int nsigma(1);
 
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
@@ -584,17 +587,26 @@ namespace {
         nsigma = boost::lexical_cast<unsigned int>(ip->second);
       }
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string titleMap = "SiStrip APV Gain ratio per module average (IOV: ";
 
@@ -652,44 +664,34 @@ namespace {
       //=========================
       auto range = SiStripPI::getTheRange(cachedRatio, nsigma);
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       tmap->save(true, range.first, range.second, fileName);
 
       return true;
     }
   };
 
-  class SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap
-      : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase {
-  public:
-    SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap() : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase() {
-      this->setSingleIov(false);
-    }
-  };
-
-  class SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags : public SiStripApvGainsRatioWithPreviousIOVTrackerMapBase {
-  public:
-    SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags() : SiStripApvGainsRatioWithPreviousIOVTrackerMapBase() {
-      this->setTwoTags(true);
-    }
-  };
+  using SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap =
+      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags =
+      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   /************************************************
    TrackerMap of SiStripApvGains (ratio for largest deviation with previous gain per detid)
   *************************************************/
 
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
   class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase
-      : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>(
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
               "Tracker Map of ratio (for largest deviation) of SiStripGains with previous IOV") {
       cond::payloadInspector::PlotBase::addInputParam("nsigma");
     }
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
       unsigned int nsigma(1);
-
       auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
       auto ip = paramValues.find("nsigma");
       if (ip != paramValues.end()) {
@@ -699,18 +701,26 @@ namespace {
         std::cout << "using default saturation: " << nsigma << " sigmas" << std::endl;
       }
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string titleMap = "SiStrip APV Gain ratio for largest deviation per module (IOV: ";
 
@@ -787,43 +797,32 @@ namespace {
 
       //=========================
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       tmap->save(true, range.first, range.second, fileName);
 
       return true;
     }
   };
 
-  class SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap
-      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase {
-  public:
-    SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap()
-        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase() {
-      this->setSingleIov(false);
-    }
-  };
+  using SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap =
+      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<1, cond::payloadInspector::MULTI_IOV>;
 
-  class SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags
-      : public SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase {
-  public:
-    SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags()
-        : SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase() {
-      this->setTwoTags(true);
-    }
-  };
+  using SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags =
+      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   /************************************************
     TrackerMap of SiStripApvGains (maximum gain per detid)
   *************************************************/
-  class SiStripApvGainsMaximumTrackerMap : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  class SiStripApvGainsMaximumTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsMaximumTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of SiStripAPVGains (maximum per DetId)") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStripAPVGains (maximum per DetId)") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap = "SiStrip APV Gain maximum per module (payload : " + std::get<1>(iov) + ")";
@@ -868,15 +867,17 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (minimum gain per detid)
   *************************************************/
-  class SiStripApvGainsMinimumTrackerMap : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  class SiStripApvGainsMinimumTrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsMinimumTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Tracker Map of SiStripAPVGains (minimum per DetId)") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of SiStripAPVGains (minimum per DetId)") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap = "SiStrip APV Gain minumum per module (payload : " + std::get<1>(iov) + ")";
@@ -1159,15 +1160,14 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripApvGainsTest : public cond::payloadInspector::Histogram1D<SiStripApvGain> {
+  class SiStripApvGainsTest
+      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsTest()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain>(
+        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
               "SiStripApv Gains test", "SiStripApv Gains test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      Base::setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -1207,23 +1207,33 @@ namespace {
     Compare Gains from 2 IOVs, 2 pads canvas, firsr for ratio, second for scatter plot
   *************************************************/
 
-  class SiStripApvGainsComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripApvGainsComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
-    SiStripApvGainsComparatorBase() : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStripGains Comparison") {}
+    SiStripApvGainsComparatorBase()
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
@@ -1391,47 +1401,49 @@ namespace {
 
       legend2.Draw("same");
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
     }
   };
 
-  class SiStripApvGainsComparatorSingleTag : public SiStripApvGainsComparatorBase {
-  public:
-    SiStripApvGainsComparatorSingleTag() : SiStripApvGainsComparatorBase() { setSingleIov(false); }
-  };
-
-  class SiStripApvGainsComparatorTwoTags : public SiStripApvGainsComparatorBase {
-  public:
-    SiStripApvGainsComparatorTwoTags() : SiStripApvGainsComparatorBase() { setTwoTags(true); }
-  };
+  using SiStripApvGainsComparatorSingleTag = SiStripApvGainsComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripApvGainsComparatorTwoTags = SiStripApvGainsComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   //*******************************************//
   // Compare Gains from 2 IOVs
   //******************************************//
 
-  class SiStripApvGainsValuesComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripApvGainsValuesComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsValuesComparatorBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Comparison of SiStrip APV gains values") {}
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("Comparison of SiStrip APV gains values") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
       TH1F::SetDefaultSumw2(true);
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
@@ -1567,50 +1579,56 @@ namespace {
       hratio->GetXaxis()->SetLabelFont(43);  // Absolute font size in pixel (precision 3)
       hratio->GetXaxis()->SetTitleOffset(3.);
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
     }
   };
 
-  class SiStripApvGainsValuesComparatorSingleTag : public SiStripApvGainsValuesComparatorBase {
-  public:
-    SiStripApvGainsValuesComparatorSingleTag() : SiStripApvGainsValuesComparatorBase() { setSingleIov(false); }
-  };
-
-  class SiStripApvGainsValuesComparatorTwoTags : public SiStripApvGainsValuesComparatorBase {
-  public:
-    SiStripApvGainsValuesComparatorTwoTags() : SiStripApvGainsValuesComparatorBase() { setTwoTags(true); }
-  };
+  using SiStripApvGainsValuesComparatorSingleTag =
+      SiStripApvGainsValuesComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripApvGainsValuesComparatorTwoTags =
+      SiStripApvGainsValuesComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   //*******************************************//
   // Compare Gains ratio from 2 IOVs, region by region
   //******************************************//
 
-  class SiStripApvGainsRatioComparatorByRegionBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripApvGainsRatioComparatorByRegionBase
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("Module by Module Comparison of SiStrip APV gains"),
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
+              "Module by Module Comparison of SiStrip APV gains"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
+    bool fill() override {
       //gStyle->SetPalette(5);
       SiStripPI::setPaletteStyle(SiStripPI::GRAY);
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::string lastIOVsince = std::to_string(std::get<0>(lastiov));
       std::string firstIOVsince = std::to_string(std::get<0>(firstiov));
@@ -1739,7 +1757,7 @@ namespace {
       hpfx_tmp->SetMarkerStyle(20);
       hpfx_tmp->Draw("same");
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       delete hpfx_tmp;
@@ -1784,42 +1802,44 @@ namespace {
     }
   };
 
-  class SiStripApvGainsRatioComparatorByRegionSingleTag : public SiStripApvGainsRatioComparatorByRegionBase {
-  public:
-    SiStripApvGainsRatioComparatorByRegionSingleTag() : SiStripApvGainsRatioComparatorByRegionBase() {
-      setSingleIov(false);
-    }
-  };
-
-  class SiStripApvGainsRatioComparatorByRegionTwoTags : public SiStripApvGainsRatioComparatorByRegionBase {
-  public:
-    SiStripApvGainsRatioComparatorByRegionTwoTags() : SiStripApvGainsRatioComparatorByRegionBase() { setTwoTags(true); }
-  };
+  using SiStripApvGainsRatioComparatorByRegionSingleTag =
+      SiStripApvGainsRatioComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripApvGainsRatioComparatorByRegionTwoTags =
+      SiStripApvGainsRatioComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   /************************************************
     Compare Gains for each tracker region
   *************************************************/
 
-  class SiStripApvGainsComparatorByRegionBase : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
+  class SiStripApvGainsComparatorByRegionBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStripGains Comparison By Region"),
+        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash>> sorted_iovs = iovs;
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
 
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
 
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
 
-      std::shared_ptr<SiStripApvGain> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<SiStripApvGain> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<SiStripApvGain> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<SiStripApvGain> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::vector<uint32_t> detid;
       last_payload->getDetIds(detid);
@@ -1955,7 +1975,7 @@ namespace {
       legend.AddEntry(hlast.get(), ("IOV: " + std::to_string(std::get<0>(lastiov))).c_str(), "PL");
       legend.Draw("same");
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
@@ -1965,31 +1985,27 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
-  class SiStripApvGainsComparatorByRegionSingleTag : public SiStripApvGainsComparatorByRegionBase {
-  public:
-    SiStripApvGainsComparatorByRegionSingleTag() : SiStripApvGainsComparatorByRegionBase() { setSingleIov(false); }
-  };
-
-  class SiStripApvGainsComparatorByRegionTwoTags : public SiStripApvGainsComparatorByRegionBase {
-  public:
-    SiStripApvGainsComparatorByRegionTwoTags() : SiStripApvGainsComparatorByRegionBase() { setTwoTags(true); }
-  };
+  using SiStripApvGainsComparatorByRegionSingleTag =
+      SiStripApvGainsComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripApvGainsComparatorByRegionTwoTags =
+      SiStripApvGainsComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
 
   /************************************************
     Plot gain averages by region 
   *************************************************/
 
-  class SiStripApvGainsByRegion : public cond::payloadInspector::PlotImage<SiStripApvGain> {
+  class SiStripApvGainsByRegion
+      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripApvGainsByRegion()
-        : cond::payloadInspector::PlotImage<SiStripApvGain>("SiStripGains By Region"),
+        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripGains By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash>>& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripApvGain> payload = fetchPayload(std::get<1>(iov));
 
       std::vector<uint32_t> detid;

--- a/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripApvGain_PayloadInspector.cc
@@ -40,17 +40,18 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     1d histogram of SiStripApvGains of 1 IOV 
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvGainsValue
-      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsValue : public Histogram1D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsValue()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains values", "SiStripApv Gains values", 200, 0.0, 2.0) {}
+        : Histogram1D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains values", "SiStripApv Gains values", 200, 0.0, 2.0) {
+    }
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -80,17 +81,15 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvBarrelGainsByLayer
-      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvBarrelGainsByLayer : public Histogram1D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvBarrelGainsByLayer()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains averages by Barrel layer",
-              "Barrel layer (0-3: TIB), (4-9: TOB)",
-              10,
-              0,
-              10,
-              "average SiStripApv Gain") {}
+        : Histogram1D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains averages by Barrel layer",
+                                                  "Barrel layer (0-3: TIB), (4-9: TOB)",
+                                                  10,
+                                                  0,
+                                                  10,
+                                                  "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -141,20 +140,18 @@ namespace {
     SiStripApvGains for Tracker Barrel of 1 IOV
   *************************************************/
 
-  class SiStripApvAbsoluteBarrelGainsByLayer
-      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvAbsoluteBarrelGainsByLayer : public Histogram2D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvAbsoluteBarrelGainsByLayer()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains by Barrel layer",
-              "Barrel layer (0-3: TIB), (4-9: TOB)",
-              10,
-              0,
-              10,
-              "SiStripApv Gain",
-              200,
-              0.0,
-              2.0) {}
+        : Histogram2D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains by Barrel layer",
+                                                  "Barrel layer (0-3: TIB), (4-9: TOB)",
+                                                  10,
+                                                  0,
+                                                  10,
+                                                  "SiStripApv Gain",
+                                                  200,
+                                                  0.0,
+                                                  2.0) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       for (auto const& iov : tag.iovs) {
@@ -189,17 +186,15 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvEndcapMinusGainsByDisk
-      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvEndcapMinusGainsByDisk : public Histogram1D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvEndcapMinusGainsByDisk()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains averages by Endcap (minus) disk",
-              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
-              12,
-              0,
-              12,
-              "average SiStripApv Gain") {}
+        : Histogram1D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains averages by Endcap (minus) disk",
+                                                  "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
+                                                  12,
+                                                  0,
+                                                  12,
+                                                  "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -259,17 +254,15 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripApvEndcapPlusGainsByDisk
-      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvEndcapPlusGainsByDisk : public Histogram1D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvEndcapPlusGainsByDisk()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains averages by Endcap (plus) disk",
-              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
-              12,
-              0,
-              12,
-              "average SiStripApv Gain") {}
+        : Histogram1D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains averages by Endcap (plus) disk",
+                                                  "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
+                                                  12,
+                                                  0,
+                                                  12,
+                                                  "average SiStripApv Gain") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -328,20 +321,18 @@ namespace {
     2D histogram of absolute (i.e. not average)
     SiStripApv Gains on the Endcap- for 1 IOV
    ************************************************/
-  class SiStripApvAbsoluteEndcapMinusGainsByDisk
-      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvAbsoluteEndcapMinusGainsByDisk : public Histogram2D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvAbsoluteEndcapMinusGainsByDisk()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains averages by Endcap (minus) disk",
-              "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
-              12,
-              0,
-              12,
-              "SiStripApv Gain",
-              200,
-              0.0,
-              2.0) {}
+        : Histogram2D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains averages by Endcap (minus) disk",
+                                                  "Endcap (minus) disk (0-2: TID), (3-11: TEC)",
+                                                  12,
+                                                  0,
+                                                  12,
+                                                  "SiStripApv Gain",
+                                                  200,
+                                                  0.0,
+                                                  2.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -388,20 +379,18 @@ namespace {
     2D histogram of absolute (i.e. not average)
     SiStripApv Gains on the Endcap+ for 1 IOV
    ************************************************/
-  class SiStripApvAbsoluteEndcapPlusGainsByDisk
-      : public cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvAbsoluteEndcapPlusGainsByDisk : public Histogram2D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvAbsoluteEndcapPlusGainsByDisk()
-        : cond::payloadInspector::Histogram2D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains averages by Endcap (plus) disk",
-              "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
-              12,
-              0,
-              12,
-              "SiStripApv Gain",
-              200,
-              0.0,
-              2.0) {}
+        : Histogram2D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains averages by Endcap (plus) disk",
+                                                  "Endcap (plus) disk (0-2: TID), (3-11: TEC)",
+                                                  12,
+                                                  0,
+                                                  12,
+                                                  "SiStripApv Gain",
+                                                  200,
+                                                  0.0,
+                                                  2.0) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       for (auto const& iov : tag.iovs) {
@@ -446,12 +435,9 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (average gain per detid)
   *************************************************/
-  class SiStripApvGainsAverageTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsAverageTrackerMap : public PlotImage<SiStripApvGain, SINGLE_IOV> {
   public:
-    SiStripApvGainsAverageTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of average SiStripGains") {}
+    SiStripApvGainsAverageTrackerMap() : PlotImage<SiStripApvGain, SINGLE_IOV>("Tracker Map of average SiStripGains") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -496,12 +482,10 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (module with default)
   *************************************************/
-  class SiStripApvGainsDefaultTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsDefaultTrackerMap : public PlotImage<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsDefaultTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStripGains to default") {}
+        : PlotImage<SiStripApvGain, SINGLE_IOV>("Tracker Map of SiStripGains to default") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -567,29 +551,27 @@ namespace {
     TrackerMap of SiStripApvGains (ratio with previous gain per detid)
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsRatioWithPreviousIOVTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
-              "Tracker Map of ratio of SiStripGains with previous IOV") {
-      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+        : PlotImage<SiStripApvGain, nIOVs, ntags>("Tracker Map of ratio of SiStripGains with previous IOV") {
+      PlotBase::addInputParam("nsigma");
     }
 
     bool fill() override {
       // determine n. sigmas
       unsigned int nsigma(1);
 
-      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto paramValues = PlotBase::inputParamValues();
       auto ip = paramValues.find("nsigma");
       if (ip != paramValues.end()) {
         nsigma = boost::lexical_cast<unsigned int>(ip->second);
       }
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -598,8 +580,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -672,27 +654,26 @@ namespace {
   };
 
   using SiStripApvGainsAvgDeviationRatioWithPreviousIOVTrackerMap =
-      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<1, cond::payloadInspector::MULTI_IOV>;
+      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<1, MULTI_IOV>;
   using SiStripApvGainsAvgDeviationRatioTrackerMapTwoTags =
-      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<2, cond::payloadInspector::SINGLE_IOV>;
+      SiStripApvGainsRatioWithPreviousIOVTrackerMapBase<2, SINGLE_IOV>;
 
   /************************************************
    TrackerMap of SiStripApvGains (ratio for largest deviation with previous gain per detid)
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
+        : PlotImage<SiStripApvGain, nIOVs, ntags>(
               "Tracker Map of ratio (for largest deviation) of SiStripGains with previous IOV") {
-      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+      PlotBase::addInputParam("nsigma");
     }
 
     bool fill() override {
       unsigned int nsigma(1);
-      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto paramValues = PlotBase::inputParamValues();
       auto ip = paramValues.find("nsigma");
       if (ip != paramValues.end()) {
         nsigma = boost::lexical_cast<unsigned int>(ip->second);
@@ -702,8 +683,8 @@ namespace {
       }
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -712,8 +693,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -805,20 +786,18 @@ namespace {
   };
 
   using SiStripApvGainsMaxDeviationRatioWithPreviousIOVTrackerMap =
-      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<1, cond::payloadInspector::MULTI_IOV>;
+      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<1, MULTI_IOV>;
 
   using SiStripApvGainsMaxDeviationRatioTrackerMapTwoTags =
-      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<2, cond::payloadInspector::SINGLE_IOV>;
+      SiStripApvGainsRatioMaxDeviationWithPreviousIOVTrackerMapBase<2, SINGLE_IOV>;
 
   /************************************************
     TrackerMap of SiStripApvGains (maximum gain per detid)
   *************************************************/
-  class SiStripApvGainsMaximumTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsMaximumTrackerMap : public PlotImage<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsMaximumTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStripAPVGains (maximum per DetId)") {}
+        : PlotImage<SiStripApvGain, SINGLE_IOV>("Tracker Map of SiStripAPVGains (maximum per DetId)") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -867,12 +846,10 @@ namespace {
   /************************************************
     TrackerMap of SiStripApvGains (minimum gain per detid)
   *************************************************/
-  class SiStripApvGainsMinimumTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsMinimumTrackerMap : public PlotImage<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsMinimumTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStripAPVGains (minimum per DetId)") {}
+        : PlotImage<SiStripApvGain, SINGLE_IOV>("Tracker Map of SiStripAPVGains (minimum per DetId)") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -923,11 +900,10 @@ namespace {
     time history histogram of SiStripApvGains 
   *************************************************/
 
-  class SiStripApvGainByRunMeans : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvGainByRunMeans : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvGainByRunMeans()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average",
-                                                                     "average Strip APV gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average", "average Strip APV gain value") {}
     ~SiStripApvGainByRunMeans() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -954,11 +930,11 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripApvGainProperties : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvGainProperties : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvGainProperties()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains " + estimatorType(est),
-                                                                     estimatorType(est) + " Strip APV gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains " + estimatorType(est),
+                                             estimatorType(est) + " Strip APV gain value") {}
     ~SiStripApvGainProperties() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -1021,11 +997,11 @@ namespace {
     time history histogram of TIB SiStripApvGains 
   *************************************************/
 
-  class SiStripApvTIBGainByRunMeans : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvTIBGainByRunMeans : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvTIBGainByRunMeans()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average",
-                                                                     "average Tracker Inner Barrel APV gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average",
+                                             "average Tracker Inner Barrel APV gain value") {}
     ~SiStripApvTIBGainByRunMeans() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -1056,11 +1032,10 @@ namespace {
     time history histogram of TOB SiStripApvGains 
   *************************************************/
 
-  class SiStripApvTOBGainByRunMeans : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvTOBGainByRunMeans : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvTOBGainByRunMeans()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average",
-                                                                     "average Tracker Outer Barrel gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average", "average Tracker Outer Barrel gain value") {}
     ~SiStripApvTOBGainByRunMeans() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -1091,11 +1066,11 @@ namespace {
     time history histogram of TID SiStripApvGains 
   *************************************************/
 
-  class SiStripApvTIDGainByRunMeans : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvTIDGainByRunMeans : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvTIDGainByRunMeans()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average",
-                                                                     "average Tracker Inner Disks APV gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average", "average Tracker Inner Disks APV gain value") {
+    }
     ~SiStripApvTIDGainByRunMeans() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -1125,11 +1100,11 @@ namespace {
     time history histogram of TEC SiStripApvGains 
   *************************************************/
 
-  class SiStripApvTECGainByRunMeans : public cond::payloadInspector::HistoryPlot<SiStripApvGain, float> {
+  class SiStripApvTECGainByRunMeans : public HistoryPlot<SiStripApvGain, float> {
   public:
     SiStripApvTECGainByRunMeans()
-        : cond::payloadInspector::HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average in TEC",
-                                                                     "average Tracker Endcaps APV gain value") {}
+        : HistoryPlot<SiStripApvGain, float>("SiStripApv Gains average in TEC",
+                                             "average Tracker Endcaps APV gain value") {}
     ~SiStripApvTECGainByRunMeans() override = default;
 
     float getFromPayload(SiStripApvGain& payload) override {
@@ -1160,12 +1135,10 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripApvGainsTest
-      : public cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsTest : public Histogram1D<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsTest()
-        : cond::payloadInspector::Histogram1D<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripApv Gains test", "SiStripApv Gains test", 10, 0.0, 10.0),
+        : Histogram1D<SiStripApvGain, SINGLE_IOV>("SiStripApv Gains test", "SiStripApv Gains test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -1207,16 +1180,15 @@ namespace {
     Compare Gains from 2 IOVs, 2 pads canvas, firsr for ratio, second for scatter plot
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsComparatorBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
-    SiStripApvGainsComparatorBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison") {}
+    SiStripApvGainsComparatorBase() : PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1225,8 +1197,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1408,25 +1380,25 @@ namespace {
     }
   };
 
-  using SiStripApvGainsComparatorSingleTag = SiStripApvGainsComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripApvGainsComparatorTwoTags = SiStripApvGainsComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripApvGainsComparatorSingleTag = SiStripApvGainsComparatorBase<1, MULTI_IOV>;
+  using SiStripApvGainsComparatorTwoTags = SiStripApvGainsComparatorBase<2, SINGLE_IOV>;
 
   //*******************************************//
   // Compare Gains from 2 IOVs
   //******************************************//
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsValuesComparatorBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsValuesComparatorBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsValuesComparatorBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("Comparison of SiStrip APV gains values") {}
+        : PlotImage<SiStripApvGain, nIOVs, ntags>("Comparison of SiStrip APV gains values") {}
 
     bool fill() override {
       TH1F::SetDefaultSumw2(true);
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1435,8 +1407,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1586,22 +1558,18 @@ namespace {
     }
   };
 
-  using SiStripApvGainsValuesComparatorSingleTag =
-      SiStripApvGainsValuesComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripApvGainsValuesComparatorTwoTags =
-      SiStripApvGainsValuesComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripApvGainsValuesComparatorSingleTag = SiStripApvGainsValuesComparatorBase<1, MULTI_IOV>;
+  using SiStripApvGainsValuesComparatorTwoTags = SiStripApvGainsValuesComparatorBase<2, SINGLE_IOV>;
 
   //*******************************************//
   // Compare Gains ratio from 2 IOVs, region by region
   //******************************************//
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsRatioComparatorByRegionBase
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsRatioComparatorByRegionBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsRatioComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>(
-              "Module by Module Comparison of SiStrip APV gains"),
+        : PlotImage<SiStripApvGain, nIOVs, ntags>("Module by Module Comparison of SiStrip APV gains"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -1610,8 +1578,8 @@ namespace {
       SiStripPI::setPaletteStyle(SiStripPI::GRAY);
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1620,8 +1588,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1802,27 +1770,25 @@ namespace {
     }
   };
 
-  using SiStripApvGainsRatioComparatorByRegionSingleTag =
-      SiStripApvGainsRatioComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripApvGainsRatioComparatorByRegionTwoTags =
-      SiStripApvGainsRatioComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripApvGainsRatioComparatorByRegionSingleTag = SiStripApvGainsRatioComparatorByRegionBase<1, MULTI_IOV>;
+  using SiStripApvGainsRatioComparatorByRegionTwoTags = SiStripApvGainsRatioComparatorByRegionBase<2, SINGLE_IOV>;
 
   /************************************************
     Compare Gains for each tracker region
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripApvGainsComparatorByRegionBase : public cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripApvGainsComparatorByRegionBase : public PlotImage<SiStripApvGain, nIOVs, ntags> {
   public:
     SiStripApvGainsComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison By Region"),
+        : PlotImage<SiStripApvGain, nIOVs, ntags>("SiStripGains Comparison By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1831,8 +1797,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1985,21 +1951,17 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
-  using SiStripApvGainsComparatorByRegionSingleTag =
-      SiStripApvGainsComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripApvGainsComparatorByRegionTwoTags =
-      SiStripApvGainsComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripApvGainsComparatorByRegionSingleTag = SiStripApvGainsComparatorByRegionBase<1, MULTI_IOV>;
+  using SiStripApvGainsComparatorByRegionTwoTags = SiStripApvGainsComparatorByRegionBase<2, SINGLE_IOV>;
 
   /************************************************
     Plot gain averages by region 
   *************************************************/
 
-  class SiStripApvGainsByRegion
-      : public cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripApvGainsByRegion : public PlotImage<SiStripApvGain, SINGLE_IOV> {
   public:
     SiStripApvGainsByRegion()
-        : cond::payloadInspector::PlotImage<SiStripApvGain, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripGains By Region"),
+        : PlotImage<SiStripApvGain, SINGLE_IOV>("SiStripGains By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -33,16 +33,17 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     1d histogram of SiStripBackPlaneCorrection of 1 IOV 
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripBackPlaneCorrectionValue
-      : public cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBackPlaneCorrectionValue : public Histogram1D<SiStripBackPlaneCorrection, SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrectionValue()
-        : cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripBackPlaneCorrection, SINGLE_IOV>(
               "SiStrip BackPlaneCorrection values", "SiStrip BackPlaneCorrection values", 100, 0.0, 0.1) {}
 
     bool fill() override {
@@ -64,12 +65,10 @@ namespace {
   /************************************************
     TrackerMap of SiStrip BackPlane Correction
   *************************************************/
-  class SiStripBackPlaneCorrection_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBackPlaneCorrection_TrackerMap : public PlotImage<SiStripBackPlaneCorrection, SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrection_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map SiStrip Backplane correction") {}
+        : PlotImage<SiStripBackPlaneCorrection, SINGLE_IOV>("Tracker Map SiStrip Backplane correction") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -106,12 +105,10 @@ namespace {
     Plot SiStrip BackPlane Correction averages by partition 
   *************************************************/
 
-  class SiStripBackPlaneCorrectionByRegion
-      : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBackPlaneCorrectionByRegion : public PlotImage<SiStripBackPlaneCorrection, SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrectionByRegion()
-        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripBackPlaneCorrection By Region"),
+        : PlotImage<SiStripBackPlaneCorrection, SINGLE_IOV>("SiStripBackPlaneCorrection By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBackPlaneCorrection_PayloadInspector.cc
@@ -38,13 +38,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripBackPlaneCorrectionValue : public cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection> {
+  class SiStripBackPlaneCorrectionValue
+      : public cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrectionValue()
-        : cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection>(
-              "SiStrip BackPlaneCorrection values", "SiStrip BackPlaneCorrection values", 100, 0.0, 0.1) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip BackPlaneCorrection values", "SiStrip BackPlaneCorrection values", 100, 0.0, 0.1) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -65,15 +64,16 @@ namespace {
   /************************************************
     TrackerMap of SiStrip BackPlane Correction
   *************************************************/
-  class SiStripBackPlaneCorrection_TrackerMap : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection> {
+  class SiStripBackPlaneCorrection_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrection_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection>("Tracker Map SiStrip Backplane correction") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map SiStrip Backplane correction") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripBackPlaneCorrection> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripBackPlaneCorrection");
@@ -106,17 +106,18 @@ namespace {
     Plot SiStrip BackPlane Correction averages by partition 
   *************************************************/
 
-  class SiStripBackPlaneCorrectionByRegion : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection> {
+  class SiStripBackPlaneCorrectionByRegion
+      : public cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripBackPlaneCorrectionByRegion()
-        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection>("SiStripBackPlaneCorrection By Region"),
+        : cond::payloadInspector::PlotImage<SiStripBackPlaneCorrection, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripBackPlaneCorrection By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripBackPlaneCorrection> payload = fetchPayload(std::get<1>(iov));
 
       SiStripDetSummary summaryBP{&m_trackerTopo};

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -219,10 +219,10 @@ namespace {
       std::string titleMap = "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag: " + tagname + ")";
 
       SiStripTkMaps myMap("COLZA0 L");
-      myMap.bookMap(titleMap,"");
+      myMap.bookMap(titleMap, "");
 
       SiStripTkMaps ghost("AL");
-      ghost.bookMap(titleMap,"");
+      ghost.bookMap(titleMap, "");
 
       std::vector<uint32_t> detid;
       payload->getDetIds(detid);
@@ -254,9 +254,7 @@ namespace {
       ltx.SetTextFont(62);
       ltx.SetTextSize(0.045);
       ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-		       1 - gPad->GetTopMargin() + 0.02,
-		       titleMap.c_str());
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.02, titleMap.c_str());
 
       canvas.SaveAs(fileName.c_str());
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -47,16 +47,16 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     test class
   *************************************************/
 
-  class SiStripBadStripTest
-      : public cond::payloadInspector::Histogram1D<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadStripTest : public Histogram1D<SiStripBadStrip, SINGLE_IOV> {
   public:
     SiStripBadStripTest()
-        : cond::payloadInspector::Histogram1D<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Bad Strip test", "SiStrip Bad Strip test", 10, 0.0, 10.0) {}
+        : Histogram1D<SiStripBadStrip, SINGLE_IOV>("SiStrip Bad Strip test", "SiStrip Bad Strip test", 10, 0.0, 10.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -95,17 +95,14 @@ namespace {
   /************************************************
     TrackerMap of SiStripBadStrip (bad strip per detid)
   *************************************************/
-  class SiStripBadModuleTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadModuleTrackerMap : public PlotImage<SiStripBadStrip, SINGLE_IOV> {
   public:
-    SiStripBadModuleTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStrip Bad Strips") {}
+    SiStripBadModuleTrackerMap() : PlotImage<SiStripBadStrip, SINGLE_IOV>("Tracker Map of SiStrip Bad Strips") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
-      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
@@ -135,17 +132,15 @@ namespace {
   /************************************************
     TrackerMap of SiStripBadStrip (bad strips fraction)
   *************************************************/
-  class SiStripBadStripFractionTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadStripFractionTrackerMap : public PlotImage<SiStripBadStrip, SINGLE_IOV> {
   public:
     SiStripBadStripFractionTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStrip Bad Components fraction") {}
+        : PlotImage<SiStripBadStrip, SINGLE_IOV>("Tracker Map of SiStrip Bad Components fraction") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
-      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -195,12 +190,10 @@ namespace {
   /************************************************
     TrackerMap of SiStripBadStrip (bad strips fraction)
   *************************************************/
-  class SiStripBadStripFractionTkMap
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadStripFractionTkMap : public PlotImage<SiStripBadStrip, SINGLE_IOV> {
   public:
     SiStripBadStripFractionTkMap()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStrip Bad Components fraction") {}
+        : PlotImage<SiStripBadStrip, SINGLE_IOV>("Tracker Map of SiStrip Bad Components fraction") {}
 
     bool fill() override {
       //SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
@@ -208,7 +201,7 @@ namespace {
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
-      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto tagname = PlotBase::getTag<0>().name;
       std::shared_ptr<SiStripBadStrip> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -258,11 +251,10 @@ namespace {
     time history histogram of bad components fraction
   *************************************************/
 
-  class SiStripBadStripFractionByRun : public cond::payloadInspector::HistoryPlot<SiStripBadStrip, float> {
+  class SiStripBadStripFractionByRun : public HistoryPlot<SiStripBadStrip, float> {
   public:
     SiStripBadStripFractionByRun()
-        : cond::payloadInspector::HistoryPlot<SiStripBadStrip, float>("SiStrip Bad Strip fraction per run",
-                                                                      "Bad Strip fraction [%]") {}
+        : HistoryPlot<SiStripBadStrip, float>("SiStrip Bad Strip fraction per run", "Bad Strip fraction [%]") {}
     ~SiStripBadStripFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
@@ -301,11 +293,11 @@ namespace {
     time history histogram of bad components fraction (TIB)
   *************************************************/
 
-  class SiStripBadStripTIBFractionByRun : public cond::payloadInspector::HistoryPlot<SiStripBadStrip, float> {
+  class SiStripBadStripTIBFractionByRun : public HistoryPlot<SiStripBadStrip, float> {
   public:
     SiStripBadStripTIBFractionByRun()
-        : cond::payloadInspector::HistoryPlot<SiStripBadStrip, float>("SiStrip Inner Barrel Bad Strip fraction per run",
-                                                                      "TIB Bad Strip fraction [%]") {}
+        : HistoryPlot<SiStripBadStrip, float>("SiStrip Inner Barrel Bad Strip fraction per run",
+                                              "TIB Bad Strip fraction [%]") {}
     ~SiStripBadStripTIBFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
@@ -347,11 +339,11 @@ namespace {
     time history histogram of bad components fraction (TOB)
   *************************************************/
 
-  class SiStripBadStripTOBFractionByRun : public cond::payloadInspector::HistoryPlot<SiStripBadStrip, float> {
+  class SiStripBadStripTOBFractionByRun : public HistoryPlot<SiStripBadStrip, float> {
   public:
     SiStripBadStripTOBFractionByRun()
-        : cond::payloadInspector::HistoryPlot<SiStripBadStrip, float>("SiStrip Outer Barrel Bad Strip fraction per run",
-                                                                      "TOB Bad Strip fraction [%]") {}
+        : HistoryPlot<SiStripBadStrip, float>("SiStrip Outer Barrel Bad Strip fraction per run",
+                                              "TOB Bad Strip fraction [%]") {}
     ~SiStripBadStripTOBFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
@@ -393,11 +385,11 @@ namespace {
     time history histogram of bad components fraction (TID)
    *************************************************/
 
-  class SiStripBadStripTIDFractionByRun : public cond::payloadInspector::HistoryPlot<SiStripBadStrip, float> {
+  class SiStripBadStripTIDFractionByRun : public HistoryPlot<SiStripBadStrip, float> {
   public:
     SiStripBadStripTIDFractionByRun()
-        : cond::payloadInspector::HistoryPlot<SiStripBadStrip, float>("SiStrip Inner Disks Bad Strip fraction per run",
-                                                                      "TID Bad Strip fraction [%]") {}
+        : HistoryPlot<SiStripBadStrip, float>("SiStrip Inner Disks Bad Strip fraction per run",
+                                              "TID Bad Strip fraction [%]") {}
     ~SiStripBadStripTIDFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
@@ -439,11 +431,11 @@ namespace {
     time history histogram of bad components fraction (TEC)
    *************************************************/
 
-  class SiStripBadStripTECFractionByRun : public cond::payloadInspector::HistoryPlot<SiStripBadStrip, float> {
+  class SiStripBadStripTECFractionByRun : public HistoryPlot<SiStripBadStrip, float> {
   public:
     SiStripBadStripTECFractionByRun()
-        : cond::payloadInspector::HistoryPlot<SiStripBadStrip, float>("SiStrip Endcaps Bad Strip fraction per run",
-                                                                      "TEC Bad Strip fraction [%]") {}
+        : HistoryPlot<SiStripBadStrip, float>("SiStrip Endcaps Bad Strip fraction per run",
+                                              "TEC Bad Strip fraction [%]") {}
     ~SiStripBadStripTECFractionByRun() override = default;
 
     float getFromPayload(SiStripBadStrip& payload) override {
@@ -485,12 +477,10 @@ namespace {
     Plot BadStrip by region 
   *************************************************/
 
-  class SiStripBadStripByRegion
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadStripByRegion : public PlotImage<SiStripBadStrip, SINGLE_IOV> {
   public:
     SiStripBadStripByRegion()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip BadStrip By Region"),
+        : PlotImage<SiStripBadStrip, SINGLE_IOV>("SiStrip BadStrip By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -620,19 +610,18 @@ namespace {
     Plot BadStrip by region comparison
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripBadStripByRegionComparisonBase
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripBadStripByRegionComparisonBase : public PlotImage<SiStripBadStrip, nIOVs, ntags> {
   public:
     SiStripBadStripByRegionComparisonBase()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags>("SiStrip BadStrip By Region Comparison"),
+        : PlotImage<SiStripBadStrip, nIOVs, ntags>("SiStrip BadStrip By Region Comparison"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -641,8 +630,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -838,27 +827,23 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
-  using SiStripBadStripByRegionComparisonSingleTag =
-      SiStripBadStripByRegionComparisonBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripBadStripByRegionComparisonTwoTags =
-      SiStripBadStripByRegionComparisonBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripBadStripByRegionComparisonSingleTag = SiStripBadStripByRegionComparisonBase<1, MULTI_IOV>;
+  using SiStripBadStripByRegionComparisonTwoTags = SiStripBadStripByRegionComparisonBase<2, SINGLE_IOV>;
 
   /************************************************
     TrackerMap of SiStripBadStrip (bad strips fraction difference)
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripBadStripFractionComparisonTrackerMapBase
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripBadStripFractionComparisonTrackerMapBase : public PlotImage<SiStripBadStrip, nIOVs, ntags> {
   public:
     SiStripBadStripFractionComparisonTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags>(
-              "Tracker Map of SiStrip bad strip fraction difference") {}
+        : PlotImage<SiStripBadStrip, nIOVs, ntags>("Tracker Map of SiStrip bad strip fraction difference") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -867,8 +852,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -961,20 +946,18 @@ namespace {
   };
 
   using SiStripBadStripFractionComparisonTrackerMapSingleTag =
-      SiStripBadStripFractionComparisonTrackerMapBase<1, cond::payloadInspector::MULTI_IOV>;
+      SiStripBadStripFractionComparisonTrackerMapBase<1, MULTI_IOV>;
   using SiStripBadStripFractionComparisonTrackerMapTwoTags =
-      SiStripBadStripFractionComparisonTrackerMapBase<2, cond::payloadInspector::SINGLE_IOV>;
+      SiStripBadStripFractionComparisonTrackerMapBase<2, SINGLE_IOV>;
 
   /************************************************
     Plot BadStrip Quality analysis 
   *************************************************/
 
-  class SiStripBadStripQualityAnalysis
-      : public cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripBadStripQualityAnalysis : public PlotImage<SiStripBadStrip, SINGLE_IOV> {
   public:
     SiStripBadStripQualityAnalysis()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip BadStrip Quality Analysis"),
+        : PlotImage<SiStripBadStrip, SINGLE_IOV>("SiStrip BadStrip Quality Analysis"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -1150,12 +1133,11 @@ namespace {
     Plot BadStrip Quality Comparison
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripBadStripQualityComparisonBase : public cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripBadStripQualityComparisonBase : public PlotImage<SiStripBadStrip, nIOVs, ntags> {
   public:
     SiStripBadStripQualityComparisonBase()
-        : cond::payloadInspector::PlotImage<SiStripBadStrip, nIOVs, ntags>(
-              "SiStrip BadStrip Quality Comparison Analysis"),
+        : PlotImage<SiStripBadStrip, nIOVs, ntags>("SiStrip BadStrip Quality Comparison Analysis"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -1164,8 +1146,8 @@ namespace {
       gStyle->SetPalette(kTemperatureMap);
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1174,8 +1156,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1369,10 +1351,8 @@ namespace {
     TrackerTopology m_trackerTopo;
   };
 
-  using SiStripBadStripQualityComparisonSingleTag =
-      SiStripBadStripQualityComparisonBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripBadStripQualityComparisonTwoTags =
-      SiStripBadStripQualityComparisonBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripBadStripQualityComparisonSingleTag = SiStripBadStripQualityComparisonBase<1, MULTI_IOV>;
+  using SiStripBadStripQualityComparisonTwoTags = SiStripBadStripQualityComparisonBase<2, SINGLE_IOV>;
 
 }  // namespace
 

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -216,10 +216,11 @@ namespace {
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
 
-      std::string titleMap = "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag: " + tagname + ")";
+      std::string titleMap =
+          "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag: #color[2]{" + tagname + "})";
 
       SiStripTkMaps myMap("COLZA0 L");
-      myMap.bookMap(titleMap, "");
+      myMap.bookMap(titleMap, "Fraction of bad Strips per module");
 
       SiStripTkMaps ghost("AL");
       ghost.bookMap(titleMap, "");

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -248,7 +248,6 @@ namespace {
       TCanvas canvas("Bad Components fraction", "bad components fraction");
       myMap.drawMap(canvas, "");
       ghost.drawMap(canvas, "same");
-      ghost.dressMap(canvas);
       canvas.SaveAs(fileName.c_str());
 
       delete reader;

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -204,7 +204,8 @@ namespace {
               "Tracker Map of SiStrip Bad Components fraction") {}
 
     bool fill() override {
-      gStyle->SetPalette(kRainBow);
+      //SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
+      gStyle->SetPalette(1);
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
@@ -217,7 +218,7 @@ namespace {
       auto theIOVsince = std::to_string(std::get<0>(iov));
 
       std::string titleMap =
-          "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag: #color[2]{" + tagname + "})";
+          "Fraction of bad Strips per module, Run: " + theIOVsince + " (tag:#color[2]{" + tagname + "})";
 
       SiStripTkMaps myMap("COLZA0 L");
       myMap.bookMap(titleMap, "Fraction of bad Strips per module");
@@ -234,7 +235,6 @@ namespace {
         SiStripBadStrip::Range range = payload->getRange(d);
         for (std::vector<unsigned int>::const_iterator badStrip = range.first; badStrip != range.second; ++badStrip) {
           badStripsPerDetId[d] += payload->decode(*badStrip).range;
-          //ss << "DetId="<< d << " Strip=" << payload->decode(*badStrip).firstStrip <<":"<< payload->decode(*badStrip).range << " flag="<< payload->decode(*badStrip).flag << std::endl;
         }
         float fraction = badStripsPerDetId[d] / (128. * reader->getNumberOfApvsAndStripLength(d).first);
         if (fraction > 0.) {
@@ -245,18 +245,10 @@ namespace {
       //=========================
 
       std::string fileName(m_imageFileName);
-
-      //myMap.setZAxisRange(-0.4,1.);
-      TCanvas canvas("Bad Components fraction", "bad components fraction", 3000, 1200);
+      TCanvas canvas("Bad Components fraction", "bad components fraction");
       myMap.drawMap(canvas, "");
       ghost.drawMap(canvas, "same");
-
-      auto ltx = TLatex();
-      ltx.SetTextFont(62);
-      ltx.SetTextSize(0.045);
-      ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.02, titleMap.c_str());
-
+      ghost.dressMap(canvas);
       canvas.SaveAs(fileName.c_str());
 
       delete reader;

--- a/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc
@@ -929,11 +929,11 @@ namespace {
         }
       }
 
-      /*
-	std::cout<<"In 2 but not in 1:"<<  countLastButNotFirst << std::endl;
-	std::cout<<"In 1 but not in 2:"<<  countFirstButNotLast << std::endl;
-	std::cout<<"In both:"<<  countBoth << std::endl;
-      */
+#ifdef MMDEBUG
+      std::cout << "In 2 but not in 1:" << countLastButNotFirst << std::endl;
+      std::cout << "In 1 but not in 2:" << countFirstButNotLast << std::endl;
+      std::cout << "In both:" << countBoth << std::endl;
+#endif
 
       //=========================
 

--- a/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
@@ -36,12 +36,13 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   // test class
-  class SiStripConfObjectTest
-      : public cond::payloadInspector::Histogram1D<SiStripConfObject, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripConfObjectTest : public Histogram1D<SiStripConfObject, SINGLE_IOV> {
   public:
     SiStripConfObjectTest()
-        : cond::payloadInspector::Histogram1D<SiStripConfObject, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripConfObject, SINGLE_IOV>(
               "SiStrip Configuration Object test", "SiStrip Configuration Object test", 1, 0.0, 1.0) {}
 
     bool fill() override {
@@ -68,12 +69,9 @@ namespace {
   };
 
   // display class
-  class SiStripConfObjectDisplay
-      : public cond::payloadInspector::PlotImage<SiStripConfObject, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripConfObjectDisplay : public PlotImage<SiStripConfObject, SINGLE_IOV> {
   public:
-    SiStripConfObjectDisplay()
-        : cond::payloadInspector::PlotImage<SiStripConfObject, cond::payloadInspector::SINGLE_IOV>(
-              "Display Configuration Values") {}
+    SiStripConfObjectDisplay() : PlotImage<SiStripConfObject, SINGLE_IOV>("Display Configuration Values") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripConfObject_PayloadInspector.cc
@@ -37,13 +37,12 @@
 namespace {
 
   // test class
-  class SiStripConfObjectTest : public cond::payloadInspector::Histogram1D<SiStripConfObject> {
+  class SiStripConfObjectTest
+      : public cond::payloadInspector::Histogram1D<SiStripConfObject, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripConfObjectTest()
-        : cond::payloadInspector::Histogram1D<SiStripConfObject>(
-              "SiStrip Configuration Object test", "SiStrip Configuration Object test", 1, 0.0, 1.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripConfObject, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Configuration Object test", "SiStrip Configuration Object test", 1, 0.0, 1.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -69,14 +68,16 @@ namespace {
   };
 
   // display class
-  class SiStripConfObjectDisplay : public cond::payloadInspector::PlotImage<SiStripConfObject> {
+  class SiStripConfObjectDisplay
+      : public cond::payloadInspector::PlotImage<SiStripConfObject, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiStripConfObjectDisplay() : cond::payloadInspector::PlotImage<SiStripConfObject>("Display Configuration Values") {
-      setSingleIov(true);
-    }
+    SiStripConfObjectDisplay()
+        : cond::payloadInspector::PlotImage<SiStripConfObject, cond::payloadInspector::SINGLE_IOV>(
+              "Display Configuration Values") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripConfObject> payload = fetchPayload(std::get<1>(iov));
 
       unsigned int run = std::get<0>(iov);

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -44,15 +44,16 @@ namespace {
   /************************************************
     TrackerMap of Module VOff
   *************************************************/
-  class SiStripDetVOff_IsModuleVOff_TrackerMap : public cond::payloadInspector::PlotImage<SiStripDetVOff> {
+  class SiStripDetVOff_IsModuleVOff_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOff_IsModuleVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff>("Tracker Map IsModuleVOff") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map IsModuleVOff") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripIsModuleVOff");
@@ -79,15 +80,16 @@ namespace {
   /************************************************
     TrackerMap of Module HVOff
   *************************************************/
-  class SiStripDetVOff_IsModuleHVOff_TrackerMap : public cond::payloadInspector::PlotImage<SiStripDetVOff> {
+  class SiStripDetVOff_IsModuleHVOff_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOff_IsModuleHVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff>("Tracker Map IsModuleHVOff") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map IsModuleHVOff") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripIsModuleHVOff");
@@ -114,15 +116,16 @@ namespace {
   /************************************************
     TrackerMap of Module LVOff
   *************************************************/
-  class SiStripDetVOff_IsModuleLVOff_TrackerMap : public cond::payloadInspector::PlotImage<SiStripDetVOff> {
+  class SiStripDetVOff_IsModuleLVOff_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOff_IsModuleLVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff>("Tracker Map IsModuleLVOff") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map IsModuleLVOff") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripIsModuleLVOff");
@@ -155,13 +158,12 @@ namespace {
   }
 
   template <SiStripDetVOffPI::type my_type>
-  class SiStripDetVOffListOfModules : public cond::payloadInspector::Histogram1DD<SiStripDetVOff> {
+  class SiStripDetVOffListOfModules
+      : public cond::payloadInspector::Histogram1DD<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOffListOfModules()
-        : cond::payloadInspector::Histogram1DD<SiStripDetVOff>(
-              "SiStrip Off modules", "SiStrip Off modules", 15148, 0., 15148., "DetId of VOff module") {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1DD<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Off modules", "SiStrip Off modules", 15148, 0., 15148., "DetId of VOff module") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -217,15 +219,14 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripDetVOffTest : public cond::payloadInspector::Histogram1D<SiStripDetVOff> {
+  class SiStripDetVOffTest
+      : public cond::payloadInspector::Histogram1D<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOffTest()
-        : cond::payloadInspector::Histogram1D<SiStripDetVOff>(
+        : cond::payloadInspector::Histogram1D<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
               "SiStrip DetVOff test", "SiStrip DetVOff test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      Base::setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -271,17 +272,18 @@ namespace {
     Plot DetVOff by region 
   *************************************************/
 
-  class SiStripDetVOffByRegion : public cond::payloadInspector::PlotImage<SiStripDetVOff> {
+  class SiStripDetVOffByRegion
+      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripDetVOffByRegion()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff>("SiStrip DetVOff By Region"),
+        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip DetVOff By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripDetVOff> payload = fetchPayload(std::get<1>(iov));
 
       std::vector<uint32_t> detid;

--- a/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripDetVOff_PayloadInspector.cc
@@ -25,18 +25,18 @@
 
 namespace {
 
-  class SiStripDetVOff_LV : public cond::payloadInspector::TimeHistoryPlot<SiStripDetVOff, int> {
+  using namespace cond::payloadInspector;
+
+  class SiStripDetVOff_LV : public TimeHistoryPlot<SiStripDetVOff, int> {
   public:
-    SiStripDetVOff_LV()
-        : cond::payloadInspector::TimeHistoryPlot<SiStripDetVOff, int>("Nr of mod with LV OFF vs time", "nLVOff") {}
+    SiStripDetVOff_LV() : TimeHistoryPlot<SiStripDetVOff, int>("Nr of mod with LV OFF vs time", "nLVOff") {}
 
     int getFromPayload(SiStripDetVOff& payload) override { return payload.getLVoffCounts(); }
   };
 
-  class SiStripDetVOff_HV : public cond::payloadInspector::TimeHistoryPlot<SiStripDetVOff, int> {
+  class SiStripDetVOff_HV : public TimeHistoryPlot<SiStripDetVOff, int> {
   public:
-    SiStripDetVOff_HV()
-        : cond::payloadInspector::TimeHistoryPlot<SiStripDetVOff, int>("Nr of mod with HV OFF vs time", "nHVOff") {}
+    SiStripDetVOff_HV() : TimeHistoryPlot<SiStripDetVOff, int>("Nr of mod with HV OFF vs time", "nHVOff") {}
 
     int getFromPayload(SiStripDetVOff& payload) override { return payload.getHVoffCounts(); }
   };
@@ -44,12 +44,9 @@ namespace {
   /************************************************
     TrackerMap of Module VOff
   *************************************************/
-  class SiStripDetVOff_IsModuleVOff_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOff_IsModuleVOff_TrackerMap : public PlotImage<SiStripDetVOff, SINGLE_IOV> {
   public:
-    SiStripDetVOff_IsModuleVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map IsModuleVOff") {}
+    SiStripDetVOff_IsModuleVOff_TrackerMap() : PlotImage<SiStripDetVOff, SINGLE_IOV>("Tracker Map IsModuleVOff") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -80,12 +77,9 @@ namespace {
   /************************************************
     TrackerMap of Module HVOff
   *************************************************/
-  class SiStripDetVOff_IsModuleHVOff_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOff_IsModuleHVOff_TrackerMap : public PlotImage<SiStripDetVOff, SINGLE_IOV> {
   public:
-    SiStripDetVOff_IsModuleHVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map IsModuleHVOff") {}
+    SiStripDetVOff_IsModuleHVOff_TrackerMap() : PlotImage<SiStripDetVOff, SINGLE_IOV>("Tracker Map IsModuleHVOff") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -116,12 +110,9 @@ namespace {
   /************************************************
     TrackerMap of Module LVOff
   *************************************************/
-  class SiStripDetVOff_IsModuleLVOff_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOff_IsModuleLVOff_TrackerMap : public PlotImage<SiStripDetVOff, SINGLE_IOV> {
   public:
-    SiStripDetVOff_IsModuleLVOff_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map IsModuleLVOff") {}
+    SiStripDetVOff_IsModuleLVOff_TrackerMap() : PlotImage<SiStripDetVOff, SINGLE_IOV>("Tracker Map IsModuleLVOff") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -158,11 +149,10 @@ namespace {
   }
 
   template <SiStripDetVOffPI::type my_type>
-  class SiStripDetVOffListOfModules
-      : public cond::payloadInspector::Histogram1DD<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOffListOfModules : public Histogram1DD<SiStripDetVOff, SINGLE_IOV> {
   public:
     SiStripDetVOffListOfModules()
-        : cond::payloadInspector::Histogram1DD<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1DD<SiStripDetVOff, SINGLE_IOV>(
               "SiStrip Off modules", "SiStrip Off modules", 15148, 0., 15148., "DetId of VOff module") {}
 
     bool fill() override {
@@ -219,12 +209,10 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripDetVOffTest
-      : public cond::payloadInspector::Histogram1D<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOffTest : public Histogram1D<SiStripDetVOff, SINGLE_IOV> {
   public:
     SiStripDetVOffTest()
-        : cond::payloadInspector::Histogram1D<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip DetVOff test", "SiStrip DetVOff test", 10, 0.0, 10.0),
+        : Histogram1D<SiStripDetVOff, SINGLE_IOV>("SiStrip DetVOff test", "SiStrip DetVOff test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -272,12 +260,10 @@ namespace {
     Plot DetVOff by region 
   *************************************************/
 
-  class SiStripDetVOffByRegion
-      : public cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripDetVOffByRegion : public PlotImage<SiStripDetVOff, SINGLE_IOV> {
   public:
     SiStripDetVOffByRegion()
-        : cond::payloadInspector::PlotImage<SiStripDetVOff, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip DetVOff By Region"),
+        : PlotImage<SiStripDetVOff, SINGLE_IOV>("SiStrip DetVOff By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 

--- a/CondCore/SiStripPlugins/plugins/SiStripFedCabling_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripFedCabling_PayloadInspector.cc
@@ -27,15 +27,14 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     TrackerMap of SiStrip FED Cabling
   *************************************************/
-  class SiStripFedCabling_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripFedCabling_TrackerMap : public PlotImage<SiStripFedCabling, SINGLE_IOV> {
   public:
-    SiStripFedCabling_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map SiStrip Fed Cabling") {}
+    SiStripFedCabling_TrackerMap() : PlotImage<SiStripFedCabling, SINGLE_IOV>("Tracker Map SiStrip Fed Cabling") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -76,12 +75,9 @@ namespace {
   /************************************************
     Summary Plot of SiStrip FED Cabling
   *************************************************/
-  class SiStripFedCabling_Summary
-      : public cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripFedCabling_Summary : public PlotImage<SiStripFedCabling, SINGLE_IOV> {
   public:
-    SiStripFedCabling_Summary()
-        : cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Fed Cabling Summary") {}
+    SiStripFedCabling_Summary() : PlotImage<SiStripFedCabling, SINGLE_IOV>("SiStrip Fed Cabling Summary") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/SiStripPlugins/plugins/SiStripFedCabling_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripFedCabling_PayloadInspector.cc
@@ -30,15 +30,16 @@ namespace {
   /************************************************
     TrackerMap of SiStrip FED Cabling
   *************************************************/
-  class SiStripFedCabling_TrackerMap : public cond::payloadInspector::PlotImage<SiStripFedCabling> {
+  class SiStripFedCabling_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripFedCabling_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripFedCabling>("Tracker Map SiStrip Fed Cabling") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map SiStrip Fed Cabling") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripFedCabling> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripFedCabling");
@@ -75,14 +76,16 @@ namespace {
   /************************************************
     Summary Plot of SiStrip FED Cabling
   *************************************************/
-  class SiStripFedCabling_Summary : public cond::payloadInspector::PlotImage<SiStripFedCabling> {
+  class SiStripFedCabling_Summary
+      : public cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV> {
   public:
-    SiStripFedCabling_Summary() : cond::payloadInspector::PlotImage<SiStripFedCabling>("SiStrip Fed Cabling Summary") {
-      setSingleIov(true);
-    }
+    SiStripFedCabling_Summary()
+        : cond::payloadInspector::PlotImage<SiStripFedCabling, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Fed Cabling Summary") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripFedCabling> payload = fetchPayload(std::get<1>(iov));
       int IOV = std::get<0>(iov);
       std::vector<uint32_t> activeDetIds;

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -40,16 +40,16 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
    ***************  test class ******************
   *************************************************/
 
-  class SiStripLatencyTest
-      : public cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLatencyTest : public Histogram1D<SiStripLatency, SINGLE_IOV> {
   public:
     SiStripLatencyTest()
-        : cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripLatency values", "SiStripLatency values", 5, 0.0, 5.0) {}
+        : Histogram1D<SiStripLatency, SINGLE_IOV>("SiStripLatency values", "SiStripLatency values", 5, 0.0, 5.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -67,12 +67,9 @@ namespace {
   /***********************************************
   // 1d histogram of mode  of 1 IOV 
   ************************************************/
-  class SiStripLatencyMode
-      : public cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLatencyMode : public Histogram1D<SiStripLatency, SINGLE_IOV> {
   public:
-    SiStripLatencyMode()
-        : cond::payloadInspector::Histogram1D<SiStripLatency>(
-              "SiStripLatency mode", "SiStripLatency mode", 70, -10, 60) {}
+    SiStripLatencyMode() : Histogram1D<SiStripLatency>("SiStripLatency mode", "SiStripLatency mode", 70, -10, 60) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -98,10 +95,9 @@ namespace {
    *******************1D histo of mode as a function of the run****************
    *****************************************************************************/
 
-  class SiStripLatencyModeHistory : public cond::payloadInspector::HistoryPlot<SiStripLatency, uint16_t> {
+  class SiStripLatencyModeHistory : public HistoryPlot<SiStripLatency, uint16_t> {
   public:
-    SiStripLatencyModeHistory()
-        : cond::payloadInspector::HistoryPlot<SiStripLatency, uint16_t>("Mode vs run number", "Mode vs run number") {}
+    SiStripLatencyModeHistory() : HistoryPlot<SiStripLatency, uint16_t>("Mode vs run number", "Mode vs run number") {}
 
     uint16_t getFromPayload(SiStripLatency& payload) override {
       uint16_t singlemode = payload.singleMode();
@@ -112,11 +108,10 @@ namespace {
   /****************************************************************************    
    *****************number of modes  per run *************************************
    **************************************************************************/
-  class SiStripLatencyNumbOfModeHistory : public cond::payloadInspector::HistoryPlot<SiStripLatency, int> {
+  class SiStripLatencyNumbOfModeHistory : public HistoryPlot<SiStripLatency, int> {
   public:
     SiStripLatencyNumbOfModeHistory()
-        : cond::payloadInspector::HistoryPlot<SiStripLatency, int>("Number of modes vs run ",
-                                                                   "Number of modes vs run") {}
+        : HistoryPlot<SiStripLatency, int>("Number of modes vs run ", "Number of modes vs run") {}
 
     int getFromPayload(SiStripLatency& payload) override {
       std::vector<uint16_t> modes;

--- a/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc
@@ -44,13 +44,12 @@ namespace {
    ***************  test class ******************
   *************************************************/
 
-  class SiStripLatencyTest : public cond::payloadInspector::Histogram1D<SiStripLatency> {
+  class SiStripLatencyTest
+      : public cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripLatencyTest()
-        : cond::payloadInspector::Histogram1D<SiStripLatency>(
-              "SiStripLatency values", "SiStripLatency values", 5, 0.0, 5.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripLatency values", "SiStripLatency values", 5, 0.0, 5.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -68,13 +67,12 @@ namespace {
   /***********************************************
   // 1d histogram of mode  of 1 IOV 
   ************************************************/
-  class SiStripLatencyMode : public cond::payloadInspector::Histogram1D<SiStripLatency> {
+  class SiStripLatencyMode
+      : public cond::payloadInspector::Histogram1D<SiStripLatency, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripLatencyMode()
         : cond::payloadInspector::Histogram1D<SiStripLatency>(
-              "SiStripLatency mode", "SiStripLatency mode", 70, -10, 60) {
-      Base::setSingleIov(true);
-    }
+              "SiStripLatency mode", "SiStripLatency mode", 70, -10, 60) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -40,13 +40,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripLorentzAngleValue : public cond::payloadInspector::Histogram1D<SiStripLorentzAngle> {
+  class SiStripLorentzAngleValue
+      : public cond::payloadInspector::Histogram1D<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripLorentzAngleValue()
-        : cond::payloadInspector::Histogram1D<SiStripLorentzAngle>(
-              "SiStrip LorentzAngle values", "SiStrip LorentzAngle values", 100, 0.0, 0.05) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip LorentzAngle values", "SiStrip LorentzAngle values", 100, 0.0, 0.05) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -67,15 +66,16 @@ namespace {
   /************************************************
     TrackerMap of SiStrip Lorentz Angle
   *************************************************/
-  class SiStripLorentzAngle_TrackerMap : public cond::payloadInspector::PlotImage<SiStripLorentzAngle> {
+  class SiStripLorentzAngle_TrackerMap
+      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripLorentzAngle_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle>("Tracker Map SiStrip Lorentz Angle") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map SiStrip Lorentz Angle") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       std::unique_ptr<TrackerMap> tmap = std::make_unique<TrackerMap>("SiStripLorentzAngle");
@@ -152,17 +152,18 @@ namespace {
     Plot Lorentz Angle averages by partition 
   *************************************************/
 
-  class SiStripLorentzAngleByRegion : public cond::payloadInspector::PlotImage<SiStripLorentzAngle> {
+  class SiStripLorentzAngleByRegion
+      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripLorentzAngleByRegion()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle>("SiStripLorentzAngle By Region"),
+        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+              "SiStripLorentzAngle By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<SiStripLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       SiStripDetSummary summaryLA{&m_trackerTopo};

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -115,8 +115,7 @@ namespace {
               "Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
-      //gStyle->SetPalette(kRainBow);
-      SiStripPI::setPaletteStyle(SiStripPI::BLUERED);
+      SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
@@ -125,7 +124,7 @@ namespace {
       std::shared_ptr<SiStripLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
-      std::string titleMap = "SiStrip Lorentz Angle Map, Run: " + theIOVsince + " (tag: " + tagname + ")";
+      std::string titleMap = "SiStrip Lorentz Angle Map, Run: " + theIOVsince + " (tag: #color[2]{" + tagname + "})";
 
       SiStripTkMaps myMap("COLZA L");
       myMap.bookMap(titleMap, "SiStrip #mu_{H}=(tan#theta_{L}/B) [1/T]");

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -35,16 +35,17 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     1d histogram of SiStripLorentzAngle of 1 IOV 
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripLorentzAngleValue
-      : public cond::payloadInspector::Histogram1D<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLorentzAngleValue : public Histogram1D<SiStripLorentzAngle, SINGLE_IOV> {
   public:
     SiStripLorentzAngleValue()
-        : cond::payloadInspector::Histogram1D<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripLorentzAngle, SINGLE_IOV>(
               "SiStrip LorentzAngle values", "SiStrip LorentzAngle values", 100, 0.0, 0.05) {}
 
     bool fill() override {
@@ -66,12 +67,10 @@ namespace {
   /************************************************
     TrackerMap of SiStrip Lorentz Angle
   *************************************************/
-  class SiStripLorentzAngle_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLorentzAngle_TrackerMap : public PlotImage<SiStripLorentzAngle, SINGLE_IOV> {
   public:
     SiStripLorentzAngle_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map SiStrip Lorentz Angle") {}
+        : PlotImage<SiStripLorentzAngle, SINGLE_IOV>("Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -107,12 +106,9 @@ namespace {
   /************************************************
     SiStripTkMaps of SiStrip Lorentz Angle
   *************************************************/
-  class SiStripLorentzAngleTkMap
-      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLorentzAngleTkMap : public PlotImage<SiStripLorentzAngle, SINGLE_IOV> {
   public:
-    SiStripLorentzAngleTkMap()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map SiStrip Lorentz Angle") {}
+    SiStripLorentzAngleTkMap() : PlotImage<SiStripLorentzAngle, SINGLE_IOV>("Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
       //SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
@@ -120,7 +116,7 @@ namespace {
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
-      auto tagname = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto tagname = PlotBase::getTag<0>().name;
 
       std::shared_ptr<SiStripLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
@@ -152,12 +148,10 @@ namespace {
     Plot Lorentz Angle averages by partition 
   *************************************************/
 
-  class SiStripLorentzAngleByRegion
-      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripLorentzAngleByRegion : public PlotImage<SiStripLorentzAngle, SINGLE_IOV> {
   public:
     SiStripLorentzAngleByRegion()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, cond::payloadInspector::SINGLE_IOV>(
-              "SiStripLorentzAngle By Region"),
+        : PlotImage<SiStripLorentzAngle, SINGLE_IOV>("SiStripLorentzAngle By Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -268,20 +262,18 @@ namespace {
     Plot SiStripLorentz Angle averages by partition comparison
   *************************************************/
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripLorentzAngleComparatorByRegionBase
-      : public cond::payloadInspector::PlotImage<SiStripLorentzAngle, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripLorentzAngleComparatorByRegionBase : public PlotImage<SiStripLorentzAngle, nIOVs, ntags> {
   public:
     SiStripLorentzAngleComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripLorentzAngle, nIOVs, ntags>(
-              "SiStripLorentzAngle By Region Comparison"),
+        : PlotImage<SiStripLorentzAngle, nIOVs, ntags>("SiStripLorentzAngle By Region Comparison"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -290,8 +282,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -443,10 +435,8 @@ namespace {
     }
   };
 
-  using SiStripLorentzAngleByRegionCompareSingleTag =
-      SiStripLorentzAngleComparatorByRegionBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripLorentzAngleByRegionCompareTwoTags =
-      SiStripLorentzAngleComparatorByRegionBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripLorentzAngleByRegionCompareSingleTag = SiStripLorentzAngleComparatorByRegionBase<1, MULTI_IOV>;
+  using SiStripLorentzAngleByRegionCompareTwoTags = SiStripLorentzAngleComparatorByRegionBase<2, SINGLE_IOV>;
 
 }  // namespace
 

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -115,7 +115,8 @@ namespace {
               "Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
-      gStyle->SetPalette(kRainBow);
+      //gStyle->SetPalette(kRainBow);
+      SiStripPI::setPaletteStyle(SiStripPI::BLUERED);
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
@@ -127,7 +128,7 @@ namespace {
       std::string titleMap = "SiStrip Lorentz Angle Map, Run: " + theIOVsince + " (tag: " + tagname + ")";
 
       SiStripTkMaps myMap("COLZA L");
-      myMap.bookMap(titleMap,"SiStrip #mu_{H}=(tan#theta_{L}/B) [1/T]");
+      myMap.bookMap(titleMap, "SiStrip #mu_{H}=(tan#theta_{L}/B) [1/T]");
 
       std::map<uint32_t, float> LAMap_ = payload->getLorentzAngles();
 
@@ -138,15 +139,13 @@ namespace {
       std::string fileName(m_imageFileName);
 
       TCanvas canvas("LA map", "LA map", 3000, 1200);
-      myMap.drawMap(canvas);
+      myMap.drawMap(canvas, "");
 
       auto ltx = TLatex();
       ltx.SetTextFont(62);
       ltx.SetTextSize(0.045);
       ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(),
-		       1 - gPad->GetTopMargin() + 0.02,
-		       titleMap.c_str());
+      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.02, titleMap.c_str());
 
       canvas.SaveAs(fileName.c_str());
       canvas.SaveAs("test.root");

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -115,7 +115,8 @@ namespace {
               "Tracker Map SiStrip Lorentz Angle") {}
 
     bool fill() override {
-      SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
+      //SiStripPI::setPaletteStyle(SiStripPI::DEFAULT);
+      gStyle->SetPalette(1);
 
       auto tag = PlotBase::getTag<0>();
       auto iov = tag.iovs.front();
@@ -124,7 +125,7 @@ namespace {
       std::shared_ptr<SiStripLorentzAngle> payload = fetchPayload(std::get<1>(iov));
 
       auto theIOVsince = std::to_string(std::get<0>(iov));
-      std::string titleMap = "SiStrip Lorentz Angle Map, Run: " + theIOVsince + " (tag: #color[2]{" + tagname + "})";
+      std::string titleMap = "SiStrip Lorentz Angle Map, Run: " + theIOVsince + " (tag:#color[2]{" + tagname + "})";
 
       SiStripTkMaps myMap("COLZA L");
       myMap.bookMap(titleMap, "SiStrip #mu_{H}=(tan#theta_{L}/B) [1/T]");
@@ -136,19 +137,14 @@ namespace {
       }  // loop over the LA MAP
 
       std::string fileName(m_imageFileName);
-
-      TCanvas canvas("LA map", "LA map", 3000, 1200);
+      TCanvas canvas("LA map", "LA map");
       myMap.drawMap(canvas, "");
-
-      auto ltx = TLatex();
-      ltx.SetTextFont(62);
-      ltx.SetTextSize(0.045);
-      ltx.SetTextAlign(11);
-      ltx.DrawLatexNDC(gPad->GetLeftMargin(), 1 - gPad->GetTopMargin() + 0.02, titleMap.c_str());
-
+      myMap.dressMap(canvas);
       canvas.SaveAs(fileName.c_str());
-      canvas.SaveAs("test.root");
 
+#ifdef MMDEBUG
+      canvas.SaveAs("test.root");
+#endif
       return true;
     }
   };

--- a/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector.cc
@@ -139,7 +139,6 @@ namespace {
       std::string fileName(m_imageFileName);
       TCanvas canvas("LA map", "LA map");
       myMap.drawMap(canvas, "");
-      myMap.dressMap(canvas);
       canvas.SaveAs(fileName.c_str());
 
 #ifdef MMDEBUG

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -47,16 +47,16 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     test class
   *************************************************/
 
-  class SiStripNoisesTest
-      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoisesTest : public Histogram1D<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoisesTest()
-        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Noise test", "SiStrip Noise test", 10, 0.0, 10.0),
+        : Histogram1D<SiStripNoises, SINGLE_IOV>("SiStrip Noise test", "SiStrip Noise test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -100,13 +100,10 @@ namespace {
     SiStrip Noise Profile of 1 IOV for one selected DetId
   *************************************************/
 
-  class SiStripNoisePerDetId
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoisePerDetId : public PlotImage<SiStripNoises, SINGLE_IOV> {
   public:
-    SiStripNoisePerDetId()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Noise values Per DetId") {
-      cond::payloadInspector::PlotBase::addInputParam("DetIds");
+    SiStripNoisePerDetId() : PlotImage<SiStripNoises, SINGLE_IOV>("SiStrip Noise values Per DetId") {
+      PlotBase::addInputParam("DetIds");
     }
 
     bool fill() override {
@@ -117,7 +114,7 @@ namespace {
 
       std::vector<uint32_t> the_detids = {};
 
-      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto paramValues = PlotBase::inputParamValues();
       auto ip = paramValues.find("DetIds");
       if (ip != paramValues.end()) {
         auto input = boost::lexical_cast<std::string>(ip->second);
@@ -272,12 +269,10 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripNoiseValue
-      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseValue : public Histogram1D<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoiseValue()
-        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Noise values", "SiStrip Noise values", 100, 0.0, 10.0) {}
+        : Histogram1D<SiStripNoises, SINGLE_IOV>("SiStrip Noise values", "SiStrip Noise values", 100, 0.0, 10.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -306,13 +301,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripNoiseValuePerDetId
-      : public cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseValuePerDetId : public Histogram1D<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoiseValuePerDetId()
-        : cond::payloadInspector::Histogram1D<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripNoises, SINGLE_IOV>(
               "SiStrip Noise values per DetId", "SiStrip Noise values per DetId", 100, 0.0, 10.0) {
-      cond::payloadInspector::PlotBase::addInputParam("DetId");
+      PlotBase::addInputParam("DetId");
     }
 
     bool fill() override {
@@ -320,7 +314,7 @@ namespace {
       for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripNoises> payload = Base::fetchPayload(std::get<1>(iov));
         unsigned int the_detid(0xFFFFFFFF);
-        auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+        auto paramValues = PlotBase::inputParamValues();
         auto ip = paramValues.find("DetId");
         if (ip != paramValues.end()) {
           the_detid = boost::lexical_cast<unsigned int>(ip->second);
@@ -345,12 +339,9 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
   template <SiStripPI::OpMode op_mode_>
-  class SiStripNoiseDistribution
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseDistribution : public PlotImage<SiStripNoises, SINGLE_IOV> {
   public:
-    SiStripNoiseDistribution()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>("SiStrip Noise values") {
-    }
+    SiStripNoiseDistribution() : PlotImage<SiStripNoises, SINGLE_IOV>("SiStrip Noise values") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -466,16 +457,16 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: PlotImage
-  template <SiStripPI::OpMode op_mode_, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripNoiseDistributionComparisonBase : public cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags> {
+  template <SiStripPI::OpMode op_mode_, int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseDistributionComparisonBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
     SiStripNoiseDistributionComparisonBase()
-        : cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
+        : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -484,8 +475,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -655,12 +646,10 @@ namespace {
   };
 
   template <SiStripPI::OpMode op_mode_>
-  using SiStripNoiseDistributionComparisonSingleTag =
-      SiStripNoiseDistributionComparisonBase<op_mode_, 1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripNoiseDistributionComparisonSingleTag = SiStripNoiseDistributionComparisonBase<op_mode_, 1, MULTI_IOV>;
 
   template <SiStripPI::OpMode op_mode_>
-  using SiStripNoiseDistributionComparisonTwoTags =
-      SiStripNoiseDistributionComparisonBase<op_mode_, 2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripNoiseDistributionComparisonTwoTags = SiStripNoiseDistributionComparisonBase<op_mode_, 2, SINGLE_IOV>;
 
   typedef SiStripNoiseDistributionComparisonSingleTag<SiStripPI::STRIP_BASED>
       SiStripNoiseValueComparisonPerStripSingleTag;
@@ -678,16 +667,15 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
 
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripNoiseValueComparisonBase : public cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseValueComparisonBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
-    SiStripNoiseValueComparisonBase()
-        : cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
+    SiStripNoiseValueComparisonBase() : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise values comparison") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -696,8 +684,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -794,20 +782,18 @@ namespace {
     }
   };
 
-  using SiStripNoiseValueComparisonSingleTag = SiStripNoiseValueComparisonBase<1, cond::payloadInspector::MULTI_IOV>;
-  using SiStripNoiseValueComparisonTwoTags = SiStripNoiseValueComparisonBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripNoiseValueComparisonSingleTag = SiStripNoiseValueComparisonBase<1, MULTI_IOV>;
+  using SiStripNoiseValueComparisonTwoTags = SiStripNoiseValueComparisonBase<2, SINGLE_IOV>;
 
   /************************************************
     SiStrip Noise Tracker Map 
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripNoiseTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseTrackerMap : public PlotImage<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoiseTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStripNoise " + estimatorType(est) + " per module") {}
+        : PlotImage<SiStripNoises, SINGLE_IOV>("Tracker Map of SiStripNoise " + estimatorType(est) + " per module") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -906,14 +892,13 @@ namespace {
     SiStrip Noise Tracker Map  (ratio with previous gain per detid)
   *************************************************/
 
-  template <SiStripPI::estimator est, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripNoiseRatioWithPreviousIOVTrackerMapBase
-      : public cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags> {
+  template <SiStripPI::estimator est, int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseRatioWithPreviousIOVTrackerMapBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
     SiStripNoiseRatioWithPreviousIOVTrackerMapBase()
-        : cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags>("Tracker Map of ratio of SiStripNoises " +
-                                                                         estimatorType(est) + "with previous IOV") {
-      cond::payloadInspector::PlotBase::addInputParam("nsigma");
+        : PlotImage<SiStripNoises, nIOVs, ntags>("Tracker Map of ratio of SiStripNoises " + estimatorType(est) +
+                                                 "with previous IOV") {
+      PlotBase::addInputParam("nsigma");
     }
 
     std::map<unsigned int, float> computeEstimator(std::shared_ptr<SiStripNoises> payload) {
@@ -975,15 +960,15 @@ namespace {
     bool fill() override {
       unsigned int nsigma(1);
 
-      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto paramValues = PlotBase::inputParamValues();
       auto ip = paramValues.find("nsigma");
       if (ip != paramValues.end()) {
         nsigma = boost::lexical_cast<unsigned int>(ip->second);
       }
 
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -992,8 +977,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1042,11 +1027,11 @@ namespace {
 
   template <SiStripPI::estimator est>
   using SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag =
-      SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, 1, cond::payloadInspector::MULTI_IOV>;
+      SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, 1, MULTI_IOV>;
 
   template <SiStripPI::estimator est>
   using SiStripNoiseRatioWithPreviousIOVTrackerMapTwoTags =
-      SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, 2, cond::payloadInspector::SINGLE_IOV>;
+      SiStripNoiseRatioWithPreviousIOVTrackerMapBase<est, 2, SINGLE_IOV>;
 
   typedef SiStripNoiseRatioWithPreviousIOVTrackerMapSingleTag<SiStripPI::min>
       SiStripNoiseMin_RatioWithPreviousIOVTrackerMapSingleTag;
@@ -1071,12 +1056,10 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripNoiseByRegion
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseByRegion : public PlotImage<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoiseByRegion()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Noise " + estimatorType(est) + " by Region"),
+        : PlotImage<SiStripNoises, SINGLE_IOV>("SiStrip Noise " + estimatorType(est) + " by Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -1198,19 +1181,18 @@ namespace {
   SiStrip Noise Comparator
   *************************************************/
 
-  template <SiStripPI::estimator est, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripNoiseComparatorByRegionBase : public cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags> {
+  template <SiStripPI::estimator est, int ntags, IOVMultiplicity nIOVs>
+  class SiStripNoiseComparatorByRegionBase : public PlotImage<SiStripNoises, nIOVs, ntags> {
   public:
     SiStripNoiseComparatorByRegionBase()
-        : cond::payloadInspector::PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise " + estimatorType(est) +
-                                                                         " comparator by Region"),
+        : PlotImage<SiStripNoises, nIOVs, ntags>("SiStrip Noise " + estimatorType(est) + " comparator by Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -1219,8 +1201,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1386,12 +1368,10 @@ namespace {
   };
 
   template <SiStripPI::estimator est>
-  using SiStripNoiseComparatorByRegionSingleTag =
-      SiStripNoiseComparatorByRegionBase<est, 1, cond::payloadInspector::MULTI_IOV>;
+  using SiStripNoiseComparatorByRegionSingleTag = SiStripNoiseComparatorByRegionBase<est, 1, MULTI_IOV>;
 
   template <SiStripPI::estimator est>
-  using SiStripNoiseComparatorByRegionTwoTags =
-      SiStripNoiseComparatorByRegionBase<est, 2, cond::payloadInspector::SINGLE_IOV>;
+  using SiStripNoiseComparatorByRegionTwoTags = SiStripNoiseComparatorByRegionBase<est, 2, SINGLE_IOV>;
 
   typedef SiStripNoiseComparatorByRegionSingleTag<SiStripPI::mean> SiStripNoiseComparatorMeanByRegionSingleTag;
   typedef SiStripNoiseComparatorByRegionSingleTag<SiStripPI::min> SiStripNoiseComparatorMinByRegionSingleTag;
@@ -1406,12 +1386,10 @@ namespace {
   /************************************************
     Noise linearity
   *************************************************/
-  class SiStripNoiseLinearity
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripNoiseLinearity : public PlotImage<SiStripNoises, SINGLE_IOV> {
   public:
     SiStripNoiseLinearity()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::SINGLE_IOV>(
-              "Linearity of Strip Noise as a fuction of strip length") {}
+        : PlotImage<SiStripNoises, SINGLE_IOV>("Linearity of Strip Noise as a fuction of strip length") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -1532,10 +1510,10 @@ namespace {
   *************************************************/
 
   template <StripSubdetector::SubDetector sub>
-  class NoiseHistory : public cond::payloadInspector::HistoryPlot<SiStripNoises, std::pair<double, double>> {
+  class NoiseHistory : public HistoryPlot<SiStripNoises, std::pair<double, double>> {
   public:
     NoiseHistory()
-        : cond::payloadInspector::HistoryPlot<SiStripNoises, std::pair<double, double>>(
+        : HistoryPlot<SiStripNoises, std::pair<double, double>>(
               "Average " + SiStripPI::getStringFromSubdet(sub) + " noise vs run number",
               "average " + SiStripPI::getStringFromSubdet(sub) + " Noise") {}
 
@@ -1577,10 +1555,10 @@ namespace {
   *************************************************/
 
   template <StripSubdetector::SubDetector sub>
-  class NoiseRunHistory : public cond::payloadInspector::RunHistoryPlot<SiStripNoises, std::pair<double, double>> {
+  class NoiseRunHistory : public RunHistoryPlot<SiStripNoises, std::pair<double, double>> {
   public:
     NoiseRunHistory()
-        : cond::payloadInspector::RunHistoryPlot<SiStripNoises, std::pair<double, double>>(
+        : RunHistoryPlot<SiStripNoises, std::pair<double, double>>(
               "Average " + SiStripPI::getStringFromSubdet(sub) + " noise vs run number",
               "average " + SiStripPI::getStringFromSubdet(sub) + " Noise") {}
 
@@ -1622,10 +1600,10 @@ namespace {
   *************************************************/
 
   template <StripSubdetector::SubDetector sub>
-  class NoiseTimeHistory : public cond::payloadInspector::TimeHistoryPlot<SiStripNoises, std::pair<double, double>> {
+  class NoiseTimeHistory : public TimeHistoryPlot<SiStripNoises, std::pair<double, double>> {
   public:
     NoiseTimeHistory()
-        : cond::payloadInspector::TimeHistoryPlot<SiStripNoises, std::pair<double, double>>(
+        : TimeHistoryPlot<SiStripNoises, std::pair<double, double>>(
               "Average " + SiStripPI::getStringFromSubdet(sub) + " noise vs run number",
               "average " + SiStripPI::getStringFromSubdet(sub) + " Noise") {}
 
@@ -1666,12 +1644,10 @@ namespace {
    template Noise run history  per layer
   *************************************************/
   template <StripSubdetector::SubDetector sub>
-  class NoiseLayerRunHistory
-      : public cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::MULTI_IOV> {
+  class NoiseLayerRunHistory : public PlotImage<SiStripNoises, MULTI_IOV> {
   public:
     NoiseLayerRunHistory()
-        : cond::payloadInspector::PlotImage<SiStripNoises, cond::payloadInspector::MULTI_IOV>(
-              "SiStrip Noise values comparison"),
+        : PlotImage<SiStripNoises, MULTI_IOV>("SiStrip Noise values comparison"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -150,7 +150,7 @@ namespace {
         TCanvas canvas("ByDetId", "ByDetId", sides.second * 800, sides.first * 600);
         canvas.Divide(sides.second, sides.first);
         edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
-        SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
+	auto reader = std::make_unique<SiStripDetInfoFileReader>(fp_.fullPath());
 
         for (const auto& the_detid : the_detids) {
           edm::LogPrint("SiStripNoisePerDetId") << "DetId:" << the_detid << std::endl;

--- a/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripNoises_PayloadInspector.cc
@@ -150,7 +150,7 @@ namespace {
         TCanvas canvas("ByDetId", "ByDetId", sides.second * 800, sides.first * 600);
         canvas.Divide(sides.second, sides.first);
         edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
-	auto reader = std::make_unique<SiStripDetInfoFileReader>(fp_.fullPath());
+        auto reader = std::make_unique<SiStripDetInfoFileReader>(fp_.fullPath());
 
         for (const auto& the_detid : the_detids) {
           edm::LogPrint("SiStripNoisePerDetId") << "DetId:" << the_detid << std::endl;

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -148,7 +148,7 @@ namespace {
         TCanvas canvas("ByDetId", "ByDetId", sides.second * 800, sides.first * 600);
         canvas.Divide(sides.second, sides.first);
         edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
-        SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
+        auto reader = std::make_unique<SiStripDetInfoFileReader>(fp_.fullPath());
 
         for (const auto& the_detid : the_detids) {
           edm::LogPrint("SiStripNoisePerDetId") << "DetId:" << the_detid << std::endl;
@@ -689,7 +689,7 @@ namespace {
       std::shared_ptr<SiStripPedestals> payload = fetchPayload(std::get<1>(iov));
 
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
-      SiStripDetInfoFileReader* reader = new SiStripDetInfoFileReader(fp_.fullPath());
+      auto reader = std::make_unique<SiStripDetInfoFileReader>(fp_.fullPath());
 
       std::string titleMap =
           "Tracker Map of Zero SiStrip Pedestals fraction per module (payload : " + std::get<1>(iov) + ")";

--- a/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripPedestals_PayloadInspector.cc
@@ -46,16 +46,16 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     test class
   *************************************************/
 
-  class SiStripPedestalsTest
-      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalsTest : public Histogram1D<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripPedestalsTest()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Pedestals test", "SiStrip Pedestals test", 10, 0.0, 10.0),
+        : Histogram1D<SiStripPedestals, SINGLE_IOV>("SiStrip Pedestals test", "SiStrip Pedestals test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -99,13 +99,10 @@ namespace {
     SiStrip Pedestals Profile of 1 IOV for one selected DetId
   *************************************************/
 
-  class SiStripPedestalPerDetId
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalPerDetId : public PlotImage<SiStripPedestals, SINGLE_IOV> {
   public:
-    SiStripPedestalPerDetId()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Pedestal values per DetId") {
-      cond::payloadInspector::PlotBase::addInputParam("DetIds");
+    SiStripPedestalPerDetId() : PlotImage<SiStripPedestals, SINGLE_IOV>("SiStrip Pedestal values per DetId") {
+      PlotBase::addInputParam("DetIds");
     }
 
     bool fill() override {
@@ -116,7 +113,7 @@ namespace {
 
       std::vector<uint32_t> the_detids = {};
 
-      auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+      auto paramValues = PlotBase::inputParamValues();
       auto ip = paramValues.find("DetIds");
       if (ip != paramValues.end()) {
         auto input = boost::lexical_cast<std::string>(ip->second);
@@ -270,11 +267,10 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripPedestalsValue
-      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalsValue : public Histogram1D<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripPedestalsValue()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripPedestals, SINGLE_IOV>(
               "SiStrip Pedestals values", "SiStrip Pedestals values", 300, 0.0, 300.0) {}
 
     bool fill() override {
@@ -304,13 +300,12 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class: Histogram1D
-  class SiStripPedestalsValuePerDetId
-      : public cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalsValuePerDetId : public Histogram1D<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripPedestalsValuePerDetId()
-        : cond::payloadInspector::Histogram1D<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<SiStripPedestals, SINGLE_IOV>(
               "SiStrip Pedestal values per DetId", "SiStrip Pedestal values per DetId", 100, 0.0, 10.0) {
-      cond::payloadInspector::PlotBase::addInputParam("DetId");
+      PlotBase::addInputParam("DetId");
     }
 
     bool fill() override {
@@ -318,7 +313,7 @@ namespace {
       for (auto const& iov : tag.iovs) {
         std::shared_ptr<SiStripPedestals> payload = Base::fetchPayload(std::get<1>(iov));
         unsigned int the_detid(0xFFFFFFFF);
-        auto paramValues = cond::payloadInspector::PlotBase::inputParamValues();
+        auto paramValues = PlotBase::inputParamValues();
         auto ip = paramValues.find("DetId");
         if (ip != paramValues.end()) {
           the_detid = boost::lexical_cast<unsigned int>(ip->second);
@@ -343,12 +338,9 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
   template <SiStripPI::OpMode op_mode_>
-  class SiStripPedestalDistribution
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalDistribution : public PlotImage<SiStripPedestals, SINGLE_IOV> {
   public:
-    SiStripPedestalDistribution()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Pedestal values") {}
+    SiStripPedestalDistribution() : PlotImage<SiStripPedestals, SINGLE_IOV>("SiStrip Pedestal values") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -463,17 +455,16 @@ namespace {
 
   // inherit from one of the predefined plot class: PlotImage
 
-  template <SiStripPI::OpMode op_mode_, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class SiStripPedestalDistributionComparisonBase
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, nIOVs, ntags> {
+  template <SiStripPI::OpMode op_mode_, int ntags, IOVMultiplicity nIOVs>
+  class SiStripPedestalDistributionComparisonBase : public PlotImage<SiStripPedestals, nIOVs, ntags> {
   public:
     SiStripPedestalDistributionComparisonBase()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, nIOVs, ntags>("SiStrip Pedestal values comparison") {}
+        : PlotImage<SiStripPedestals, nIOVs, ntags>("SiStrip Pedestal values comparison") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -482,8 +473,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -653,11 +644,11 @@ namespace {
 
   template <SiStripPI::OpMode op_mode_>
   using SiStripPedestalDistributionComparisonSingleTag =
-      SiStripPedestalDistributionComparisonBase<op_mode_, 1, cond::payloadInspector::MULTI_IOV>;
+      SiStripPedestalDistributionComparisonBase<op_mode_, 1, MULTI_IOV>;
 
   template <SiStripPI::OpMode op_mode_>
   using SiStripPedestalDistributionComparisonTwoTags =
-      SiStripPedestalDistributionComparisonBase<op_mode_, 2, cond::payloadInspector::SINGLE_IOV>;
+      SiStripPedestalDistributionComparisonBase<op_mode_, 2, SINGLE_IOV>;
 
   typedef SiStripPedestalDistributionComparisonSingleTag<SiStripPI::STRIP_BASED>
       SiStripPedestalValueComparisonPerStripSingleTag;
@@ -677,12 +668,10 @@ namespace {
   *************************************************/
 
   // inherit from one of the predefined plot class PlotImage
-  class SiStripZeroPedestalsFraction_TrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripZeroPedestalsFraction_TrackerMap : public PlotImage<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripZeroPedestalsFraction_TrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of Zero SiStripPedestals fraction per module") {}
+        : PlotImage<SiStripPedestals, SINGLE_IOV>("Tracker Map of Zero SiStripPedestals fraction per module") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -736,12 +725,11 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripPedestalsTrackerMap
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalsTrackerMap : public PlotImage<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripPedestalsTrackerMap()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of SiStripPedestals " + estimatorType(est) + " per module") {}
+        : PlotImage<SiStripPedestals, SINGLE_IOV>("Tracker Map of SiStripPedestals " + estimatorType(est) +
+                                                  " per module") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -822,12 +810,10 @@ namespace {
   *************************************************/
 
   template <SiStripPI::estimator est>
-  class SiStripPedestalsByRegion
-      : public cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripPedestalsByRegion : public PlotImage<SiStripPedestals, SINGLE_IOV> {
   public:
     SiStripPedestalsByRegion()
-        : cond::payloadInspector::PlotImage<SiStripPedestals, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Pedestals " + estimatorType(est) + " by Region"),
+        : PlotImage<SiStripPedestals, SINGLE_IOV>("SiStrip Pedestals " + estimatorType(est) + " by Region"),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 

--- a/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
@@ -48,15 +48,14 @@ namespace {
     test class
   *************************************************/
 
-  class SiStripThresholdTest : public cond::payloadInspector::Histogram1D<SiStripThreshold> {
+  class SiStripThresholdTest
+      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripThresholdTest()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold>(
+        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
               "SiStrip Threshold test", "SiStrip Threshold test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
-              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {
-      Base::setSingleIov(true);
-    }
+              edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -86,17 +85,16 @@ namespace {
     1d histogram of SiStripThresholds of 1 IOV - High Threshold 
   *************************************************************/
 
-  class SiStripThresholdValueHigh : public cond::payloadInspector::Histogram1D<SiStripThreshold> {
+  class SiStripThresholdValueHigh
+      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripThresholdValueHigh()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold>("SiStrip High threshold values (checked per APV)",
-                                                                "SiStrip High threshold values (cheched per APV)",
-                                                                10,
-                                                                0.0,
-                                                                10) {
-      Base::setSingleIov(true);
-    }
-
+        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip High threshold values (checked per APV)",
+              "SiStrip High threshold values (cheched per APV)",
+              10,
+              0.0,
+              10) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -132,17 +130,16 @@ namespace {
     1d histogram of SiStripThresholds of 1 IOV - Low Threshold 
   *************************************************************/
 
-  class SiStripThresholdValueLow : public cond::payloadInspector::Histogram1D<SiStripThreshold> {
+  class SiStripThresholdValueLow
+      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
   public:
     SiStripThresholdValueLow()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold>("SiStrip Low threshold values (checked per APV)",
-                                                                "SiStrip Low threshold values (cheched per APV)",
-                                                                10,
-                                                                0.0,
-                                                                10) {
-      Base::setSingleIov(true);
-    }
-
+        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
+              "SiStrip Low threshold values (checked per APV)",
+              "SiStrip Low threshold values (cheched per APV)",
+              10,
+              0.0,
+              10) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");

--- a/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc
@@ -44,16 +44,16 @@ using namespace std;
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   /************************************************
     test class
   *************************************************/
 
-  class SiStripThresholdTest
-      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripThresholdTest : public Histogram1D<SiStripThreshold, SINGLE_IOV> {
   public:
     SiStripThresholdTest()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Threshold test", "SiStrip Threshold test", 10, 0.0, 10.0),
+        : Histogram1D<SiStripThreshold, SINGLE_IOV>("SiStrip Threshold test", "SiStrip Threshold test", 10, 0.0, 10.0),
           m_trackerTopo{StandaloneTrackerTopology::fromTrackerParametersXMLFile(
               edm::FileInPath("Geometry/TrackerCommonData/data/trackerParameters.xml").fullPath())} {}
 
@@ -85,16 +85,14 @@ namespace {
     1d histogram of SiStripThresholds of 1 IOV - High Threshold 
   *************************************************************/
 
-  class SiStripThresholdValueHigh
-      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripThresholdValueHigh : public Histogram1D<SiStripThreshold, SINGLE_IOV> {
   public:
     SiStripThresholdValueHigh()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip High threshold values (checked per APV)",
-              "SiStrip High threshold values (cheched per APV)",
-              10,
-              0.0,
-              10) {}
+        : Histogram1D<SiStripThreshold, SINGLE_IOV>("SiStrip High threshold values (checked per APV)",
+                                                    "SiStrip High threshold values (cheched per APV)",
+                                                    10,
+                                                    0.0,
+                                                    10) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");
@@ -130,16 +128,14 @@ namespace {
     1d histogram of SiStripThresholds of 1 IOV - Low Threshold 
   *************************************************************/
 
-  class SiStripThresholdValueLow
-      : public cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV> {
+  class SiStripThresholdValueLow : public Histogram1D<SiStripThreshold, SINGLE_IOV> {
   public:
     SiStripThresholdValueLow()
-        : cond::payloadInspector::Histogram1D<SiStripThreshold, cond::payloadInspector::SINGLE_IOV>(
-              "SiStrip Low threshold values (checked per APV)",
-              "SiStrip Low threshold values (cheched per APV)",
-              10,
-              0.0,
-              10) {}
+        : Histogram1D<SiStripThreshold, SINGLE_IOV>("SiStrip Low threshold values (checked per APV)",
+                                                    "SiStrip Low threshold values (cheched per APV)",
+                                                    10,
+                                                    0.0,
+                                                    10) {}
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
       edm::FileInPath fp_ = edm::FileInPath("CalibTracker/SiStripCommon/data/SiStripDetInfo.dat");

--- a/CondCore/SiStripPlugins/test/test.sh
+++ b/CondCore/SiStripPlugins/test/test.sh
@@ -119,3 +119,24 @@ getPayloadData.py \
     --iovs '{"start_iov": "6850066318803433472", "end_iov": "6850066318803433472"}' \
     --db Prod \
     --test;
+
+######################
+# Test SiStripTkMaps
+######################
+getPayloadData.py \
+    --plugin pluginSiStripBadStrip_PayloadInspector \
+    --plot plot_SiStripBadStripFractionTkMap \
+    --tag SiStripBadComponents_startupMC_for2017_v1_mc \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test ;
+
+getPayloadData.py \
+    --plugin pluginSiStripLorentzAngle_PayloadInspector \
+    --plot plot_SiStripLorentzAngleTkMap \
+    --tag  SiStripLorentzAngleDeco_GR10_v1_prompt \
+    --time_type Run \
+    --iovs '{"start_iov": "1", "end_iov": "1"}' \
+    --db Prod \
+    --test;

--- a/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
+++ b/CondCore/SiStripPlugins/test/testSiStripPayloadInspector.cpp
@@ -7,6 +7,7 @@
 #include "CondCore/SiStripPlugins/plugins/SiStripThreshold_PayloadInspector.cc"
 #include "CondCore/SiStripPlugins/plugins/SiStripLatency_PayloadInspector.cc"
 #include "CondCore/SiStripPlugins/plugins/SiStripFedCabling_PayloadInspector.cc"
+#include "CondCore/SiStripPlugins/plugins/SiStripBadStrip_PayloadInspector.cc"
 
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
@@ -142,6 +143,17 @@ int main(int argc, char** argv) {
   SiStripThresholdValueHigh histo14;
   histo14.process(connectionString, PI::mk_input(tag, start, start));
   edm::LogPrint("testSiStripPayloadInspector") << histo14.data() << std::endl;
+
+  // test SiStripTkMaps
+  tag = "SiStripBadComponents_startupMC_for2017_v1_mc";
+  start = boost::lexical_cast<unsigned long long>(1);
+  end = boost::lexical_cast<unsigned long long>(1);
+
+  edm::LogPrint("testSiStripPayloadInspector") << "## Exercising SiStripTkMaps plots " << std::endl;
+
+  SiStripBadStripFractionTkMap histoTkMap;
+  histoTkMap.process(connectionString, PI::mk_input(tag, start, start));
+  edm::LogPrint("testSiStripPayloadInspector") << histoTkMap.data() << std::endl;
 
   inputs.clear();
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
#### PR description:

This PR adds the possibility to produce and display Tracker Maps of the SiStrip detector conditions using `TH2Poly` and the `TPolyLine` vertices stored as externals (in the  `cms-data/DQM-SiStripMonitorClient` repository) in this PR: https://github.com/cms-data/DQM-SiStripMonitorClient/pull/1 via the newly introduced class `SiStripTkMaps` .
A couple of examples are implemented as well.
I profit of this PR to introduce a couple of clean-up commits:
   * 5bf310094af0cebd6bf40eda93d1457b8bd392aa migrates wherever possible to the new PayloadInspector class interfaces introduced at PR https://github.com/cms-sw/cmssw/pull/29622 
   * c0ff2c5b01ef8d89a7326ccd60377a1c25538006 makes use of the namespace `cond::payloadInspector` in all `CondCore/SiStripPlugins` in all plugins avoiding heavy repetitions in the code. 

#### PR validation:

Relies on private validation and augmented unit tests.
A couple of example outputs are pasted here:

![LAMap](https://user-images.githubusercontent.com/5082376/102909792-c9a99d80-4479-11eb-8d7c-9c00b719b54a.png)
===
![BCMap](https://user-images.githubusercontent.com/5082376/102909826-d7f7b980-4479-11eb-876a-c53ea41329d0.png)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport and no backport is needed.
