### PR TITLE
Do not allow unscheduled execution after prefetching

### DIFF
--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -389,33 +389,13 @@ namespace edm {
                                                                               ModuleCallingContext const* mcc) const {
     if (!skipCurrentProcess and worker_) {
       return resolveProductImpl<true>([this, sra, mcc]() {
-        try {
-          ParentContext parentContext(mcc);
-          aux_->preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()), *mcc);
-
-          auto workCall = [this, &parentContext, mcc]() {
-            auto sentry(make_sentry(mcc, [this](ModuleCallingContext const* iContext) {
-              aux_->postModuleDelayedGetSignal_.emit(*(iContext->getStreamContext()), *iContext);
-            }));
-
-            EventTransitionInfo const& info = aux_->eventTransitionInfo();
-            worker_->doWork<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(
-                info, info.principal().streamID(), parentContext, mcc->getStreamContext());
-          };
-
-          if (sra) {
-            assert(false);
-          } else {
-            workCall();
-          }
-
-        } catch (cms::Exception& ex) {
-          std::ostringstream ost;
-          ost << "Calling produce method for unscheduled module " << worker_->description()->moduleName() << "/'"
-              << worker_->description()->moduleLabel() << "'";
-          ex.addContext(ost.str());
-          throw;
-        }
+        edm::Exception ex(errors::UnimplementedFeature);
+        ex << "Attempting to run unscheduled module without doing prefetching";
+        std::ostringstream ost;
+        ost << "Calling produce method for unscheduled module " << worker_->description()->moduleName() << "/'"
+            << worker_->description()->moduleLabel() << "'";
+        ex.addContext(ost.str());
+        throw ex;
       });
     }
     return Resolution(nullptr);

--- a/FWCore/Framework/src/ProductResolvers.cc
+++ b/FWCore/Framework/src/ProductResolvers.cc
@@ -385,10 +385,10 @@ namespace edm {
 
   ProductResolverBase::Resolution UnscheduledProductResolver::resolveProduct_(Principal const&,
                                                                               bool skipCurrentProcess,
-                                                                              SharedResourcesAcquirer* sra,
-                                                                              ModuleCallingContext const* mcc) const {
+                                                                              SharedResourcesAcquirer*,
+                                                                              ModuleCallingContext const*) const {
     if (!skipCurrentProcess and worker_) {
-      return resolveProductImpl<true>([this, sra, mcc]() {
+      return resolveProductImpl<true>([this]() {
         edm::Exception ex(errors::UnimplementedFeature);
         ex << "Attempting to run unscheduled module without doing prefetching";
         std::ostringstream ost;


### PR DESCRIPTION
#### PR description:

- Remove unneeded ability to allow unscheduled execution after prefetching. This was used in the past to allow asking for data product provenance information to trigger unscheduled execution. That ability was removed from the framework in a previous PR.
- Remove unused Worker::doWork function.

#### PR validation:

The code compiles and all framework unit tests pass.