### PR TITLE
Principal::getProvenance can no longer trigger unscheduled execution

### DIFF
--- a/DQMOffline/L1Trigger/src/L1TTauOffline.cc
+++ b/DQMOffline/L1Trigger/src/L1TTauOffline.cc
@@ -668,7 +668,7 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       {
         const edm::Provenance* prov = antimu.provenance();
         const std::vector<edm::ParameterSet> psetsFromProvenance =
-            edm::parameterSet(*prov, iEvent.processHistory())
+            edm::parameterSet(prov->stable(), iEvent.processHistory())
                 .getParameter<std::vector<edm::ParameterSet>>("IDWPdefinitions");
         for (uint i = 0; i < psetsFromProvenance.size(); i++) {
           if (psetsFromProvenance[i].getParameter<std::string>("IDname") == AntiMuWP_)
@@ -678,7 +678,8 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       {
         const edm::Provenance* prov = antiele.provenance();
         const std::vector<std::string> psetsFromProvenance =
-            edm::parameterSet(*prov, iEvent.processHistory()).getParameter<std::vector<std::string>>("workingPoints");
+            edm::parameterSet(prov->stable(), iEvent.processHistory())
+                .getParameter<std::vector<std::string>>("workingPoints");
         for (uint i = 0; i < psetsFromProvenance.size(); i++) {
           if (psetsFromProvenance[i] == AntiEleWP_)
             AntiEleWPIndex_ = i;
@@ -687,7 +688,7 @@ void L1TTauOffline::getProbeTaus(const edm::Event& iEvent,
       {
         const edm::Provenance* prov = comb3T.provenance();
         const std::vector<edm::ParameterSet> psetsFromProvenance =
-            edm::parameterSet(*prov, iEvent.processHistory())
+            edm::parameterSet(prov->stable(), iEvent.processHistory())
                 .getParameter<std::vector<edm::ParameterSet>>("IDWPdefinitions");
         for (uint i = 0; i < psetsFromProvenance.size(); i++) {
           if (psetsFromProvenance[i].getParameter<std::string>("IDname") == comb3TWP_)

--- a/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/plugins/HLTTauRefProducer.cc
@@ -149,7 +149,7 @@ void HLTTauRefProducer::doPFTaus(edm::StreamID iID, edm::Event& iEvent) const {
         auto const aProv = aHandle.provenance();
         if (aProv == nullptr)
           aHandle.whyFailed()->raise();
-        const auto& psetsFromProvenance = edm::parameterSet(*aProv, iEvent.processHistory());
+        const auto& psetsFromProvenance = edm::parameterSet(aProv->stable(), iEvent.processHistory());
         if (psetsFromProvenance.exists("workingPoints")) {
           auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("workingPoints");
           bool found = false;

--- a/FWCore/Common/interface/Provenance.h
+++ b/FWCore/Common/interface/Provenance.h
@@ -2,12 +2,12 @@
 #define FWCore_Common_Provenance_h
 
 #include <string>
-#include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/Provenance/interface/StableProvenance.h"
 
 namespace edm {
   class ParameterSet;
   class ProcessHistory;
-  std::string moduleName(Provenance const& provenance, ProcessHistory const& history);
-  ParameterSet const& parameterSet(Provenance const& provenance, ProcessHistory const& history);
+  std::string moduleName(StableProvenance const& provenance, ProcessHistory const& history);
+  ParameterSet const& parameterSet(StableProvenance const& provenance, ProcessHistory const& history);
 }  // namespace edm
 #endif

--- a/FWCore/Common/src/Provenance.cc
+++ b/FWCore/Common/src/Provenance.cc
@@ -8,7 +8,7 @@ namespace edm {
   static std::string const source("source");
   static std::string const triggerResultsInserter("TriggerResultsInserter");
 
-  ParameterSet const& parameterSet(Provenance const& provenance, ProcessHistory const& history) {
+  ParameterSet const& parameterSet(StableProvenance const& provenance, ProcessHistory const& history) {
     ProcessConfiguration pc;
     history.getConfigurationForProcess(provenance.processName(), pc);
     ParameterSet const& processParameterSet = *pset::Registry::instance()->getMapped(pc.parameterSetID());
@@ -24,7 +24,7 @@ namespace edm {
     return processParameterSet.getParameterSet(label);
   }
 
-  std::string moduleName(Provenance const& provenance, ProcessHistory const& history) {
+  std::string moduleName(StableProvenance const& provenance, ProcessHistory const& history) {
     // Trigger results ia a special case
     if (provenance.moduleLabel() == triggerResults) {
       return triggerResultsInserter;

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -219,9 +219,9 @@ namespace edm {
     template <typename ELEMENT>
     Handle<View<ELEMENT>> fillView_(BasicHandle& bh) const;
 
-    Provenance getProvenance(BranchID const& theID) const;
+    Provenance const& getProvenance(BranchID const& theID) const;
 
-    Provenance getProvenance(ProductID const& theID) const;
+    Provenance const& getProvenance(ProductID const& theID) const;
 
     StableProvenance const& getStableProvenance(BranchID const& theID) const;
 

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -223,6 +223,10 @@ namespace edm {
 
     Provenance getProvenance(ProductID const& theID) const;
 
+    StableProvenance const& getStableProvenance(BranchID const& theID) const;
+
+    StableProvenance const& getStableProvenance(ProductID const& theID) const;
+
     // Get the provenance for all products that may be in the event
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -118,6 +118,7 @@ namespace edm {
     BranchListIndexes const& branchListIndexes() const;
 
     Provenance getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const;
+    StableProvenance const& getStableProvenance(ProductID const& pid) const;
 
     BasicHandle getByProductID(ProductID const& oid) const;
 
@@ -148,6 +149,7 @@ namespace edm {
     }
 
     using Base::getProvenance;
+    using Base::getStableProvenance;
 
   private:
     BranchID pidToBid(ProductID const& pid) const;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -117,7 +117,7 @@ namespace edm {
 
     BranchListIndexes const& branchListIndexes() const;
 
-    Provenance getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const;
+    Provenance getProvenance(ProductID const& pid) const;
     StableProvenance const& getStableProvenance(ProductID const& pid) const;
 
     BasicHandle getByProductID(ProductID const& oid) const;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -117,7 +117,7 @@ namespace edm {
 
     BranchListIndexes const& branchListIndexes() const;
 
-    Provenance getProvenance(ProductID const& pid) const;
+    Provenance const& getProvenance(ProductID const& pid) const;
     StableProvenance const& getStableProvenance(ProductID const& pid) const;
 
     BasicHandle getByProductID(ProductID const& oid) const;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -134,9 +134,9 @@ namespace edm {
     template <typename PROD, typename... Args>
     void emplace(EDPutToken token, Args&&... args);
 
-    Provenance getProvenance(BranchID const& theID) const;
+    Provenance const& getProvenance(BranchID const& theID) const;
 
-    StableProvenance getStableProvenance(BranchID const& theID) const;
+    StableProvenance const& getStableProvenance(BranchID const& theID) const;
 
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -136,6 +136,8 @@ namespace edm {
 
     Provenance getProvenance(BranchID const& theID) const;
 
+    StableProvenance getStableProvenance(BranchID const& theID) const;
+
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
     ProcessHistoryID const& processHistoryID() const;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -172,7 +172,7 @@ namespace edm {
       return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());
     }
 
-    Provenance getProvenance(BranchID const& bid) const;
+    Provenance const& getProvenance(BranchID const& bid) const;
     StableProvenance const& getStableProvenance(BranchID const& bid) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -172,7 +172,7 @@ namespace edm {
       return boost::make_filter_iterator<FilledProductPtr>(productResolvers_.end(), productResolvers_.end());
     }
 
-    Provenance getProvenance(BranchID const& bid, ModuleCallingContext const* mcc) const;
+    Provenance getProvenance(BranchID const& bid) const;
     StableProvenance const& getStableProvenance(BranchID const& bid) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -173,6 +173,7 @@ namespace edm {
     }
 
     Provenance getProvenance(BranchID const& bid, ModuleCallingContext const* mcc) const;
+    StableProvenance const& getStableProvenance(BranchID const& bid) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -127,9 +127,9 @@ namespace edm {
     template <typename PROD, typename... Args>
     void emplace(EDPutToken token, Args&&... args);
 
-    Provenance getProvenance(BranchID const& theID) const;
+    Provenance const& getProvenance(BranchID const& theID) const;
 
-    StableProvenance getStableProvenance(BranchID const& theID) const;
+    StableProvenance const& getStableProvenance(BranchID const& theID) const;
 
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -129,6 +129,8 @@ namespace edm {
 
     Provenance getProvenance(BranchID const& theID) const;
 
+    StableProvenance getStableProvenance(BranchID const& theID) const;
+
     void getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const;
 
     // Return true if this Run has been subjected to a process with

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -114,13 +114,9 @@ namespace edm {
 
   ProcessHistoryID const& Event::processHistoryID() const { return eventPrincipal().processHistoryID(); }
 
-  Provenance Event::getProvenance(BranchID const& bid) const {
-    return provRecorder_.principal().getProvenance(bid, moduleCallingContext_);
-  }
+  Provenance Event::getProvenance(BranchID const& bid) const { return provRecorder_.principal().getProvenance(bid); }
 
-  Provenance Event::getProvenance(ProductID const& pid) const {
-    return eventPrincipal().getProvenance(pid, moduleCallingContext_);
-  }
+  Provenance Event::getProvenance(ProductID const& pid) const { return eventPrincipal().getProvenance(pid); }
 
   StableProvenance const& Event::getStableProvenance(BranchID const& bid) const {
     return provRecorder_.principal().getStableProvenance(bid);

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -114,9 +114,11 @@ namespace edm {
 
   ProcessHistoryID const& Event::processHistoryID() const { return eventPrincipal().processHistoryID(); }
 
-  Provenance Event::getProvenance(BranchID const& bid) const { return provRecorder_.principal().getProvenance(bid); }
+  Provenance const& Event::getProvenance(BranchID const& bid) const {
+    return provRecorder_.principal().getProvenance(bid);
+  }
 
-  Provenance Event::getProvenance(ProductID const& pid) const { return eventPrincipal().getProvenance(pid); }
+  Provenance const& Event::getProvenance(ProductID const& pid) const { return eventPrincipal().getProvenance(pid); }
 
   StableProvenance const& Event::getStableProvenance(BranchID const& bid) const {
     return provRecorder_.principal().getStableProvenance(bid);

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -122,6 +122,14 @@ namespace edm {
     return eventPrincipal().getProvenance(pid, moduleCallingContext_);
   }
 
+  StableProvenance const& Event::getStableProvenance(BranchID const& bid) const {
+    return provRecorder_.principal().getStableProvenance(bid);
+  }
+
+  StableProvenance const& Event::getStableProvenance(ProductID const& pid) const {
+    return eventPrincipal().getStableProvenance(pid);
+  }
+
   void Event::getAllProvenance(std::vector<Provenance const*>& provenances) const {
     provRecorder_.principal().getAllProvenance(provenances);
   }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -351,7 +351,7 @@ namespace edm {
     }
   }
 
-  Provenance EventPrincipal::getProvenance(ProductID const& pid) const {
+  Provenance const& EventPrincipal::getProvenance(ProductID const& pid) const {
     BranchID bid = pidToBid(pid);
     return getProvenance(bid);
   }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -356,6 +356,11 @@ namespace edm {
     return getProvenance(bid, mcc);
   }
 
+  StableProvenance const& EventPrincipal::getStableProvenance(ProductID const& pid) const {
+    BranchID bid = pidToBid(pid);
+    return getStableProvenance(bid);
+  }
+
   EventSelectionIDVector const& EventPrincipal::eventSelectionIDs() const { return eventSelectionIDs_; }
 
   BranchListIndexes const& EventPrincipal::branchListIndexes() const { return branchListIndexes_; }

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -351,9 +351,9 @@ namespace edm {
     }
   }
 
-  Provenance EventPrincipal::getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const {
+  Provenance EventPrincipal::getProvenance(ProductID const& pid) const {
     BranchID bid = pidToBid(pid);
-    return getProvenance(bid, mcc);
+    return getProvenance(bid);
   }
 
   StableProvenance const& EventPrincipal::getStableProvenance(ProductID const& pid) const {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -62,7 +62,7 @@ namespace edm {
   }
 
   Provenance LuminosityBlock::getProvenance(BranchID const& bid) const {
-    return luminosityBlockPrincipal().getProvenance(bid, moduleCallingContext_);
+    return luminosityBlockPrincipal().getProvenance(bid);
   }
 
   StableProvenance LuminosityBlock::getStableProvenance(BranchID const& bid) const {

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -65,6 +65,10 @@ namespace edm {
     return luminosityBlockPrincipal().getProvenance(bid, moduleCallingContext_);
   }
 
+  StableProvenance LuminosityBlock::getStableProvenance(BranchID const& bid) const {
+    return luminosityBlockPrincipal().getStableProvenance(bid);
+  }
+
   void LuminosityBlock::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     luminosityBlockPrincipal().getAllStableProvenance(provenances);
   }

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -61,11 +61,11 @@ namespace edm {
     return dynamic_cast<LuminosityBlockPrincipal const&>(provRecorder_.principal());
   }
 
-  Provenance LuminosityBlock::getProvenance(BranchID const& bid) const {
+  Provenance const& LuminosityBlock::getProvenance(BranchID const& bid) const {
     return luminosityBlockPrincipal().getProvenance(bid);
   }
 
-  StableProvenance LuminosityBlock::getStableProvenance(BranchID const& bid) const {
+  StableProvenance const& LuminosityBlock::getStableProvenance(BranchID const& bid) const {
     return luminosityBlockPrincipal().getStableProvenance(bid);
   }
 

--- a/FWCore/Framework/src/OccurrenceForOutput.cc
+++ b/FWCore/Framework/src/OccurrenceForOutput.cc
@@ -26,7 +26,7 @@ namespace edm {
   ProcessHistoryID const& OccurrenceForOutput::processHistoryID() const { return principal().processHistoryID(); }
 
   Provenance OccurrenceForOutput::getProvenance(BranchID const& bid) const {
-    return provRecorder_.principal().getProvenance(bid, moduleCallingContext_);
+    return provRecorder_.principal().getProvenance(bid);
   }
 
   void OccurrenceForOutput::getAllProvenance(std::vector<Provenance const*>& provenances) const {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -821,7 +821,7 @@ namespace edm {
     return productData;
   }
 
-  Provenance Principal::getProvenance(BranchID const& bid) const {
+  Provenance const& Principal::getProvenance(BranchID const& bid) const {
     ConstProductResolverPtr const phb = getProductResolver(bid);
     if (phb == nullptr) {
       throwProductNotFoundException("getProvenance", errors::ProductNotFound, bid);

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -821,16 +821,15 @@ namespace edm {
     return productData;
   }
 
-  Provenance Principal::getProvenance(BranchID const& bid, ModuleCallingContext const* mcc) const {
+  Provenance Principal::getProvenance(BranchID const& bid) const {
     ConstProductResolverPtr const phb = getProductResolver(bid);
     if (phb == nullptr) {
       throwProductNotFoundException("getProvenance", errors::ProductNotFound, bid);
     }
 
     if (phb->unscheduledWasNotRun()) {
-      if (not phb->resolveProduct(*this, false, nullptr, mcc).data()) {
-        throwProductNotFoundException("getProvenance(onDemand)", errors::ProductNotFound, bid);
-      }
+      throw edm::Exception(errors::UnimplementedFeature)
+          << "Requesting provenance from unrun EDProducer. The requested branch ID was: " << bid;
     }
     return *phb->provenance();
   }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -835,6 +835,15 @@ namespace edm {
     return *phb->provenance();
   }
 
+  StableProvenance const& Principal::getStableProvenance(BranchID const& bid) const {
+    ConstProductResolverPtr const phb = getProductResolver(bid);
+    if (phb == nullptr) {
+      throwProductNotFoundException("getStableProvenance", errors::ProductNotFound, bid);
+    }
+    //NOTE: in all implementations, this never returns a nullptr
+    return *phb->stableProvenance();
+  }
+
   // This one is mostly for test printout purposes
   // No attempt to trigger on demand execution
   // Skips provenance when the EDProduct is not there

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -26,9 +26,9 @@ namespace edm {
 
   RunPrincipal const& Run::runPrincipal() const { return dynamic_cast<RunPrincipal const&>(provRecorder_.principal()); }
 
-  Provenance Run::getProvenance(BranchID const& bid) const { return runPrincipal().getProvenance(bid); }
+  Provenance const& Run::getProvenance(BranchID const& bid) const { return runPrincipal().getProvenance(bid); }
 
-  StableProvenance Run::getStableProvenance(BranchID const& bid) const {
+  StableProvenance const& Run::getStableProvenance(BranchID const& bid) const {
     return runPrincipal().getStableProvenance(bid);
   }
 

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -26,9 +26,7 @@ namespace edm {
 
   RunPrincipal const& Run::runPrincipal() const { return dynamic_cast<RunPrincipal const&>(provRecorder_.principal()); }
 
-  Provenance Run::getProvenance(BranchID const& bid) const {
-    return runPrincipal().getProvenance(bid, moduleCallingContext_);
-  }
+  Provenance Run::getProvenance(BranchID const& bid) const { return runPrincipal().getProvenance(bid); }
 
   StableProvenance Run::getStableProvenance(BranchID const& bid) const {
     return runPrincipal().getStableProvenance(bid);

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -30,6 +30,10 @@ namespace edm {
     return runPrincipal().getProvenance(bid, moduleCallingContext_);
   }
 
+  StableProvenance Run::getStableProvenance(BranchID const& bid) const {
+    return runPrincipal().getStableProvenance(bid);
+  }
+
   void Run::getAllStableProvenance(std::vector<StableProvenance const*>& provenances) const {
     runPrincipal().getAllStableProvenance(provenances);
   }

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -251,5 +251,5 @@ void test_ep::failgetbyInvalidIdTest() {
 
 void test_ep::failgetProvenanceTest() {
   edm::BranchID id;
-  CPPUNIT_ASSERT_THROW(pEvent_->getProvenance(id, nullptr), edm::Exception);
+  CPPUNIT_ASSERT_THROW(pEvent_->getProvenance(id), edm::Exception);
 }

--- a/FWCore/Framework/test/stubs/TestTriggerNames.cc
+++ b/FWCore/Framework/test/stubs/TestTriggerNames.cc
@@ -183,7 +183,7 @@ namespace edmtest {
       // Test this by getting this parameter set and verifying the trigger
       // paths are the correct size.
       if (!streamerSource_) {
-        ParameterSet const& trigpset = parameterSet(*prod[index].provenance(), e.processHistory());
+        ParameterSet const& trigpset = parameterSet(prod[index].provenance()->stable(), e.processHistory());
         Strings trigpaths = trigpset.getParameter<Strings>("@trigger_paths");
         if (trigpaths.size() != expected_trigger_previous_.size()) {
           throw cms::Exception("Test Failure")

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -369,32 +369,28 @@ namespace edm {
                                     << " (productId = " << provenance->productID() << ")" << std::endl;
 
         if (listProvenance_) {
-          auto const& prov = iEvent.getProvenance(provenance->branchID());
-          auto const* productProvenance = prov.productProvenance();
-          if (productProvenance) {
-            const bool isAlias = productProvenance->branchID() != provenance->branchID();
-            std::string aliasForModLabel;
-            LogAbsolute("EventContent") << prov;
-            if (isAlias) {
-              aliasForModLabel = iEvent.getProvenance(productProvenance->branchID()).moduleLabel();
-              LogAbsolute("EventContent") << "Is an alias for " << aliasForModLabel;
-            }
-            ProcessHistory const& processHistory = iEvent.processHistory();
-            for (ProcessConfiguration const& pc : processHistory) {
-              if (pc.processName() == prov.processName()) {
-                ParameterSetID const& psetID = pc.parameterSetID();
-                pset::Registry const* psetRegistry = pset::Registry::instance();
-                ParameterSet const* processPset = psetRegistry->getMapped(psetID);
-                if (processPset) {
-                  if (processPset->existsAs<ParameterSet>(modLabel)) {
-                    if (isAlias) {
-                      LogAbsolute("EventContent") << "Alias PSet";
-                    }
-                    LogAbsolute("EventContent") << processPset->getParameterSet(modLabel);
+          const bool isAlias = provenance->branchDescription().isAlias();
+          std::string aliasForModLabel;
+          LogAbsolute("EventContent") << *provenance;
+          if (isAlias) {
+            aliasForModLabel = iEvent.getStableProvenance(provenance->originalBranchID()).moduleLabel();
+            LogAbsolute("EventContent") << "Is an alias for " << aliasForModLabel;
+          }
+          ProcessHistory const& processHistory = iEvent.processHistory();
+          for (ProcessConfiguration const& pc : processHistory) {
+            if (pc.processName() == provenance->processName()) {
+              ParameterSetID const& psetID = pc.parameterSetID();
+              pset::Registry const* psetRegistry = pset::Registry::instance();
+              ParameterSet const* processPset = psetRegistry->getMapped(psetID);
+              if (processPset) {
+                if (processPset->existsAs<ParameterSet>(modLabel)) {
+                  if (isAlias) {
+                    LogAbsolute("EventContent") << "Alias PSet";
                   }
-                  if (isAlias and processPset->existsAs<ParameterSet>(aliasForModLabel)) {
-                    LogAbsolute("EventContent") << processPset->getParameterSet(aliasForModLabel);
-                  }
+                  LogAbsolute("EventContent") << processPset->getParameterSet(modLabel);
+                }
+                if (isAlias and processPset->existsAs<ParameterSet>(aliasForModLabel)) {
+                  LogAbsolute("EventContent") << processPset->getParameterSet(aliasForModLabel);
                 }
               }
             }

--- a/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
+++ b/HLTrigger/HLTcore/plugins/TriggerSummaryProducerAOD.cc
@@ -628,9 +628,10 @@ void TriggerSummaryProducerAOD::fillFilterObjectMembers(const edm::Event& iEvent
     } else {
       auto itOffset = offset.find(pid);
       if (itOffset == offset.end()) {
-        const string& label(iEvent.getProvenance(pid).moduleLabel());
-        const string& instance(iEvent.getProvenance(pid).productInstanceName());
-        const string& process(iEvent.getProvenance(pid).processName());
+        const auto& prov = iEvent.getStableProvenance(pid);
+        const string& label(prov.moduleLabel());
+        const string& instance(prov.productInstanceName());
+        const string& process(prov.processName());
         std::ostringstream ost;
         ost << "Uunknown pid: " << pid << " FilterTag / Key: " << tag.encode() << " / " << i << "of" << n
             << " CollectionTag / Key: " << InputTag(label, instance, process).encode() << " / " << refs[i].key()

--- a/HLTrigger/HLTfilters/plugins/HLTDoublet.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTDoublet.cc
@@ -135,9 +135,10 @@ bool HLTDoublet<T1, T2>::hltFilter(edm::Event& iEvent,
       tagOld = InputTag();
       for (size_type i1 = 0; i1 != n1; ++i1) {
         const ProductID pid(coll1[i1].id());
-        const string& label(iEvent.getProvenance(pid).moduleLabel());
-        const string& instance(iEvent.getProvenance(pid).productInstanceName());
-        const string& process(iEvent.getProvenance(pid).processName());
+        const auto& prov = iEvent.getStableProvenance(pid);
+        const string& label(prov.moduleLabel());
+        const string& instance(prov.productInstanceName());
+        const string& process(prov.processName());
         InputTag tagNew(InputTag(label, instance, process));
         if (tagOld.encode() != tagNew.encode()) {
           filterproduct.addCollectionTag(tagNew);
@@ -153,9 +154,10 @@ bool HLTDoublet<T1, T2>::hltFilter(edm::Event& iEvent,
       tagOld = InputTag();
       for (size_type i2 = 0; i2 != n2; ++i2) {
         const ProductID pid(coll2[i2].id());
-        const string& label(iEvent.getProvenance(pid).moduleLabel());
-        const string& instance(iEvent.getProvenance(pid).productInstanceName());
-        const string& process(iEvent.getProvenance(pid).processName());
+        const auto& prov = iEvent.getStableProvenance(pid);
+        const string& label(prov.moduleLabel());
+        const string& instance(prov.productInstanceName());
+        const string& process(prov.processName());
         InputTag tagNew(InputTag(label, instance, process));
         if (tagOld.encode() != tagNew.encode()) {
           filterproduct.addCollectionTag(tagNew);

--- a/HLTrigger/HLTfilters/plugins/HLTDoubletDZ.cc
+++ b/HLTrigger/HLTfilters/plugins/HLTDoubletDZ.cc
@@ -282,9 +282,10 @@ HLTDoubletDZ<T1, T2>::getCollections(edm::Event& iEvent,
       tagOld = edm::InputTag();
       for (trigger::size_type i1 = 0; i1 != n1; ++i1) {
         const edm::ProductID pid(coll1[i1].id());
-        const std::string& label(iEvent.getProvenance(pid).moduleLabel());
-        const std::string& instance(iEvent.getProvenance(pid).productInstanceName());
-        const std::string& process(iEvent.getProvenance(pid).processName());
+        const auto& prov = iEvent.getStableProvenance(pid);
+        const std::string& label(prov.moduleLabel());
+        const std::string& instance(prov.productInstanceName());
+        const std::string& process(prov.processName());
         edm::InputTag tagNew(edm::InputTag(label, instance, process));
         if (tagOld.encode() != tagNew.encode()) {
           filterproduct.addCollectionTag(tagNew);
@@ -297,9 +298,10 @@ HLTDoubletDZ<T1, T2>::getCollections(edm::Event& iEvent,
       tagOld = edm::InputTag();
       for (trigger::size_type i2 = 0; i2 != n2; ++i2) {
         const edm::ProductID pid(coll2[i2].id());
-        const std::string& label(iEvent.getProvenance(pid).moduleLabel());
-        const std::string& instance(iEvent.getProvenance(pid).productInstanceName());
-        const std::string& process(iEvent.getProvenance(pid).processName());
+        const auto& prov = iEvent.getStableProvenance(pid);
+        const std::string& label(prov.moduleLabel());
+        const std::string& instance(prov.productInstanceName());
+        const std::string& process(prov.processName());
         edm::InputTag tagNew(edm::InputTag(label, instance, process));
         if (tagOld.encode() != tagNew.encode()) {
           filterproduct.addCollectionTag(tagNew);

--- a/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonL3PreFilter.cc
@@ -175,7 +175,7 @@ bool HLTMuonL3PreFilter::hltFilter(Event& iEvent,
       edm::Ref<L3MuonTrajectorySeedCollection> l3seedRef =
           tk->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >();
       TrackRef staTrack = l3seedRef->l2Track();
-      LogDebug("HLTMuonL3PreFilter") << "L2 from: " << iEvent.getProvenance(staTrack.id()).moduleLabel()
+      LogDebug("HLTMuonL3PreFilter") << "L2 from: " << iEvent.getStableProvenance(staTrack.id()).moduleLabel()
                                      << " index: " << staTrack.key();
       L2toL3s[staTrack].push_back(RecoChargedCandidateRef(mucands, i));
     }

--- a/HLTrigger/btau/plugins/HLTJetTag.cc
+++ b/HLTrigger/btau/plugins/HLTJetTag.cc
@@ -93,7 +93,7 @@ bool HLTJetTag<T>::hltFilter(edm::Event& event,
   auto const& dependent = handle->keyProduct();
   if (not dependent.isNull() and not dependent.hasCache()) {
     // only an empty AssociationVector can have a invalid dependent collection
-    edm::Provenance const& dependent_provenance = event.getProvenance(dependent.id());
+    edm::StableProvenance const& dependent_provenance = event.getStableProvenance(dependent.id());
     if (dependent_provenance.branchDescription().dropped())
       // FIXME the error message should be made prettier
       throw edm::Exception(edm::errors::ProductNotFound)

--- a/HLTrigger/btau/plugins/HLTJetTagWithMatching.cc
+++ b/HLTrigger/btau/plugins/HLTJetTagWithMatching.cc
@@ -109,7 +109,7 @@ bool HLTJetTagWithMatching<T>::hltFilter(edm::Event& event,
   auto const& dependent = handle->keyProduct();
   if (not dependent.isNull() and not dependent.hasCache()) {
     // only an empty AssociationVector can have a invalid dependent collection
-    edm::Provenance const& dependent_provenance = event.getProvenance(dependent.id());
+    edm::StableProvenance const& dependent_provenance = event.getStableProvenance(dependent.id());
     if (dependent_provenance.branchDescription().dropped())
       // FIXME the error message should be made prettier
       throw edm::Exception(edm::errors::ProductNotFound)

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -11,17 +11,17 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
   const edm::Provenance *prov = handle.provenance();
   if (prov == nullptr)
     throw cms::Exception("CorruptData") << "Vertex handle doesn't have provenance.";
-  edm::ParameterSet psetFromProvenance = edm::parameterSet(*prov, iEvent.processHistory());
+  edm::ParameterSet psetFromProvenance = edm::parameterSet(prov->stable(), iEvent.processHistory());
 
   bool is_primary_available = false;
   const edm::Provenance *parent_prov = prov;
-  if (edm::moduleName(*prov, iEvent.processHistory()) != "PrimaryVertexProducer") {
+  if (edm::moduleName(prov->stable(), iEvent.processHistory()) != "PrimaryVertexProducer") {
     std::vector<edm::BranchID> parents = prov->productProvenance()->parentage().parents();
     for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {
       edm::Provenance parprov = iEvent.getProvenance(*it);
       if (parprov.friendlyClassName() == "recoVertexs") {  // for AOD actually this the parent we should look for
         parent_prov = &parprov;
-        psetFromProvenance = edm::parameterSet(parprov, iEvent.processHistory());
+        psetFromProvenance = edm::parameterSet(parprov.stable(), iEvent.processHistory());
         is_primary_available = true;
         break;
       }

--- a/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
+++ b/HeavyFlavorAnalysis/Onia2MuMu/src/OniaVtxReProducer.cc
@@ -40,7 +40,7 @@ OniaVtxReProducer::OniaVtxReProducer(const edm::Handle<reco::VertexCollection> &
   bool foundTracks = false;
   bool foundBeamSpot = false;
   for (std::vector<edm::BranchID>::const_iterator it = parents.begin(), ed = parents.end(); it != ed; ++it) {
-    edm::Provenance parprov = iEvent.getProvenance(*it);
+    const edm::Provenance &parprov = iEvent.getProvenance(*it);
     if (parprov.friendlyClassName() == "recoTracks") {
       tracksTag_ = edm::InputTag(parprov.moduleLabel(), parprov.productInstanceName(), parprov.processName());
       foundTracks = true;

--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -140,7 +140,7 @@ void HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup&
 
     std::string moduleName = "";
     if (genEvtInfoProduct.isValid()) {
-      const edm::Provenance& prov = iEvent.getProvenance(genEvtInfoProduct.id());
+      const edm::StableProvenance& prov = iEvent.getStableProvenance(genEvtInfoProduct.id());
       moduleName = edm::moduleName(prov, iEvent.processHistory());
     }
 

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.cc
@@ -386,7 +386,7 @@ void PATTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
             bool found = false;
             if (prov_cfg_label == "rawValues" || prov_cfg_label == "workingPoints") {
               const std::vector<std::string> psetsFromProvenance =
-                  edm::parameterSet(*prov, iEvent.processHistory())
+                  edm::parameterSet(prov->stable(), iEvent.processHistory())
                       .getParameter<std::vector<std::string>>(prov_cfg_label);
               for (size_t i = 0; i < psetsFromProvenance.size(); ++i) {
                 if (psetsFromProvenance[i] == prov_ID_label) {
@@ -400,7 +400,7 @@ void PATTauProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
               }
             } else if (prov_cfg_label == "IDdefinitions" || prov_cfg_label == "IDWPdefinitions") {
               const std::vector<edm::ParameterSet> psetsFromProvenance =
-                  edm::parameterSet(*prov, iEvent.processHistory())
+                  edm::parameterSet(prov->stable(), iEvent.processHistory())
                       .getParameter<std::vector<edm::ParameterSet>>(prov_cfg_label);
               for (size_t i = 0; i < psetsFromProvenance.size(); ++i) {
                 if (psetsFromProvenance[i].getParameter<std::string>("IDname") == prov_ID_label) {

--- a/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/DeepFlavourTagInfoProducer.cc
@@ -48,6 +48,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "RecoBTag/TrackProbability/interface/HistogramProbabilityEstimator.h"
 class HistogramProbabilityEstimator;
+#include <memory>
+
 #include <typeinfo>
 #include "CondFormats/BTauObjects/interface/TrackProbabilityCalibration.h"
 #include "CondFormats/DataRecord/interface/BTagTrackProbability2DRcd.h"
@@ -201,7 +203,7 @@ void DeepFlavourTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSet
   double negative_cut = 0;  //used only with flip_
   if (flip_) {              //FIXME: Check if can do even less often than once per event
     const edm::Provenance* prov = shallow_tag_infos.provenance();
-    const edm::ParameterSet& psetFromProvenance = edm::parameterSet(*prov, iEvent.processHistory());
+    const edm::ParameterSet& psetFromProvenance = edm::parameterSet(prov->stable(), iEvent.processHistory());
     negative_cut = ((psetFromProvenance.getParameter<edm::ParameterSet>("computer"))
                         .getParameter<edm::ParameterSet>("trackSelection"))
                        .getParameter<double>("sip3dSigMax");
@@ -470,7 +472,8 @@ void DeepFlavourTagInfoProducer::checkEventSetup(const edm::EventSetup& iSetup) 
   {
     ESHandle<TrackProbabilityCalibration> calib2DHandle = iSetup.getHandle(calib2d_token_);
     ESHandle<TrackProbabilityCalibration> calib3DHandle = iSetup.getHandle(calib3d_token_);
-    probabilityEstimator_.reset(new HistogramProbabilityEstimator(calib3DHandle.product(), calib2DHandle.product()));
+    probabilityEstimator_ =
+        std::make_unique<HistogramProbabilityEstimator>(calib3DHandle.product(), calib2DHandle.product());
   }
 
   calibrationCacheId3D_ = cacheId3D;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -545,7 +545,7 @@ void GsfElectronProducer::produce(edm::Event& event, const edm::EventSetup& setu
           << "Cannot check consistency of parameters with ecal seeding ones,"
           << " because the original collection of seeds is not any more available.";
     } else {
-      checkEcalSeedingParameters(edm::parameterSet(*seeds.provenance(), event.processHistory()));
+      checkEcalSeedingParameters(edm::parameterSet(seeds.provenance()->stable(), event.processHistory()));
     }
   }
 

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -143,14 +143,15 @@ void GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSet
 
     if (!staTrack.isNull())
       LogTrace(theCategory) << "GLBQual: Used UpdatedAtVtx : "
-                            << (iEvent.getProvenance(staTrack.id()).productInstanceName() ==
+                            << (iEvent.getStableProvenance(staTrack.id()).productInstanceName() ==
                                 std::string("UpdatedAtVtx"));
 
     float maxFloat01 =
         std::numeric_limits<float>::max() * 0.1;  // a better solution would be to use float above .. m/be not
     reco::MuonQuality muQual;
     if (!staTrack.isNull())
-      muQual.updatedSta = iEvent.getProvenance(staTrack.id()).productInstanceName() == std::string("UpdatedAtVtx");
+      muQual.updatedSta =
+          iEvent.getStableProvenance(staTrack.id()).productInstanceName() == std::string("UpdatedAtVtx");
     muQual.trkKink = thisKink.first > maxFloat01 ? maxFloat01 : thisKink.first;
     muQual.glbKink = thisKink.second > maxFloat01 ? maxFloat01 : thisKink.second;
     muQual.trkRelChi2 = relative_tracker_chi2 > maxFloat01 ? maxFloat01 : relative_tracker_chi2;

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -143,7 +143,7 @@ void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
     //check whether there is a "shared" seed in addition
     if (!gotL3seeds) {
       //need to fetch the handle from the ref
-      const edm::Provenance& seedsProv = event.getProvenance(l3seedRef.id());
+      const edm::StableProvenance& seedsProv = event.getStableProvenance(l3seedRef.id());
       edm::InputTag l3seedsTag(seedsProv.moduleLabel(), seedsProv.productInstanceName(), seedsProv.processName());
       event.getByLabel(l3seedsTag, l3seeds);
       gotL3seeds = true;

--- a/RecoTauTag/RecoTau/plugins/DeepTauId.cc
+++ b/RecoTauTag/RecoTau/plugins/DeepTauId.cc
@@ -1086,7 +1086,7 @@ public:
     auto const aProv = aHandle.provenance();
     if (aProv == nullptr)
       aHandle.whyFailed()->raise();
-    const auto& psetsFromProvenance = edm::parameterSet(*aProv, event.processHistory());
+    const auto& psetsFromProvenance = edm::parameterSet(aProv->stable(), event.processHistory());
     auto const idlist = psetsFromProvenance.getParameter<std::vector<edm::ParameterSet>>("IDdefinitions");
     for (size_t j = 0; j < idlist.size(); ++j) {
       std::string idname = idlist[j].getParameter<std::string>("IDname");

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByMVAIsolationRun2.cc
@@ -196,7 +196,7 @@ namespace reco {
         phID_ = evt.processHistoryID();
         const edm::Provenance* prov = basicTauDiscriminators_.provenance();
         const std::vector<edm::ParameterSet> psetsFromProvenance =
-            edm::parameterSet(*prov, evt.processHistory())
+            edm::parameterSet(prov->stable(), evt.processHistory())
                 .getParameter<std::vector<edm::ParameterSet>>("IDdefinitions");
         for (uint i = 0; i < psetsFromProvenance.size(); i++) {
           if (psetsFromProvenance[i].getParameter<std::string>("IDname") == "ChargedIsoPtSum" + input_id_name_suffix_)

--- a/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
+++ b/RecoTauTag/RecoTau/plugins/PFTauSelectorDefinition.h
@@ -96,7 +96,7 @@ struct PFTauSelectorDefinition {
     if (phID_ != e.processHistoryID()) {
       phID_ = e.processHistoryID();
       for (auto& disc : discriminatorContainers_) {
-        auto const& psetsFromProvenance = edm::parameterSet(*disc.handle.provenance(), e.processHistory());
+        auto const& psetsFromProvenance = edm::parameterSet(disc.handle.provenance()->stable(), e.processHistory());
         // find raw value indices
         if (psetsFromProvenance.exists("rawValues")) {
           auto const idlist = psetsFromProvenance.getParameter<std::vector<std::string>>("rawValues");

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -761,7 +761,7 @@ void TrackListMerger::produce(edm::Event& e, const edm::EventSetup& es) {
             // the cluster collection either produced a removalInfo or mot
             //get the clusterremoval info from the provenance: will rekey if this is found
             edm::Handle<reco::ClusterRemovalInfo> CRIh;
-            edm::Provenance prov = e.getProvenance(pID);
+            edm::StableProvenance const& prov = e.getStableProvenance(pID);
             clusterRemovalInfos = edm::InputTag(prov.moduleLabel(), prov.productInstanceName(), prov.processName());
             doRekeyOnThisSeed = e.getByLabel(clusterRemovalInfos, CRIh);
           }  //valid hit

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -339,7 +339,7 @@ bool EcalSelectiveReadoutProducer::getBinOfMax(const edm::Event& evt,
                                                const edm::ProductID& noZsDigiId,
                                                int& binOfMax) const {
   bool rc;
-  const edm::StableProvenance p = evt.getStableProvenance(noZsDigiId);
+  const edm::StableProvenance& p = evt.getStableProvenance(noZsDigiId);
   const edm::ParameterSet& result = parameterSet(p, evt.processHistory());
   vector<string> ebDigiParamList = result.getParameterNames();
   string bofm("binOfMaximum");

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -339,7 +339,7 @@ bool EcalSelectiveReadoutProducer::getBinOfMax(const edm::Event& evt,
                                                const edm::ProductID& noZsDigiId,
                                                int& binOfMax) const {
   bool rc;
-  const edm::Provenance p = evt.getProvenance(noZsDigiId);
+  const edm::StableProvenance p = evt.getStableProvenance(noZsDigiId);
   const edm::ParameterSet& result = parameterSet(p, evt.processHistory());
   vector<string> ebDigiParamList = result.getParameterNames();
   string bofm("binOfMaximum");

--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -245,7 +245,7 @@ TopDecaySubset::ShowerModel TopDecaySubset::checkShowerModel(edm::Event& event) 
 
   std::string moduleName = "";
   if (genEvtInfoProduct.isValid()) {
-    const edm::Provenance& prov = event.getProvenance(genEvtInfoProduct.id());
+    const edm::StableProvenance& prov = event.getStableProvenance(genEvtInfoProduct.id());
     moduleName = edm::moduleName(prov, event.processHistory());
   }
 

--- a/Validation/RecoTau/src/TauTagValidation.cc
+++ b/Validation/RecoTau/src/TauTagValidation.cc
@@ -561,8 +561,8 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
         string prov_ID_label = currentDiscriminatorContainerIdName_[idx].second;
         bool found = false;
         if (prov_cfg_label == "rawValues" || prov_cfg_label == "workingPoints") {
-          const std::vector<string> psetsFromProvenance =
-              edm::parameterSet(*prov, iEvent.processHistory()).getParameter<std::vector<string>>(prov_cfg_label);
+          const std::vector<string> psetsFromProvenance = edm::parameterSet(prov->stable(), iEvent.processHistory())
+                                                              .getParameter<std::vector<string>>(prov_cfg_label);
           for (size_t i = 0; i < psetsFromProvenance.size(); ++i) {
             if (psetsFromProvenance[i] == prov_ID_label) {
               // using negative indices for raw values
@@ -575,7 +575,7 @@ void TauTagValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& 
           }
         } else if (prov_cfg_label == "IDdefinitions" || prov_cfg_label == "IDWPdefinitions") {
           const std::vector<edm::ParameterSet> psetsFromProvenance =
-              edm::parameterSet(*prov, iEvent.processHistory())
+              edm::parameterSet(prov->stable(), iEvent.processHistory())
                   .getParameter<std::vector<edm::ParameterSet>>(prov_cfg_label);
           for (size_t i = 0; i < psetsFromProvenance.size(); ++i) {
             if (psetsFromProvenance[i].getParameter<string>("IDname") == prov_ID_label) {


### PR DESCRIPTION
#### PR description:

- Removed the ability to cause unscheduled execution of an EDProducer be triggered by asking for its Provenance. Only 1 framework test module could actually have caused such behavior.
- Added new Principal::getStableProvenance method which gives access to the provenance information which is stable for the entire job.
- Switched modules to use getStableProvenance if applicable.

#### PR validation:

The code compiles and framework unit tests pass.