### PR TITLE
[DD4hep] Make special Sim script output stay same after DD4hep units change

### DIFF
--- a/SimG4CMS/CherenkovAnalysis/BuildFile.xml
+++ b/SimG4CMS/CherenkovAnalysis/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>
 <use name="geant4core"/>
+<use name="dd4hep"/>
 <export>
   <lib name="1"/>
 </export>

--- a/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
+++ b/SimG4CMS/CherenkovAnalysis/interface/DreamSD.h
@@ -6,6 +6,8 @@
 
 #include "G4PhysicsOrderedFreeVector.hh"
 
+#include <DD4hep/DD4hepUnits.h>
+
 #include <map>
 
 const int MAXPHOTONS = 500;  // Maximum number of photons we can store
@@ -50,7 +52,7 @@ private:
   bool setPbWO2MaterialProperties_(G4Material *aMaterial);
 
   static constexpr double k_ScaleFromDDDToG4 = 1.0;
-  static constexpr double k_ScaleFromDD4HepToG4 = 10.0;
+  static constexpr double k_ScaleFromDD4HepToG4 = 1.0 / dd4hep::mm;
 
   bool useBirk_, doCherenkov_, readBothSide_, dd4hep_;
   double birk1_, birk2_, birk3_;

--- a/SimG4Core/PrintGeomInfo/BuildFile.xml
+++ b/SimG4Core/PrintGeomInfo/BuildFile.xml
@@ -6,4 +6,5 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
 <use name="geant4core"/>
+<use name="dd4hep"/>
 <use name="boost"/>

--- a/SimG4Core/PrintGeomInfo/python/g4PrintGeomInfo_cfi.py
+++ b/SimG4Core/PrintGeomInfo/python/g4PrintGeomInfo_cfi.py
@@ -43,18 +43,17 @@ def printGeomInfo(process):
         DumpLVTree     = cms.untracked.bool(True),
         DumpMaterial   = cms.untracked.bool(False),
         DumpLVList     = cms.untracked.bool(True),
-        DumpLV         = cms.untracked.bool(False),
+        DumpLV         = cms.untracked.bool(True),
         DumpSolid      = cms.untracked.bool(True),
         DumpAttributes = cms.untracked.bool(False),
-        DumpPV         = cms.untracked.bool(False),
+        DumpPV         = cms.untracked.bool(True),
         DumpRotation   = cms.untracked.bool(False),
         DumpReplica    = cms.untracked.bool(False),
-        DumpTouch      = cms.untracked.bool(True),
-        DumpSense      = cms.untracked.bool(True),
+        DumpTouch      = cms.untracked.bool(False),
+        DumpSense      = cms.untracked.bool(False),
         DD4Hep         = cms.untracked.bool(False),
-        # For Name with DD4hep, include namespace in Name, but omit it for DDD
-        Name           = cms.untracked.string('csc:ME11*'),
-        Names          = cms.untracked.vstring('EcalHitsEB'),
+        Name           = cms.untracked.string('TotemT*'),
+        Names          = cms.untracked.vstring(' '),
         type           = cms.string('PrintGeomInfoAction')
     ))
 

--- a/SimG4Core/PrintGeomInfo/python/g4PrintGeomInfo_cfi.py
+++ b/SimG4Core/PrintGeomInfo/python/g4PrintGeomInfo_cfi.py
@@ -43,17 +43,18 @@ def printGeomInfo(process):
         DumpLVTree     = cms.untracked.bool(True),
         DumpMaterial   = cms.untracked.bool(False),
         DumpLVList     = cms.untracked.bool(True),
-        DumpLV         = cms.untracked.bool(True),
+        DumpLV         = cms.untracked.bool(False),
         DumpSolid      = cms.untracked.bool(True),
         DumpAttributes = cms.untracked.bool(False),
-        DumpPV         = cms.untracked.bool(True),
+        DumpPV         = cms.untracked.bool(False),
         DumpRotation   = cms.untracked.bool(False),
         DumpReplica    = cms.untracked.bool(False),
-        DumpTouch      = cms.untracked.bool(False),
-        DumpSense      = cms.untracked.bool(False),
+        DumpTouch      = cms.untracked.bool(True),
+        DumpSense      = cms.untracked.bool(True),
         DD4Hep         = cms.untracked.bool(False),
-        Name           = cms.untracked.string('TotemT*'),
-        Names          = cms.untracked.vstring(' '),
+        # For Name with DD4hep, include namespace in Name, but omit it for DDD
+        Name           = cms.untracked.string('csc:ME11*'),
+        Names          = cms.untracked.vstring('EcalHitsEB'),
         type           = cms.string('PrintGeomInfoAction')
     ))
 

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
@@ -5,6 +5,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "DataFormats/Math/interface/angle_units.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "DetectorDescription/Core/interface/DDFilter.h"
@@ -14,6 +15,8 @@
 #include "DetectorDescription/Core/interface/DDValue.h"
 #include "DetectorDescription/DDCMS/interface/DDCompactView.h"
 #include "DetectorDescription/DDCMS/interface/DDFilteredView.h"
+
+#include <DD4hep/DD4hepUnits.h>
 
 #include "G4Run.hh"
 #include "G4PhysicalVolumeStore.hh"
@@ -29,6 +32,8 @@
 
 #include <set>
 #include <map>
+
+using angle_units::operators::convertRadToDeg;
 
 PrintGeomInfoAction::PrintGeomInfoAction(const edm::ParameterSet &p) {
   dumpSummary_ = p.getUntrackedParameter<bool>("DumpSummary", true);
@@ -78,18 +83,19 @@ void PrintGeomInfoAction::update(const BeginOfJob *job) {
         const cms::DDFilter filter("ReadOutName", sd);
         cms::DDFilteredView fv(*pDD, filter);
         G4cout << "PrintGeomInfoAction:: Get Filtered view for ReadOutName = " << sd << G4endl;
+        G4cout << "Lengths are in mm, angles in degrees" << G4endl;
 
         std::string spaces = spacesFromLeafDepth(1);
 
         while (fv.firstChild()) {
-          auto tran = fv.translation();
+          auto tran = fv.translation() / dd4hep::mm;
           std::vector<int> copy = fv.copyNos();
           auto lvname = fv.name();
           unsigned int leafDepth = copy.size();
           G4cout << leafDepth << spaces << "### VOLUME = " << lvname << " Copy No";
           for (unsigned int k = 0; k < leafDepth; ++k)
             G4cout << " " << copy[k];
-          G4cout << " Centre at " << tran << " (r = " << tran.Rho() << ", phi = " << tran.phi() / CLHEP::deg << ")"
+          G4cout << " Centre at " << tran << " (r = " << tran.Rho() << ", phi = " << convertRadToDeg(tran.phi()) << ")"
                  << G4endl;
         }
       }
@@ -105,6 +111,7 @@ void PrintGeomInfoAction::update(const BeginOfJob *job) {
         DDSpecificsMatchesValueFilter filter{DDValue(attribute, sd, 0)};
         DDFilteredView fv(*pDD, filter);
         G4cout << "PrintGeomInfoAction:: Get Filtered view for " << attribute << " = " << sd << G4endl;
+        G4cout << "Lengths are in mm, angles in degrees" << G4endl;
         bool dodet = fv.firstChild();
 
         std::string spaces = spacesFromLeafDepth(1);
@@ -119,7 +126,7 @@ void PrintGeomInfoAction::update(const BeginOfJob *job) {
           G4cout << leafDepth << spaces << "### VOLUME = " << lvname << " Copy No";
           for (int k = leafDepth - 1; k >= 0; k--)
             G4cout << " " << copy[k];
-          G4cout << " Centre at " << tran << " (r = " << tran.Rho() << ", phi = " << tran.phi() / CLHEP::deg << ")"
+          G4cout << " Centre at " << tran << " (r = " << tran.Rho() << ", phi = " << convertRadToDeg(tran.phi()) << ")"
                  << G4endl;
           dodet = fv.next();
         }
@@ -388,7 +395,7 @@ void PrintGeomInfoAction::dumpTouch(G4VPhysicalVolume *pv, unsigned int leafDept
   if (lvname == name_)
     out << leafDepth << spaces << "### VOLUME = " << lv->GetName() << " Copy No " << pv->GetCopyNo() << " in " << mother
         << " global position of centre " << globalpoint << " (r = " << globalpoint.perp()
-        << ", phi = " << globalpoint.phi() / CLHEP::deg << ")" << G4endl;
+        << ", phi = " << convertRadToDeg(globalpoint.phi()) << ")" << G4endl;
 
   int NoDaughters = lv->GetNoDaughters();
   while ((NoDaughters--) > 0) {

--- a/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
@@ -32,8 +32,25 @@ process.DDCompactViewESProducer = cms.ESProducer("DDCompactViewESProducer",
 )
 
 process.g4SimHits.g4GeometryDD4hepSource = cms.bool(True)
-process.g4SimHits.Watchers.Names = cms.untracked.vstring('HcalBarrel')
-process.g4SimHits.Watchers.DD4Hep = cms.untracked.bool(True)
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    DumpSummary    = cms.untracked.bool(True),
+    DumpLVTree     = cms.untracked.bool(True),
+    DumpMaterial   = cms.untracked.bool(False),
+    DumpLVList     = cms.untracked.bool(True),
+    DumpLV         = cms.untracked.bool(False),
+    DumpSolid      = cms.untracked.bool(True),
+    DumpAttributes = cms.untracked.bool(False),
+    DumpPV         = cms.untracked.bool(False),
+    DumpRotation   = cms.untracked.bool(False),
+    DumpReplica    = cms.untracked.bool(False),
+    DumpTouch      = cms.untracked.bool(True),
+    DumpSense      = cms.untracked.bool(True),
+    DD4Hep         = cms.untracked.bool(True),
+    Name           = cms.untracked.string('csc:ME11*'),
+    Names          = cms.untracked.vstring('EcalHitsEB'),
+    type           = cms.string('PrintGeomInfoAction')
+))
+
 process.hcalParameters.fromDD4Hep = cms.bool(True)
 process.hcalSimulationParameters.fromDD4Hep = cms.bool(True)
 process.caloSimulationParameters.fromDD4Hep = cms.bool(True)

--- a/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py
@@ -3,14 +3,16 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("G4PrintGeometry")
 
 process.load('Configuration.ProcessModifiers.dd4hep_cff')
+process.load('Geometry.CMSCommonData.cmsExtendedGeometry2021XML_cfi')
 process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
-process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_phase2TkT14_cff')
 process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
 process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cff')
 process.load('Geometry.HGCalCommonData.hgcalParametersInitialization_cfi')
 process.load('Geometry.HGCalCommonData.hgcalNumberingInitialization_cfi')
 process.load('Geometry.MTDNumberingBuilder.mtdNumberingGeometry_cfi')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('FWCore.MessageService.MessageLogger_cfi')
+
 
 from SimG4Core.PrintGeomInfo.g4PrintGeomInfo_cfi import *
 

--- a/SimG4Core/PrintGeomInfo/test/python/runDDD_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDDD_cfg.py
@@ -2,13 +2,13 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("G4PrintGeometry")
 
-#process.load('SimG4Core.PrintGeomInfo.testTotemGeometryXML_cfi')
-#process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
-#process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
-#process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
-#process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cff')
-process.load('Configuration.Geometry.GeometryExtended2026D41_cff')
+process.load('Configuration.Geometry.GeometryExtended2021_cff')
+process.load('Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi')
+process.load('Geometry.EcalCommonData.ecalSimulationParameters_cff')
+process.load('Geometry.HcalCommonData.hcalDDDSimConstants_cff')
+process.load("Geometry.MuonNumbering.muonGeometryConstants_cff")
 process.load('FWCore.MessageService.MessageLogger_cfi')
+
 
 from SimG4Core.PrintGeomInfo.g4PrintGeomInfo_cfi import *
 
@@ -18,5 +18,8 @@ if hasattr(process,'MessageLogger'):
     process.MessageLogger.G4cerr=dict()
     process.MessageLogger.G4cout=dict()
 
-process.g4SimHits.Watchers.Names = cms.untracked.vstring('HGCalEE')
-#process.g4SimHits.Watchers.Names = cms.untracked.vstring('Internal_CSC_for_TotemT1_Plane_0_0_5', 'Internal_CSC_for_TotemT1_Plane_1_0_5','Internal_CSC_for_TotemT1_Plane_2_0_5','Internal_CSC_for_TotemT1_Plane_3_0_5','Internal_CSC_for_TotemT1_Plane_4_0_5','Internal_CSC_for_TotemT1_Plane_0_5_5','Internal_CSC_for_TotemT1_Plane_1_5_5','Internal_CSC_for_TotemT1_Plane_2_5_5','Internal_CSC_for_TotemT1_Plane_3_5_5','Internal_CSC_for_TotemT1_Plane_4_5_5','TotemT2gem_driftspace7r')
+
+
+process.g4SimHits.g4GeometryDD4hepSource = cms.bool(False)
+process.g4SimHits.Watchers.Names = cms.untracked.vstring('EcalSB')
+process.g4SimHits.Watchers.DD4Hep = cms.untracked.bool(False)

--- a/SimG4Core/PrintGeomInfo/test/python/runDDD_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runDDD_cfg.py
@@ -21,5 +21,21 @@ if hasattr(process,'MessageLogger'):
 
 
 process.g4SimHits.g4GeometryDD4hepSource = cms.bool(False)
-process.g4SimHits.Watchers.Names = cms.untracked.vstring('EcalSB')
-process.g4SimHits.Watchers.DD4Hep = cms.untracked.bool(False)
+process.g4SimHits.Watchers = cms.VPSet(cms.PSet(
+    DumpSummary    = cms.untracked.bool(True),
+    DumpLVTree     = cms.untracked.bool(True),
+    DumpMaterial   = cms.untracked.bool(False),
+    DumpLVList     = cms.untracked.bool(True),
+    DumpLV         = cms.untracked.bool(False),
+    DumpSolid      = cms.untracked.bool(True),
+    DumpAttributes = cms.untracked.bool(False),
+    DumpPV         = cms.untracked.bool(False),
+    DumpRotation   = cms.untracked.bool(False),
+    DumpReplica    = cms.untracked.bool(False),
+    DumpTouch      = cms.untracked.bool(True),
+    DumpSense      = cms.untracked.bool(True),
+    DD4Hep         = cms.untracked.bool(False),
+    Name           = cms.untracked.string('ME11*'),
+    Names          = cms.untracked.vstring('EcalHitsEB'),
+    type           = cms.string('PrintGeomInfoAction')
+))


### PR DESCRIPTION
This PR prepares two special-purpose scripts for the upcoming DD4hep units change. Code changes are made so that the output of the scripts will be the same before and after the DD4hep units change.

Note that the scripts ` SimG4Core/PrintGeomInfo/test/python/runDD4HEP_cfg.py` and ` SimG4Core/PrintGeomInfo/test/python/runDDD_cfg.py` needed some fixes just to be able to run. 

#### PR validation:

The output of the scripts was compared between old DD and DD4hep and verified to be the same.

No backport is needed.