### PR TITLE
[11_2_X] Fix the ExternalGeneratorFilter argument passing to python config

### DIFF
--- a/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
+++ b/GeneratorInterface/Core/python/ExternalGeneratorFilter.py
@@ -39,7 +39,8 @@ class ExternalGeneratorFilter(cms.EDFilter):
         options.indent()
         result += "\n"+options.indentation() + self._prod.dumpPython(options)
         result +=options.indentation()+",\n"
-        result += options.indentation() + self._external_process_verbose_.dumpPython(options)
+        result += options.indentation() + "_external_process_waitTime_ = " + self._external_process_waitTime_.dumpPython(options) + ',\n'
+        result += options.indentation() + "_external_process_verbose_ = " + self._external_process_verbose_.dumpPython(options) + ','
         options.unindent()
         result += "\n)\n"
         return result


### PR DESCRIPTION
#### PR description:

**This is a 11_2_X backport from #32636**

Fix the ExternalGeneratorFilter argument passing to python config. 
The fix is needed by UL run on 10_6_X. It is therefore applied to 11_3_X, 11_2_X, 11_1_X, and 10_6_X.

#### PR validation:

See #32636.