### PR TITLE
switch modifiers to pp_on_AA for hiEvtPlane

### DIFF
--- a/RecoHI/HiEvtPlaneAlgos/python/HiEvtPlane_cfi.py
+++ b/RecoHI/HiEvtPlaneAlgos/python/HiEvtPlane_cfi.py
@@ -34,10 +34,8 @@ hiEvtPlane = cms.EDProducer("EvtPlaneProducer",
                             cutEra = cms.int32(2) # 0:ppReco, 1:HIReco, 2:Pixel, 3: GenMC
                             )
 
-from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
-from Configuration.Eras.Modifier_pp_on_PbPb_run3_cff import pp_on_PbPb_run3
-
-(pp_on_AA_2018 | pp_on_PbPb_run3).toModify(hiEvtPlane,
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toModify(hiEvtPlane,
     vertexTag = "offlinePrimaryVertices",
     trackTag = "packedPFCandidates",
     caloTag = "particleFlow",


### PR DESCRIPTION
pp_on_AA is a common modifier for HI, as introduced in #31935.
RecoHI/HiEvtPlaneAlgos/python/HiEvtPlane_cfi.py was apparently left over.
The update should be technical at this point.

this update was confirmed with @mandrenguyen 
