### PR TITLE
Tracker Alignment Payload Inspector: migration to new class templates

### DIFF
--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -55,17 +55,16 @@ namespace {
 
   // inherit from one of the predefined plot class: Histogram1D
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedValue : public cond::payloadInspector::Histogram1D<AlignmentErrorsExtended> {
+  class TrackerAlignmentErrorExtendedValue
+      : public cond::payloadInspector::Histogram1D<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedValue()
-        : cond::payloadInspector::Histogram1D<AlignmentErrorsExtended>(
+        : cond::payloadInspector::Histogram1D<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
               "TrackerAlignmentErrorExtendedValue",
               "TrackerAlignmentErrorExtendedValue sqrt(d_{" + getStringFromIndex(i) + "})",
               500,
               0.0,
-              500.0) {
-      Base::setSingleIov(true);
-    }
+              500.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -108,16 +107,16 @@ namespace {
   // *************************************************/
 
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedSummary : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
+  class TrackerAlignmentErrorExtendedSummary
+      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedSummary()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended>("Summary per Tracker Partition of sqrt(d_{" +
-                                                                     getStringFromIndex(i) + "}) of APE matrix") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
+              "Summary per Tracker Partition of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<AlignmentErrorsExtended> payload = fetchPayload(std::get<1>(iov));
       std::vector<AlignTransformErrorExtended> alignErrors = payload->m_alignError;
 
@@ -243,16 +242,16 @@ namespace {
   //   TrackerMap of sqrt(d_ii) of 1 IOV
   // *************************************************/
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedTrackerMap : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
+  class TrackerAlignmentErrorExtendedTrackerMap
+      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedTrackerMap()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended>("Tracker Map of sqrt(d_{" + getStringFromIndex(i) +
-                                                                     "}) of APE matrix") {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<AlignmentErrorsExtended> payload = fetchPayload(std::get<1>(iov));
 
       std::string titleMap = "APE #sqrt{d_{" + getStringFromIndex(i) + "}} value (payload : " + std::get<1>(iov) + ")";
@@ -325,18 +324,18 @@ namespace {
   //  Partition details of 1 IOV
   // *************************************************/
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentErrorExtendedDetail : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
+  class TrackerAlignmentErrorExtendedDetail
+      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedDetail()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended>("Details for " +
-                                                                     AlignmentPI::getStringFromPart(q)) {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
+              "Details for " + AlignmentPI::getStringFromPart(q)) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       gStyle->SetPaintTextFormat(".1f");
-
-      auto iov = iovs.front();
       std::shared_ptr<AlignmentErrorsExtended> payload = fetchPayload(std::get<1>(iov));
 
       std::vector<AlignTransformErrorExtended> alignErrors = payload->m_alignError;
@@ -506,29 +505,37 @@ namespace {
   //  Tracker Aligment Extended Errors grand summary comparison of 2 IOVs
   // *************************************************/
 
-  template <AlignmentPI::index i>
+  template <AlignmentPI::index i, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
   class TrackerAlignmentErrorExtendedComparatorBase
-      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended> {
+      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, nIOVs, ntags> {
   public:
     TrackerAlignmentErrorExtendedComparatorBase()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended>("Summary per Tracker region of sqrt(d_{" +
-                                                                     getStringFromIndex(i) + "}) of APE matrix") {}
+        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, nIOVs, ntags>(
+              "Summary per Tracker region of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> >& iovs) override {
+    bool fill() override {
+      // trick to deal with the multi-ioved tag and two tag case at the same time
+      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
+      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      std::string tagname2 = "";
+      auto firstiov = theIOVs.front();
+      std::tuple<cond::Time_t, cond::Hash> lastiov;
+
+      // we don't support (yet) comparison with more than 2 tags
+      assert(this->m_plotAnnotations.ntags < 3);
+
+      if (this->m_plotAnnotations.ntags == 2) {
+        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
+        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        lastiov = tag2iovs.front();
+      } else {
+        lastiov = theIOVs.back();
+      }
+
       gStyle->SetPaintTextFormat(".1f");
 
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
-
-      // make absolute sure the IOVs are sortd by since
-      std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const& t1, auto const& t2) {
-        return std::get<0>(t1) < std::get<0>(t2);
-      });
-
-      auto firstiov = sorted_iovs.front();
-      auto lastiov = sorted_iovs.back();
-
-      std::shared_ptr<AlignmentErrorsExtended> last_payload = fetchPayload(std::get<1>(lastiov));
-      std::shared_ptr<AlignmentErrorsExtended> first_payload = fetchPayload(std::get<1>(firstiov));
+      std::shared_ptr<AlignmentErrorsExtended> last_payload = this->fetchPayload(std::get<1>(lastiov));
+      std::shared_ptr<AlignmentErrorsExtended> first_payload = this->fetchPayload(std::get<1>(firstiov));
 
       std::vector<AlignTransformErrorExtended> f_alignErrors = first_payload->m_alignError;
       std::vector<AlignTransformErrorExtended> l_alignErrors = last_payload->m_alignError;
@@ -730,7 +737,7 @@ namespace {
       legend.SetTextSize(0.025);
       legend.Draw("same");
 
-      std::string fileName(m_imageFileName);
+      std::string fileName(this->m_imageFileName);
       canvas.SaveAs(fileName.c_str());
 
       return true;
@@ -739,20 +746,12 @@ namespace {
   };
 
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedComparator : public TrackerAlignmentErrorExtendedComparatorBase<i> {
-  public:
-    TrackerAlignmentErrorExtendedComparator() : TrackerAlignmentErrorExtendedComparatorBase<i>() {
-      this->setSingleIov(false);
-    }
-  };
+  using TrackerAlignmentErrorExtendedComparator =
+      TrackerAlignmentErrorExtendedComparatorBase<i, 1, cond::payloadInspector::MULTI_IOV>;
 
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedComparatorTwoTags : public TrackerAlignmentErrorExtendedComparatorBase<i> {
-  public:
-    TrackerAlignmentErrorExtendedComparatorTwoTags() : TrackerAlignmentErrorExtendedComparatorBase<i>() {
-      this->setTwoTags(true);
-    }
-  };
+  using TrackerAlignmentErrorExtendedComparatorTwoTags =
+      TrackerAlignmentErrorExtendedComparatorBase<i, 2, cond::payloadInspector::SINGLE_IOV>;
 
   // diagonal elements
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::XX> TrackerAlignmentErrorExtendedXXComparator;

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignmentErrorExtended_PayloadInspector.cc
@@ -41,6 +41,8 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   const std::map<AlignmentPI::partitions, std::pair<AlignmentPI::regions, AlignmentPI::regions> > partLimits = {
       {AlignmentPI::BPix, std::make_pair(AlignmentPI::BPixL1o, AlignmentPI::BPixL4i)},
       {AlignmentPI::FPix, std::make_pair(AlignmentPI::FPixmL1, AlignmentPI::FPixpL3)},
@@ -55,11 +57,10 @@ namespace {
 
   // inherit from one of the predefined plot class: Histogram1D
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedValue
-      : public cond::payloadInspector::Histogram1D<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentErrorExtendedValue : public Histogram1D<AlignmentErrorsExtended, SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedValue()
-        : cond::payloadInspector::Histogram1D<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<AlignmentErrorsExtended, SINGLE_IOV>(
               "TrackerAlignmentErrorExtendedValue",
               "TrackerAlignmentErrorExtendedValue sqrt(d_{" + getStringFromIndex(i) + "})",
               500,
@@ -107,12 +108,11 @@ namespace {
   // *************************************************/
 
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedSummary
-      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentErrorExtendedSummary : public PlotImage<AlignmentErrorsExtended, SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedSummary()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
-              "Summary per Tracker Partition of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
+        : PlotImage<AlignmentErrorsExtended, SINGLE_IOV>("Summary per Tracker Partition of sqrt(d_{" +
+                                                         getStringFromIndex(i) + "}) of APE matrix") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -242,12 +242,11 @@ namespace {
   //   TrackerMap of sqrt(d_ii) of 1 IOV
   // *************************************************/
   template <AlignmentPI::index i>
-  class TrackerAlignmentErrorExtendedTrackerMap
-      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentErrorExtendedTrackerMap : public PlotImage<AlignmentErrorsExtended, SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedTrackerMap()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
-              "Tracker Map of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
+        : PlotImage<AlignmentErrorsExtended, SINGLE_IOV>("Tracker Map of sqrt(d_{" + getStringFromIndex(i) +
+                                                         "}) of APE matrix") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -324,12 +323,10 @@ namespace {
   //  Partition details of 1 IOV
   // *************************************************/
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentErrorExtendedDetail
-      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentErrorExtendedDetail : public PlotImage<AlignmentErrorsExtended, SINGLE_IOV> {
   public:
     TrackerAlignmentErrorExtendedDetail()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, cond::payloadInspector::SINGLE_IOV>(
-              "Details for " + AlignmentPI::getStringFromPart(q)) {}
+        : PlotImage<AlignmentErrorsExtended, SINGLE_IOV>("Details for " + AlignmentPI::getStringFromPart(q)) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -505,18 +502,17 @@ namespace {
   //  Tracker Aligment Extended Errors grand summary comparison of 2 IOVs
   // *************************************************/
 
-  template <AlignmentPI::index i, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class TrackerAlignmentErrorExtendedComparatorBase
-      : public cond::payloadInspector::PlotImage<AlignmentErrorsExtended, nIOVs, ntags> {
+  template <AlignmentPI::index i, int ntags, IOVMultiplicity nIOVs>
+  class TrackerAlignmentErrorExtendedComparatorBase : public PlotImage<AlignmentErrorsExtended, nIOVs, ntags> {
   public:
     TrackerAlignmentErrorExtendedComparatorBase()
-        : cond::payloadInspector::PlotImage<AlignmentErrorsExtended, nIOVs, ntags>(
-              "Summary per Tracker region of sqrt(d_{" + getStringFromIndex(i) + "}) of APE matrix") {}
+        : PlotImage<AlignmentErrorsExtended, nIOVs, ntags>("Summary per Tracker region of sqrt(d_{" +
+                                                           getStringFromIndex(i) + "}) of APE matrix") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -525,8 +521,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -746,12 +742,10 @@ namespace {
   };
 
   template <AlignmentPI::index i>
-  using TrackerAlignmentErrorExtendedComparator =
-      TrackerAlignmentErrorExtendedComparatorBase<i, 1, cond::payloadInspector::MULTI_IOV>;
+  using TrackerAlignmentErrorExtendedComparator = TrackerAlignmentErrorExtendedComparatorBase<i, 1, MULTI_IOV>;
 
   template <AlignmentPI::index i>
-  using TrackerAlignmentErrorExtendedComparatorTwoTags =
-      TrackerAlignmentErrorExtendedComparatorBase<i, 2, cond::payloadInspector::SINGLE_IOV>;
+  using TrackerAlignmentErrorExtendedComparatorTwoTags = TrackerAlignmentErrorExtendedComparatorBase<i, 2, SINGLE_IOV>;
 
   // diagonal elements
   typedef TrackerAlignmentErrorExtendedComparator<AlignmentPI::XX> TrackerAlignmentErrorExtendedXXComparator;

--- a/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerAlignment_PayloadInspector.cc
@@ -46,6 +46,8 @@
 
 namespace {
 
+  using namespace cond::payloadInspector;
+
   // M.M. 2017/09/29
   // Hardcoded Tracker Global Position Record
   // Without accessing the ES, it is not possible to access to the GPR with the PI technology,
@@ -62,17 +64,17 @@ namespace {
   // Size of the movement over all partitions
   //******************************************//
 
-  template <AlignmentPI::coordinate coord, int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class TrackerAlignmentComparatorBase : public cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags> {
+  template <AlignmentPI::coordinate coord, int ntags, IOVMultiplicity nIOVs>
+  class TrackerAlignmentComparatorBase : public PlotImage<Alignments, nIOVs, ntags> {
   public:
     TrackerAlignmentComparatorBase()
-        : cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags>(
-              "comparison of " + AlignmentPI::getStringFromCoordinate(coord) + " coordinate between two geometries") {}
+        : PlotImage<Alignments, nIOVs, ntags>("comparison of " + AlignmentPI::getStringFromCoordinate(coord) +
+                                              " coordinate between two geometries") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -81,8 +83,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -277,10 +279,10 @@ namespace {
   };
 
   template <AlignmentPI::coordinate coord>
-  using TrackerAlignmentCompare = TrackerAlignmentComparatorBase<coord, 1, cond::payloadInspector::MULTI_IOV>;
+  using TrackerAlignmentCompare = TrackerAlignmentComparatorBase<coord, 1, MULTI_IOV>;
 
   template <AlignmentPI::coordinate coord>
-  using TrackerAlignmentCompareTwoTags = TrackerAlignmentComparatorBase<coord, 2, cond::payloadInspector::SINGLE_IOV>;
+  using TrackerAlignmentCompareTwoTags = TrackerAlignmentComparatorBase<coord, 2, SINGLE_IOV>;
 
   typedef TrackerAlignmentCompare<AlignmentPI::t_x> TrackerAlignmentCompareX;
   typedef TrackerAlignmentCompare<AlignmentPI::t_y> TrackerAlignmentCompareY;
@@ -303,12 +305,11 @@ namespace {
   //******************************************//
 
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentSummary
-      : public cond::payloadInspector::PlotImage<Alignments, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentSummary : public PlotImage<Alignments, SINGLE_IOV> {
   public:
     TrackerAlignmentSummary()
-        : cond::payloadInspector::PlotImage<Alignments, cond::payloadInspector::SINGLE_IOV>(
-              "Comparison of all coordinates between two geometries for " + getStringFromPart(q)) {}
+        : PlotImage<Alignments, SINGLE_IOV>("Comparison of all coordinates between two geometries for " +
+                                            getStringFromPart(q)) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -500,10 +501,10 @@ namespace {
   //******************************************//
 
   template <AlignmentPI::coordinate coord>
-  class BPixBarycenterHistory : public cond::payloadInspector::HistoryPlot<Alignments, float> {
+  class BPixBarycenterHistory : public HistoryPlot<Alignments, float> {
   public:
     BPixBarycenterHistory()
-        : cond::payloadInspector::HistoryPlot<Alignments, float>(
+        : HistoryPlot<Alignments, float>(
               " Barrel Pixel " + AlignmentPI::getStringFromCoordinate(coord) + " positions vs time",
               AlignmentPI::getStringFromCoordinate(coord) + " position [cm]") {}
     ~BPixBarycenterHistory() override = default;
@@ -563,12 +564,9 @@ namespace {
   /************************************************
     Display of Tracker Detector barycenters
   *************************************************/
-  class TrackerAlignmentBarycenters
-      : public cond::payloadInspector::PlotImage<Alignments, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentBarycenters : public PlotImage<Alignments, SINGLE_IOV> {
   public:
-    TrackerAlignmentBarycenters()
-        : cond::payloadInspector::PlotImage<Alignments, cond::payloadInspector::SINGLE_IOV>(
-              "Display of Tracker Alignment Barycenters") {}
+    TrackerAlignmentBarycenters() : PlotImage<Alignments, SINGLE_IOV>("Display of Tracker Alignment Barycenters") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -691,16 +689,16 @@ namespace {
   /************************************************
     Comparator of Tracker Detector barycenters
   *************************************************/
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class TrackerAlignmentBarycentersComparatorBase : public cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class TrackerAlignmentBarycentersComparatorBase : public PlotImage<Alignments, nIOVs, ntags> {
   public:
     TrackerAlignmentBarycentersComparatorBase()
-        : cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags>("Comparison of Tracker Alignment Barycenters") {}
+        : PlotImage<Alignments, nIOVs, ntags>("Comparison of Tracker Alignment Barycenters") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -709,8 +707,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -805,24 +803,21 @@ namespace {
     bool isFinalPhase0;
   };
 
-  using TrackerAlignmentBarycentersCompare =
-      TrackerAlignmentBarycentersComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
-  using TrackerAlignmentBarycentersCompareTwoTags =
-      TrackerAlignmentBarycentersComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using TrackerAlignmentBarycentersCompare = TrackerAlignmentBarycentersComparatorBase<1, MULTI_IOV>;
+  using TrackerAlignmentBarycentersCompareTwoTags = TrackerAlignmentBarycentersComparatorBase<2, SINGLE_IOV>;
 
   /************************************************
     Comparator of Pixel Tracker Detector barycenters
   *************************************************/
-  template <int ntags, cond::payloadInspector::IOVMultiplicity nIOVs>
-  class PixelBarycentersComparatorBase : public cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags> {
+  template <int ntags, IOVMultiplicity nIOVs>
+  class PixelBarycentersComparatorBase : public PlotImage<Alignments, nIOVs, ntags> {
   public:
-    PixelBarycentersComparatorBase()
-        : cond::payloadInspector::PlotImage<Alignments, nIOVs, ntags>("Comparison of Pixel Barycenters") {}
+    PixelBarycentersComparatorBase() : PlotImage<Alignments, nIOVs, ntags>("Comparison of Pixel Barycenters") {}
 
     bool fill() override {
       // trick to deal with the multi-ioved tag and two tag case at the same time
-      auto theIOVs = cond::payloadInspector::PlotBase::getTag<0>().iovs;
-      auto tagname1 = cond::payloadInspector::PlotBase::getTag<0>().name;
+      auto theIOVs = PlotBase::getTag<0>().iovs;
+      auto tagname1 = PlotBase::getTag<0>().name;
       std::string tagname2 = "";
       auto firstiov = theIOVs.front();
       std::tuple<cond::Time_t, cond::Hash> lastiov;
@@ -831,8 +826,8 @@ namespace {
       assert(this->m_plotAnnotations.ntags < 3);
 
       if (this->m_plotAnnotations.ntags == 2) {
-        auto tag2iovs = cond::payloadInspector::PlotBase::getTag<1>().iovs;
-        tagname2 = cond::payloadInspector::PlotBase::getTag<1>().name;
+        auto tag2iovs = PlotBase::getTag<1>().iovs;
+        tagname2 = PlotBase::getTag<1>().name;
         lastiov = tag2iovs.front();
       } else {
         lastiov = theIOVs.back();
@@ -1054,8 +1049,8 @@ namespace {
     bool isFinalPhase0;
   };
 
-  using PixelBarycentersCompare = PixelBarycentersComparatorBase<1, cond::payloadInspector::MULTI_IOV>;
-  using PixelBarycentersCompareTwoTags = PixelBarycentersComparatorBase<2, cond::payloadInspector::SINGLE_IOV>;
+  using PixelBarycentersCompare = PixelBarycentersComparatorBase<1, MULTI_IOV>;
+  using PixelBarycentersCompareTwoTags = PixelBarycentersComparatorBase<2, SINGLE_IOV>;
 
 }  // namespace
 

--- a/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
@@ -44,11 +44,12 @@
 
 namespace {
 
-  class TrackerSurfaceDeformationsTest
-      : public cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
+  using namespace cond::payloadInspector;
+
+  class TrackerSurfaceDeformationsTest : public Histogram1D<AlignmentSurfaceDeformations, SINGLE_IOV> {
   public:
     TrackerSurfaceDeformationsTest()
-        : cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
+        : Histogram1D<AlignmentSurfaceDeformations, SINGLE_IOV>(
               "TrackerSurfaceDeformationsTest", "TrackerSurfaceDeformationsTest", 2, 0.0, 2.0) {}
 
     bool fill() override {
@@ -83,12 +84,10 @@ namespace {
   //*******************************************************
 
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentSurfaceDeformationsSummary
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
+  class TrackerAlignmentSurfaceDeformationsSummary : public PlotImage<AlignmentSurfaceDeformations, SINGLE_IOV> {
   public:
     TrackerAlignmentSurfaceDeformationsSummary()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
-              "Details for " + AlignmentPI::getStringFromPart(q)) {}
+        : PlotImage<AlignmentSurfaceDeformations, SINGLE_IOV>("Details for " + AlignmentPI::getStringFromPart(q)) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -178,12 +177,10 @@ namespace {
   //*******************************************************
 
   template <AlignmentPI::partitions q>
-  class TrackerAlignmentSurfaceDeformationsComparison
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
+  class TrackerAlignmentSurfaceDeformationsComparison : public PlotImage<AlignmentSurfaceDeformations, MULTI_IOV> {
   public:
     TrackerAlignmentSurfaceDeformationsComparison()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
-              "Details for " + AlignmentPI::getStringFromPart(q)) {}
+        : PlotImage<AlignmentSurfaceDeformations, MULTI_IOV>("Details for " + AlignmentPI::getStringFromPart(q)) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -301,11 +298,10 @@ namespace {
   //   TrackerMap of single parameter
   // *************************************************/
   template <unsigned int par>
-  class SurfaceDeformationTrackerMap
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
+  class SurfaceDeformationTrackerMap : public PlotImage<AlignmentSurfaceDeformations, SINGLE_IOV> {
   public:
     SurfaceDeformationTrackerMap()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
+        : PlotImage<AlignmentSurfaceDeformations, SINGLE_IOV>(
               "Tracker Map of Tracker Surface deformations - parameter: " + std::to_string(par)) {}
 
     bool fill() override {
@@ -398,11 +394,10 @@ namespace {
   //   TrackerMap of single parameter
   // *************************************************/
   template <unsigned int m_par>
-  class SurfaceDeformationsTkMapDelta
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
+  class SurfaceDeformationsTkMapDelta : public PlotImage<AlignmentSurfaceDeformations, MULTI_IOV> {
   public:
     SurfaceDeformationsTkMapDelta()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
+        : PlotImage<AlignmentSurfaceDeformations, MULTI_IOV>(
               "Tracker Map of Tracker Surface deformations differences - parameter: " + std::to_string(m_par)) {}
 
     bool fill() override {
@@ -568,12 +563,11 @@ namespace {
   // *************************************************/
 
   template <unsigned int m_par>
-  class TrackerSurfaceDeformationsComparator
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
+  class TrackerSurfaceDeformationsComparator : public PlotImage<AlignmentSurfaceDeformations, MULTI_IOV> {
   public:
     TrackerSurfaceDeformationsComparator()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
-              "Summary per Tracker region of parameter " + std::to_string(m_par) + " of Surface Deformations") {}
+        : PlotImage<AlignmentSurfaceDeformations, MULTI_IOV>("Summary per Tracker region of parameter " +
+                                                             std::to_string(m_par) + " of Surface Deformations") {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();

--- a/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
+++ b/CondCore/AlignmentPlugins/plugins/TrackerSurfaceDeformations_PayloadInspector.cc
@@ -44,13 +44,12 @@
 
 namespace {
 
-  class TrackerSurfaceDeformationsTest : public cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations> {
+  class TrackerSurfaceDeformationsTest
+      : public cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerSurfaceDeformationsTest()
-        : cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations>(
-              "TrackerSurfaceDeformationsTest", "TrackerSurfaceDeformationsTest", 2, 0.0, 2.0) {
-      Base::setSingleIov(true);
-    }
+        : cond::payloadInspector::Histogram1D<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
+              "TrackerSurfaceDeformationsTest", "TrackerSurfaceDeformationsTest", 2, 0.0, 2.0) {}
 
     bool fill() override {
       auto tag = PlotBase::getTag<0>();
@@ -85,16 +84,15 @@ namespace {
 
   template <AlignmentPI::partitions q>
   class TrackerAlignmentSurfaceDeformationsSummary
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations> {
+      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
   public:
     TrackerAlignmentSurfaceDeformationsSummary()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations>("Details for " +
-                                                                          AlignmentPI::getStringFromPart(q)) {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
+              "Details for " + AlignmentPI::getStringFromPart(q)) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
       std::shared_ptr<AlignmentSurfaceDeformations> payload = fetchPayload(std::get<1>(iov));
       auto listOfItems = payload->items();
 
@@ -181,16 +179,15 @@ namespace {
 
   template <AlignmentPI::partitions q>
   class TrackerAlignmentSurfaceDeformationsComparison
-      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations> {
+      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
   public:
     TrackerAlignmentSurfaceDeformationsComparison()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations>("Details for " +
-                                                                          AlignmentPI::getStringFromPart(q)) {
-      setSingleIov(false);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
+              "Details for " + AlignmentPI::getStringFromPart(q)) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto sorted_iovs = tag.iovs;
 
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
@@ -304,16 +301,17 @@ namespace {
   //   TrackerMap of single parameter
   // *************************************************/
   template <unsigned int par>
-  class SurfaceDeformationTrackerMap : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations> {
+  class SurfaceDeformationTrackerMap
+      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV> {
   public:
     SurfaceDeformationTrackerMap()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations>(
-              "Tracker Map of Tracker Surface deformations - parameter: " + std::to_string(par)) {
-      setSingleIov(true);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::SINGLE_IOV>(
+              "Tracker Map of Tracker Surface deformations - parameter: " + std::to_string(par)) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      auto iov = iovs.front();
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto iov = tag.iovs.front();
+
       std::shared_ptr<AlignmentSurfaceDeformations> payload = fetchPayload(std::get<1>(iov));
       auto listOfItems = payload->items();
 
@@ -400,16 +398,16 @@ namespace {
   //   TrackerMap of single parameter
   // *************************************************/
   template <unsigned int m_par>
-  class SurfaceDeformationsTkMapDelta : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations> {
+  class SurfaceDeformationsTkMapDelta
+      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
   public:
     SurfaceDeformationsTkMapDelta()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations>(
-              "Tracker Map of Tracker Surface deformations differences - parameter: " + std::to_string(m_par)) {
-      setSingleIov(false);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
+              "Tracker Map of Tracker Surface deformations differences - parameter: " + std::to_string(m_par)) {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto sorted_iovs = tag.iovs;
 
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {
@@ -570,19 +568,19 @@ namespace {
   // *************************************************/
 
   template <unsigned int m_par>
-  class TrackerSurfaceDeformationsComparator : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations> {
+  class TrackerSurfaceDeformationsComparator
+      : public cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV> {
   public:
     TrackerSurfaceDeformationsComparator()
-        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations>(
-              "Summary per Tracker region of parameter " + std::to_string(m_par) + " of Surface Deformations") {
-      setSingleIov(false);
-    }
+        : cond::payloadInspector::PlotImage<AlignmentSurfaceDeformations, cond::payloadInspector::MULTI_IOV>(
+              "Summary per Tracker region of parameter " + std::to_string(m_par) + " of Surface Deformations") {}
 
-    bool fill(const std::vector<std::tuple<cond::Time_t, cond::Hash> > &iovs) override {
+    bool fill() override {
+      auto tag = PlotBase::getTag<0>();
+      auto sorted_iovs = tag.iovs;
+
       TGaxis::SetMaxDigits(3);
       gStyle->SetPaintTextFormat(".1f");
-
-      std::vector<std::tuple<cond::Time_t, cond::Hash> > sorted_iovs = iovs;
 
       // make absolute sure the IOVs are sortd by since
       std::sort(begin(sorted_iovs), end(sorted_iovs), [](auto const &t1, auto const &t2) {


### PR DESCRIPTION
#### PR description:

This PR is purely technical. It consists of two commits:
   * f25417d migrates the Tracker Alignment Payload Inspector classes to new `PayloadInspector` class interfaces introduced in PR #29622
   * ef0897d  makes use of the namespace `cond::payloadInspector` in all `CondCore/AlignmentPlugins` plugins avoiding heavy repetitions in the code.

#### PR validation:

Relies on existing unit tests.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport, not backport is needed.