### PR TITLE
[Phase2 3D Digitizer] Fix several bugs related with charge migration

### DIFF
--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -338,7 +338,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
                                                      << "****************";
         // Drift this charges on the other pixel
         auto mig_colpoints = drift(hit, pixdet, bfield, migrated_charges, false);
-        collection_points.insert(std::end(collection_points),mig_colpoints.begin(),mig_colpoints.end());
+        collection_points.insert(std::end(collection_points), mig_colpoints.begin(), mig_colpoints.end());
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "*****************"
                                                      << "DOME MIGRATION"
                                                      << "****************";

--- a/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
+++ b/SimTracker/SiPhase2Digitizer/plugins/Pixel3DDigitizerAlgorithm.cc
@@ -126,10 +126,10 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
 
   // Check the group is near the edge of the pixel, so diffusion will
   // be relevant in order to migrate between pixel cells
-  if (std::abs(pos.x() - hpitches.first) < max_migration_radius) {
+  if (hpitches.first - std::abs(pos.x()) < max_migration_radius) {
     displ_ind = 0;
     pitch = hpitches.first;
-  } else if (std::abs(pos.y() - hpitches.second) < max_migration_radius) {
+  } else if (hpitches.second - std::abs(pos.y()) < max_migration_radius) {
     displ_ind = 1;
     pitch = hpitches.second;
   } else {
@@ -175,12 +175,12 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
   float distance_edge = 0.0_um;
   do {
     std::transform(pos_moving.begin(), pos_moving.end(), do_step(i).begin(), pos_moving.begin(), std::plus<float>());
-    distance_edge = std::abs(pos_moving[displ_ind] - pitch);
+    distance_edge = pitch - std::abs(pos_moving[displ_ind]);
     // current diffusion value
     double sigma = std::sqrt(i * diffusion_step / distance0) * (distance0 / thickness) * sigma0;
     // Get the amount of charge on the neighbor pixel: note the
     // transformation to a Normal
-    float migrated_e = current_carriers * (1.0 - std::erf(distance_edge / sigma));
+    float migrated_e = current_carriers * 0.5 * (1.0 - std::erf(distance_edge / sigma));
 
     LogDebug("(super-)charge diffusion") << "step-" << i << ", Initial Ne= " << ncarriers << ", "
                                          << "r=(" << pos_moving[0] * 1.0_um_inv << ", " << pos_moving[1] * 1.0_um_inv
@@ -206,7 +206,7 @@ std::vector<DigitizerUtility::EnergyDepositUnit> Pixel3DDigitizerAlgorithm::diff
     }
     // Next step
     ++i;
-  } while (std::abs(distance_edge) < max_migration_radius);
+  } while (std::abs(distance_edge) < max_migration_radius && current_carriers > 0.5 * ncarriers);
 
   return migrated_charge;
 }
@@ -338,6 +338,7 @@ std::vector<DigitizerUtility::SignalPoint> Pixel3DDigitizerAlgorithm::drift(
                                                      << "****************";
         // Drift this charges on the other pixel
         auto mig_colpoints = drift(hit, pixdet, bfield, migrated_charges, false);
+        collection_points.insert(std::end(collection_points),mig_colpoints.begin(),mig_colpoints.end());
         LogDebug("Pixel3DDigitizerAlgorithm::drift") << "*****************"
                                                      << "DOME MIGRATION"
                                                      << "****************";


### PR DESCRIPTION
Some bug fixes related with the charge migration in the 3D digitizer. 

#### PR description:

Charge was not properly migrated between cells due to the combined effect of the bugs fixed at this commit:
- Maximum migrated charge could be large than the 1/2 of the initial charge.
- Collection points created with the recursive call of the drift function were not added to the final collection points.
- Some checks of the energy deposit position relative to the  pixel cell were erroneously calculated.

This PR **affects only the Phase-2 upgrade** related packages, and only the 2026D65 geometry (T23). It is expected in that geometry, a slightly increase of digis due to the recovery of the migrated charges. 

watchers: @claralasa, @emiglior , @skinnari 

#### PR validation:
 * Passed the `runTheMatrix.py -l limited -i all --ibeos` tests, not sure if they are relevant because I'm not sure if they were tested against 2026D65 geometry. 
 * Checked successfully with the 30210.0

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
It is not (although we will like to backport to 11.2.X ... I suppose that I should open a new PR when this is merged?)
