### PR TITLE
Clean BuildFiles in CUDADataFormats and HeterogeneousCore

### DIFF
--- a/CUDADataFormats/CaloCommon/BuildFile.xml
+++ b/CUDADataFormats/CaloCommon/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="CUDADataFormats/Common" />
 <use name="HeterogeneousCore/CUDAUtilities"/>
 
 <export>

--- a/CUDADataFormats/EcalDigi/BuildFile.xml
+++ b/CUDADataFormats/EcalDigi/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="CUDADataFormats/Common"/>
 <use name="CUDADataFormats/CaloCommon"/>
 <use name="DataFormats/Common"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
 
 <export>
   <lib   name="1"/>

--- a/CUDADataFormats/HcalDigi/BuildFile.xml
+++ b/CUDADataFormats/HcalDigi/BuildFile.xml
@@ -1,6 +1,6 @@
 <use name="DataFormats/Common"/>
 <use name="CUDADataFormats/CaloCommon"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
+<use name="CUDADataFormats/Common"/>
 <use name="cuda"/>
 
 <export>

--- a/HeterogeneousCore/CUDACore/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/BuildFile.xml
@@ -4,7 +4,6 @@
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/ParameterSet"/>
   <use name="CUDADataFormats/Common"/>
-  <use name="DataFormats/Provenance"/>
   <use name="HeterogeneousCore/CUDAServices"/>
   <use name="cuda"/>
   <export>

--- a/HeterogeneousCore/CUDACore/test/BuildFile.xml
+++ b/HeterogeneousCore/CUDACore/test/BuildFile.xml
@@ -5,9 +5,7 @@
     <use name="FWCore/ParameterSetReader"/>
     <use name="FWCore/PluginManager"/>
     <use name="FWCore/ServiceRegistry"/>
-    <use name="FWCore/TestProcessor"/>
     <use name="HeterogeneousCore/CUDACore"/>
-    <use name="HeterogeneousCore/CUDAServices"/>
     <use name="catch2"/>
     <use name="cuda"/>
   </bin>

--- a/HeterogeneousCore/CUDAServices/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/BuildFile.xml
@@ -1,5 +1,4 @@
 <iftool name="cuda">
-  <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/ParameterSet"/>
   <use name="FWCore/MessageLogger"/>

--- a/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDAServices/plugins/BuildFile.xml
@@ -2,12 +2,8 @@
   <use name="cuda"/>
   <use name="DataFormats/Common"/>
   <use name="DataFormats/Provenance"/>
-  <use name="DataFormats/Streamer"/>
-  <use name="FWCore/Concurrency"/>
-  <use name="FWCore/Framework"/>
   <use name="FWCore/MessageLogger"/>
   <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/PluginManager"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="FWCore/Utilities"/>
   <use name="HeterogeneousCore/CUDAServices"/>

--- a/HeterogeneousCore/CUDATest/BuildFile.xml
+++ b/HeterogeneousCore/CUDATest/BuildFile.xml
@@ -1,5 +1,5 @@
 <iftool name="cuda-gcc-support">
   <use name="DataFormats/Common"/>
-  <use name="HeterogeneousCore/CUDACore"/>
+  <use name="CUDADataFormats/Common"/>
   <use name="rootcore"/>
 </iftool>

--- a/HeterogeneousCore/CUDATest/plugins/BuildFile.xml
+++ b/HeterogeneousCore/CUDATest/plugins/BuildFile.xml
@@ -1,8 +1,8 @@
 <iftool name="cuda-gcc-support">
   <library file="*.cc *.cu" name="HeterogeneousCoreCUDATestPlugins">
     <flags EDM_PLUGIN="1"/>
+    <use name="CUDADataFormats/Common"/>
     <use name="FWCore/Framework"/>
-    <use name="FWCore/PluginManager"/>
     <use name="FWCore/ParameterSet"/>
     <use name="HeterogeneousCore/CUDACore"/>
     <use name="HeterogeneousCore/CUDAUtilities"/>

--- a/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
+++ b/HeterogeneousCore/MPIServices/plugins/BuildFile.xml
@@ -1,4 +1,4 @@
 <use name="openmpi"/>
-<use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/ServiceRegistry"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/32570).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.