### PR TITLE
Added missing package dependency needed for UBSAN in GeneratorInterface/ExhumeInterface

### DIFF
--- a/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
+++ b/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <flags EDM_PLUGIN="1"/>
 <library file="ExhumeAnalyzer.cc" name="ExhumeAnalyzer">
+  <use name="DataFormats/Candidate"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="roothistmatrix"/>
 </library>


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

The code links properly under UBSAN.