### PR TITLE
E/gamma HLT L1 Track Isolation Producer & TTTrack typedef: 11_3_X

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/L1Track.h
+++ b/DataFormats/L1TrackTrigger/interface/L1Track.h
@@ -1,0 +1,7 @@
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include <vector>
+
+using L1Track = TTTrack<Ref_Phase2TrackerDigi_>;
+using L1TrackCollection = std::vector<L1Track>;
+

--- a/DataFormats/L1TrackTrigger/interface/L1Track.h
+++ b/DataFormats/L1TrackTrigger/interface/L1Track.h
@@ -4,4 +4,3 @@
 
 using L1Track = TTTrack<Ref_Phase2TrackerDigi_>;
 using L1TrackCollection = std::vector<L1Track>;
-

--- a/DataFormats/L1TrackTrigger/interface/L1Track.h
+++ b/DataFormats/L1TrackTrigger/interface/L1Track.h
@@ -1,6 +1,11 @@
+#ifndef DataFormats_L1TrackTrigger_L1Track_h
+#define DataFormats_L1TrackTrigger_L1Track_h
+
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include <vector>
 
 using L1Track = TTTrack<Ref_Phase2TrackerDigi_>;
 using L1TrackCollection = std::vector<L1Track>;
+
+#endif

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
@@ -35,7 +35,7 @@
 class EgammaHLTEleL1TrackIsolProducer : public edm::global::EDProducer<> {
 public:
   explicit EgammaHLTEleL1TrackIsolProducer(const edm::ParameterSet&);
-  ~EgammaHLTEleL1TrackIsolProducer() override;
+  ~EgammaHLTEleL1TrackIsolProducer() override = default;
   void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -54,14 +54,12 @@ EgammaHLTEleL1TrackIsolProducer::EgammaHLTEleL1TrackIsolProducer(const edm::Para
   produces<reco::RecoEcalCandidateIsolationMap>();
 }
 
-EgammaHLTEleL1TrackIsolProducer::~EgammaHLTEleL1TrackIsolProducer() {}
-
 void EgammaHLTEleL1TrackIsolProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("ecalCands", edm::InputTag("hltEgammaCandidates"));
   desc.add<edm::InputTag>("eles", edm::InputTag("hltEgammaGsfElectrons"));
   desc.add<edm::InputTag>("l1Tracks", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
-  desc.add("isolCfg", EgammaL1TkIsolation::pSetDescript());
+  desc.add("isolCfg", EgammaL1TkIsolation::makePSetDescription());
   descriptions.add("hltEgammaHLTEleL1TrackIsolProducer", desc);
 }
 void EgammaHLTEleL1TrackIsolProducer::produce(edm::StreamID sid,

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
@@ -1,0 +1,97 @@
+// Author: Sam Harper (RAL/CERN)
+// L1 track isolation producer for the HLT
+// A quick primer on how the E/gamma HLT works w.r.t to ID variables
+// 1. the supercluster is the primary object
+// 2. superclusters get id variables associated to them via association maps keyed
+//    to the supercluster
+// However here we also need to read in electron objects as we need to solve for which
+// GsfTrack associated to the supercluster to use for the isolation
+// The electron producer solves for this and assigns the electron the best GsfTrack
+// which we will use for the vz of the electron
+// One thing which Swagata Mukherjee pointed out is that we have to be careful of
+// is getting a bad GsfTrack with a bad vertex which  will give us a fake vz which then 
+// leads to a perfectly isolated electron as that random vz is not a vertex
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h"
+
+#include <memory>
+
+class EgammaHLTEleL1TrackIsolProducer : public edm::global::EDProducer<> {
+public:
+  explicit EgammaHLTEleL1TrackIsolProducer(const edm::ParameterSet&);
+  ~EgammaHLTEleL1TrackIsolProducer() override;
+  void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::EDGetTokenT<reco::RecoEcalCandidateCollection> ecalCandsToken_;
+  const edm::EDGetTokenT<reco::ElectronCollection> elesToken_;
+  const edm::EDGetTokenT<L1TrackCollection> l1TrksToken_;
+  EgammaL1TkIsolation isolAlgo_;
+};
+
+EgammaHLTEleL1TrackIsolProducer::EgammaHLTEleL1TrackIsolProducer(const edm::ParameterSet& config)
+  : ecalCandsToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("ecalCands"))),
+    elesToken_(consumes<reco::ElectronCollection>(config.getParameter<edm::InputTag>("eles"))),
+    l1TrksToken_(consumes<L1TrackCollection>(config.getParameter<edm::InputTag>("l1Tracks"))),
+    isolAlgo_(config.getParameter<edm::ParameterSet>("isolCfg"))
+{
+    produces<reco::RecoEcalCandidateIsolationMap>();
+}
+
+EgammaHLTEleL1TrackIsolProducer::~EgammaHLTEleL1TrackIsolProducer() {}
+
+void EgammaHLTEleL1TrackIsolProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("ecalCands", edm::InputTag("hltEgammaCandidates"));
+  desc.add<edm::InputTag>("eles", edm::InputTag("hltEgammaGsfElectrons"));
+  desc.add<edm::InputTag>("l1Tracks", edm::InputTag("TTTracksFromTrackletEmulation","Level1TTTracks"));
+  desc.add("isolCfg", EgammaL1TkIsolation::pSetDescript());
+  descriptions.add("hltEgammaHLTEleL1TrackIsolProducer", desc);
+}
+void EgammaHLTEleL1TrackIsolProducer::produce(edm::StreamID sid,
+                                                       edm::Event& iEvent,
+                                                       const edm::EventSetup& iSetup) const {
+
+  auto ecalCands = iEvent.getHandle(ecalCandsToken_);
+  auto eles = iEvent.getHandle(elesToken_);
+  auto l1Trks = iEvent.getHandle(l1TrksToken_);
+
+  auto recoEcalCandMap  = std::make_unique<reco::RecoEcalCandidateIsolationMap>(ecalCands);
+  
+  for (size_t candNr = 0; candNr<ecalCands->size();candNr++){
+    reco::RecoEcalCandidateRef recoEcalCandRef(ecalCands, candNr);  
+    reco::ElectronRef eleRef;
+    for (size_t eleNr = 0; eleNr<eles->size(); eleNr++){
+      if ((*eles)[eleNr].superCluster() == recoEcalCandRef->superCluster()) {
+	eleRef = reco::ElectronRef(eles, eleNr);
+	break;
+      }
+    }
+    
+    float isol = eleRef.isNonnull() ? isolAlgo_.calIsol(*eleRef->gsfTrack(),*l1Trks).second : std::numeric_limits<float>::max();
+    
+    recoEcalCandMap->insert(recoEcalCandRef, isol);
+  }
+  iEvent.put(std::move(recoEcalCandMap));
+    
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(EgammaHLTEleL1TrackIsolProducer);

--- a/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/plugins/EgammaHLTEleL1TrackIsolProducer.cc
@@ -9,7 +9,7 @@
 // The electron producer solves for this and assigns the electron the best GsfTrack
 // which we will use for the vz of the electron
 // One thing which Swagata Mukherjee pointed out is that we have to be careful of
-// is getting a bad GsfTrack with a bad vertex which  will give us a fake vz which then 
+// is getting a bad GsfTrack with a bad vertex which  will give us a fake vz which then
 // leads to a perfectly isolated electron as that random vz is not a vertex
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -47,12 +47,11 @@ private:
 };
 
 EgammaHLTEleL1TrackIsolProducer::EgammaHLTEleL1TrackIsolProducer(const edm::ParameterSet& config)
-  : ecalCandsToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("ecalCands"))),
-    elesToken_(consumes<reco::ElectronCollection>(config.getParameter<edm::InputTag>("eles"))),
-    l1TrksToken_(consumes<L1TrackCollection>(config.getParameter<edm::InputTag>("l1Tracks"))),
-    isolAlgo_(config.getParameter<edm::ParameterSet>("isolCfg"))
-{
-    produces<reco::RecoEcalCandidateIsolationMap>();
+    : ecalCandsToken_(consumes<reco::RecoEcalCandidateCollection>(config.getParameter<edm::InputTag>("ecalCands"))),
+      elesToken_(consumes<reco::ElectronCollection>(config.getParameter<edm::InputTag>("eles"))),
+      l1TrksToken_(consumes<L1TrackCollection>(config.getParameter<edm::InputTag>("l1Tracks"))),
+      isolAlgo_(config.getParameter<edm::ParameterSet>("isolCfg")) {
+  produces<reco::RecoEcalCandidateIsolationMap>();
 }
 
 EgammaHLTEleL1TrackIsolProducer::~EgammaHLTEleL1TrackIsolProducer() {}
@@ -61,36 +60,35 @@ void EgammaHLTEleL1TrackIsolProducer::fillDescriptions(edm::ConfigurationDescrip
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("ecalCands", edm::InputTag("hltEgammaCandidates"));
   desc.add<edm::InputTag>("eles", edm::InputTag("hltEgammaGsfElectrons"));
-  desc.add<edm::InputTag>("l1Tracks", edm::InputTag("TTTracksFromTrackletEmulation","Level1TTTracks"));
+  desc.add<edm::InputTag>("l1Tracks", edm::InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks"));
   desc.add("isolCfg", EgammaL1TkIsolation::pSetDescript());
   descriptions.add("hltEgammaHLTEleL1TrackIsolProducer", desc);
 }
 void EgammaHLTEleL1TrackIsolProducer::produce(edm::StreamID sid,
-                                                       edm::Event& iEvent,
-                                                       const edm::EventSetup& iSetup) const {
-
+                                              edm::Event& iEvent,
+                                              const edm::EventSetup& iSetup) const {
   auto ecalCands = iEvent.getHandle(ecalCandsToken_);
   auto eles = iEvent.getHandle(elesToken_);
   auto l1Trks = iEvent.getHandle(l1TrksToken_);
 
-  auto recoEcalCandMap  = std::make_unique<reco::RecoEcalCandidateIsolationMap>(ecalCands);
-  
-  for (size_t candNr = 0; candNr<ecalCands->size();candNr++){
-    reco::RecoEcalCandidateRef recoEcalCandRef(ecalCands, candNr);  
+  auto recoEcalCandMap = std::make_unique<reco::RecoEcalCandidateIsolationMap>(ecalCands);
+
+  for (size_t candNr = 0; candNr < ecalCands->size(); candNr++) {
+    reco::RecoEcalCandidateRef recoEcalCandRef(ecalCands, candNr);
     reco::ElectronRef eleRef;
-    for (size_t eleNr = 0; eleNr<eles->size(); eleNr++){
+    for (size_t eleNr = 0; eleNr < eles->size(); eleNr++) {
       if ((*eles)[eleNr].superCluster() == recoEcalCandRef->superCluster()) {
-	eleRef = reco::ElectronRef(eles, eleNr);
-	break;
+        eleRef = reco::ElectronRef(eles, eleNr);
+        break;
       }
     }
-    
-    float isol = eleRef.isNonnull() ? isolAlgo_.calIsol(*eleRef->gsfTrack(),*l1Trks).second : std::numeric_limits<float>::max();
-    
+
+    float isol =
+        eleRef.isNonnull() ? isolAlgo_.calIsol(*eleRef->gsfTrack(), *l1Trks).second : std::numeric_limits<float>::max();
+
     recoEcalCandMap->insert(recoEcalCandRef, isol);
   }
   iEvent.put(std::move(recoEcalCandMap));
-    
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
@@ -12,26 +12,17 @@
 
 class EgammaL1TkIsolation {
 public:
-private:
-  struct TrkCuts {
-    float minPt;
-    float minDR2;
-    float maxDR2;
-    float minDEta;
-    float maxDZ;
-    explicit TrkCuts(const edm::ParameterSet& para);
-    static edm::ParameterSetDescription pSetDescript();
-  };
-
-  TrkCuts barrelCuts_, endcapCuts_;
-
-public:
   explicit EgammaL1TkIsolation(const edm::ParameterSet& para);
   EgammaL1TkIsolation(const EgammaL1TkIsolation&) = default;
   ~EgammaL1TkIsolation() = default;
   EgammaL1TkIsolation& operator=(const EgammaL1TkIsolation&) = default;
 
-  static edm::ParameterSetDescription pSetDescript();
+  static void fillPSetDescription(edm::ParameterSetDescription& desc);
+  static edm::ParameterSetDescription makePSetDescription() {
+    edm::ParameterSetDescription desc;
+    fillPSetDescription(desc);
+    return desc;
+  }
 
   std::pair<int, double> calIsol(const reco::TrackBase& trk, const L1TrackCollection& l1Tks) const;
 
@@ -47,6 +38,21 @@ public:
   }
 
 private:
+  struct TrkCuts {
+    float minPt;
+    float minDR2;
+    float maxDR2;
+    float minDEta;
+    float maxDZ;
+    explicit TrkCuts(const edm::ParameterSet& para);
+    static edm::ParameterSetDescription makePSetDescription();
+  };
+
+  bool useAbsEta_;
+  std::vector<double> etaBoundaries_;
+  std::vector<TrkCuts> trkCuts_;
+
+  size_t etaBinNr(double eta) const;
   static bool passTrkSel(const L1Track& trk,
                          const double trkPt,
                          const TrkCuts& cuts,

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
@@ -7,12 +7,11 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-//author S. Harper (RAL/CERN) 
+//author S. Harper (RAL/CERN)
 //based on the work of Swagata Mukherjee and Giulia Sorrentino
 
 class EgammaL1TkIsolation {
 public:
-
 private:
   struct TrkCuts {
     float minPt;
@@ -34,20 +33,18 @@ public:
 
   static edm::ParameterSetDescription pSetDescript();
 
-  std::pair<int, double> calIsol(const reco::TrackBase& trk,
-				 const L1TrackCollection& l1Tks)const;
+  std::pair<int, double> calIsol(const reco::TrackBase& trk, const L1TrackCollection& l1Tks) const;
 
   std::pair<int, double> calIsol(const double objEta,
                                  const double objPhi,
                                  const double objZ,
-                                 const L1TrackCollection& l1Tks)const;
+                                 const L1TrackCollection& l1Tks) const;
 
   //little helper function for the two calIsol functions for it to directly return the pt
   template <typename... Args>
   double calIsolPt(Args&&... args) const {
     return calIsol(std::forward<Args>(args)...).second;
   }
-
 
 private:
   static bool passTrkSel(const L1Track& trk,

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
@@ -1,0 +1,61 @@
+#ifndef RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAL1TKISOLATION_H
+#define RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAL1TKISOLATION_H
+
+#include "DataFormats/L1TrackTrigger/interface/L1Track.h"
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+//author S. Harper (RAL/CERN) 
+//based on the work of Swagata Mukherjee and Giulia Sorrentino
+
+class EgammaL1TkIsolation {
+public:
+
+private:
+  struct TrkCuts {
+    float minPt;
+    float minDR2;
+    float maxDR2;
+    float minDEta;
+    float maxDZ;
+    explicit TrkCuts(const edm::ParameterSet& para);
+    static edm::ParameterSetDescription pSetDescript();
+  };
+
+  TrkCuts barrelCuts_, endcapCuts_;
+
+public:
+  explicit EgammaL1TkIsolation(const edm::ParameterSet& para);
+  EgammaL1TkIsolation(const EgammaL1TkIsolation&) = default;
+  ~EgammaL1TkIsolation() = default;
+  EgammaL1TkIsolation& operator=(const EgammaL1TkIsolation&) = default;
+
+  static edm::ParameterSetDescription pSetDescript();
+
+  std::pair<int, double> calIsol(const reco::TrackBase& trk,
+				 const L1TrackCollection& l1Tks)const;
+
+  std::pair<int, double> calIsol(const double objEta,
+                                 const double objPhi,
+                                 const double objZ,
+                                 const L1TrackCollection& l1Tks)const;
+
+  //little helper function for the two calIsol functions for it to directly return the pt
+  template <typename... Args>
+  double calIsolPt(Args&&... args) const {
+    return calIsol(std::forward<Args>(args)...).second;
+  }
+
+
+private:
+  static bool passTrkSel(const L1Track& trk,
+                         const double trkPt,
+                         const TrkCuts& cuts,
+                         const double objEta,
+                         const double objPhi,
+                         const double objZ);
+};
+
+#endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h
@@ -1,5 +1,5 @@
-#ifndef RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAL1TKISOLATION_H
-#define RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAL1TKISOLATION_H
+#ifndef RecoEgamma_EgammaIsolationAlgos_EgammaL1TkIsolation_h
+#define RecoEgamma_EgammaIsolationAlgos_EgammaL1TkIsolation_h
 
 #include "DataFormats/L1TrackTrigger/interface/L1Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
@@ -13,9 +13,6 @@
 class EgammaL1TkIsolation {
 public:
   explicit EgammaL1TkIsolation(const edm::ParameterSet& para);
-  EgammaL1TkIsolation(const EgammaL1TkIsolation&) = default;
-  ~EgammaL1TkIsolation() = default;
-  EgammaL1TkIsolation& operator=(const EgammaL1TkIsolation&) = default;
 
   static void fillPSetDescription(edm::ParameterSetDescription& desc);
   static edm::ParameterSetDescription makePSetDescription() {
@@ -48,10 +45,6 @@ private:
     static edm::ParameterSetDescription makePSetDescription();
   };
 
-  bool useAbsEta_;
-  std::vector<double> etaBoundaries_;
-  std::vector<TrkCuts> trkCuts_;
-
   size_t etaBinNr(double eta) const;
   static bool passTrkSel(const L1Track& trk,
                          const double trkPt,
@@ -59,6 +52,10 @@ private:
                          const double objEta,
                          const double objPhi,
                          const double objZ);
+
+  bool useAbsEta_;
+  std::vector<double> etaBoundaries_;
+  std::vector<TrkCuts> trkCuts_;
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
@@ -1,0 +1,80 @@
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaL1TkIsolation.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+EgammaL1TkIsolation::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
+  minPt = para.getParameter<double>("minPt");
+  auto sq = [](double val) { return val * val; };
+  minDR2 = sq(para.getParameter<double>("minDR"));
+  maxDR2 = sq(para.getParameter<double>("maxDR"));
+  minDEta = para.getParameter<double>("minDEta");
+  maxDZ = para.getParameter<double>("maxDZ");
+}
+
+edm::ParameterSetDescription EgammaL1TkIsolation::TrkCuts::pSetDescript() {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("minPt", 2.0);
+  desc.add<double>("maxDR", 0.3);
+  desc.add<double>("minDR", 0.01);
+  desc.add<double>("minDEta", 0.003);
+  desc.add<double>("maxDZ", 0.7);
+  return desc;
+}
+
+EgammaL1TkIsolation::EgammaL1TkIsolation(const edm::ParameterSet& para)
+    : barrelCuts_(para.getParameter<edm::ParameterSet>("barrelCuts")),
+      endcapCuts_(para.getParameter<edm::ParameterSet>("endcapCuts")) {}
+
+edm::ParameterSetDescription EgammaL1TkIsolation::pSetDescript() {
+  edm::ParameterSetDescription desc;
+  desc.add("barrelCuts", TrkCuts::pSetDescript());
+  desc.add("endcapCuts", TrkCuts::pSetDescript());
+  return desc;
+}
+
+
+
+std::pair<int, double> EgammaL1TkIsolation::calIsol(const reco::TrackBase& trk,
+                                                   const L1TrackCollection& tracks) const {
+  return calIsol(trk.eta(), trk.phi(), trk.vz(), tracks);
+}
+
+std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
+                                                   const double objPhi,
+                                                   const double objZ,
+                                                   const L1TrackCollection& tracks) const {
+  double ptSum = 0.;
+  int nrTrks = 0;
+
+  std::cout <<"obj eta "<<objEta<<" obj phi "<<objPhi<<" objZ "<<objZ<<std::endl;
+
+  const TrkCuts& cuts = std::abs(objEta) < 1.5 ? barrelCuts_ : endcapCuts_;
+
+  for (auto& trk : tracks) {
+    const float trkPt = trk.momentum().perp();
+    if (passTrkSel(trk, trkPt, cuts, objEta, objPhi, objZ)) {
+      ptSum += trkPt;
+      nrTrks++;
+    }
+  }
+  return {nrTrks, ptSum};
+}
+
+bool EgammaL1TkIsolation::passTrkSel(const L1Track& trk,
+				     const double trkPt,
+				     const TrkCuts& cuts,
+				     const double objEta,
+				     const double objPhi,
+				     const double objZ) {
+
+  if(trkPt > cuts.minPt && 
+     std::abs(objZ-trk.z0()) < cuts.maxDZ){
+    const float trkEta = trk.eta();
+    const float dEta =  trkEta - objEta;
+    const float dR2 = reco::deltaR2(objEta, objPhi, trkEta, trk.phi());
+    return dR2 >= cuts.minDR2 && dR2 <= cuts.maxDR2 && std::abs(dEta) >= cuts.minDEta;
+  }
+
+  return false;
+}
+

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
@@ -43,8 +43,6 @@ std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
   double ptSum = 0.;
   int nrTrks = 0;
 
-  std::cout << "obj eta " << objEta << " obj phi " << objPhi << " objZ " << objZ << std::endl;
-
   const TrkCuts& cuts = std::abs(objEta) < 1.5 ? barrelCuts_ : endcapCuts_;
 
   for (auto& trk : tracks) {

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
@@ -9,7 +9,7 @@ EgammaL1TkIsolation::EgammaL1TkIsolation(const edm::ParameterSet& para)
       etaBoundaries_(para.getParameter<std::vector<double>>("etaBoundaries")) {
   const auto& trkCutParams = para.getParameter<std::vector<edm::ParameterSet>>("trkCuts");
   for (const auto& params : trkCutParams) {
-    trkCuts_.push_back(TrkCuts(params));
+    trkCuts_.emplace_back(TrkCuts(params));
   }
   if (etaBoundaries_.size() + 1 != trkCuts_.size()) {
     throw cms::Exception("ConfigError") << "EgammaL1TkIsolation: etaBoundaries parameters size ("
@@ -52,6 +52,25 @@ std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
   return {nrTrks, ptSum};
 }
 
+EgammaL1TkIsolation::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
+  minPt = para.getParameter<double>("minPt");
+  auto sq = [](double val) { return val * val; };
+  minDR2 = sq(para.getParameter<double>("minDR"));
+  maxDR2 = sq(para.getParameter<double>("maxDR"));
+  minDEta = para.getParameter<double>("minDEta");
+  maxDZ = para.getParameter<double>("maxDZ");
+}
+
+edm::ParameterSetDescription EgammaL1TkIsolation::TrkCuts::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("minPt", 2.0);
+  desc.add<double>("maxDR", 0.3);
+  desc.add<double>("minDR", 0.01);
+  desc.add<double>("minDEta", 0.003);
+  desc.add<double>("maxDZ", 0.7);
+  return desc;
+}
+
 //as we have verfied that trkCuts_ size is etaBoundaries_ size +1
 //then this is always a valid binnr for trkCuts_
 size_t EgammaL1TkIsolation::etaBinNr(double eta) const {
@@ -77,23 +96,4 @@ bool EgammaL1TkIsolation::passTrkSel(const L1Track& trk,
   }
 
   return false;
-}
-
-EgammaL1TkIsolation::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
-  minPt = para.getParameter<double>("minPt");
-  auto sq = [](double val) { return val * val; };
-  minDR2 = sq(para.getParameter<double>("minDR"));
-  maxDR2 = sq(para.getParameter<double>("maxDR"));
-  minDEta = para.getParameter<double>("minDEta");
-  maxDZ = para.getParameter<double>("maxDZ");
-}
-
-edm::ParameterSetDescription EgammaL1TkIsolation::TrkCuts::makePSetDescription() {
-  edm::ParameterSetDescription desc;
-  desc.add<double>("minPt", 2.0);
-  desc.add<double>("maxDR", 0.3);
-  desc.add<double>("minDR", 0.01);
-  desc.add<double>("minDEta", 0.003);
-  desc.add<double>("maxDZ", 0.7);
-  return desc;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
@@ -2,34 +2,31 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-EgammaL1TkIsolation::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
-  minPt = para.getParameter<double>("minPt");
-  auto sq = [](double val) { return val * val; };
-  minDR2 = sq(para.getParameter<double>("minDR"));
-  maxDR2 = sq(para.getParameter<double>("maxDR"));
-  minDEta = para.getParameter<double>("minDEta");
-  maxDZ = para.getParameter<double>("maxDZ");
-}
-
-edm::ParameterSetDescription EgammaL1TkIsolation::TrkCuts::pSetDescript() {
-  edm::ParameterSetDescription desc;
-  desc.add<double>("minPt", 2.0);
-  desc.add<double>("maxDR", 0.3);
-  desc.add<double>("minDR", 0.01);
-  desc.add<double>("minDEta", 0.003);
-  desc.add<double>("maxDZ", 0.7);
-  return desc;
-}
+#include <algorithm>
 
 EgammaL1TkIsolation::EgammaL1TkIsolation(const edm::ParameterSet& para)
-    : barrelCuts_(para.getParameter<edm::ParameterSet>("barrelCuts")),
-      endcapCuts_(para.getParameter<edm::ParameterSet>("endcapCuts")) {}
+    : useAbsEta_(para.getParameter<bool>("useAbsEta")),
+      etaBoundaries_(para.getParameter<std::vector<double>>("etaBoundaries")) {
+  const auto& trkCutParams = para.getParameter<std::vector<edm::ParameterSet>>("trkCuts");
+  for (const auto& params : trkCutParams) {
+    trkCuts_.push_back(TrkCuts(params));
+  }
+  if (etaBoundaries_.size() + 1 != trkCuts_.size()) {
+    throw cms::Exception("ConfigError") << "EgammaL1TkIsolation: etaBoundaries parameters size ("
+                                        << etaBoundaries_.size()
+                                        << ") should be one less than the size of trkCuts VPSet (" << trkCuts_.size()
+                                        << ")";
+  }
+  if (!std::is_sorted(etaBoundaries_.begin(), etaBoundaries_.end())) {
+    throw cms::Exception("ConfigError")
+        << "EgammaL1TkIsolation: etaBoundaries parameter's entries should be in increasing value";
+  }
+}
 
-edm::ParameterSetDescription EgammaL1TkIsolation::pSetDescript() {
-  edm::ParameterSetDescription desc;
-  desc.add("barrelCuts", TrkCuts::pSetDescript());
-  desc.add("endcapCuts", TrkCuts::pSetDescript());
-  return desc;
+void EgammaL1TkIsolation::fillPSetDescription(edm::ParameterSetDescription& desc) {
+  desc.add("useAbsEta", true);
+  desc.add("etaBoundaries", std::vector{1.5});
+  desc.addVPSet("trkCuts", TrkCuts::makePSetDescription(), {edm::ParameterSet(), edm::ParameterSet()});
 }
 
 std::pair<int, double> EgammaL1TkIsolation::calIsol(const reco::TrackBase& trk, const L1TrackCollection& tracks) const {
@@ -43,9 +40,9 @@ std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
   double ptSum = 0.;
   int nrTrks = 0;
 
-  const TrkCuts& cuts = std::abs(objEta) < 1.5 ? barrelCuts_ : endcapCuts_;
+  const TrkCuts& cuts = trkCuts_[etaBinNr(objEta)];
 
-  for (auto& trk : tracks) {
+  for (const auto& trk : tracks) {
     const float trkPt = trk.momentum().perp();
     if (passTrkSel(trk, trkPt, cuts, objEta, objPhi, objZ)) {
       ptSum += trkPt;
@@ -53,6 +50,17 @@ std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
     }
   }
   return {nrTrks, ptSum};
+}
+
+//as we have verfied that trkCuts_ size is etaBoundaries_ size +1
+//then this is always a valid binnr for trkCuts_
+size_t EgammaL1TkIsolation::etaBinNr(double eta) const {
+  if (useAbsEta_) {
+    eta = std::abs(eta);
+  }
+  auto res = std::upper_bound(etaBoundaries_.begin(), etaBoundaries_.end(), eta);
+  size_t binNr = std::distance(etaBoundaries_.begin(), res);
+  return binNr;
 }
 
 bool EgammaL1TkIsolation::passTrkSel(const L1Track& trk,
@@ -69,4 +77,23 @@ bool EgammaL1TkIsolation::passTrkSel(const L1Track& trk,
   }
 
   return false;
+}
+
+EgammaL1TkIsolation::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
+  minPt = para.getParameter<double>("minPt");
+  auto sq = [](double val) { return val * val; };
+  minDR2 = sq(para.getParameter<double>("minDR"));
+  maxDR2 = sq(para.getParameter<double>("maxDR"));
+  minDEta = para.getParameter<double>("minDEta");
+  maxDZ = para.getParameter<double>("maxDZ");
+}
+
+edm::ParameterSetDescription EgammaL1TkIsolation::TrkCuts::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("minPt", 2.0);
+  desc.add<double>("maxDR", 0.3);
+  desc.add<double>("minDR", 0.01);
+  desc.add<double>("minDEta", 0.003);
+  desc.add<double>("maxDZ", 0.7);
+  return desc;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaL1TkIsolation.cc
@@ -32,21 +32,18 @@ edm::ParameterSetDescription EgammaL1TkIsolation::pSetDescript() {
   return desc;
 }
 
-
-
-std::pair<int, double> EgammaL1TkIsolation::calIsol(const reco::TrackBase& trk,
-                                                   const L1TrackCollection& tracks) const {
+std::pair<int, double> EgammaL1TkIsolation::calIsol(const reco::TrackBase& trk, const L1TrackCollection& tracks) const {
   return calIsol(trk.eta(), trk.phi(), trk.vz(), tracks);
 }
 
 std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
-                                                   const double objPhi,
-                                                   const double objZ,
-                                                   const L1TrackCollection& tracks) const {
+                                                    const double objPhi,
+                                                    const double objZ,
+                                                    const L1TrackCollection& tracks) const {
   double ptSum = 0.;
   int nrTrks = 0;
 
-  std::cout <<"obj eta "<<objEta<<" obj phi "<<objPhi<<" objZ "<<objZ<<std::endl;
+  std::cout << "obj eta " << objEta << " obj phi " << objPhi << " objZ " << objZ << std::endl;
 
   const TrkCuts& cuts = std::abs(objEta) < 1.5 ? barrelCuts_ : endcapCuts_;
 
@@ -61,20 +58,17 @@ std::pair<int, double> EgammaL1TkIsolation::calIsol(const double objEta,
 }
 
 bool EgammaL1TkIsolation::passTrkSel(const L1Track& trk,
-				     const double trkPt,
-				     const TrkCuts& cuts,
-				     const double objEta,
-				     const double objPhi,
-				     const double objZ) {
-
-  if(trkPt > cuts.minPt && 
-     std::abs(objZ-trk.z0()) < cuts.maxDZ){
+                                     const double trkPt,
+                                     const TrkCuts& cuts,
+                                     const double objEta,
+                                     const double objPhi,
+                                     const double objZ) {
+  if (trkPt > cuts.minPt && std::abs(objZ - trk.z0()) < cuts.maxDZ) {
     const float trkEta = trk.eta();
-    const float dEta =  trkEta - objEta;
+    const float dEta = trkEta - objEta;
     const float dR2 = reco::deltaR2(objEta, objPhi, trkEta, trk.phi());
     return dR2 >= cuts.minDR2 && dR2 <= cuts.maxDR2 && std::abs(dEta) >= cuts.minDEta;
   }
 
   return false;
 }
-


### PR DESCRIPTION
#### PR description:

This is allows track isolation with L1 tracks to be produced for electrons for the E/g HLT. Part of this PR also introduces a typedef for a TTTrack<Ref_Phase2TrackerDigi_> to L1Track. This in my opinion should have been done a long time ago and such a typedef needs to exist centrally as people are already making their own. I dont care too much about the name. 

Additionally in validation a "bug" was found with the track ambiguity solving for electrons in the HLT which will be fixed at a later date. Ie we seem to be picking the wrong track in a few cases and we should solve it. 

Note, an example test config will not be provided for 11_3_X because of the difficulties of porting the HLT phase II between releases.  A test config can be provided for 11_1_X on request but it'll be 50K lines of python

#### PR validation:

Tested in phase-II HLT setup and gives expected results.


