### PR TITLE
Run3-gex44 Correct use of unit coversion for CaloGeometryLoader

### DIFF
--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.h
@@ -8,6 +8,7 @@
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
 
+#include "DD4hep/DD4hepUnits.h"
 #include "CLHEP/Geometry/Transform3D.h"
 #include <string>
 #include <vector>
@@ -25,8 +26,8 @@ public:
   using ParVec = CaloSubdetectorGeometry::ParVec;
   using ParVecVec = CaloSubdetectorGeometry::ParVecVec;
 
-  static constexpr double k_ScaleFromDDDtoGeant = 0.1;
-  static constexpr double k_ScaleFromDD4HeptoGeant = 1.0;
+  static constexpr double k_ScaleFromDDD = 0.1;
+  static constexpr double k_ScaleFromDD4Hep = (1.0 / dd4hep::cm);
 
   CaloGeometryLoader<T>() {}
 

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -84,7 +84,7 @@ void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
     const CLHEP::HepRotation hr(temp);
     const CLHEP::Hep3Vector h3v(fv.translation().X(), fv.translation().Y(), fv.translation().Z());
     const HepGeom::Transform3D ht3d(hr,  // only scale translation
-                                    k_ScaleFromDDDtoGeant * h3v);
+                                    k_ScaleFromDDD * h3v);
 
     const DetId id(getDetIdForDDDNode(fv));
 
@@ -105,7 +105,7 @@ void CaloGeometryLoader<T>::makeGeometry(const DDCompactView* cpv,
         nullptr == at ? ht3d
                       : (nullptr == globalT ? at->transform() * ht3d : at->transform() * globalT->transform() * ht3d));
 
-    fillGeom(geom, parameters, atr, id, k_ScaleFromDDDtoGeant);
+    fillGeom(geom, parameters, atr, id, k_ScaleFromDDD);
   }
 
   assert(counter <= T::k_NumberOfCellsForCorners);
@@ -149,7 +149,7 @@ void CaloGeometryLoader<T>::makeGeometry(const cms::DDCompactView* cpv,
     const CLHEP::HepRotation hr(temp);
     const CLHEP::Hep3Vector h3v(fv.translation().X(), fv.translation().Y(), fv.translation().Z());
     const HepGeom::Transform3D ht3d(hr,  // only scale translation
-                                    k_ScaleFromDD4HeptoGeant * h3v);
+                                    k_ScaleFromDD4Hep * h3v);
 
     const DetId id(getDetIdForDD4HepNode(fv));
 
@@ -170,7 +170,7 @@ void CaloGeometryLoader<T>::makeGeometry(const cms::DDCompactView* cpv,
         nullptr == at ? ht3d
                       : (nullptr == globalT ? at->transform() * ht3d : at->transform() * globalT->transform() * ht3d));
 
-    fillGeom(geom, parameters, atr, id, k_ScaleFromDD4HeptoGeant);
+    fillGeom(geom, parameters, atr, id, k_ScaleFromDD4Hep);
   }
 
   assert(counter <= T::k_NumberOfCellsForCorners);


### PR DESCRIPTION
#### PR description:

Correct use of unit coversion for CaloGeometryLoader

#### PR validation:

Use runTheMatrix test workflows

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special
