### PR TITLE
drop type spec in RecoLocalTracker

### DIFF
--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *
 
-phase2StripCPEGeometricESProducer = phase2StripCPEESProducer.clone()
-#phase2StripCPEGeometricESProducer.ComponentName = cms.string('Phase2StripCPEGeometric')
-phase2StripCPEGeometricESProducer.ComponentType = 'Phase2StripCPEGeometric'
-phase2StripCPEGeometricESProducer.parameters    = cms.PSet()
+phase2StripCPEGeometricESProducer = phase2StripCPEESProducer.clone(
+    #ComponentName = 'Phase2StripCPEGeometric',
+    ComponentType = 'Phase2StripCPEGeometric',
+    parameters    = cms.PSet()
+)

--- a/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
+++ b/RecoLocalTracker/Phase2TrackerRecHits/python/Phase2StripCPEGeometricESProducer_cfi.py
@@ -3,7 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoLocalTracker.Phase2TrackerRecHits.Phase2StripCPEESProducer_cfi import *
 
 phase2StripCPEGeometricESProducer = phase2StripCPEESProducer.clone(
-    #ComponentName = 'Phase2StripCPEGeometric',
     ComponentType = 'Phase2StripCPEGeometric',
     parameters    = cms.PSet()
 )

--- a/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
+++ b/RecoLocalTracker/SiStripZeroSuppression/python/SiStripZeroSuppression_cfi.py
@@ -24,7 +24,7 @@ siStripZeroSuppression = cms.EDProducer("SiStripZeroSuppression",
 # This part has to be clean up when they will be officially removed from the entire flow
 from Configuration.Eras.Modifier_phase2_tracker_cff import phase2_tracker
 phase2_tracker.toModify(siStripZeroSuppression, # FIXME
-  RawDigiProducersList = cms.VInputTag( cms.InputTag('simSiStripDigis','VirginRaw'),
-                                        cms.InputTag('simSiStripDigis','ProcessedRaw'),
-                                        cms.InputTag('simSiStripDigis','ScopeMode'))
+  RawDigiProducersList = [ 'simSiStripDigis:VirginRaw',
+                           'simSiStripDigis:ProcessedRaw',
+                           'simSiStripDigis:ScopeMode' ]
 )


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- drop type specifications where the original parameter exists.
-  move all parameter inside the clone
Instead of modifying parameters with full type specs, which can be interpreted as an insertion of a new parameter, it is a safer way to protect from parameter name mistakes and will also help in possible parameter migrations.
(The previous PR for RecoLocalTracker is [PR#30147](https://github.com/cms-sw/cmssw/pull30147). )

In this PR, a total of 2 files changed. 
RecoLocalTracker/Phase2TrackerRecHits
RecoLocalTracker/SiStripZeroSuppression

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).