### PR TITLE
Switching MCSmartSingleParticleFilter to use an input tag (11.1.x)

### DIFF
--- a/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
@@ -55,8 +55,7 @@ private:
 using namespace std;
 
 MCSmartSingleParticleFilter::MCSmartSingleParticleFilter(const edm::ParameterSet& iConfig)
-    : token_(consumes<edm::HepMCProduct>(
-          edm::InputTag(iConfig.getUntrackedParameter("moduleLabel", std::string("generator")), "unsmeared"))),
+  : token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator","unsmeared")))),
       betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)) {
   vector<int> defpid;
   defpid.push_back(0);

--- a/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
+++ b/GeneratorInterface/GenFilters/plugins/MCSmartSingleParticleFilter.cc
@@ -55,7 +55,8 @@ private:
 using namespace std;
 
 MCSmartSingleParticleFilter::MCSmartSingleParticleFilter(const edm::ParameterSet& iConfig)
-  : token_(consumes<edm::HepMCProduct>(iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator","unsmeared")))),
+    : token_(consumes<edm::HepMCProduct>(
+          iConfig.getUntrackedParameter<edm::InputTag>("moduleLabel", edm::InputTag("generator", "unsmeared")))),
       betaBoost(iConfig.getUntrackedParameter("BetaBoost", 0.)) {
   vector<int> defpid;
   defpid.push_back(0);


### PR DESCRIPTION
#### PR description:

This PR updates the `MCSmartSingleParticleFilter` to use an `edm::InputTag` rather than a string to specify its input.
This allows to use an instance label different than `"unsmeared"`.

#### PR validation:

See #32491.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32491.