### PR TITLE
Fix ProdCuts and Sensitive detectors lists creation in DD4hep workflow

### DIFF
--- a/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
+++ b/SimG4Core/Geometry/src/DD4hep_DDG4Builder.cc
@@ -48,7 +48,8 @@ G4VPhysicalVolume *DDG4Builder::BuildGeometry(SensitiveDetectorCatalog &catalog)
   for (auto const &it : map_) {
     for (auto const &fit : specs) {
       for (auto const &pit : fit.second->paths) {
-        if (dd4hep::dd::compareEqualName(dd4hep::dd::realTopName(pit), dd4hep::dd::noNamespace(it.first.name()))) {
+        if (dd4hep::dd::compareEqualName(dd4hep::dd::noNamespace(dd4hep::dd::realTopName(pit)),
+                                         dd4hep::dd::noNamespace(it.first.name()))) {
           dd4hepVec.emplace_back(&*it.second, &*fit.second);
         }
       }

--- a/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
+++ b/SimG4Core/Geometry/src/DDG4ProductionCuts.cc
@@ -115,11 +115,11 @@ void DDG4ProductionCuts::dd4hepInitialize() {
   for (auto const& it : *dd4hepMap_) {
     for (auto const& fit : specs) {
       for (auto const& pit : fit.second->paths) {
-        const std::string_view selection = dd4hep::dd::realTopName(pit);
+        const std::string_view selection = dd4hep::dd::noNamespace(dd4hep::dd::realTopName(pit));
         const std::string_view name = dd4hep::dd::noNamespace(it.first.name());
         if (!(dd4hep::dd::isRegex(selection))
                 ? dd4hep::dd::compareEqual(name, selection)
-                : std::regex_match(name.begin(), name.end(), std::regex(std::string(selection)))) {
+                : std::regex_match(name.begin(), name.end(), std::regex(selection.begin(), selection.end()))) {
           dd4hepVec_.emplace_back(std::make_pair<G4LogicalVolume*, const dd4hep::SpecPar*>(&*it.second, &*fit.second));
         }
       }


### PR DESCRIPTION
ProdCuts and sensitive detectors lists creation: Cannot compare names with namespace on one side and no namespace on the other side. 
In practice, for all CMSSW ProdCuts and sens XMLs, and all scenarios, it is sufficient to compare names with no namespace.

PR check: This now makes the sensitive detectors lists identical for old DD versus DD4hep in full CMS.

