### PR TITLE
Added missing package dependency needed for UBSAN in GeneratorInterface/TauolaInterface

### DIFF
--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -17,6 +17,8 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="SimDataFormats/GeneratorProducts"/>
+  <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/HepMCCandidate"/>
   <use name="tauolapp"/>
   <use name="lhapdf"/>
   <use name="root"/>


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

Links properly on UBSAN.