### PR TITLE
Ecal laser hdf5 support

### DIFF
--- a/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
+++ b/CalibCalorimetry/EcalTrivialCondModules/BuildFile.xml
@@ -2,6 +2,7 @@
 <use name="rootcore"/>
 <use name="root"/>
 <use name="boost"/>
+<use name="hdf5"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="CondTools/Ecal"/>

--- a/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
+++ b/CalibCalorimetry/EcalTrivialCondModules/interface/EcalLaserCondTools.h
@@ -43,6 +43,7 @@ public:
    * @param es events setup
    */
   void analyze(const edm::Event& evt, const edm::EventSetup& es) override;
+  void from_hdf_to_db();
 
 private:
   static std::string toNth(int n);

--- a/CalibCalorimetry/EcalTrivialCondModules/python/EcalLaserCondTools_cfi.py
+++ b/CalibCalorimetry/EcalTrivialCondModules/python/EcalLaserCondTools_cfi.py
@@ -1,0 +1,44 @@
+import FWCore.ParameterSet.Config as cms
+
+ecalLaserCondTools = cms.EDAnalyzer("EcalLaserCondTools",
+                                    #File with a list of events for whose IOVs must be filled in the database
+                                    #Use empty string to include all the IOVs found in the input files 
+                                    eventListFile = cms.string(""),
+
+                                    #Module verbosity level
+                                    verbosity = cms.int32(1),
+
+                                    #Running mode:
+                                    # ascii_file_to_db: fill the database with corrections read from an ascii file
+                                    # hdf_file_to_db: fill the database with corrections read from a HDF5 file
+                                    # db_to_ascii_file: export IOVS from the database to an ascii file, corr_dump.txt
+                                    mode = cms.string(""),
+
+                                    #List of input files for file-to-database modes
+                                    inputFiles = cms.vstring(),
+
+                                    #Numbre of first IOVs to skip when importing IOVs from a file
+                                    skipIov = cms.int32(0),
+                                    
+                                    #Number of IOVs to insert in the database, use -1 to insert
+                                    #all the IOVs found in the input files
+                                    nIovs = cms.int32(-1),
+
+                                    #Limit database IOV insertion for IOV after the
+                                    #provided time, expressed in unix time
+                                    fromTime = cms.int32(0),
+                                    
+                                    #If positive,  IOV insertion for IOV before the
+                                    #provided time, expressed in unix time
+                                    toTime = cms.int32(-1),
+                                    
+                                    #Force p1, p2, or p3 to 1 if its value
+                                    #is lower than the provided bound value
+                                    transparencyMin = cms.double(-1.),
+
+                                    #Force p1, p2, or p3 to 1 if its value
+                                    #is lower than the provided bound value
+                                    transparencyMax = cms.double(9999.)
+                                )
+
+

--- a/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
+++ b/CalibCalorimetry/EcalTrivialCondModules/src/EcalLaserCondTools.cc
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <memory>
 
-
 EcalLaserCondTools::EcalLaserCondTools(const edm::ParameterSet& ps)
     : fout_(nullptr),
       eventList_(nullptr),
@@ -89,7 +88,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
   hsize_t dims[2] = {};
 
   for (unsigned int ifile = 0; ifile < fnames_.size(); ++ifile) {
-    if (verb_){
+    if (verb_) {
       std::cout << " - converting file: " << fnames_[ifile] << "\n";
     }
 
@@ -97,21 +96,22 @@ void EcalLaserCondTools::from_hdf_to_db() {
 
     dset_rawid = H5Dopen(file, "cmssw_id", H5P_DEFAULT);
     space = H5Dget_space(dset_rawid);
-    H5Sget_simple_extent_dims(space, dims, NULL);
+    H5Sget_simple_extent_dims(space, dims, nullptr);
 
     unsigned int nCrystals = dims[0];
     int rawid[nCrystals];
     herr_t status;
 
     status = H5Dread(dset_rawid, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, rawid);
-    if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+    if (status < 0)
+      throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
     H5Dclose(dset_rawid);
     H5Sclose(space);
 
     dset_t2 = H5Dopen(file, "t2", H5P_DEFAULT);
     space = H5Dget_space(dset_t2);
-    H5Sget_simple_extent_dims(space, dims, NULL);
+    H5Sget_simple_extent_dims(space, dims, nullptr);
 
     unsigned int nIovs = dims[0];
     unsigned int nLME = dims[1];
@@ -129,7 +129,8 @@ void EcalLaserCondTools::from_hdf_to_db() {
       std::cout << " * reading t2 table "
                 << "\n";
     status = H5Dread(dset_t2, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, t2[0]);
-    if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+    if (status < 0)
+      throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
     H5Dclose(dset_t2);
     //H5Sclose(space);
@@ -139,7 +140,8 @@ void EcalLaserCondTools::from_hdf_to_db() {
                 << "\n";
     dset = H5Dopen(file, "t1", H5P_DEFAULT);
     status = H5Dread(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, t1);
-    if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+    if (status < 0)
+      throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
     H5Dclose(dset);
 
@@ -148,7 +150,8 @@ void EcalLaserCondTools::from_hdf_to_db() {
                 << "\n";
     dset = H5Dopen(file, "t3", H5P_DEFAULT);
     status = H5Dread(dset, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, t3);
-    if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+    if (status < 0)
+      throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
     H5Dclose(dset);
 
@@ -157,7 +160,7 @@ void EcalLaserCondTools::from_hdf_to_db() {
     // read crystal info IOV by IOV (otherwise too large)
     float p1[nCrystals], p2[nCrystals], p3[nCrystals];
     hsize_t iov_dim[1] = {nCrystals};
-    memspace = H5Screate_simple(1, iov_dim, NULL);
+    memspace = H5Screate_simple(1, iov_dim, nullptr);
 
     auto corrSet = std::make_unique<EcalLaserAPDPNRatios>();
     for (unsigned int iIov = skipIov_; iIov < nIovs && iIov < unsigned(nIovs_); ++iIov) {
@@ -175,33 +178,39 @@ void EcalLaserCondTools::from_hdf_to_db() {
 
       dset = H5Dopen(file, "p1", H5P_DEFAULT);
       space = H5Dget_space(dset);
-      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, NULL, count, NULL);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, nullptr, count, nullptr);
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
       status = H5Dread(dset, H5T_NATIVE_FLOAT, memspace, space, H5P_DEFAULT, p1);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
       H5Dclose(dset);
       //H5Sclose(space);
 
       dset = H5Dopen(file, "p2", H5P_DEFAULT);
       space = H5Dget_space(dset);
-      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, NULL, count, NULL);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, nullptr, count, nullptr);
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
       status = H5Dread(dset, H5T_NATIVE_FLOAT, memspace, space, H5P_DEFAULT, p2);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
       H5Dclose(dset);
       //      H5Sclose(space);
 
       dset = H5Dopen(file, "p3", H5P_DEFAULT);
       space = H5Dget_space(dset);
-      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, NULL, count, NULL);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      status = H5Sselect_hyperslab(space, H5S_SELECT_SET, offset, nullptr, count, nullptr);
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
 
       status = H5Dread(dset, H5T_NATIVE_FLOAT, memspace, space, H5P_DEFAULT, p3);
-      if(status < 0) throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
+      if (status < 0)
+        throw cms::Exception("EcalLaserCondTool:HDF") << "Error while reading HD file.";
       H5Dclose(dset);
       H5Sclose(space);
 
@@ -244,9 +253,9 @@ void EcalLaserCondTools::from_hdf_to_db() {
 
     }  // loop over IOVs
 
-    H5Sclose (memspace); 
-    H5Fclose (file);
-  }    // loop over input files
+    H5Sclose(memspace);
+    H5Fclose(file);
+  }  // loop over input files
 }
 
 void EcalLaserCondTools::fillDb(CorrReader& r) {
@@ -392,7 +401,7 @@ void EcalLaserCondTools::processIov(CorrReader& r, int t1, int t2[EcalLaserCondT
 
     if (!isfinite(corr.p1) || !isfinite(corr.p2) || !isfinite(corr.p3) || corr.p1 < minP_ || corr.p1 > maxP_ ||
         corr.p2 < minP_ || corr.p2 > maxP_ || corr.p3 < minP_ || corr.p3 > maxP_) {
-      fprintf(ferr_, "%d %d %f %f %f\n", t1,(int)detid, corr.p1, corr.p2, corr.p3);
+      fprintf(ferr_, "%d %d %f %f %f\n", t1, (int)detid, corr.p1, corr.p2, corr.p3);
       corr.p1 = corr.p2 = corr.p3 = 1;
     }
 

--- a/CalibCalorimetry/EcalTrivialCondModules/test/ecalLaserCondTools_cfg.py
+++ b/CalibCalorimetry/EcalTrivialCondModules/test/ecalLaserCondTools_cfg.py
@@ -1,0 +1,139 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+
+# Export or inport Ecal laser correction to/from the condition database or
+# an sqlite file.
+# 
+# Usage: cmsRun ecalLaseCondTools_cfg.py [mode=MODE] [connect=CONNECT_STRING] [authenticationPath=AUTHENTICATION_PATH] [inputFiles=INPUT_FILE_1] [inputFiles=INPUT_FILE2 ...]
+#
+
+# Default options:
+options = VarParsing.VarParsing()
+
+default_file_format = 'hdf'
+defaults = {
+    'verbosity': 5,
+    'mode': '%s_file_to_db' % default_file_format,
+    'connect':  'sqlite:///output.sqlite',
+    'authenticationPath': '/nfshome0/popcondev/conddb',
+    'inputFiles': 'input.%s' % default_file_format,
+    'tag': 'test',
+    'gtag': '',
+    'start': 0,
+    'stop': 10,
+    'firstTime': -1,
+    'timeBetweenEvents': 1,
+    'lastTime': -1,
+    'maxEvents': 1,
+}
+
+options.register('verbosity',
+                 defaults['verbosity'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.int,
+                 "Vebosity level")
+
+options.register('mode', 
+                 defaults['mode'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.string,
+                 "Running mode: db_to_ascii_file, ascii_file_to_db, or hdf_file_to_db (default: %s)" % defaults["mode"]);
+
+options.register('connect',
+                 defaults['connect'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.string,
+                 "Database connection string (default: %s)" % defaults["connect"]);
+
+options.register('authenticationPath',
+                 defaults['authenticationPath'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.string,
+                 "Path to the file with the database authentication credentials")
+
+options.register('gtag',
+                 defaults['gtag'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.string,
+                 "Global condition tag used when reading the database. Use empty string to use the default tag.")
+
+
+options.register('tag',
+                 defaults['tag'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.string,
+                 "Condition tag to use when filling the database")
+
+options.register('inputFiles',
+                 defaults['inputFiles'],
+                 VarParsing.VarParsing.multiplicity.list, 
+                 VarParsing.VarParsing.varType.string,
+                 "List of input files for file-to-database modes")
+
+options.register('firstTime',
+                 defaults['firstTime'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.int,
+                 "Time in nanoseconds of the first event generated to extract the IOVs (see EmptySource parameters).")
+
+options.register('timeBetween',
+                 defaults['timeBetweenEvents'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.int,
+                 "Time in nanoseconds between two events generated to extract the IOVs (see EmptySource parameters).")
+
+options.register('maxEvents',
+                 defaults['maxEvents'],
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.int,
+                 "Number of events to generated. Use 1 for file-to-database mode")
+
+
+#Parse options from the command line
+options.parseArguments()
+
+process = cms.Process("EcalLaserDB")
+
+process.source = cms.Source("EmptySource",
+                            firstTime = cms.untracked.uint64(1),
+                            timeBetweenEvents = cms.untracked.uint64(1))
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(options.maxEvents)
+
+)
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = options.connect
+process.CondDB.DBParameters.authenticationPath = options.authenticationPath
+
+if options.mode in [ 'hdf_file_to_db', 'ascii_file_to_db']:
+    process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+                                              process.CondDB,
+                                              toPut = cms.VPSet(cms.PSet(
+                                                record = cms.string('EcalLaserAPDPNRatiosRcd'),
+                                                tag = cms.string(options.tag),
+                                                timetype = cms.untracked.string('timestamp')
+                                              )))
+
+if options.mode in ['db_to_ascii_file']:
+    process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+    if options.gtag:
+        process.GlobalTag.globaltag = option.gtag
+
+    process.ecalConditions = cms.ESSource("PoolDBESSource",
+                                          process.CondDB,
+                                          #siteLocalConfig = cms.untracked.bool(True),
+                                          toGet = cms.VPSet(
+                                              cms.PSet(
+                                                  record = cms.string('EcalLaserAPDPNRatiosRcd'),
+                                                  tag = cms.string(options.tag),
+                                              )))
+                                              
+
+process.load("CalibCalorimetry.EcalTrivialCondModules.EcalLaserCondTools_cfi")
+
+process.ecalLaserCondTools.mode = options.mode
+process.ecalLaserCondTools.inputFiles = options.inputFiles
+process.ecalLaserCondTools.verbosity = options.verbosity
+
+process.path = cms.Path(process.ecalLaserCondTools)

--- a/CalibCalorimetry/EcalTrivialCondModules/test/ecalLaserCondTools_cfg.py
+++ b/CalibCalorimetry/EcalTrivialCondModules/test/ecalLaserCondTools_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 # Export or inport Ecal laser correction to/from the condition database or
 # an sqlite file.
 # 
-# Usage: cmsRun ecalLaseCondTools_cfg.py [mode=MODE] [connect=CONNECT_STRING] [authenticationPath=AUTHENTICATION_PATH] [inputFiles=INPUT_FILE_1] [inputFiles=INPUT_FILE2 ...]
+# Usage: cmsRun ecalLaserCondTools_cfg.py [mode=MODE] [connect=CONNECT_STRING] [authenticationPath=AUTHENTICATION_PATH] [inputFiles=INPUT_FILE_1] [inputFiles=INPUT_FILE2 ...]
 #
 
 # Default options:


### PR DESCRIPTION
#### PR description:

Adds support for HDF5 input format to the ECAL laser transparency correction import tool.

#### PR validation:

Code validated with a test input file and the CalibCalorimetry/EcalTrivialCondModules/test/ecalLaserCondTools_cfg.py CMSSW steering file.
