### PR TITLE
[DD4hep] Fix PPS simulation so physical volume names are recognized

### DIFF
--- a/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSDiamondOrganization.cc
@@ -15,16 +15,17 @@
 //******************************************************************** Constructor and destructor
 
 PPSDiamondOrganization ::PPSDiamondOrganization()
-    : theArm_(-1), theStation_(-1), theRoman_pot_(-1), thePlane_(-1), theDetector_(-1) {}
+    : theArm_(0), theStation_(0), theRoman_pot_(0), thePlane_(0), theDetector_(0) {}
 
 uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
   G4VPhysicalVolume* physVol;
   const G4VTouchable* touch = aStep->GetPreStepPoint()->GetTouchable();
+  bool foundVacuum = false;
 
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
 
-    if (physVol->GetName() == "CTPPS_Diamond_Segment" || physVol->GetName() == "CTPPS_UFSD_Segment") {
+    if (physVol->GetName().contains("CTPPS_Diamond_Segment") || physVol->GetName().contains("CTPPS_UFSD_Segment")) {
       theDetector_ = physVol->GetCopyNo() % 100;
       thePlane_ = physVol->GetCopyNo() / 100;
       LogDebug("PPSSimDiamond") << "\n---------------------CTPPS_Diamond_Segment-------------------------------------"
@@ -34,15 +35,18 @@ uint32_t PPSDiamondOrganization::unitID(const G4Step* aStep) {
       LogDebug("PPSSimDiamond") << "\t\t\t\t\tdetector= " << theDetector_ << " plane= " << thePlane_ << " ii = " << ii;
     }
 
-    else if (physVol->GetName() == "Primary_Vacuum") {
+    else if (physVol->GetName().contains("Primary_Vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       theArm_ = (cpy_no / 100) % 10;
       theStation_ = (cpy_no / 10) % 10;
       theRoman_pot_ = cpy_no % 10;
+      foundVacuum = true;
     }
-    LogDebug("PPSSimDiamond") << "Diamond"
-                              << "physVol =" << physVol->GetName() << ", level=" << ii
+    LogDebug("PPSSimDiamond") << "Diamond physVol =" << physVol->GetName() << ", level=" << ii
                               << ", physVol->GetCopyNo()=" << physVol->GetCopyNo() << std::endl;
+  }
+  if (foundVacuum == false) {
+    edm::LogError("PPSSimDiamond") << "Physical volume Primary_Vacuum not found. Cannot determine CTPPSDiamondDetId.";
   }
   return CTPPSDiamondDetId(theArm_, theStation_, theRoman_pot_, thePlane_, theDetector_).rawId();
 }

--- a/SimG4CMS/PPS/src/PPSStripOrganization.cc
+++ b/SimG4CMS/PPS/src/PPSStripOrganization.cc
@@ -20,9 +20,9 @@ uint32_t PPSStripOrganization::unitID(const G4Step* aStep) {
 
   for (int ii = 0; ii < touch->GetHistoryDepth(); ii++) {
     physVol = touch->GetVolume(ii);
-    if (physVol->GetName() == "RP_Silicon_Detector") {
+    if (physVol->GetName().contains("RP_Silicon_Detector")) {
       detector = physVol->GetCopyNo();
-    } else if (physVol->GetName() == "RP_box_primary_vacuum") {
+    } else if (physVol->GetName().contains("RP_box_primary_vacuum")) {
       int cpy_no = physVol->GetCopyNo();
       arm = (cpy_no / 100) % 10;
       station = (cpy_no / 10) % 10;


### PR DESCRIPTION
In old DD, physical volume names have no prefix or suffix, but, with DD4hep, physical volume names are prefixed with the namespace and suffixed with the copy number. PPS code searches for specific physical volumes, and these searches were failing because of the additional prefix and suffix added by DD4hep. The solution is to search for a string that somewhere contains the base physical volume name, rather than requiring an exact match.

This PR fixes issue #32653. The exception described in the issue occurred because the intended physical volume was not found, resulting in an attempt to construct a nonsense DetId, which caused the exception. In addition to fixing the search for the volume, this PR changes the initialization of the data members used to create the DetId. These members had been initialized to -1, which was a poor choice since they were converted into unsigned ints for use in the DetId, which gave the maximum unsigned value instead of -1 and thus generated an exception. This PR changes the initialized values to 0, which will not generate an exception in the case that the physical volume cannot be found. Instead, this PR adds error messages to cover this case.

#### PR validation:

The sim step of DD4hep workflow 11642.911 was run to see the bug occur. After the code was fixed, the sim step was run again to see that it could successfully handle 50 events without the error occurring. Also, debug statements were checked to see that the fix was working.

No backport is planned.
