### PR TITLE
Added missing ROOT dependency for test in CondCore/SiStripPlugins

### DIFF
--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -2,5 +2,6 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
+<use name="roothistpainter"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
 </bin>


### PR DESCRIPTION
#### PR description:

This is needed for the UBSAN build as it requires access to virtual tables.

#### PR validation:

The code compiles and links find under the UBSAN build.