### PR TITLE
Updates to the L1 prefiring weight producer

### DIFF
--- a/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
@@ -55,6 +55,7 @@ private:
   std::string dataera_;
   bool useEMpt_;
   double prefiringRateSystUnc_;
+  double jetMaxMuonFraction_;
   bool skipwarnings_;
 };
 
@@ -65,6 +66,7 @@ L1ECALPrefiringWeightProducer::L1ECALPrefiringWeightProducer(const edm::Paramete
   dataera_ = iConfig.getParameter<std::string>("DataEra");
   useEMpt_ = iConfig.getParameter<bool>("UseJetEMPt");
   prefiringRateSystUnc_ = iConfig.getParameter<double>("PrefiringRateSystematicUncty");
+  jetMaxMuonFraction_ = iConfig.getParameter<double>("JetMaxMuonFraction");
   skipwarnings_ = iConfig.getParameter<bool>("SkipWarnings");
 
   TFile* file_prefiringmaps_;
@@ -135,7 +137,8 @@ void L1ECALPrefiringWeightProducer::produce(edm::StreamID, edm::Event& iEvent, c
         continue;
       if (fabs(eta_jet) > 3.)
         continue;
-
+      if (jetMaxMuonFraction_ > 0 && jet.muonEnergyFraction() > jetMaxMuonFraction_)
+        continue;
       //Loop over photons to remove overlap
       double nonprefiringprobfromoverlappingphotons = 1.;
       for (const auto& photon : *thePhotons) {
@@ -219,6 +222,7 @@ void L1ECALPrefiringWeightProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::string>("DataEra", "2017BtoF");
   desc.add<bool>("UseJetEMPt", false);
   desc.add<double>("PrefiringRateSystematicUncty", 0.2);
+  desc.add<double>("JetMaxMuonFraction", -1);
   desc.add<bool>("SkipWarnings", true);
   descriptions.add("l1ECALPrefiringWeightProducer", desc);
 }


### PR DESCRIPTION
#### PR description:

This PR provides a few updates of the L1 prefiring weight producer. 

1. Protection against muon jets (only feature right now) 
In the L1 prefiring weight producer, a customized protection is added to veto jets mostly made of muons that have very little chance to prefire (since prefiring is related to the jet EM energy). 
The default value is no protection, but the recommended value is = 0.5. 
Physics wise, the change has often a negligible impact, except for (very) precise measurements including muons in the final states (e.g. Wmass) or final states involving high pt forward muons (e.g. Z'->mumu).

2. We have now prefiring maps for Ultra Legacy 2017 (update of the following root file):  
https://github.com/cms-data/PhysicsTools-PatUtils/blob/master/L1PrefiringMaps.root
Could you indicate me how to proceed? 

3. In order to update the maps and switch on the muon jet protection for next NANOAOD productions in 106X, some lines should be added bellow behind a new process/era modifier: 
https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/triggerObjects_cff.py#L222
Could you advise what modifier to use? 



#### PR validation:

The code as is (without modifier) generates no difference in workflows: the producer is only called in the NANO step and has currently the same settings as before. 

Validation of the muon protection (setting JetMaxMuonFraction = 0.5) was performed on a QCD and a high mass Z->mumu samples. 
QCD is untouched, prefiring weights increase as expected in ZMuMu. 
![prefQCDHT500To700](https://user-images.githubusercontent.com/4995867/102618627-6c40e400-413b-11eb-8ddd-8829bc64f7ee.png)
![prefPRzmumum400to800](https://user-images.githubusercontent.com/4995867/102618628-6cd97a80-413b-11eb-9f84-b6102f2d85d4.png)

The new maps were presented at this meeting: 
https://indico.cern.ch/event/985369/#3-ul2017-prefiring-maps-tbc

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport. I understand a backport is needed for 10_6_X. Do we also need one for 11_2? Thanks ! 
