### PR TITLE
Move parameters inside the modifier

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -11,9 +11,9 @@ from RecoEcal.EgammaCoreTools.EcalSCDynamicDPhiParametersESProducer_cff import *
 particleFlowSuperClusterECAL = _particleFlowSuperClusterECALMustache.clone()
 
 from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
-pp_on_AA.toModify(particleFlowSuperClusterECAL, useDynamicDPhiWindow = False)
-pp_on_AA.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterBarrel = 0.20)
-pp_on_AA.toModify(particleFlowSuperClusterECAL, phiwidth_SuperClusterEndcap = 0.20)
+pp_on_AA.toModify(particleFlowSuperClusterECAL, useDynamicDPhiWindow = False,
+                                                phiwidth_SuperClusterBarrel = 0.20,
+                                                phiwidth_SuperClusterEndcap = 0.20)
 
 from Configuration.ProcessModifiers.egamma_lowPt_exclusive_cff import egamma_lowPt_exclusive
 egamma_lowPt_exclusive.toModify(particleFlowSuperClusterECAL,


### PR DESCRIPTION
#### PR description: 
Update the safer syntax for existing parameter :
- move all parameters inside the clone/modifier
(The previous PR for RecoEcal is [PR#31332](https://github.com/cms-sw/cmssw/pull31332). )

In this PR, one file changed. 
RecoEcal/EgammaClusterProducers

#### PR validation:
Event Content comparison check was also done and there is no change with these updates.
Tested in CMSSW_11_2_X, the basic test all passed in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html).