### PR TITLE
Avoid seg fault in HTXSRivetProducer

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
+++ b/GeneratorInterface/RivetInterface/plugins/HTXSRivetProducer.cc
@@ -163,7 +163,10 @@ void HTXSRivetProducer::produce(edm::Event& iEvent, const edm::EventSetup&) {
   }
 }
 
-void HTXSRivetProducer::endRun(edm::Run const& iRun, edm::EventSetup const& es) { _HTXS->printClassificationSummary(); }
+void HTXSRivetProducer::endRun(edm::Run const& iRun, edm::EventSetup const& es) {
+  if (_HTXS)
+    _HTXS->printClassificationSummary();
+}
 
 void HTXSRivetProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& es) {
   if (_prodMode == "AUTO") {


### PR DESCRIPTION
#### PR description:

If used in a job which processes no events, HTXSRivetProducer no longer seg faults.

#### PR validation:

Code compiles.