### PR TITLE
New HGCal silicon module rotation class

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -3,27 +3,28 @@
 
 class HGCalGeomRotation {
 public:
-
   enum SectorType { Sector120Degrees, Sector60Degrees };
   enum WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
 
-  HGCalGeomRotation(SectorType sectorType){_sectorType = sectorType;};
+  HGCalGeomRotation(SectorType sectorType) { _sectorType = sectorType; };
   ~HGCalGeomRotation() {}
 
   void uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
   unsigned uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
 
 private:
-
-  void RotateModule60DegreesAnticlockwise(int& moduleU, int& moduleV) const;
-  void RotateModule60DegreesClockwise(int& moduleU, int& moduleV) const;
+  void uvMappingFrom120DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
+  void uvMappingFrom60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
 
   unsigned uvMappingTo120DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
   unsigned uvMappingTo60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
 
+  void RotateModule60DegreesAnticlockwise(int& moduleU, int& moduleV) const;
+  void RotateModule60DegreesClockwise(int& moduleU, int& moduleV) const;
+  void RotateModule120DegreesAnticlockwise(int& moduleU, int& moduleV, int offset) const;
+  void RotateModule120DegreesClockwise(int& moduleU, int& moduleV, int offset) const;
+
   SectorType _sectorType;
-
-
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -6,7 +6,7 @@ public:
   enum class SectorType { Sector120Degrees, Sector60Degrees };
   enum class WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
 
-  HGCalGeomRotation(SectorType sectorType) { _sectorType = sectorType; };
+  HGCalGeomRotation(SectorType sectorType) { sectorType_ = sectorType; };
   ~HGCalGeomRotation() {}
 
   void uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
@@ -24,7 +24,7 @@ private:
   void RotateModule120DegreesAnticlockwise(int& moduleU, int& moduleV, int offset) const;
   void RotateModule120DegreesClockwise(int& moduleU, int& moduleV, int offset) const;
 
-  SectorType _sectorType;
+  SectorType sectorType_;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -3,13 +3,27 @@
 
 class HGCalGeomRotation {
 public:
-  HGCalGeomRotation();
-  ~HGCalGeomRotation() {}
 
+  enum SectorType { Sector120Degrees, Sector60Degrees };
   enum WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
+
+  HGCalGeomRotation(SectorType sectorType){_sectorType = sectorType;};
+  ~HGCalGeomRotation() {}
 
   void uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
   unsigned uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
+
+private:
+
+  void RotateModule60DegreesAnticlockwise(int& moduleU, int& moduleV) const;
+  void RotateModule60DegreesClockwise(int& moduleU, int& moduleV) const;
+
+  unsigned uvMappingTo120DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
+  unsigned uvMappingTo60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
+
+  SectorType _sectorType;
+
+
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -1,0 +1,17 @@
+#ifndef Geometry_HGCalCommonData_HGCalGeomRotation_h
+#define Geometry_HGCalCommonData_HGCalGeomRotation_h
+
+
+class HGCalGeomRotation {
+public:
+  HGCalGeomRotation();
+  ~HGCalGeomRotation() {}
+
+  enum WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
+
+  void uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
+  unsigned uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
+
+};
+
+#endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -1,7 +1,6 @@
 #ifndef Geometry_HGCalCommonData_HGCalGeomRotation_h
 #define Geometry_HGCalCommonData_HGCalGeomRotation_h
 
-
 class HGCalGeomRotation {
 public:
   HGCalGeomRotation();
@@ -11,7 +10,6 @@ public:
 
   void uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const;
   unsigned uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const;
-
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomRotation.h
@@ -3,8 +3,8 @@
 
 class HGCalGeomRotation {
 public:
-  enum SectorType { Sector120Degrees, Sector60Degrees };
-  enum WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
+  enum class SectorType { Sector120Degrees, Sector60Degrees };
+  enum class WaferCentring { WaferCentred, CornerCentredY, CornerCentredMercedes };
 
   HGCalGeomRotation(SectorType sectorType) { _sectorType = sectorType; };
   ~HGCalGeomRotation() {}

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -1,88 +1,94 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeomRotation.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const{
-
-  if (sector==0){
+void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
+                                             int& moduleU,
+                                             int& moduleV,
+                                             unsigned sector) const {
+  if (sector == 0) {
     return;
   }
 
   int offset;
 
-  if (waferCentring == WaferCentred){
-    offset=0;
-  } else if(waferCentring == CornerCentredY){
-    offset=-1;
-  } else if(waferCentring == CornerCentredMercedes){
-    offset=1;
-  }
-  else{
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
+  if (waferCentring == WaferCentred) {
+    offset = 0;
+  } else if (waferCentring == CornerCentredY) {
+    offset = -1;
+  } else if (waferCentring == CornerCentredMercedes) {
+    offset = 1;
+  } else {
+    throw cms::Exception("RotationException")
+        << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
 
-  int uPrime,vPrime;
+  int uPrime, vPrime;
 
-  if(sector==1) {
-    uPrime=-moduleV + offset;
-    vPrime=moduleU - moduleV + offset;
-  }else if(sector==2) {
-    uPrime=moduleV - moduleU;
-    vPrime=-moduleU + offset;
-  }
-  else{
+  if (sector == 1) {
+    uPrime = -moduleV + offset;
+    vPrime = moduleU - moduleV + offset;
+  } else if (sector == 2) {
+    uPrime = moduleV - moduleU;
+    vPrime = -moduleU + offset;
+  } else {
     throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be eother 0, 1 or 2";
   }
-  moduleU=uPrime;
-  moduleV=vPrime;
-
+  moduleU = uPrime;
+  moduleV = vPrime;
 }
 
-
-unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const{
-
+unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
   unsigned sector = 0;
 
   int offset;
 
-  if (waferCentring == WaferCentred){
-    if(moduleU>0 && moduleV>=0) return sector;
-    
-    offset=0;
-    if(moduleU>=moduleV && moduleV<0) sector=2;
-    else sector=1;
-    
-  } else if(waferCentring == CornerCentredY){
-    if(moduleU>=0 && moduleV>=0) return sector;
-    
-    offset=-1;    
-    if(moduleU>moduleV && moduleV<0) sector=2;
-    else sector=1;
-    
-  } else if(waferCentring == CornerCentredMercedes){
-    if(moduleU>=1 && moduleV>=1) return sector;
-    
-    offset=1;
-    if(moduleU>=moduleV && moduleV<1) sector=2;
-    else sector=1;
-  }
-  else{
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
-  }  
+  if (waferCentring == WaferCentred) {
+    if (moduleU > 0 && moduleV >= 0)
+      return sector;
 
-  int moduleURotated,moduleVRotated;
-  
-  if(sector==1) {
-    moduleURotated=moduleV-moduleU;
-    moduleVRotated=-moduleU+offset;    
-    
-  }else if (sector==2) {
-    moduleURotated=-moduleV+offset;
-    moduleVRotated=moduleU-moduleV+offset;
+    offset = 0;
+    if (moduleU >= moduleV && moduleV < 0)
+      sector = 2;
+    else
+      sector = 1;
+
+  } else if (waferCentring == CornerCentredY) {
+    if (moduleU >= 0 && moduleV >= 0)
+      return sector;
+
+    offset = -1;
+    if (moduleU > moduleV && moduleV < 0)
+      sector = 2;
+    else
+      sector = 1;
+
+  } else if (waferCentring == CornerCentredMercedes) {
+    if (moduleU >= 1 && moduleV >= 1)
+      return sector;
+
+    offset = 1;
+    if (moduleU >= moduleV && moduleV < 1)
+      sector = 2;
+    else
+      sector = 1;
+  } else {
+    throw cms::Exception("RotationException")
+        << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
-  
-  moduleU=moduleURotated;
-  moduleV=moduleVRotated;
+
+  int moduleURotated, moduleVRotated;
+
+  if (sector == 1) {
+    moduleURotated = moduleV - moduleU;
+    moduleVRotated = -moduleU + offset;
+
+  } else if (sector == 2) {
+    moduleURotated = -moduleV + offset;
+    moduleVRotated = moduleU - moduleV + offset;
+  }
+
+  moduleU = moduleURotated;
+  moduleV = moduleVRotated;
 
   return sector;
-
 }

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -10,21 +10,19 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
     return;
   }
 
-  if (_sectorType == Sector120Degrees) {
-    uvMappingFrom120DegreeSector0(waferCentring, moduleU, moduleV, sector);
-
-  } else if (_sectorType == Sector60Degrees) {
+  if (_sectorType == SectorType::Sector60Degrees) {
     uvMappingFrom60DegreeSector0(waferCentring, moduleU, moduleV, sector);
+  } else if (_sectorType == SectorType::Sector120Degrees) {
+    uvMappingFrom120DegreeSector0(waferCentring, moduleU, moduleV, sector);
   }
 }
 
 unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
   unsigned sector = 0;
 
-  if (_sectorType == Sector60Degrees) {
+  if (_sectorType == SectorType::Sector60Degrees) {
     sector = uvMappingTo60DegreeSector0(waferCentring, moduleU, moduleV);
-
-  } else if (_sectorType == Sector120Degrees) {
+  } else if (_sectorType == SectorType::Sector120Degrees) {
     sector = uvMappingTo120DegreeSector0(waferCentring, moduleU, moduleV);
   }
 
@@ -35,11 +33,11 @@ void HGCalGeomRotation::uvMappingFrom60DegreeSector0(WaferCentring waferCentring
                                                      int& moduleU,
                                                      int& moduleV,
                                                      unsigned sector) const {
-  if (waferCentring != WaferCentred) {
+  if (waferCentring != WaferCentring::WaferCentred) {
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
            "incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentred;
+    waferCentring = WaferCentring::WaferCentred;
   }
 
   if (sector > 5) {
@@ -57,11 +55,11 @@ void HGCalGeomRotation::uvMappingFrom120DegreeSector0(WaferCentring waferCentrin
                                                       unsigned sector) const {
   int offset;
 
-  if (waferCentring == WaferCentred) {
+  if (waferCentring == WaferCentring::WaferCentred) {
     offset = 0;
-  } else if (waferCentring == CornerCentredY) {
+  } else if (waferCentring == WaferCentring::CornerCentredY) {
     offset = -1;
-  } else if (waferCentring == CornerCentredMercedes) {
+  } else if (waferCentring == WaferCentring::CornerCentredMercedes) {
     offset = 1;
   } else {
     throw cms::Exception("RotationException")
@@ -80,7 +78,7 @@ unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentr
   unsigned sector = 0;
   int offset;
 
-  if (waferCentring == WaferCentred) {
+  if (waferCentring == WaferCentring::WaferCentred) {
     if (moduleU > 0 && moduleV >= 0)
       return sector;
 
@@ -90,7 +88,7 @@ unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentr
     else
       sector = 1;
 
-  } else if (waferCentring == CornerCentredY) {
+  } else if (waferCentring == WaferCentring::CornerCentredY) {
     if (moduleU >= 0 && moduleV >= 0)
       return sector;
 
@@ -100,7 +98,7 @@ unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentr
     else
       sector = 1;
 
-  } else if (waferCentring == CornerCentredMercedes) {
+  } else if (waferCentring == WaferCentring::CornerCentredMercedes) {
     if (moduleU >= 1 && moduleV >= 1)
       return sector;
 
@@ -124,11 +122,11 @@ unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentr
 unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
   unsigned sector = 0;
 
-  if (waferCentring != WaferCentred) {
+  if (waferCentring != WaferCentring::WaferCentred) {
     edm::LogError("HGCalGeomRotation")
         << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
            "incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentred;
+    waferCentring = WaferCentring::WaferCentred;
   }
 
   if (moduleU > 0 && moduleV >= 0) {

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -41,8 +41,7 @@ void HGCalGeomRotation::uvMappingFrom60DegreeSector0(WaferCentring waferCentring
   }
 
   if (sector > 5) {
-    throw cms::Exception("RotationException")
-        << "HGCalGeomRotation: desired sector must be either 0, 1, 2, 3, 4, 5 or 6";
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1, 2, 3, 4, or 5";
   }
   for (unsigned rot = 0; rot < sector; rot++) {
     RotateModule60DegreesAnticlockwise(moduleU, moduleV);
@@ -67,7 +66,8 @@ void HGCalGeomRotation::uvMappingFrom120DegreeSector0(WaferCentring waferCentrin
   }
 
   if (sector > 2) {
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
+    edm::LogError("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
+    return;
   }
   for (unsigned rot = 0; rot < sector; rot++) {
     RotateModule120DegreesAnticlockwise(moduleU, moduleV, offset);

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -1,0 +1,88 @@
+#include "Geometry/HGCalCommonData/interface/HGCalGeomRotation.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring, int& moduleU, int& moduleV, unsigned sector) const{
+
+  if (sector==0){
+    return;
+  }
+
+  int offset;
+
+  if (waferCentring == WaferCentred){
+    offset=0;
+  } else if(waferCentring == CornerCentredY){
+    offset=-1;
+  } else if(waferCentring == CornerCentredMercedes){
+    offset=1;
+  }
+  else{
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
+  }
+
+  int uPrime,vPrime;
+
+  if(sector==1) {
+    uPrime=-moduleV + offset;
+    vPrime=moduleU - moduleV + offset;
+  }else if(sector==2) {
+    uPrime=moduleV - moduleU;
+    vPrime=-moduleU + offset;
+  }
+  else{
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be eother 0, 1 or 2";
+  }
+  moduleU=uPrime;
+  moduleV=vPrime;
+
+}
+
+
+unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const{
+
+  unsigned sector = 0;
+
+  int offset;
+
+  if (waferCentring == WaferCentred){
+    if(moduleU>0 && moduleV>=0) return sector;
+    
+    offset=0;
+    if(moduleU>=moduleV && moduleV<0) sector=2;
+    else sector=1;
+    
+  } else if(waferCentring == CornerCentredY){
+    if(moduleU>=0 && moduleV>=0) return sector;
+    
+    offset=-1;    
+    if(moduleU>moduleV && moduleV<0) sector=2;
+    else sector=1;
+    
+  } else if(waferCentring == CornerCentredMercedes){
+    if(moduleU>=1 && moduleV>=1) return sector;
+    
+    offset=1;
+    if(moduleU>=moduleV && moduleV<1) sector=2;
+    else sector=1;
+  }
+  else{
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
+  }  
+
+  int moduleURotated,moduleVRotated;
+  
+  if(sector==1) {
+    moduleURotated=moduleV-moduleU;
+    moduleVRotated=-moduleU+offset;    
+    
+  }else if (sector==2) {
+    moduleURotated=-moduleV+offset;
+    moduleVRotated=moduleU-moduleV+offset;
+  }
+  
+  moduleU=moduleURotated;
+  moduleV=moduleVRotated;
+
+  return sector;
+
+}

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -1,10 +1,12 @@
 #include "Geometry/HGCalCommonData/interface/HGCalGeomRotation.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
                                              int& moduleU,
                                              int& moduleV,
                                              unsigned sector) const {
+
   if (sector == 0) {
     return;
   }
@@ -22,75 +24,178 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
         << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
 
+  if (_sectorType == Sector60Degrees && waferCentring != WaferCentred){
+    edm::LogError("HGCalGeomRotation") << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is incompatible, switching to WaferCentred centring";
+    waferCentring = WaferCentred;
+  }
+
   int uPrime, vPrime;
 
-  if (sector == 1) {
-    uPrime = -moduleV + offset;
-    vPrime = moduleU - moduleV + offset;
-  } else if (sector == 2) {
-    uPrime = moduleV - moduleU;
-    vPrime = -moduleU + offset;
-  } else {
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be eother 0, 1 or 2";
+  if ( _sectorType == Sector120Degrees ){
+    if (sector == 1) {
+      uPrime = -moduleV + offset;
+      vPrime = moduleU - moduleV + offset;
+    } else if (sector == 2) {
+      uPrime = moduleV - moduleU;
+      vPrime = -moduleU + offset;
+    } else {
+      throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
+    }
+
+    moduleU = uPrime;
+    moduleV = vPrime;
+
   }
-  moduleU = uPrime;
-  moduleV = vPrime;
+  else if( _sectorType == Sector60Degrees){
+    if ( sector > 5 ){
+      throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1, 2, 3, 4, 5 or 6";
+    }
+    for (unsigned rot = 0; rot < sector; rot++){
+      RotateModule60DegreesAnticlockwise( moduleU, moduleV);
+    }
+  }
+
 }
 
 unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
   unsigned sector = 0;
 
+  if (_sectorType == Sector60Degrees){
+
+    sector = uvMappingTo60DegreeSector0( waferCentring, moduleU, moduleV );
+
+  } else if (_sectorType == Sector120Degrees){
+
+    sector = uvMappingTo120DegreeSector0( waferCentring, moduleU, moduleV );
+
+  }
+
+  return sector;
+
+}
+
+unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
+
+  unsigned sector = 0;
   int offset;
 
   if (waferCentring == WaferCentred) {
     if (moduleU > 0 && moduleV >= 0)
       return sector;
-
+    
     offset = 0;
     if (moduleU >= moduleV && moduleV < 0)
       sector = 2;
     else
       sector = 1;
-
+    
   } else if (waferCentring == CornerCentredY) {
     if (moduleU >= 0 && moduleV >= 0)
       return sector;
-
+    
     offset = -1;
     if (moduleU > moduleV && moduleV < 0)
       sector = 2;
     else
       sector = 1;
-
+    
   } else if (waferCentring == CornerCentredMercedes) {
     if (moduleU >= 1 && moduleV >= 1)
       return sector;
-
+    
     offset = 1;
-    if (moduleU >= moduleV && moduleV < 1)
-      sector = 2;
-    else
-      sector = 1;
+      if (moduleU >= moduleV && moduleV < 1)
+	sector = 2;
+      else
+	sector = 1;
   } else {
     throw cms::Exception("RotationException")
-        << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
+      << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
 
   int moduleURotated, moduleVRotated;
-
+    
   if (sector == 1) {
     moduleURotated = moduleV - moduleU;
     moduleVRotated = -moduleU + offset;
-
+    
   } else if (sector == 2) {
     moduleURotated = -moduleV + offset;
     moduleVRotated = moduleU - moduleV + offset;
   } else {
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be eother 0, 1 or 2";
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
   }
 
   moduleU = moduleURotated;
   moduleV = moduleVRotated;
 
   return sector;
+}
+
+
+
+unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
+
+  unsigned sector = 0;
+
+  if ( waferCentring != WaferCentred ){
+
+    edm::LogError("HGCalGeomRotation") << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is incompatible, switching to WaferCentred centring";
+    waferCentring = WaferCentred;
+
+  }
+
+  if (moduleU > 0 && moduleV >= 0){
+    if (moduleV <= moduleU){
+      return sector;
+    }
+    else{
+      sector = 1;
+    }
+  }
+  if (moduleU >= moduleV && moduleV < 0){
+    if ( moduleU >= 0 ){
+      sector = 5;
+    }
+    else{
+      sector = 4;
+    }
+  }
+  else{
+    if ( moduleV > 0 ){
+      sector = 2;
+    }
+    else{
+      sector = 3;
+    }
+  }
+
+  for (unsigned rot = 0; rot < sector; rot++){
+    RotateModule60DegreesClockwise( moduleU, moduleV);
+  }
+
+  return sector;
+
+}
+
+void HGCalGeomRotation::RotateModule60DegreesAnticlockwise(int& moduleU, int& moduleV) const {
+  
+  int moduleURotated, moduleVRotated;
+  moduleURotated = moduleU - moduleV;
+  moduleVRotated = moduleU;
+
+  moduleU = moduleURotated;
+  moduleV = moduleVRotated;
+
+}
+
+void HGCalGeomRotation::RotateModule60DegreesClockwise(int& moduleU, int& moduleV) const {
+  
+  int moduleURotated, moduleVRotated;
+  moduleURotated = moduleV;
+  moduleVRotated = moduleV - moduleU;
+
+  moduleU = moduleURotated;
+  moduleV = moduleVRotated;
+
 }

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -6,11 +6,55 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
                                              int& moduleU,
                                              int& moduleV,
                                              unsigned sector) const {
-
   if (sector == 0) {
     return;
   }
 
+  if (_sectorType == Sector120Degrees) {
+    uvMappingFrom120DegreeSector0(waferCentring, moduleU, moduleV, sector);
+
+  } else if (_sectorType == Sector60Degrees) {
+    uvMappingFrom60DegreeSector0(waferCentring, moduleU, moduleV, sector);
+  }
+}
+
+unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
+  unsigned sector = 0;
+
+  if (_sectorType == Sector60Degrees) {
+    sector = uvMappingTo60DegreeSector0(waferCentring, moduleU, moduleV);
+
+  } else if (_sectorType == Sector120Degrees) {
+    sector = uvMappingTo120DegreeSector0(waferCentring, moduleU, moduleV);
+  }
+
+  return sector;
+}
+
+void HGCalGeomRotation::uvMappingFrom60DegreeSector0(WaferCentring waferCentring,
+                                                     int& moduleU,
+                                                     int& moduleV,
+                                                     unsigned sector) const {
+  if (waferCentring != WaferCentred) {
+    edm::LogError("HGCalGeomRotation")
+        << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
+           "incompatible, switching to WaferCentred centring";
+    waferCentring = WaferCentred;
+  }
+
+  if (sector > 5) {
+    throw cms::Exception("RotationException")
+        << "HGCalGeomRotation: desired sector must be either 0, 1, 2, 3, 4, 5 or 6";
+  }
+  for (unsigned rot = 0; rot < sector; rot++) {
+    RotateModule60DegreesAnticlockwise(moduleU, moduleV);
+  }
+}
+
+void HGCalGeomRotation::uvMappingFrom120DegreeSector0(WaferCentring waferCentring,
+                                                      int& moduleU,
+                                                      int& moduleV,
+                                                      unsigned sector) const {
   int offset;
 
   if (waferCentring == WaferCentred) {
@@ -24,178 +68,131 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
         << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
 
-  if (_sectorType == Sector60Degrees && waferCentring != WaferCentred){
-    edm::LogError("HGCalGeomRotation") << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is incompatible, switching to WaferCentred centring";
-    waferCentring = WaferCentred;
+  if (sector > 2) {
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
   }
-
-  int uPrime, vPrime;
-
-  if ( _sectorType == Sector120Degrees ){
-    if (sector == 1) {
-      uPrime = -moduleV + offset;
-      vPrime = moduleU - moduleV + offset;
-    } else if (sector == 2) {
-      uPrime = moduleV - moduleU;
-      vPrime = -moduleU + offset;
-    } else {
-      throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
-    }
-
-    moduleU = uPrime;
-    moduleV = vPrime;
-
+  for (unsigned rot = 0; rot < sector; rot++) {
+    RotateModule120DegreesAnticlockwise(moduleU, moduleV, offset);
   }
-  else if( _sectorType == Sector60Degrees){
-    if ( sector > 5 ){
-      throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1, 2, 3, 4, 5 or 6";
-    }
-    for (unsigned rot = 0; rot < sector; rot++){
-      RotateModule60DegreesAnticlockwise( moduleU, moduleV);
-    }
-  }
-
-}
-
-unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
-  unsigned sector = 0;
-
-  if (_sectorType == Sector60Degrees){
-
-    sector = uvMappingTo60DegreeSector0( waferCentring, moduleU, moduleV );
-
-  } else if (_sectorType == Sector120Degrees){
-
-    sector = uvMappingTo120DegreeSector0( waferCentring, moduleU, moduleV );
-
-  }
-
-  return sector;
-
 }
 
 unsigned HGCalGeomRotation::uvMappingTo120DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
-
   unsigned sector = 0;
   int offset;
 
   if (waferCentring == WaferCentred) {
     if (moduleU > 0 && moduleV >= 0)
       return sector;
-    
+
     offset = 0;
     if (moduleU >= moduleV && moduleV < 0)
       sector = 2;
     else
       sector = 1;
-    
+
   } else if (waferCentring == CornerCentredY) {
     if (moduleU >= 0 && moduleV >= 0)
       return sector;
-    
+
     offset = -1;
     if (moduleU > moduleV && moduleV < 0)
       sector = 2;
     else
       sector = 1;
-    
+
   } else if (waferCentring == CornerCentredMercedes) {
     if (moduleU >= 1 && moduleV >= 1)
       return sector;
-    
+
     offset = 1;
-      if (moduleU >= moduleV && moduleV < 1)
-	sector = 2;
-      else
-	sector = 1;
+    if (moduleU >= moduleV && moduleV < 1)
+      sector = 2;
+    else
+      sector = 1;
   } else {
     throw cms::Exception("RotationException")
-      << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
+        << "HGCalGeomRotation: WaferCentring must be one of: WaferCentred, CornerCentredY or CornerCentredMercedes";
   }
 
-  int moduleURotated, moduleVRotated;
-    
-  if (sector == 1) {
-    moduleURotated = moduleV - moduleU;
-    moduleVRotated = -moduleU + offset;
-    
-  } else if (sector == 2) {
-    moduleURotated = -moduleV + offset;
-    moduleVRotated = moduleU - moduleV + offset;
-  } else {
-    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be either 0, 1 or 2";
+  for (unsigned rot = 0; rot < sector; rot++) {
+    RotateModule120DegreesClockwise(moduleU, moduleV, offset);
   }
-
-  moduleU = moduleURotated;
-  moduleV = moduleVRotated;
 
   return sector;
 }
 
-
-
 unsigned HGCalGeomRotation::uvMappingTo60DegreeSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
-
   unsigned sector = 0;
 
-  if ( waferCentring != WaferCentred ){
-
-    edm::LogError("HGCalGeomRotation") << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is incompatible, switching to WaferCentred centring";
+  if (waferCentring != WaferCentred) {
+    edm::LogError("HGCalGeomRotation")
+        << "HGCalGeomRotation: 60 degree sector defintion selected, but not WaferCentred centring. This is "
+           "incompatible, switching to WaferCentred centring";
     waferCentring = WaferCentred;
-
   }
 
-  if (moduleU > 0 && moduleV >= 0){
-    if (moduleV <= moduleU){
+  if (moduleU > 0 && moduleV >= 0) {
+    if (moduleV <= moduleU) {
       return sector;
-    }
-    else{
+    } else {
       sector = 1;
     }
   }
-  if (moduleU >= moduleV && moduleV < 0){
-    if ( moduleU >= 0 ){
+  if (moduleU >= moduleV && moduleV < 0) {
+    if (moduleU >= 0) {
       sector = 5;
-    }
-    else{
+    } else {
       sector = 4;
     }
-  }
-  else{
-    if ( moduleV > 0 ){
+  } else {
+    if (moduleV > 0) {
       sector = 2;
-    }
-    else{
+    } else {
       sector = 3;
     }
   }
 
-  for (unsigned rot = 0; rot < sector; rot++){
-    RotateModule60DegreesClockwise( moduleU, moduleV);
+  for (unsigned rot = 0; rot < sector; rot++) {
+    RotateModule60DegreesClockwise(moduleU, moduleV);
   }
 
   return sector;
-
 }
 
 void HGCalGeomRotation::RotateModule60DegreesAnticlockwise(int& moduleU, int& moduleV) const {
-  
   int moduleURotated, moduleVRotated;
   moduleURotated = moduleU - moduleV;
   moduleVRotated = moduleU;
 
   moduleU = moduleURotated;
   moduleV = moduleVRotated;
-
 }
 
 void HGCalGeomRotation::RotateModule60DegreesClockwise(int& moduleU, int& moduleV) const {
-  
   int moduleURotated, moduleVRotated;
   moduleURotated = moduleV;
   moduleVRotated = moduleV - moduleU;
 
   moduleU = moduleURotated;
   moduleV = moduleVRotated;
+}
 
+void HGCalGeomRotation::RotateModule120DegreesAnticlockwise(int& moduleU, int& moduleV, int offset) const {
+  int moduleURotated, moduleVRotated;
+
+  moduleURotated = -moduleV + offset;
+  moduleVRotated = moduleU - moduleV + offset;
+
+  moduleU = moduleURotated;
+  moduleV = moduleVRotated;
+}
+
+void HGCalGeomRotation::RotateModule120DegreesClockwise(int& moduleU, int& moduleV, int offset) const {
+  int moduleURotated, moduleVRotated;
+
+  moduleURotated = moduleV - moduleU;
+  moduleVRotated = -moduleU + offset;
+
+  moduleU = moduleURotated;
+  moduleV = moduleVRotated;
 }

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -85,6 +85,8 @@ unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int&
   } else if (sector == 2) {
     moduleURotated = -moduleV + offset;
     moduleVRotated = moduleU - moduleV + offset;
+  } else {
+    throw cms::Exception("RotationException") << "HGCalGeomRotation: desired sector must be eother 0, 1 or 2";
   }
 
   moduleU = moduleURotated;

--- a/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
+++ b/Geometry/HGCalCommonData/src/HGCalGeomRotation.cc
@@ -10,9 +10,9 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
     return;
   }
 
-  if (_sectorType == SectorType::Sector60Degrees) {
+  if (sectorType_ == SectorType::Sector60Degrees) {
     uvMappingFrom60DegreeSector0(waferCentring, moduleU, moduleV, sector);
-  } else if (_sectorType == SectorType::Sector120Degrees) {
+  } else if (sectorType_ == SectorType::Sector120Degrees) {
     uvMappingFrom120DegreeSector0(waferCentring, moduleU, moduleV, sector);
   }
 }
@@ -20,9 +20,9 @@ void HGCalGeomRotation::uvMappingFromSector0(WaferCentring waferCentring,
 unsigned HGCalGeomRotation::uvMappingToSector0(WaferCentring waferCentring, int& moduleU, int& moduleV) const {
   unsigned sector = 0;
 
-  if (_sectorType == SectorType::Sector60Degrees) {
+  if (sectorType_ == SectorType::Sector60Degrees) {
     sector = uvMappingTo60DegreeSector0(waferCentring, moduleU, moduleV);
-  } else if (_sectorType == SectorType::Sector120Degrees) {
+  } else if (sectorType_ == SectorType::Sector120Degrees) {
     sector = uvMappingTo120DegreeSector0(waferCentring, moduleU, moduleV);
   }
 


### PR DESCRIPTION
#### PR description:

Add a new class in `Geometry/HGCalCommonData/` which transforms the `(u,v)` coordinates of a module in "sector 0" (i.e. 0º-120º) to the correct coordinates in sectors 1 or 2. The reverse function is also provided.

This is a base class intended for use in derived classes, and as such does not modify any existing code or output, at present.

This PR is made in conjunction with @jbsauvan 

#### PR validation:

Standard tests have been run successfully. No changes to output expected.
