### PR TITLE
Remove gpu workflows from runTheMatrix defaults

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -79,7 +79,7 @@ class MatrixReader(object):
                              'relval_production':True,
                              'relval_ged':True,
                              'relval_upgrade':False,
-                             'relval_gpu':True,
+                             'relval_gpu':False,
                              'relval_2017':True,
                              'relval_2026':True,
                              'relval_identity':False,


### PR DESCRIPTION
@silviodonato , @qliphy this should avoid running gopu workflows a part of default runTheMatrix. One need to explicitly use -w gpu` to run gpu workflows. 

This should avoid the 4 failing workflows in IBs