### PR TITLE
Add roothistpainter dependence to fix UBSAN linking

### DIFF
--- a/CondCore/SiStripPlugins/test/BuildFile.xml
+++ b/CondCore/SiStripPlugins/test/BuildFile.xml
@@ -2,5 +2,6 @@
 <use name="CondCore/Utilities"/>
 <use name="FWCore/PluginManager"/>
 <use name="CalibTracker/StandaloneTrackerTopology"/>
+<use name="roothistpainter"/>
 <bin file="testSiStripPayloadInspector.cpp" name="testSiStripPayloadInspector">
 </bin>


### PR DESCRIPTION
#### PR description:

https://github.com/cms-sw/cmssw/pull/32608 added `roothistpainter` dependence in `plugins/BuildFile.xml`, but the UBSAN build still complained an error in building the tests. This PR adds `roothistpainter` dependence in the `test/BuildFile.xml` as well.

#### PR validation:

UBSAN builds.