### PR TITLE
[DD4hep] Keep mag. field geom. builder shape lengths same with DD4hep units change

### DIFF
--- a/MagneticField/GeomBuilder/BuildFile.xml
+++ b/MagneticField/GeomBuilder/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="Utilities/BinningTools"/>
 <use name="CondFormats/MFObjects"/>
 <use name="clhep"/>
+<use name="dd4hep"/>
 <export>
   <lib name="1"/>
 </export>

--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
@@ -95,16 +95,30 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
     } break;
     case DDSolidShape::ddpseudotrap: {
       vector<double> d = solid.parameters();
+
+      // The pseudo-trapezoid parameters are:
+      // d[0] -- x1
+      // d[1] -- x2
+      // d[2] -- y1
+      // d[3] -- y2
+      // d[4] -- halfZ
+      // d[5] -- radius
+      // d[6] -- atMinusZ (0 or 1)
+      // Note all are lengths except for the last one. The lengths come from
+      // DD4hep in DD4hep units and must be converted to cm for use.
+
       if (d.size() >= 7)
         LogTrace("MagGeoBuilder") << " Pseudo trap params raw =  " << d[0] << ", " << d[1] << ", " << d[2] << ", "
                                   << d[3] << ", " << d[4] << ", " << d[5] << ", " << d[6];
 
+      // Convert all but last parameter to cm (last one is a boolean).
       transform(d.begin(), --(d.end()), d.begin(), [](double val) { return val / dd4hep::cm; });
 
       if (d.size() >= 7)
         LogTrace("MagGeoBuilder") << " Pseudo trap params converted =  " << d[0] << ", " << d[1] << ", " << d[2] << ", "
                                   << d[3] << ", " << d[4] << ", " << d[5] << ", " << d[6];
-      buildPseudoTrap(d[0], d[1], d[2], d[3], d[4], d[5], d[6]);
+
+      buildPseudoTrap(d[0], d[1], d[2], d[3], d[4], d[5], static_cast<bool>(d[6]));
     } break;
     case DDSolidShape::ddtrunctubs: {
       DDTruncTubs tubs(solid.solid());

--- a/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/DD4hep_volumeHandle.cc
@@ -14,6 +14,8 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <DD4hep/DD4hepUnits.h>
+
 #include <string>
 #include <iterator>
 
@@ -33,7 +35,9 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
   name = fv.name();
   copyno = fv.copyNum();
   const auto *const transArray = fv.trans();
-  center_ = GlobalPoint(transArray[0], transArray[1], transArray[2]);
+
+  // Convert from DD4hep units to cm
+  center_ = GlobalPoint(transArray[0] / dd4hep::cm, transArray[1] / dd4hep::cm, transArray[2] / dd4hep::cm);
 
   // ASSUMPTION: volume names ends with "_NUM" where NUM is the volume number
   string volName = name;
@@ -47,23 +51,23 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
   switch (theShape) {
     case DDSolidShape::ddbox: {
       DDBox box(solid.solid());
-      // DD4hep returns units in cm, no conversion needed.
-      double halfX = box.x();
-      double halfY = box.y();
-      double halfZ = box.z();
+      // Convert from DD4hep units to cm
+      double halfX = box.x() / dd4hep::cm;
+      double halfY = box.y() / dd4hep::cm;
+      double halfZ = box.z() / dd4hep::cm;
       buildBox(halfX, halfY, halfZ);
     } break;
     case DDSolidShape::ddtrap: {
       DDTrap trap(solid.solid());
-      double x1 = trap.bottomLow1();
-      double x2 = trap.topLow1();
-      double x3 = trap.bottomLow2();
-      double x4 = trap.topLow2();
-      double y1 = trap.high1();
-      double y2 = trap.high2();
+      double x1 = trap.bottomLow1() / dd4hep::cm;
+      double x2 = trap.topLow1() / dd4hep::cm;
+      double x3 = trap.bottomLow2() / dd4hep::cm;
+      double x4 = trap.topLow2() / dd4hep::cm;
+      double y1 = trap.high1() / dd4hep::cm;
+      double y2 = trap.high2() / dd4hep::cm;
       double theta = trap.theta();
       double phi = trap.phi();
-      double halfZ = trap.dZ();
+      double halfZ = trap.dZ() / dd4hep::cm;
       double alpha1 = trap.alpha1();
       double alpha2 = trap.alpha2();
       buildTrap(x1, x2, x3, x4, y1, y2, theta, phi, halfZ, alpha1, alpha2);
@@ -71,38 +75,47 @@ volumeHandle::volumeHandle(const cms::DDFilteredView &fv, bool expand2Pi, bool d
 
     case DDSolidShape::ddcons: {
       DDCons cons(solid.solid());
-      double zhalf = cons.dZ();
-      double rInMinusZ = cons.rMin1();
-      double rOutMinusZ = cons.rMax1();
-      double rInPlusZ = cons.rMin2();
-      double rOutPlusZ = cons.rMax2();
+      double zhalf = cons.dZ() / dd4hep::cm;
+      double rInMinusZ = cons.rMin1() / dd4hep::cm;
+      double rOutMinusZ = cons.rMax1() / dd4hep::cm;
+      double rInPlusZ = cons.rMin2() / dd4hep::cm;
+      double rOutPlusZ = cons.rMax2() / dd4hep::cm;
       double startPhi = cons.startPhi();
       double deltaPhi = reco::deltaPhi(cons.endPhi(), startPhi);
       buildCons(zhalf, rInMinusZ, rOutMinusZ, rInPlusZ, rOutPlusZ, startPhi, deltaPhi);
     } break;
     case DDSolidShape::ddtubs: {
       DDTubs tubs(solid.solid());
-      double zhalf = tubs.dZ();
-      double rIn = tubs.rMin();
-      double rOut = tubs.rMax();
+      double zhalf = tubs.dZ() / dd4hep::cm;
+      double rIn = tubs.rMin() / dd4hep::cm;
+      double rOut = tubs.rMax() / dd4hep::cm;
       double startPhi = tubs.startPhi();
       double deltaPhi = tubs.endPhi() - startPhi;
       buildTubs(zhalf, rIn, rOut, startPhi, deltaPhi);
     } break;
     case DDSolidShape::ddpseudotrap: {
       vector<double> d = solid.parameters();
+      if (d.size() >= 7)
+        LogTrace("MagGeoBuilder") << " Pseudo trap params raw =  " << d[0] << ", " << d[1] << ", " << d[2] << ", "
+                                  << d[3] << ", " << d[4] << ", " << d[5] << ", " << d[6];
+
+      transform(d.begin(), --(d.end()), d.begin(), [](double val) { return val / dd4hep::cm; });
+
+      if (d.size() >= 7)
+        LogTrace("MagGeoBuilder") << " Pseudo trap params converted =  " << d[0] << ", " << d[1] << ", " << d[2] << ", "
+                                  << d[3] << ", " << d[4] << ", " << d[5] << ", " << d[6];
       buildPseudoTrap(d[0], d[1], d[2], d[3], d[4], d[5], d[6]);
     } break;
     case DDSolidShape::ddtrunctubs: {
       DDTruncTubs tubs(solid.solid());
-      double zhalf = tubs.dZ();               // half of the z-Axis
-      double rIn = tubs.rMin();               // inner radius
-      double rOut = tubs.rMax();              // outer radius
-      double startPhi = tubs.startPhi();      // angular start of the tube-section
-      double deltaPhi = tubs.deltaPhi();      // angular span of the tube-section
-      double cutAtStart = tubs.cutAtStart();  // truncation at begin of the tube-section
-      double cutAtDelta = tubs.cutAtDelta();  // truncation at end of the tube-section
-      bool cutInside = tubs.cutInside();      // true, if truncation is on the inner side of the tube-section
+      double zhalf = tubs.dZ() / dd4hep::cm;               // half of the z-Axis
+      double rIn = tubs.rMin() / dd4hep::cm;               // inner radius
+      double rOut = tubs.rMax() / dd4hep::cm;              // outer radius
+      double startPhi = tubs.startPhi();                   // angular start of the tube-section
+      double deltaPhi = tubs.deltaPhi();                   // angular span of the tube-section
+      double cutAtStart = tubs.cutAtStart() / dd4hep::cm;  // truncation at begin of the tube-section
+      double cutAtDelta = tubs.cutAtDelta() / dd4hep::cm;  // truncation at end of the tube-section
+      bool cutInside = tubs.cutInside();  // true, if truncation is on the inner side of the tube-section
       buildTruncTubs(zhalf, rIn, rOut, startPhi, deltaPhi, cutAtStart, cutAtDelta, cutInside);
     } break;
     default:


### PR DESCRIPTION
DD4hep currently follows the ROOT units convention (cm = 1). In January it will be switched to follow the Geant4 units convention (mm = 1). This PR changes the magnetic field geometry builder code so shape sizes will stay the same before and after the change.

#### PR validation:

The output of the `MagneticField/GeomBuilder/test/python/testMagGeometry.py` script (with debugBuilder = cms.untracked.bool(True)) before and after the PR was checked and seen to be identical.

No backport is needed.
