### PR TITLE
(11_1_X) L1 Phase2 for HLT TDR - Multy Primary Vtx, TkMuons Fix for low-pt

### DIFF
--- a/DataFormats/L1TCorrelator/interface/TkMuon.h
+++ b/DataFormats/L1TCorrelator/interface/TkMuon.h
@@ -7,6 +7,7 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCand.h"
 #include "DataFormats/L1TMuon/interface/RegionalMuonCandFwd.h"
+#include "DataFormats/L1TMuon/interface/EMTFTrack.h"
 
 namespace l1t {
   class TkMuon : public L1Candidate {
@@ -21,6 +22,11 @@ namespace l1t {
            const edm::Ptr<L1TTTrackType>& trkPtr,
            float tkisol = -999.);
 
+    TkMuon(const LorentzVector& p4,
+           const edm::Ref<l1t::EMTFTrackCollection>& emtfTrk,
+           const edm::Ptr<L1TTTrackType>& trkPtr,
+           float tkisol = -999.);
+
     //One more constructor for Tracker+ Stubs algorithm not requiring the Muon candidate
     TkMuon(const LorentzVector& p4, const edm::Ptr<L1TTTrackType>& trkPtr, float tkisol = -999.);
 
@@ -30,6 +36,7 @@ namespace l1t {
     const edm::Ptr<L1TTTrackType>& trkPtr() const { return trkPtr_; }
 
     const edm::Ref<l1t::RegionalMuonCandBxCollection>& muRef() const { return muRef_; }
+    const edm::Ref<l1t::EMTFTrackCollection>& emtfTrk() const { return emtfTrk_; }
 
     float trkIsol() const { return theIsolation; }
     float trkzVtx() const { return TrkzVtx_; }
@@ -58,6 +65,7 @@ namespace l1t {
   private:
     // used for the Naive producer
     edm::Ref<l1t::RegionalMuonCandBxCollection> muRef_;
+    edm::Ref<l1t::EMTFTrackCollection> emtfTrk_;
 
     edm::Ptr<L1TTTrackType> trkPtr_;
 

--- a/DataFormats/L1TCorrelator/src/TkMuon.cc
+++ b/DataFormats/L1TCorrelator/src/TkMuon.cc
@@ -17,6 +17,16 @@ TkMuon::TkMuon(const LorentzVector& p4,
   }
 }
 
+TkMuon::TkMuon(const LorentzVector& p4,
+               const edm::Ref<EMTFTrackCollection>& emtfRef,
+               const edm::Ptr<L1TTTrackType>& trackPtr,
+               float tkisol)
+    : L1Candidate(p4), emtfTrk_(emtfRef), trkPtr_(trackPtr), theIsolation(tkisol), TrkzVtx_(999), quality_(999) {
+  if (trkPtr_.isNonnull()) {
+    setTrkzVtx(trkPtr()->POCA().z());
+  }
+}
+
 TkMuon::TkMuon(const LorentzVector& p4, const edm::Ptr<L1TTTrackType>& trackPtr, float tkisol)
     : L1Candidate(p4), trkPtr_(trackPtr), theIsolation(tkisol), TrkzVtx_(999), quality_(999) {
   if (trkPtr_.isNonnull()) {

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -1,18 +1,19 @@
 
 <lcgdict>
 
- <class name="l1t::TkPrimaryVertex" ClassVersion="3">
-  <version ClassVersion="3" checksum="2843779965"/>
- </class>
- <class name="std::vector<l1t::TkPrimaryVertex>"/>
- <class name="edm::Wrapper<std::vector<l1t::TkPrimaryVertex> >"/>
+  <class name="l1t::TkPrimaryVertex" ClassVersion="3">
+   <version ClassVersion="3" checksum="2843779965"/>
+  </class>
+  <class name="std::vector<l1t::TkPrimaryVertex>"/>
+  <class name="edm::Wrapper<std::vector<l1t::TkPrimaryVertex> >"/>
   <class name="edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> > >"/>
 
   <class name="l1t::TkEtMiss" ClassVersion="3">
    <version ClassVersion="3" checksum="77762919"/>
   </class>
   <class name="std::vector<l1t::TkEtMiss>"/>
- <class name="edm::Wrapper<l1t::TkEtMiss>"/>
+  <class name="edm::Wrapper<l1t::TkEtMiss>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEtMiss> >"/>
 
   <class name="l1t::TkEm" ClassVersion="3">
@@ -21,6 +22,7 @@
   <class name="std::vector<l1t::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEm> >"/>
   <class name="edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> > >"/>
 
   <class name="l1t::TkEGTau" ClassVersion="3">
    <version ClassVersion="3" checksum="3759113668"/>
@@ -49,6 +51,7 @@
   <class name="std::vector<l1t::TkElectron>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkElectron> >"/>
   <class name="edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> > >"/>
 
   <class name="l1t::TkJet" ClassVersion="3">
    <version ClassVersion="3" checksum="3336007399"/>
@@ -72,6 +75,7 @@
   <class name="std::vector<l1t::TkMuon>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkMuon> >"/>
   <class name="edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> >"/>
+  <class name="std::vector<edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> > >"/>
   <class name="edm::Ref<vector<l1t::EMTFTrack>,l1t::EMTFTrack,edm::refhelper::FindUsingAdvance<vector<l1t::EMTFTrack>,l1t::EMTFTrack> >" />
 
   <class name="l1t::TkGlbMuon" ClassVersion="3">

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -71,6 +71,8 @@
 
   <class name="l1t::TkMuon" ClassVersion="4">
    <version ClassVersion="4" checksum="2325700664"/>
+   <version ClassVersion="3" checksum="4118337663"/>
+
   </class>
   <class name="std::vector<l1t::TkMuon>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkMuon> >"/>

--- a/DataFormats/L1TCorrelator/src/classes_def.xml
+++ b/DataFormats/L1TCorrelator/src/classes_def.xml
@@ -6,9 +6,7 @@
  </class>
  <class name="std::vector<l1t::TkPrimaryVertex>"/>
  <class name="edm::Wrapper<std::vector<l1t::TkPrimaryVertex> >"/>
- <class name="edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> >"/>
- <class name="std::vector<edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> > >"/>
-
+  <class name="edm::Ref<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkPrimaryVertex>,l1t::TkPrimaryVertex> >"/>
 
   <class name="l1t::TkEtMiss" ClassVersion="3">
    <version ClassVersion="3" checksum="77762919"/>
@@ -23,8 +21,6 @@
   <class name="std::vector<l1t::TkEm>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkEm> >"/>
   <class name="edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> >"/>
-  <class name="std::vector<edm::Ref<std::vector<l1t::TkEm>,l1t::TkEm,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkEm>,l1t::TkEm> > >"/>
-
 
   <class name="l1t::TkEGTau" ClassVersion="3">
    <version ClassVersion="3" checksum="3759113668"/>
@@ -53,7 +49,6 @@
   <class name="std::vector<l1t::TkElectron>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkElectron> >"/>
   <class name="edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> >"/>
-  <class name="std::vector<edm::Ref<std::vector<l1t::TkElectron>,l1t::TkElectron,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkElectron>,l1t::TkElectron> > >"/>
 
   <class name="l1t::TkJet" ClassVersion="3">
    <version ClassVersion="3" checksum="3336007399"/>
@@ -71,13 +66,13 @@
   <class name="edm::Wrapper<l1t::TkHTMiss>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkHTMiss> >"/>
 
-  <class name="l1t::TkMuon" ClassVersion="3">
-   <version ClassVersion="3" checksum="4118337663"/>
+  <class name="l1t::TkMuon" ClassVersion="4">
+   <version ClassVersion="4" checksum="2325700664"/>
   </class>
   <class name="std::vector<l1t::TkMuon>"/>
   <class name="edm::Wrapper<std::vector<l1t::TkMuon> >"/>
   <class name="edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> >"/>
-  <class name="std::vector<edm::Ref<std::vector<l1t::TkMuon>,l1t::TkMuon,edm::refhelper::FindUsingAdvance<std::vector<l1t::TkMuon>,l1t::TkMuon> > >"/>
+  <class name="edm::Ref<vector<l1t::EMTFTrack>,l1t::EMTFTrack,edm::refhelper::FindUsingAdvance<vector<l1t::EMTFTrack>,l1t::EMTFTrack> >" />
 
   <class name="l1t::TkGlbMuon" ClassVersion="3">
    <version ClassVersion="3"  checksum="2811548892"/>

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -5,7 +5,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -42,7 +42,7 @@ static constexpr float max_mu_propagator_eta = 2.5;
 
 using namespace l1t;
 
-class L1TkMuonProducer : public edm::stream::EDProducer<> {
+class L1TkMuonProducer : public edm::global::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -66,7 +66,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   PropState propagateToGMT(const L1TTTrackType& l1tk) const;
   double sigmaEtaTP(const RegionalMuonCand& mu) const;
   double sigmaPhiTP(const RegionalMuonCand& mu) const;
@@ -89,6 +89,12 @@ private:
                                const edm::Handle<RegionalMuonCandBxCollection>& muonH,
                                int detector) const;
 
+  void build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                               const std::vector<int>& matches,
+                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                               const edm::Handle<EMTFTrackCollection>& emtfTksH,
+                               int detector) const;
+
   // dump and convert tracks to the format needed for the MAnTra correlator
   std::vector<L1TkMuMantraDF::track_df> product_to_trkvec(const L1TTTrackCollectionType& l1tks) const;  // tracks
   // regional muon finder
@@ -98,7 +104,10 @@ private:
 
   float etaMin_;
   float etaMax_;
-  float zMax_;  // |z_track| < zMax_ in cm
+  float etaBO_;  //eta value for barrel-overlap fontier
+  float etaOE_;  //eta value for overlap-endcap fontier
+  bool useRegionEtaMatching_;
+  float zMax_;   // |z_track| < zMax_ in cm
   float chi2Max_;
   float pTMinTra_;
   float dRMax_;
@@ -106,6 +115,7 @@ private:
   bool correctGMTPropForTkZ_;
   bool use5ParameterFit_;
   bool useTPMatchWindows_;
+  bool applyQuality_;
 
   AlgoType bmtfMatchAlgoVersion_;
   AlgoType omtfMatchAlgoVersion_;
@@ -129,11 +139,15 @@ private:
 L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
     : etaMin_((float)iConfig.getParameter<double>("ETAMIN")),
       etaMax_((float)iConfig.getParameter<double>("ETAMAX")),
+      etaBO_(iConfig.exists("ETABARRELOVERLAP") ? (float)iConfig.getParameter<double>("ETABARRELOVERLAP") : 0.83),
+      etaOE_(iConfig.exists("ETAOVERLAPENDCAP") ? (float)iConfig.getParameter<double>("ETAOVERLAPENDCAP") : 1.24),
+      useRegionEtaMatching_(iConfig.exists("useRegionEtaMatching") ? iConfig.getParameter<bool>("useRegionEtaMatching") : true),
       zMax_((float)iConfig.getParameter<double>("ZMAX")),
       chi2Max_((float)iConfig.getParameter<double>("CHI2MAX")),
       pTMinTra_((float)iConfig.getParameter<double>("PTMINTRA")),
       dRMax_((float)iConfig.getParameter<double>("DRmax")),
       nStubsmin_(iConfig.getParameter<int>("nStubsmin")),
+
       // --- mantra corr params
       mantra_n_trk_par_(iConfig.getParameter<int>("mantra_n_trk_par")),
       bmtfToken_(consumes<RegionalMuonCandBxCollection>(iConfig.getParameter<edm::InputTag>("L1BMTFInputTag"))),
@@ -192,6 +206,8 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
 
   use5ParameterFit_ = iConfig.getParameter<bool>("use5ParameterFit");
   useTPMatchWindows_ = iConfig.getParameter<bool>("useTPMatchWindows");
+  applyQuality_ = iConfig.exists("applyQualityCuts") ? iConfig.getParameter<bool>("applyQualityCuts") : false;
+
   produces<TkMuonCollection>();
 
   // initializations
@@ -290,7 +306,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
 L1TkMuonProducer::~L1TkMuonProducer() {}
 
 // ------------ method called to produce the data  ------------
-void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   // the L1Mu objects
   edm::Handle<RegionalMuonCandBxCollection> l1bmtfH;
   edm::Handle<RegionalMuonCandBxCollection> l1omtfH;
@@ -347,9 +363,8 @@ void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   else if (emtfMatchAlgoVersion_ == kMantra) {
     const auto& muons = product_to_muvec(*l1emtfTCH.product());
     const auto& match_idx = mantracorr_endc_->find_match(mantradf_tracks, muons);
-    //for the TkMu that were built from a EMTFCollection - do not produce a valid muon ref
-    edm::Handle<RegionalMuonCandBxCollection> invalidMuonH;
-    build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, invalidMuonH, endcap_MTF_region);
+    //for the TkMu that were built from a EMTFCollection - pass the emtf track as ref
+    build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, l1emtfTCH, endcap_MTF_region);
   } else
     throw cms::Exception("TkMuAlgoConfig") << "endcap : trying to run an invalid algorithm version "
                                            << emtfMatchAlgoVersion_ << " (this should never happen)\n";
@@ -468,11 +483,26 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
 
         TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
 
+	if (useRegionEtaMatching_) {
+	  if (detector == barrel_MTF_region) {
+	    if (std::abs(l1tkmu.eta()) > etaBO_)
+	      continue;
+	  } else if (detector == overlap_MTF_region) {
+	    if (std::abs(l1tkmu.eta()) < etaBO_)
+	      continue;
+	    if (std::abs(l1tkmu.eta()) > etaOE_)
+	      continue;
+	  } else if (detector == endcap_MTF_region) {
+	    if (std::abs(l1tkmu.eta()) < etaOE_)
+	      continue;
+	  }
+	}
         l1tkmu.setTrackCurvature(matchTk.rInv());
         l1tkmu.setTrkzVtx((float)tkv3.z());
         l1tkmu.setdR(drmin);
         l1tkmu.setNTracksMatched(nTracksMatch);
         l1tkmu.setMuonDetector(detector);
+	l1tkmu.setQuality(l1muRef->hwQual());
         tkMuons.push_back(l1tkmu);
       }
     }
@@ -509,6 +539,11 @@ void L1TkMuonProducer::runOnMTFCollection_v2(const edm::Handle<EMTFTrackCollecti
     edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, il1ttrack);
     float trkisol = -999;  // now doing as in the TP algo
     TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
+
+    // avoid leaking of candidates to overlap region...
+    if (useRegionEtaMatching_ && std::abs(l1tkmu.eta()) < etaOE_)
+      continue;
+
     l1tkmu.setTrackCurvature(matchTk.rInv());
     l1tkmu.setTrkzVtx((float)tkv3.z());
     l1tkmu.setMuonDetector(endcap_MTF_region);
@@ -635,6 +670,12 @@ std::vector<L1TkMuMantraDF::muon_df> L1TkMuonProducer::product_to_muvec(const EM
   std::vector<L1TkMuMantraDF::muon_df> result(l1mus.size());
   for (uint imu = 0; imu < l1mus.size(); ++imu) {
     auto& mu = l1mus[imu];
+
+    // dropping the emtf tracks with certain quality...
+    int emtfQual = (mu.Mode() == 11 || mu.Mode() == 13 || mu.Mode() == 14 || mu.Mode() == 15);
+    if (applyQuality_ && !emtfQual)
+      continue;
+
     result[imu].pt = mu.Pt();
     result[imu].eta = mu.Eta();
     result[imu].theta = L1TkMuMantra::to_mpio2_pio2(L1TkMuMantra::eta_to_theta(mu.Eta()));
@@ -670,6 +711,61 @@ void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
     l1tkmu.setTrackCurvature(matchTk.rInv());
     l1tkmu.setTrkzVtx((float)tkv3.z());
     l1tkmu.setMuonDetector(detector);
+    l1tkmu.setQuality(l1muRef->hwQual());
+
+    // apply region cleaning (probably this is not the best way, but since this is going to
+    // be a patch and temporary, it is OK)
+    if (useRegionEtaMatching_) {
+      if (detector == barrel_MTF_region) {
+	if (std::abs(l1tkmu.eta()) > etaBO_)
+	  continue;
+      } else if (detector == overlap_MTF_region) {
+	if (std::abs(l1tkmu.eta()) < etaBO_)
+	  continue;
+	if (std::abs(l1tkmu.eta()) > etaOE_)
+	  continue;
+      } else if (detector == endcap_MTF_region) {
+	if (std::abs(l1tkmu.eta()) < etaOE_)
+	  continue;
+      }
+    }
+    tkMuons.push_back(l1tkmu);
+  }
+  return;
+}
+
+void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
+                                               const std::vector<int>& matches,
+                                               const edm::Handle<L1TTTrackCollectionType>& l1tksH,
+                                               const edm::Handle<EMTFTrackCollection>& emtfTksH,
+                                               int detector) const {
+  for (uint imatch = 0; imatch < matches.size(); ++imatch) {
+    int match_trk_idx = matches[imatch];
+    if (match_trk_idx < 0)
+      continue;  // this muon was not matched to any candidate
+
+    // take properties of the track
+    const L1TTTrackType& matchTk = (*l1tksH.product())[match_trk_idx];
+    const auto& p3 = matchTk.momentum();
+    const auto& tkv3 = matchTk.POCA();
+    float p4e = sqrt(mu_mass * mu_mass + p3.mag2());
+    math::XYZTLorentzVector l1tkp4(p3.x(), p3.y(), p3.z(), p4e);
+
+    edm::Ptr<L1TTTrackType> l1tkPtr(l1tksH, match_trk_idx);
+
+    auto l1emtfTrk =
+        emtfTksH.isValid() ? edm::Ref<EMTFTrackCollection>(emtfTksH, imatch) : edm::Ref<EMTFTrackCollection>();
+
+    float trkisol = -999;
+    TkMuon l1tkmu(l1tkp4, l1emtfTrk, l1tkPtr, trkisol);
+    l1tkmu.setTrackCurvature(matchTk.rInv());
+    l1tkmu.setTrkzVtx((float)tkv3.z());
+    l1tkmu.setMuonDetector(detector);
+    l1tkmu.setQuality(l1emtfTrk->Mode());
+
+    if (useRegionEtaMatching_ && std::abs(l1tkmu.eta()) < etaOE_)
+      continue;
+
     tkMuons.push_back(l1tkmu);
   }
   return;

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -107,7 +107,7 @@ private:
   float etaBO_;  //eta value for barrel-overlap fontier
   float etaOE_;  //eta value for overlap-endcap fontier
   bool useRegionEtaMatching_;
-  float zMax_;   // |z_track| < zMax_ in cm
+  float zMax_;  // |z_track| < zMax_ in cm
   float chi2Max_;
   float pTMinTra_;
   float dRMax_;
@@ -141,7 +141,8 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
       etaMax_((float)iConfig.getParameter<double>("ETAMAX")),
       etaBO_(iConfig.exists("ETABARRELOVERLAP") ? (float)iConfig.getParameter<double>("ETABARRELOVERLAP") : 0.83),
       etaOE_(iConfig.exists("ETAOVERLAPENDCAP") ? (float)iConfig.getParameter<double>("ETAOVERLAPENDCAP") : 1.24),
-      useRegionEtaMatching_(iConfig.exists("useRegionEtaMatching") ? iConfig.getParameter<bool>("useRegionEtaMatching") : true),
+      useRegionEtaMatching_(iConfig.exists("useRegionEtaMatching") ? iConfig.getParameter<bool>("useRegionEtaMatching")
+                                                                   : true),
       zMax_((float)iConfig.getParameter<double>("ZMAX")),
       chi2Max_((float)iConfig.getParameter<double>("CHI2MAX")),
       pTMinTra_((float)iConfig.getParameter<double>("PTMINTRA")),
@@ -483,26 +484,26 @@ void L1TkMuonProducer::runOnMTFCollection_v1(const edm::Handle<RegionalMuonCandB
 
         TkMuon l1tkmu(l1tkp4, l1muRef, l1tkPtr, trkisol);
 
-	if (useRegionEtaMatching_) {
-	  if (detector == barrel_MTF_region) {
-	    if (std::abs(l1tkmu.eta()) > etaBO_)
-	      continue;
-	  } else if (detector == overlap_MTF_region) {
-	    if (std::abs(l1tkmu.eta()) < etaBO_)
-	      continue;
-	    if (std::abs(l1tkmu.eta()) > etaOE_)
-	      continue;
-	  } else if (detector == endcap_MTF_region) {
-	    if (std::abs(l1tkmu.eta()) < etaOE_)
-	      continue;
-	  }
-	}
+        if (useRegionEtaMatching_) {
+          if (detector == barrel_MTF_region) {
+            if (std::abs(l1tkmu.eta()) > etaBO_)
+              continue;
+          } else if (detector == overlap_MTF_region) {
+            if (std::abs(l1tkmu.eta()) < etaBO_)
+              continue;
+            if (std::abs(l1tkmu.eta()) > etaOE_)
+              continue;
+          } else if (detector == endcap_MTF_region) {
+            if (std::abs(l1tkmu.eta()) < etaOE_)
+              continue;
+          }
+        }
         l1tkmu.setTrackCurvature(matchTk.rInv());
         l1tkmu.setTrkzVtx((float)tkv3.z());
         l1tkmu.setdR(drmin);
         l1tkmu.setNTracksMatched(nTracksMatch);
         l1tkmu.setMuonDetector(detector);
-	l1tkmu.setQuality(l1muRef->hwQual());
+        l1tkmu.setQuality(l1muRef->hwQual());
         tkMuons.push_back(l1tkmu);
       }
     }
@@ -717,16 +718,16 @@ void L1TkMuonProducer::build_tkMuons_from_idxs(TkMuonCollection& tkMuons,
     // be a patch and temporary, it is OK)
     if (useRegionEtaMatching_) {
       if (detector == barrel_MTF_region) {
-	if (std::abs(l1tkmu.eta()) > etaBO_)
-	  continue;
+        if (std::abs(l1tkmu.eta()) > etaBO_)
+          continue;
       } else if (detector == overlap_MTF_region) {
-	if (std::abs(l1tkmu.eta()) < etaBO_)
-	  continue;
-	if (std::abs(l1tkmu.eta()) > etaOE_)
-	  continue;
+        if (std::abs(l1tkmu.eta()) < etaBO_)
+          continue;
+        if (std::abs(l1tkmu.eta()) > etaOE_)
+          continue;
       } else if (detector == endcap_MTF_region) {
-	if (std::abs(l1tkmu.eta()) < etaOE_)
-	  continue;
+        if (std::abs(l1tkmu.eta()) < etaOE_)
+          continue;
       }
     }
     tkMuons.push_back(l1tkmu);

--- a/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
+++ b/L1Trigger/L1TTrackMatch/plugins/L1TkMuonProducer.cc
@@ -5,7 +5,7 @@
 // user include files
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -42,7 +42,7 @@ static constexpr float max_mu_propagator_eta = 2.5;
 
 using namespace l1t;
 
-class L1TkMuonProducer : public edm::global::EDProducer<> {
+class L1TkMuonProducer : public edm::stream::EDProducer<> {
 public:
   typedef TTTrack<Ref_Phase2TrackerDigi_> L1TTTrackType;
   typedef std::vector<L1TTTrackType> L1TTTrackCollectionType;
@@ -66,7 +66,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
   PropState propagateToGMT(const L1TTTrackType& l1tk) const;
   double sigmaEtaTP(const RegionalMuonCand& mu) const;
   double sigmaPhiTP(const RegionalMuonCand& mu) const;
@@ -307,7 +307,7 @@ L1TkMuonProducer::L1TkMuonProducer(const edm::ParameterSet& iConfig)
 L1TkMuonProducer::~L1TkMuonProducer() {}
 
 // ------------ method called to produce the data  ------------
-void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+void L1TkMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // the L1Mu objects
   edm::Handle<RegionalMuonCandBxCollection> l1bmtfH;
   edm::Handle<RegionalMuonCandBxCollection> l1omtfH;
@@ -341,9 +341,11 @@ void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     const auto& muons = product_to_muvec(*l1bmtfH.product());
     const auto& match_idx = mantracorr_barr_->find_match(mantradf_tracks, muons);
     build_tkMuons_from_idxs(oc_bmtf_tkmuon, match_idx, l1tksH, l1bmtfH, barrel_MTF_region);
-  } else
+  } else {
     throw cms::Exception("TkMuAlgoConfig") << " barrel : trying to run an invalid algorithm version "
                                            << bmtfMatchAlgoVersion_ << " (this should never happen)\n";
+    return;
+  }
 
   // ----------------------------------------------------- overlap
   if (omtfMatchAlgoVersion_ == kTP)
@@ -352,9 +354,11 @@ void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     const auto& muons = product_to_muvec(*l1omtfH.product());
     const auto& match_idx = mantracorr_ovrl_->find_match(mantradf_tracks, muons);
     build_tkMuons_from_idxs(oc_omtf_tkmuon, match_idx, l1tksH, l1omtfH, overlap_MTF_region);
-  } else
+  } else {
     throw cms::Exception("TkMuAlgoConfig") << " overlap : trying to run an invalid algorithm version "
                                            << omtfMatchAlgoVersion_ << " (this should never happen)\n";
+    return;
+  }
 
   // ----------------------------------------------------- endcap
   if (emtfMatchAlgoVersion_ == kTP)
@@ -366,9 +370,11 @@ void L1TkMuonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     const auto& match_idx = mantracorr_endc_->find_match(mantradf_tracks, muons);
     //for the TkMu that were built from a EMTFCollection - pass the emtf track as ref
     build_tkMuons_from_idxs(oc_emtf_tkmuon, match_idx, l1tksH, l1emtfTCH, endcap_MTF_region);
-  } else
+  } else {
     throw cms::Exception("TkMuAlgoConfig") << "endcap : trying to run an invalid algorithm version "
                                            << emtfMatchAlgoVersion_ << " (this should never happen)\n";
+    return;
+  }
 
   // now combine all trk muons into a single output collection!
   auto oc_tkmuon = std::make_unique<TkMuonCollection>();

--- a/L1Trigger/L1TTrackMatch/python/L1TkMuonProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkMuonProducer_cfi.py
@@ -16,6 +16,9 @@ L1TkMuons = cms.EDProducer("L1TkMuonProducer",
     ############################################### TP algo
     ETAMIN = cms.double(0),
     ETAMAX = cms.double(5.),        # no cut
+    ETABARRELOVERLAP = cms.double(0.83),                           
+    ETAOVERLAPENDCAP = cms.double(1.24),                           
+    useRegionEtaMatching = cms.bool(True),
     ZMAX = cms.double( 25. ),       # in cm
     CHI2MAX = cms.double( 100. ),
     PTMINTRA = cms.double( 2. ),    # in GeV

--- a/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
+++ b/L1Trigger/L1TTrackMatch/python/L1TkPrimaryVertexProducer_cfi.py
@@ -11,6 +11,7 @@ L1TkPrimaryVertex = cms.EDProducer('L1TkFastVertexProducer',
      ZMAX = cms.double ( 25. ) ,        # in cm
      CHI2MAX = cms.double( 100. ),
      PTMINTRA = cms.double( 2.),        # PTMIN of L1Tracks, in GeV
+     nVtx = cms.int32( 1 ),              # number of vertices to return
      nStubsmin = cms.int32( 4 ) ,       # minimum number of stubs
      nStubsPSmin = cms.int32( 3 ),       # minimum number of stubs in PS modules 
      nBinning = cms.int32( 601 ),        # number of bins for the temp histo (from -30 cm to + 30 cm)


### PR DESCRIPTION
#### PR description:
11_1_X PR (backport of https://github.com/cms-sw/cmssw/pull/32571)

LT Phase2 for HLT TDR, featuring:
- Multy Primary Vtx: adjust the producer to provide more than just the best-ranked PrimVtx (ported from  integration tag **l1t-phase2-v3.3.5**)
- TkMuons Fix for low-pt: do the the cleaning of duplicate between regions to reduce rate and keep efficiency (ported from integration tag **l1t-phase2-v3.3.0**)

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

(backport of https://github.com/cms-sw/cmssw/pull/32571)

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
