### PR TITLE
Add missing dependencies to various packages

### DIFF
--- a/DQM/DataScouting/BuildFile.xml
+++ b/DQM/DataScouting/BuildFile.xml
@@ -2,7 +2,9 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="DataFormats/JetReco"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/METReco"/>
 <use name="DQMServices/Core"/>
 <export>
   <use name="FWCore/Framework"/>

--- a/DQM/DataScouting/interface/AlphaTVarProducer.h
+++ b/DQM/DataScouting/interface/AlphaTVarProducer.h
@@ -8,7 +8,6 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
-#include "DataFormats/METReco/interface/CaloMETFwd.h"
 #include "TLorentzVector.h"
 
 #include <vector>

--- a/DQM/DataScouting/src/AlphaTVarProducer.cc
+++ b/DQM/DataScouting/src/AlphaTVarProducer.cc
@@ -5,9 +5,6 @@
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
-#include "DataFormats/METReco/interface/CaloMET.h"
-#include "DataFormats/METReco/interface/CaloMETCollection.h"
-
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/FastSimulation/ForwardDetectors/plugins/BuildFile.xml
+++ b/FastSimulation/ForwardDetectors/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
   <use name="boost"/>
   <use name="root"/>
   <use name="DataFormats/Common"/>
+  <use name="DataFormats/CaloTowers"/>
   <use name="DataFormats/HcalDetId"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
+++ b/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
@@ -3,5 +3,7 @@
 <flags EDM_PLUGIN="1"/>
 <library file="ExhumeAnalyzer.cc" name="ExhumeAnalyzer">
   <use name="CommonTools/UtilAlgos"/>
+  <use name="DataFormats/Common"/>
+  <use name="DataFormats/HepMCCandidate"/>
   <use name="roothistmatrix"/>
 </library>

--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -16,6 +16,8 @@
 <library file="TauSpinner/*.cc" name="TauSpinnerInterface">
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
+  <use name="DataFormats/Common"/>
+  <use name="DataFormats/HepMCCandidate"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <use name="tauolapp"/>
   <use name="lhapdf"/>

--- a/IOMC/EventVertexGenerators/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/BuildFile.xml
@@ -4,6 +4,7 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
+<use name="DataFormats/HepMCCandidate"/>
 <use name="SimDataFormats/GeneratorProducts"/>
 <use name="boost"/>
 <use name="clhep"/>

--- a/JetMETCorrections/Type1MET/plugins/BuildFile.xml
+++ b/JetMETCorrections/Type1MET/plugins/BuildFile.xml
@@ -14,5 +14,6 @@
   <use name="DataFormats/PatCandidates"/>
   <use name="DataFormats/VertexReco"/>
   <use name="JetMETCorrections/Objects"/>
+  <use name="JetMETCorrections/JetCorrector"/>
   <use name="JetMETCorrections/Type1MET"/>
 </library>


### PR DESCRIPTION
#### PR description:

This PR adds missing dependencies to BuildFile.xml in various packages (and in case of `DQM/DataScouting` removes a few unnecessary header inclusions). In all cases headers from the added packages are `#include`d in the corresponding package. These were found in UBSAN IBs (as build errors).


#### PR validation:

These packages build successfully in an UBSAN IB.