### PR TITLE
Added missing package dependency needed for UBSAN in IOMC/EventVertexGenerators

### DIFF
--- a/IOMC/EventVertexGenerators/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/BuildFile.xml
@@ -12,3 +12,4 @@
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/PPSObjects"/>
 <use name="CondCore/DBOutputService"/>
+<use name="DataFormats/Candidate"/>


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

Links properly under UBSAN.