### PR TITLE
tobTecStepTrackCandidates.onlyPixelHitsForSeedCleaner False

### DIFF
--- a/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/TobTecStep_cff.py
@@ -259,7 +259,7 @@ tobTecStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTra
     clustersToSkip              = cms.InputTag('tobTecStepClusters'),
     ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
     numHitsForSeedCleaner       = cms.int32(50),
-    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    onlyPixelHitsForSeedCleaner = cms.bool(False),
 
     TrajectoryBuilderPSet       = cms.PSet(refToPSet_ = cms.string('tobTecStepTrajectoryBuilder')),
     doSeedingRegionRebuilding   = True,


### PR DESCRIPTION
mixed an pixel-less have `onlyPixelHitsForSeedCleaner` set to False (or not defined), while intuitively pixel-based seeding has it set to True. Compared to that the tobtec configuration requires pixel hits in seed cleaning.

Looking at history, it seems like this was introduced in LS1 together with looper reco and seems more like a typo.
@VinInn @rovere @mtosi @vmariani please check , perhaps you have a record of this being a deliberate choice to disable seed cleaning for tobTec (in that case the PR can be closed)

I ran on 20 events with PU50 and found only one trackCandidate difference (counting only) without much difference in time; let's see if the jenkins tests pick up anything more significant.