### PR TITLE
Fix the ExternalGeneratorFilter argument passing to python config

### DIFF
--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -39,7 +39,8 @@ class ExternalGeneratorFilter(cms.EDFilter):
         options.indent()
         result += "\n"+options.indentation() + self._prod.dumpPython(options)
         result +=options.indentation()+",\n"
-        result += options.indentation() + self._external_process_verbose_.dumpPython(options)
+        result += options.indentation() + "_external_process_waitTime_ = " + self._external_process_waitTime_.dumpPython(options) + ',\n'
+        result += options.indentation() + "_external_process_verbose_ = " + self._external_process_verbose_.dumpPython(options) + ','
         options.unindent()
         result += "\n)\n"
         return result


### PR DESCRIPTION
#### PR description:

Fix the ExternalGeneratorFilter argument passing to python config. 
The fix is needed by UL run on 10_6_X. It is therefore applied to 11_3_X, 11_2_X, 11_1_X, and 10_6_X.

#### PR validation:

Validated on [`PPD-MultiValidationUL17GEN-00004`](https://cms-pdmv.cern.ch/mcm/requests?page=0&prepid=PPD-MultiValidationUL17GEN-00004), which uses `ExternalGeneratorFilter` with given argument `_external_process_waitTime_`.

(A test script for this UL sample on 10_6_X):
```shell
export SCRAM_ARCH=slc7_amd64_gcc700
cmsrel CMSSW_10_6_X_2021-01-11-1100
cd CMSSW_10_6_X_2021-01-11-1100/src
cmsenv
git cms-merge-topic colizz:dev-106X-fixExternalGeneratorFilterArgsPassing
curl -s -k https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/PPD-MultiValidationUL17GEN-00004 --retry 3 --create-dirs -o Configuration/GenProduction/python/PPD-MultiValidationUL17GEN-00004-fragment.py
## Modify the fragment to provide _external_process_waitTime_ argument
sed -i "s/ExternalGeneratorFilter(_generator)/ExternalGeneratorFilter(_generator, _external_process_waitTime_=cms.untracked.uint32(600))/g" Configuration/GenProduction/python/PPD-MultiValidationUL17GEN-00004-fragment.py
scram b -j8
cd ../..
cmsDriver.py Configuration/GenProduction/python/PPD-MultiValidationUL17GEN-00004-fragment.py --python_filename PPD-MultiValidationUL17GEN-00004_1_cfg.py --eventcontent RAWSIM --customise Configuration/DataProcessing/Utils.addMonitoring --datatier GEN --fileout file:PPD-MultiValidationUL17GEN-00004.root --conditions 106X_mc2017_realistic_v6 --beamspot Realistic25ns13TeVEarly2017Collision --customise_commands process.source.numberEventsInLuminosityBlock="cms.untracked.uint32(100)" --step GEN --geometry DB:Extended --era Run2_2017 --no_exec --mc -n 1000 --nThreads 4
cmsRun -e -j PPD-MultiValidationUL17GEN-00004_report.xml PPD-MultiValidationUL17GEN-00004_1_cfg.py
```
