### PR TITLE
PPS: fix z sign in diamond geometry

### DIFF
--- a/Geometry/VeryForwardData/data/2021/v1/CTPPS_Timing_Stations_Assembly.xml
+++ b/Geometry/VeryForwardData/data/2021/v1/CTPPS_Timing_Stations_Assembly.xml
@@ -2,10 +2,10 @@
 <DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
   <ConstantsSection label="CTPPS_Timing_Stations_Assembly.xml" eval="true">
     <!--positions of the stations from the IP5 to the first element of the station-->
-    <Constant name="CTPPS_Timing_Negative_Station_Position_z_1" value="-215.078*m"/>
-    <Constant name="CTPPS_Timing_Positive_Station_Position_z_1" value="215.078*m"/>
-    <Constant name="CTPPS_Timing_Negative_Station_Position_z_2" value="-215.7*m"/>
-    <Constant name="CTPPS_Timing_Positive_Station_Position_z_2" value="215.7*m"/>
+    <Constant name="CTPPS_Timing_Negative_Station_Position_z_1" value="+215.078*m"/>
+    <Constant name="CTPPS_Timing_Positive_Station_Position_z_1" value="-215.078*m"/>
+    <Constant name="CTPPS_Timing_Negative_Station_Position_z_2" value="+215.700*m"/>
+    <Constant name="CTPPS_Timing_Positive_Station_Position_z_2" value="-215.700*m"/>
   </ConstantsSection>
   <PosPartSection label="CTPPS_Timing_Stations_Assembly.xml">
     <PosPart copyNumber="22">

--- a/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
+++ b/Geometry/VeryForwardGeometryBuilder/interface/DetGeomDesc.h
@@ -107,6 +107,8 @@ public:
 
   void print() const;
 
+  void invertZSign() { m_trans.SetZ(-m_trans.z()); }
+
 private:
   void deleteComponents();      // deletes just the first daughters
   void deepDeleteComponents();  // traverses the tree and deletes all nodes.

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDescBuilder.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDescBuilder.cc
@@ -1,5 +1,6 @@
 #include "Geometry/VeryForwardGeometryBuilder/interface/DetGeomDescBuilder.h"
 
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
 #include "DetectorDescription/DDCMS/interface/DDDetector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -33,8 +34,15 @@ void detgeomdescbuilder::buildDetGeomDescDescendants(DDFilteredView& fv, DetGeom
     return;
 
   do {
-    // Create node, and add it to the geoInfoParent's list.
+    // Create node
     DetGeomDesc* child = new DetGeomDesc(fv, isRun2);
+
+    // legacy Run2 z sign fix for diamond detectors
+    const auto &detId = child->geographicalID();
+    if (isRun2 && detId.subdetId() == CTPPSDetId::sdTimingDiamond)
+      child->invertZSign();
+
+    // add the to the geoInfoParent's list.
     geoInfo->addComponent(child);
 
     // Recursion
@@ -62,8 +70,15 @@ std::unique_ptr<DetGeomDesc> detgeomdescbuilder::buildDetGeomDescFromCompactView
 
   // Construct the tree of children geo info (DetGeomDesc).
   do {
-    // Create node, and add it to the geoInfoRoot's list.
+    // Create node
     DetGeomDesc* child = new DetGeomDesc(fv, isRun2);
+
+    // legacy Run2 z sign fix for diamond detectors
+    const auto &detId = child->geographicalID();
+    if (isRun2 && detId.subdetId() == CTPPSDetId::sdTimingDiamond)
+      child->invertZSign();
+
+    // add the node to the geoInfoRoot's list.
     geoInfoRoot->addComponent(child);
   } while (fv.next(0));
 

--- a/Geometry/VeryForwardGeometryBuilder/src/DetGeomDescBuilder.cc
+++ b/Geometry/VeryForwardGeometryBuilder/src/DetGeomDescBuilder.cc
@@ -38,7 +38,7 @@ void detgeomdescbuilder::buildDetGeomDescDescendants(DDFilteredView& fv, DetGeom
     DetGeomDesc* child = new DetGeomDesc(fv, isRun2);
 
     // legacy Run2 z sign fix for diamond detectors
-    const auto &detId = child->geographicalID();
+    const auto& detId = child->geographicalID();
     if (isRun2 && detId.subdetId() == CTPPSDetId::sdTimingDiamond)
       child->invertZSign();
 
@@ -74,7 +74,7 @@ std::unique_ptr<DetGeomDesc> detgeomdescbuilder::buildDetGeomDescFromCompactView
     DetGeomDesc* child = new DetGeomDesc(fv, isRun2);
 
     // legacy Run2 z sign fix for diamond detectors
-    const auto &detId = child->geographicalID();
+    const auto& detId = child->geographicalID();
     if (isRun2 && detId.subdetId() == CTPPSDetId::sdTimingDiamond)
       child->invertZSign();
 

--- a/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -411,8 +411,7 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
                 continue;
 
               // interpolation from tracking RPs
-              const double z_ti =
-                  -hGeometry->rpTranslation(tr_ti.rpId()).z();  // the minus sign fixes a bug in the diamond geometry
+              const double z_ti = hGeometry->rpTranslation(tr_ti.rpId()).z();
               const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
               const double x_inter = f_i * tr_i.x() + f_j * tr_j.x();
               const double x_inter_unc_sq =

--- a/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -498,7 +498,7 @@ void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSe
 
         // save single-RP results (un-indexed)
         for (const auto &p : singleRPResultsIndexed)
-          pOutSingleRP->emplace_back(std::move(p.second));
+          pOutSingleRP->emplace_back(p.second);
       }
 
       // dump log

--- a/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
+++ b/Validation/CTPPS/plugins/CTPPSDirectProtonSimulation.cc
@@ -458,9 +458,7 @@ void CTPPSDirectProtonSimulation::processProton(
       const auto &gl_a1 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(1, 0, 0)) - gl_o;
       const auto &gl_a2 = geometry.localToGlobal(detId, CTPPSGeometry::Vector(0, 1, 0)) - gl_o;
 
-      double gl_o_z = gl_o.z();
-      if (detId.subdetId() == CTPPSDetId::sdTimingDiamond)
-        gl_o_z = -gl_o_z;  // fix bug in diamond geometry
+      const double gl_o_z = gl_o.z();
 
       TMatrixD A(3, 3);
       TVectorD B(3);


### PR DESCRIPTION
#### PR description:

Up to now, the z sign of diamond-RP geometry has been wrong (i.e. inconsistent with other PPS RPs).

This PR brings a fix:
  * for Run3 geometry, the fix is applied directly in the geometry XML file
  * for Run2 geometry, the fix is applied in the geometry builder code - in order to avoid the need to re-upload the geometry to DB, revalidate, ...

Thanks to the fix, the mitigation code is removed from:
  * proton-reco module
  * direct-simulation module

This is a technical PR, no change in results is expected.

#### PR validation:

Below few snippets from PPS geometry print out (module ``CTPPSGeometryInfo``). ``ce`` stands for the detector centre, the z component is the last number.

  * 2018, before PR:
```
2054160384 (diamd RP  16) | ce=(+73.050, -0.000, +215700.000)
2070937600 (diamd RP 116) | ce=(+73.050, -0.000, -215700.000)

2054160384 (diamd RP  16, plane 0, channel  0) | ce=(+3.325, +0.000, +215679.449)
2054164480 (diamd RP  16, plane 0, channel  1) | ce=(+4.825, +0.000, +215679.449)

2070937600 (diamd RP 116, plane 0, channel  0) | ce=(+3.325, +0.000, -215720.551)
2070941696 (diamd RP 116, plane 0, channel  1) | ce=(+4.825, +0.000, -215720.551)
```

  * 2018, after PR:
```
2054160384 (diamd RP  16) | ce=(+73.050, -0.000, -215700.000)
2070937600 (diamd RP 116) | ce=(+73.050, -0.000, +215700.000)

2054160384 (diamd RP  16, plane 0, channel  0) | ce=(+3.325, +0.000, -215679.449)
2054164480 (diamd RP  16, plane 0, channel  1) | ce=(+4.825, +0.000, -215679.449)

2070937600 (diamd RP 116, plane 0, channel  0) | ce=(+3.325, +0.000, +215720.551)
2070941696 (diamd RP 116, plane 0, channel  1) | ce=(+4.825, +0.000, +215720.551)
```

  * 2021, after PR:
```
2054160384 (diamd RP  16) | ce=(+72.050, -0.000, -215700.000)
2056257536 (diamd RP  22) | ce=(+72.050, -0.000, -215078.000)
2070937600 (diamd RP 116) | ce=(+72.050, -0.000, +215700.000)
2073034752 (diamd RP 122) | ce=(+72.050, -0.000, +215078.000)

2054160384 (diamd RP  16, plane 0, channel  0) | ce=(+2.325, +0.000, -215720.551)
2054164480 (diamd RP  16, plane 0, channel  1) | ce=(+3.825, +0.000, -215720.551)

2070937600 (diamd RP 116, plane 0, channel  0) | ce=(+2.325, +0.000, +215679.449)
2070941696 (diamd RP 116, plane 0, channel  1) | ce=(+3.825, +0.000, +215679.449)
```

Interpretation of the snippets:
  * 2018, comparison of before and after this PR: only the z component changed sign, as expected
  * comparison 2018 and 2021, both after the PR: the z signs are identical and correct (negative for LHC sector 45, positive for LHC sector 56)

Addition comparison plots (before and after the PR):
  * [dirsim_cmp.pdf](https://github.com/cms-sw/cmssw/files/5771116/dirsim_cmp.pdf): direct simulation of PPS
  * [reco_cmp.pdf](https://github.com/cms-sw/cmssw/files/5771118/reco_cmp.pdf): PPS reco of Run2 data
  * no difference observed - as expected 
