### PR TITLE
Use EDPutToken in ReducedEGProducer and modernize GEDPhotonCoreProducer

### DIFF
--- a/CommonTools/Egamma/src/ConversionTools.cc
+++ b/CommonTools/Egamma/src/ConversionTools.cc
@@ -69,10 +69,8 @@ bool ConversionTools::matchesConversion(const reco::GsfElectron &ele,
              ele.reco::GsfElectron::closestCtfTrackRef().key() == it->key())
       return true;
     if (allowAmbiguousGsfMatch) {
-      for (reco::GsfTrackRefVector::const_iterator tk = ele.ambiguousGsfTracksBegin();
-           tk != ele.ambiguousGsfTracksEnd();
-           ++tk) {
-        if (tk->isNonnull() && tk->id() == it->id() && tk->key() == it->key())
+      for (auto const &tk : ele.ambiguousGsfTracks()) {
+        if (tk.isNonnull() && tk.id() == it->id() && tk.key() == it->key())
           return true;
       }
     }

--- a/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
+++ b/CommonTools/ParticleFlow/interface/ElectronIDPFCandidateSelectorDefinition.h
@@ -81,8 +81,7 @@ namespace pf2pat {
 
         int match = -1;
         // try first the non-ambiguous tracks
-        for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed;
-             ++it) {
+        for (auto it = electrons->begin(), ed = electrons->end(); it != ed; ++it) {
           if (it->gsfTrack() == PfTk) {
             match = it - electrons->begin();
             break;
@@ -90,9 +89,8 @@ namespace pf2pat {
         }
         // then the ambiguous ones
         if (match == -1) {
-          for (reco::GsfElectronCollection::const_iterator it = electrons->begin(), ed = electrons->end(); it != ed;
-               ++it) {
-            if (std::count(it->ambiguousGsfTracksBegin(), it->ambiguousGsfTracksEnd(), PfTk) > 0) {
+          for (auto it = electrons->begin(), ed = electrons->end(); it != ed; ++it) {
+            if (std::count(it->ambiguousGsfTracks().begin(), it->ambiguousGsfTracks().end(), PfTk) > 0) {
               match = it - electrons->begin();
               break;
             }

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -680,8 +680,7 @@ namespace reco {
     bool passingPflowPreselection() const { return passPflowPreselection_; }
     bool ambiguous() const { return ambiguous_; }
     GsfTrackRefVector::size_type ambiguousGsfTracksSize() const { return ambiguousGsfTracks_.size(); }
-    GsfTrackRefVector::const_iterator ambiguousGsfTracksBegin() const { return ambiguousGsfTracks_.begin(); }
-    GsfTrackRefVector::const_iterator ambiguousGsfTracksEnd() const { return ambiguousGsfTracks_.end(); }
+    auto const &ambiguousGsfTracks() const { return ambiguousGsfTracks_; }
 
     // setters
     void setPassCutBasedPreselection(bool flag) { passCutBasedPreselection_ = flag; }

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
@@ -383,10 +383,8 @@ void PATElectronProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         if (itElectron->gsfTrack() == i->gsfTrackRef()) {
           Matched = true;
         } else {
-          for (reco::GsfTrackRefVector::const_iterator it = itElectron->ambiguousGsfTracksBegin();
-               it != itElectron->ambiguousGsfTracksEnd();
-               it++) {
-            MatchedToAmbiguousGsfTrack |= (bool)(i->gsfTrackRef() == (*it));
+          for (auto const& it : itElectron->ambiguousGsfTracks()) {
+            MatchedToAmbiguousGsfTrack |= (bool)(i->gsfTrackRef() == it);
           }
         }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonCoreProducer.cc
@@ -6,87 +6,52 @@
  ***/
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/RefToPtr.h"
-#include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonCore.h"
-#include "DataFormats/EgammaReco/interface/ClusterShape.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
-#include "DataFormats/GeometryVector/interface/GlobalVector.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
-#include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtra.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/Exception.h"
 
-// GEDPhotonCoreProducer inherits from EDProducer, so it can be a module:
 class GEDPhotonCoreProducer : public edm::stream::EDProducer<> {
 public:
   GEDPhotonCoreProducer(const edm::ParameterSet& ps);
-  ~GEDPhotonCoreProducer() override;
 
   void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
 private:
-  std::string GEDPhotonCoreCollection_;
-  edm::EDGetTokenT<reco::PFCandidateCollection> pfEgammaCandidates_;
-  edm::EDGetTokenT<reco::ElectronSeedCollection> pixelSeedProducer_;
-
-  double minSCEt_;
-  bool validConversions_;
-  edm::ParameterSet conf_;
-  bool validPixelSeeds_;
+  const edm::EDGetTokenT<reco::PFCandidateCollection> pfEgammaCandidates_;
+  const edm::EDGetTokenT<reco::ElectronSeedCollection> pixelSeedProducer_;
+  const edm::EDPutTokenT<reco::PhotonCoreCollection> putToken_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(GEDPhotonCoreProducer);
 
 GEDPhotonCoreProducer::GEDPhotonCoreProducer(const edm::ParameterSet& config)
-    : conf_(config)
+    : pfEgammaCandidates_{consumes(config.getParameter<edm::InputTag>("pfEgammaCandidates"))},
+      pixelSeedProducer_{consumes(config.getParameter<edm::InputTag>("pixelSeedProducer"))},
+      putToken_{produces<reco::PhotonCoreCollection>(config.getParameter<std::string>("gedPhotonCoreCollection"))} {}
 
-{
-  // use onfiguration file to setup input/output collection names
-  pfEgammaCandidates_ = consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfEgammaCandidates"));
-  pixelSeedProducer_ = consumes<reco::ElectronSeedCollection>(conf_.getParameter<edm::InputTag>("pixelSeedProducer"));
-
-  GEDPhotonCoreCollection_ = conf_.getParameter<std::string>("gedPhotonCoreCollection");
-
-  // Register the product
-  produces<reco::PhotonCoreCollection>(GEDPhotonCoreCollection_);
-}
-
-GEDPhotonCoreProducer::~GEDPhotonCoreProducer() {}
-
-void GEDPhotonCoreProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
-  using namespace edm;
-  //  nEvt_++;
-
+void GEDPhotonCoreProducer::produce(edm::Event& event, const edm::EventSetup&) {
   reco::PhotonCoreCollection outputPhotonCoreCollection;
-  auto outputPhotonCoreCollection_p = std::make_unique<reco::PhotonCoreCollection>();
 
   // Get the  PF refined cluster  collection
-  Handle<reco::PFCandidateCollection> pfCandidateHandle;
-  theEvent.getByToken(pfEgammaCandidates_, pfCandidateHandle);
+  auto pfCandidateHandle = event.getHandle(pfEgammaCandidates_);
   if (!pfCandidateHandle.isValid()) {
     edm::LogError("GEDPhotonCoreProducer") << "Error! Can't get the pfEgammaCandidates";
   }
 
   // Get ElectronPixelSeeds
-  validPixelSeeds_ = true;
-  Handle<reco::ElectronSeedCollection> pixelSeedHandle;
-  reco::ElectronSeedCollection pixelSeeds;
-  theEvent.getByToken(pixelSeedProducer_, pixelSeedHandle);
+  bool validPixelSeeds = true;
+  auto pixelSeedHandle = event.getHandle(pixelSeedProducer_);
   if (!pixelSeedHandle.isValid()) {
-    validPixelSeeds_ = false;
+    validPixelSeeds = false;
   }
 
   //  std::cout <<  "  GEDPhotonCoreProducer::produce input PFcandidate size " <<   pfCandidateHandle->size() << std::endl;
@@ -99,12 +64,6 @@ void GEDPhotonCoreProducer::produce(edm::Event& theEvent, const edm::EventSetup&
     reco::PFCandidateEGammaExtraRef pfPhoRef = candRef->egammaExtraRef();
     reco::SuperClusterRef refinedSC = pfPhoRef->superClusterRef();
     reco::SuperClusterRef boxSC = pfPhoRef->superClusterPFECALRef();
-    const reco::ConversionRefVector& doubleLegConv = pfPhoRef->conversionRef();
-    const reco::ConversionRefVector& singleLegConv = pfPhoRef->singleLegConversionRef();
-    reco::CaloClusterPtr refinedSCPtr = edm::refToPtr(refinedSC);
-
-    //    std::cout << "newCandidate  doubleLegConv="<<doubleLegConv.size()<< std::endl;
-    //std::cout << "newCandidate  singleLegConv="<<  pfPhoRef->singleLegConvTrackRef().size()<< std::endl;
 
     //////////
     reco::PhotonCore newCandidate;
@@ -112,21 +71,20 @@ void GEDPhotonCoreProducer::produce(edm::Event& theEvent, const edm::EventSetup&
     newCandidate.setStandardPhoton(false);
     newCandidate.setSuperCluster(refinedSC);
     newCandidate.setParentSuperCluster(boxSC);
+
     // fill conversion infos
-
-    for (unsigned int lConv = 0; lConv < doubleLegConv.size(); lConv++) {
-      newCandidate.addConversion(doubleLegConv[lConv]);
+    for (auto const& conv : pfPhoRef->conversionRef()) {
+      newCandidate.addConversion(conv);
     }
-
-    for (unsigned int lConv = 0; lConv < singleLegConv.size(); lConv++) {
-      newCandidate.addOneLegConversion(singleLegConv[lConv]);
+    for (auto const& conv : pfPhoRef->singleLegConversionRef()) {
+      newCandidate.addOneLegConversion(conv);
     }
 
     //    std::cout << "newCandidate pf refined SC energy="<< newCandidate.superCluster()->energy()<<std::endl;
     //std::cout << "newCandidate pf SC energy="<< newCandidate.parentSuperCluster()->energy()<<std::endl;
     //std::cout << "newCandidate  nconv2leg="<<newCandidate.conversions().size()<< std::endl;
 
-    if (validPixelSeeds_) {
+    if (validPixelSeeds) {
       for (unsigned int icp = 0; icp < pixelSeedHandle->size(); icp++) {
         reco::ElectronSeedRef cpRef(pixelSeedHandle, icp);
         if (boxSC.isNonnull() && boxSC.id() == cpRef->caloCluster().id() && boxSC.key() == cpRef->caloCluster().key()) {
@@ -140,6 +98,5 @@ void GEDPhotonCoreProducer::produce(edm::Event& theEvent, const edm::EventSetup&
 
   // put the product in the event
   //  edm::LogInfo("GEDPhotonCoreProducer") << " Put in the event " << iSC << " Photon Candidates \n";
-  outputPhotonCoreCollection_p->assign(outputPhotonCoreCollection.begin(), outputPhotonCoreCollection.end());
-  theEvent.put(std::move(outputPhotonCoreCollection_p), GEDPhotonCoreCollection_);
+  event.emplace(putToken_, std::move(outputPhotonCoreCollection));
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -32,7 +32,6 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/ESGetToken.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
@@ -182,27 +181,27 @@ private:
 
   edm::ESGetToken<CaloTopology, CaloTopologyRecord> caloTopology_;
   //names for output collections
-  const std::string outPhotons_;
-  const std::string outPhotonCores_;
-  const std::string outOOTPhotons_;
-  const std::string outOOTPhotonCores_;
-  const std::string outGsfElectrons_;
-  const std::string outGsfElectronCores_;
-  const std::string outGsfTracks_;
-  const std::string outConversions_;
-  const std::string outSingleConversions_;
-  const std::string outSuperClusters_;
-  const std::string outEBEEClusters_;
-  const std::string outESClusters_;
-  const std::string outOOTSuperClusters_;
-  const std::string outOOTEBEEClusters_;
-  const std::string outOOTESClusters_;
-  const std::string outEBRecHits_;
-  const std::string outEERecHits_;
-  const std::string outESRecHits_;
-  const std::string outHBHERecHits_;
-  const std::string outPhotonPfCandMap_;
-  const std::string outGsfElectronPfCandMap_;
+  const edm::EDPutTokenT<reco::PhotonCollection> outPhotons_;
+  const edm::EDPutTokenT<reco::PhotonCoreCollection> outPhotonCores_;
+  edm::EDPutTokenT<reco::PhotonCollection> outOOTPhotons_;
+  edm::EDPutTokenT<reco::PhotonCoreCollection> outOOTPhotonCores_;
+  const edm::EDPutTokenT<reco::GsfElectronCollection> outGsfElectrons_;
+  const edm::EDPutTokenT<reco::GsfElectronCoreCollection> outGsfElectronCores_;
+  const edm::EDPutTokenT<reco::GsfTrackCollection> outGsfTracks_;
+  const edm::EDPutTokenT<reco::ConversionCollection> outConversions_;
+  const edm::EDPutTokenT<reco::ConversionCollection> outSingleConversions_;
+  const edm::EDPutTokenT<reco::SuperClusterCollection> outSuperClusters_;
+  const edm::EDPutTokenT<reco::CaloClusterCollection> outEBEEClusters_;
+  const edm::EDPutTokenT<reco::CaloClusterCollection> outESClusters_;
+  edm::EDPutTokenT<reco::SuperClusterCollection> outOOTSuperClusters_;
+  edm::EDPutTokenT<reco::CaloClusterCollection> outOOTEBEEClusters_;
+  edm::EDPutTokenT<reco::CaloClusterCollection> outOOTESClusters_;
+  const edm::EDPutTokenT<EcalRecHitCollection> outEBRecHits_;
+  const edm::EDPutTokenT<EcalRecHitCollection> outEERecHits_;
+  edm::EDPutTokenT<EcalRecHitCollection> outESRecHits_;
+  const edm::EDPutTokenT<HBHERecHitCollection> outHBHERecHits_;
+  const edm::EDPutTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> outPhotonPfCandMap_;
+  const edm::EDPutTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef>>> outGsfElectronPfCandMap_;
   const std::vector<std::string> outPhotonIds_;
   const std::vector<std::string> outGsfElectronIds_;
   const std::vector<std::string> outPhotonFloatValueMaps_;
@@ -226,21 +225,19 @@ private:
 DEFINE_FWK_MODULE(ReducedEGProducer);
 
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
-    : photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
-      gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
-      conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),
-      singleConversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("singleConversions"))),
-      barrelEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"))),
-      endcapEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalHits"))),
+    : photonT_(consumes(config.getParameter<edm::InputTag>("photons"))),
+      gsfElectronT_(consumes(config.getParameter<edm::InputTag>("gsfElectrons"))),
+      conversionT_(consumes(config.getParameter<edm::InputTag>("conversions"))),
+      singleConversionT_(consumes(config.getParameter<edm::InputTag>("singleConversions"))),
+      barrelEcalHits_(consumes(config.getParameter<edm::InputTag>("barrelEcalHits"))),
+      endcapEcalHits_(consumes(config.getParameter<edm::InputTag>("endcapEcalHits"))),
       doPreshowerEcalHits_(!config.getParameter<edm::InputTag>("preshowerEcalHits").label().empty()),
       preshowerEcalHits_(doPreshowerEcalHits_
                              ? consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("preshowerEcalHits"))
                              : edm::EDGetTokenT<EcalRecHitCollection>()),
       hbheHits_(consumes<HBHERecHitCollection>(config.getParameter<edm::InputTag>("hbheHits"))),
-      photonPfCandMapT_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
-          config.getParameter<edm::InputTag>("photonsPFValMap"))),
-      gsfElectronPfCandMapT_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(
-          config.getParameter<edm::InputTag>("gsfElectronsPFValMap"))),
+      photonPfCandMapT_(consumes(config.getParameter<edm::InputTag>("photonsPFValMap"))),
+      gsfElectronPfCandMapT_(consumes(config.getParameter<edm::InputTag>("gsfElectronsPFValMap"))),
       recoHIPhotonIsolationMapInputToken_{
           !config.getParameter<edm::InputTag>("hiPhotonIsolationMapInput").label().empty()
               ? consumes<reco::HIPhotonIsolationMap>(config.getParameter<edm::InputTag>("hiPhotonIsolationMapInput"))
@@ -254,27 +251,22 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
       applyGsfElectronCalibOnData_(config.getParameter<bool>("applyGsfElectronCalibOnData")),
       applyGsfElectronCalibOnMC_(config.getParameter<bool>("applyGsfElectronCalibOnMC")),
       //output collections
-      outPhotons_("reducedGedPhotons"),
-      outPhotonCores_("reducedGedPhotonCores"),
-      outOOTPhotons_("reducedOOTPhotons"),
-      outOOTPhotonCores_("reducedOOTPhotonCores"),
-      outGsfElectrons_("reducedGedGsfElectrons"),
-      outGsfElectronCores_("reducedGedGsfElectronCores"),
-      outGsfTracks_("reducedGsfTracks"),
-      outConversions_("reducedConversions"),
-      outSingleConversions_("reducedSingleLegConversions"),
-      outSuperClusters_("reducedSuperClusters"),
-      outEBEEClusters_("reducedEBEEClusters"),
-      outESClusters_("reducedESClusters"),
-      outOOTSuperClusters_("reducedOOTSuperClusters"),
-      outOOTEBEEClusters_("reducedOOTEBEEClusters"),
-      outOOTESClusters_("reducedOOTESClusters"),
-      outEBRecHits_("reducedEBRecHits"),
-      outEERecHits_("reducedEERecHits"),
-      outESRecHits_("reducedESRecHits"),
-      outHBHERecHits_("reducedHBHEHits"),
-      outPhotonPfCandMap_("reducedPhotonPfCandMap"),
-      outGsfElectronPfCandMap_("reducedGsfElectronPfCandMap"),
+      outPhotons_{produces<reco::PhotonCollection>("reducedGedPhotons")},
+      outPhotonCores_{produces<reco::PhotonCoreCollection>("reducedGedPhotonCores")},
+      outGsfElectrons_{produces<reco::GsfElectronCollection>("reducedGedGsfElectrons")},
+      outGsfElectronCores_{produces<reco::GsfElectronCoreCollection>("reducedGedGsfElectronCores")},
+      outGsfTracks_{produces<reco::GsfTrackCollection>("reducedGsfTracks")},
+      outConversions_{produces<reco::ConversionCollection>("reducedConversions")},
+      outSingleConversions_{produces<reco::ConversionCollection>("reducedSingleLegConversions")},
+      outSuperClusters_{produces<reco::SuperClusterCollection>("reducedSuperClusters")},
+      outEBEEClusters_{produces<reco::CaloClusterCollection>("reducedEBEEClusters")},
+      outESClusters_{produces<reco::CaloClusterCollection>("reducedESClusters")},
+      outEBRecHits_{produces<EcalRecHitCollection>("reducedEBRecHits")},
+      outEERecHits_{produces<EcalRecHitCollection>("reducedEERecHits")},
+      outHBHERecHits_{produces<HBHERecHitCollection>("reducedHBHEHits")},
+      outPhotonPfCandMap_{produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("reducedPhotonPfCandMap")},
+      outGsfElectronPfCandMap_{
+          produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>("reducedGsfElectronPfCandMap")},
       outPhotonIds_(config.getParameter<std::vector<std::string>>("photonIDOutput")),
       outGsfElectronIds_(config.getParameter<std::vector<std::string>>("gsfElectronIDOutput")),
       outPhotonFloatValueMaps_(config.getParameter<std::vector<std::string>>("photonFloatValueMapOutput")),
@@ -290,7 +282,7 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
       slimRelinkGsfElectronSel_(config.getParameter<std::string>("slimRelinkGsfElectrons")),
       relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons")),
       hcalHitSel_(config.getParameter<edm::ParameterSet>("hcalHitSel"), consumesCollector()) {
-  const edm::InputTag& aTag = config.getParameter<edm::InputTag>("ootPhotons");
+  const auto& aTag = config.getParameter<edm::InputTag>("ootPhotons");
   caloTopology_ = esConsumes();
   if (not aTag.label().empty())
     ootPhotonT_ = consumes<reco::PhotonCollection>(aTag);
@@ -326,32 +318,18 @@ ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config)
     setToken(gsfElectronCalibEcalEnergyErrT_, config, "gsfElectronCalibEcalEnergyErrSource");
   }
 
-  produces<reco::PhotonCollection>(outPhotons_);
-  produces<reco::PhotonCoreCollection>(outPhotonCores_);
   if (!ootPhotonT_.isUninitialized()) {
-    produces<reco::PhotonCollection>(outOOTPhotons_);
-    produces<reco::PhotonCoreCollection>(outOOTPhotonCores_);
+    outOOTPhotons_ = produces<reco::PhotonCollection>("reducedOOTPhotons");
+    outOOTPhotonCores_ = produces<reco::PhotonCoreCollection>("reducedOOTPhotonCores");
   }
-  produces<reco::GsfElectronCollection>(outGsfElectrons_);
-  produces<reco::GsfElectronCoreCollection>(outGsfElectronCores_);
-  produces<reco::GsfTrackCollection>(outGsfTracks_);
-  produces<reco::ConversionCollection>(outConversions_);
-  produces<reco::ConversionCollection>(outSingleConversions_);
-  produces<reco::SuperClusterCollection>(outSuperClusters_);
-  produces<reco::CaloClusterCollection>(outEBEEClusters_);
-  produces<reco::CaloClusterCollection>(outESClusters_);
   if (!ootPhotonT_.isUninitialized()) {
-    produces<reco::SuperClusterCollection>(outOOTSuperClusters_);
-    produces<reco::CaloClusterCollection>(outOOTEBEEClusters_);
-    produces<reco::CaloClusterCollection>(outOOTESClusters_);
+    outOOTSuperClusters_ = produces<reco::SuperClusterCollection>("reducedOOTSuperClusters");
+    outOOTEBEEClusters_ = produces<reco::CaloClusterCollection>("reducedOOTEBEEClusters");
+    outOOTESClusters_ = produces<reco::CaloClusterCollection>("reducedOOTESClusters");
   }
-  produces<EcalRecHitCollection>(outEBRecHits_);
-  produces<EcalRecHitCollection>(outEERecHits_);
-  if (doPreshowerEcalHits_)
-    produces<EcalRecHitCollection>(outESRecHits_);
-  produces<HBHERecHitCollection>(outHBHERecHits_);
-  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(outPhotonPfCandMap_);
-  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(outGsfElectronPfCandMap_);
+  if (doPreshowerEcalHits_) {
+    outESRecHits_ = produces<EcalRecHitCollection>("reducedESRecHits");
+  }
   for (const std::string& outid : outPhotonIds_) {
     produces<edm::ValueMap<bool>>(outid);
   }
@@ -451,27 +429,27 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   auto const& caloTopology = theEventSetup.getData(caloTopology_);
 
   //initialize output collections
-  auto photons = std::make_unique<reco::PhotonCollection>();
-  auto photonCores = std::make_unique<reco::PhotonCoreCollection>();
-  auto ootPhotons = std::make_unique<reco::PhotonCollection>();
-  auto ootPhotonCores = std::make_unique<reco::PhotonCoreCollection>();
-  auto gsfElectrons = std::make_unique<reco::GsfElectronCollection>();
-  auto gsfElectronCores = std::make_unique<reco::GsfElectronCoreCollection>();
-  auto gsfTracks = std::make_unique<reco::GsfTrackCollection>();
-  auto conversions = std::make_unique<reco::ConversionCollection>();
-  auto singleConversions = std::make_unique<reco::ConversionCollection>();
-  auto superClusters = std::make_unique<reco::SuperClusterCollection>();
-  auto ebeeClusters = std::make_unique<reco::CaloClusterCollection>();
-  auto esClusters = std::make_unique<reco::CaloClusterCollection>();
-  auto ootSuperClusters = std::make_unique<reco::SuperClusterCollection>();
-  auto ootEbeeClusters = std::make_unique<reco::CaloClusterCollection>();
-  auto ootEsClusters = std::make_unique<reco::CaloClusterCollection>();
-  auto ebRecHits = std::make_unique<EcalRecHitCollection>();
-  auto eeRecHits = std::make_unique<EcalRecHitCollection>();
-  auto esRecHits = std::make_unique<EcalRecHitCollection>();
-  auto hbheRecHits = std::make_unique<HBHERecHitCollection>();
-  auto photonPfCandMap = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
-  auto gsfElectronPfCandMap = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
+  reco::PhotonCollection photons{};
+  reco::PhotonCoreCollection photonCores{};
+  reco::PhotonCollection ootPhotons{};
+  reco::PhotonCoreCollection ootPhotonCores{};
+  reco::GsfElectronCollection gsfElectrons{};
+  reco::GsfElectronCoreCollection gsfElectronCores{};
+  reco::GsfTrackCollection gsfTracks{};
+  reco::ConversionCollection conversions{};
+  reco::ConversionCollection singleConversions{};
+  reco::SuperClusterCollection superClusters{};
+  reco::CaloClusterCollection ebeeClusters{};
+  reco::CaloClusterCollection esClusters{};
+  reco::SuperClusterCollection ootSuperClusters{};
+  reco::CaloClusterCollection ootEbeeClusters{};
+  reco::CaloClusterCollection ootEsClusters{};
+  EcalRecHitCollection ebRecHits{};
+  EcalRecHitCollection eeRecHits{};
+  EcalRecHitCollection esRecHits{};
+  HBHERecHitCollection hbheRecHits{};
+  edm::ValueMap<std::vector<reco::PFCandidateRef>> photonPfCandMap{};
+  edm::ValueMap<std::vector<reco::PFCandidateRef>> gsfElectronPfCandMap{};
 
   //maps to collection indices of output objects
   std::map<reco::PhotonCoreRef, unsigned int> photonCoreMap;
@@ -515,8 +493,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     index++;
 
     reco::PhotonRef photonref(photonHandle, index);
-    photons->push_back(photon);
-    auto& newPhoton = photons->back();
+    photons.push_back(photon);
+    auto& newPhoton = photons.back();
 
     if ((applyPhotonCalibOnData_ && theEvent.isRealData()) || (applyPhotonCalibOnMC_ && !theEvent.isRealData())) {
       calibratePhoton(newPhoton, photonref, *photonCalibEnergyHandle, *photonCalibEnergyErrHandle);
@@ -525,7 +503,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     //we do this after calibration
     bool keep = keepPhotonSel_(newPhoton);
     if (!keep) {
-      photons->pop_back();
+      photons.pop_back();
       continue;
     }
 
@@ -550,7 +528,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
     //link photon core
     const reco::PhotonCoreRef& photonCore = photon.photonCore();
-    linkCore(photonCore, *photonCores, photonCoreMap);
+    linkCore(photonCore, photonCores, photonCoreMap);
 
     bool slimRelink = slimRelinkPhotonSel_(newPhoton);
     //no supercluster relinking unless slimRelink selection is satisfied
@@ -561,18 +539,18 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
     //link supercluster
     const reco::SuperClusterRef& superCluster = photon.superCluster();
-    linkSuperCluster(superCluster, superClusterMap, *superClusters, relink, superClusterFullRelinkMap);
+    linkSuperCluster(superCluster, superClusterMap, superClusters, relink, superClusterFullRelinkMap);
 
     //conversions only for full relinking
     if (!relink)
       continue;
 
     const reco::ConversionRefVector& convrefs = photon.conversions();
-    linkConversions(convrefs, *conversions, conversionMap);
+    linkConversions(convrefs, conversions, conversionMap);
 
     //explicitly references conversions
     const reco::ConversionRefVector& singleconvrefs = photon.conversionsOneLeg();
-    linkConversions(singleconvrefs, *singleConversions, singleConversionMap);
+    linkConversions(singleconvrefs, singleConversions, singleConversionMap);
 
     //hcal hits
     linkHcalHits(*photon.superCluster(), *hbheHitHandle, hcalRechitMap);
@@ -593,7 +571,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
       reco::PhotonRef ootPhotonref(ootPhotonHandle, index);
 
-      ootPhotons->push_back(ootPhoton);
+      ootPhotons.push_back(ootPhoton);
 
       //fill photon pfclusteriso valuemap vectors
       int subindex = 0;
@@ -603,7 +581,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
       //link photon core
       const reco::PhotonCoreRef& ootPhotonCore = ootPhoton.photonCore();
-      linkCore(ootPhotonCore, *ootPhotonCores, ootPhotonCoreMap);
+      linkCore(ootPhotonCore, ootPhotonCores, ootPhotonCoreMap);
 
       bool slimRelink = slimRelinkOOTPhotonSel_(ootPhoton);
       //no supercluster relinking unless slimRelink selection is satisfied
@@ -613,7 +591,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
       bool relink = relinkOOTPhotonSel_(ootPhoton);
 
       const reco::SuperClusterRef& ootSuperCluster = ootPhoton.superCluster();
-      linkSuperCluster(ootSuperCluster, ootSuperClusterMap, *ootSuperClusters, relink, ootSuperClusterFullRelinkMap);
+      linkSuperCluster(ootSuperCluster, ootSuperClusterMap, ootSuperClusters, relink, ootSuperClusterFullRelinkMap);
       //hcal hits
       linkHcalHits(*ootPhoton.superCluster(), *hbheHitHandle, hcalRechitMap);
     }
@@ -625,8 +603,8 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     index++;
 
     reco::GsfElectronRef gsfElectronref(gsfElectronHandle, index);
-    gsfElectrons->push_back(gsfElectron);
-    auto& newGsfElectron = gsfElectrons->back();
+    gsfElectrons.push_back(gsfElectron);
+    auto& newGsfElectron = gsfElectrons.back();
     if ((applyGsfElectronCalibOnData_ && theEvent.isRealData()) ||
         (applyGsfElectronCalibOnMC_ && !theEvent.isRealData())) {
       calibrateElectron(newGsfElectron,
@@ -639,7 +617,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
     bool keep = keepGsfElectronSel_(newGsfElectron);
     if (!keep) {
-      gsfElectrons->pop_back();
+      gsfElectrons.pop_back();
       continue;
     }
 
@@ -657,22 +635,22 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     }
 
     const reco::GsfElectronCoreRef& gsfElectronCore = gsfElectron.core();
-    linkCore(gsfElectronCore, *gsfElectronCores, gsfElectronCoreMap);
+    linkCore(gsfElectronCore, gsfElectronCores, gsfElectronCoreMap);
 
     const reco::GsfTrackRef& gsfTrack = gsfElectron.gsfTrack();
 
     // Save the main gsfTrack
     if (!gsfTrackMap.count(gsfTrack)) {
-      gsfTracks->push_back(*gsfTrack);
-      gsfTrackMap[gsfTrack] = gsfTracks->size() - 1;
+      gsfTracks.push_back(*gsfTrack);
+      gsfTrackMap[gsfTrack] = gsfTracks.size() - 1;
     }
 
     // Save additional ambiguous gsf tracks in a map:
     for (auto igsf = gsfElectron.ambiguousGsfTracksBegin(); igsf != gsfElectron.ambiguousGsfTracksEnd(); ++igsf) {
       const reco::GsfTrackRef& ambigGsfTrack = *igsf;
       if (!gsfTrackMap.count(ambigGsfTrack)) {
-        gsfTracks->push_back(*ambigGsfTrack);
-        gsfTrackMap[ambigGsfTrack] = gsfTracks->size() - 1;
+        gsfTracks.push_back(*ambigGsfTrack);
+        gsfTrackMap[ambigGsfTrack] = gsfTracks.size() - 1;
       }
     }
 
@@ -684,24 +662,24 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     bool relink = relinkGsfElectronSel_(newGsfElectron);
 
     const reco::SuperClusterRef& superCluster = gsfElectron.superCluster();
-    linkSuperCluster(superCluster, superClusterMap, *superClusters, relink, superClusterFullRelinkMap);
+    linkSuperCluster(superCluster, superClusterMap, superClusters, relink, superClusterFullRelinkMap);
 
     //conversions only for full relinking
     if (!relink)
       continue;
 
     const reco::ConversionRefVector& convrefs = gsfElectron.core()->conversions();
-    linkConversions(convrefs, *conversions, conversionMap);
+    linkConversions(convrefs, conversions, conversionMap);
 
     //explicitly references conversions
     const reco::ConversionRefVector& singleconvrefs = gsfElectron.core()->conversionsOneLeg();
-    linkConversions(singleconvrefs, *singleConversions, singleConversionMap);
+    linkConversions(singleconvrefs, singleConversions, singleConversionMap);
 
     //conversions matched by trackrefs
-    linkConversionsByTrackRef(conversionHandle, gsfElectron, *conversions, conversionMap);
+    linkConversionsByTrackRef(conversionHandle, gsfElectron, conversions, conversionMap);
 
     //single leg conversions matched by trackrefs
-    linkConversionsByTrackRef(singleConversionHandle, gsfElectron, *singleConversions, singleConversionMap);
+    linkConversionsByTrackRef(singleConversionHandle, gsfElectron, singleConversions, singleConversionMap);
 
     //hcal hits
     linkHcalHits(*gsfElectron.superCluster(), *hbheHitHandle, hcalRechitMap);
@@ -709,10 +687,10 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
   //loop over output SuperClusters and fill maps
   index = 0;
-  for (auto& superCluster : *superClusters) {
+  for (auto& superCluster : superClusters) {
     //link seed cluster no matter what
     const reco::CaloClusterPtr& seedCluster = superCluster.seed();
-    linkCaloCluster(seedCluster, *ebeeClusters, ebeeClusterMap);
+    linkCaloCluster(seedCluster, ebeeClusters, ebeeClusterMap);
 
     //only proceed if superCluster is marked for full relinking
     bool fullrelink = superClusterFullRelinkMap.count(index++);
@@ -724,29 +702,29 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
     // link calo clusters
     linkCaloClusters(superCluster,
-                     *ebeeClusters,
+                     ebeeClusters,
                      ebeeClusterMap,
                      rechitMap,
                      barrelHitHandle,
                      endcapHitHandle,
                      caloTopology,
-                     *esClusters,
+                     esClusters,
                      esClusterMap);
 
     //conversions matched geometrically
-    linkConversionsByTrackRef(conversionHandle, superCluster, *conversions, conversionMap);
+    linkConversionsByTrackRef(conversionHandle, superCluster, conversions, conversionMap);
 
     //single leg conversions matched by trackrefs
-    linkConversionsByTrackRef(singleConversionHandle, superCluster, *singleConversions, singleConversionMap);
+    linkConversionsByTrackRef(singleConversionHandle, superCluster, singleConversions, singleConversionMap);
   }
 
   //loop over output OOTSuperClusters and fill maps
   if (!ootPhotonT_.isUninitialized()) {
     index = 0;
-    for (auto& ootSuperCluster : *ootSuperClusters) {
+    for (auto& ootSuperCluster : ootSuperClusters) {
       //link seed cluster no matter what
       const reco::CaloClusterPtr& ootSeedCluster = ootSuperCluster.seed();
-      linkCaloCluster(ootSeedCluster, *ootEbeeClusters, ootEbeeClusterMap);
+      linkCaloCluster(ootSeedCluster, ootEbeeClusters, ootEbeeClusterMap);
 
       //only proceed if ootSuperCluster is marked for full relinking
       bool fullrelink = ootSuperClusterFullRelinkMap.count(index++);
@@ -758,13 +736,13 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
 
       // link calo clusters
       linkCaloClusters(ootSuperCluster,
-                       *ootEbeeClusters,
+                       ootEbeeClusters,
                        ootEbeeClusterMap,
                        rechitMap,
                        barrelHitHandle,
                        endcapHitHandle,
                        caloTopology,
-                       *ootEsClusters,
+                       ootEsClusters,
                        ootEsClusterMap);
     }
   }
@@ -773,43 +751,43 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   //rechits (fill output collections of rechits to be stored)
   for (const EcalRecHit& rechit : *barrelHitHandle) {
     if (rechitMap.count(rechit.detid())) {
-      ebRecHits->push_back(rechit);
+      ebRecHits.push_back(rechit);
     }
   }
 
   for (const EcalRecHit& rechit : *endcapHitHandle) {
     if (rechitMap.count(rechit.detid())) {
-      eeRecHits->push_back(rechit);
+      eeRecHits.push_back(rechit);
     }
   }
 
-  theEvent.put(std::move(ebRecHits), outEBRecHits_);
-  theEvent.put(std::move(eeRecHits), outEERecHits_);
+  theEvent.emplace(outEBRecHits_, std::move(ebRecHits));
+  theEvent.emplace(outEERecHits_, std::move(eeRecHits));
 
   if (doPreshowerEcalHits_) {
     for (const EcalRecHit& rechit : *preshowerHitHandle) {
       if (rechitMap.count(rechit.detid())) {
-        esRecHits->push_back(rechit);
+        esRecHits.push_back(rechit);
       }
     }
-    theEvent.put(std::move(esRecHits), outESRecHits_);
+    theEvent.emplace(outESRecHits_, std::move(esRecHits));
   }
 
   for (const HBHERecHit& rechit : *hbheHitHandle) {
     if (hcalRechitMap.count(rechit.detid())) {
-      hbheRecHits->push_back(rechit);
+      hbheRecHits.push_back(rechit);
     }
   }
-  theEvent.put(std::move(hbheRecHits), outHBHERecHits_);
+  theEvent.emplace(outHBHERecHits_, std::move(hbheRecHits));
 
   //CaloClusters
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const auto& outEBEEClusterHandle = theEvent.put(std::move(ebeeClusters), outEBEEClusters_);
-  const auto& outESClusterHandle = theEvent.put(std::move(esClusters), outESClusters_);
+  const auto& outEBEEClusterHandle = theEvent.emplace(outEBEEClusters_, std::move(ebeeClusters));
+  const auto& outESClusterHandle = theEvent.emplace(outESClusters_, std::move(esClusters));
   ;
 
   //Loop over SuperClusters and relink GEDPhoton + GSFElectron CaloClusters
-  for (reco::SuperCluster& superCluster : *superClusters) {
+  for (reco::SuperCluster& superCluster : superClusters) {
     relinkCaloClusters(superCluster, ebeeClusterMap, esClusterMap, outEBEEClusterHandle, outESClusterHandle);
   }
 
@@ -819,21 +797,21 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   edm::OrphanHandle<reco::CaloClusterCollection> outOOTESClusterHandle;
   //Loop over OOTSuperClusters and relink OOTPhoton CaloClusters
   if (!ootPhotonT_.isUninitialized()) {
-    outOOTEBEEClusterHandle = theEvent.put(std::move(ootEbeeClusters), outOOTEBEEClusters_);
-    outOOTESClusterHandle = theEvent.put(std::move(ootEsClusters), outOOTESClusters_);
-    for (reco::SuperCluster& ootSuperCluster : *ootSuperClusters) {
+    outOOTEBEEClusterHandle = theEvent.emplace(outOOTEBEEClusters_, std::move(ootEbeeClusters));
+    outOOTESClusterHandle = theEvent.emplace(outOOTESClusters_, std::move(ootEsClusters));
+    for (reco::SuperCluster& ootSuperCluster : ootSuperClusters) {
       relinkCaloClusters(
           ootSuperCluster, ootEbeeClusterMap, ootEsClusterMap, outOOTEBEEClusterHandle, outOOTESClusterHandle);
     }
   }
   //put superclusters and conversions in the event
-  const auto& outSuperClusterHandle = theEvent.put(std::move(superClusters), outSuperClusters_);
-  const auto& outConversionHandle = theEvent.put(std::move(conversions), outConversions_);
-  const auto& outSingleConversionHandle = theEvent.put(std::move(singleConversions), outSingleConversions_);
-  const auto& outGsfTrackHandle = theEvent.put(std::move(gsfTracks), outGsfTracks_);
+  const auto& outSuperClusterHandle = theEvent.emplace(outSuperClusters_, std::move(superClusters));
+  const auto& outConversionHandle = theEvent.emplace(outConversions_, std::move(conversions));
+  const auto& outSingleConversionHandle = theEvent.emplace(outSingleConversions_, std::move(singleConversions));
+  const auto& outGsfTrackHandle = theEvent.emplace(outGsfTracks_, std::move(gsfTracks));
 
   //Loop over PhotonCores and relink GEDPhoton SuperClusters (and conversions)
-  for (reco::PhotonCore& photonCore : *photonCores) {
+  for (reco::PhotonCore& photonCore : photonCores) {
     // superclusters
     relinkSuperCluster(photonCore, superClusterMap, outSuperClusterHandle);
 
@@ -847,7 +825,7 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
 
   //Relink GSFElectron SuperClusters and main GSF Tracks
-  for (reco::GsfElectronCore& gsfElectronCore : *gsfElectronCores) {
+  for (reco::GsfElectronCore& gsfElectronCore : gsfElectronCores) {
     relinkSuperCluster(gsfElectronCore, superClusterMap, outSuperClusterHandle);
     relinkGsfTrack(gsfElectronCore, gsfTrackMap, outGsfTrackHandle);
   }
@@ -855,32 +833,32 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   //put ootsuperclusters in the event
   edm::OrphanHandle<reco::SuperClusterCollection> outOOTSuperClusterHandle;
   if (!ootPhotonT_.isUninitialized())
-    outOOTSuperClusterHandle = theEvent.put(std::move(ootSuperClusters), outOOTSuperClusters_);
+    outOOTSuperClusterHandle = theEvent.emplace(outOOTSuperClusters_, std::move(ootSuperClusters));
 
   //Relink OOTPhoton SuperClusters
-  for (reco::PhotonCore& ootPhotonCore : *ootPhotonCores) {
+  for (reco::PhotonCore& ootPhotonCore : ootPhotonCores) {
     relinkSuperCluster(ootPhotonCore, ootSuperClusterMap, outOOTSuperClusterHandle);
   }
 
   //put photoncores and gsfelectroncores into the event
-  const auto& outPhotonCoreHandle = theEvent.put(std::move(photonCores), outPhotonCores_);
+  const auto& outPhotonCoreHandle = theEvent.emplace(outPhotonCores_, std::move(photonCores));
   edm::OrphanHandle<reco::PhotonCoreCollection> outOOTPhotonCoreHandle;
   if (!ootPhotonT_.isUninitialized())
-    outOOTPhotonCoreHandle = theEvent.put(std::move(ootPhotonCores), outOOTPhotonCores_);
-  const auto& outgsfElectronCoreHandle = theEvent.put(std::move(gsfElectronCores), outGsfElectronCores_);
+    outOOTPhotonCoreHandle = theEvent.emplace(outOOTPhotonCores_, std::move(ootPhotonCores));
+  const auto& outgsfElectronCoreHandle = theEvent.emplace(outGsfElectronCores_, std::move(gsfElectronCores));
 
   //loop over photons, oot photons, and electrons and relink the cores
-  for (reco::Photon& photon : *photons) {
+  for (reco::Photon& photon : photons) {
     relinkPhotonCore(photon, photonCoreMap, outPhotonCoreHandle);
   }
 
   if (!ootPhotonT_.isUninitialized()) {
-    for (reco::Photon& ootPhoton : *ootPhotons) {
+    for (reco::Photon& ootPhoton : ootPhotons) {
       relinkPhotonCore(ootPhoton, ootPhotonCoreMap, outOOTPhotonCoreHandle);
     }
   }
 
-  for (reco::GsfElectron& gsfElectron : *gsfElectrons) {
+  for (reco::GsfElectron& gsfElectron : gsfElectrons) {
     relinkGsfElectronCore(gsfElectron, gsfElectronCoreMap, outgsfElectronCoreHandle);
 
     // -----
@@ -912,26 +890,26 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   }
 
   //(finally) store the output photon and electron collections
-  const auto& outPhotonHandle = theEvent.put(std::move(photons), outPhotons_);
+  const auto& outPhotonHandle = theEvent.emplace(outPhotons_, std::move(photons));
   edm::OrphanHandle<reco::PhotonCollection> outOOTPhotonHandle;
   if (!ootPhotonT_.isUninitialized())
-    outOOTPhotonHandle = theEvent.put(std::move(ootPhotons), outOOTPhotons_);
-  const auto& outGsfElectronHandle = theEvent.put(std::move(gsfElectrons), outGsfElectrons_);
+    outOOTPhotonHandle = theEvent.emplace(outOOTPhotons_, std::move(ootPhotons));
+  const auto& outGsfElectronHandle = theEvent.emplace(outGsfElectrons_, std::move(gsfElectrons));
 
   //still need to output relinked valuemaps
 
   //photon pfcand isolation valuemap
-  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerPhotons(*photonPfCandMap);
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerPhotons(photonPfCandMap);
   fillerPhotons.insert(outPhotonHandle, pfCandIsoPairVecPho.begin(), pfCandIsoPairVecPho.end());
   fillerPhotons.fill();
 
   //electron pfcand isolation valuemap
-  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerGsfElectrons(*gsfElectronPfCandMap);
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerGsfElectrons(gsfElectronPfCandMap);
   fillerGsfElectrons.insert(outGsfElectronHandle, pfCandIsoPairVecEle.begin(), pfCandIsoPairVecEle.end());
   fillerGsfElectrons.fill();
 
-  theEvent.put(std::move(photonPfCandMap), outPhotonPfCandMap_);
-  theEvent.put(std::move(gsfElectronPfCandMap), outGsfElectronPfCandMap_);
+  theEvent.emplace(outPhotonPfCandMap_, std::move(photonPfCandMap));
+  theEvent.emplace(outGsfElectronPfCandMap_, std::move(gsfElectronPfCandMap));
 
   auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = "") {
     typedef edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -644,8 +644,7 @@ void ReducedEGProducer::produce(edm::Event& event, const edm::EventSetup& eventS
     }
 
     // Save additional ambiguous gsf tracks in a map:
-    for (auto igsf = gsfElectron.ambiguousGsfTracksBegin(); igsf != gsfElectron.ambiguousGsfTracksEnd(); ++igsf) {
-      const reco::GsfTrackRef& ambigGsfTrack = *igsf;
+    for (auto const& ambigGsfTrack : gsfElectron.ambiguousGsfTracks()) {
       if (!gsfTrackMap.count(ambigGsfTrack)) {
         gsfTracks.push_back(*ambigGsfTrack);
         gsfTrackMap[ambigGsfTrack] = gsfTracks.size() - 1;
@@ -863,8 +862,8 @@ void ReducedEGProducer::produce(edm::Event& event, const edm::EventSetup& eventS
     // Also in this loop let's relink ambiguous tracks
     std::vector<reco::GsfTrackRef> ambigTracksInThisElectron;
     // Here we loop over the ambiguous tracks and save them in a vector
-    for (auto igsf = gsfElectron.ambiguousGsfTracksBegin(); igsf != gsfElectron.ambiguousGsfTracksEnd(); ++igsf) {
-      ambigTracksInThisElectron.push_back(*igsf);
+    for (auto const& igsf : gsfElectron.ambiguousGsfTracks()) {
+      ambigTracksInThisElectron.push_back(igsf);
     }
 
     // Now we need to clear them (they are the refs to original collection):


### PR DESCRIPTION
#### PR description:

When working a bit with the ReducedEGProducer module in https://github.com/cms-sw/cmssw/pull/32462, I realized that this module produces many products and once. Using the `EDPutToken` instead of carrying the strings with product names around makes this a bit clearer I think, so this PR suggests to use the `EDPutToken` for all products.

Furthermore, the `GEDPhotonCoreProducer` module is modernized, and includes of `*Handle.h` are avoided in the package, because these includes are necessarily inherited from the inclusion of `Event.h` or `EventSetup.h`.

#### PR validation:

CMSSW compiles, local matrix tests pass.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.