### PR TITLE
Removed unnecessary dependency from RecoParticleFlow/PFProducer

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
+++ b/RecoParticleFlow/PFProducer/plugins/BuildFile.xml
@@ -80,7 +80,5 @@
   <use name="RecoParticleFlow/PFTracking"/>
   <use name="RecoEcal/EgammaCoreTools"/>
   <use name="PhysicsTools/TensorFlow"/>
-  <use name="HeterogeneousCore/SonicCore"/>
-  <use name="HeterogeneousCore/SonicTriton"/>
   <flags EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
#### PR description:

The dependency upon the Sonic packages is unnecessary and caused a linking problem on the UBSAN builds.

#### PR validation:

The code compiles.