### PR TITLE
Added missing package dependency needed for UBSAN in JetMETCorrections/Type1MET

### DIFF
--- a/JetMETCorrections/Type1MET/BuildFile.xml
+++ b/JetMETCorrections/Type1MET/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/ParticleFlowCandidate"/>
 <use name="DataFormats/METReco"/>
 <use name="DataFormats/MuonReco"/>
+<use name="JetMETCorrections/JetCorrector"/>
 <use name="root"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

Code links cleanly under UBSAN.