### PR TITLE
Add low pT electron payloads to Run 3 prompt data GT [11_2_X]

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -47,7 +47,7 @@ autoCond = {
     # GlobalTag for Run3 data relvals (express GT)
     'run3_data_express'        :   '111X_dataRun3_Express_v4',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v4',
+    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v5',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
     'phase1_2017_design'       :  '112X_mc2017_design_v2',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector


### PR DESCRIPTION
#### PR description:

This PR is a backport of the portion of PR #32435 that is relevant for the 11_2_X series. It consists of a single update to the Run 3 prompt GT. The reason for the backport is essentially technical: since new labeled records were introduced to the PR in master, the Run 3 prompt GT in autoCond needed to be updated as well. But I don't want to needlessly branch the prompt GT queues ahead of the release series that is used online. So I updated the 11_1_X GTs and therefore the updates need to be backported to 11_1_X and 11_2_X.

The GT diff is as follows:

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v4/111X_dataRun3_Prompt_v5

#### PR validation:

`runTheMatrix.py -l limited,138.1 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of PR #32435. See the PR description for the technical reason that the backport is needed.