### PR TITLE
ETL v5 (D73) units of measurement moved to constant section

### DIFF
--- a/Geometry/MTDCommonData/data/etl/v5/etl.xml
+++ b/Geometry/MTDCommonData/data/etl/v5/etl.xml
@@ -9,63 +9,86 @@
     <Constant name="Disc2center" value="3030.42*mm+0.2*mm"/>
     <Constant name="ETLrmin" value="[caloBase:Rmin100]"/>
     <Constant name="ETLrmax" value="[caloBase:Rmax100]"/>
-    <Constant name="Disc_thickness" value="27.9"/>
-    <Constant name="Al_Disc_thickness" value="7.24"/>
-    <Constant name="Disc_Rmin" value="300"/>
-    <Constant name="Disc_Rmax" value="1190"/>
-    <Constant name="DeltaX" value="0.5"/>
-    <Constant name="ServiceHybrid_Y" value="34"/>
+    <Constant name="Disc_thickness" value="27.9*mm"/>
+    <Constant name="Al_Disc_thickness" value="7.24*mm"/>
+    <Constant name="Disc_Rmin" value="300*mm"/>
+    <Constant name="Disc_Rmax" value="1190*mm"/>
+    <Constant name="DeltaX" value="0.5*mm"/>
+    <Constant name="ServiceHybrid_Y" value="34*mm"/>
+    <Constant name="SensorModule_Y" value="25.85*mm"/>  <!-- 28.25mm - 2.4mm overlapping with SH -->
+    <Constant name="SensorModule_X" value="43.1*mm"/>
+    <Constant name="SensorModule_Z" value="2.29*mm"/>
     <Constant name="ServiceHybrid_X3" value="3*[SensorModule_X]"/>
     <Constant name="ServiceHybrid_X6" value="6*[SensorModule_X]"/>
     <Constant name="ServiceHybrid_X7" value="7*[SensorModule_X]"/>
-    <Constant name="ServiceHybrid_Z" value="10.33"/>
-    <Constant name="SensorModule_Y" value="25.85"/>  <!-- 28.25mm - 2.4mm overlapping with SH -->
-    <Constant name="SensorModule_X" value="43.1"/>
-    <Constant name="SensorModule_Z" value="2.29"/>
-    <Constant name="DeltaY_ServiceModule" value="29.925"/>  <!-- ServiceHybrid_Y/2 + SensorModule_Y/2 -->
-    <Constant name="DeltaX_Service3_Service6" value="194.45"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X6/2 -->
-    <Constant name="DeltaX_Service3_Service7" value="216"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X7/2 -->
-    <Constant name="DeltaX_Service6_Service7" value="280.65"/>  <!-- DeltaX + ServiceHybrid_X6/2 + ServiceHybrid_X7/2 -->
-    <Constant name="LGADdy" value="21.2"/>
-    <Constant name="LGADdx" value="42"/>
-    <Constant name="EModule_Timingactive" value="0.05"/> 
-    <Constant name="LGAD_Substrate" value="0.25"/>
-    <Constant name="LGADdz" value="0.3"/>
-    <Constant name="lgadSep_Y" value="0.25"/>
-    <Constant name="lgadSep_X" value="0.5"/>
-    <Constant name="ETROCdy" value="22.3"/>
-    <Constant name="ETROCdx" value="20.8"/>
-    <Constant name="ETROCdz" value="0.25"/>
-    <Constant name="etrocSep_Y" value="0.3"/>
-    <Constant name="etrocSep_X" value="0.1"/>
-    <Constant name="y_start_front" value="1190-33.05-[SensorModule_Y]/2"/>
-    <Constant name="y_start_back" value="-1190+16.05+[ServiceHybrid_Y]/2"/>
-    <Constant name="x_offset" value="1+[SensorModule_X]/2"/>
+    <Constant name="ServiceHybrid_Z" value="10.33*mm"/>
+    <Constant name="DeltaY_ServiceModule" value="29.925*mm"/>  <!-- ServiceHybrid_Y/2 + SensorModule_Y/2 -->
+    <Constant name="DeltaX_Service3_Service6" value="194.45*mm"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X6/2 -->
+    <Constant name="DeltaX_Service3_Service7" value="216*mm"/>  <!-- DeltaX + ServiceHybrid_X3/2 + ServiceHybrid_X7/2 -->
+    <Constant name="DeltaX_Service6_Service7" value="280.65*mm"/>  <!-- DeltaX + ServiceHybrid_X6/2 + ServiceHybrid_X7/2 -->
+    <Constant name="LGADdy" value="21.2*mm"/>
+    <Constant name="LGADdx" value="42*mm"/>
+    <Constant name="EModule_Timingactive" value="0.05*mm"/>
+    <Constant name="LGAD_Substrate" value="0.25*mm"/>
+    <Constant name="LGADdz" value="0.3*mm"/>
+    <Constant name="lgadSep_Y" value="0.25*mm"/>
+    <Constant name="lgadSep_X" value="0.5*mm"/>
+    <Constant name="ETROCdy" value="22.3*mm"/>
+    <Constant name="ETROCdx" value="20.8*mm"/>
+    <Constant name="ETROCdz" value="0.25*mm"/>
+    <Constant name="ETROCdz_bump" value="0.28*mm"/> <!-- solder bumps not considered in ETROCdz, their thickness is included in that of the ETROC -->
+    <Constant name="etrocSep_Y" value="0.3*mm"/>
+    <Constant name="etrocSep_X" value="0.1*mm"/>
+    <Constant name="y_start_front" value="1190*mm - 33.05*mm - [SensorModule_Y]/2"/>
+    <Constant name="y_start_back" value="-1190*mm + 16.05*mm + [ServiceHybrid_Y]/2"/>
+    <Constant name="x_offset" value="1*mm + [SensorModule_X]/2"/>
+    <Constant name="ThermalPad_dz" value="0.25*mm"/>
+    <Constant name="AIN_Carrier_dz" value="0.79*mm"/>
+    <Constant name="LairdFilm_dz" value="0.08*mm"/>
+    <Constant name="AIN_Cover_dz" value="0.59*mm"/> <!-- epoxy included in the thickness of the AlN cover -->
+    <Constant name="ETL_translation_z" value="3024.68497*mm"/>
+    <Constant name="Disk_translation_z" value="8.785*mm"/>
+    <Constant name="ThermalPad_translation_z" value="1.02*mm"/>
+    <Constant name="AIN_Carrier_translation_z" value="0.5*mm"/>
+    <Constant name="LairdFilm_translation_y" value="1.7*mm"/>
+    <Constant name="LairdFilm_translation_z" value="0.065*mm"/>
+    <Constant name="ETROC_translation_x" value="10.45*mm"/>
+    <Constant name="ETROC_translation_y" value="1.625*mm"/>
+    <Constant name="ETROC_translation_z" value="0.115*mm"/>
+    <Constant name="LGAD_translation_y" value="2.2*mm"/>
+    <Constant name="LGAD_translation_z" value="-0.405*mm"/>
+    <Constant name="EModule_Timingactive_translation_z" value="-0.125*mm"/>
+    <Constant name="LGAD_Substrate_translation_z" value="0.025*mm"/>
+    <Constant name="AIN_Cover_translation_y" value="2.2*mm"/>
+    <Constant name="AIN_Cover_translation_z" value="-0.85*mm"/>
+    <Constant name="Zpos1" value="4.02*mm"/>
+    <Constant name="Zpos2" value="0.*mm"/>
+    <Constant name="xoffset_servicehybrid" value="1*mm"/>
   </ConstantsSection>
 
 
   <SolidSection label="etl.xml">
     <Tubs name="EndcapTimingLayer" rMin="[ETLrmin]" rMax="[ETLrmax]" dz="0.5*[ETLthickness]" startPhi="0*deg" deltaPhi="360*deg"/>
-    <Tubs name="Disc" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[Disc_thickness]*mm" startPhi="0*deg" deltaPhi="360*deg"/>
-    <Tubs name="Al_Disc" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[Al_Disc_thickness]*mm" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Disc" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Disc_thickness]" startPhi="0*deg" deltaPhi="360*deg"/>
+    <Tubs name="Al_Disc" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[Al_Disc_thickness]" startPhi="0*deg" deltaPhi="360*deg"/>
     
     <!-- FRONT: face closest to IP, BACK: furthest from IP -->
-    <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
-    <Tubs name="DiscSector_Back" rMin="[Disc_Rmin]*mm" rMax="[Disc_Rmax]*mm" dz="0.5*[ServiceHybrid_Z]*mm" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on back face -->
+    <Tubs name="DiscSector_Front" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[ServiceHybrid_Z]" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on front face -->
+    <Tubs name="DiscSector_Back" rMin="[Disc_Rmin]" rMax="[Disc_Rmax]" dz="0.5*[ServiceHybrid_Z]" startPhi="-90*deg" deltaPhi="180*deg"/> <!-- half-disc on back face -->
     
-    <Box name="SensorModule" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*[SensorModule_Z]*mm"/>
-    <Box name="ServiceHybrid3" dx="0.5*[ServiceHybrid_X3]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
-    <Box name="ServiceHybrid6" dx="0.5*[ServiceHybrid_X6]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
-    <Box name="ServiceHybrid7" dx="0.5*[ServiceHybrid_X7]*mm" dy="0.5*[ServiceHybrid_Y]*mm" dz="0.5*[ServiceHybrid_Z]*mm"/>
+    <Box name="SensorModule" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[SensorModule_Z]"/>
+    <Box name="ServiceHybrid3" dx="0.5*[ServiceHybrid_X3]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
+    <Box name="ServiceHybrid6" dx="0.5*[ServiceHybrid_X6]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
+    <Box name="ServiceHybrid7" dx="0.5*[ServiceHybrid_X7]" dy="0.5*[ServiceHybrid_Y]" dz="0.5*[ServiceHybrid_Z]"/>
     
-    <Box name="ThermalPad" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*(0.25)*mm"/>
-    <Box name="AlN_Carrier" dx="0.5*[SensorModule_X]*mm" dy="0.5*[SensorModule_Y]*mm" dz="0.5*(0.79)*mm"/>
-    <Box name="LairdFilm" dx="0.5*([ETROCdx]*2+[etrocSep_X])*mm" dy="0.5*([ETROCdy]+0.5*[etrocSep_Y])*mm" dz="0.5*(0.08)*mm"/>
-    <Box name="ETROC" dx="0.5*[ETROCdx]*mm" dy="0.5*[ETROCdy]*mm" dz="0.5*(0.28)*mm"/>  <!-- solder bumps not considered, their thickness is included in that of the ETROC -->
-    <Box name="LGAD" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[LGADdz]*mm"/>
-    <Box name="EModule_Timingactive" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[EModule_Timingactive]*mm"/>
-    <Box name="LGAD_Substrate" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*[LGAD_Substrate]*mm"/>
-    <Box name="AlN_Cover" dx="0.5*[LGADdx]*mm" dy="0.5*[LGADdy]*mm" dz="0.5*(0.59)*mm"/>  <!-- epoxy included in the thickness of the AlN cover -->
+    <Box name="ThermalPad" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[ThermalPad_dz]"/>
+    <Box name="AlN_Carrier" dx="0.5*[SensorModule_X]" dy="0.5*[SensorModule_Y]" dz="0.5*[AIN_Carrier_dz]"/>
+    <Box name="LairdFilm" dx="0.5*([ETROCdx]*2+[etrocSep_X])" dy="0.5*([ETROCdy]+0.5*[etrocSep_Y])" dz="0.5*[LairdFilm_dz]"/>
+    <Box name="ETROC" dx="0.5*[ETROCdx]" dy="0.5*[ETROCdy]" dz="0.5*[ETROCdz_bump]"/>
+    <Box name="LGAD" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[LGADdz]"/>
+    <Box name="EModule_Timingactive" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[EModule_Timingactive]"/>
+    <Box name="LGAD_Substrate" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[LGAD_Substrate]"/>
+    <Box name="AlN_Cover" dx="0.5*[LGADdx]" dy="0.5*[LGADdy]" dz="0.5*[AIN_Cover_dz]"/>
   </SolidSection>
 
 
@@ -224,240 +247,243 @@
     <PosPart copyNumber="1">                                           
       <rParent name="caloBase:CALOECFront"/>               
       <rChild name="etl:EndcapTimingLayer"/>  
-      <Translation x="0." y="0." z="3024.68497*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[ETL_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:EndcapTimingLayer"/>                         
       <rChild name="etl:Disc1Timing"/>  
-      <Translation x="0." y="0." z="[Disc1center]-[ETLcenter]" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disc1center]-[ETLcenter]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:EndcapTimingLayer"/>                         
       <rChild name="etl:Disc2Timing"/>  
-      <Translation x="0." y="0." z="[Disc2center]-[ETLcenter]" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disc2center]-[ETLcenter]" />
     </PosPart> 
     
     <!-- Children volumes Disc1Timing -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:Al_Disc"/> 
-      <Translation x="0*mm" y="0*mm" z="0*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="0." />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Front"/> 
       <rRotation name="etl:0"/> 
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Front"/>  
       <rRotation name="etl:180"/>
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>  
       <rRotation name="etl:0"/>
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc1Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>
       <rRotation name="etl:180"/>  
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart> 
 
     <!-- Children volumes Disc2Timing -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:Al_Disc"/> 
-      <Translation x="0*mm" y="0*mm" z="0*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="0." />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Front"/> 
       <rRotation name="etl:0"/> 
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Front"/>  
       <rRotation name="etl:180"/>
-      <Translation x="0*mm" y="0*mm" z="-8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[Disk_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>  
       <rRotation name="etl:0"/>
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:Disc2Timing"/>                         
       <rChild name="etl:DiscSector_Back"/>
       <rRotation name="etl:180"/>  
-      <Translation x="0*mm" y="0*mm" z="8.785*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[Disk_translation_z]" />
     </PosPart>
     
+
     <!-- Elements composing SensorModule_Front_Right -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:ThermalPad"/>  
-      <Translation x="0." y="0." z="1.02*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[ThermalPad_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:AlN_Carrier"/>  
-      <Translation x="0." y="0." z="0.5*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[AIN_Carrier_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="0." y="1.7" z="0.065*mm" />
+      <Translation x="0.*mm" y="[LairdFilm_translation_y]" z="[LairdFilm_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="10.45*mm" y="1.625*mm" z="-0.115*mm" />
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-10.45*mm" y="1.625*mm" z="-0.115*mm" />
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:LGAD"/>  
-      <Translation x="0." y="2.2*mm" z="-0.405*mm" />
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="[LGAD_translation_z]" />
     </PosPart>
     <!-- definition of LGAD active/substrate volumes -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:LGAD"/>                         
       <rChild name="etl:EModule_Timingactive"/>  
-      <Translation x="0.*mm" y="0.*mm" z="-0.125*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[EModule_Timingactive_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:LGAD"/>                         
       <rChild name="etl:LGAD_Substrate"/>  
-      <Translation x="0.*mm" y="0.*mm" z="0.025*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[LGAD_Substrate_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Right"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="0." y="2.2*mm" z="-0.85*mm" />
+      <Translation x="0.*mm" y="[AIN_Cover_translation_y]" z="[AIN_Cover_translation_z]" />
     </PosPart> 
+    
     
     <!-- Elements composing SensorModule_Front_Left -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:ThermalPad"/>  
-      <Translation x="0." y="0." z="1.02*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[ThermalPad_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:AlN_Carrier"/>  
-      <Translation x="0." y="0." z="0.5*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="[AIN_Carrier_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="0." y="-0.17" z="0.065*mm" />
+      <Translation x="0.*mm" y="-1*[LairdFilm_translation_y]" z="[LairdFilm_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="10.45*mm" y="-1.625*mm" z="-0.115*mm" />
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-10.45*mm" y="-1.625*mm" z="-0.115*mm" />
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="-1*[ETROC_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:LGAD"/>  
-      <Translation x="0." y="-2.2*mm" z="-0.405*mm" />
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="[LGAD_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Front_Left"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="0." y="-2.2*mm" z="-0.85*mm" />
+      <Translation x="0.*mm" y="-1*[AIN_Cover_translation_y]" z="[AIN_Cover_translation_z]" />
     </PosPart>
 
     <!-- Elements composing SensorModule_Back_Left -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:ThermalPad"/>  
-      <Translation x="0." y="0." z="-1.02*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[ThermalPad_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:AlN_Carrier"/>  
-      <Translation x="0." y="0." z="-0.5*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[AIN_Carrier_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="0." y="0.17" z="-0.065*mm" />
+      <Translation x="0.*mm" y="[LairdFilm_translation_y]" z="-1*[LairdFilm_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="10.45*mm" y="1.625*mm" z="0.115*mm" />
+      <Translation x="[ETROC_translation_x]" y="[ETROC_translation_y]" z="[ETROC_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-10.45*mm" y="1.625*mm" z="0.115*mm" />
+      <Translation x="-1*[ETROC_translation_x]" y="[ETROC_translation_y]" z="[ETROC_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:LGAD"/>
       <rRotation name="etl:Reverse" />  
-      <Translation x="0." y="2.2*mm" z="0.405*mm" />
+      <Translation x="0.*mm" y="[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Left"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="0." y="2.2*mm" z="0.85*mm" />
+      <Translation x="0.*mm" y="[AIN_Cover_translation_y]" z="-1*[AIN_Cover_translation_z]" />
     </PosPart>
 
+    
     <!-- Elements composing SensorModule_Back_Right -->
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:ThermalPad"/>  
-      <Translation x="0." y="0." z="-1.02*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[ThermalPad_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:AlN_Carrier"/>  
-      <Translation x="0." y="0." z="-0.5*mm" />
+      <Translation x="0.*mm" y="0.*mm" z="-1*[AIN_Carrier_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:LairdFilm"/>  
-      <Translation x="0." y="-0.17" z="-0.065*mm" />
+      <Translation x="0.*mm" y="-1*[LairdFilm_translation_y]" z="-1*[LairdFilm_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="10.45*mm" y="-1.625*mm" z="0.115*mm" />
+      <Translation x="[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[ETROC_translation_z]" />
     </PosPart>
     <PosPart copyNumber="2">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:ETROC"/>  
-      <Translation x="-10.45*mm" y="-1.625*mm" z="0.115*mm" />
+      <Translation x="-1*[ETROC_translation_x]" y="-1*[ETROC_translation_y]" z="[ETROC_translation_z]" />
     </PosPart> 
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:LGAD"/>  
       <rRotation name="etl:Reverse" />
-      <Translation x="0." y="-2.2*mm" z="0.405*mm" />
+      <Translation x="0.*mm" y="-1*[LGAD_translation_y]" z="-1*[LGAD_translation_z]" />
     </PosPart>
     <PosPart copyNumber="1">                                           
       <rParent name="etl:SensorModule_Back_Right"/>                         
       <rChild name="etl:AlN_Cover"/>  
-      <Translation x="0." y="-2.2*mm" z="0.85*mm" />
+      <Translation x="0.*mm" y="-1*[AIN_Cover_translation_y]" z="-1*[AIN_Cover_translation_z]" />
     </PosPart>     
   </PosPartSection> 
 
@@ -474,8 +500,8 @@
     <Numeric name="N" value="6"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -487,8 +513,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_front]-[DeltaY_ServiceModule])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_front]-[DeltaY_ServiceModule]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -500,8 +526,8 @@
     <Numeric name="N" value="7"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-2*[DeltaY_ServiceModule])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-2*[DeltaY_ServiceModule]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -513,8 +539,8 @@
     <Numeric name="N" value="11"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-2*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-2*[DeltaY_ServiceModule]-[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -526,8 +552,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X6]/2), ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -539,8 +565,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]-3*[DeltaY_ServiceModule]-[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -552,8 +578,8 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-4*[DeltaY_ServiceModule]-[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-4*[DeltaY_ServiceModule]-[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -565,8 +591,8 @@
     <Numeric name="N" value="15"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-4*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-4*[DeltaY_ServiceModule]-2*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -578,8 +604,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X3]/2), ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -591,8 +617,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid] +[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -604,8 +630,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-5*[DeltaY_ServiceModule]-2*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -617,8 +643,8 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-6*[DeltaY_ServiceModule]-2*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-6*[DeltaY_ServiceModule]-2*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -630,8 +656,8 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-6*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-6*[DeltaY_ServiceModule]-3*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -643,8 +669,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-7*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-7*[DeltaY_ServiceModule]-3*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -656,8 +682,8 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="37"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-8*[DeltaY_ServiceModule]-3*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-8*[DeltaY_ServiceModule]-3*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -669,8 +695,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="50"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-8*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-8*[DeltaY_ServiceModule]-4*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -682,8 +708,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -695,8 +721,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]-9*[DeltaY_ServiceModule]-4*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -708,8 +734,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="55"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-10*[DeltaY_ServiceModule]-4*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-10*[DeltaY_ServiceModule]-4*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -721,8 +747,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="69"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-10*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-10*[DeltaY_ServiceModule]-5*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -734,8 +760,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -747,8 +773,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -760,8 +786,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]-11*[DeltaY_ServiceModule]-5*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -773,8 +799,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="75"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-12*[DeltaY_ServiceModule]-5*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-12*[DeltaY_ServiceModule]-5*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -786,8 +812,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="90"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-12*[DeltaY_ServiceModule]-6*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -799,8 +825,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -812,8 +838,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -825,8 +851,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-13*[DeltaY_ServiceModule]-6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -838,8 +864,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="97"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-14*[DeltaY_ServiceModule]-6*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-14*[DeltaY_ServiceModule]-6*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -851,8 +877,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="112"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-14*[DeltaY_ServiceModule]-7*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -864,8 +890,8 @@
     <Numeric name="N" value="4"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-15*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-15*[DeltaY_ServiceModule]-7*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -877,8 +903,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="120"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-16*[DeltaY_ServiceModule]-7*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-16*[DeltaY_ServiceModule]-7*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -890,8 +916,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="136"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-16*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-16*[DeltaY_ServiceModule]-8*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -903,8 +929,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -916,8 +942,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]-17*[DeltaY_ServiceModule]-8*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -929,8 +955,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="144"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-18*[DeltaY_ServiceModule]-8*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-18*[DeltaY_ServiceModule]-8*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -942,8 +968,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="161"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-18*[DeltaY_ServiceModule]-9*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -955,8 +981,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -968,8 +994,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -981,8 +1007,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-19*[DeltaY_ServiceModule]-9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -994,8 +1020,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="169"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX])*mm, ([y_start_front]-20*[DeltaY_ServiceModule]-9*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX]), ([y_start_front]-20*[DeltaY_ServiceModule]-9*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1007,8 +1033,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="186"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX])*mm, ([y_start_front]-20*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX]), ([y_start_front]-20*[DeltaY_ServiceModule]-10*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1020,8 +1046,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1033,8 +1059,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-21*[DeltaY_ServiceModule]-10*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1046,8 +1072,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="193"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-22*[DeltaY_ServiceModule]-10*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-22*[DeltaY_ServiceModule]-10*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1059,8 +1085,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="207"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-22*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-22*[DeltaY_ServiceModule]-11*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1072,8 +1098,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1085,8 +1111,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-23*[DeltaY_ServiceModule]-11*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1098,8 +1124,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="213"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-24*[DeltaY_ServiceModule]-11*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-24*[DeltaY_ServiceModule]-11*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1111,8 +1137,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="227"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-24*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-24*[DeltaY_ServiceModule]-12*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1124,8 +1150,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1137,8 +1163,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="12"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_front]-25*[DeltaY_ServiceModule]-12*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1150,8 +1176,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="233"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-26*[DeltaY_ServiceModule]-12*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-26*[DeltaY_ServiceModule]-12*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1163,8 +1189,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="247"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-26*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-26*[DeltaY_ServiceModule]-13*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1176,8 +1202,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]), ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1189,8 +1215,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="24"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1202,8 +1228,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+9*[SensorModule_X]+9*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-27*[DeltaY_ServiceModule]-13*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1215,8 +1241,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="252"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-28*[DeltaY_ServiceModule]-13*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-28*[DeltaY_ServiceModule]-13*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1228,8 +1254,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="266"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-28*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-28*[DeltaY_ServiceModule]-14*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1241,8 +1267,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="12"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1254,8 +1280,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.7+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_front]-29*[DeltaY_ServiceModule]-14*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1267,8 +1293,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="271"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-30*[DeltaY_ServiceModule]-14*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-30*[DeltaY_ServiceModule]-14*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1280,8 +1306,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="285"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-30*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-30*[DeltaY_ServiceModule]-15*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1293,8 +1319,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1306,8 +1332,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5.78+ --> [x_offset]+7*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-31*[DeltaY_ServiceModule]-15*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1319,8 +1345,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="291"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-32*[DeltaY_ServiceModule]-15*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-32*[DeltaY_ServiceModule]-15*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1332,8 +1358,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="305"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-32*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-32*[DeltaY_ServiceModule]-16*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1345,8 +1371,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1358,8 +1384,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-33*[DeltaY_ServiceModule]-16*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1371,8 +1397,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="311"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX])*mm, ([y_start_front]-34*[DeltaY_ServiceModule]-16*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+5*[SensorModule_X]+5*[DeltaX]), ([y_start_front]-34*[DeltaY_ServiceModule]-16*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1384,8 +1410,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="325"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX])*mm, ([y_start_front]-34*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+2*[SensorModule_X]+2*[DeltaX]), ([y_start_front]-34*[DeltaY_ServiceModule]-17*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1397,8 +1423,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1410,8 +1436,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="31"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1423,8 +1449,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-35*[DeltaY_ServiceModule]-17*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1436,8 +1462,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="332"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-36*[DeltaY_ServiceModule]-17*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-36*[DeltaY_ServiceModule]-17*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1449,8 +1475,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="349"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-36*[DeltaY_ServiceModule]-18*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1462,8 +1488,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="32"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1475,8 +1501,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+2*[ServiceHybrid_X6]+2*[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]-37*[DeltaY_ServiceModule]-18*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1488,8 +1514,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="357"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-38*[DeltaY_ServiceModule]-18*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-38*[DeltaY_ServiceModule]-18*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1501,8 +1527,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="374"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-38*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-38*[DeltaY_ServiceModule]-19*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1514,8 +1540,8 @@
     <Numeric name="N" value="4"/>
     <Numeric name="StartCopyNo" value="35"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-39*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-39*[DeltaY_ServiceModule]-19*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1527,8 +1553,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="382"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-40*[DeltaY_ServiceModule]-19*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-40*[DeltaY_ServiceModule]-19*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1540,8 +1566,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="398"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-40*[DeltaY_ServiceModule]-20*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1553,8 +1579,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1566,8 +1592,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="39"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1579,8 +1605,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-41*[DeltaY_ServiceModule]-20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1592,8 +1618,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="406"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-42*[DeltaY_ServiceModule]-20*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-42*[DeltaY_ServiceModule]-20*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1605,8 +1631,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="421"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-42*[DeltaY_ServiceModule]-21*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1618,8 +1644,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1631,8 +1657,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="40"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1644,8 +1670,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="22"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_front]-43*[DeltaY_ServiceModule]-21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1657,8 +1683,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="428"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-44*[DeltaY_ServiceModule]-21*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-44*[DeltaY_ServiceModule]-21*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1670,8 +1696,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="443"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-44*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-44*[DeltaY_ServiceModule]-22*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1683,8 +1709,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="42"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1696,8 +1722,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]-45*[DeltaY_ServiceModule]-22*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1709,8 +1735,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="449"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-46*[DeltaY_ServiceModule]-22*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-46*[DeltaY_ServiceModule]-22*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1722,8 +1748,8 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="463"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-46*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-46*[DeltaY_ServiceModule]-23*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1735,8 +1761,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="43"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-47*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-47*[DeltaY_ServiceModule]-23*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1748,8 +1774,8 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="468"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-48*[DeltaY_ServiceModule]-23*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-48*[DeltaY_ServiceModule]-23*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1761,8 +1787,8 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="481"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-48*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-48*[DeltaY_ServiceModule]-24*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1774,8 +1800,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1787,8 +1813,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="46"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1800,8 +1826,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_front]-49*[DeltaY_ServiceModule]-24*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1813,8 +1839,8 @@
     <Numeric name="N" value="15"/>
     <Numeric name="StartCopyNo" value="485"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-50*[DeltaY_ServiceModule]-24*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-50*[DeltaY_ServiceModule]-24*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1826,8 +1852,8 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="497"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-50*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-50*[DeltaY_ServiceModule]-25*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1839,8 +1865,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="47"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1852,8 +1878,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="26"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7])*mm, ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[DeltaX_Service6_Service7]), ([y_start_front]-51*[DeltaY_ServiceModule]-25*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1865,8 +1891,8 @@
     <Numeric name="N" value="11"/>
     <Numeric name="StartCopyNo" value="500"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-52*[DeltaY_ServiceModule]-25*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-52*[DeltaY_ServiceModule]-25*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1878,8 +1904,8 @@
     <Numeric name="N" value="7"/>
     <Numeric name="StartCopyNo" value="510"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-52*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-52*[DeltaY_ServiceModule]-26*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1891,8 +1917,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="27"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_front]-53*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_front]-53*[DeltaY_ServiceModule]-26*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1904,8 +1930,8 @@
     <Numeric name="N" value="6"/>
     <Numeric name="StartCopyNo" value="511"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_front]-54*[DeltaY_ServiceModule]-26*[SensorModule_Y])*mm, 4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_front]-54*[DeltaY_ServiceModule]-26*[SensorModule_Y]), ([Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1924,8 +1950,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1937,8 +1963,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+[DeltaY_ServiceModule])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+[DeltaY_ServiceModule]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1950,8 +1976,8 @@
     <Numeric name="N" value="9"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+[DeltaY_ServiceModule]+[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+[DeltaY_ServiceModule]+[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1963,8 +1989,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1976,8 +2002,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]+2*[DeltaY_ServiceModule]+[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -1989,8 +2015,8 @@
     <Numeric name="N" value="10"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+3*[DeltaY_ServiceModule]+[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+3*[DeltaY_ServiceModule]+[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2002,8 +2028,8 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+3*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+3*[DeltaY_ServiceModule]+2*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2015,8 +2041,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="2"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+4*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]+4*[DeltaY_ServiceModule]+2*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2028,8 +2054,8 @@
     <Numeric name="N" value="14"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+5*[DeltaY_ServiceModule]+2*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2041,8 +2067,8 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+5*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+5*[DeltaY_ServiceModule]+3*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2054,8 +2080,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2067,8 +2093,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]+6*[DeltaY_ServiceModule]+3*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2080,8 +2106,8 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+7*[DeltaY_ServiceModule]+3*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+7*[DeltaY_ServiceModule]+3*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2093,8 +2119,8 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="39"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+7*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+7*[DeltaY_ServiceModule]+4*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2106,8 +2132,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="1"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2119,8 +2145,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+8*[DeltaY_ServiceModule]+4*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2132,8 +2158,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="45"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+9*[DeltaY_ServiceModule]+4*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+9*[DeltaY_ServiceModule]+4*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2145,8 +2171,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="57"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+9*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+9*[DeltaY_ServiceModule]+5*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2158,8 +2184,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="7"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+10*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]+10*[DeltaY_ServiceModule]+5*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2171,8 +2197,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="64"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+11*[DeltaY_ServiceModule]+5*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2184,8 +2210,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="77"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+11*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+11*[DeltaY_ServiceModule]+6*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2197,8 +2223,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="4"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2210,8 +2236,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="3"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2223,8 +2249,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+12*[DeltaY_ServiceModule]+6*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2236,8 +2262,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="85"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+13*[DeltaY_ServiceModule]+6*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2249,8 +2275,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="99"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+13*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+13*[DeltaY_ServiceModule]+7*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2262,8 +2288,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="5"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2275,8 +2301,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="5"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2288,8 +2314,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="11"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_back]+14*[DeltaY_ServiceModule]+7*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2301,8 +2327,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="107"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+15*[DeltaY_ServiceModule]+7*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+15*[DeltaY_ServiceModule]+7*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2314,8 +2340,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="122"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+15*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+15*[DeltaY_ServiceModule]+8*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2327,8 +2353,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2340,8 +2366,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="6"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]+16*[DeltaY_ServiceModule]+8*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2353,8 +2379,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="130"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+17*[DeltaY_ServiceModule]+8*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+17*[DeltaY_ServiceModule]+8*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2366,8 +2392,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="146"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+17*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+17*[DeltaY_ServiceModule]+9*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2379,8 +2405,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="8"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2392,8 +2418,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="9"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2405,8 +2431,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+18*[DeltaY_ServiceModule]+9*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2418,8 +2444,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="154"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+19*[DeltaY_ServiceModule]+9*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2431,8 +2457,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="171"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX])*mm, ([y_start_back]+19*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX]), ([y_start_back]+19*[DeltaY_ServiceModule]+10*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2444,8 +2470,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="10"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2457,8 +2483,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="14"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+20*[DeltaY_ServiceModule]+10*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2470,8 +2496,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="179"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+21*[DeltaY_ServiceModule]+10*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]+21*[DeltaY_ServiceModule]+10*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2483,8 +2509,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="194"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+21*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]+21*[DeltaY_ServiceModule]+11*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2496,8 +2522,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2509,8 +2535,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+22*[DeltaY_ServiceModule]+11*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2522,8 +2548,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="201"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+23*[DeltaY_ServiceModule]+11*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]+23*[DeltaY_ServiceModule]+11*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2535,8 +2561,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="214"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+23*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+23*[DeltaY_ServiceModule]+12*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2548,8 +2574,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="15"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2561,8 +2587,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="18"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+24*[DeltaY_ServiceModule]+12*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2574,8 +2600,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="221"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+25*[DeltaY_ServiceModule]+12*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+25*[DeltaY_ServiceModule]+12*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2587,8 +2613,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="234"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+25*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+25*[DeltaY_ServiceModule]+13*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2600,8 +2626,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2613,8 +2639,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="20"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+26*[DeltaY_ServiceModule]+13*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2626,8 +2652,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="241"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+27*[DeltaY_ServiceModule]+13*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2639,8 +2665,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="254"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+27*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+27*[DeltaY_ServiceModule]+14*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2652,8 +2678,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2665,8 +2691,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="22"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 5+ --> [x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+28*[DeltaY_ServiceModule]+14*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2678,8 +2704,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="260"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+29*[DeltaY_ServiceModule]+14*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+29*[DeltaY_ServiceModule]+14*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2691,8 +2717,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="273"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+29*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+29*[DeltaY_ServiceModule]+15*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2704,8 +2730,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="21"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX])*mm, ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]), ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2717,8 +2743,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="24"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+8*[SensorModule_X]+8*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+30*[DeltaY_ServiceModule]+15*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2730,8 +2756,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="280"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+31*[DeltaY_ServiceModule]+15*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([SensorModule_X]/2+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+31*[DeltaY_ServiceModule]+15*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2743,8 +2769,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="293"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+31*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]+31*[DeltaY_ServiceModule]+16*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2756,8 +2782,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="23"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX])*mm, ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]), ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2769,8 +2795,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="26"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+7*[SensorModule_X]+7*[DeltaX]+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+32*[DeltaY_ServiceModule]+16*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2782,8 +2808,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="300"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX])*mm, ([y_start_back]+33*[DeltaY_ServiceModule]+16*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+6*[SensorModule_X]+6*[DeltaX]), ([y_start_back]+33*[DeltaY_ServiceModule]+16*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2795,8 +2821,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="313"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+33*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> (<!-- 1+ --> [x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]+33*[DeltaY_ServiceModule]+17*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2808,8 +2834,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="25"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX])*mm, ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]), ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2821,8 +2847,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7])*mm, ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+4*[SensorModule_X]+4*[DeltaX]+2*[ServiceHybrid_X3]+2*[DeltaX]+[DeltaX_Service3_Service7]), ([y_start_back]+34*[DeltaY_ServiceModule]+17*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2834,8 +2860,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="320"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX])*mm, ([y_start_back]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]+3*[SensorModule_X]+3*[DeltaX]), ([y_start_back]+35*[DeltaY_ServiceModule]+17*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2847,8 +2873,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="335"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+35*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+35*[DeltaY_ServiceModule]+18*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2860,8 +2886,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="28"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2873,8 +2899,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="11"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2886,8 +2912,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="30"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+36*[DeltaY_ServiceModule]+18*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2899,8 +2925,8 @@
     <Numeric name="N" value="25"/>
     <Numeric name="StartCopyNo" value="343"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+37*[DeltaY_ServiceModule]+18*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+37*[DeltaY_ServiceModule]+18*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2912,8 +2938,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="360"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+37*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+37*[DeltaY_ServiceModule]+19*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2925,8 +2951,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="30"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2938,8 +2964,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="13"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6])*mm, ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[ServiceHybrid_X3]+[DeltaX]+[DeltaX_Service3_Service6]), ([y_start_back]+38*[DeltaY_ServiceModule]+19*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2951,8 +2977,8 @@
     <Numeric name="N" value="24"/>
     <Numeric name="StartCopyNo" value="368"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+39*[DeltaY_ServiceModule]+19*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+39*[DeltaY_ServiceModule]+19*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2964,8 +2990,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="384"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+39*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+39*[DeltaY_ServiceModule]+20*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2977,8 +3003,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="32"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -2990,8 +3016,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="16"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3003,8 +3029,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="31"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[DeltaX_Service6_Service7]), ([y_start_back]+40*[DeltaY_ServiceModule]+20*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3016,8 +3042,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="392"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+41*[DeltaY_ServiceModule]+20*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3029,8 +3055,8 @@
     <Numeric name="N" value="23"/>
     <Numeric name="StartCopyNo" value="407"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+41*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+41*[DeltaY_ServiceModule]+21*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3042,8 +3068,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3055,8 +3081,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="17"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6])*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]), ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3068,8 +3094,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="33"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service6]+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+42*[DeltaY_ServiceModule]+21*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3081,8 +3107,8 @@
     <Numeric name="N" value="22"/>
     <Numeric name="StartCopyNo" value="415"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+43*[DeltaY_ServiceModule]+21*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3094,8 +3120,8 @@
     <Numeric name="N" value="21"/>
     <Numeric name="StartCopyNo" value="430"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+43*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+43*[DeltaY_ServiceModule]+22*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3107,8 +3133,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="34"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+44*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]+44*[DeltaY_ServiceModule]+22*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3120,8 +3146,8 @@
     <Numeric name="N" value="20"/>
     <Numeric name="StartCopyNo" value="437"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+45*[DeltaY_ServiceModule]+22*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+45*[DeltaY_ServiceModule]+22*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3133,8 +3159,8 @@
     <Numeric name="N" value="19"/>
     <Numeric name="StartCopyNo" value="451"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+45*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+45*[DeltaY_ServiceModule]+23*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3146,8 +3172,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="19"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2)*mm, ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X6]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2), ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3159,8 +3185,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="37"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7])*mm, ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X6]/2+[ServiceHybrid_X6]+[DeltaX]+[DeltaX_Service6_Service7]), ([y_start_back]+46*[DeltaY_ServiceModule]+23*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3172,8 +3198,8 @@
     <Numeric name="N" value="18"/>
     <Numeric name="StartCopyNo" value="457"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+47*[DeltaY_ServiceModule]+23*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+47*[DeltaY_ServiceModule]+23*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3185,8 +3211,8 @@
     <Numeric name="N" value="17"/>
     <Numeric name="StartCopyNo" value="470"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+47*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+47*[DeltaY_ServiceModule]+24*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3198,8 +3224,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="34"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3211,8 +3237,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="38"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]+48*[DeltaY_ServiceModule]+24*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3224,8 +3250,8 @@
     <Numeric name="N" value="16"/>
     <Numeric name="StartCopyNo" value="475"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+49*[DeltaY_ServiceModule]+24*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3237,8 +3263,8 @@
     <Numeric name="N" value="14"/>
     <Numeric name="StartCopyNo" value="487"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+49*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+49*[DeltaY_ServiceModule]+25*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3250,8 +3276,8 @@
     <Numeric name="N" value="2"/>
     <Numeric name="StartCopyNo" value="40"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X7]/2)*mm, ([y_start_back]+50*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X7]/2), ([y_start_back]+50*[DeltaY_ServiceModule]+25*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3263,8 +3289,8 @@
     <Numeric name="N" value="13"/>
     <Numeric name="StartCopyNo" value="491"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+51*[DeltaY_ServiceModule]+25*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+51*[DeltaY_ServiceModule]+25*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3276,8 +3302,8 @@
     <Numeric name="N" value="10"/>
     <Numeric name="StartCopyNo" value="501"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+51*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+51*[DeltaY_ServiceModule]+26*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3289,8 +3315,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="35"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3302,8 +3328,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="42"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7])*mm, ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X7]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2+[DeltaX_Service3_Service7]), ([y_start_back]+52*[DeltaY_ServiceModule]+26*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3315,8 +3341,8 @@
     <Numeric name="N" value="9"/>
     <Numeric name="StartCopyNo" value="504"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+53*[DeltaY_ServiceModule]+26*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+53*[DeltaY_ServiceModule]+26*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3328,8 +3354,8 @@
     <Numeric name="N" value="3"/>
     <Numeric name="StartCopyNo" value="511"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset])*mm, ([y_start_back]+53*[DeltaY_ServiceModule]+27*[SensorModule_Y])*mm, -4.02*mm </Vector>
+    <Numeric name="Delta" value="([SensorModule_X]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([x_offset]), ([y_start_back]+53*[DeltaY_ServiceModule]+27*[SensorModule_Y]), (-1*[Zpos1]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 
@@ -3341,8 +3367,8 @@
     <Numeric name="N" value="1"/>
     <Numeric name="StartCopyNo" value="36"/>
     <Numeric name="IncrCopyNo" value="1"/>
-    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])*mm"/>
-    <Vector  name="Base" type="numeric" nEntries="3"> (1+[ServiceHybrid_X3]/2)*mm, ([y_start_back]+54*[DeltaY_ServiceModule]+27*[SensorModule_Y])*mm, 0.*mm </Vector>
+    <Numeric name="Delta" value="([ServiceHybrid_X3]+[DeltaX])"/>
+    <Vector  name="Base" type="numeric" nEntries="3"> ([xoffset_servicehybrid]+[ServiceHybrid_X3]/2), ([y_start_back]+54*[DeltaY_ServiceModule]+27*[SensorModule_Y]), ([Zpos2]) </Vector>
     <Numeric name="Theta" value="90.*deg"/> 
     <Numeric name="Phi" value="0.*deg"/>
     <Numeric name="Theta_obj" value="90.*deg"/> 


### PR DESCRIPTION
#### PR description:

All the units of measurement have been moved to the constant section.
Numeric values previously hard coded have been associated to new constants, which have been added to the constant section.  

#### PR validation:

The modules positions have been checked with the dump of the geometry using both testMTDinDDD.py and testMTDinDD4hep.py and compared with the output of the previous xml version, verifying they are identical.
Overlaps have been checked with g4OverlapCheck_cfg.py.
Visual check performed with Fireworks.


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)


@fabiocos FYI