### PR TITLE
Minor updates to improve performance of METSignificance::getCovariance

### DIFF
--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -16,8 +16,6 @@ Implementation:
 #ifndef METAlgorithms_METSignificance_h
 #define METAlgorithms_METSignificance_h
 //____________________________________________________________________________||
-#include "CondFormats/JetMETObjects/interface/JetResolution.h"
-
 #include "JetMETCorrections/Modules/interface/JetResolution.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -117,23 +117,24 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
       continue;
 
     double jpt = jet.pt();
-    double jeta = jet.eta();
-    double feta = std::abs(jeta);
-    double c = jet.px() / jet.pt();
-    double s = jet.py() / jet.pt();
-
-    JME::JetParameters parameters;
-    parameters.setJetPt(jpt).setJetEta(jeta).setRho(rho);
-
-    // jet energy resolutions
-    double sigmapt = resPtObj.getResolution(parameters);
-    double sigmaphi = resPhiObj.getResolution(parameters);
-    // SF not needed since is already embedded in the sigma in the dataGlobalTag
-    //      double sigmaSF = isRealData ? resSFObj.getScaleFactor(parameters) : 1.0;
 
     // split into high-pt and low-pt sector
     if (jpt > jetThreshold_) {
       // high-pt jets enter into the covariance matrix via JER
+
+      double jeta = jet.eta();
+      double feta = std::abs(jeta);
+      double c = jet.px() / jpt;
+      double s = jet.py() / jpt;
+
+      JME::JetParameters parameters;
+      parameters.setJetPt(jpt).setJetEta(jeta).setRho(rho);
+
+      // jet energy resolutions
+      double sigmapt = resPtObj.getResolution(parameters);
+      double sigmaphi = resPhiObj.getResolution(parameters);
+      // SF not needed since is already embedded in the sigma in the dataGlobalTag
+      //      double sigmaSF = isRealData ? resSFObj.getScaleFactor(parameters) : 1.0;
 
       double scale = 0;
       if (feta < jetEtas_[0])
@@ -166,8 +167,9 @@ reco::METCovMatrix metsig::METSignificance::getCovariance(const edm::View<reco::
     sumPtUnclustered = 0;
 
   // add pseudo-jet to metsig covariance matrix
-  cov_xx += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPtUnclustered;
-  cov_yy += pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPtUnclustered;
+  double pseudoJetCov = pjetParams_[0] * pjetParams_[0] + pjetParams_[1] * pjetParams_[1] * sumPtUnclustered;
+  cov_xx += pseudoJetCov;
+  cov_yy += pseudoJetCov;
 
   reco::METCovMatrix cov;
   cov(0, 0) = cov_xx;


### PR DESCRIPTION
#### PR description:

Following the proposed solution for issue #32546, the diagonal elements of the MET covariance are calculated only once, and the same value is added to cov_xx and cov_yy

While doing so I also noticed that there are several computations and assignments which were uselessly performed when the jet pt is below threshold: here those calculation are only made conditionally.

Also an unused header include of JetResolution was noticed, and removed.

#### PR validation:

It builds