### PR TITLE
Maintain access to genParticles from signal event in packed collection for HI miniAOD

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -591,6 +591,7 @@
   <class name="edm::Wrapper<pat::HemisphereRefVector>" />
   <class name="edm::Wrapper<pat::ConversionRefVector>" />
   <class name="edm::Wrapper<pat::PackedCandidateRefVector>" />
+  <class name="edm::Wrapper<pat::PackedGenParticleRefVector>" />
 
   <!-- RefToBase<Candidate> from PATObjects -->
     <!-- With direct Holder -->

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -30,7 +30,9 @@ namespace pat {
 
 }  // namespace pat
 
-void pat::PackedGenParticleSignalProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void pat::PackedGenParticleSignalProducer::produce(edm::StreamID iID,
+                                                   edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup) const {
   const auto& genParticles = iEvent.getHandle(genParticleToken_);
   const auto& orig2packed = iEvent.get(assoToken_);
 

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -14,17 +14,19 @@ namespace pat {
   class PackedGenParticleSignalProducer : public edm::stream::EDProducer<> {
   public:
     explicit PackedGenParticleSignalProducer(const edm::ParameterSet& iConfig)
-      : packedGenParticleToken_(consumes<pat::PackedGenParticleCollection>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
-	genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
-	assoToken_(consumes<edm::Association<std::vector<pat::PackedGenParticle>>>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))){
+        : packedGenParticleToken_(
+              consumes<pat::PackedGenParticleCollection>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
+          genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+          assoToken_(consumes<edm::Association<std::vector<pat::PackedGenParticle>>>(
+              iConfig.getParameter<edm::InputTag>("packedGenParticles"))) {
       produces<pat::PackedGenParticleRefVector>();
     }
     ~PackedGenParticleSignalProducer() override = default;
-    
+
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     static void fillDescriptions(edm::ConfigurationDescriptions&);
-    
+
   private:
     const edm::EDGetTokenT<pat::PackedGenParticleCollection> packedGenParticleToken_;
     const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
@@ -38,24 +40,22 @@ void pat::PackedGenParticleSignalProducer::produce(edm::Event& iEvent, const edm
   const auto& genParticles = iEvent.getHandle(genParticleToken_);
   const auto& packed2Orig = iEvent.get(assoToken_);
 
-
   pat::PackedGenParticleRefVector* signalGenParticleRefs = new pat::PackedGenParticleRefVector();
 
   for (size_t i = 0; i < genParticles->size(); ++i) {
-    const auto& orig = reco::GenParticleRef(genParticles, i); 
+    const auto& orig = reco::GenParticleRef(genParticles, i);
 
-    if (orig.isNonnull()) {      
-      if(orig->collisionId()==0){
-	const auto &packed = packed2Orig[orig];
-	if (packed.isNonnull() ) signalGenParticleRefs->push_back(packed);
+    if (orig.isNonnull()) {
+      if (orig->collisionId() == 0) {
+        const auto& packed = packed2Orig[orig];
+        if (packed.isNonnull())
+          signalGenParticleRefs->push_back(packed);
       }
     }
-    
   }
 
-  std::unique_ptr<pat::PackedGenParticleRefVector > ptr(signalGenParticleRefs);
+  std::unique_ptr<pat::PackedGenParticleRefVector> ptr(signalGenParticleRefs);
   iEvent.put(std::move(ptr));
-
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
@@ -63,7 +63,7 @@ void pat::PackedGenParticleSignalProducer::fillDescriptions(edm::ConfigurationDe
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"))->setComment("genParticles input collection");
   desc.add<edm::InputTag>("packedGenParticles", edm::InputTag("packedGenParticles"))
-    ->setComment("packedGenParticles input collection");
+      ->setComment("packedGenParticles input collection");
   descriptions.add("packedGenParticlesSignal", desc);
 }
 

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -1,0 +1,72 @@
+
+#include <memory>
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace pat {
+
+  class PackedGenParticleSignalProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PackedGenParticleSignalProducer(const edm::ParameterSet& iConfig)
+      : packedGenParticleToken_(consumes<pat::PackedGenParticleCollection>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
+	genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+	assoToken_(consumes<edm::Association<std::vector<pat::PackedGenParticle>>>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))){
+      produces<pat::PackedGenParticleRefVector>();
+    }
+    ~PackedGenParticleSignalProducer() override = default;
+    
+    void produce(edm::Event&, const edm::EventSetup&) override;
+    
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+    
+  private:
+    const edm::EDGetTokenT<pat::PackedGenParticleCollection> packedGenParticleToken_;
+    const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
+    const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle>>> assoToken_;
+  };
+
+}  // namespace pat
+
+void pat::PackedGenParticleSignalProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  const auto& packedGenParticles = iEvent.getHandle(packedGenParticleToken_);
+  const auto& genParticles = iEvent.getHandle(genParticleToken_);
+  const auto& packed2Orig = iEvent.get(assoToken_);
+
+
+  pat::PackedGenParticleRefVector* signalGenParticleRefs = new pat::PackedGenParticleRefVector();
+
+  for (size_t i = 0; i < genParticles->size(); ++i) {
+    const auto& orig = reco::GenParticleRef(genParticles, i); 
+
+    if (orig.isNonnull()) {      
+      if(orig->collisionId()==0){
+	const auto &packed = packed2Orig[orig];
+	if (packed.isNonnull() ) signalGenParticleRefs->push_back(packed);
+      }
+    }
+    
+  }
+
+  std::unique_ptr<pat::PackedGenParticleRefVector > ptr(signalGenParticleRefs);
+  iEvent.put(std::move(ptr));
+
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::PackedGenParticleSignalProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"))->setComment("genParticles input collection");
+  desc.add<edm::InputTag>("packedGenParticles", edm::InputTag("packedGenParticles"))
+    ->setComment("packedGenParticles input collection");
+  descriptions.add("packedGenParticlesSignal", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(PackedGenParticleSignalProducer);

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -1,6 +1,4 @@
-
 #include <memory>
-
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -14,9 +12,7 @@ namespace pat {
   class PackedGenParticleSignalProducer : public edm::stream::EDProducer<> {
   public:
     explicit PackedGenParticleSignalProducer(const edm::ParameterSet& iConfig)
-        : packedGenParticleToken_(
-              consumes<pat::PackedGenParticleCollection>(iConfig.getParameter<edm::InputTag>("packedGenParticles"))),
-          genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+        : genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
           assoToken_(consumes<edm::Association<std::vector<pat::PackedGenParticle>>>(
               iConfig.getParameter<edm::InputTag>("packedGenParticles"))) {
       produces<pat::PackedGenParticleRefVector>();
@@ -28,7 +24,6 @@ namespace pat {
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
   private:
-    const edm::EDGetTokenT<pat::PackedGenParticleCollection> packedGenParticleToken_;
     const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
     const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle>>> assoToken_;
   };
@@ -36,26 +31,22 @@ namespace pat {
 }  // namespace pat
 
 void pat::PackedGenParticleSignalProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const auto& packedGenParticles = iEvent.getHandle(packedGenParticleToken_);
   const auto& genParticles = iEvent.getHandle(genParticleToken_);
-  const auto& packed2Orig = iEvent.get(assoToken_);
+  const auto& orig2packed = iEvent.get(assoToken_);
 
-  pat::PackedGenParticleRefVector* signalGenParticleRefs = new pat::PackedGenParticleRefVector();
+  auto signalGenParticleRefs = std::make_unique<pat::PackedGenParticleRefVector>();
 
-  for (size_t i = 0; i < genParticles->size(); ++i) {
-    const auto& orig = reco::GenParticleRef(genParticles, i);
-
-    if (orig.isNonnull()) {
-      if (orig->collisionId() == 0) {
-        const auto& packed = packed2Orig[orig];
-        if (packed.isNonnull())
-          signalGenParticleRefs->push_back(packed);
-      }
+  for (auto it = genParticles->begin(); it != genParticles->end(); ++it) {
+    const auto& orig = reco::GenParticleRef(genParticles, it - genParticles->begin());
+    const auto& packed = orig2packed[orig];
+    if (orig->collisionId() != 0)
+      continue;
+    if (packed.isNonnull()) {
+      signalGenParticleRefs->push_back(packed);
     }
   }
 
-  std::unique_ptr<pat::PackedGenParticleRefVector> ptr(signalGenParticleRefs);
-  iEvent.put(std::move(ptr));
+  iEvent.put(std::move(signalGenParticleRefs));
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -2,14 +2,14 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 namespace pat {
 
-  class PackedGenParticleSignalProducer : public edm::stream::EDProducer<> {
+  class PackedGenParticleSignalProducer : public edm::global::EDProducer<> {
   public:
     explicit PackedGenParticleSignalProducer(const edm::ParameterSet& iConfig)
         : genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
@@ -19,7 +19,7 @@ namespace pat {
     }
     ~PackedGenParticleSignalProducer() override = default;
 
-    void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions&);
 
@@ -30,7 +30,7 @@ namespace pat {
 
 }  // namespace pat
 
-void pat::PackedGenParticleSignalProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PackedGenParticleSignalProducer::produce(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   const auto& genParticles = iEvent.getHandle(genParticleToken_);
   const auto& orig2packed = iEvent.get(assoToken_);
 
@@ -38,9 +38,9 @@ void pat::PackedGenParticleSignalProducer::produce(edm::Event& iEvent, const edm
 
   for (auto it = genParticles->begin(); it != genParticles->end(); ++it) {
     const auto& orig = reco::GenParticleRef(genParticles, it - genParticles->begin());
-    const auto& packed = orig2packed[orig];
     if (orig->collisionId() != 0)
       continue;
+    const auto& packed = orig2packed[orig];
     if (packed.isNonnull()) {
       signalGenParticleRefs->push_back(packed);
     }

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -132,7 +132,6 @@ _pp_on_AA_extraCommands = [
     'keep patPackedCandidates_hiPixelTracks_*_*',
     'keep patPackedCandidates_packedPFCandidatesRemoved_*_*',
     'keep *_packedCandidateMuonID_*_*',
-    'keep *_packedGenParticlesSignal_*_*',
     'keep *_slimmedJets_pfCandidates_*',
     'keep floatedmValueMap_packedPFCandidateTrackChi2_*_*',
     'keep floatedmValueMap_lostTrackChi2_*_*',
@@ -145,6 +144,7 @@ _pp_on_AA_extraCommands = [
     'keep *_hiEvtPlaneFlat_*_*',
     'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
 ]
+
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
 pp_on_AA.toModify(MicroEventContent, outputCommands = MicroEventContent.outputCommands + _pp_on_AA_extraCommands)
 
@@ -157,6 +157,8 @@ MicroEventContentMC.outputCommands += [
                                         # RUN
                                         'keep L1GtTriggerMenuLite_l1GtTriggerMenuLite__*'
                                       ]
+_pp_on_AA_MC_extraCommands = ['keep *_packedGenParticlesSignal_*_*']
+pp_on_AA.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_MC_extraCommands)
 
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 strips_vfp30_2016.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + [

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -132,6 +132,7 @@ _pp_on_AA_extraCommands = [
     'keep patPackedCandidates_hiPixelTracks_*_*',
     'keep patPackedCandidates_packedPFCandidatesRemoved_*_*',
     'keep *_packedCandidateMuonID_*_*',
+    'keep *_packedGenParticlesSignal_*_*',
     'keep *_slimmedJets_pfCandidates_*',
     'keep floatedmValueMap_packedPFCandidateTrackChi2_*_*',
     'keep floatedmValueMap_lostTrackChi2_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
@@ -16,3 +16,11 @@ genParticlesTask = cms.Task(
     packedGenParticles,
     prunedGenParticlesWithStatusOne
 )
+
+from PhysicsTools.PatAlgos.packedGenParticlesSignal_cfi import *
+
+_genParticlesHITask = genParticlesTask.copy()
+_genParticlesHITask.add(packedGenParticlesSignal)
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toReplaceWith(genParticlesTask, _genParticlesHITask)


### PR DESCRIPTION
#### PR description:

For event-overlay MC workflows, we need to know which particles are from the signal event, i.e., the one with collisionID =0.  This method is not available in the packedGenParticle collection.  This PR adds a PackedGenParticleRefVector containing the PackedGenParticles with collisionID =0.  It's run for all HI eras; there is no change to pp workflows. 

#### PR validation:

Tested with 158.01

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Will need an 11_2_X backport

@ttrk @stepobr @stahlleiton 

