### PR TITLE
[PPS] Systematic use of emplace_back

### DIFF
--- a/CalibPPS/AlignmentRelative/plugins/PPSFastLocalSimulation.cc
+++ b/CalibPPS/AlignmentRelative/plugins/PPSFastLocalSimulation.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
-* Authors: 
-*  Jan Kašpar (jan.kaspar@gmail.com) 
+* Authors:
+*  Jan Kašpar (jan.kaspar@gmail.com)
 ****************************************************************************/
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -349,7 +349,7 @@ void PPSFastLocalSimulation::GenerateTrack(unsigned int idx,
           printf(" | m=%+8.4f, sigma=%+8.4f\n", v, sigma);
 
         DetSet<TotemRPRecHit> &hits = stripHitColl->find_or_insert(detId);
-        hits.push_back(TotemRPRecHit(v, sigma));
+        hits.emplace_back(v, sigma);
       }
 
       // diamonds
@@ -364,8 +364,7 @@ void PPSFastLocalSimulation::GenerateTrack(unsigned int idx,
         const double width = pitchDiamonds_;
 
         DetSet<CTPPSDiamondRecHit> &hits = diamondHitColl->find_or_insert(detId);
-        HPTDCErrorFlags flags;
-        hits.push_back(CTPPSDiamondRecHit(h_loc.x(), width, 0., 0., 0., 0., 0., 0., 0., 0, flags, false));
+        hits.emplace_back(h_loc.x(), width, 0., 0., 0., 0., 0., 0., 0., 0, HPTDCErrorFlags(), false);
       }
 
       // pixels
@@ -384,7 +383,7 @@ void PPSFastLocalSimulation::GenerateTrack(unsigned int idx,
         const LocalError le(sigma, 0., sigma);
 
         DetSet<CTPPSPixelRecHit> &hits = pixelHitColl->find_or_insert(detId);
-        hits.push_back(CTPPSPixelRecHit(lp, le));
+        hits.emplace_back(lp, le);
       }
     }
   }

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -113,11 +113,10 @@ void CTPPSPixelDataFormatter::interpretRawData(
     LogTrace("") << "DATA: " << print(*word);
 
     auto ww = *word;
-    if
-      UNLIKELY(ww == 0) {
-        m_WordCounter--;
-        continue;
-      }
+    if UNLIKELY (ww == 0) {
+      m_WordCounter--;
+      continue;
+    }
     int nlink = (ww >> m_LINK_shift) & m_LINK_mask;
     int nroc = (ww >> m_ROC_shift) & m_ROC_mask;
 

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -239,7 +239,7 @@ void CTPPSPixelDataFormatter::formatRawData(unsigned int lvl1_ID,
     // since raw words are written in the form of 64-bit packets
     // add extra 32-bit word to make number of words even if necessary
     if (words.find(fedId)->second.size() % 2 != 0)
-      words[fedId].push_back(Word32(0));
+      words[fedId].emplace_back(0);
 
     // size in Bytes; create output structure
     size_t dataSize = words.find(fedId)->second.size() * sizeof(Word32);

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSTotemDataFormatter.cc
@@ -101,8 +101,8 @@ void CTPPSTotemDataFormatter::formatRawData(unsigned int lvl1_ID,
     int fedId = itFed.first;
     int wordsS = words.find(fedId)->second.size();
     //due to OrbitCounter block at RawDataUnpacker
-    words16[fedId].push_back(Word16(0));
-    words16[fedId].push_back(Word16(0));
+    words16[fedId].emplace_back(0);
+    words16[fedId].emplace_back(0);
     //writing data in 16-bit words
     for (int k = 0; k < wordsS; k++) {
       for (int b = 0; b < 12; b++) {
@@ -112,7 +112,7 @@ void CTPPSTotemDataFormatter::formatRawData(unsigned int lvl1_ID,
     // since raw words are written in the form of 64-bit packets
     // add extra 16-bit words to make number of words even if necessary
     while (words16.find(fedId)->second.size() % 4 != 0)
-      words16[fedId].push_back(Word16(0));
+      words16[fedId].emplace_back(0);
 
     // size in Bytes; create output structure
     auto dataSize = (words16.find(fedId)->second.size()) * sizeof(Word16);

--- a/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
@@ -21,8 +21,7 @@ bool RPixErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* tr
   LogDebug("CRCCheck") << "CRC check failed,  errorType = 39";
   if (includeErrors_) {
     int errorType = 39;
-    CTPPSPixelDataError error(*trailer, errorType, fedId);
-    errors[dummyDetId].push_back(error);
+    errors[dummyDetId].emplace_back(*trailer, errorType, fedId);
   }
   return false;
 }
@@ -37,8 +36,7 @@ bool RPixErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64*
     errorsInEvent = true;
     if (includeErrors_) {
       int errorType = 32;
-      CTPPSPixelDataError error(*header, errorType, fedId);
-      errors[dummyDetId].push_back(error);
+      errors[dummyDetId].emplace_back(*header, errorType, fedId);
     }
   }
   return fedHeader.moreHeaders();
@@ -50,8 +48,7 @@ bool RPixErrorChecker::checkTrailer(
   if (!fedTrailer.check()) {
     if (includeErrors_) {
       int errorType = 33;
-      CTPPSPixelDataError error(*trailer, errorType, fedId);
-      errors[dummyDetId].push_back(error);
+      errors[dummyDetId].emplace_back(*trailer, errorType, fedId);
     }
     errorsInEvent = true;
     LogDebug("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
@@ -62,8 +59,7 @@ bool RPixErrorChecker::checkTrailer(
     errorsInEvent = true;
     if (includeErrors_) {
       int errorType = 34;
-      CTPPSPixelDataError error(*trailer, errorType, fedId);
-      errors[dummyDetId].push_back(error);
+      errors[dummyDetId].emplace_back(*trailer, errorType, fedId);
     }
   }
   return fedTrailer.moreTrailers();
@@ -129,9 +125,7 @@ bool RPixErrorChecker::checkROC(
     }
 
     /// store error
-    CTPPSPixelDataError error(errorWord, errorType, fedId);
-
-    errors[iD].push_back(error);
+    errors[iD].emplace_back(errorWord, errorType, fedId);
   }
 
   return false;
@@ -162,8 +156,6 @@ void RPixErrorChecker::conversionError(
       LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << state;
   };
 
-  if (includeErrors_ && errorType > 0) {
-    CTPPSPixelDataError error(errorWord, errorType, fedId);
-    errors[iD].push_back(error);
-  }
+  if (includeErrors_ && errorType > 0)
+    errors[iD].emplace_back(errorWord, errorType, fedId);
 }

--- a/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
@@ -68,8 +68,8 @@ bool RPixErrorChecker::checkTrailer(
 bool RPixErrorChecker::checkROC(
     bool& errorsInEvent, int fedId, uint32_t iD, const Word32& errorWord, Errors& errors) const {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if
-    LIKELY(errorType < 25) return true;
+  if LIKELY (errorType < 25)
+    return true;
 
   switch (errorType) {
     case (25): {

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -30,7 +30,7 @@ int RawDataUnpacker::run(int fedId,
     return 1;
   }
 
-  fedInfoColl.push_back(TotemFEDInfo(fedId));
+  fedInfoColl.emplace_back(fedId);
 
   return processOptoRxFrame((const word *)data.data(), size_in_words, fedInfoColl.back(), &coll);
 }

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -220,7 +220,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
         // skip masked channels
         if (!anMa.fullMask && anMa.maskedChannels.find(ch) == anMa.maskedChannels.end()) {
           DetSet<TotemRPDigi> &digiDetSet = rpData.find_or_insert(detId);
-          digiDetSet.push_back(TotemRPDigi(offset + ch));
+          digiDetSet.emplace_back(offset + ch);
         }
       }
     }

--- a/RecoPPS/Local/src/RPixClusterToHit.cc
+++ b/RecoPPS/Local/src/RPixClusterToHit.cc
@@ -112,7 +112,16 @@ void RPixClusterToHit::make_hit(CTPPSPixelCluster aCluster, std::vector<CTPPSPix
   if (verbosity_)
     edm::LogInfo("RPixClusterToHit") << lp << " with error " << le;
 
-  hits.emplace_back(lp, le, anEdgePixel, aBadPixel, twoRocs, thisClusterMinRow, thisClusterMinCol, thisClusterSize, thisClusterRowSize, thisClusterColSize);
+  hits.emplace_back(lp,
+                    le,
+                    anEdgePixel,
+                    aBadPixel,
+                    twoRocs,
+                    thisClusterMinRow,
+                    thisClusterMinCol,
+                    thisClusterSize,
+                    thisClusterRowSize,
+                    thisClusterColSize);
 
   return;
 }

--- a/RecoPPS/Local/src/RPixClusterToHit.cc
+++ b/RecoPPS/Local/src/RPixClusterToHit.cc
@@ -109,20 +109,10 @@ void RPixClusterToHit::make_hit(CTPPSPixelCluster aCluster, std::vector<CTPPSPix
 
   LocalPoint lp(avgLocalX, avgLocalY, 0);
   LocalError le(varianceX, 0, varianceY);
-  CTPPSPixelRecHit rh(lp,
-                      le,
-                      anEdgePixel,
-                      aBadPixel,
-                      twoRocs,
-                      thisClusterMinRow,
-                      thisClusterMinCol,
-                      thisClusterSize,
-                      thisClusterRowSize,
-                      thisClusterColSize);
   if (verbosity_)
     edm::LogInfo("RPixClusterToHit") << lp << " with error " << le;
 
-  hits.push_back(rh);
+  hits.emplace_back(lp, le, anEdgePixel, aBadPixel, twoRocs, thisClusterMinRow, thisClusterMinCol, thisClusterSize, thisClusterRowSize, thisClusterColSize);
 
   return;
 }

--- a/RecoPPS/Local/src/RPixDetClusterizer.cc
+++ b/RecoPPS/Local/src/RPixDetClusterizer.cc
@@ -103,8 +103,7 @@ void RPixDetClusterizer::make_cluster(RPixCalibDigi const &aSeed, std::vector<CT
         unsigned int currIndex = c * maxRow + r;
         if (calib_rpix_digi_map_.find(currIndex) != calib_rpix_digi_map_.end()) {
           if (!atempCluster.addPixel(r, c, calib_rpix_digi_map_[currIndex].electrons())) {
-            CTPPSPixelCluster acluster(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
-            clusters.push_back(acluster);
+            clusters.emplace_back(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
             return;
           }
           calib_rpix_digi_map_.erase(currIndex);
@@ -114,8 +113,7 @@ void RPixDetClusterizer::make_cluster(RPixCalibDigi const &aSeed, std::vector<CT
 
   }  // while accretion
 
-  CTPPSPixelCluster cluster(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
-  clusters.push_back(cluster);
+  clusters.emplace_back(atempCluster.isize, atempCluster.adc, atempCluster.row, atempCluster.col);
 }
 
 int RPixDetClusterizer::calibrate(

--- a/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
+++ b/RecoPPS/Local/src/RPixPlaneCombinatoryTracking.cc
@@ -69,7 +69,7 @@ void RPixPlaneCombinatoryTracking::getPlaneCombinations(const std::vector<uint32
 
   // store the combination and permute bitmask
   do {
-    planeCombinations.push_back(std::vector<uint32_t>());
+    planeCombinations.emplace_back();
     for (uint32_t i = 0; i < numberOfPlanes; ++i) {  // [0..numberOfPlanes-1] integers
       if (bitmask[i])
         planeCombinations.back().push_back(inputPlaneList.at(i));

--- a/RecoPPS/Local/src/RPixRoadFinder.cc
+++ b/RecoPPS/Local/src/RPixRoadFinder.cc
@@ -75,8 +75,7 @@ void RPixRoadFinder::findPattern() {
                                       theRotationTMatrix(2, 2));
 
       math::Error<3>::type globalError = ROOT::Math::SimilarityT(theRotationTMatrix, localError);
-      PointInPlane thePointAndRecHit = {globalV, globalError, it_rh, myid};
-      temp_all_hits.push_back(thePointAndRecHit);
+      temp_all_hits.emplace_back(PointInPlane{globalV, globalError, it_rh, myid});
     }
   }
 

--- a/RecoPPS/Local/src/TotemRPClusterProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemRPClusterProducerAlgorithm.cc
@@ -49,7 +49,7 @@ int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId,
       iter_beg = false;
     } else if (non_continuity) {
       cluster_end = prev_strip;
-      clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t)cluster_end));
+      clusters.emplace_back((uint16_t)cluster_beg, (uint16_t)cluster_end);
 
       cluster_beg = cur_strip;
     }
@@ -59,7 +59,7 @@ int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId,
 
   if (!iter_beg) {
     cluster_end = prev_strip;
-    clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t)cluster_end));
+    clusters.emplace_back((uint16_t)cluster_beg, (uint16_t)cluster_end);
   }
 
   return clusters.size();

--- a/RecoPPS/Local/src/TotemRPRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemRPRecHitProducerAlgorithm.cc
@@ -13,9 +13,8 @@
 
 void TotemRPRecHitProducerAlgorithm::buildRecoHits(const edm::DetSet<TotemRPCluster>& input,
                                                    edm::DetSet<TotemRPRecHit>& output) {
-  for (edm::DetSet<TotemRPCluster>::const_iterator it = input.begin(); it != input.end(); ++it) {
+  for (const auto& clus : input) {
     constexpr double nominal_sigma = 0.0191;
-    output.push_back(
-        TotemRPRecHit(rp_topology_.GetHitPositionInReadoutDirection(it->centerStripPosition()), nominal_sigma));
+    output.emplace_back(rp_topology_.GetHitPositionInReadoutDirection(clus.centerStripPosition()), nominal_sigma);
   }
 }

--- a/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -85,7 +85,18 @@ void TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
       mode_ = TotemTimingRecHit::CFD;
 
-      rec_hits.emplace_back(x_pos, x_width, y_pos, y_width, z_pos, z_width, t, triggerCellTimeInstant, timePrecision, *max_corrected_it, baselineRegression.rms, mode_);
+      rec_hits.emplace_back(x_pos,
+                            x_width,
+                            y_pos,
+                            y_width,
+                            z_pos,
+                            z_width,
+                            t,
+                            triggerCellTimeInstant,
+                            timePrecision,
+                            *max_corrected_it,
+                            baselineRegression.rms,
+                            mode_);
     }
   }
 }

--- a/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoPPS/Local/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -85,18 +85,7 @@ void TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
       mode_ = TotemTimingRecHit::CFD;
 
-      rec_hits.push_back(TotemTimingRecHit(x_pos,
-                                           x_width,
-                                           y_pos,
-                                           y_width,
-                                           z_pos,
-                                           z_width,  // spatial information
-                                           t,
-                                           triggerCellTimeInstant,
-                                           timePrecision,
-                                           *max_corrected_it,
-                                           baselineRegression.rms,
-                                           mode_));
+      rec_hits.emplace_back(x_pos, x_width, y_pos, y_width, z_pos, z_width, t, triggerCellTimeInstant, timePrecision, *max_corrected_it, baselineRegression.rms, mode_);
     }
   }
 }

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -528,11 +528,11 @@ void CTPPSDirectProtonSimulation::processProton(
           ssLog << " | m=" << v << ", sigma=" << sigma << std::endl;
 
         edm::DetSet<TotemRPRecHit> &hits = out_strip_hits.find_or_insert(detId);
-        hits.push_back(TotemRPRecHit(v, sigma));
+        hits.emplace_back(v, sigma);
 
         edm::DetSet<TotemRPRecHit> &hits_per_particle =
             out_strip_hits_per_particle[in_trk->barcode()].find_or_insert(detId);
-        hits_per_particle.push_back(TotemRPRecHit(v, sigma));
+        hits_per_particle.emplace_back(v, sigma);
       }
 
       // diamonds
@@ -617,11 +617,11 @@ void CTPPSDirectProtonSimulation::processProton(
         const LocalError le(sigmaHor, 0., sigmaVer);
 
         edm::DetSet<CTPPSPixelRecHit> &hits = out_pixel_hits.find_or_insert(detId);
-        hits.push_back(CTPPSPixelRecHit(lp, le));
+        hits.emplace_back(lp, le);
 
         edm::DetSet<CTPPSPixelRecHit> &hits_per_particle =
             out_pixel_hits_per_particle[in_trk->barcode()].find_or_insert(detId);
-        hits_per_particle.push_back(CTPPSPixelRecHit(lp, le));
+        hits_per_particle.emplace_back(lp, le);
       }
     }
   }


### PR DESCRIPTION
#### PR description:

This PR drops unnecessary constructor+copy operations for several producer plugins within the "PPS space". All thanks to the `emplace_back` method introduced in #26069 for `edm::DetSet<T>` containers.

#### PR validation:

Code compiles, plugins run.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

N/A

Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen branch
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
