### PR TITLE
MTD geometry: fix mtd.xml for scenario D49 for DD4hep compatibility

### DIFF
--- a/Geometry/MTDCommonData/data/CrystalBarPhiFlat/v3/mtd.xml
+++ b/Geometry/MTDCommonData/data/CrystalBarPhiFlat/v3/mtd.xml
@@ -4841,8 +4841,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="313.5"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="313.5*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4855,8 +4855,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="6.54545*deg"/>
-<Numeric name="Radius" value="313.5"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="313.5*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -4869,8 +4869,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="404.69"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="404.69*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4883,8 +4883,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="5.07042*deg"/>
-<Numeric name="Radius" value="404.69"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="404.69*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -4897,8 +4897,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="489.88"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="489.88*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4911,8 +4911,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="5*deg"/>
-<Numeric name="Radius" value="489.88"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="489.88*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -4925,8 +4925,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="581.61"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="581.61*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4939,8 +4939,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="4.09091*deg"/>
-<Numeric name="Radius" value="581.61"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="581.61*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -4953,8 +4953,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="665.13"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="665.13*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4967,8 +4967,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="3.49515*deg"/>
-<Numeric name="Radius" value="665.13"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="665.13*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -4981,8 +4981,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="757.36"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="757.36*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -4995,8 +4995,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="3.46154*deg"/>
-<Numeric name="Radius" value="757.36"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="757.36*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -5009,8 +5009,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="839.19"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="839.19*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -5023,8 +5023,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="3*deg"/>
-<Numeric name="Radius" value="839.19"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="839.19*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -5037,8 +5037,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="931.88"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="931.88*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -5051,8 +5051,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="2.64706*deg"/>
-<Numeric name="Radius" value="931.88"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="931.88*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -5065,8 +5065,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="1012"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="1012*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -5079,8 +5079,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="2.36842*deg"/>
-<Numeric name="Radius" value="1012"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="1012*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -5093,8 +5093,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="1105.11"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="1105.11*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -5107,8 +5107,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="2.36842*deg"/>
-<Numeric name="Radius" value="1105.11"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="1105.11*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>
@@ -5121,8 +5121,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="0*deg"/>
-<Numeric name="Radius" value="1183.5"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,2.85</Vector>
+<Numeric name="Radius" value="1183.5*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="0"/>
@@ -5135,8 +5135,8 @@ note: see MTD_D38ETLV2_V0001_2019_03_14.cfg for full config files
 <Numeric name="IncrCopyNo" value="2"/>
 <Numeric name="RangeAngle" value="360*deg"/>
 <Numeric name="StartAngle" value="2.14286*deg"/>
-<Numeric name="Radius" value="1183.5"/>
-<Vector name="Center" type="numeric" nEntries="3">0,0,-2.85</Vector>
+<Numeric name="Radius" value="1183.5*mm"/>
+<Vector name="Center" type="numeric" nEntries="3">0*mm,0*mm,-2.85*mm</Vector>
 <Numeric name="IsZPlus" value="1"/>
 <Numeric name="TiltAngle" value="90*deg"/>
 <Numeric name="IsFlipped" value="1"/>


### PR DESCRIPTION
#### PR description:

Addition of units where needed and missing in ```mtd.xml``` for scenario D49. The DD4hep porting of MTD geometry was based on the D50 test scenario, equivalent to D49 as far as MTD is concerned. This PR backports into the legacy baseline scenario a few needed fixes.

#### PR validation:

Unit test runs, showing identical results for both DDD and DD4hep