### PR TITLE
drop type specifications in RecoLocalCalo

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowerremaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowerremaker_cfi.py
@@ -64,5 +64,5 @@ ct2ct = cms.EDProducer("CaloTowersReCreator",
 )
 
 from Configuration.Eras.Modifier_run2_HE_2018_cff import run2_HE_2018
-run2_HE_2018.toModify(ct2ct, HcalPhase = cms.int32(1))
+run2_HE_2018.toModify(ct2ct, HcalPhase = 1)
 

--- a/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
+++ b/RecoLocalCalo/HcalRecAlgos/python/hcalRecAlgoESProd_cfi.py
@@ -31,24 +31,21 @@ from Configuration.Eras.Modifier_run2_HCAL_2017_cff import run2_HCAL_2017
 run2_HCAL_2017.toModify(hcalRecAlgos,
     phase = 1,
     SeverityLevels = {
-        2 : dict( RecHitFlags = cms.vstring('HBHEIsolatedNoise',
-                                            'HFAnomalousHit'
-                )
+        2 : dict( RecHitFlags = ['HBHEIsolatedNoise',
+                                 'HFAnomalousHit']
             ),
-        3 : dict( RecHitFlags = cms.vstring('HBHEHpdHitMultiplicity',  
-                                            'HBHEFlatNoise', 
-                                            'HBHESpikeNoise', 
-                                            'HBHETS4TS5Noise', 
-                                            'HBHENegativeNoise', 
-                                            'HBHEOOTPU'
-                )
+        3 : dict( RecHitFlags = ['HBHEHpdHitMultiplicity',  
+                                 'HBHEFlatNoise', 
+                                 'HBHESpikeNoise', 
+                                 'HBHETS4TS5Noise', 
+                                 'HBHENegativeNoise', 
+                                 'HBHEOOTPU']
             ),
-        4 : dict( RecHitFlags = cms.vstring('HFLongShort', 
-                                            'HFS8S1Ratio',  
-                                            'HFPET', 
-                                            'HFSignalAsymmetry'
-                )
+        4 : dict( RecHitFlags = ['HFLongShort', 
+                                 'HFS8S1Ratio',  
+                                 'HFPET', 
+                                 'HFSignalAsymmetry']
             ),
     },
-    RecoveredRecHitBits = cms.vstring('')
+    RecoveredRecHitBits = ['']
 )

--- a/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HBHEPhase1Reconstructor_cfi.py
@@ -107,7 +107,7 @@ hbheprereco = cms.EDProducer(
 )
 
 # Disable the "triangle peak fit" and the corresponding HBHETriangleNoise flag
-hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = cms.uint32(10000)
+hbheprereco.pulseShapeParametersQIE8.TrianglePeakTS = 10000
 
 from Configuration.Eras.Modifier_run2_HE_2017_cff import run2_HE_2017
 run2_HE_2017.toModify(hbheprereco, saveEffectivePedestal = True)


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.

Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR for RecoLocalCalo is [PR#29979](https://github.com/cms-sw/cmssw/pull29979) and [PR#30147](https://github.com/cms-sw/cmssw/pull/30147). )

In this PR, a total of 3 files changed. 
RecoLocalCalo/CaloTowersCreator
RecoLocalCalo/HcalRecAlgos
RecoLocalCalo/HcalRecProducers

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).