### PR TITLE
Migrate to esConsumes two Cond* packages

### DIFF
--- a/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
+++ b/CondTools/SiPhase2Tracker/plugins/DTCCablingMapTestReader.cc
@@ -24,7 +24,6 @@ Implementation:
 #include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -50,6 +49,9 @@ private:
   void beginJob() override;
   void analyze(const edm::Event&, const edm::EventSetup&) override;
   void endJob() override;
+
+  // ----------member data ---------------------------
+  const edm::ESGetToken<TrackerDetToDTCELinkCablingMap, TrackerDetToDTCELinkCablingMapRcd> cablingMapToken_;
 };
 
 void DTCCablingMapTestReader::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -60,7 +62,7 @@ void DTCCablingMapTestReader::fillDescriptions(edm::ConfigurationDescriptions& d
   descriptions.add("DTCCablingMapTestReader", desc);
 }
 
-DTCCablingMapTestReader::DTCCablingMapTestReader(const edm::ParameterSet& iConfig) {}
+DTCCablingMapTestReader::DTCCablingMapTestReader(const edm::ParameterSet& iConfig) : cablingMapToken_(esConsumes()) {}
 
 DTCCablingMapTestReader::~DTCCablingMapTestReader() {}
 
@@ -68,9 +70,7 @@ void DTCCablingMapTestReader::analyze(const edm::Event& iEvent, const edm::Event
   using namespace edm;
   using namespace std;
 
-  edm::ESHandle<TrackerDetToDTCELinkCablingMap> cablingMapHandle;
-  iSetup.get<TrackerDetToDTCELinkCablingMapRcd>().get(cablingMapHandle);
-  TrackerDetToDTCELinkCablingMap const* p_cablingMap = cablingMapHandle.product();
+  const auto p_cablingMap = &iSetup.getData(cablingMapToken_);
 
   {
     ostringstream dump_DetToElink;

--- a/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
+++ b/CondTools/SiPhase2Tracker/plugins/SiPhase2OuterTrackerLorentzAngleWriter.cc
@@ -56,6 +56,8 @@ private:
   void endJob() override;
 
   // ----------member data ---------------------------
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> topoToken_;
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> geomToken_;
   std::string m_record;
   std::string m_tag;
   float m_value;
@@ -65,7 +67,9 @@ private:
 // constructors and destructor
 //
 SiPhase2OuterTrackerLorentzAngleWriter::SiPhase2OuterTrackerLorentzAngleWriter(const edm::ParameterSet& iConfig)
-    : m_record(iConfig.getParameter<std::string>("record")),
+    : topoToken_(esConsumes()),
+      geomToken_(esConsumes()),
+      m_record(iConfig.getParameter<std::string>("record")),
       m_tag(iConfig.getParameter<std::string>("tag")),
       m_value(iConfig.getParameter<double>("value")) {}
 
@@ -101,13 +105,10 @@ void SiPhase2OuterTrackerLorentzAngleWriter::analyze(const edm::Event& iEvent, c
   std::unordered_map<unsigned int, float> detsLAtoDB;
 
   // Retrieve tracker topology from geometry
-  edm::ESHandle<TrackerTopology> tTopoHandle;
-  iSetup.get<TrackerTopologyRcd>().get(tTopoHandle);
-  const TrackerTopology* const tTopo = tTopoHandle.product();
+  const TrackerTopology* const tTopo = &iSetup.getData(topoToken_);
 
   // Retrieve old style tracker geometry from geometry
-  edm::ESHandle<TrackerGeometry> pDD;
-  iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
+  const TrackerGeometry* pDD = &iSetup.getData(geomToken_);
   edm::LogInfo("SiPhase2OuterTrackerLorentzAngleWriter")
       << " There are " << pDD->detUnits().size() << " modules in this geometry." << std::endl;
 


### PR DESCRIPTION
#### PR description:

As title says, migrate to esConsumes two Cond* packages:  `CondFormats/PCLConfig`  and ` CondTools/SiPhase2Tracker`.

#### PR validation:

Relies on private tests

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, no backport needed.
