### PR TITLE
Fix bug where ED module tasks started in the es task_arena.

### DIFF
--- a/FWCore/Concurrency/interface/WaitingTaskHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskHolder.h
@@ -30,6 +30,7 @@ namespace edm {
   class WaitingTaskHolder {
   public:
     friend class WaitingTaskList;
+    friend class WaitingTaskWithArenaHolder;
 
     WaitingTaskHolder() : m_task(nullptr) {}
 

--- a/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
+++ b/FWCore/Concurrency/interface/WaitingTaskWithArenaHolder.h
@@ -37,6 +37,10 @@ namespace edm {
     // eventually intend for the task to be spawned.
     explicit WaitingTaskWithArenaHolder(WaitingTask* iTask);
 
+    // Takes ownership of the underlying task and uses the current
+    // arena.
+    explicit WaitingTaskWithArenaHolder(WaitingTaskHolder&& iTask);
+
     ~WaitingTaskWithArenaHolder();
 
     WaitingTaskWithArenaHolder(WaitingTaskWithArenaHolder const& iHolder);

--- a/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
+++ b/FWCore/Concurrency/src/WaitingTaskWithArenaHolder.cc
@@ -23,6 +23,9 @@ namespace edm {
     m_task->increment_ref_count();
   }
 
+  WaitingTaskWithArenaHolder::WaitingTaskWithArenaHolder(WaitingTaskHolder&& iTask)
+      : m_task(iTask.release_no_decrement()), m_arena(std::make_shared<tbb::task_arena>(tbb::task_arena::attach())) {}
+
   WaitingTaskWithArenaHolder::~WaitingTaskWithArenaHolder() {
     if (m_task) {
       doneWaiting(std::exception_ptr{});

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -303,14 +303,15 @@ namespace edm {
           }));
     } else {
       //We need iTask to run in the default arena since it is not an ES task
-      auto task = make_waiting_task(tbb::task::allocate_root(),
-                                    [holder = std::move(iTask)](std::exception_ptr const* iExcept) mutable {
-                                      if (iExcept) {
-                                        holder.doneWaiting(*iExcept);
-                                      } else {
-                                        holder.doneWaiting(std::exception_ptr{});
-                                      }
-                                    });
+      auto task = make_waiting_task(
+          tbb::task::allocate_root(),
+          [holder = WaitingTaskWithArenaHolder(std::move(iTask))](std::exception_ptr const* iExcept) mutable {
+            if (iExcept) {
+              holder.doneWaiting(*iExcept);
+            } else {
+              holder.doneWaiting(std::exception_ptr{});
+            }
+          });
 
       WaitingTaskHolder tempH(task);
       esTaskArena().execute([&]() {


### PR DESCRIPTION
#### PR description:

This fixes a bug introduced in #32510 where a `WaitingTaskWithArenaHolder` was incorrectly replaced with a `WaitingTaskHolder`.

#### PR validation:

The code compiles. Further tests are underway.