### PR TITLE
drop type specifications in RecoLocalMuon

### DIFF
--- a/RecoLocalMuon/DTSegment/python/DTSegment2DProducer_CombPatternReco2D_NoDrift_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTSegment2DProducer_CombPatternReco2D_NoDrift_CosmicData_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-#FIXME: please use the file below, this old one will disappear soon.
-from RecoLocalMuon.DTSegment.dt2DSegments_CombPatternReco2D_NoDrift_CosmicData_cfi import *
-

--- a/RecoLocalMuon/DTSegment/python/DTSegment4DProducer_CombPatternReco4D_NoDrift_CosmicData_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/DTSegment4DProducer_CombPatternReco4D_NoDrift_CosmicData_cfi.py
@@ -1,5 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-#FIXME: please use the file below, this old one will disappear soon.
-from RecoLocalMuon.DTSegment.dt4DSegments_CombPatternReco4D_NoDrift_CosmicData_cfi import *
-

--- a/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_LinearDriftFromDB_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_LinearDriftFromDB_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalMuon.DTSegment.dt4DSegments_CombPatternReco4D_LinearDriftFromDB_cfi import *
-dt4DSegments.recHits2DLabel= cms.InputTag("dt2DExtendedSegments")
+dt4DSegments.recHits2DLabel= "dt2DExtendedSegments"

--- a/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_LinearDrift_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_LinearDrift_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalMuon.DTSegment.dt4DSegments_CombPatternReco4D_LinearDrift_cfi import *
-dt4DSegments.recHits2DLabel= cms.InputTag("dt2DExtendedSegments")
+dt4DSegments.recHits2DLabel= "dt2DExtendedSegments"

--- a/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_ParamDrift_cfi.py
+++ b/RecoLocalMuon/DTSegment/python/dt4DExtendedSegments_CombPatternReco4D_ParamDrift_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoLocalMuon.DTSegment.dt4DSegments_CombPatternReco4D_ParamDrift_cfi import *
-dt4DSegments.recHits2DLabel= cms.InputTag("dt2DExtendedSegments")
+dt4DSegments.recHits2DLabel= "dt2DExtendedSegments"


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
- remove old config files (not used)

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR for RecoLocalMuon is [PR#30270](https://github.com/cms-sw/cmssw/pull/30270). )

In this PR, a total of 5 files changed. 
RecoLocalMuon/DTSegment 5 files

2 files are removed.
RecoLocalMuon/DTSegment/python/DTSegment2DProducer_CombPatternReco2D_NoDrift_CosmicData_cfi.py
RecoLocalMuon/DTSegment/python/DTSegment4DProducer_CombPatternReco4D_NoDrift_CosmicData_cfi.py

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).