### PR TITLE
add root histpainter deps to fix UBSAN issue

### DIFF
--- a/CondCore/SiStripPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiStripPlugins/plugins/BuildFile.xml
@@ -19,6 +19,7 @@
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="roothistpainter"/>
 </library>
 
 <library file="SiStripLorentzAngle_PayloadInspector.cc" name="SiStripLorentzAngle_PayloadInspector">
@@ -27,6 +28,7 @@
   <use name="CondFormats/SiStripObjects"/>
   <use name="CommonTools/TrackerMap"/>
   <use name="CalibTracker/StandaloneTrackerTopology"/>
+  <use name="roothistpainter"/>
 </library>
 
 <library file="SiStripBackPlaneCorrection_PayloadInspector.cc" name="SiStripBackPlaneCorrection_PayloadInspector">


### PR DESCRIPTION
UBSAN IBs failed to build [a]. The issue ( reported by @Dr15Jones ) is that `TPaletteAxis` is defined in `root's` `HistPainter` lib for which we do not have any tool file. https://github.com/cms-sw/cmsdist/pull/6533 adds new root tools and this PR suggest to add deps on roothistpainter to fix UBSAN link error.

```
gcc/9.3.0/bin/../lib/gcc/x86_64-unknown-linux-gnu/9.3.0/../../../../x86_64-unknown-linux-gnu/bin/ld: tmp/slc7_amd64_gcc900/src/CondCore/SiStripPlugins/plugins/SiStripLorentzAngle_PayloadInspector/SiStripLorentzAngle_PayloadInspector.cc.o:(.data.rel+0x358): undefined reference to `typeinfo for TPaletteAxis'
collect2: error: ld returned 1 exit status
```