### PR TITLE
Remove legacy memory barriers

### DIFF
--- a/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/limitedtaskqueue_t.cppunit.cpp
@@ -254,9 +254,7 @@ void LimitedTaskQueue_test::stressTest() {
     std::atomic<bool> waitToStart{true};
     {
       auto j = edm::make_functor_task(tbb::task::allocate_root(), [&queue, &waitToStart, pWaitTask, &count, &nRunningTasks] {
-        //gcc 4.7 doesn't preserve the 'atomic' nature of waitToStart in the loop
         while (waitToStart.load()) {
-          __sync_synchronize();
         };
         std::shared_ptr<tbb::task> guard{pWaitTask, [](tbb::task* iTask) { iTask->decrement_ref_count(); }};
         for (unsigned int i = 0; i < nTasks; ++i) {

--- a/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/serialtaskqueue_t.cppunit.cpp
@@ -158,9 +158,7 @@ void SerialTaskQueue_test::stressTest() {
     std::atomic<bool> waitToStart{true};
     {
       auto j = edm::make_functor_task(tbb::task::allocate_root(), [&queue, &waitToStart, pWaitTask, &count] {
-        //gcc 4.7 doesn't preserve the 'atomic' nature of waitToStart in the loop
         while (waitToStart.load()) {
-          __sync_synchronize();
         };
         for (unsigned int i = 0; i < nTasks; ++i) {
           pWaitTask->increment_ref_count();

--- a/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
+++ b/FWCore/Concurrency/test/waitingtasklist_t.cppunit.cpp
@@ -15,10 +15,6 @@
 #include "tbb/task.h"
 #include "FWCore/Concurrency/interface/WaitingTaskList.h"
 
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
-#define CXX_THREAD_AVAILABLE
-#endif
-
 class WaitingTaskList_test : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(WaitingTaskList_test);
   CPPUNIT_TEST(addThenDone);
@@ -85,12 +81,10 @@ void WaitingTaskList_test::addThenDone() {
     waitList.add(t);
 
     usleep(10);
-    __sync_synchronize();
     CPPUNIT_ASSERT(false == called);
 
     waitList.doneWaiting(std::exception_ptr{});
     waitTask->wait_for_all();
-    __sync_synchronize();
     CPPUNIT_ASSERT(true == called);
     CPPUNIT_ASSERT(bool(excPtr) == false);
   }
@@ -183,17 +177,14 @@ void WaitingTaskList_test::doneThenAddFailed() {
 }
 
 namespace {
-#if defined(CXX_THREAD_AVAILABLE)
   void join_thread(std::thread* iThread) {
     if (iThread->joinable()) {
       iThread->join();
     }
   }
-#endif
 }  // namespace
 
 void WaitingTaskList_test::stressTest() {
-#if defined(CXX_THREAD_AVAILABLE)
   std::atomic<bool> called{false};
   std::exception_ptr excPtr;
   edm::WaitingTaskList waitList;
@@ -226,7 +217,6 @@ void WaitingTaskList_test::stressTest() {
     }
     waitTask->wait_for_all();
   }
-#endif
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WaitingTaskList_test);

--- a/FWCore/Utilities/src/InputTag.cc
+++ b/FWCore/Utilities/src/InputTag.cc
@@ -179,10 +179,6 @@ namespace edm {
                                           void const* productRegistry) const {
     ProductResolverIndex index = index_.load();
 
-    // This will no longer be necessary when the compiler supports the memory
-    // order associated with atomics.
-    __sync_synchronize();
-
     if (index < ProductResolverIndexInitializing && typeID_ == typeID && branchType_ == branchType &&
         productRegistry_ == productRegistry) {
       return index;
@@ -199,11 +195,6 @@ namespace edm {
       typeID_ = typeID;
       branchType_ = branchType;
       productRegistry_ = productRegistry;
-
-      // This will no longer be necessary when the compiler supports the memory
-      // order associated with atomics.
-      __sync_synchronize();
-
       index_.store(index);
     }
   }


### PR DESCRIPTION
#### PR description:

FWCore/Utilities/src/InputTag.cc and several unit tests in FWCore/Concurrency include calls to __sync_synchronize() because gcc 4.7 didn't fully support the c++11 memory model.  All our current and future compilers support the c++ memory model, so these extra synchronization operations should no longer be necessary.

#### PR validation:

Unit tests were run repeatedly on slc7_amd64_gcc900 and slc7_aarch64_gcc9.