### PR TITLE
Avoid writing off beginning of arrays in RPCMonitorClient

### DIFF
--- a/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
+++ b/DQM/RPCMonitorClient/interface/RPCDCSSummary.h
@@ -34,8 +34,10 @@ private:
 
   MonitorElement *DCSMap_;
   MonitorElement *totalDCSFraction;
-  MonitorElement *dcsWheelFractions[5];
-  MonitorElement *dcsDiskFractions[10];
+  constexpr static int kNWheels = 5;
+  MonitorElement *dcsWheelFractions[kNWheels];
+  constexpr static int kNDisks = 10;
+  MonitorElement *dcsDiskFractions[kNDisks];
   std::pair<int, int> FEDRange_;
   int numberOfDisks_;
   int NumberOfFeds_;

--- a/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
+++ b/DQM/RPCMonitorClient/interface/RPCDaqInfo.h
@@ -29,8 +29,10 @@ private:
 
   MonitorElement *DaqFraction_;
   MonitorElement *DaqMap_;
-  MonitorElement *daqWheelFractions[5];
-  MonitorElement *daqDiskFractions[10];
+  constexpr static int kNWheels = 5;
+  MonitorElement *daqWheelFractions[kNWheels];
+  constexpr static int kNDisks = 10;
+  MonitorElement *daqDiskFractions[kNDisks];
 
   std::pair<int, int> FEDRange_;
 

--- a/DQM/RPCMonitorClient/interface/RPCDataCertification.h
+++ b/DQM/RPCMonitorClient/interface/RPCDataCertification.h
@@ -27,8 +27,10 @@ private:
 
   MonitorElement* CertMap_;
   MonitorElement* totalCertFraction;
-  MonitorElement* certWheelFractions[5];
-  MonitorElement* certDiskFractions[10];
+  constexpr static int kNWheels = 5;
+  MonitorElement* certWheelFractions[kNWheels];
+  constexpr static int kNDisks = 10;
+  MonitorElement* certDiskFractions[kNDisks];
   std::pair<int, int> FEDRange_;
   int numberOfDisks_;
   int NumberOfFeds_;

--- a/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
+++ b/DQM/RPCMonitorClient/src/RPCDCSSummary.cc
@@ -126,7 +126,7 @@ void RPCDCSSummary::myBooker(DQMStore::IBooker& ibooker) {
     limit = 2;
 
   for (int i = -1 * limit; i <= limit; i++) {  //loop on wheels and disks
-    if (i > -3 && i < 3) {                     //wheels
+    if (i > -3 && i < kNWheels - 2) {          //wheels
       std::stringstream streams;
       streams << "RPC_Wheel" << i;
       dcsWheelFractions[i + 2] = ibooker.bookFloat(streams.str());
@@ -140,8 +140,10 @@ void RPCDCSSummary::myBooker(DQMStore::IBooker& ibooker) {
     if (i > 0)
       offset--;  //used to skip case equale to zero
     std::stringstream streams;
-    streams << "RPC_Disk" << i;
-    dcsDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
-    dcsDiskFractions[i + 2]->Fill(defaultValue_);
+    if (i > -3 && i < kNDisks - 2) {
+      streams << "RPC_Disk" << i;
+      dcsDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
+      dcsDiskFractions[i + 2]->Fill(defaultValue_);
+    }
   }
 }

--- a/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
+++ b/DQM/RPCMonitorClient/src/RPCDaqInfo.cc
@@ -67,7 +67,7 @@ void RPCDaqInfo::myBooker(DQMStore::IBooker& ibooker) {
     limit = 2;
 
   for (int i = -1 * limit; i <= limit; i++) {  //loop on wheels and disks
-    if (i > -3 && i < 3) {                     //wheels
+    if (i > -3 && i < kNWheels - 2) {          //wheels
       std::stringstream streams;
       streams << "RPC_Wheel" << i;
       daqWheelFractions[i + 2] = ibooker.bookFloat(streams.str());
@@ -81,10 +81,12 @@ void RPCDaqInfo::myBooker(DQMStore::IBooker& ibooker) {
     if (i > 0)
       offset--;  //used to skip case equale to zero
 
-    std::stringstream streams;
-    streams << "RPC_Disk" << i;
-    daqDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
-    daqDiskFractions[i + 2]->Fill(-1);
+    if (i > -3 && i < kNDisks - 2) {
+      std::stringstream streams;
+      streams << "RPC_Disk" << i;
+      daqDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
+      daqDiskFractions[i + 2]->Fill(-1);
+    }
   }
 
   //daq summary for RPCs

--- a/DQM/RPCMonitorClient/src/RPCDataCertification.cc
+++ b/DQM/RPCMonitorClient/src/RPCDataCertification.cc
@@ -125,7 +125,7 @@ void RPCDataCertification::myBooker(DQMStore::IBooker& ibooker) {
     limit = 2;
 
   for (int i = -1 * limit; i <= limit; i++) {  //loop on wheels and disks
-    if (i > -3 && i < 3) {                     //wheels
+    if (i > -3 && i < kNWheels - 2) {          //wheels
       std::stringstream streams;
       streams << "RPC_Wheel" << i;
       certWheelFractions[i + 2] = ibooker.bookFloat(streams.str());
@@ -138,9 +138,11 @@ void RPCDataCertification::myBooker(DQMStore::IBooker& ibooker) {
     int offset = numberOfDisks_;
     if (i > 0)
       offset--;  //used to skip case equale to zero
-    std::stringstream streams;
-    streams << "RPC_Disk" << i;
-    certDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
-    certDiskFractions[i + 2]->Fill(defaultValue_);
+    if (i > -3 && i < kNDisks - 2) {
+      std::stringstream streams;
+      streams << "RPC_Disk" << i;
+      certDiskFractions[i + 2] = ibooker.bookFloat(streams.str());
+      certDiskFractions[i + 2]->Fill(defaultValue_);
+    }
   }
 }


### PR DESCRIPTION

#### PR description:

The UBSAN build reported that an index of -2 was being used as an index into the arrays.

#### PR validation:

Code compiles.