### PR TITLE
Revert #25298; memory leak fix for HepPDT::HeavyIonUnknownID

### DIFF
--- a/SimGeneral/HepPDTESSource/BuildFile.xml
+++ b/SimGeneral/HepPDTESSource/BuildFile.xml
@@ -1,4 +1,3 @@
 <use name="SimGeneral/HepPDTRecord"/>
-<use name="tbb"/>
 <use name="heppdt"/>
 <flags EDM_PLUGIN="1"/>

--- a/SimGeneral/HepPDTESSource/src/HepPDTESSource.cc
+++ b/SimGeneral/HepPDTESSource/src/HepPDTESSource.cc
@@ -1,26 +1,5 @@
 #include "HepPDT/HeavyIonUnknownID.hh"
 #include "SimGeneral/HepPDTESSource/interface/HepPDTESSource.h"
-#include "tbb/concurrent_vector.h"
-
-namespace {
-
-  class CachingHeavyIonUnknownID : public HepPDT::ProcessUnknownID {
-    HepPDT::ParticleData *processUnknownID(HepPDT::ParticleID id, const HepPDT::ParticleDataTable &table) final {
-      // HeavyIonUnknownID constructs a new particle but does not delete it
-      // we need to do that ourselves
-      std::unique_ptr<HepPDT::ParticleData> p{wrapped_.processUnknownID(id, table)};
-      auto *pPtr = p.get();
-      if (p) {
-        particles_.emplace_back(std::move(p));
-      }
-      return pPtr;
-    }
-
-    HepPDT::HeavyIonUnknownID wrapped_;
-    tbb::concurrent_vector<std::unique_ptr<HepPDT::ParticleData>> particles_;
-  };
-
-}  // namespace
 
 HepPDTESSource::HepPDTESSource(const edm::ParameterSet &cfg)
     : pdtFileName(cfg.getParameter<edm::FileInPath>("pdtFileName")) {
@@ -32,7 +11,7 @@ HepPDTESSource::~HepPDTESSource() {}
 
 HepPDTESSource::ReturnType HepPDTESSource::produce(const PDTRecord &iRecord) {
   using namespace edm::es;
-  auto pdt = std::make_unique<PDT>("PDG table", new CachingHeavyIonUnknownID);
+  auto pdt = std::make_unique<PDT>("PDG table", new HepPDT::HeavyIonUnknownID);
   std::ifstream pdtFile(pdtFileName.fullPath().c_str());
   if (!pdtFile)
     throw cms::Exception("FileNotFound", "can't open pdt file") << "cannot open " << pdtFileName.fullPath();


### PR DESCRIPTION
Changes needed for new HepPDT 3.04.01
Revert of #25298
This should be merged with  cms-sw/cmsdist#6548 
FYI @Dr15Jones 