### PR TITLE
Clean-up of L1 Tracker cluster, stub & track truth-reco association code

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTypes.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTypes.h
@@ -19,15 +19,26 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 
-/// The reference types
+/// Templated aliases
+template<typename T> using TTClusterDetSetVecT = edmNew::DetSetVector<TTCluster<T> >;
+template<typename T> using TTStubDetSetVecT = edmNew::DetSetVector<TTStub<T> >;
+
+template<typename T> using TTClusterRefT = edm::Ref<TTClusterDetSetVecT<T>, TTCluster<T> >;
+template<typename T> using TTStubRefT = edm::Ref<TTStubDetSetVecT<T>, TTStub<T> >;
+
+template<typename T> using TTTrackPtrT = edm::Ptr<TTTrack<T> >;
+
+/// Specialized aliases
 typedef edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> Ref_Phase2TrackerDigi_;
 
-typedef edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_> > TTClusterDetSetVec;
-typedef edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> > TTStubDetSetVec;
-
-typedef edm::Ref<TTStubDetSetVec, TTStub<Ref_Phase2TrackerDigi_> > TTStubRef;
-typedef edm::Ref<TTClusterDetSetVec, TTCluster<Ref_Phase2TrackerDigi_> > TTClusterRef;
-
 typedef edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_> > TTStubDetSet;
+
+typedef TTClusterDetSetVecT<Ref_Phase2TrackerDigi_> TTClusterDetSetVec;
+typedef TTStubDetSetVecT<Ref_Phase2TrackerDigi_> TTStubDetSetVec;
+
+typedef TTClusterRefT<Ref_Phase2TrackerDigi_> TTClusterRef;
+typedef TTStubRefT<Ref_Phase2TrackerDigi_> TTStubRef;
+
+typedef TTTrackPtrT<Ref_Phase2TrackerDigi_> TTTrackPtr;
 
 #endif

--- a/DataFormats/L1TrackTrigger/interface/TTTypes.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTypes.h
@@ -20,13 +20,18 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 
 /// Templated aliases
-template<typename T> using TTClusterDetSetVecT = edmNew::DetSetVector<TTCluster<T> >;
-template<typename T> using TTStubDetSetVecT = edmNew::DetSetVector<TTStub<T> >;
+template <typename T>
+using TTClusterDetSetVecT = edmNew::DetSetVector<TTCluster<T> >;
+template <typename T>
+using TTStubDetSetVecT = edmNew::DetSetVector<TTStub<T> >;
 
-template<typename T> using TTClusterRefT = edm::Ref<TTClusterDetSetVecT<T>, TTCluster<T> >;
-template<typename T> using TTStubRefT = edm::Ref<TTStubDetSetVecT<T>, TTStub<T> >;
+template <typename T>
+using TTClusterRefT = edm::Ref<TTClusterDetSetVecT<T>, TTCluster<T> >;
+template <typename T>
+using TTStubRefT = edm::Ref<TTStubDetSetVecT<T>, TTStub<T> >;
 
-template<typename T> using TTTrackPtrT = edm::Ptr<TTTrack<T> >;
+template <typename T>
+using TTTrackPtrT = edm::Ptr<TTTrack<T> >;
 
 /// Specialized aliases
 typedef edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> Ref_Phase2TrackerDigi_;

--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h
@@ -1,12 +1,14 @@
 #ifndef TrackingAnalysis_TrackingParticleFwd_h
 #define TrackingAnalysis_TrackingParticleFwd_h
 #include <vector>
+#include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
 class TrackingParticle;
 typedef std::vector<TrackingParticle> TrackingParticleCollection;
+typedef edm::Ptr<TrackingParticle> TrackingParticlePtr;
 typedef edm::Ref<TrackingParticleCollection> TrackingParticleRef;
 typedef edm::RefVector<TrackingParticleCollection> TrackingParticleRefVector;
 typedef edm::RefProd<TrackingParticleCollection> TrackingParticleRefProd;

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -92,14 +92,12 @@ private:
 
 };  /// Close class
 
-
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
  *           on the specific type <T> that can fit the template.
  *           Other methods, with type-specific features, are implemented
  *           in the source file.
  */
-
 
 // Static constant data members.
 template <typename T>
@@ -133,7 +131,8 @@ const std::vector<TTClusterRefT<T>>& TTClusterAssociationMap<T>::findTTClusterRe
 }
 
 template <typename T>
-const std::vector<TrackingParticlePtr>& TTClusterAssociationMap<T>::findTrackingParticlePtrs(TTClusterRefT<T> aCluster) const {
+const std::vector<TrackingParticlePtr>& TTClusterAssociationMap<T>::findTrackingParticlePtrs(
+    TTClusterRefT<T> aCluster) const {
   if (clusterToTrackingParticleVectorMap_.find(aCluster) != clusterToTrackingParticleVectorMap_.end()) {
     return clusterToTrackingParticleVectorMap_.find(aCluster)->second;
   } else {

--- a/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h
@@ -35,8 +35,10 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 // Templated aliases
-template<typename T> using MapClusToVecTP = std::map<TTClusterRefT<T>, std::vector<TrackingParticlePtr> >;
-template<typename T> using MapTPToVecClus = std::map<TrackingParticlePtr, std::vector<TTClusterRefT<T> > >;
+template <typename T>
+using MapClusToVecTP = std::map<TTClusterRefT<T>, std::vector<TrackingParticlePtr>>;
+template <typename T>
+using MapTPToVecClus = std::map<TrackingParticlePtr, std::vector<TTClusterRefT<T>>>;
 
 template <typename T>
 class TTClusterAssociationMap {
@@ -49,19 +51,11 @@ public:
 
   /// Get/set cluster <-> truth association maps
 
-  const MapClusToVecTP<T>& getTTClusterToTrackingParticlesMap() const {
-    return clusterToTrackingParticleVectorMap;
-  }
-  const MapTPToVecClus<T>& getTrackingParticleToTTClustersMap() const {
-    return trackingParticleToClusterVectorMap;
-  }
+  const MapClusToVecTP<T>& getTTClusterToTrackingParticlesMap() const { return clusterToTrackingParticleVectorMap; }
+  const MapTPToVecClus<T>& getTrackingParticleToTTClustersMap() const { return trackingParticleToClusterVectorMap; }
 
-  void setTTClusterToTrackingParticlesMap(const MapClusToVecTP<T>& aMap) {
-    clusterToTrackingParticleVectorMap = aMap;
-  }
-  void setTrackingParticleToTTClustersMap(const MapTPToVecClus<T>& aMap) {
-    trackingParticleToClusterVectorMap = aMap;
-  }
+  void setTTClusterToTrackingParticlesMap(const MapClusToVecTP<T>& aMap) { clusterToTrackingParticleVectorMap = aMap; }
+  void setTrackingParticleToTTClustersMap(const MapTPToVecClus<T>& aMap) { trackingParticleToClusterVectorMap = aMap; }
 
   /// Get all TPs associated to a cluster
   std::vector<TrackingParticlePtr> findTrackingParticlePtrs(TTClusterRefT<T> aCluster) const;
@@ -71,11 +65,11 @@ public:
   // Get all clusters associated to TP.
   std::vector<TTClusterRefT<T>> findTTClusterRefs(TrackingParticlePtr aTrackingParticle) const;
 
-  ///--- Get quality of L1 cluster based on truth info. 
+  ///--- Get quality of L1 cluster based on truth info.
   /// (exactly 1 of following 3 functions is always true)
 
   /// Cluster "genuine": i.e. cluster associated to exactly 1 TP.
-  /// (If other TPs are associated, but have in total < 1% of Pt of main TP, 
+  /// (If other TPs are associated, but have in total < 1% of Pt of main TP,
   ///  or if they are null, then they are neglected here).
   bool isGenuine(TTClusterRefT<T> aCluster) const;
   /// Cluster "unknown": i.e. not associated with any TP.
@@ -115,25 +109,24 @@ TTClusterAssociationMap<T>::~TTClusterAssociationMap() {}
 
 /// Operations
 template <typename T>
-std::vector< TTClusterRefT<T> >
-TTClusterAssociationMap<T>::findTTClusterRefs(TrackingParticlePtr aTrackingParticle) const {
+std::vector<TTClusterRefT<T>> TTClusterAssociationMap<T>::findTTClusterRefs(
+    TrackingParticlePtr aTrackingParticle) const {
   if (trackingParticleToClusterVectorMap.find(aTrackingParticle) != trackingParticleToClusterVectorMap.end()) {
     return trackingParticleToClusterVectorMap.find(aTrackingParticle)->second;
   }
 
-  std::vector< TTClusterRefT<T> > tempVector;
+  std::vector<TTClusterRefT<T>> tempVector;
   tempVector.clear();
   return tempVector;
 }
 
 template <typename T>
-std::vector<TrackingParticlePtr > TTClusterAssociationMap<T>::findTrackingParticlePtrs(
-    TTClusterRefT<T> aCluster) const {
+std::vector<TrackingParticlePtr> TTClusterAssociationMap<T>::findTrackingParticlePtrs(TTClusterRefT<T> aCluster) const {
   if (clusterToTrackingParticleVectorMap.find(aCluster) != clusterToTrackingParticleVectorMap.end()) {
     return clusterToTrackingParticleVectorMap.find(aCluster)->second;
   }
 
-  std::vector<TrackingParticlePtr > tempVector;
+  std::vector<TrackingParticlePtr> tempVector;
   tempVector.clear();
   return tempVector;
 }
@@ -165,7 +158,7 @@ std::vector<TrackingParticlePtr > TTClusterAssociationMap<T>::findTrackingPartic
 template <typename T>
 bool TTClusterAssociationMap<T>::isGenuine(TTClusterRefT<T> aCluster) const {
   /// Get the TrackingParticles
-  std::vector<TrackingParticlePtr > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
+  std::vector<TrackingParticlePtr> theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
   if (theseTrackingParticles.empty())
@@ -223,7 +216,7 @@ bool TTClusterAssociationMap<T>::isGenuine(TTClusterRefT<T> aCluster) const {
 template <typename T>
 bool TTClusterAssociationMap<T>::isUnknown(TTClusterRefT<T> aCluster) const {
   /// Get the TrackingParticles
-  std::vector<TrackingParticlePtr > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
+  std::vector<TrackingParticlePtr> theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
   if (theseTrackingParticles.empty())
@@ -258,7 +251,7 @@ bool TTClusterAssociationMap<T>::isUnknown(TTClusterRefT<T> aCluster) const {
 template <typename T>
 bool TTClusterAssociationMap<T>::isCombinatoric(TTClusterRefT<T> aCluster) const {
   /// Get the TrackingParticles
-  std::vector<TrackingParticlePtr > theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
+  std::vector<TrackingParticlePtr> theseTrackingParticles = this->findTrackingParticlePtrs(aCluster);
 
   /// If the vector is empty, then the cluster is UNKNOWN
   if (theseTrackingParticles.empty())

--- a/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
@@ -1,13 +1,18 @@
 /*! \class   TTStubAssociationMap
- *  \brief   Class to store the MC truth of L1 Track Trigger stubs
- *  \details After moving from SimDataFormats to DataFormats,
- *           the template structure of the class was maintained
- *           in order to accomodate any types other than PixelDigis
- *           in case there is such a need in the future.
+ *  \brief   Stores association of Truth Particles (TP) to L1 Track-Trigger Stubs
+ *
+ *  \details Contains two maps. One associates each stub to its principle TP.
+ *           (i.e. Not to all TP that contributed to it). 
+ *           The other associates each TP to a vector of all stubs 
+ *           it contributed to. The two maps are therefore not
+ *           forward-backward symmetric.
+ *
+ *           (The template structure is used to accomodate types
+ *           other than PixelDigis, in case they are needed in future). 
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *
+ *  (tidy up: Ian Tomalin, 2020)
  */
 
 #ifndef L1_TRACK_TRIGGER_STUB_ASSOCIATION_FORMAT_H
@@ -16,6 +21,8 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -32,6 +39,10 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
 
+// Templated aliases
+template<typename T> using MapStubToTP = std::map<TTStubRefT<T>, TrackingParticlePtr >;
+template<typename T> using MapTPToVecStub = std::map<TrackingParticlePtr, std::vector<TTStubRefT<T> > >;
+
 template <typename T>
 class TTStubAssociationMap {
 public:
@@ -41,47 +52,62 @@ public:
   /// Destructor
   ~TTStubAssociationMap();
 
-  /// Data members:   getABC( ... )
-  /// Helper methods: findABC( ... )
+  /// Get/set stub <-> truth association maps
 
-  /// Maps
-  std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> >
-  getTTStubToTrackingParticleMap() const {
+  const MapStubToTP<T>& getTTStubToTrackingParticleMap() const {
     return stubToTrackingParticleMap;
   }
-  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > >
-  getTrackingParticleToTTStubsMap() const {
+  const MapTPToVecStub<T>& getTrackingParticleToTTStubsMap() const {
     return trackingParticleToStubVectorMap;
   }
 
-  void setTTStubToTrackingParticleMap(
-      std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> > aMap) {
+  void setTTStubToTrackingParticleMap(const MapStubToTP<T>& aMap) {
     stubToTrackingParticleMap = aMap;
   }
-  void setTrackingParticleToTTStubsMap(
-      std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > > aMap) {
+  void setTrackingParticleToTTStubsMap(const MapTPToVecStub<T>& aMap) {
     trackingParticleToStubVectorMap = aMap;
   }
+
+  /// Set cluster <-> truth association object.
   void setTTClusterAssociationMap(edm::RefProd<TTClusterAssociationMap<T> > aCluAssoMap) {
     theClusterAssociationMap = aCluAssoMap;
   }
 
-  /// Operations
-  edm::Ptr<TrackingParticle> findTrackingParticlePtr(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > findTTStubRefs(
-      edm::Ptr<TrackingParticle> aTrackingParticle) const;
+  /// Get principle TP associated to a stub. (Non-NULL if isGenuine() below is true).
+  /// (N.B. There is no function returning all TP associated to a stub).
+  /// (P.S. As this function only returns principle TP, it is not used when constructing
+  ///  the TTTrackAssociationMap).
+  TrackingParticlePtr findTrackingParticlePtr(TTStubRefT<T> aStub) const;
 
-  /// MC Truth methods
-  bool isGenuine(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
-  bool isCombinatoric(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
-  bool isUnknown(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const;
+  /// Get all stubs associated to a TP.
+  /// (Even if the TP just contributes to one cluster in stub, 
+  /// and even if their are other such TP, it is still listed here).
+  std::vector<TTStubRefT<T>> findTTStubRefs(TrackingParticlePtr aTrackingParticle) const;
+
+  ///--- Get quality of stub based on truth info.
+  /// (N.B. Both genuine & combinatoric stubs contribute to "genuine" L1 tracks
+  ///  associated by TTTrackAssociationMap).
+  /// (exactly 1 of following 3 functions is always true)
+
+  /// If both clusters are unknown, the stub is "unknown".
+  /// If only one cluster is unknown, the stub is combinatoric.
+  /// If both clusters are genuine, and are associated to the same (main) TrackingParticle, 
+  /// the stub is "genuine".
+  /// If both clusters are genuine, but are associated to different (main) TrackingParticles, 
+  /// the stub is "combinatoric".
+  /// If one cluster is combinatoric and the other is genuine/combinatoric, and they both share exactly 
+  /// one TrackingParticle in common, then the stub is "genuine". (The clusters can have other 
+  /// TrackingParticles besides the shared one, as long as these are not shared). If instead the clusters 
+  /// share 0 or ≥2 TrackingParticles in common, then the stub is "combinatoric".
+
+  bool isGenuine(TTStubRefT<T> aStub) const;
+  bool isCombinatoric(TTStubRefT<T> aStub) const;
+  bool isUnknown(TTStubRefT<T> aStub) const;
 
 private:
   /// Data members
-  std::map<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> >, edm::Ptr<TrackingParticle> >
-      stubToTrackingParticleMap;
-  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > >
-      trackingParticleToStubVectorMap;
+  MapStubToTP<T> stubToTrackingParticleMap;
+  MapTPToVecStub<T> trackingParticleToStubVectorMap;
   edm::RefProd<TTClusterAssociationMap<T> > theClusterAssociationMap;
 
 };  /// Close class
@@ -110,32 +136,30 @@ TTStubAssociationMap<T>::~TTStubAssociationMap() {}
 
 /// Operations
 template <typename T>
-edm::Ptr<TrackingParticle> TTStubAssociationMap<T>::findTrackingParticlePtr(
-    edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
+TrackingParticlePtr TTStubAssociationMap<T>::findTrackingParticlePtr(TTStubRefT<T> aStub) const {
   if (stubToTrackingParticleMap.find(aStub) != stubToTrackingParticleMap.end()) {
     return stubToTrackingParticleMap.find(aStub)->second;
   }
 
   /// Default: return NULL
-  //edm::Ptr< TrackingParticle >* temp = new edm::Ptr< TrackingParticle >();
-  return edm::Ptr<TrackingParticle>();
+  return TrackingParticlePtr();
 }
 
 template <typename T>
-std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > TTStubAssociationMap<T>::findTTStubRefs(
-    edm::Ptr<TrackingParticle> aTrackingParticle) const {
+std::vector< TTStubRefT<T> > TTStubAssociationMap<T>::findTTStubRefs(
+    TrackingParticlePtr aTrackingParticle) const {
   if (trackingParticleToStubVectorMap.find(aTrackingParticle) != trackingParticleToStubVectorMap.end()) {
     return trackingParticleToStubVectorMap.find(aTrackingParticle)->second;
   }
 
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > tempVector;
+  std::vector< TTStubRefT<T> > tempVector;
   tempVector.clear();
   return tempVector;
 }
 
 /// MC truth
 template <typename T>
-bool TTStubAssociationMap<T>::isGenuine(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
+bool TTStubAssociationMap<T>::isGenuine(TTStubRefT<T> aStub) const {
   /// Check if there is a SimTrack
   if ((this->findTrackingParticlePtr(aStub)).isNull())
     return false;
@@ -144,7 +168,7 @@ bool TTStubAssociationMap<T>::isGenuine(edm::Ref<edmNew::DetSetVector<TTStub<T> 
 }
 
 template <typename T>
-bool TTStubAssociationMap<T>::isCombinatoric(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
+bool TTStubAssociationMap<T>::isCombinatoric(TTStubRefT<T> aStub) const {
   /// Defined by exclusion
   if (this->isGenuine(aStub))
     return false;
@@ -156,7 +180,7 @@ bool TTStubAssociationMap<T>::isCombinatoric(edm::Ref<edmNew::DetSetVector<TTStu
 }
 
 template <typename T>
-bool TTStubAssociationMap<T>::isUnknown(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) const {
+bool TTStubAssociationMap<T>::isUnknown(TTStubRefT<T> aStub) const {
   /// UNKNOWN means that both clusters are unknown
   //std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< T > >, TTCluster< T > > > theseClusters = aStub->getClusterRefs();
 

--- a/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
@@ -40,8 +40,10 @@
 #include "SimTracker/TrackTriggerAssociation/interface/TTClusterAssociationMap.h"
 
 // Templated aliases
-template<typename T> using MapStubToTP = std::map<TTStubRefT<T>, TrackingParticlePtr >;
-template<typename T> using MapTPToVecStub = std::map<TrackingParticlePtr, std::vector<TTStubRefT<T> > >;
+template <typename T>
+using MapStubToTP = std::map<TTStubRefT<T>, TrackingParticlePtr>;
+template <typename T>
+using MapTPToVecStub = std::map<TrackingParticlePtr, std::vector<TTStubRefT<T>>>;
 
 template <typename T>
 class TTStubAssociationMap {
@@ -54,22 +56,14 @@ public:
 
   /// Get/set stub <-> truth association maps
 
-  const MapStubToTP<T>& getTTStubToTrackingParticleMap() const {
-    return stubToTrackingParticleMap;
-  }
-  const MapTPToVecStub<T>& getTrackingParticleToTTStubsMap() const {
-    return trackingParticleToStubVectorMap;
-  }
+  const MapStubToTP<T>& getTTStubToTrackingParticleMap() const { return stubToTrackingParticleMap; }
+  const MapTPToVecStub<T>& getTrackingParticleToTTStubsMap() const { return trackingParticleToStubVectorMap; }
 
-  void setTTStubToTrackingParticleMap(const MapStubToTP<T>& aMap) {
-    stubToTrackingParticleMap = aMap;
-  }
-  void setTrackingParticleToTTStubsMap(const MapTPToVecStub<T>& aMap) {
-    trackingParticleToStubVectorMap = aMap;
-  }
+  void setTTStubToTrackingParticleMap(const MapStubToTP<T>& aMap) { stubToTrackingParticleMap = aMap; }
+  void setTrackingParticleToTTStubsMap(const MapTPToVecStub<T>& aMap) { trackingParticleToStubVectorMap = aMap; }
 
   /// Set cluster <-> truth association object.
-  void setTTClusterAssociationMap(edm::RefProd<TTClusterAssociationMap<T> > aCluAssoMap) {
+  void setTTClusterAssociationMap(edm::RefProd<TTClusterAssociationMap<T>> aCluAssoMap) {
     theClusterAssociationMap = aCluAssoMap;
   }
 
@@ -80,7 +74,7 @@ public:
   TrackingParticlePtr findTrackingParticlePtr(TTStubRefT<T> aStub) const;
 
   /// Get all stubs associated to a TP.
-  /// (Even if the TP just contributes to one cluster in stub, 
+  /// (Even if the TP just contributes to one cluster in stub,
   /// and even if their are other such TP, it is still listed here).
   std::vector<TTStubRefT<T>> findTTStubRefs(TrackingParticlePtr aTrackingParticle) const;
 
@@ -91,13 +85,13 @@ public:
 
   /// If both clusters are unknown, the stub is "unknown".
   /// If only one cluster is unknown, the stub is combinatoric.
-  /// If both clusters are genuine, and are associated to the same (main) TrackingParticle, 
+  /// If both clusters are genuine, and are associated to the same (main) TrackingParticle,
   /// the stub is "genuine".
-  /// If both clusters are genuine, but are associated to different (main) TrackingParticles, 
+  /// If both clusters are genuine, but are associated to different (main) TrackingParticles,
   /// the stub is "combinatoric".
-  /// If one cluster is combinatoric and the other is genuine/combinatoric, and they both share exactly 
-  /// one TrackingParticle in common, then the stub is "genuine". (The clusters can have other 
-  /// TrackingParticles besides the shared one, as long as these are not shared). If instead the clusters 
+  /// If one cluster is combinatoric and the other is genuine/combinatoric, and they both share exactly
+  /// one TrackingParticle in common, then the stub is "genuine". (The clusters can have other
+  /// TrackingParticles besides the shared one, as long as these are not shared). If instead the clusters
   /// share 0 or ≥2 TrackingParticles in common, then the stub is "combinatoric".
 
   bool isGenuine(TTStubRefT<T> aStub) const;
@@ -108,7 +102,7 @@ private:
   /// Data members
   MapStubToTP<T> stubToTrackingParticleMap;
   MapTPToVecStub<T> trackingParticleToStubVectorMap;
-  edm::RefProd<TTClusterAssociationMap<T> > theClusterAssociationMap;
+  edm::RefProd<TTClusterAssociationMap<T>> theClusterAssociationMap;
 
 };  /// Close class
 
@@ -126,7 +120,7 @@ TTStubAssociationMap<T>::TTStubAssociationMap() {
   /// Set default data members
   stubToTrackingParticleMap.clear();
   trackingParticleToStubVectorMap.clear();
-  edm::RefProd<TTClusterAssociationMap<T> >* aRefProd = new edm::RefProd<TTClusterAssociationMap<T> >();
+  edm::RefProd<TTClusterAssociationMap<T>>* aRefProd = new edm::RefProd<TTClusterAssociationMap<T>>();
   theClusterAssociationMap = *aRefProd;
 }
 
@@ -146,13 +140,12 @@ TrackingParticlePtr TTStubAssociationMap<T>::findTrackingParticlePtr(TTStubRefT<
 }
 
 template <typename T>
-std::vector< TTStubRefT<T> > TTStubAssociationMap<T>::findTTStubRefs(
-    TrackingParticlePtr aTrackingParticle) const {
+std::vector<TTStubRefT<T>> TTStubAssociationMap<T>::findTTStubRefs(TrackingParticlePtr aTrackingParticle) const {
   if (trackingParticleToStubVectorMap.find(aTrackingParticle) != trackingParticleToStubVectorMap.end()) {
     return trackingParticleToStubVectorMap.find(aTrackingParticle)->second;
   }
 
-  std::vector< TTStubRefT<T> > tempVector;
+  std::vector<TTStubRefT<T>> tempVector;
   tempVector.clear();
   return tempVector;
 }

--- a/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h
@@ -110,14 +110,12 @@ private:
 
 };  /// Close class
 
-
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend
  *           on the specific type <T> that can fit the template.
  *           Other methods, with type-specific features, are implemented
  *           in the source file.
  */
-
 
 // Static constant data members.
 template <typename T>

--- a/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
@@ -1,13 +1,18 @@
 /*! \class   TTTrackAssociationMap
- *  \brief   Class to store the MC truth of L1 Track Trigger tracks
- *  \details After moving from SimDataFormats to DataFormats,
- *           the template structure of the class was maintained
- *           in order to accomodate any types other than PixelDigis
- *           in case there is such a need in the future.
+ *  \brief   Stores association of Truth Particles (TP) to L1 Track-Trigger Tracks
+ * 
+ *  \details Contains two maps. One associates each L1 track its principle TP.
+ *           (i.e. Not to all TP that contributed to it). 
+ *           The other associates each TP to a vector of all L1 tracks 
+ *           it contributed to. The two maps are therefore not
+ *           forward-backward symmetric.
+ *
+ *           (The template structure is used to accomodate types
+ *           other than PixelDigis, in case they are needed in future). 
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *
+ *  (tidy up: Ian Tomalin, 2020)
  */
 
 #ifndef L1_TRACK_TRIGGER_TRACK_ASSOCIATION_FORMAT_H
@@ -15,6 +20,8 @@
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/Ptr.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "DataFormats/Common/interface/DetSet.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
@@ -22,13 +29,16 @@
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"  /// NOTE: this is needed even if it seems not
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
+
+// Templated aliases
+template<typename T> using MapL1TrackToTP = std::map<TTTrackPtrT<T>, TrackingParticlePtr >;
+template<typename T> using MapTPToVecL1Track = std::map<TrackingParticlePtr, std::vector<TTTrackPtrT<T>> >;
 
 template <typename T>
 class TTTrackAssociationMap {
@@ -39,45 +49,64 @@ public:
   /// Destructor
   ~TTTrackAssociationMap();
 
-  /// Data members:   getABC( ... )
-  /// Helper methods: findABC( ... )
+  /// Get/set stub <-> truth association maps
 
-  /// Maps
-  std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > getTTTrackToTrackingParticleMap() const {
+  const MapL1TrackToTP<T>& getTTTrackToTrackingParticleMap() const {
     return trackToTrackingParticleMap;
   }
-  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > getTrackingParticleToTTTracksMap() const {
+  const MapTPToVecL1Track<T>& getTrackingParticleToTTTracksMap() const {
     return trackingParticleToTrackVectorMap;
   }
 
-  void setTTTrackToTrackingParticleMap(std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > aMap) {
+  void setTTTrackToTrackingParticleMap(const MapL1TrackToTP<T>& aMap) {
     trackToTrackingParticleMap = aMap;
   }
-  void setTrackingParticleToTTTracksMap(
-      std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > aMap) {
+  void setTrackingParticleToTTTracksMap(const MapTPToVecL1Track<T>& aMap) {
     trackingParticleToTrackVectorMap = aMap;
   }
+
+  /// Set stub <-> truth association object.
   void setTTStubAssociationMap(edm::RefProd<TTStubAssociationMap<T> > aStubAssoMap) {
     theStubAssociationMap = aStubAssoMap;
   }
 
-  /// Operations
-  edm::Ptr<TrackingParticle> findTrackingParticlePtr(edm::Ptr<TTTrack<T> > aTrack) const;
-  std::vector<edm::Ptr<TTTrack<T> > > findTTTrackPtrs(edm::Ptr<TrackingParticle> aTrackingParticle) const;
+  /// Get principle TP associated to a L1 track. (Non-NULL if isLooselyGenuine() below is true).
+  /// (N.B. There is no function returning all TP associated to a L1 track).
+  TrackingParticlePtr findTrackingParticlePtr(TTTrackPtrT<T> aTrack) const;
 
-  /// MC Truth methods
-  bool isGenuine(edm::Ptr<TTTrack<T> > aTrack) const;
-  bool isLooselyGenuine(edm::Ptr<TTTrack<T> > aTrack) const;
-  bool isCombinatoric(edm::Ptr<TTTrack<T> > aTrack) const;
-  bool isUnknown(edm::Ptr<TTTrack<T> > aTrack) const;
+  /// Get all L1 tracks associated to a TP.
+  /// (Even if the TP just contributes to one cluster in one stub, 
+  /// and even if their are other such TP, it is still listed here).
+  std::vector<TTTrackPtrT<T> > findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
 
+  ///--- Get quality of L1 track based on truth info.
+  /// (N.B. "genuine" tracks are used for official L1 track efficiency measurements).
+
+  /// Exactly one (i.e. not 0 or >= 2) unique TP contributes to every stub on the track.
+  /// (even if it is not the principle TP in a stub, or contributes to only one cluster
+  /// in the stub, it still counts).
+  /// N.B. If cfg param getAllowOneFalse2SStub() is true, then one incorrect stub in 
+  /// a 2S module is alowed
+  /// ISSUE: a track with 4 stubs can be accepted if only 3 of its stubs are correct!
+  /// ISSUE: isLooselyGenuine() must also be true. So if 2 TPs match track, one with
+  /// an incorrect PS stub, both isGenuine() & isLooselyGenuine() will be false!
+  bool isGenuine(TTTrackPtrT<T> aTrack) const;
+  /// Same criteria as for "genuine" track, except that one incorrect stub in either
+  /// PS or 2S module is allowed, irrespective of value of cfg param getAllowOneFalse2SStub().
+  bool isLooselyGenuine(TTTrackPtrT<T> aTrack) const;
+  /// More than one stub on track is "unknown".
+  bool isUnknown(TTTrackPtrT<T> aTrack) const;
+  /// Both isLooselyGenuine() & isUnknown() are false.
+  bool isCombinatoric(TTTrackPtrT<T> aTrack) const;
+
+  // Cfg param allowing one incorrect 2S stub in "genuine" tracks.
   void setAllowOneFalse2SStub(bool allowFalse2SStub);
   bool getAllowOneFalse2SStub();
 
 private:
   /// Data members
-  std::map<edm::Ptr<TTTrack<T> >, edm::Ptr<TrackingParticle> > trackToTrackingParticleMap;
-  std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<T> > > > trackingParticleToTrackVectorMap;
+  MapL1TrackToTP<T> trackToTrackingParticleMap;
+  MapTPToVecL1Track<T> trackingParticleToTrackVectorMap;
   edm::RefProd<TTStubAssociationMap<T> > theStubAssociationMap;
 
   bool AllowOneFalse2SStub;
@@ -106,27 +135,25 @@ TTTrackAssociationMap<T>::~TTTrackAssociationMap() {}
 
 /// Operations
 template <>
-edm::Ptr<TrackingParticle> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
+TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    TTTrackPtr aTrack) const;
 
 template <>
-std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
-    edm::Ptr<TrackingParticle> aTrackingParticle) const;
-
-/// MC truth
-template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
+std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+    TrackingParticlePtr aTrackingParticle) const;
 
 /// MC truth
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(TTTrackPtr aTrack) const;
+
+/// MC truth
+template <>
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(TTTrackPtr aTrack) const;
 
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(TTTrackPtr aTrack) const;
 
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const;
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(TTTrackPtr aTrack) const;
 
 #endif

--- a/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
@@ -53,25 +53,25 @@ public:
 
   /// Get/set stub <-> truth association maps
 
-  const MapL1TrackToTP<T>& getTTTrackToTrackingParticleMap() const { return trackToTrackingParticleMap; }
-  const MapTPToVecL1Track<T>& getTrackingParticleToTTTracksMap() const { return trackingParticleToTrackVectorMap; }
+  const MapL1TrackToTP<T>& getTTTrackToTrackingParticleMap() const { return trackToTrackingParticleMap_; }
+  const MapTPToVecL1Track<T>& getTrackingParticleToTTTracksMap() const { return trackingParticleToTrackVectorMap_; }
 
-  void setTTTrackToTrackingParticleMap(const MapL1TrackToTP<T>& aMap) { trackToTrackingParticleMap = aMap; }
-  void setTrackingParticleToTTTracksMap(const MapTPToVecL1Track<T>& aMap) { trackingParticleToTrackVectorMap = aMap; }
+  void setTTTrackToTrackingParticleMap(const MapL1TrackToTP<T>& aMap) { trackToTrackingParticleMap_ = aMap; }
+  void setTrackingParticleToTTTracksMap(const MapTPToVecL1Track<T>& aMap) { trackingParticleToTrackVectorMap_ = aMap; }
 
   /// Set stub <-> truth association object.
   void setTTStubAssociationMap(edm::RefProd<TTStubAssociationMap<T>> aStubAssoMap) {
-    theStubAssociationMap = aStubAssoMap;
+    theStubAssociationMap_ = aStubAssoMap;
   }
 
   /// Get principle TP associated to a L1 track. (Non-NULL if isLooselyGenuine() below is true).
   /// (N.B. There is no function returning all TP associated to a L1 track).
-  TrackingParticlePtr findTrackingParticlePtr(TTTrackPtrT<T> aTrack) const;
+  const TrackingParticlePtr& findTrackingParticlePtr(TTTrackPtrT<T> aTrack) const;
 
   /// Get all L1 tracks associated to a TP.
   /// (Even if the TP just contributes to one cluster in one stub,
   /// and even if their are other such TP, it is still listed here).
-  std::vector<TTTrackPtrT<T>> findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
+  const std::vector<TTTrackPtrT<T>>& findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
 
   ///--- Get quality of L1 track based on truth info.
   /// (N.B. "genuine" tracks are used for official L1 track efficiency measurements).
@@ -99,11 +99,15 @@ public:
 
 private:
   /// Data members
-  MapL1TrackToTP<T> trackToTrackingParticleMap;
-  MapTPToVecL1Track<T> trackingParticleToTrackVectorMap;
-  edm::RefProd<TTStubAssociationMap<T>> theStubAssociationMap;
+  MapL1TrackToTP<T> trackToTrackingParticleMap_;
+  MapTPToVecL1Track<T> trackingParticleToTrackVectorMap_;
+  edm::RefProd<TTStubAssociationMap<T>> theStubAssociationMap_;
 
   bool AllowOneFalse2SStub;
+
+  // Allow functions to return reference to null.
+  static const TrackingParticlePtr nullTrackingParticlePtr_;
+  static const std::vector<TTTrackPtr> nullVecTTTrackPtr_;
 
 };  /// Close class
 
@@ -114,13 +118,17 @@ private:
  *           in the source file.
  */
 
+// Static constant data members.
+template <typename T>
+const TrackingParticlePtr TTTrackAssociationMap<T>::nullTrackingParticlePtr_;
+template <typename T>
+const std::vector<TTTrackPtr> TTTrackAssociationMap<T>::nullVecTTTrackPtr_;
+
 /// Default Constructor
 /// NOTE: to be used with setSomething(...) methods
 template <typename T>
 TTTrackAssociationMap<T>::TTTrackAssociationMap() {
   /// Set default data members
-  trackToTrackingParticleMap.clear();
-  trackingParticleToTrackVectorMap.clear();
 }
 
 /// Destructor
@@ -129,10 +137,10 @@ TTTrackAssociationMap<T>::~TTTrackAssociationMap() {}
 
 /// Operations
 template <>
-TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const;
+const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const;
 
 template <>
-std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+const std::vector<TTTrackPtr>& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
     TrackingParticlePtr aTrackingParticle) const;
 
 /// MC truth

--- a/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
@@ -137,7 +137,8 @@ TTTrackAssociationMap<T>::~TTTrackAssociationMap() {}
 
 /// Operations
 template <>
-const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const;
+const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    TTTrackPtr aTrack) const;
 
 template <>
 const std::vector<TTTrackPtr>& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(

--- a/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
+++ b/SimTracker/TrackTriggerAssociation/interface/TTTrackAssociationMap.h
@@ -37,8 +37,10 @@
 #include "SimTracker/TrackTriggerAssociation/interface/TTStubAssociationMap.h"
 
 // Templated aliases
-template<typename T> using MapL1TrackToTP = std::map<TTTrackPtrT<T>, TrackingParticlePtr >;
-template<typename T> using MapTPToVecL1Track = std::map<TrackingParticlePtr, std::vector<TTTrackPtrT<T>> >;
+template <typename T>
+using MapL1TrackToTP = std::map<TTTrackPtrT<T>, TrackingParticlePtr>;
+template <typename T>
+using MapTPToVecL1Track = std::map<TrackingParticlePtr, std::vector<TTTrackPtrT<T>>>;
 
 template <typename T>
 class TTTrackAssociationMap {
@@ -51,22 +53,14 @@ public:
 
   /// Get/set stub <-> truth association maps
 
-  const MapL1TrackToTP<T>& getTTTrackToTrackingParticleMap() const {
-    return trackToTrackingParticleMap;
-  }
-  const MapTPToVecL1Track<T>& getTrackingParticleToTTTracksMap() const {
-    return trackingParticleToTrackVectorMap;
-  }
+  const MapL1TrackToTP<T>& getTTTrackToTrackingParticleMap() const { return trackToTrackingParticleMap; }
+  const MapTPToVecL1Track<T>& getTrackingParticleToTTTracksMap() const { return trackingParticleToTrackVectorMap; }
 
-  void setTTTrackToTrackingParticleMap(const MapL1TrackToTP<T>& aMap) {
-    trackToTrackingParticleMap = aMap;
-  }
-  void setTrackingParticleToTTTracksMap(const MapTPToVecL1Track<T>& aMap) {
-    trackingParticleToTrackVectorMap = aMap;
-  }
+  void setTTTrackToTrackingParticleMap(const MapL1TrackToTP<T>& aMap) { trackToTrackingParticleMap = aMap; }
+  void setTrackingParticleToTTTracksMap(const MapTPToVecL1Track<T>& aMap) { trackingParticleToTrackVectorMap = aMap; }
 
   /// Set stub <-> truth association object.
-  void setTTStubAssociationMap(edm::RefProd<TTStubAssociationMap<T> > aStubAssoMap) {
+  void setTTStubAssociationMap(edm::RefProd<TTStubAssociationMap<T>> aStubAssoMap) {
     theStubAssociationMap = aStubAssoMap;
   }
 
@@ -75,9 +69,9 @@ public:
   TrackingParticlePtr findTrackingParticlePtr(TTTrackPtrT<T> aTrack) const;
 
   /// Get all L1 tracks associated to a TP.
-  /// (Even if the TP just contributes to one cluster in one stub, 
+  /// (Even if the TP just contributes to one cluster in one stub,
   /// and even if their are other such TP, it is still listed here).
-  std::vector<TTTrackPtrT<T> > findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
+  std::vector<TTTrackPtrT<T>> findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
 
   ///--- Get quality of L1 track based on truth info.
   /// (N.B. "genuine" tracks are used for official L1 track efficiency measurements).
@@ -85,7 +79,7 @@ public:
   /// Exactly one (i.e. not 0 or >= 2) unique TP contributes to every stub on the track.
   /// (even if it is not the principle TP in a stub, or contributes to only one cluster
   /// in the stub, it still counts).
-  /// N.B. If cfg param getAllowOneFalse2SStub() is true, then one incorrect stub in 
+  /// N.B. If cfg param getAllowOneFalse2SStub() is true, then one incorrect stub in
   /// a 2S module is alowed
   /// ISSUE: a track with 4 stubs can be accepted if only 3 of its stubs are correct!
   /// ISSUE: isLooselyGenuine() must also be true. So if 2 TPs match track, one with
@@ -107,7 +101,7 @@ private:
   /// Data members
   MapL1TrackToTP<T> trackToTrackingParticleMap;
   MapTPToVecL1Track<T> trackingParticleToTrackVectorMap;
-  edm::RefProd<TTStubAssociationMap<T> > theStubAssociationMap;
+  edm::RefProd<TTStubAssociationMap<T>> theStubAssociationMap;
 
   bool AllowOneFalse2SStub;
 
@@ -135,8 +129,7 @@ TTTrackAssociationMap<T>::~TTTrackAssociationMap() {}
 
 /// Operations
 template <>
-TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
-    TTTrackPtr aTrack) const;
+TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const;
 
 template <>
 std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -98,7 +98,7 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
             /// No SimLink is found by definition
             /// Then store NULL MC truth for all the digis
             TrackingParticlePtr tempTPPtr;
-	    clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
+            clusterToTrackingParticleVectorMap.find(tempCluRef)->second.push_back(tempTPPtr);
           }
 
           /// Go to the next sensor

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -64,10 +64,8 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
     iEvent.getByToken(iTag, TTClusterHandle);
 
     /// Prepare the necessary maps
-    std::map<TTClusterRef, std::vector<TrackingParticlePtr>>
-        clusterToTrackingParticleVectorMap;
-    std::map<TrackingParticlePtr, std::vector<TTClusterRef> >
-        trackingParticleToClusterVectorMap;
+    std::map<TTClusterRef, std::vector<TrackingParticlePtr>> clusterToTrackingParticleVectorMap;
+    std::map<TrackingParticlePtr, std::vector<TTClusterRef>> trackingParticleToClusterVectorMap;
     clusterToTrackingParticleVectorMap.clear();
     trackingParticleToClusterVectorMap.clear();
 
@@ -85,8 +83,7 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
 
       for (auto contentIter = clusters.begin(); contentIter != clusters.end(); ++contentIter) {
         /// Make the reference to be put in the map
-        TTClusterRef tempCluRef =
-            edmNew::makeRefTo(TTClusterHandle, contentIter);
+        TTClusterRef tempCluRef = edmNew::makeRefTo(TTClusterHandle, contentIter);
 
         /// Prepare the maps wrt TTCluster
         if (clusterToTrackingParticleVectorMap.find(tempCluRef) == clusterToTrackingParticleVectorMap.end()) {
@@ -176,8 +173,7 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
 
     /// Clean the maps that need cleaning
     /// Prepare the output map wrt TrackingParticle
-    std::map<TrackingParticlePtr,
-             std::vector<TTClusterRef>>::iterator iterMapToClean;
+    std::map<TrackingParticlePtr, std::vector<TTClusterRef>>::iterator iterMapToClean;
     for (iterMapToClean = trackingParticleToClusterVectorMap.begin();
          iterMapToClean != trackingParticleToClusterVectorMap.end();
          ++iterMapToClean) {

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.cc
@@ -33,7 +33,6 @@ void TTClusterAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, co
 
   if (not trackingParticleHandle->empty()) {
     /// Loop over TrackingParticles
-    std::vector<TrackingParticle>::const_iterator iterTPart;
     for (unsigned int tpCnt = 0; tpCnt < trackingParticleHandle->size(); tpCnt++) {
       /// Make the pointer to the TrackingParticle
       TrackingParticlePtr tempTPPtr(trackingParticleHandle, tpCnt);

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -53,17 +53,13 @@ public:
 private:
   /// Data members
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > thePixelDigiSimLinkHandle;
-  edm::Handle<std::vector<TrackingParticle> > TrackingParticleHandle;
+  edm::Handle<std::vector<TrackingParticle> > trackingParticleHandle;
 
-  std::vector<edm::InputTag> TTClustersInputTags;
+  std::vector<edm::InputTag> ttClustersInputTags;
 
   edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > digisimLinkToken;
   edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken;
-  //std::vector< edm::EDGetTokenT< edm::DetSetVector< TTCluster< T > > > > TTClustersTokens;
-  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > > TTClustersTokens;
-
-  //    const StackedTrackerGeometry                           *theStackedTrackers;
-  //unsigned int                                           ADCThreshold;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > > ttClustersTokens;
 
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   edm::ESHandle<TrackerTopology> theTrackerTopology;
@@ -89,12 +85,12 @@ TTClusterAssociator<T>::TTClusterAssociator(const edm::ParameterSet& iConfig) {
       consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getParameter<edm::InputTag>("digiSimLinks"));
   tpToken = consumes<std::vector<TrackingParticle> >(iConfig.getParameter<edm::InputTag>("trackingParts"));
 
-  TTClustersInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusters");
+  ttClustersInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusters");
 
-  for (auto iTag = TTClustersInputTags.begin(); iTag != TTClustersInputTags.end(); iTag++) {
-    TTClustersTokens.push_back(consumes<edmNew::DetSetVector<TTCluster<T> > >(*iTag));
+  for (const auto& iTag : ttClustersInputTags) {
+    ttClustersTokens.push_back(consumes<edmNew::DetSetVector<TTCluster<T> > >(iTag));
 
-    produces<TTClusterAssociationMap<T> >((*iTag).instance());
+    produces<TTClusterAssociationMap<T> >(iTag.instance());
   }
 }
 

--- a/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTClusterAssociator.h
@@ -7,6 +7,7 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
+ *  (tidy up: Ian Tomalin, 2020)
  *
  */
 
@@ -52,17 +53,17 @@ public:
 
 private:
   /// Data members
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > thePixelDigiSimLinkHandle;
-  edm::Handle<std::vector<TrackingParticle> > trackingParticleHandle;
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > thePixelDigiSimLinkHandle_;
+  edm::Handle<std::vector<TrackingParticle> > trackingParticleHandle_;
 
-  std::vector<edm::InputTag> ttClustersInputTags;
+  std::vector<edm::InputTag> ttClustersInputTags_;
 
-  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > digisimLinkToken;
-  edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken;
-  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > > ttClustersTokens;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > digisimLinkToken_;
+  edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken_;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<T> > > > ttClustersTokens_;
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  edm::ESHandle<TrackerTopology> theTrackerTopology;
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry_;
+  edm::ESHandle<TrackerTopology> theTrackerTopology_;
 
   /// Mandatory methods
   void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
@@ -81,14 +82,14 @@ private:
 /// Constructors
 template <typename T>
 TTClusterAssociator<T>::TTClusterAssociator(const edm::ParameterSet& iConfig) {
-  digisimLinkToken =
+  digisimLinkToken_ =
       consumes<edm::DetSetVector<PixelDigiSimLink> >(iConfig.getParameter<edm::InputTag>("digiSimLinks"));
-  tpToken = consumes<std::vector<TrackingParticle> >(iConfig.getParameter<edm::InputTag>("trackingParts"));
+  tpToken_ = consumes<std::vector<TrackingParticle> >(iConfig.getParameter<edm::InputTag>("trackingParts"));
 
-  ttClustersInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusters");
+  ttClustersInputTags_ = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusters");
 
-  for (const auto& iTag : ttClustersInputTags) {
-    ttClustersTokens.push_back(consumes<edmNew::DetSetVector<TTCluster<T> > >(iTag));
+  for (const auto& iTag : ttClustersInputTags_) {
+    ttClustersTokens_.push_back(consumes<edmNew::DetSetVector<TTCluster<T> > >(iTag));
 
     produces<TTClusterAssociationMap<T> >(iTag.instance());
   }
@@ -102,8 +103,8 @@ TTClusterAssociator<T>::~TTClusterAssociator() {}
 template <typename T>
 void TTClusterAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
   /// Get the geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
-  iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology);
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry_);
+  iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology_);
 
   /// Print some information when loaded
   edm::LogInfo("TTClusterAssociator< ") << templateNameFinder<T>() << " > loaded.";

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
@@ -17,7 +17,7 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
     return;
 
   /// Exit if the vectors are uncorrectly dimensioned
-  if (TTClusterTruthInputTags.size() != TTStubsInputTags.size()) {
+  if (ttClusterTruthInputTags.size() != ttStubsInputTags.size()) {
     edm::LogError("TTStubAsso ") << "E R R O R! the InputTag vectors have different size!";
     return;
   }
@@ -29,33 +29,30 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
 
   /// Loop over the InputTags to handle multiple collections
 
-  for (auto iTag = TTStubsTokens.begin(); iTag != TTStubsTokens.end(); iTag++) {
+  for (const auto& iTag : ttStubsTokens) {
     /// Prepare output
     auto associationMapForOutput = std::make_unique<TTStubAssociationMap<Ref_Phase2TrackerDigi_>>();
 
     /// Get the Stubs already stored away
-    edm::Handle<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>> TTStubHandle;
-    iEvent.getByToken(*iTag, TTStubHandle);
+    edm::Handle<TTStubDetSetVec> ttStubHandle;
+    iEvent.getByToken(iTag, ttStubHandle);
 
     /// Get the Cluster MC truth
-    edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> TTClusterAssociationMapHandle;
-    iEvent.getByToken(TTClusterTruthTokens.at(ncont1), TTClusterAssociationMapHandle);
+    edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> ttClusterAssociationMapHandle;
+    iEvent.getByToken(ttClusterTruthTokens.at(ncont1), ttClusterAssociationMapHandle);
 
     /// Prepare the necessary maps
-    std::map<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>,
-             edm::Ptr<TrackingParticle>>
-        stubToTrackingParticleMap;
-    std::map<edm::Ptr<TrackingParticle>,
-             std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>>
+    std::map<TTStubRef, TrackingParticlePtr> stubToTrackingParticleMap;
+    std::map<TrackingParticlePtr, std::vector<TTStubRef>>
         trackingParticleToStubVectorMap;
     stubToTrackingParticleMap.clear();
     trackingParticleToStubVectorMap.clear();
 
     /// Loop over the input Stubs
 
-    if (!TTStubHandle->empty()) {
-      for (auto gd = theTrackerGeom->dets().begin(); gd != theTrackerGeom->dets().end(); gd++) {
-        DetId detid = (*gd)->geographicalId();
+    if (not ttStubHandle->empty()) {
+      for (const auto& gd : theTrackerGeom->dets()) {
+        DetId detid = gd->geographicalId();
         if (detid.subdetId() != StripSubdetector::TOB && detid.subdetId() != StripSubdetector::TID)
           continue;  // only run on OT
 
@@ -64,36 +61,29 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
 
         DetId stackDetid = tTopo->stack(detid);  // Stub module detid
 
-        if (TTStubHandle->find(stackDetid) == TTStubHandle->end())
+        if (ttStubHandle->find(stackDetid) == ttStubHandle->end())
           continue;
 
         /// Get the DetSets of the Clusters
-        edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> stubs = (*TTStubHandle)[stackDetid];
+        edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> stubs = (*ttStubHandle)[stackDetid];
 
         for (auto contentIter = stubs.begin(); contentIter != stubs.end(); ++contentIter) {
           /// Make the reference to be put in the map
-          edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>> tempStubRef =
-              edmNew::makeRefTo(TTStubHandle, contentIter);
-
-          /// Get the two clusters
-          //        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = tempStubRef->getClusterRefs();
+          TTStubRef tempStubRef = edmNew::makeRefTo(ttStubHandle, contentIter);
 
           /// Fill the inclusive map which is careless of the stub classification
-          for (unsigned int ic = 0; ic < 2; ic++) {
-            std::vector<edm::Ptr<TrackingParticle>> tempTPs =
-                TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(ic));
+	  for (unsigned int ic = 0; ic < 2; ic++) {
+            std::vector<TrackingParticlePtr> tempTPs =
+                ttClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(ic));
 
-            for (unsigned int itp = 0; itp < tempTPs.size(); itp++) {
-              edm::Ptr<TrackingParticle> testTP = tempTPs.at(itp);
+            for (const TrackingParticlePtr& testTP : tempTPs) {
 
               if (testTP.isNull())
                 continue;
 
               /// Prepare the maps wrt TrackingParticle
               if (trackingParticleToStubVectorMap.find(testTP) == trackingParticleToStubVectorMap.end()) {
-                std::vector<
-                    edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-                    stubVector;
+                std::vector<TTStubRef> stubVector;
                 stubVector.clear();
                 trackingParticleToStubVectorMap.insert(std::make_pair(testTP, stubVector));
               }
@@ -104,8 +94,8 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
           /// GENUINE for clusters means not combinatoric and
           /// not unknown: same MC truth content MUST be found
           /// in both clusters composing the stub
-          if (TTClusterAssociationMapHandle->isUnknown(tempStubRef->clusterRef(0)) ||
-              TTClusterAssociationMapHandle->isUnknown(tempStubRef->clusterRef(1))) {
+          if (ttClusterAssociationMapHandle->isUnknown(tempStubRef->clusterRef(0)) ||
+              ttClusterAssociationMapHandle->isUnknown(tempStubRef->clusterRef(1))) {
             /// If at least one cluster is unknown, it means
             /// either unknown, either combinatoric
             /// Do nothing, and go to the next Stub
@@ -114,16 +104,16 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
             /// Here both are clusters are genuine/combinatoric
             /// If both clusters have some known SimTrack content
             /// they must be compared to each other
-            if (TTClusterAssociationMapHandle->isGenuine(tempStubRef->clusterRef(0)) &&
-                TTClusterAssociationMapHandle->isGenuine(tempStubRef->clusterRef(1))) {
+            if (ttClusterAssociationMapHandle->isGenuine(tempStubRef->clusterRef(0)) &&
+                ttClusterAssociationMapHandle->isGenuine(tempStubRef->clusterRef(1))) {
               /// If both clusters are genuine, they must be associated to the same TrackingParticle
               /// in order to return a genuine stub. Period. Note we can perform safely
               /// this comparison because, if both clusters are genuine, their TrackingParticle shall NEVER be NULL
-              if (TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(0)).get() ==
-                  TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(1)).get()) {
+              if (ttClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(0)).get() ==
+                  ttClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(1)).get()) {
                 /// Two genuine clusters with same SimTrack content mean genuine
-                edm::Ptr<TrackingParticle> testTP =
-                    TTClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(0));
+                TrackingParticlePtr testTP =
+                    ttClusterAssociationMapHandle->findTrackingParticlePtr(tempStubRef->clusterRef(0));
 
                 /// Fill the map: by construction, this will always be the first time the
                 /// stub is inserted into the map: no need for "find"
@@ -141,10 +131,10 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
               TrackingParticle* prevTPAddress = nullptr;
               unsigned int whichTP = 0;
 
-              std::vector<edm::Ptr<TrackingParticle>> trackingParticles0 =
-                  TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(0));
-              std::vector<edm::Ptr<TrackingParticle>> trackingParticles1 =
-                  TTClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(1));
+              std::vector<TrackingParticlePtr> trackingParticles0 =
+                  ttClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(0));
+              std::vector<TrackingParticlePtr> trackingParticles1 =
+                  ttClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(1));
 
               bool escape = false;
 
@@ -188,7 +178,7 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
                 /// even if one of the clusters (or both) are combinatoric:
                 /// this means there is only one track that participates in
                 /// both clusters, hence the stub is genuine
-                edm::Ptr<TrackingParticle> testTP = trackingParticles1.at(whichTP);
+                TrackingParticlePtr testTP = trackingParticles1.at(whichTP);
 
                 /// Fill the map: by construction, this will always be the first time the
                 /// stub is inserted into the map: no need for "find"
@@ -205,26 +195,22 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
 
     /// Clean the only map that needs cleaning
     /// Prepare the output map wrt TrackingParticle
-    typename std::map<edm::Ptr<TrackingParticle>,
-                      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>,
-                                           TTStub<Ref_Phase2TrackerDigi_>>>>::iterator iterMapToClean;
-    for (iterMapToClean = trackingParticleToStubVectorMap.begin();
-         iterMapToClean != trackingParticleToStubVectorMap.end();
-         ++iterMapToClean) {
+    typename std::map<TrackingParticlePtr,
+                      std::vector<TTStubRef>>::iterator iterMapToClean;
+    for (auto& p : trackingParticleToStubVectorMap) {
       /// Get the vector of references to TTStub
-      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-          tempVector = iterMapToClean->second;
+      std::vector<TTStubRef> tempVector = p.second;
 
       /// Sort and remove duplicates
       std::sort(tempVector.begin(), tempVector.end());
       tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
 
       /// Put the vector in the output map
-      iterMapToClean->second = tempVector;
+      p.second = tempVector;
     }
 
     /// Also, create the pointer to the TTClusterAssociationMap
-    edm::RefProd<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> theCluAssoMap(TTClusterAssociationMapHandle);
+    edm::RefProd<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> theCluAssoMap(ttClusterAssociationMapHandle);
 
     /// Put the maps in the association object
     associationMapForOutput->setTTStubToTrackingParticleMap(stubToTrackingParticleMap);
@@ -232,7 +218,7 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
     associationMapForOutput->setTTClusterAssociationMap(theCluAssoMap);
 
     /// Put output in the event
-    iEvent.put(std::move(associationMapForOutput), TTStubsInputTags.at(ncont1).instance());
+    iEvent.put(std::move(associationMapForOutput), ttStubsInputTags.at(ncont1).instance());
 
     ++ncont1;
   }  /// End of loop over InputTags

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.cc
@@ -43,8 +43,7 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
 
     /// Prepare the necessary maps
     std::map<TTStubRef, TrackingParticlePtr> stubToTrackingParticleMap;
-    std::map<TrackingParticlePtr, std::vector<TTStubRef>>
-        trackingParticleToStubVectorMap;
+    std::map<TrackingParticlePtr, std::vector<TTStubRef>> trackingParticleToStubVectorMap;
     stubToTrackingParticleMap.clear();
     trackingParticleToStubVectorMap.clear();
 
@@ -72,12 +71,11 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
           TTStubRef tempStubRef = edmNew::makeRefTo(ttStubHandle, contentIter);
 
           /// Fill the inclusive map which is careless of the stub classification
-	  for (unsigned int ic = 0; ic < 2; ic++) {
+          for (unsigned int ic = 0; ic < 2; ic++) {
             std::vector<TrackingParticlePtr> tempTPs =
                 ttClusterAssociationMapHandle->findTrackingParticlePtrs(tempStubRef->clusterRef(ic));
 
             for (const TrackingParticlePtr& testTP : tempTPs) {
-
               if (testTP.isNull())
                 continue;
 
@@ -195,8 +193,7 @@ void TTStubAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const
 
     /// Clean the only map that needs cleaning
     /// Prepare the output map wrt TrackingParticle
-    typename std::map<TrackingParticlePtr,
-                      std::vector<TTStubRef>>::iterator iterMapToClean;
+    typename std::map<TrackingParticlePtr, std::vector<TTStubRef>>::iterator iterMapToClean;
     for (auto& p : trackingParticleToStubVectorMap) {
       /// Get the vector of references to TTStub
       std::vector<TTStubRef> tempVector = p.second;

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
@@ -53,11 +53,11 @@ public:
 
 private:
   /// Data members
-  std::vector<edm::InputTag> TTStubsInputTags;
-  std::vector<edm::InputTag> TTClusterTruthInputTags;
+  std::vector<edm::InputTag> ttStubsInputTags;
+  std::vector<edm::InputTag> ttClusterTruthInputTags;
 
-  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTStub<T> > > > TTStubsTokens;
-  std::vector<edm::EDGetTokenT<TTClusterAssociationMap<T> > > TTClusterTruthTokens;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTStub<T> > > > ttStubsTokens;
+  std::vector<edm::EDGetTokenT<TTClusterAssociationMap<T> > > ttClusterTruthTokens;
 
   edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   edm::ESHandle<TrackerTopology> theTrackerTopology;
@@ -79,17 +79,17 @@ private:
 /// Constructors
 template <typename T>
 TTStubAssociator<T>::TTStubAssociator(const edm::ParameterSet& iConfig) {
-  TTStubsInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTStubs");
-  TTClusterTruthInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusterTruth");
+  ttStubsInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTStubs");
+  ttClusterTruthInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusterTruth");
 
-  for (auto iTag = TTClusterTruthInputTags.begin(); iTag != TTClusterTruthInputTags.end(); iTag++) {
-    TTClusterTruthTokens.push_back(consumes<TTClusterAssociationMap<T> >(*iTag));
+  for (const auto& iTag : ttClusterTruthInputTags) {
+    ttClusterTruthTokens.push_back(consumes<TTClusterAssociationMap<T> >(iTag));
   }
 
-  for (auto iTag = TTStubsInputTags.begin(); iTag != TTStubsInputTags.end(); iTag++) {
-    TTStubsTokens.push_back(consumes<edmNew::DetSetVector<TTStub<T> > >(*iTag));
+  for (const auto& iTag : ttStubsInputTags) {
+    ttStubsTokens.push_back(consumes<edmNew::DetSetVector<TTStub<T> > >(iTag));
 
-    produces<TTStubAssociationMap<T> >((*iTag).instance());
+    produces<TTStubAssociationMap<T> >(iTag.instance());
   }
 }
 

--- a/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTStubAssociator.h
@@ -7,6 +7,7 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
+ *  (tidy up: Ian Tomalin, 2020)
  *
  */
 
@@ -53,14 +54,14 @@ public:
 
 private:
   /// Data members
-  std::vector<edm::InputTag> ttStubsInputTags;
-  std::vector<edm::InputTag> ttClusterTruthInputTags;
+  std::vector<edm::InputTag> ttStubsInputTags_;
+  std::vector<edm::InputTag> ttClusterTruthInputTags_;
 
-  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTStub<T> > > > ttStubsTokens;
-  std::vector<edm::EDGetTokenT<TTClusterAssociationMap<T> > > ttClusterTruthTokens;
+  std::vector<edm::EDGetTokenT<edmNew::DetSetVector<TTStub<T> > > > ttStubsTokens_;
+  std::vector<edm::EDGetTokenT<TTClusterAssociationMap<T> > > ttClusterTruthTokens_;
 
-  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
-  edm::ESHandle<TrackerTopology> theTrackerTopology;
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry_;
+  edm::ESHandle<TrackerTopology> theTrackerTopology_;
 
   /// Mandatory methods
   void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
@@ -79,15 +80,15 @@ private:
 /// Constructors
 template <typename T>
 TTStubAssociator<T>::TTStubAssociator(const edm::ParameterSet& iConfig) {
-  ttStubsInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTStubs");
-  ttClusterTruthInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusterTruth");
+  ttStubsInputTags_ = iConfig.getParameter<std::vector<edm::InputTag> >("TTStubs");
+  ttClusterTruthInputTags_ = iConfig.getParameter<std::vector<edm::InputTag> >("TTClusterTruth");
 
-  for (const auto& iTag : ttClusterTruthInputTags) {
-    ttClusterTruthTokens.push_back(consumes<TTClusterAssociationMap<T> >(iTag));
+  for (const auto& iTag : ttClusterTruthInputTags_) {
+    ttClusterTruthTokens_.push_back(consumes<TTClusterAssociationMap<T> >(iTag));
   }
 
-  for (const auto& iTag : ttStubsInputTags) {
-    ttStubsTokens.push_back(consumes<edmNew::DetSetVector<TTStub<T> > >(iTag));
+  for (const auto& iTag : ttStubsInputTags_) {
+    ttStubsTokens_.push_back(consumes<edmNew::DetSetVector<TTStub<T> > >(iTag));
 
     produces<TTStubAssociationMap<T> >(iTag.instance());
   }
@@ -103,8 +104,8 @@ void TTStubAssociator<T>::beginRun(const edm::Run& run, const edm::EventSetup& i
   /// Print some information when loaded
   edm::LogInfo("TTStubAssociator< ") << templateNameFinder<T>() << " > loaded.";
 
-  iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology);
-  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
+  iSetup.get<TrackerTopologyRcd>().get(theTrackerTopology_);
+  iSetup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry_);
 }
 
 /// End run

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
@@ -59,7 +59,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
 
       /// Fill the map associating each TP to a vector of L1 tracks. 
       /// Do this using the association map of the clusters inside each stub,
-      /// rather than the stub association map. (CHECK: Why? This wastes CPU!)
+      /// as stub associator misses stub --> all TP map (FIX).
       for (const TTStubRef& stub : theseStubs) {
         for (unsigned int ic = 0; ic < 2; ic++) {
           std::vector<TrackingParticlePtr> tempTPs =

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
@@ -4,8 +4,10 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *
+ *  
  */
+
+// FIX: N.B Code below could surely be more efficiently written?
 
 #include "SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h"
 
@@ -17,62 +19,59 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
     return;
 
   /// Get the Stub and Cluster MC truth
-  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> TTClusterAssociationMapHandle;
-  iEvent.getByToken(TTClusterTruthToken, TTClusterAssociationMapHandle);
-  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> TTStubAssociationMapHandle;
-  iEvent.getByToken(TTStubTruthToken, TTStubAssociationMapHandle);
+  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> ttClusterAssociationMapHandle;
+  iEvent.getByToken(ttClusterTruthToken, ttClusterAssociationMapHandle);
+  edm::Handle<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> ttStubAssociationMapHandle;
+  iEvent.getByToken(ttStubTruthToken, ttStubAssociationMapHandle);
 
   int ncont1 = 0;
 
   /// Loop over InputTags to handle multiple collections
-  for (auto iTag = TTTracksTokens.begin(); iTag != TTTracksTokens.end(); iTag++) {
+  for (const auto& iTag : ttTracksTokens) {
     /// Prepare output
     auto associationMapForOutput = std::make_unique<TTTrackAssociationMap<Ref_Phase2TrackerDigi_>>();
 
     /// Get the Tracks already stored away
     edm::Handle<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>> TTTrackHandle;
-    iEvent.getByToken(*iTag, TTTrackHandle);
+    iEvent.getByToken(iTag, TTTrackHandle);
 
     /// Prepare the necessary maps
-    std::map<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>, edm::Ptr<TrackingParticle>> trackToTrackingParticleMap;
-    std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>
+    std::map<TTTrackPtr, TrackingParticlePtr> trackToTrackingParticleMap;
+    std::map<TrackingParticlePtr, std::vector<TTTrackPtr>>
         trackingParticleToTrackVectorMap;
     trackToTrackingParticleMap.clear();
     trackingParticleToTrackVectorMap.clear();
 
     // Start the loop on tracks
 
-    unsigned int j = 0;  /// Counter needed to build the edm::Ptr to the TTTrack
     typename std::vector<TTTrack<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
-    for (inputIter = TTTrackHandle->begin(); inputIter != TTTrackHandle->end(); ++inputIter) {
+    for (unsigned int jTrk = 0; jTrk < TTTrackHandle->size(); jTrk++) {
       /// Make the pointer to be put in the map
-      edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> tempTrackPtr(TTTrackHandle, j++);
+      TTTrackPtr tempTrackPtr(TTTrackHandle, jTrk);
 
-      /// Get the stubs of the TTTrack (theseStubs)
-      std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-          theseStubs = tempTrackPtr->getStubRefs();
+      /// Get all the stubs of the TTTrack (theseStubs)
+      std::vector<TTStubRef> theseStubs = tempTrackPtr->getStubRefs();
 
-      /// Auxiliary map to store TP addresses and TP edm::Ptr
-      std::map<const TrackingParticle*, edm::Ptr<TrackingParticle>> auxMap;
+      /// Auxiliary map to relate TP addresses and TP edm::Ptr
+      std::map<const TrackingParticle*, TrackingParticlePtr> auxMap;
       auxMap.clear();
       int mayCombinUnknown = 0;
 
-      /// Fill the inclusive map which is careless of the stub classification
-      for (unsigned int is = 0; is < theseStubs.size(); is++) {
-        //        std::vector< edm::Ref< edmNew::DetSetVector< TTCluster< Ref_Phase2TrackerDigi_ > >, TTCluster< Ref_Phase2TrackerDigi_ > > > theseClusters = theseStubs.at(is)->getClusterRefs();
+      /// Fill the map associating each TP to a vector of L1 tracks. 
+      /// Do this using the association map of the clusters inside each stub,
+      /// rather than the stub association map. (CHECK: Why? This wastes CPU!)
+      for (const TTStubRef& stub : theseStubs) {
         for (unsigned int ic = 0; ic < 2; ic++) {
-          std::vector<edm::Ptr<TrackingParticle>> tempTPs =
-              TTClusterAssociationMapHandle->findTrackingParticlePtrs(theseStubs.at(is)->clusterRef(ic));
-          for (unsigned int itp = 0; itp < tempTPs.size(); itp++)  // List of TPs linked to stub clusters
+          std::vector<TrackingParticlePtr> tempTPs =
+              ttClusterAssociationMapHandle->findTrackingParticlePtrs(stub->clusterRef(ic));
+          for (const TrackingParticlePtr& testTP : tempTPs)  // List of TPs linked to stub clusters
           {
-            edm::Ptr<TrackingParticle> testTP = tempTPs.at(itp);
-
             if (testTP.isNull())  // No TP linked to this cluster
               continue;
 
             /// Prepare the maps wrt TrackingParticle
             if (trackingParticleToTrackVectorMap.find(testTP) == trackingParticleToTrackVectorMap.end()) {
-              std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> trackVector;
+              std::vector<TTTrackPtr> trackVector;
               trackVector.clear();
               trackingParticleToTrackVectorMap.insert(std::make_pair(testTP, trackVector));
             }
@@ -86,91 +85,90 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
         }  /// End of loop over the clusters
 
         /// Check if the stub is unknown
-        if (TTStubAssociationMapHandle->isUnknown(theseStubs.at(is)))
+        if (ttStubAssociationMapHandle->isUnknown(stub))
           ++mayCombinUnknown;
 
       }  /// End of loop over the stubs
 
-      /// If there more than 2 unknown stubs, go to the next track
+      /// If there are >= 2 unknown stubs, go to the next track
       /// as this track may be COMBINATORIC or UNKNOWN
+      /// (One unknown is allowed, if in 2S module).
       if (mayCombinUnknown >= 2)
         continue;
 
-      /// If we are here, all the stubs are either combinatoric or genuine
+      /// If we are here, all the stubs on track are either combinatoric or genuine
       /// and there is no more than one fake stub in the track
-      /// Loop over all the TrackingParticle which have been found in the track at some point
-      /// (stored in auxMap)
+      /// Loop over all the TrackingParticle which have been found in the track
+      /// (stored in auxMap), to check if any are present in all stubs on Track.
 
       std::vector<const TrackingParticle*> tpInAllStubs;
 
-      std::map<const TrackingParticle*, edm::Ptr<TrackingParticle>>::const_iterator iterAuxMap;
-      for (iterAuxMap = auxMap.begin(); iterAuxMap != auxMap.end(); ++iterAuxMap) {
-        /// Get all the stubs from this TrackingParticle
-        std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-            tempStubs = TTStubAssociationMapHandle->findTTStubRefs(iterAuxMap->second);
+      for (const auto& auxPair : auxMap) {
+        /// Get all associated stubs of this TrackingParticle
+        std::vector<TTStubRef> tempStubs =
+	  ttStubAssociationMapHandle->findTTStubRefs(auxPair.second);
 
+	// Count stubs on track that are not related to this TP
         int nnotfound = 0;
-        //bool allFound = true;
-        /// Loop over the stubs
-        //        for ( unsigned int js = 0; js < theseStubs.size() && allFound; js++ )
-        for (unsigned int js = 0; js < theseStubs.size(); js++) {
+	for (const TTStubRef& stub : theseStubs) {
           /// We want that all the stubs of the track are included in the container of
           /// all the stubs produced by this particular TrackingParticle which we
           /// already know is one of the TrackingParticles that released hits
           /// in this track we are evaluating right now
-          if (std::find(tempStubs.begin(), tempStubs.end(), theseStubs.at(js)) == tempStubs.end()) {
-            //  allFound = false;
+          if (std::find(tempStubs.begin(), tempStubs.end(), stub) == tempStubs.end()) {
             ++nnotfound;
           }
         }
 
-        /// If the TrackingParticle does not appear in all stubs but one
-        /// then go to the next track
+        /// If this TP does not appear in all stubs (allowing one wrong stub)
+        /// then try next TP.
         if (nnotfound > 1)
-          //if (!allFound)
           continue;
 
         /// If we are here, it means that the TrackingParticle
-        /// generates hits in all stubs but one of the current track
+        /// generates hits in all stubs (allowing one incorrect one) of the current track
         /// so put it into the vector
-        tpInAllStubs.push_back(iterAuxMap->first);
+        tpInAllStubs.push_back(auxPair.first);
       }
 
-      /// Count how many TrackingParticles we do have
+      /// Count how many TrackingParticles were associated to all stubs on this track.
+      /// FIX: Could avoid this by using std::set for tpInAllStubs?
       std::sort(tpInAllStubs.begin(), tpInAllStubs.end());
       tpInAllStubs.erase(std::unique(tpInAllStubs.begin(), tpInAllStubs.end()), tpInAllStubs.end());
       unsigned int nTPs = tpInAllStubs.size();
 
-      /// If only one TrackingParticle, GENUINE
-      /// if different than one, COMBINATORIC
+      /// If only one TP associated to all stubs (allowing one incorrect) on track: GENUINE or LOOSELY_GENUINE.
+      /// If 0 or >= 2 TP: COMBINATORIC
+      /// WARNING: This means if one TP matches all stubs, and another matches all STUBS except
+      /// one, then the trackToTrackingParticleMap will not be filled.
+      /// WARNING: This also means that trackToTrackingParticleMap will be filled if 
+      /// one TP matches all stubs, except for an incorrect one in either PS or 2S modules.
       if (nTPs != 1)
         continue;
 
-      /// Here, the track may only be GENUINE
-      /// Fill the map
+      /// Here, the track may only be GENUINE/LOOSELY_GENUINE
+      /// CHECK: Surely if one incorrect PS stub, it can also be COMBINATORIC?
+      /// Fill the map associating track to its principle TP.
       trackToTrackingParticleMap.insert(std::make_pair(tempTrackPtr, auxMap.find(tpInAllStubs.at(0))->second));
 
     }  /// End of loop over Tracks
 
-    /// Clean the only map that needs cleaning
-    /// Prepare the output map wrt TrackingParticle
-    typename std::map<edm::Ptr<TrackingParticle>, std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>>>::iterator
-        iterMapToClean;
-    for (iterMapToClean = trackingParticleToTrackVectorMap.begin();
-         iterMapToClean != trackingParticleToTrackVectorMap.end();
-         ++iterMapToClean) {
+    /// Remove duplicates from the only output map that needs it.
+    /// (Map gets multiple entries per track if it has several stubs belonging to same TP).
+    for (auto& p : trackingParticleToTrackVectorMap) {
       /// Get the vector of edm::Ptr< TTTrack >
-      std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>>> tempVector = iterMapToClean->second;
+      /// (CHECK: Couldn't this be done by reference, to save CPU?)
+      std::vector<TTTrackPtr> tempVector = p.second;
 
-      /// Sort and remove duplicates
+      /// Sort and remove duplicates 
       std::sort(tempVector.begin(), tempVector.end());
       tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
 
-      iterMapToClean->second = tempVector;
+      p.second = tempVector;
     }
 
     /// Also, create the pointer to the TTClusterAssociationMap
-    edm::RefProd<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> theStubAssoMap(TTStubAssociationMapHandle);
+    edm::RefProd<TTStubAssociationMap<Ref_Phase2TrackerDigi_>> theStubAssoMap(ttStubAssociationMapHandle);
 
     /// Put the maps in the association object
     associationMapForOutput->setTTTrackToTrackingParticleMap(trackToTrackingParticleMap);
@@ -179,7 +177,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
     associationMapForOutput->setAllowOneFalse2SStub(TTTrackAllowOneFalse2SStub);
 
     /// Put output in the event
-    iEvent.put(std::move(associationMapForOutput), TTTracksInputTags.at(ncont1).instance());
+    iEvent.put(std::move(associationMapForOutput), ttTracksInputTags.at(ncont1).instance());
 
     ++ncont1;
   }  /// End of loop over InputTags

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
@@ -7,8 +7,6 @@
  *  
  */
 
-// FIX: N.B Code below could surely be more efficiently written?
-
 #include "SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h"
 
 /// Implement the producer
@@ -43,7 +41,6 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
 
     // Start the loop on tracks
 
-    typename std::vector<TTTrack<Ref_Phase2TrackerDigi_>>::const_iterator inputIter;
     for (unsigned int jTrk = 0; jTrk < TTTrackHandle->size(); jTrk++) {
       /// Make the pointer to be put in the map
       TTTrackPtr tempTrackPtr(TTTrackHandle, jTrk);

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.cc
@@ -37,8 +37,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
 
     /// Prepare the necessary maps
     std::map<TTTrackPtr, TrackingParticlePtr> trackToTrackingParticleMap;
-    std::map<TrackingParticlePtr, std::vector<TTTrackPtr>>
-        trackingParticleToTrackVectorMap;
+    std::map<TrackingParticlePtr, std::vector<TTTrackPtr>> trackingParticleToTrackVectorMap;
     trackToTrackingParticleMap.clear();
     trackingParticleToTrackVectorMap.clear();
 
@@ -57,7 +56,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
       auxMap.clear();
       int mayCombinUnknown = 0;
 
-      /// Fill the map associating each TP to a vector of L1 tracks. 
+      /// Fill the map associating each TP to a vector of L1 tracks.
       /// Do this using the association map of the clusters inside each stub,
       /// as stub associator misses stub --> all TP map (FIX).
       for (const TTStubRef& stub : theseStubs) {
@@ -105,12 +104,11 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
 
       for (const auto& auxPair : auxMap) {
         /// Get all associated stubs of this TrackingParticle
-        std::vector<TTStubRef> tempStubs =
-	  ttStubAssociationMapHandle->findTTStubRefs(auxPair.second);
+        std::vector<TTStubRef> tempStubs = ttStubAssociationMapHandle->findTTStubRefs(auxPair.second);
 
-	// Count stubs on track that are not related to this TP
+        // Count stubs on track that are not related to this TP
         int nnotfound = 0;
-	for (const TTStubRef& stub : theseStubs) {
+        for (const TTStubRef& stub : theseStubs) {
           /// We want that all the stubs of the track are included in the container of
           /// all the stubs produced by this particular TrackingParticle which we
           /// already know is one of the TrackingParticles that released hits
@@ -141,7 +139,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
       /// If 0 or >= 2 TP: COMBINATORIC
       /// WARNING: This means if one TP matches all stubs, and another matches all STUBS except
       /// one, then the trackToTrackingParticleMap will not be filled.
-      /// WARNING: This also means that trackToTrackingParticleMap will be filled if 
+      /// WARNING: This also means that trackToTrackingParticleMap will be filled if
       /// one TP matches all stubs, except for an incorrect one in either PS or 2S modules.
       if (nTPs != 1)
         continue;
@@ -160,7 +158,7 @@ void TTTrackAssociator<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, cons
       /// (CHECK: Couldn't this be done by reference, to save CPU?)
       std::vector<TTTrackPtr> tempVector = p.second;
 
-      /// Sort and remove duplicates 
+      /// Sort and remove duplicates
       std::sort(tempVector.begin(), tempVector.end());
       tempVector.erase(std::unique(tempVector.begin(), tempVector.end()), tempVector.end());
 

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
@@ -49,12 +49,12 @@ public:
 
 private:
   /// Data members
-  std::vector<edm::InputTag> TTTracksInputTags;
+  std::vector<edm::InputTag> ttTracksInputTags;
 
-  std::vector<edm::EDGetTokenT<std::vector<TTTrack<T> > > > TTTracksTokens;
+  std::vector<edm::EDGetTokenT<std::vector<TTTrack<T> > > > ttTracksTokens;
 
-  edm::EDGetTokenT<TTStubAssociationMap<T> > TTStubTruthToken;
-  edm::EDGetTokenT<TTClusterAssociationMap<T> > TTClusterTruthToken;
+  edm::EDGetTokenT<TTStubAssociationMap<T> > ttStubTruthToken;
+  edm::EDGetTokenT<TTClusterAssociationMap<T> > ttClusterTruthToken;
 
   bool TTTrackAllowOneFalse2SStub;
 
@@ -75,9 +75,9 @@ private:
 /// Constructors
 template <typename T>
 TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
-  TTTracksInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
-  TTClusterTruthToken = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
-  TTStubTruthToken = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
+  ttTracksInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
+  ttClusterTruthToken = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
+  ttStubTruthToken = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
   TTTrackAllowOneFalse2SStub = iConfig.getParameter<bool>("TTTrackAllowOneFalse2SStub");
   if (TTTrackAllowOneFalse2SStub) {
     edm::LogInfo("TTTrackAssociator< ") << "Allow track if no more than one 2S stub doesn't match truth.";
@@ -85,10 +85,10 @@ TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
     edm::LogInfo("TTTrackAssociator< ") << "All 2S stubs must match truth.";
   }
 
-  for (auto iTag = TTTracksInputTags.begin(); iTag != TTTracksInputTags.end(); iTag++) {
-    TTTracksTokens.push_back(consumes<std::vector<TTTrack<T> > >(*iTag));
+  for (const auto& iTag : ttTracksInputTags) {
+    ttTracksTokens.push_back(consumes<std::vector<TTTrack<T> > >(iTag));
 
-    produces<TTTrackAssociationMap<T> >((*iTag).instance());
+    produces<TTTrackAssociationMap<T> >(iTag.instance());
   }
 }
 

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
@@ -7,6 +7,7 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
+ *  (tidy up: Ian Tomalin, 2020)
  *
  */
 
@@ -49,12 +50,11 @@ public:
 
 private:
   /// Data members
-  std::vector<edm::InputTag> ttTracksInputTags;
+  std::vector<edm::InputTag> ttTracksInputTags_;
 
-  std::vector<edm::EDGetTokenT<std::vector<TTTrack<T> > > > ttTracksTokens;
-
-  edm::EDGetTokenT<TTStubAssociationMap<T> > ttStubTruthToken;
-  edm::EDGetTokenT<TTClusterAssociationMap<T> > ttClusterTruthToken;
+  std::vector<edm::EDGetTokenT<std::vector<TTTrack<T> > > > ttTracksTokens_;
+  edm::EDGetTokenT<TTStubAssociationMap<T> > ttStubTruthToken_;
+  edm::EDGetTokenT<TTClusterAssociationMap<T> > ttClusterTruthToken_;
 
   bool TTTrackAllowOneFalse2SStub;
 
@@ -75,9 +75,9 @@ private:
 /// Constructors
 template <typename T>
 TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
-  ttTracksInputTags = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
-  ttClusterTruthToken = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
-  ttStubTruthToken = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
+  ttTracksInputTags_ = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
+  ttClusterTruthToken_ = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
+  ttStubTruthToken_ = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
   TTTrackAllowOneFalse2SStub = iConfig.getParameter<bool>("TTTrackAllowOneFalse2SStub");
   if (TTTrackAllowOneFalse2SStub) {
     edm::LogInfo("TTTrackAssociator< ") << "Allow track if no more than one 2S stub doesn't match truth.";
@@ -85,8 +85,8 @@ TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
     edm::LogInfo("TTTrackAssociator< ") << "All 2S stubs must match truth.";
   }
 
-  for (const auto& iTag : ttTracksInputTags) {
-    ttTracksTokens.push_back(consumes<std::vector<TTTrack<T> > >(iTag));
+  for (const auto& iTag : ttTracksInputTags_) {
+    ttTracksTokens_.push_back(consumes<std::vector<TTTrack<T> > >(iTag));
 
     produces<TTTrackAssociationMap<T> >(iTag.instance());
   }

--- a/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
+++ b/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
@@ -9,34 +9,33 @@
 
 /// Operations
 template <>
-edm::Ptr<TrackingParticle> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    TTTrackPtr aTrack) const {
   if (trackToTrackingParticleMap.find(aTrack) != trackToTrackingParticleMap.end()) {
     return trackToTrackingParticleMap.find(aTrack)->second;
   }
 
   /// Default: return NULL
-  edm::Ptr<TrackingParticle>* temp = new edm::Ptr<TrackingParticle>();
+  TrackingParticlePtr* temp = new TrackingParticlePtr();
   return *temp;
 }
 
 template <>
-std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
-    edm::Ptr<TrackingParticle> aTrackingParticle) const {
+std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+    TrackingParticlePtr aTrackingParticle) const {
   if (trackingParticleToTrackVectorMap.find(aTrackingParticle) != trackingParticleToTrackVectorMap.end()) {
     return trackingParticleToTrackVectorMap.find(aTrackingParticle)->second;
   }
 
   /// Default: return empty vector
-  std::vector<edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > > tempVec;
+  std::vector<TTTrackPtr > tempVec;
   tempVec.clear();
   return tempVec;
 }
 
 /// MC truth
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(TTTrackPtr aTrack) const {
   /// Check if there is a TrackingParticle
   if ((this->findTrackingParticlePtr(aTrack)).isNull())
     return false;
@@ -46,16 +45,14 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(
 
 /// MC truth
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
-  /// Check if there is a TrackingParticle
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(TTTrackPtr aTrack) const {
+  /// Check if there is an associated TrackingParticle
   if ((this->findTrackingParticlePtr(aTrack)).isNull())
     return false;
 
-  /// Get all the stubs from this TrackingParticle
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
-      TP_Stubs = theStubAssociationMap->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
-      TRK_Stubs = aTrack->getStubRefs();
+  /// Get all the stubs from this track & associated TrackingParticle
+  std::vector<TTStubRef> TRK_Stubs = aTrack->getStubRefs();
+  std::vector<TTStubRef> TP_Stubs = theStubAssociationMap->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
 
   bool one2SStub = false;
   for (unsigned int js = 0; js < TRK_Stubs.size(); js++) {
@@ -78,8 +75,7 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(edm::Ptr<TTTrack<R
 }
 
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(
-    edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(TTTrackPtr aTrack) const {
   /// Defined by exclusion
   if (this->isLooselyGenuine(aTrack))
     return false;
@@ -91,12 +87,11 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(
 }
 
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_> > aTrack) const {
-  /// UNKNOWN means that more than 2 stubs are unknown
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(TTTrackPtr aTrack) const {
+  /// UNKNOWN means that >= 2 stubs are unknown
   int unknownstubs = 0;
 
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
-      theseStubs = aTrack->getStubRefs();
+  std::vector<TTStubRef> theseStubs = aTrack->getStubRefs();
   for (unsigned int i = 0; i < theseStubs.size(); i++) {
     if (theStubAssociationMap->isUnknown(theseStubs.at(i)) == false) {
       ++unknownstubs;

--- a/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
+++ b/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
@@ -9,7 +9,8 @@
 
 /// Operations
 template <>
-const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const {
+const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
+    TTTrackPtr aTrack) const {
   if (trackToTrackingParticleMap_.find(aTrack) != trackToTrackingParticleMap_.end()) {
     return trackToTrackingParticleMap_.find(aTrack)->second;
   } else {
@@ -46,7 +47,8 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(TTTrackPtr aTrack)
 
   /// Get all the stubs from this track & associated TrackingParticle
   const std::vector<TTStubRef>& TRK_Stubs = aTrack->getStubRefs();
-  const std::vector<TTStubRef>& TP_Stubs = theStubAssociationMap_->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
+  const std::vector<TTStubRef>& TP_Stubs =
+      theStubAssociationMap_->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
 
   bool one2SStub = false;
   for (unsigned int js = 0; js < TRK_Stubs.size(); js++) {

--- a/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
+++ b/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
@@ -9,27 +9,22 @@
 
 /// Operations
 template <>
-TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const {
-  if (trackToTrackingParticleMap.find(aTrack) != trackToTrackingParticleMap.end()) {
-    return trackToTrackingParticleMap.find(aTrack)->second;
+const TrackingParticlePtr& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const {
+  if (trackToTrackingParticleMap_.find(aTrack) != trackToTrackingParticleMap_.end()) {
+    return trackToTrackingParticleMap_.find(aTrack)->second;
+  } else {
+    return nullTrackingParticlePtr_;
   }
-
-  /// Default: return NULL
-  TrackingParticlePtr* temp = new TrackingParticlePtr();
-  return *temp;
 }
 
 template <>
-std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
+const std::vector<TTTrackPtr>& TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTrackPtrs(
     TrackingParticlePtr aTrackingParticle) const {
-  if (trackingParticleToTrackVectorMap.find(aTrackingParticle) != trackingParticleToTrackVectorMap.end()) {
-    return trackingParticleToTrackVectorMap.find(aTrackingParticle)->second;
+  if (trackingParticleToTrackVectorMap_.find(aTrackingParticle) != trackingParticleToTrackVectorMap_.end()) {
+    return trackingParticleToTrackVectorMap_.find(aTrackingParticle)->second;
+  } else {
+    return nullVecTTTrackPtr_;
   }
-
-  /// Default: return empty vector
-  std::vector<TTTrackPtr> tempVec;
-  tempVec.clear();
-  return tempVec;
 }
 
 /// MC truth
@@ -50,8 +45,8 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(TTTrackPtr aTrack)
     return false;
 
   /// Get all the stubs from this track & associated TrackingParticle
-  std::vector<TTStubRef> TRK_Stubs = aTrack->getStubRefs();
-  std::vector<TTStubRef> TP_Stubs = theStubAssociationMap->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
+  const std::vector<TTStubRef>& TRK_Stubs = aTrack->getStubRefs();
+  const std::vector<TTStubRef>& TP_Stubs = theStubAssociationMap_->findTTStubRefs(this->findTrackingParticlePtr(aTrack));
 
   bool one2SStub = false;
   for (unsigned int js = 0; js < TRK_Stubs.size(); js++) {
@@ -90,9 +85,9 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isUnknown(TTTrackPtr aTrack)
   /// UNKNOWN means that >= 2 stubs are unknown
   int unknownstubs = 0;
 
-  std::vector<TTStubRef> theseStubs = aTrack->getStubRefs();
+  const std::vector<TTStubRef>& theseStubs = aTrack->getStubRefs();
   for (unsigned int i = 0; i < theseStubs.size(); i++) {
-    if (theStubAssociationMap->isUnknown(theseStubs.at(i)) == false) {
+    if (theStubAssociationMap_->isUnknown(theseStubs.at(i)) == false) {
       ++unknownstubs;
       if (unknownstubs >= 2)
         return false;

--- a/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
+++ b/SimTracker/TrackTriggerAssociation/src/TTTrackAssociationMap.cc
@@ -9,8 +9,7 @@
 
 /// Operations
 template <>
-TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(
-    TTTrackPtr aTrack) const {
+TrackingParticlePtr TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTrackingParticlePtr(TTTrackPtr aTrack) const {
   if (trackToTrackingParticleMap.find(aTrack) != trackToTrackingParticleMap.end()) {
     return trackToTrackingParticleMap.find(aTrack)->second;
   }
@@ -28,7 +27,7 @@ std::vector<TTTrackPtr> TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::findTTTra
   }
 
   /// Default: return empty vector
-  std::vector<TTTrackPtr > tempVec;
+  std::vector<TTTrackPtr> tempVec;
   tempVec.clear();
   return tempVec;
 }


### PR DESCRIPTION
#### PR description:

This is a clean-up of the code in SimTracker/TrackTriggerAssociation/ , which should not change the performance at all. The changes are:

1) Comments added to the reco-truth association classes of the CMS Upgrade L1 clusters, L1 stubs & L1 tracks in SimTracker/TrackTriggerAssociation/interface/*.h , to explain what they do, and the exact association criteria they use.
2) Several typedefs defined (some in SimTracker/TrackAssociation/ and others in DataFormats/ or SimDataFormats/ to replace the very long object type names (some exceeding 100 characters) appearing in SimTracker/TrackAssociation/
3) A very superficial cleanup of the producers in SimTracker/TrackAssociation/plugins/ , simply replacing a few "for loops" by their C++11 versions.

I've rerun the cluster & stub production & association on a GEN-SIM-RAW-MC (ttbar + 200PU), and checked that the L1 tracking performance is unchanged.
