### PR TITLE
L1 Tk DQM, plot range

### DIFF
--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -77,8 +77,6 @@ public:
   MonitorElement *Stub_R = nullptr;           // TTstub r distribution
   MonitorElement *Stub_bendFE = nullptr;      // TTstub trigger bend
   MonitorElement *Stub_bendBE = nullptr;      // TTstub hardware bend
-  MonitorElement *Stub_rawBend = nullptr;     // TTstub raw bend
-  MonitorElement *Stub_bendOffset = nullptr;  // TTstub bend offset
   MonitorElement *Stub_isPS = nullptr;        // is this stub a PS module?
 
   // STUB Displacement - offset
@@ -166,8 +164,6 @@ void OuterTrackerMonitorTTStub::analyze(const edm::Event &iEvent, const edm::Eve
       Stub_RZ->Fill(posStub.z(), posStub.perp());
       Stub_bendFE->Fill(tempStubRef->bendFE());
       Stub_bendBE->Fill(tempStubRef->bendBE());
-      Stub_rawBend->Fill(rawBend);
-      Stub_bendOffset->Fill(bendOffset);
       Stub_isPS->Fill(tempStubRef->moduleTypePS());
 
       if (detIdStub.subdetId() == static_cast<int>(StripSubdetector::TOB)) {  // Phase 2 Outer Tracker Barrel
@@ -318,26 +314,6 @@ void OuterTrackerMonitorTTStub::bookHistograms(DQMStore::IBooker &iBooker,
                                psTTStub_bend.getParameter<double>("xmax"));
   Stub_bendBE->setAxisTitle("Hardware bend", 1);
   Stub_bendBE->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub raw bend
-  HistoName = "Stub_rawBend";
-  Stub_rawBend = iBooker.book1D(HistoName,
-                                HistoName,
-                                psTTStub_bend.getParameter<int32_t>("Nbinsx"),
-                                psTTStub_bend.getParameter<double>("xmin"),
-                                psTTStub_bend.getParameter<double>("xmax"));
-  Stub_rawBend->setAxisTitle("Raw bend", 1);
-  Stub_rawBend->setAxisTitle("# L1 Stubs ", 2);
-
-  // TTStub bend offset
-  HistoName = "Stub_bendOffset";
-  Stub_bendOffset = iBooker.book1D(HistoName,
-                                   HistoName,
-                                   psTTStub_bend.getParameter<int32_t>("Nbinsx"),
-                                   psTTStub_bend.getParameter<double>("xmin"),
-                                   psTTStub_bend.getParameter<double>("xmax"));
-  Stub_bendOffset->setAxisTitle("Bend offset", 1);
-  Stub_bendOffset->setAxisTitle("# L1 Stubs ", 2);
 
   // TTStub, is PS?
   edm::ParameterSet psTTStub_isPS = conf_.getParameter<edm::ParameterSet>("TH1TTStub_isPS");

--- a/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
+++ b/DQM/SiOuterTracker/plugins/OuterTrackerMonitorTTStub.cc
@@ -72,12 +72,12 @@ public:
   MonitorElement *Stub_Endcap_Ring_Bw[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};  // TTStub per EC ring
 
   // Stub distribution
-  MonitorElement *Stub_Eta = nullptr;         // TTstub eta distribution
-  MonitorElement *Stub_Phi = nullptr;         // TTstub phi distribution
-  MonitorElement *Stub_R = nullptr;           // TTstub r distribution
-  MonitorElement *Stub_bendFE = nullptr;      // TTstub trigger bend
-  MonitorElement *Stub_bendBE = nullptr;      // TTstub hardware bend
-  MonitorElement *Stub_isPS = nullptr;        // is this stub a PS module?
+  MonitorElement *Stub_Eta = nullptr;     // TTstub eta distribution
+  MonitorElement *Stub_Phi = nullptr;     // TTstub phi distribution
+  MonitorElement *Stub_R = nullptr;       // TTstub r distribution
+  MonitorElement *Stub_bendFE = nullptr;  // TTstub trigger bend
+  MonitorElement *Stub_bendBE = nullptr;  // TTstub hardware bend
+  MonitorElement *Stub_isPS = nullptr;    // is this stub a PS module?
 
   // STUB Displacement - offset
   MonitorElement *Stub_Barrel_W = nullptr;       // TTstub Pos-Corr Displacement (layer)

--- a/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
+++ b/DQM/SiOuterTracker/python/OuterTrackerMonitorTTStub_cfi.py
@@ -49,9 +49,9 @@ OuterTrackerMonitorTTStub = DQMEDAnalyzer('OuterTrackerMonitorTTStub',
 
 #TTStub bend distribution
     TH1TTStub_bend = cms.PSet(
-        Nbinsx = cms.int32(60),
-        xmin = cms.double(-8.5),
-        xmax = cms.double(8.5)
+        Nbinsx = cms.int32(69),
+        xmin = cms.double(-8.625),
+        xmax = cms.double(8.625)
         ),
 
 #TTStub, isPS?


### PR DESCRIPTION
#### PR description:
Remove stub raw bend and bend offset - no longer useful quantities to monitor. Any problems with either would show up in FE bend and stub width.
Change range of stub bend to accommodate half- and quarter-integer values. Makes RelVal comparison easier since there are no more "border cases," like 0.5, that could fall into two different bins.

#### PR validation:
Verified the code compiles and runs successfully.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
Not a backport.

