### PR TITLE
Use correct L1TMuonEndCapParams tag for 2017, 2018, Run 3 and Phase 2 MC [11_1_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -47,39 +47,39 @@ autoCond = {
     # GlobalTag for Run3 data relvals
     'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '111X_mc2017_design_v2',
+    'phase1_2017_design'       :  '111X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '111X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '111X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '111X_mc2017cosmics_realistic_deco_v1',
+    'phase1_2017_cosmics'      :  '111X_mc2017cosmics_realistic_deco_v2',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '111X_mc2017cosmics_realistic_peak_v1',
+    'phase1_2017_cosmics_peak' :  '111X_mc2017cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '111X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '111X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    :  '111X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '111X_upgrade2018_realistic_HI_v1',
+    'phase1_2018_realistic_hi' :  '111X_upgrade2018_realistic_HI_v2',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v2',
+    'phase1_2018_realistic_HEfail' :  '111X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :   '111X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak' :   '111X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '111X_mcRun3_2021_design_v7', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '111X_mcRun3_2021_design_v8', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v7', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '111X_mcRun3_2021_realistic_v8', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v7',
+    'phase1_2021_cosmics'      : '111X_mcRun3_2021cosmics_realistic_deco_v8',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '111X_mcRun3_2021_realistic_HI_v9',
+    'phase1_2021_realistic_hi' : '111X_mcRun3_2021_realistic_HI_v10',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v6', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '111X_mcRun3_2023_realistic_v7', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v6', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v2'
+    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v3'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This is a backport of PR #32513.

Since PR #29767, which was merged in the 11_1_X series, the EMTF emulator has been configured using the global tag. However, the tags contained in the 2017, 2018, Run 3 or Phase-2 MC specified the incorrect firmware version. This PR updates the tags for `L1TMuonEndCapParamsRcd` as follows:

- 2017: `L1TMuonEndCapParams_Stage2v1`
- 2018, Run 3 and Phase 2: `L1TMuonEndCapParams_Stage2v3_2018_HI_mc`

In particular, despite the "HI" in the 2018 MC string, this is indeed the correct tag for pp collisions as well.

More detail can be found at https://indico.cern.ch/event/983008/#41-l1t-emtf-tag-for-run3-mc-gt.

The GT diffs are as follows:

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017_design_v2/111X_mc2017_design_v3

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017_realistic_v2/111X_mc2017_realistic_v3

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017cosmics_realistic_deco_v1/111X_mc2017cosmics_realistic_deco_v2

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mc2017cosmics_realistic_peak_v1/111X_mc2017cosmics_realistic_peak_v2

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_design_v2/111X_upgrade2018_design_v3

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_v2/111X_upgrade2018_realistic_v3

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_HI_v1/111X_upgrade2018_realistic_HI_v2

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018_realistic_HEfail_v2/111X_upgrade2018_realistic_HEfail_v3

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_deco_v2/111X_upgrade2018cosmics_realistic_deco_v3

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_upgrade2018cosmics_realistic_peak_v2/111X_upgrade2018cosmics_realistic_peak_v3

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_design_v7/111X_mcRun3_2021_design_v8

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_v7/111X_mcRun3_2021_realistic_v8

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021cosmics_realistic_deco_v7/111X_mcRun3_2021cosmics_realistic_deco_v8

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2021_realistic_HI_v9/111X_mcRun3_2021_realistic_HI_v10

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2023_realistic_v6/111X_mcRun3_2023_realistic_v7

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun3_2024_realistic_v6/111X_mcRun3_2024_realistic_v7

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun4_realistic_T15_v2/111X_mcRun4_realistic_T15_v3

#### PR validation:

L1T experts have confirmed that this is the tag contains the correct firmware version and that the comparison tests in PR #32513 are expected. In addition, the following technical tests were performed:

`runTheMatrix.py -l limited,10424.0,7.21,11224.0,11024.2,7.4,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #32513. It is a bug fix for the incorrect firmware specified in the `L1TMuonEndCapParams` tag.