### PR TITLE
Added missing package dependency needed for UBSAN in FastSimulation/ForwardDetectors

### DIFF
--- a/FastSimulation/ForwardDetectors/plugins/BuildFile.xml
+++ b/FastSimulation/ForwardDetectors/plugins/BuildFile.xml
@@ -6,6 +6,7 @@
   <use name="root"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/HcalDetId"/>
+  <use name="DataFormats/Candidate"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

After change, code links fine under UBSAN.