### PR TITLE
[11_2_X] Maintain access to genParticles from signal event in packed collection for HI miniAOD 

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -589,6 +589,7 @@
   <class name="edm::Wrapper<pat::HemisphereRefVector>" />
   <class name="edm::Wrapper<pat::ConversionRefVector>" />
   <class name="edm::Wrapper<pat::PackedCandidateRefVector>" />
+  <class name="edm::Wrapper<pat::PackedGenParticleRefVector>" />
 
   <!-- RefToBase<Candidate> from PATObjects -->
     <!-- With direct Holder -->

--- a/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedGenParticleSignalProducer.cc
@@ -1,0 +1,65 @@
+#include <memory>
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+namespace pat {
+
+  class PackedGenParticleSignalProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PackedGenParticleSignalProducer(const edm::ParameterSet& iConfig)
+        : genParticleToken_(consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParticles"))),
+          assoToken_(consumes<edm::Association<std::vector<pat::PackedGenParticle>>>(
+              iConfig.getParameter<edm::InputTag>("packedGenParticles"))) {
+      produces<pat::PackedGenParticleRefVector>();
+    }
+    ~PackedGenParticleSignalProducer() override = default;
+
+    void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+  private:
+    const edm::EDGetTokenT<reco::GenParticleCollection> genParticleToken_;
+    const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle>>> assoToken_;
+  };
+
+}  // namespace pat
+
+void pat::PackedGenParticleSignalProducer::produce(edm::StreamID iID,
+                                                   edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup) const {
+  const auto& genParticles = iEvent.getHandle(genParticleToken_);
+  const auto& orig2packed = iEvent.get(assoToken_);
+
+  auto signalGenParticleRefs = std::make_unique<pat::PackedGenParticleRefVector>();
+
+  for (auto it = genParticles->begin(); it != genParticles->end(); ++it) {
+    const auto& orig = reco::GenParticleRef(genParticles, it - genParticles->begin());
+    if (orig->collisionId() != 0)
+      continue;
+    const auto& packed = orig2packed[orig];
+    if (packed.isNonnull()) {
+      signalGenParticleRefs->push_back(packed);
+    }
+  }
+
+  iEvent.put(std::move(signalGenParticleRefs));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::PackedGenParticleSignalProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("genParticles", edm::InputTag("genParticles"))->setComment("genParticles input collection");
+  desc.add<edm::InputTag>("packedGenParticles", edm::InputTag("packedGenParticles"))
+      ->setComment("packedGenParticles input collection");
+  descriptions.add("packedGenParticlesSignal", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(PackedGenParticleSignalProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -166,6 +166,8 @@ MicroEventContentMC.outputCommands += [
                                         # RUN
                                         'keep L1GtTriggerMenuLite_l1GtTriggerMenuLite__*'
                                       ]
+_pp_on_AA_MC_extraCommands = ['keep *_packedGenParticlesSignal_*_*']
+pp_on_AA.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + _pp_on_AA_MC_extraCommands)
 
 from Configuration.Eras.Modifier_strips_vfp30_2016_cff import strips_vfp30_2016
 strips_vfp30_2016.toModify(MicroEventContentMC, outputCommands = MicroEventContentMC.outputCommands + [

--- a/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/genParticles_cff.py
@@ -16,3 +16,11 @@ genParticlesTask = cms.Task(
     packedGenParticles,
     prunedGenParticlesWithStatusOne
 )
+
+from PhysicsTools.PatAlgos.packedGenParticlesSignal_cfi import *
+
+_genParticlesHITask = genParticlesTask.copy()
+_genParticlesHITask.add(packedGenParticlesSignal)
+
+from Configuration.ProcessModifiers.pp_on_AA_cff import pp_on_AA
+pp_on_AA.toReplaceWith(genParticlesTask, _genParticlesHITask)


### PR DESCRIPTION
#### PR description:

For event-overlay MC workflows, we need to know which particles are from the signal event, i.e., the one with collisionID =0. This method is not available in the packedGenParticle collection. This PR adds a PackedGenParticleRefVector containing the PackedGenParticles with collisionID =0. It's run for all HI eras; there is no change to pp workflows.

#### PR validation:

Tested on 158.01 using as input
/store/himc/HINPbPbAutumn18DR/Bjet_pThat-15_TuneCP5_HydjetDrumMB_5p02TeV_Pythia8/AODSIM/mva98_103X_upgrade2018_realistic_HI_v11-v1/30000/7D8C962E-9A46-9541-94AA-69C01C817F2E.root

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Backport of #32668 

