### PR TITLE
Make units dd4hep-dependent in PPS

### DIFF
--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -37,7 +37,7 @@ class CTPPSRPAlignmentCorrectionData;
  \endverbatim
  *
  * July 2020: Migrated to DD4hep
- * To avoid any regression with values from XMLs / Geant4, all lengths are converted from cm (DD4hep) to mm.
+ * To avoid any regression with values from XMLs / Geant4, all lengths are converted from DD4hep unit to mm.
  *
  **/
 
@@ -80,7 +80,7 @@ public:
   // params() is left for general access to solid shape parameters, but should be used
   // only with great care, for two reasons: 1. order of parameters may possibly change from
   // a version to another of DD4hep; 2. length parameters unit is cm while PPS uses mm.
-  const std::vector<double>& params() const { return m_params; }  // default unit: mm from oldDD, cm from DD4hep
+  const std::vector<double>& params() const { return m_params; }  // default unit: mm for oldDD, DD4hep unit for DD4hep
   bool isABox() const { return m_isABox; }
   const DiamondDimensions& getDiamondDimensions() const {
     if (!isABox()) {
@@ -132,7 +132,7 @@ private:
   bool m_isDD4hep;
   Translation m_trans;  // in mm
   RotationMatrix m_rot;
-  std::vector<double> m_params;  // default unit: mm from oldDD, cm from DD4hep
+  std::vector<double> m_params;  // default unit: mm from oldDD, DD4hep unit for DD4hep
   bool m_isABox;
   DiamondDimensions m_diamondBoxParams;  // in mm
   std::string m_sensorType;

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -77,9 +77,10 @@ public:
   const RotationMatrix& rotation() const { return m_rot; }
 
   // shape info
-  // params() is left for general access to solid shape parameters, but should be used
-  // only with great care, for two reasons: 1. order of parameters may possibly change from
-  // a version to another of DD4hep; 2. length parameters unit is cm while PPS uses mm.
+  // params() is left for general access to solid shape parameters (any shape, not only box!).
+  // Though, it should be used only with great care, for two reasons: 
+  // 1. Order of shape parameters may possibly change from a version of DD4hep to another. 
+  // 2. Among all parameters, those representing a length are expressed in mm (for old DD) or the DD4hep-configured unit (for DD4hep), while PPS uses mm.
   const std::vector<double>& params() const { return m_params; }  // default unit: mm for oldDD, DD4hep unit for DD4hep
   bool isABox() const { return m_isABox; }
   const DiamondDimensions& getDiamondDimensions() const {

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -78,8 +78,8 @@ public:
 
   // shape info
   // params() is left for general access to solid shape parameters (any shape, not only box!).
-  // Though, it should be used only with great care, for two reasons: 
-  // 1. Order of shape parameters may possibly change from a version of DD4hep to another. 
+  // Though, it should be used only with great care, for two reasons:
+  // 1. Order of shape parameters may possibly change from a version of DD4hep to another.
   // 2. Among all parameters, those representing a length are expressed in mm (for old DD) or the DD4hep-configured unit (for DD4hep), while PPS uses mm.
   const std::vector<double>& params() const { return m_params; }  // default unit: mm for oldDD, DD4hep unit for DD4hep
   bool isABox() const { return m_isABox; }

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -47,14 +47,14 @@ DetGeomDesc::DetGeomDesc(const cms::DDFilteredView& fv, const bool isRun2)
     : m_name(computeNameWithNoNamespace(fv.name())),
       m_copy(fv.copyNum()),
       m_isDD4hep(true),
-      m_trans(fv.translation() / dd4hep::mm),  // converted from cm (DD4hep) to mm
+      m_trans(fv.translation() / dd4hep::mm),  // converted from DD4hep unit to mm
       m_rot(fv.rotation()),
-      m_params(computeParameters(fv)),  // default unit from DD4hep (cm)
+      m_params(computeParameters(fv)),  // default unit from DD4hep
       m_isABox(dd4hep::isA<dd4hep::Box>(fv.solid())),
-      m_diamondBoxParams(computeDiamondDimensions(m_isABox, m_isDD4hep, m_params)),  // converted from cm (DD4hep) to mm
+      m_diamondBoxParams(computeDiamondDimensions(m_isABox, m_isDD4hep, m_params)),  // converted from DD4hep unit to mm
       m_sensorType(computeSensorType(fv.name())),
       m_geographicalID(computeDetIDFromDD4hep(m_name, fv.copyNos(), fv.copyNum(), isRun2)),
-      m_z(fv.translation().z() / dd4hep::mm)  // converted from cm (DD4hep) to mm
+      m_z(fv.translation().z() / dd4hep::mm)  // converted from DD4hep unit to mm
 {}
 
 DetGeomDesc::DetGeomDesc(const DetGeomDesc& ref, CopyMode cm) {
@@ -140,7 +140,7 @@ std::vector<double> DetGeomDesc::computeParameters(const cms::DDFilteredView& fv
  * Compute diamond dimensions.
  * The diamond sensors are represented by the Box shape parameters.
  * oldDD: params are already in mm.
- * DD4hep: convert params from cm (DD4hep) to mm (legacy expected by PPS reco software).
+ * DD4hep: convert params from DD4hep unit to mm (legacy expected by PPS reco software).
  */
 DiamondDimensions DetGeomDesc::computeDiamondDimensions(const bool isABox,
                                                         const bool isDD4hep,
@@ -151,7 +151,7 @@ DiamondDimensions DetGeomDesc::computeDiamondDimensions(const bool isABox,
       // mm (legacy)
       boxShapeParameters = {params.at(0), params.at(1), params.at(2)};
     } else {
-      // convert cm (DD4hep) to mm (legacy expected by PPS reco software)
+      // convert from DD4hep unit to mm (legacy expected by PPS reco software)
       boxShapeParameters = {params.at(0) / dd4hep::mm, params.at(1) / dd4hep::mm, params.at(2) / dd4hep::mm};
     }
   }

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -20,7 +20,7 @@
 #include "DataFormats/CTPPSDetId/interface/TotemTimingDetId.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSPixelDetId.h"
 #include "DataFormats/CTPPSDetId/interface/CTPPSDiamondDetId.h"
-#include "DataFormats/Math/interface/GeantUnits.h"
+#include <DD4hep/DD4hepUnits.h>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /*
@@ -47,14 +47,14 @@ DetGeomDesc::DetGeomDesc(const cms::DDFilteredView& fv, const bool isRun2)
     : m_name(computeNameWithNoNamespace(fv.name())),
       m_copy(fv.copyNum()),
       m_isDD4hep(true),
-      m_trans(geant_units::operators::convertCmToMm(fv.translation())),  // converted from cm (DD4hep) to mm
+      m_trans(fv.translation() / dd4hep::mm),  // converted from cm (DD4hep) to mm
       m_rot(fv.rotation()),
       m_params(computeParameters(fv)),  // default unit from DD4hep (cm)
       m_isABox(dd4hep::isA<dd4hep::Box>(fv.solid())),
       m_diamondBoxParams(computeDiamondDimensions(m_isABox, m_isDD4hep, m_params)),  // converted from cm (DD4hep) to mm
       m_sensorType(computeSensorType(fv.name())),
       m_geographicalID(computeDetIDFromDD4hep(m_name, fv.copyNos(), fv.copyNum(), isRun2)),
-      m_z(geant_units::operators::convertCmToMm(fv.translation().z()))  // converted from cm (DD4hep) to mm
+      m_z(fv.translation().z() / dd4hep::mm)  // converted from cm (DD4hep) to mm
 {}
 
 DetGeomDesc::DetGeomDesc(const DetGeomDesc& ref, CopyMode cm) {
@@ -152,9 +152,7 @@ DiamondDimensions DetGeomDesc::computeDiamondDimensions(const bool isABox,
       boxShapeParameters = {params.at(0), params.at(1), params.at(2)};
     } else {
       // convert cm (DD4hep) to mm (legacy expected by PPS reco software)
-      boxShapeParameters = {geant_units::operators::convertCmToMm(params.at(0)),
-                            geant_units::operators::convertCmToMm(params.at(1)),
-                            geant_units::operators::convertCmToMm(params.at(2))};
+      boxShapeParameters = {params.at(0) / dd4hep::mm, params.at(1) / dd4hep::mm, params.at(2) / dd4hep::mm};
     }
   }
   return boxShapeParameters;

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDesc.cc
@@ -140,7 +140,7 @@ std::vector<double> DetGeomDesc::computeParameters(const cms::DDFilteredView& fv
  * Compute diamond dimensions.
  * The diamond sensors are represented by the Box shape parameters.
  * oldDD: params are already in mm.
- * DD4hep: convert params from DD4hep unit to mm (legacy expected by PPS reco software).
+ * DD4hep: convert params from DD4hep unit to mm (mm is legacy expected by PPS reco software).
  */
 DiamondDimensions DetGeomDesc::computeDiamondDimensions(const bool isABox,
                                                         const bool isDD4hep,
@@ -148,10 +148,10 @@ DiamondDimensions DetGeomDesc::computeDiamondDimensions(const bool isABox,
   DiamondDimensions boxShapeParameters{};
   if (isABox) {
     if (!isDD4hep) {
-      // mm (legacy)
+      // mm (old DD)
       boxShapeParameters = {params.at(0), params.at(1), params.at(2)};
     } else {
-      // convert from DD4hep unit to mm (legacy expected by PPS reco software)
+      // convert from DD4hep unit to mm (mm is legacy expected by PPS reco software)
       boxShapeParameters = {params.at(0) / dd4hep::mm, params.at(1) / dd4hep::mm, params.at(2) / dd4hep::mm};
     }
   }


### PR DESCRIPTION
Make units of values from XMLs dd4hep-dependent. 
This will allow the values to change automatically, when DD4hep changes its reference unit.

@ianna @cvuosalo @civanch 

