### PR TITLE
Bug fix for coral MessageService wrapper

### DIFF
--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -64,14 +64,13 @@ namespace cond {
       std::string m_authPath = std::string("");
       int m_authSys = 0;
       coral::MsgLevel m_messageLevel = coral::Error;
-      std::unique_ptr<CoralMsgReporter> m_msgReporter;
+      CoralMsgReporter* m_msgReporter = nullptr;
       bool m_loggingEnabled = false;
       //The frontier security option is turned on for all sessions
       //usig this wrapper of the CORAL connection setup for configuring the server access
       std::string m_frontierSecurity = std::string("");
       // this one has to be moved!
       cond::CoralServiceManager* m_pluginManager = nullptr;
-      std::map<std::string, int> m_dbTypes;
     };
   }  // namespace persistency
 }  // namespace cond

--- a/CondCore/CondDB/interface/Logger.h
+++ b/CondCore/CondDB/interface/Logger.h
@@ -14,13 +14,14 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 //
 #include <sstream>
+#include <memory>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace cond {
 
   namespace persistency {
 
-    class ConnectionPool;
+    class MsgDispatcher;
 
     template <typename EdmLogger>
     class EchoedLogStream {
@@ -93,7 +94,10 @@ namespace cond {
       virtual ~Logger();
 
       //
-      void setDbDestination(const std::string& connectionString, ConnectionPool& connectionPool);
+      void subscribeCoralMessages(const std::weak_ptr<MsgDispatcher>& dispatcher);
+
+      //
+      void setDbDestination(const std::string& connectionString);
 
       //
       void start();
@@ -124,12 +128,12 @@ namespace cond {
     private:
       std::string m_jobName;
       std::string m_connectionString;
-      ConnectionPool* m_sharedConnectionPool;
       bool m_started;
       boost::posix_time::ptime m_startTime;
       boost::posix_time::ptime m_endTime;
       int m_retCode;
       std::stringstream m_log;
+      std::weak_ptr<MsgDispatcher> m_dispatcher;
     };
 
   }  // namespace persistency

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -23,6 +23,8 @@ namespace cond {
 
     ConnectionPool::ConnectionPool() {
       m_pluginManager = new cond::CoralServiceManager;
+      m_msgReporter = new CoralMsgReporter;
+      coral::MessageStream::installMsgReporter(m_msgReporter);
       configure();
     }
 
@@ -73,10 +75,8 @@ namespace cond {
       coralConfig.disableConnectionSharing();
       // message streaming
       coral::MessageStream::setMsgVerbosity(m_messageLevel);
-      if (m_msgReporter.get() != nullptr) {
-        m_msgReporter->setOutputLevel(m_messageLevel);
-        coral::MessageStream::installMsgReporter(static_cast<coral::IMsgReporter*>(m_msgReporter.get()));
-      }
+      m_msgReporter->setOutputLevel(m_messageLevel);
+
       // authentication
       std::string authServiceName("CORAL/Services/EnvironmentAuthenticationService");
       std::string authPath = m_authPath;
@@ -171,9 +171,7 @@ namespace cond {
 
     void ConnectionPool::setMessageVerbosity(coral::MsgLevel level) { m_messageLevel = level; }
 
-    void ConnectionPool::setLogDestination(Logger& logger) {
-      m_msgReporter = std::make_unique<CoralMsgReporter>(logger);
-    }
+    void ConnectionPool::setLogDestination(Logger& logger) { m_msgReporter->subscribe(logger); }
 
   }  // namespace persistency
 }  // namespace cond

--- a/CondCore/CondDB/src/CoralMsgReporter.h
+++ b/CondCore/CondDB/src/CoralMsgReporter.h
@@ -4,6 +4,7 @@
 //#include "CondCore/CondDB/interface/Logger.h"
 
 #include <mutex>
+#include <set>
 #include "CoralBase/MessageStream.h"
 
 namespace cond {
@@ -12,16 +13,28 @@ namespace cond {
 
     class Logger;
 
+    class MsgDispatcher {
+    public:
+      MsgDispatcher() = delete;
+      explicit MsgDispatcher(Logger& logger);
+      virtual ~MsgDispatcher() {}
+
+      void unsubscribe();
+
+      bool hasRecipient();
+      Logger& recipient();
+
+    private:
+      Logger* m_recipient = nullptr;
+    };
+
     class CoralMsgReporter : public coral::IMsgReporter {
     public:
-      // Empty ctr is suppressed
-      CoralMsgReporter() = delete;
-
       /// Default constructor
-      explicit CoralMsgReporter(Logger& logger);
+      CoralMsgReporter();
 
       /// Destructor
-      ~CoralMsgReporter() override {}
+      ~CoralMsgReporter() override{};
 
       /// Release reference to reporter
       void release() override { delete this; }
@@ -35,9 +48,11 @@ namespace cond {
       /// Report a message
       void report(int lvl, const std::string& src, const std::string& msg) override;
 
+      void subscribe(Logger& logger);
+
     private:
       // the destination of the streams...
-      Logger& m_logger;
+      std::shared_ptr<MsgDispatcher> m_dispatcher;
 
       /// The current message level threshold
       coral::MsgLevel m_level;

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -55,7 +55,7 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet&
   m_session = m_connection.createSession(connectionString, true);
   bool saveLogsOnDb = iConfig.getUntrackedParameter<bool>("saveLogsOnDB", false);
   if (saveLogsOnDb)
-    m_logger.setDbDestination(connectionString, m_connection);
+    m_logger.setDbDestination(connectionString);
   // implicit start
   doStartTransaction();
 


### PR DESCRIPTION
#### PR description:

Back-port of #32503:

Addressing #31896

The fixes involve a wrapper for the Coral message Reporter:

- complying with expected pointer ownership in coral
- ensuring better hand-shake while de-scoping objects

#### PR validation:

Unit test, integration test ( with BeamSpot workflow )

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Back-port of #32503.  Needed to avoid memory corruption issues. Involved in MWGR operations.

