### PR TITLE
Added missing package dependency needed for UBSAN in DQM/DataScouting

### DIFF
--- a/DQM/DataScouting/BuildFile.xml
+++ b/DQM/DataScouting/BuildFile.xml
@@ -3,6 +3,7 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/Candidate"/>
 <use name="DQMServices/Core"/>
 <export>
   <use name="FWCore/Framework"/>


### PR DESCRIPTION
#### PR description:

A virtual table from the missing package is needed to run UBSAN.

#### PR validation:

Compilation under UBSAN build now links properly.