### PR TITLE
Reduce use of Worker::doWork

### DIFF
--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -696,7 +696,10 @@ namespace edm {
         ParentContext parentContext(&streamContext_);
         using Traits = OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>;
 
-        results_inserter_->doWork<Traits>(info, streamID_, parentContext, &streamContext_);
+        auto expt = results_inserter_->runModuleDirectly<Traits>(info, streamID_, parentContext, &streamContext_);
+        if (expt) {
+          std::rethrow_exception(expt);
+        }
       } catch (cms::Exception& ex) {
         if (not iExcept) {
           if (ex.context().empty()) {

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
@@ -125,7 +126,14 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(
+        edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), s_streamID0, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicProd : public edm::global::EDFilter<> {
@@ -476,6 +484,7 @@ namespace {
 
 template <typename T>
 void testGlobalFilter::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
   edm::maker::ModuleHolderT<edm::global::EDFilterBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
 

--- a/FWCore/Framework/test/global_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/global_filter_t.cppunit.cc
@@ -29,6 +29,25 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID() : value(0) {}
+    unsigned int value;
+  };
+
+  union IDUnion {
+    IDUnion() : m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}  // namespace
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
 class testGlobalFilter : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testGlobalFilter);
 
@@ -103,6 +122,11 @@ private:
 
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+  }
 
   class BasicProd : public edm::global::EDFilter<> {
   public:
@@ -328,25 +352,6 @@ private:
   };
 };
 
-namespace {
-  struct ShadowStreamID {
-    constexpr ShadowStreamID() : value(0) {}
-    unsigned int value;
-  };
-
-  union IDUnion {
-    IDUnion() : m_shadow() {}
-    ShadowStreamID m_shadow;
-    edm::StreamID m_id;
-  };
-}  // namespace
-static edm::StreamID makeID() {
-  IDUnion u;
-  assert(u.m_id.value() == 0);
-  return u.m_id;
-}
-static const edm::StreamID s_streamID0 = makeID();
-
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalFilter);
 
@@ -386,26 +391,26 @@ testGlobalFilter::testGlobalFilter()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
@@ -414,33 +419,33 @@ testGlobalFilter::testGlobalFilter()
     edm::ParentContext nullParentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {

--- a/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/global_outputmodule_t.cppunit.cc
@@ -93,6 +93,11 @@ private:
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
 
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, id, iContext, nullptr);
+  }
+
   class BasicOutputModule : public edm::global::OutputModule<> {
   public:
     using edm::global::OutputModuleBase::doPreallocate;
@@ -181,14 +186,14 @@ testGlobalOutputModule::testGlobalOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
@@ -197,14 +202,14 @@ testGlobalOutputModule::testGlobalOutputModule()
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, s_streamID0, parentContext);
   };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
@@ -218,7 +223,7 @@ testGlobalOutputModule::testGlobalOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
@@ -125,7 +126,14 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(
+        edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), s_streamID0, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicProd : public edm::global::EDProducer<> {
@@ -440,6 +448,8 @@ namespace {
 
 template <typename T>
 void testGlobalProducer::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   edm::maker::ModuleHolderT<edm::global::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
 

--- a/FWCore/Framework/test/global_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/global_producer_t.cppunit.cc
@@ -29,6 +29,25 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID() : value(0) {}
+    unsigned int value;
+  };
+
+  union IDUnion {
+    IDUnion() : m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}  // namespace
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
 class testGlobalProducer : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testGlobalProducer);
 
@@ -103,6 +122,11 @@ private:
 
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+  }
 
   class BasicProd : public edm::global::EDProducer<> {
   public:
@@ -292,25 +316,6 @@ private:
   };
 };
 
-namespace {
-  struct ShadowStreamID {
-    constexpr ShadowStreamID() : value(0) {}
-    unsigned int value;
-  };
-
-  union IDUnion {
-    IDUnion() : m_shadow() {}
-    ShadowStreamID m_shadow;
-    edm::StreamID m_id;
-  };
-}  // namespace
-static edm::StreamID makeID() {
-  IDUnion u;
-  assert(u.m_id.value() == 0);
-  return u.m_id;
-}
-static const edm::StreamID s_streamID0 = makeID();
-
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalProducer);
 
@@ -350,26 +355,26 @@ testGlobalProducer::testGlobalProducer()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
@@ -378,33 +383,33 @@ testGlobalProducer::testGlobalProducer()
     edm::ParentContext nullParentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {

--- a/FWCore/Framework/test/limited_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_filter_t.cppunit.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/EDFilter.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
@@ -135,7 +136,14 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(
+        edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), s_streamID0, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicProd : public edm::limited::EDFilter<> {
@@ -504,6 +512,8 @@ namespace {
 
 template <typename T>
 void testLimitedFilter::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   edm::maker::ModuleHolderT<edm::limited::EDFilterBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
   edm::WorkerT<edm::limited::EDFilterBase> w{iMod, m_desc, nullptr};

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -93,6 +93,11 @@ private:
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
 
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, id, iContext, nullptr);
+  }
+
   class BasicOutputModule : public edm::limited::OutputModule<> {
   public:
     using edm::limited::OutputModuleBase::doPreallocate;
@@ -180,14 +185,14 @@ testLimitedOutputModule::testLimitedOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
@@ -196,14 +201,14 @@ testLimitedOutputModule::testLimitedOutputModule()
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, s_streamID0, parentContext);
   };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
@@ -217,7 +222,7 @@ testLimitedOutputModule::testLimitedOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);

--- a/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_outputmodule_t.cppunit.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/OutputModule.h"
 #include "FWCore/Framework/src/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
@@ -95,7 +96,13 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, id, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), id, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicOutputModule : public edm::limited::OutputModule<> {
@@ -283,6 +290,8 @@ namespace {
 
 template <typename T>
 void testLimitedOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::limited::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
   edm::OutputModuleCommunicatorT<edm::limited::OutputModuleBase> comm(iMod.get());

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -40,6 +40,25 @@ namespace {
   const edm::ParameterSet s_pset = makePSet();
 }  // namespace
 
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID() : value(0) {}
+    unsigned int value;
+  };
+
+  union IDUnion {
+    IDUnion() : m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}  // namespace
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
 class testLimitedProducer : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testLimitedProducer);
 
@@ -113,6 +132,11 @@ private:
 
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
+
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+  }
 
   class BasicProd : public edm::limited::EDProducer<> {
   public:
@@ -324,25 +348,6 @@ private:
   };
 };
 
-namespace {
-  struct ShadowStreamID {
-    constexpr ShadowStreamID() : value(0) {}
-    unsigned int value;
-  };
-
-  union IDUnion {
-    IDUnion() : m_shadow() {}
-    ShadowStreamID m_shadow;
-    edm::StreamID m_id;
-  };
-}  // namespace
-static edm::StreamID makeID() {
-  IDUnion u;
-  assert(u.m_id.value() == 0);
-  return u.m_id;
-}
-static const edm::StreamID s_streamID0 = makeID();
-
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testLimitedProducer);
 
@@ -381,26 +386,26 @@ testLimitedProducer::testLimitedProducer()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
@@ -409,33 +414,33 @@ testLimitedProducer::testLimitedProducer()
     edm::ParentContext nullParentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext nullParentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, nullParentContext, nullptr);
+    doWork<Traits>(iBase, info, nullParentContext);
   };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {

--- a/FWCore/Framework/test/limited_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/limited_producer_t.cppunit.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/limited/EDProducer.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
@@ -135,7 +136,14 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(
+        edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), s_streamID0, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicProd : public edm::limited::EDProducer<> {
@@ -471,6 +479,8 @@ namespace {
 
 template <typename T>
 void testLimitedProducer::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   edm::maker::ModuleHolderT<edm::limited::EDProducerBase> h(iMod, nullptr);
   h.preallocate(edm::PreallocationConfiguration{});
   edm::WorkerT<edm::limited::EDProducerBase> w{iMod, m_desc, nullptr};

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -10,6 +10,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/src/OutputModuleCommunicatorT.h"
 #include "FWCore/Framework/src/TransitionInfoTypes.h"
@@ -107,7 +108,13 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, id, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), id, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   class BasicOutputModule : public edm::one::OutputModule<> {
@@ -378,6 +385,8 @@ namespace {
 
 template <typename T>
 void testOneOutputModule::testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   iMod->doPreallocate(m_preallocConfig);
   edm::WorkerT<edm::one::OutputModuleBase> w{iMod, m_desc, m_params.actions_};
   w.beginJob();

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -105,6 +105,11 @@ private:
   template <typename T>
   void testTransitions(std::shared_ptr<T> iMod, Expectations const& iExpect);
 
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::StreamID id, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, id, iContext, nullptr);
+  }
+
   class BasicOutputModule : public edm::one::OutputModule<> {
   public:
     using edm::one::OutputModuleBase::doPreallocate;
@@ -275,14 +280,14 @@ testOneOutputModule::testOneOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator*) {
@@ -291,14 +296,14 @@ testOneOutputModule::testOneOutputModule()
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, s_streamID0, parentContext);
   };
 
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase, edm::OutputModuleCommunicator* iComm) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeLumiAsync(edm::WaitingTaskHolder(t.get()), *m_lbp, nullptr, &activityRegistry);
@@ -312,7 +317,7 @@ testOneOutputModule::testOneOutputModule()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, edm::StreamID::invalidStreamID(), parentContext, nullptr);
+    doWork<Traits>(iBase, info, edm::StreamID::invalidStreamID(), parentContext);
     auto t = edm::make_empty_waiting_task();
     t->increment_ref_count();
     iComm->writeRunAsync(edm::WaitingTaskHolder(t.get()), *m_rp, nullptr, &activityRegistry, nullptr);

--- a/FWCore/Framework/test/stream_filter_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_filter_t.cppunit.cc
@@ -29,6 +29,25 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID() : value(0) {}
+    unsigned int value;
+  };
+
+  union IDUnion {
+    IDUnion() : m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}  // namespace
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
 class testStreamFilter : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testStreamFilter);
 
@@ -102,6 +121,11 @@ private:
 
   template <typename T, typename U>
   void testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect);
+
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+  }
 
   template <typename T>
   void runTest(Expectations const& iExpect);
@@ -403,25 +427,6 @@ bool testStreamFilter::EndLumiSummaryProd::m_globalEndLuminosityBlockSummaryCall
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testStreamFilter);
 
-namespace {
-  struct ShadowStreamID {
-    constexpr ShadowStreamID() : value(0) {}
-    unsigned int value;
-  };
-
-  union IDUnion {
-    IDUnion() : m_shadow() {}
-    ShadowStreamID m_shadow;
-    edm::StreamID m_id;
-  };
-}  // namespace
-static edm::StreamID makeID() {
-  IDUnion u;
-  assert(u.m_id.value() == 0);
-  return u.m_id;
-}
-static const edm::StreamID s_streamID0 = makeID();
-
 testStreamFilter::testStreamFilter()
     : m_prodReg(new edm::ProductRegistry{}),
       m_idHelper(new edm::BranchIDListHelper{}),
@@ -464,26 +469,26 @@ testStreamFilter::testStreamFilter()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
@@ -492,33 +497,33 @@ testStreamFilter::testStreamFilter()
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -29,6 +29,25 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+namespace {
+  struct ShadowStreamID {
+    constexpr ShadowStreamID() : value(0) {}
+    unsigned int value;
+  };
+
+  union IDUnion {
+    IDUnion() : m_shadow() {}
+    ShadowStreamID m_shadow;
+    edm::StreamID m_id;
+  };
+}  // namespace
+static edm::StreamID makeID() {
+  IDUnion u;
+  assert(u.m_id.value() == 0);
+  return u.m_id;
+}
+static const edm::StreamID s_streamID0 = makeID();
+
 class testStreamProducer : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testStreamProducer);
 
@@ -102,6 +121,11 @@ private:
 
   template <typename T, typename U>
   void testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect);
+
+  template <typename Traits, typename Info>
+  void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
+    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+  }
 
   template <typename T>
   void runTest(Expectations const& iExpect);
@@ -364,25 +388,6 @@ bool testStreamProducer::EndLumiSummaryProd::m_globalEndLuminosityBlockSummaryCa
 ///registration of the test so that the runner can find it
 CPPUNIT_TEST_SUITE_REGISTRATION(testStreamProducer);
 
-namespace {
-  struct ShadowStreamID {
-    constexpr ShadowStreamID() : value(0) {}
-    unsigned int value;
-  };
-
-  union IDUnion {
-    IDUnion() : m_shadow() {}
-    ShadowStreamID m_shadow;
-    edm::StreamID m_id;
-  };
-}  // namespace
-static edm::StreamID makeID() {
-  IDUnion u;
-  assert(u.m_id.value() == 0);
-  return u.m_id;
-}
-static const edm::StreamID s_streamID0 = makeID();
-
 testStreamProducer::testStreamProducer()
     : m_prodReg(new edm::ProductRegistry{}),
       m_idHelper(new edm::BranchIDListHelper{}),
@@ -425,26 +430,26 @@ testStreamProducer::testStreamProducer()
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
@@ -453,33 +458,33 @@ testStreamProducer::testStreamProducer()
     edm::ParentContext parentContext(&streamContext);
     iBase->setActivityRegistry(m_actReg);
     edm::EventTransitionInfo info(*m_ep, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::LumiTransitionInfo info(*m_lbp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
   m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
     edm::ParentContext parentContext;
     edm::RunTransitionInfo info(*m_rp, *m_es);
-    iBase->doWork<Traits>(info, s_streamID0, parentContext, nullptr);
+    doWork<Traits>(iBase, info, parentContext);
   };
 
   m_transToFunc[Trans::kEndStream] = [](edm::Worker* iBase) {

--- a/FWCore/Framework/test/stream_producer_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_producer_t.cppunit.cc
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include "tbb/global_control.h"
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/src/ModuleHolder.h"
@@ -124,7 +125,14 @@ private:
 
   template <typename Traits, typename Info>
   void doWork(edm::Worker* iBase, Info const& info, edm::ParentContext const& iContext) {
-    iBase->doWork<Traits>(info, s_streamID0, iContext, nullptr);
+    auto task = edm::make_empty_waiting_task();
+    task->increment_ref_count();
+    iBase->doWorkAsync<Traits>(
+        edm::WaitingTaskHolder(task.get()), info, edm::ServiceToken(), s_streamID0, iContext, nullptr);
+    task->wait_for_all();
+    if (auto e = task->exceptionPtr()) {
+      std::rethrow_exception(*e);
+    }
   }
 
   template <typename T>
@@ -524,6 +532,8 @@ namespace {
 
 template <typename T, typename U>
 void testStreamProducer::testTransitions(std::shared_ptr<U> iMod, Expectations const& iExpect) {
+  tbb::global_control control(tbb::global_control::max_allowed_parallelism, 1);
+
   edm::WorkerT<edm::stream::EDProducerAdaptorBase> w{iMod, m_desc, nullptr};
   for (auto& keyVal : m_transToFunc) {
     testTransition<T>(&w, keyVal.first, iExpect, keyVal.second);

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_unscheduled.log
@@ -244,8 +244,6 @@ ModuleCallingContext state = Running
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
@@ -360,8 +358,6 @@ ModuleCallingContext state = Running
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
@@ -476,8 +472,6 @@ ModuleCallingContext state = Running
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030

--- a/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_onPath_unscheduled.log
@@ -84,8 +84,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
@@ -112,8 +110,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
@@ -140,8 +136,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'p' id = 2
 ++++++++ finished: processing event for module: stream = 0 label = 'p' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -603,8 +603,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
@@ -831,8 +829,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8
@@ -1059,8 +1055,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 be16549dc0c1f4b03231a8b98d235dac
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 8

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -294,8 +294,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
@@ -444,8 +442,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5
@@ -594,8 +590,6 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 7da3661f4f7dead5e42f07cf3ddf5a59
 
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 5

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -423,8 +423,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
@@ -484,8 +482,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -526,8 +522,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -585,8 +579,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
@@ -646,8 +638,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -688,8 +678,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -747,8 +735,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
@@ -808,8 +794,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -850,8 +834,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -909,8 +891,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
@@ -970,8 +950,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -1012,8 +990,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -1213,8 +1189,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
@@ -1274,8 +1248,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -1316,8 +1288,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -1375,8 +1345,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
@@ -1436,8 +1404,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -1478,8 +1444,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -1537,8 +1501,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
@@ -1598,8 +1560,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -1640,8 +1600,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -1699,8 +1657,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
@@ -1760,8 +1716,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -1802,8 +1756,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -2003,8 +1955,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
@@ -2064,8 +2014,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -2106,8 +2054,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -2165,8 +2111,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
@@ -2226,8 +2170,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -2268,8 +2210,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -2611,8 +2551,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
@@ -2672,8 +2610,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -2714,8 +2650,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -2773,8 +2707,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
@@ -2834,8 +2766,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -2876,8 +2806,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -2935,8 +2863,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
@@ -2996,8 +2922,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3038,8 +2962,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -3097,8 +3019,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
@@ -3158,8 +3078,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3200,8 +3118,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -3401,8 +3317,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
@@ -3462,8 +3376,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3504,8 +3416,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -3563,8 +3473,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
@@ -3624,8 +3532,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3666,8 +3572,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -3725,8 +3629,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
@@ -3786,8 +3688,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3828,8 +3728,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -3887,8 +3785,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
@@ -3948,8 +3844,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -3990,8 +3884,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -4191,8 +4083,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
@@ -4252,8 +4142,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -4294,8 +4182,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -4353,8 +4239,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
@@ -4414,8 +4298,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -4456,8 +4338,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -4799,8 +4679,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
@@ -4860,8 +4738,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -4902,8 +4778,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -4961,8 +4835,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
@@ -5022,8 +4894,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -5064,8 +4934,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -5123,8 +4991,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
@@ -5184,8 +5050,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -5226,8 +5090,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -5285,8 +5147,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
@@ -5346,8 +5206,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -5388,8 +5246,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -5589,8 +5445,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
@@ -5650,8 +5504,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -5692,8 +5544,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -5751,8 +5601,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
@@ -5812,8 +5660,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -5854,8 +5700,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -5913,8 +5757,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
@@ -5974,8 +5816,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -6016,8 +5856,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -6075,8 +5913,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
@@ -6136,8 +5972,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -6178,8 +6012,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -6379,8 +6211,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
@@ -6440,8 +6270,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -6482,8 +6310,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37
@@ -6541,8 +6367,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++++ finished: processing event for module: stream = 0 label = 'path2' id = 4
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
@@ -6602,8 +6426,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 16
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 12
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 24
@@ -6644,8 +6466,6 @@
 ++++++++ starting: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++++ finished: processing event for module: stream = 0 label = 'path4' id = 29
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
-++++++++ finished: prefetching before processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 25
 ++++++++ starting: prefetching before processing event for module: stream = 0 label = 'out' id = 37


### PR DESCRIPTION
#### PR description:

Remove all but one call to Worker::doWork which is still used in the implementation of Event::getProvenance.
Worker::doWork is the only place that uses the pushAndWait ability of the task queues. In the migration to using tbb::task_group we would like to do away with pushAndWait.

There is one visible change seen by this PR, the TriggerResults EDProducer internal to the framework no longer sends a pre/post prefetch signal as it has no need for prefetching. This makes it behave like the EDProducers handling the individual Path results.

#### PR validation:

The code compiles and all framework unit tests pass.