### PR TITLE
CT-PPS DQM: Minor bug fix and improved readability

### DIFF
--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -732,14 +732,15 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
             hRPotActivBX[index]->Fill(event.bunchCrossing());
           hRPotActivBXall[index]->Fill(event.bunchCrossing(), float(RPdigiSize[index]));
         }
-        int rocf[NplaneMAX];
+	 
+        int planesFiredAtROC[NROCsMAX]; // how many planes registered hits on ROC r
         for (int r = 0; r < NROCsMAX; r++)
-          rocf[r] = 0;
+          planesFiredAtROC[r] = 0;
         for (int p = 0; p < NplaneMAX; p++) {
           int indp = getPlaneIndex(arm, stn, rp, p);
           for (int r = 0; r < NROCsMAX; r++)
             if (HitsMultROC[indp][r] > 0)
-              ++rocf[r];
+              ++planesFiredAtROC[r];
           for (int r = 0; r < NROCsMAX; r++) {
             if (onlinePlots)
               h2HitsMultROC[index]->Fill(p, r, HitsMultROC[indp][r]);
@@ -748,9 +749,9 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
         }
         int max = 0;
         for (int r = 0; r < NROCsMAX; r++)
-          if (max < rocf[r])
-            max = rocf[r];
-        if (max >= 4 && onlinePlots)
+          if (max < planesFiredAtROC[r])
+            max = planesFiredAtROC[r];
+        if (max >= 4 && onlinePlots) // fill only if there are at least 4 aligned ROCs firing
           hRPotActivBXroc[index]->Fill(event.bunchCrossing());
       }  // end for(int rp=0; rp<NRPotsMAX; rp++) {
     }

--- a/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
+++ b/DQM/CTPPS/plugins/CTPPSPixelDQMSource.cc
@@ -732,8 +732,8 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
             hRPotActivBX[index]->Fill(event.bunchCrossing());
           hRPotActivBXall[index]->Fill(event.bunchCrossing(), float(RPdigiSize[index]));
         }
-	 
-        int planesFiredAtROC[NROCsMAX]; // how many planes registered hits on ROC r
+
+        int planesFiredAtROC[NROCsMAX];  // how many planes registered hits on ROC r
         for (int r = 0; r < NROCsMAX; r++)
           planesFiredAtROC[r] = 0;
         for (int p = 0; p < NplaneMAX; p++) {
@@ -751,7 +751,7 @@ void CTPPSPixelDQMSource::analyze(edm::Event const &event, edm::EventSetup const
         for (int r = 0; r < NROCsMAX; r++)
           if (max < planesFiredAtROC[r])
             max = planesFiredAtROC[r];
-        if (max >= 4 && onlinePlots) // fill only if there are at least 4 aligned ROCs firing
+        if (max >= 4 && onlinePlots)  // fill only if there are at least 4 aligned ROCs firing
           hRPotActivBXroc[index]->Fill(event.bunchCrossing());
       }  // end for(int rp=0; rp<NRPotsMAX; rp++) {
     }


### PR DESCRIPTION
Since rocf represents the number of planes in which ROC 'i' fired, the name has been changed to planesFiredAtROC and its range has been fixed to be NROCsMAX. This bug has not produced any issues up to now, because the maximum number of ROCs has always been equal to the number of planes, although it's better to have it fixed for the future. 