### PR TITLE
Migrate EcalBasicClusterLocalContCorrection to ESTokens

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h
@@ -14,6 +14,7 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 
+#include <functional>
 #include <map>
 #include <string>
 
@@ -39,8 +40,9 @@ public:
 
   // take a SuperCluster and return a local containment corrected SuperCluster
 
-  reco::SuperCluster applyLocalContCorrection(const reco::SuperCluster& cl,
-                                              EcalClusterFunctionBaseClass* localContCorrectionFunction);
+  reco::SuperCluster applyLocalContCorrection(
+      const reco::SuperCluster& cl,
+      std::function<float(reco::BasicCluster const&, EcalRecHitCollection const&)> localContCorrectionFunction);
 
 private:
   // correction factor as a function of number of crystals,

--- a/RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h
@@ -1,18 +1,15 @@
 #ifndef RecoECAL_ECALClusters_EgammaSCEnergyCorrectionAlgo_h_
 #define RecoECAL_ECALClusters_EgammaSCEnergyCorrectionAlgo_h_
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 
 #include <functional>
 #include <map>
@@ -20,9 +17,10 @@
 
 class EgammaSCEnergyCorrectionAlgo {
 public:
+  using BasicClusterFunction = std::function<float(reco::BasicCluster const&, EcalRecHitCollection const&)>;
+
   // public member functions
-  EgammaSCEnergyCorrectionAlgo(float noise, reco::CaloCluster::AlgoId theAlgo, const edm::ParameterSet& pset);
-  ~EgammaSCEnergyCorrectionAlgo() {}
+  EgammaSCEnergyCorrectionAlgo(float noise);
 
   // take a SuperCluster and return a corrected SuperCluster
   reco::SuperCluster applyCorrection(const reco::SuperCluster& cl,
@@ -35,14 +33,13 @@ public:
                                      int modeEE_);
 
   // take a SuperCluster and return a crack-corrected SuperCluster
-  reco::SuperCluster applyCrackCorrection(const reco::SuperCluster& cl,
-                                          EcalClusterFunctionBaseClass* crackCorrectionFunction);
+  static reco::SuperCluster applyCrackCorrection(const reco::SuperCluster& cl,
+                                                 EcalClusterFunctionBaseClass* crackCorrectionFunction);
 
   // take a SuperCluster and return a local containment corrected SuperCluster
 
-  reco::SuperCluster applyLocalContCorrection(
-      const reco::SuperCluster& cl,
-      std::function<float(reco::BasicCluster const&, EcalRecHitCollection const&)> localContCorrectionFunction);
+  static reco::SuperCluster applyLocalContCorrection(const reco::SuperCluster& cl,
+                                                     BasicClusterFunction localContCorrectionFunction);
 
 private:
   // correction factor as a function of number of crystals,
@@ -54,8 +51,6 @@ private:
   int nCrystalsGT2Sigma(reco::BasicCluster const& seed, EcalRecHitCollection const& rhc) const;
 
   float sigmaElectronicNoise_;
-
-  reco::CaloCluster::AlgoId theAlgo_;
 };
 
 #endif /*RecoECAL_ECALClusters_EgammaSCEnergyCorrectionAlgo_h_*/

--- a/RecoEcal/EgammaClusterAlgos/src/EgammaSCEnergyCorrectionAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/EgammaSCEnergyCorrectionAlgo.cc
@@ -1,20 +1,16 @@
 //
 // Author: David Evans, Bristol
 //
+
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <iostream>
+
 #include <string>
 #include <vector>
 
-EgammaSCEnergyCorrectionAlgo::EgammaSCEnergyCorrectionAlgo(float noise,
-                                                           reco::CaloCluster::AlgoId theAlgo,
-                                                           const edm::ParameterSet& pset)
-
-{
-  sigmaElectronicNoise_ = noise;
-}
+EgammaSCEnergyCorrectionAlgo::EgammaSCEnergyCorrectionAlgo(float noise) : sigmaElectronicNoise_{noise} {}
 
 reco::SuperCluster EgammaSCEnergyCorrectionAlgo::applyCorrection(const reco::SuperCluster& cl,
                                                                  const EcalRecHitCollection& rhc,
@@ -235,8 +231,7 @@ reco::SuperCluster EgammaSCEnergyCorrectionAlgo::applyCrackCorrection(
 // Assume that the correction function provides correction for the seed Basic Cluster
 
 reco::SuperCluster EgammaSCEnergyCorrectionAlgo::applyLocalContCorrection(
-    const reco::SuperCluster& cl,
-    std::function<float(reco::BasicCluster const&, EcalRecHitCollection const&)> localContCorrectionFunction) {
+    reco::SuperCluster const& cl, BasicClusterFunction localContCorrectionFunction) {
   const EcalRecHitCollection dummy;
 
   const reco::CaloClusterPtr& seedBC = cl.seed();

--- a/RecoEcal/EgammaClusterAlgos/src/EgammaSCEnergyCorrectionAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/EgammaSCEnergyCorrectionAlgo.cc
@@ -235,12 +235,13 @@ reco::SuperCluster EgammaSCEnergyCorrectionAlgo::applyCrackCorrection(
 // Assume that the correction function provides correction for the seed Basic Cluster
 
 reco::SuperCluster EgammaSCEnergyCorrectionAlgo::applyLocalContCorrection(
-    const reco::SuperCluster& cl, EcalClusterFunctionBaseClass* localContCorrectionFunction) {
+    const reco::SuperCluster& cl,
+    std::function<float(reco::BasicCluster const&, EcalRecHitCollection const&)> localContCorrectionFunction) {
   const EcalRecHitCollection dummy;
 
   const reco::CaloClusterPtr& seedBC = cl.seed();
   float seedBCene = seedBC->energy();
-  float correctedSeedBCene = localContCorrectionFunction->getValue(*seedBC, dummy) * seedBCene;
+  float correctedSeedBCene = localContCorrectionFunction(*seedBC, dummy) * seedBCene;
 
   reco::SuperCluster correctedSC = cl;
   correctedSC.setEnergy(cl.energy() - seedBCene + correctedSeedBCene);

--- a/RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h
@@ -10,22 +10,19 @@
   *  \author Federico Ferri, CEA Saclay, November 2008
   */
 
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
 #include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
-#include "TVector2.h"
 
 class EcalBasicClusterLocalContCorrection {
 public:
-  // get/set explicit methods for parameters
-  const EcalClusterLocalContCorrParameters *getParameters() const { return params_; }
+  EcalBasicClusterLocalContCorrection(edm::ConsumesCollector &&cc);
+
   // check initialization
   void checkInit() const;
 
@@ -38,9 +35,11 @@ public:
 private:
   int getEcalModule(DetId id) const;
 
-  edm::ESHandle<EcalClusterLocalContCorrParameters> esParams_;
-  const EcalClusterLocalContCorrParameters *params_;
-  const edm::EventSetup *es_;  //needed to access the ECAL geometry
+  const edm::ESGetToken<EcalClusterLocalContCorrParameters, EcalClusterLocalContCorrParametersRcd> paramsToken_;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometryToken_;
+
+  EcalClusterLocalContCorrParameters const *params_;
+  CaloGeometry const *caloGeometry_;
 };
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h
@@ -1,0 +1,46 @@
+#ifndef RecoEcal_EgammaClusterProducers_EcalBasicClusterLocalContCorrection_h_
+#define RecoEcal_EgammaClusterProducers_EcalBasicClusterLocalContCorrection_h_
+
+/** \class EcalBasicClusterLocalContCorrection
+  *  Function to correct em object energy for energy not contained in a 5x5 crystal area in the calorimeter
+  *
+  *  $Id: EcalBasicClusterLocalContCorrection.h
+  *  $Date:
+  *  $Revision:
+  *  \author Federico Ferri, CEA Saclay, November 2008
+  */
+
+#include "DataFormats/EcalDetId/interface/EBDetId.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "TVector2.h"
+
+class EcalBasicClusterLocalContCorrection {
+public:
+  // get/set explicit methods for parameters
+  const EcalClusterLocalContCorrParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
+
+  // compute the correction
+  float operator()(const reco::BasicCluster &, const EcalRecHitCollection &) const;
+
+  // set parameters
+  void init(const edm::EventSetup &es);
+
+private:
+  int getEcalModule(DetId id) const;
+
+  edm::ESHandle<EcalClusterLocalContCorrParameters> esParams_;
+  const EcalClusterLocalContCorrParameters *params_;
+  const edm::EventSetup *es_;  //needed to access the ECAL geometry
+};
+
+#endif

--- a/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
@@ -39,7 +39,6 @@
 class EgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 public:
   explicit EgammaSCCorrectionMaker(const edm::ParameterSet&);
-  ~EgammaSCCorrectionMaker() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:

--- a/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
@@ -34,6 +34,8 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
+#include "RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h"
+
 class EgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 public:
   explicit EgammaSCCorrectionMaker(const edm::ParameterSet&);
@@ -43,7 +45,7 @@ public:
 private:
   std::unique_ptr<EcalClusterFunctionBaseClass> energyCorrectionFunction_;
   std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
-  std::unique_ptr<EcalClusterFunctionBaseClass> localContCorrectionFunction_;
+  std::unique_ptr<EcalBasicClusterLocalContCorrection> localContCorrectionFunction_;
 
   // pointer to the correction algo object
   std::unique_ptr<EgammaSCEnergyCorrectionAlgo> energyCorrector_;
@@ -55,7 +57,6 @@ private:
 
   std::string energyCorrectorName_;
   std::string crackCorrectorName_;
-  std::string localContCorrectorName_;
 
   int modeEB_;
   int modeEE_;

--- a/RecoEcal/EgammaClusterProducers/python/correctedHybridSuperClusters_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedHybridSuperClusters_cfi.py
@@ -14,7 +14,6 @@ correctedHybridSuperClusters = cms.EDProducer("EgammaSCCorrectionMaker",
     applyCrackCorrection = cms.bool(True),
     crackCorrectorName = cms.string('EcalClusterCrackCorrection'),
     applyLocalContCorrection= cms.bool(True),
-    localContCorrectorName = cms.string('EcalBasicClusterLocalContCorrection'),                                          
     # energy correction
     hyb_fCorrPset = cms.PSet(
 

--- a/RecoEcal/EgammaClusterProducers/python/correctedMulti5x5SuperClustersWithPreshower_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/correctedMulti5x5SuperClustersWithPreshower_cfi.py
@@ -14,7 +14,6 @@ correctedMulti5x5SuperClustersWithPreshower = cms.EDProducer("EgammaSCCorrection
     applyCrackCorrection = cms.bool(True),
     crackCorrectorName = cms.string('EcalClusterCrackCorrection'),
     applyLocalContCorrection= cms.bool(False),
-    localContCorrectorName = cms.string('EcalBasicClusterLocalContCorrection'),
     # energy correction
     fix_fCorrPset = cms.PSet(
        brLinearLowThr = cms.double(0.9),

--- a/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalBasicClusterLocalContCorrection.cc
@@ -1,47 +1,4 @@
-/** \class EcalBasicClusterLocalContCorrection
-  *  Function to correct em object energy for energy not contained in a 5x5 crystal area in the calorimeter
-  *
-  *  $Id: EcalBasicClusterLocalContCorrection.h
-  *  $Date:
-  *  $Revision:
-  *  \author Federico Ferri, CEA Saclay, November 2008
-  */
-
-#include "DataFormats/EcalDetId/interface/EBDetId.h"
-#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
-#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-#include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-#include "CondFormats/EcalObjects/interface/EcalClusterLocalContCorrParameters.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-
-#include "TVector2.h"
-
-class EcalBasicClusterLocalContCorrection : public EcalClusterFunctionBaseClass {
-public:
-  EcalBasicClusterLocalContCorrection(const edm::ParameterSet &){};
-
-  // get/set explicit methods for parameters
-  const EcalClusterLocalContCorrParameters *getParameters() const { return params_; }
-  // check initialization
-  void checkInit() const;
-
-  // compute the correction
-  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override;
-  float getValue(const reco::SuperCluster &, const int mode) const override;
-
-  // set parameters
-  void init(const edm::EventSetup &es) override;
-
-private:
-  int getEcalModule(DetId id) const;
-
-  edm::ESHandle<EcalClusterLocalContCorrParameters> esParams_;
-  const EcalClusterLocalContCorrParameters *params_;
-  const edm::EventSetup *es_;  //needed to access the ECAL geometry
-};
+#include "RecoEcal/EgammaClusterProducers/interface/EcalBasicClusterLocalContCorrection.h"
 
 void EcalBasicClusterLocalContCorrection::init(const edm::EventSetup &es) {
   es.get<EcalClusterLocalContCorrParametersRcd>().get(esParams_);
@@ -61,13 +18,8 @@ void EcalBasicClusterLocalContCorrection::checkInit() const {
 using namespace std;
 using namespace edm;
 
-float EcalBasicClusterLocalContCorrection::getValue(const reco::SuperCluster &superCluster, const int mode) const {
-  //checkInit();
-  return 1;
-}
-
-float EcalBasicClusterLocalContCorrection::getValue(const reco::BasicCluster &basicCluster,
-                                                    const EcalRecHitCollection &recHit) const {
+float EcalBasicClusterLocalContCorrection::operator()(const reco::BasicCluster &basicCluster,
+                                                      const EcalRecHitCollection &recHit) const {
   checkInit();
 
   // number of parameters needed by this parametrization
@@ -211,9 +163,3 @@ int EcalBasicClusterLocalContCorrection::getEcalModule(DetId id) const {
 
   return (mod);
 }
-//------------------------------------------------------------------------------------------------------
-
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory,
-                  EcalBasicClusterLocalContCorrection,
-                  "EcalBasicClusterLocalContCorrection");

--- a/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
@@ -58,9 +58,6 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps) {
   crackCorrectorName_ = ps.existsAs<std::string>("crackCorrectorName")
                             ? ps.getParameter<std::string>("crackCorrectorName")
                             : std::string("EcalClusterCrackCorrection");
-  localContCorrectorName_ = ps.existsAs<std::string>("localContCorrectorName")
-                                ? ps.getParameter<std::string>("localContCorrectorName")
-                                : std::string("EcalBasicClusterLocalContCorrection");
 
   modeEB_ = ps.getParameter<int>("modeEB");
   modeEE_ = ps.getParameter<int>("modeEE");
@@ -85,7 +82,7 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps) {
     crackCorrectionFunction_ = EcalClusterFunctionFactory::get()->create(crackCorrectorName_, ps);
 
   if (applyLocalContCorrection_)
-    localContCorrectionFunction_ = EcalClusterFunctionFactory::get()->create(localContCorrectorName_, ps);
+    localContCorrectionFunction_ = std::make_unique<EcalBasicClusterLocalContCorrection>();
 }
 
 EgammaSCCorrectionMaker::~EgammaSCCorrectionMaker() = default;
@@ -165,7 +162,7 @@ void EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es
       crackcorrClus = enecorrClus;
 
     if (applyLocalContCorrection_)
-      localContCorrClus = energyCorrector_->applyLocalContCorrection(crackcorrClus, localContCorrectionFunction_.get());
+      localContCorrClus = energyCorrector_->applyLocalContCorrection(crackcorrClus, *localContCorrectionFunction_);
     else
       localContCorrClus = crackcorrClus;
 

--- a/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
@@ -71,7 +71,7 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps) {
   produces<reco::SuperClusterCollection>(outputCollection_);
 
   // instanciate the correction algo object
-  energyCorrector_ = std::make_unique<EgammaSCEnergyCorrectionAlgo>(sigmaElectronicNoise_, sCAlgo_, fCorrPset);
+  energyCorrector_ = std::make_unique<EgammaSCEnergyCorrectionAlgo>(sigmaElectronicNoise_);
 
   // energy correction class
   if (applyEnergyCorrection_)
@@ -82,10 +82,8 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps) {
     crackCorrectionFunction_ = EcalClusterFunctionFactory::get()->create(crackCorrectorName_, ps);
 
   if (applyLocalContCorrection_)
-    localContCorrectionFunction_ = std::make_unique<EcalBasicClusterLocalContCorrection>();
+    localContCorrectionFunction_ = std::make_unique<EcalBasicClusterLocalContCorrection>(consumesCollector());
 }
-
-EgammaSCCorrectionMaker::~EgammaSCCorrectionMaker() = default;
 
 void EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es) {
   using namespace edm;
@@ -157,12 +155,13 @@ void EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es
       enecorrClus = *aClus;
 
     if (applyCrackCorrection_)
-      crackcorrClus = energyCorrector_->applyCrackCorrection(enecorrClus, crackCorrectionFunction_.get());
+      crackcorrClus = EgammaSCEnergyCorrectionAlgo::applyCrackCorrection(enecorrClus, crackCorrectionFunction_.get());
     else
       crackcorrClus = enecorrClus;
 
     if (applyLocalContCorrection_)
-      localContCorrClus = energyCorrector_->applyLocalContCorrection(crackcorrClus, *localContCorrectionFunction_);
+      localContCorrClus =
+          EgammaSCEnergyCorrectionAlgo::applyLocalContCorrection(crackcorrClus, *localContCorrectionFunction_);
     else
       localContCorrClus = crackcorrClus;
 


### PR DESCRIPTION
#### PR description:

This PR is in the previous spirit as my previous PR https://github.com/cms-sw/cmssw/pull/32498.

After https://github.com/cms-sw/cmssw/pull/32424, the ES consumes migration of RecoEgamma plugins is still on my radar. On thing that makes the migration complicated is this factory pattern with functions inheriting from the `EcalClusterFunctionBaseClass`.

But before thinking of a solution for these ECAL cluster functions, maybe this this is a good opportunity to think about where this factory pattern is really needed to reduce the complexity of the migration a bit.

I spotted the `EcalBasicClusterLocalContCorrection`, which is only used once in the `EgammaSCCorrectionMaker`. It was and is never swapped with alternative corrector functions, so the factory pattern doesn't seem really necessary.

Hence, this PR suggests to turn `EcalBasicClusterLocalContCorrection` into a usual helper class that is migrated to the ESGetTokens.

#### PR validation:

CMSSW compiles, local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.