### PR TITLE
Have JetCorrectorParameter::Record::operator< handle more cases

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -83,11 +83,20 @@ public:
         return true;
       if (xMin(0) > other.xMin(0))
         return false;
-      if (xMin(1) < other.xMin(1))
-        return true;
-      if (xMin(1) > other.xMin(1))
-        return false;
-      return (xMin(2) < other.xMin(2));
+      auto const sz = mMin.size();
+      auto const otherSz = other.mMin.size();
+      if (sz > 1 and otherSz > 1) {
+        if (xMin(1) < other.xMin(1))
+          return true;
+        if (xMin(1) > other.xMin(1))
+          return false;
+        if (sz > 2 and otherSz > 2) {
+          return (xMin(2) < other.xMin(2));
+        }
+      }
+      //xMins were equal up until one of them
+      // ran out of values
+      return sz < otherSz;
     }
 
   private:


### PR DESCRIPTION
#### PR description:

The code now handles the case where one object has less entries in its mMin vector than the other object.

#### PR validation:

This is meant to fix a problem seen in the ASAN build where JetCorrectorParameter::Record::operator< was reading a value outside of its memory bounds.