### PR TITLE
(11.1.X) New producers and filters for the Phase 2 Muon HLT

### DIFF
--- a/HLTrigger/HLTfilters/plugins/BuildFile.xml
+++ b/HLTrigger/HLTfilters/plugins/BuildFile.xml
@@ -19,4 +19,5 @@
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
 <use name="HLTrigger/HLTcore"/>
+<use name="L1Trigger/L1TMuon"/>
 <flags EDM_PLUGIN="1"/>

--- a/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.cc
+++ b/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.cc
@@ -103,25 +103,19 @@ bool HLT2L1TkMuonL1TkMuonMuRefDR::getCollections(edm::Event& iEvent,
     return false;
 }
 
-bool HLT2L1TkMuonL1TkMuonMuRefDR::computeDR(edm::Event& iEvent,
-                                            l1t::TkMuonRef& r1,
-                                            l1t::TkMuonRef& r2) const {
-
+bool HLT2L1TkMuonL1TkMuonMuRefDR::computeDR(edm::Event& iEvent, l1t::TkMuonRef& r1, l1t::TkMuonRef& r2) const {
   float muRef1_eta = 0.;
   float muRef1_phi = 0.;
   if (r1->muonDetector() != 3) {
-    if(r1->muRef().isNull())
+    if (r1->muRef().isNull())
       return false;
 
     muRef1_eta = r1->muRef()->hwEta() * 0.010875;
-    muRef1_phi = static_cast<float>(
-                  l1t::MicroGMTConfiguration::calcGlobalPhi(r1->muRef()->hwPhi(),
-                                                            r1->muRef()->trackFinderType(),
-                                                            r1->muRef()->processor()));
+    muRef1_phi = static_cast<float>(l1t::MicroGMTConfiguration::calcGlobalPhi(
+        r1->muRef()->hwPhi(), r1->muRef()->trackFinderType(), r1->muRef()->processor()));
     muRef1_phi = muRef1_phi * 2. * M_PI / 576.;
-  }
-  else {
-    if(r1->emtfTrk().isNull())
+  } else {
+    if (r1->emtfTrk().isNull())
       return false;
 
     muRef1_eta = r1->emtfTrk()->Eta();
@@ -132,18 +126,15 @@ bool HLT2L1TkMuonL1TkMuonMuRefDR::computeDR(edm::Event& iEvent,
   float muRef2_eta = 0.;
   float muRef2_phi = 0.;
   if (r2->muonDetector() != 3) {
-    if(r2->muRef().isNull())
+    if (r2->muRef().isNull())
       return false;
 
     muRef2_eta = r2->muRef()->hwEta() * 0.010875;
-    muRef2_phi = static_cast<float>(
-                  l1t::MicroGMTConfiguration::calcGlobalPhi(r2->muRef()->hwPhi(),
-                                                            r2->muRef()->trackFinderType(),
-                                                            r2->muRef()->processor()));
+    muRef2_phi = static_cast<float>(l1t::MicroGMTConfiguration::calcGlobalPhi(
+        r2->muRef()->hwPhi(), r2->muRef()->trackFinderType(), r2->muRef()->processor()));
     muRef2_phi = muRef2_phi * 2. * M_PI / 576.;
-  }
-  else {
-    if(r2->emtfTrk().isNull())
+  } else {
+    if (r2->emtfTrk().isNull())
       return false;
 
     muRef2_eta = r2->emtfTrk()->Eta();
@@ -156,7 +147,6 @@ bool HLT2L1TkMuonL1TkMuonMuRefDR::computeDR(edm::Event& iEvent,
 
   return false;
 }
-
 
 // ------------ method called to produce the data  ------------
 bool HLT2L1TkMuonL1TkMuonMuRefDR::hltFilter(edm::Event& iEvent,

--- a/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.cc
+++ b/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.cc
@@ -1,0 +1,202 @@
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "HLT2L1TkMuonL1TkMuonMuRefDR.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "L1Trigger/L1TMuon/interface/MicroGMTConfiguration.h"
+
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+#include <cmath>
+
+//
+// constructors and destructor
+//
+HLT2L1TkMuonL1TkMuonMuRefDR::HLT2L1TkMuonL1TkMuonMuRefDR(const edm::ParameterSet& iConfig)
+    : HLTFilter(iConfig),
+      originTag1_(iConfig.getParameter<std::vector<edm::InputTag>>("originTag1")),
+      originTag2_(iConfig.getParameter<std::vector<edm::InputTag>>("originTag2")),
+      inputTag1_(iConfig.getParameter<edm::InputTag>("inputTag1")),
+      inputTag2_(iConfig.getParameter<edm::InputTag>("inputTag2")),
+      inputToken1_(consumes<trigger::TriggerFilterObjectWithRefs>(inputTag1_)),
+      inputToken2_(consumes<trigger::TriggerFilterObjectWithRefs>(inputTag2_)),
+      minDR_(iConfig.getParameter<double>("MinDR")),
+      min_N_(iConfig.getParameter<int>("MinN")),
+      same_(inputTag1_.encode() == inputTag2_.encode())  // same collections to be compared?
+{}
+
+HLT2L1TkMuonL1TkMuonMuRefDR::~HLT2L1TkMuonL1TkMuonMuRefDR() {}
+
+void HLT2L1TkMuonL1TkMuonMuRefDR::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  std::vector<edm::InputTag> originTag1(1, edm::InputTag("hltOriginal1"));
+  std::vector<edm::InputTag> originTag2(1, edm::InputTag("hltOriginal2"));
+  desc.add<std::vector<edm::InputTag>>("originTag1", originTag1);
+  desc.add<std::vector<edm::InputTag>>("originTag2", originTag2);
+  desc.add<edm::InputTag>("inputTag1", edm::InputTag("hltFiltered1"));
+  desc.add<edm::InputTag>("inputTag2", edm::InputTag("hltFiltered2"));
+  desc.add<double>("MinDR", -1.0);
+  desc.add<int>("MinN", 1);
+
+  descriptions.add("HLT2L1TkMuonL1TkMuonMuRefDR", desc);
+}
+
+bool HLT2L1TkMuonL1TkMuonMuRefDR::getCollections(edm::Event& iEvent,
+                                                 std::vector<l1t::TkMuonRef>& coll1,
+                                                 std::vector<l1t::TkMuonRef>& coll2,
+                                                 trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> handle1, handle2;
+  if (iEvent.getByToken(inputToken1_, handle1) and iEvent.getByToken(inputToken2_, handle2)) {
+    // get hold of pre-filtered object collections
+    handle1->getObjects(trigger::TriggerObjectType::TriggerL1TkMu, coll1);
+    handle2->getObjects(trigger::TriggerObjectType::TriggerL1TkMu, coll2);
+    const trigger::size_type n1(coll1.size());
+    const trigger::size_type n2(coll2.size());
+
+    if (saveTags()) {
+      edm::InputTag tagOld;
+      for (unsigned int i = 0; i < originTag1_.size(); ++i) {
+        filterproduct.addCollectionTag(originTag1_[i]);
+      }
+      tagOld = edm::InputTag();
+      for (trigger::size_type i1 = 0; i1 != n1; ++i1) {
+        const edm::ProductID pid(coll1[i1].id());
+        const std::string& label(iEvent.getProvenance(pid).moduleLabel());
+        const std::string& instance(iEvent.getProvenance(pid).productInstanceName());
+        const std::string& process(iEvent.getProvenance(pid).processName());
+        edm::InputTag tagNew(edm::InputTag(label, instance, process));
+        if (tagOld.encode() != tagNew.encode()) {
+          filterproduct.addCollectionTag(tagNew);
+          tagOld = tagNew;
+        }
+      }
+      for (unsigned int i = 0; i < originTag2_.size(); ++i) {
+        filterproduct.addCollectionTag(originTag2_[i]);
+      }
+      tagOld = edm::InputTag();
+      for (trigger::size_type i2 = 0; i2 != n2; ++i2) {
+        const edm::ProductID pid(coll2[i2].id());
+        const std::string& label(iEvent.getProvenance(pid).moduleLabel());
+        const std::string& instance(iEvent.getProvenance(pid).productInstanceName());
+        const std::string& process(iEvent.getProvenance(pid).processName());
+        edm::InputTag tagNew(edm::InputTag(label, instance, process));
+        if (tagOld.encode() != tagNew.encode()) {
+          filterproduct.addCollectionTag(tagNew);
+          tagOld = tagNew;
+        }
+      }
+    }
+
+    return true;
+  } else
+    return false;
+}
+
+bool HLT2L1TkMuonL1TkMuonMuRefDR::computeDR(edm::Event& iEvent,
+                                            l1t::TkMuonRef& r1,
+                                            l1t::TkMuonRef& r2) const {
+
+  float muRef1_eta = 0.;
+  float muRef1_phi = 0.;
+  if (r1->muonDetector() != 3) {
+    if(r1->muRef().isNull())
+      return false;
+
+    muRef1_eta = r1->muRef()->hwEta() * 0.010875;
+    muRef1_phi = static_cast<float>(
+                  l1t::MicroGMTConfiguration::calcGlobalPhi(r1->muRef()->hwPhi(),
+                                                            r1->muRef()->trackFinderType(),
+                                                            r1->muRef()->processor()));
+    muRef1_phi = muRef1_phi * 2. * M_PI / 576.;
+  }
+  else {
+    if(r1->emtfTrk().isNull())
+      return false;
+
+    muRef1_eta = r1->emtfTrk()->Eta();
+    muRef1_phi = angle_units::operators::convertDegToRad(r1->emtfTrk()->Phi_glob());
+  }
+  muRef1_phi = reco::reduceRange(muRef1_phi);
+
+  float muRef2_eta = 0.;
+  float muRef2_phi = 0.;
+  if (r2->muonDetector() != 3) {
+    if(r2->muRef().isNull())
+      return false;
+
+    muRef2_eta = r2->muRef()->hwEta() * 0.010875;
+    muRef2_phi = static_cast<float>(
+                  l1t::MicroGMTConfiguration::calcGlobalPhi(r2->muRef()->hwPhi(),
+                                                            r2->muRef()->trackFinderType(),
+                                                            r2->muRef()->processor()));
+    muRef2_phi = muRef2_phi * 2. * M_PI / 576.;
+  }
+  else {
+    if(r2->emtfTrk().isNull())
+      return false;
+
+    muRef2_eta = r2->emtfTrk()->Eta();
+    muRef2_phi = angle_units::operators::convertDegToRad(r2->emtfTrk()->Phi_glob());
+  }
+  muRef2_phi = reco::reduceRange(muRef2_phi);
+
+  if (reco::deltaR(muRef1_eta, muRef1_phi, muRef2_eta, muRef2_phi) > minDR_)
+    return true;
+
+  return false;
+}
+
+
+// ------------ method called to produce the data  ------------
+bool HLT2L1TkMuonL1TkMuonMuRefDR::hltFilter(edm::Event& iEvent,
+                                            const edm::EventSetup& iSetup,
+                                            trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+  bool accept(false);
+
+  std::vector<l1t::TkMuonRef> coll1;
+  std::vector<l1t::TkMuonRef> coll2;
+
+  if (getCollections(iEvent, coll1, coll2, filterproduct)) {
+    int n(0);
+    l1t::TkMuonRef r1;
+    l1t::TkMuonRef r2;
+
+    for (unsigned int i1 = 0; i1 != coll1.size(); i1++) {
+      r1 = coll1[i1];
+      unsigned int I(0);
+      if (same_) {
+        I = i1 + 1;
+      }
+      for (unsigned int i2 = I; i2 != coll2.size(); i2++) {
+        r2 = coll2[i2];
+
+        if (!computeDR(iEvent, r1, r2))
+          continue;
+
+        n++;
+        filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkMu, r1);
+        filterproduct.addObject(trigger::TriggerObjectType::TriggerL1TkMu, r2);
+      }
+    }
+
+    accept = accept || (n >= min_N_);
+  }
+
+  return accept;
+}
+
+DEFINE_FWK_MODULE(HLT2L1TkMuonL1TkMuonMuRefDR);

--- a/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.h
+++ b/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.h
@@ -42,9 +42,9 @@ private:
   const edm::InputTag inputTag2_;                // input tag identifying filtered 2nd product
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
   const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
-  const double minDR_;         // minimum dR between two muon regional candidates linked to L1TkMuon
-  const int min_N_;            // number of pairs passing cuts required
-  const bool same_;            // 1st and 2nd product are one and the same
+  const double minDR_;  // minimum dR between two muon regional candidates linked to L1TkMuon
+  const int min_N_;     // number of pairs passing cuts required
+  const bool same_;     // 1st and 2nd product are one and the same
 };
 
 #endif  //HLT2L1TkMuonL1TkMuonMuRefDR_h

--- a/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.h
+++ b/HLTrigger/HLTfilters/plugins/HLT2L1TkMuonL1TkMuonMuRefDR.h
@@ -1,0 +1,50 @@
+#ifndef HLT2L1TkMuonL1TkMuonMuRefDR_h
+#define HLT2L1TkMuonL1TkMuonMuRefDR_h
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+#include <string>
+#include <vector>
+namespace trigger {
+  class TriggerFilterObjectWithRefs;
+}
+
+//
+// class declaration
+//
+
+class HLT2L1TkMuonL1TkMuonMuRefDR : public HLTFilter {
+public:
+  explicit HLT2L1TkMuonL1TkMuonMuRefDR(const edm::ParameterSet&);
+  ~HLT2L1TkMuonL1TkMuonMuRefDR() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+  bool getCollections(edm::Event& iEvent,
+                      std::vector<l1t::TkMuonRef>& coll1,
+                      std::vector<l1t::TkMuonRef>& coll2,
+                      trigger::TriggerFilterObjectWithRefs& filterproduct) const;
+  bool computeDR(edm::Event& iEvent, l1t::TkMuonRef& c1, l1t::TkMuonRef& c2) const;
+
+private:
+  // configuration
+  const std::vector<edm::InputTag> originTag1_;  // input tag identifying originals 1st product
+  const std::vector<edm::InputTag> originTag2_;  // input tag identifying originals 2nd product
+  const edm::InputTag inputTag1_;                // input tag identifying filtered 1st product
+  const edm::InputTag inputTag2_;                // input tag identifying filtered 2nd product
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
+  const double minDR_;         // minimum dR between two muon regional candidates linked to L1TkMuon
+  const int min_N_;            // number of pairs passing cuts required
+  const bool same_;            // 1st and 2nd product are one and the same
+};
+
+#endif  //HLT2L1TkMuonL1TkMuonMuRefDR_h

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
@@ -1,0 +1,137 @@
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "HLTMuonTrkL1TkMuFilter.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+
+#include "TrackingTools/PatternTools/interface/ClosestApproachInRPhi.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+HLTMuonTrkL1TkMuFilter::HLTMuonTrkL1TkMuFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) {
+  m_muonsTag = iConfig.getParameter<edm::InputTag>("inputMuonCollection");
+  m_muonsToken = consumes<reco::MuonCollection>(m_muonsTag);
+  m_candsTag = iConfig.getParameter<edm::InputTag>("inputCandCollection");
+  m_candsToken = consumes<reco::RecoChargedCandidateCollection>(m_candsTag);
+  m_previousCandTag = iConfig.getParameter<edm::InputTag>("previousCandTag");
+  m_previousCandToken = consumes<trigger::TriggerFilterObjectWithRefs>(m_previousCandTag);
+  m_minTrkHits = iConfig.getParameter<int>("minTrkHits");
+  m_minMuonHits = iConfig.getParameter<int>("minMuonHits");
+  m_minMuonStations = iConfig.getParameter<int>("minMuonStations");
+  m_maxNormalizedChi2 = iConfig.getParameter<double>("maxNormalizedChi2");
+  m_minPt = iConfig.getParameter<double>("minPt");
+  m_minN = iConfig.getParameter<unsigned int>("minN");
+  m_maxAbsEta = iConfig.getParameter<double>("maxAbsEta");
+}
+
+void HLTMuonTrkL1TkMuFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<edm::InputTag>("inputMuonCollection", edm::InputTag(""));
+  desc.add<edm::InputTag>("inputCandCollection", edm::InputTag(""));
+  desc.add<edm::InputTag>("previousCandTag", edm::InputTag(""));
+  desc.add<int>("minTrkHits", -1);
+  desc.add<int>("minMuonHits", -1);
+  desc.add<int>("minMuonStations", -1);
+  desc.add<double>("maxNormalizedChi2", 1e99);
+  desc.add<unsigned int>("trkMuonId", 0);
+  desc.add<double>("minPt", 24);
+  desc.add<unsigned int>("minN", 1);
+  desc.add<double>("maxAbsEta", 1e99);
+  descriptions.add("hltMuonTrkL1TkMuFilter", desc);
+}
+
+bool HLTMuonTrkL1TkMuFilter::hltFilter(edm::Event& iEvent,
+                                    const edm::EventSetup& iSetup,
+                                    trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(m_muonsToken, muons);
+  edm::Handle<reco::RecoChargedCandidateCollection> cands;
+  iEvent.getByToken(m_candsToken, cands);
+  if (saveTags())
+    filterproduct.addCollectionTag(m_candsTag);
+  if (cands->size() != muons->size())
+    throw edm::Exception(edm::errors::Configuration)
+        << "Both input collection must be aligned and represent same physical muon objects";
+
+  edm::Handle<trigger::TriggerFilterObjectWithRefs> previousLevelCands;
+  std::vector<l1t::TkMuonRef> vl1cands;
+  std::vector<l1t::TkMuonRef>::iterator vl1cands_begin;
+  std::vector<l1t::TkMuonRef>::iterator vl1cands_end;
+
+  bool check_l1match = true;
+  if (m_previousCandTag == edm::InputTag(""))
+    check_l1match = false;
+  if (check_l1match) {
+    iEvent.getByToken(m_previousCandToken, previousLevelCands);
+    previousLevelCands->getObjects(trigger::TriggerL1TkMu, vl1cands);
+    vl1cands_begin = vl1cands.begin();
+    vl1cands_end = vl1cands.end();
+  }
+
+  std::vector<unsigned int> filteredMuons;
+  for (unsigned int i = 0; i < muons->size(); ++i) {
+    const reco::Muon& muon(muons->at(i));
+    // check for dR match to L1 muons
+    if (check_l1match) {
+      bool matchl1 = false;
+      for (auto l1cand = vl1cands_begin; l1cand != vl1cands_end; ++l1cand) {
+        if (deltaR(muon, **l1cand) < 0.3) {
+          matchl1 = true;
+          break;
+        }
+      }
+      if (!matchl1)
+        continue;
+    }
+
+    if (muon.numberOfMatchedStations() < m_minMuonStations)
+      continue;
+
+    if (!muon.innerTrack().isNull()) {
+      if (muon.innerTrack()->numberOfValidHits() < m_minTrkHits)
+        continue;
+    }
+
+    if (!muon.globalTrack().isNull()) {
+      if (muon.globalTrack()->normalizedChi2() > m_maxNormalizedChi2)
+        continue;
+      if (muon.globalTrack()->hitPattern().numberOfValidMuonHits() < m_minMuonHits)
+        continue;
+    }
+
+    if (muon.pt() < m_minPt)
+      continue;
+
+    if (std::abs(muon.eta()) > m_maxAbsEta)
+      continue;
+
+    filteredMuons.push_back(i);
+  }
+
+  for (std::vector<unsigned int>::const_iterator itr = filteredMuons.begin(); itr != filteredMuons.end(); ++itr)
+    filterproduct.addObject(trigger::TriggerMuon, reco::RecoChargedCandidateRef(cands, *itr));
+
+  return filteredMuons.size() >= m_minN;
+}
+
+// declare this class as a framework plugin
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HLTMuonTrkL1TkMuFilter);

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.cc
@@ -59,8 +59,8 @@ void HLTMuonTrkL1TkMuFilter::fillDescriptions(edm::ConfigurationDescriptions& de
 }
 
 bool HLTMuonTrkL1TkMuFilter::hltFilter(edm::Event& iEvent,
-                                    const edm::EventSetup& iSetup,
-                                    trigger::TriggerFilterObjectWithRefs& filterproduct) const {
+                                       const edm::EventSetup& iSetup,
+                                       trigger::TriggerFilterObjectWithRefs& filterproduct) const {
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_muonsToken, muons);
   edm::Handle<reco::RecoChargedCandidateCollection> cands;

--- a/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.h
+++ b/HLTrigger/Muon/plugins/HLTMuonTrkL1TkMuFilter.h
@@ -1,0 +1,44 @@
+#ifndef HLTMuonTrkL1TkMuFilter_h
+#define HLTMuonTrkL1TkMuFilter_h
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
+class HLTMuonTrkL1TkMuFilter : public HLTFilter {
+public:
+  HLTMuonTrkL1TkMuFilter(const edm::ParameterSet&);
+  ~HLTMuonTrkL1TkMuFilter() override {}
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  bool hltFilter(edm::Event&,
+                 const edm::EventSetup&,
+                 trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+
+private:
+  // WARNING: two input collection represent should be aligned and represent
+  // the same list of muons, just stored in different containers
+  edm::InputTag m_muonsTag;                             // input collection of muons
+  edm::EDGetTokenT<reco::MuonCollection> m_muonsToken;  // input collection of muons
+  edm::InputTag m_candsTag;                             // input collection of candidates to be referenced
+  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> m_candsToken;  // input collection of candidates to be referenced
+  edm::InputTag m_previousCandTag;  // input tag identifying product contains muons passing the previous level
+  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>
+      m_previousCandToken;  // token identifying product contains muons passing the previous level
+  int m_minTrkHits;
+  int m_minMuonHits;
+  int m_minMuonStations;
+  double m_maxNormalizedChi2;
+  double m_minPt;
+  unsigned int m_minN;
+  double m_maxAbsEta;
+  bool m_saveTags;
+};
+
+#endif  //HLTMuonTrkL1TkMuFilter_h

--- a/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
@@ -15,5 +15,8 @@
 <use name="TrackingTools/KalmanUpdators"/>
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="TrackingTools/TrajectoryState"/>
+<use name="TrackingTools/TrackAssociator"/>
+<use name="Geometry/CommonTopologies"/>
+<use name="DataFormats/L1TrackTrigger"/>
 <use name="clhep"/>
 <flags EDM_PLUGIN="1"/>

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.cc
@@ -1,0 +1,432 @@
+/*  \class L2MuonSeedGeneratorFromL1TkMu
+ *
+ *   L2 muon seed generator:
+ *   Transform the L1TkMuon informations in seeds
+ *   for the L2 muon reconstruction
+ *   (mimicking L2MuonSeedGeneratorFromL1T)
+ *
+ *    Author: H. Kwon
+ *    Modified by M. Oh
+ */
+
+// Class Header
+#include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h"
+
+// Framework
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
+#include "TrackingTools/TrajectoryParametrization/interface/CurvilinearTrajectoryError.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "TrackingTools/DetLayers/interface/DetLayer.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+using namespace std;
+using namespace edm;
+using namespace l1t;
+
+// constructors
+L2MuonSeedGeneratorFromL1TkMu::L2MuonSeedGeneratorFromL1TkMu(const edm::ParameterSet &iConfig)
+    : theSource(iConfig.getParameter<InputTag>("InputObjects")),
+      thePropagatorName(iConfig.getParameter<string>("Propagator")),
+      theL1MinPt(iConfig.getParameter<double>("L1MinPt")),
+      theL1MaxEta(iConfig.getParameter<double>("L1MaxEta")),
+      theMinPtBarrel(iConfig.getParameter<double>("SetMinPtBarrelTo")),
+      theMinPtEndcap(iConfig.getParameter<double>("SetMinPtEndcapTo")),
+      theMinPL1Tk(iConfig.getParameter<double>("MinPL1Tk")),
+      theMinPtL1TkBarrel(iConfig.getParameter<double>("MinPtL1TkBarrel")),
+      useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
+      useUnassociatedL1(iConfig.getParameter<bool>("UseUnassociatedL1")),
+      matchingDR(iConfig.getParameter<std::vector<double>>("MatchDR")),
+      etaBins(iConfig.getParameter<std::vector<double>>("EtaMatchingBins"))
+{
+  muCollToken_ = consumes<l1t::TkMuonCollection>(theSource);
+
+  if (useOfflineSeed) {
+    theOfflineSeedLabel = iConfig.getUntrackedParameter<InputTag>("OfflineSeedLabel");
+    offlineSeedToken_ = consumes<edm::View<TrajectorySeed>>(theOfflineSeedLabel);
+
+    // check that number of eta bins -1 matches number of dR cones
+    if (matchingDR.size() != etaBins.size() - 1) {
+      throw cms::Exception("Configuration") << "Size of MatchDR "
+                                            << "does not match number of eta bins." << endl;
+    }
+  }
+
+  // service parameters
+  ParameterSet serviceParameters = iConfig.getParameter<ParameterSet>("ServiceParameters");
+
+  // the services
+  theService = new MuonServiceProxy(serviceParameters, consumesCollector());
+
+  // the estimator
+  theEstimator = new Chi2MeasurementEstimator(10000.);
+
+  produces<L2MuonTrajectorySeedCollection>();
+}
+
+// destructor
+L2MuonSeedGeneratorFromL1TkMu::~L2MuonSeedGeneratorFromL1TkMu() {
+  if (theService)
+    delete theService;
+  if (theEstimator)
+    delete theEstimator;
+}
+
+void L2MuonSeedGeneratorFromL1TkMu::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("InputObjects", edm::InputTag("hltGmtStage2Digis"));
+  desc.add<string>("Propagator", "");
+  desc.add<double>("L1MinPt", -1.);
+  desc.add<double>("L1MaxEta", 5.0);
+  desc.add<double>("SetMinPtBarrelTo", 3.5);
+  desc.add<double>("SetMinPtEndcapTo", 1.0);
+  desc.add<double>("MinPL1Tk", 3.5);
+  desc.add<double>("MinPtL1TkBarrel", 3.5);
+  desc.addUntracked<bool>("UseOfflineSeed", false);
+  desc.add<bool>("UseUnassociatedL1", true);
+  desc.add<std::vector<double>>("MatchDR", {0.3});
+  desc.add<std::vector<double>>("EtaMatchingBins", {0., 2.5});
+  desc.addUntracked<edm::InputTag>("OfflineSeedLabel", edm::InputTag(""));
+
+  edm::ParameterSetDescription psd0;
+  psd0.addUntracked<std::vector<std::string>>("Propagators", {"SteppingHelixPropagatorAny"});
+  psd0.add<bool>("RPCLayers", true);
+  psd0.addUntracked<bool>("UseMuonNavigation", true);
+  desc.add<edm::ParameterSetDescription>("ServiceParameters", psd0);
+  descriptions.add("L2MuonSeedGeneratorFromL1TkMu", desc);
+}
+
+void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  const std::string metname = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1TkMu";
+  MuonPatternRecoDumper debug;
+
+  auto output = std::make_unique<L2MuonTrajectorySeedCollection>();
+
+  edm::Handle<l1t::TkMuonCollection> muColl;
+  iEvent.getByToken(muCollToken_, muColl);
+  LogDebug(metname) << "Number of muons " << muColl->size() << endl;
+
+  edm::Handle<edm::View<TrajectorySeed>> offlineSeedHandle;
+  vector<int> offlineSeedMap;
+  if (useOfflineSeed) {
+    iEvent.getByToken(offlineSeedToken_, offlineSeedHandle);
+    offlineSeedMap = vector<int>(offlineSeedHandle->size(), 0);
+  }
+
+  for (auto ittkmu = muColl->begin(); ittkmu != muColl->end(); ittkmu++) {
+
+    // L1 tracker track
+    auto it = ittkmu->trkPtr();
+
+    // propagate to GMT
+    auto p3 = it->momentum();
+    float tk_pt = p3.perp();
+    float tk_p = p3.mag();
+    float tk_eta = p3.eta();
+    float tk_aeta = std::abs(tk_eta);
+    float tk_phi = p3.phi();
+    float tk_q = it->rInv() > 0 ? 1. : -1.;
+    float tk_z = it->POCA().z();
+
+    if (tk_p < theMinPL1Tk)
+      continue;
+    if (tk_aeta < 1.1 && tk_pt < theMinPtL1TkBarrel)
+      continue;
+
+    float dzCorrPhi = 1.;
+    float deta = 0;
+    float etaProp = tk_aeta;
+
+    if (tk_aeta < 1.1) {
+      etaProp = 1.1;
+      deta = tk_z / 550. / cosh(tk_aeta);
+    } else {
+      float delta = tk_z / 850.;  //roughly scales as distance to 2nd station
+      if (tk_eta > 0)
+        delta *= -1;
+      dzCorrPhi = 1. + delta;
+
+      float zOzs = tk_z / 850.;
+      if (tk_eta > 0)
+        deta = zOzs / (1. - zOzs);
+      else
+        deta = zOzs / (1. + zOzs);
+      deta = deta * tanh(tk_eta);
+    }
+    float resPhi = tk_phi - 1.464 * tk_q * cosh(1.7) / cosh(etaProp) / tk_pt * dzCorrPhi - M_PI / 144.;
+    resPhi = reco::reduceRange(resPhi);
+
+    float pt = tk_pt;  //not corrected for eloss
+    float eta = tk_eta + deta;
+    float theta = 2 * atan(exp(-eta));
+    float phi = resPhi;
+    int charge = it->rInv() > 0 ? 1 : -1;
+
+    bool barrel = tk_aeta < 1.1 ? true : false;
+
+    if (pt < theL1MinPt || fabs(eta) > theL1MaxEta)
+      continue;
+
+    LogDebug(metname) << "New L2 Muon Seed";
+    LogDebug(metname) << "Pt = " << pt << " GeV/c";
+    LogDebug(metname) << "eta = " << eta;
+    LogDebug(metname) << "theta = " << theta << " rad";
+    LogDebug(metname) << "phi = " << phi << " rad";
+    LogDebug(metname) << "charge = " << charge;
+    LogDebug(metname) << "In Barrel? = " << barrel;
+
+    // Update the services
+    theService->update(iSetup);
+
+    const DetLayer *detLayer = nullptr;
+    float radius = 0.;
+
+    CLHEP::Hep3Vector vec(0., 1., 0.);
+    vec.setTheta(theta);
+    vec.setPhi(phi);
+
+    DetId theid;
+    // Get the det layer on which the state should be put
+    if (barrel) {
+      LogDebug(metname) << "The seed is in the barrel";
+
+      // MB2
+      theid = DTChamberId(0, 2, 0);
+      detLayer = theService->detLayerGeometry()->idToLayer(theid);
+      LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+      const BoundSurface *sur = &(detLayer->surface());
+      const BoundCylinder *bc = dynamic_cast<const BoundCylinder *>(sur);
+
+      radius = fabs(bc->radius() / sin(theta));
+
+      LogDebug(metname) << "radius " << radius;
+
+      if (pt < theMinPtBarrel)
+        pt = theMinPtBarrel;
+    } else {
+      LogDebug(metname) << "The seed is in the endcap";
+
+      // ME2
+      theid = theta < Geom::pi() / 2. ? CSCDetId(1, 2, 0, 0, 0) : CSCDetId(2, 2, 0, 0, 0);
+
+      detLayer = theService->detLayerGeometry()->idToLayer(theid);
+      LogDebug(metname) << "L2 Layer: " << debug.dumpLayer(detLayer);
+
+      radius = fabs(detLayer->position().z() / cos(theta));
+
+      if (pt < theMinPtEndcap)
+        pt = theMinPtEndcap;
+    }
+
+    vec.setMag(radius);
+
+    GlobalPoint pos(vec.x(), vec.y(), vec.z());
+
+    GlobalVector mom(pt * cos(phi), pt * sin(phi), pt * cos(theta) / sin(theta));
+
+    GlobalTrajectoryParameters param(pos, mom, charge, &*theService->magneticField());
+    AlgebraicSymMatrix55 mat;
+
+    mat[0][0] = (0.25 / pt) * (0.25 / pt);  // sigma^2(charge/abs_momentum)
+    if (!barrel)
+      mat[0][0] = (0.4 / pt) * (0.4 / pt);
+
+    mat[1][1] = 0.05 * 0.05;  // sigma^2(lambda)
+    mat[2][2] = 0.2 * 0.2;    // sigma^2(phi)
+    mat[3][3] = 20. * 20.;    // sigma^2(x_transverse))
+    mat[4][4] = 20. * 20.;    // sigma^2(y_transverse))
+
+    CurvilinearTrajectoryError error(mat);
+
+    const FreeTrajectoryState state(param, error);
+
+    LogDebug(metname) << "Free trajectory State from the parameters";
+    LogDebug(metname) << debug.dumpFTS(state);
+
+    // Propagate the state on the MB2/ME2 surface
+    TrajectoryStateOnSurface tsos =
+        theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+
+    LogDebug(metname) << "State after the propagation on the layer";
+    LogDebug(metname) << debug.dumpLayer(detLayer);
+    LogDebug(metname) << debug.dumpTSOS(tsos);
+
+    double dRcone = matchingDR[0];
+    if (fabs(eta) < etaBins.back()) {
+      std::vector<double>::iterator lowEdge = std::upper_bound(etaBins.begin(), etaBins.end(), fabs(eta));
+      dRcone = matchingDR.at(lowEdge - etaBins.begin() - 1);
+    }
+
+    if (tsos.isValid()) {
+      edm::OwnVector<TrackingRecHit> container;
+
+      if (useOfflineSeed) {
+        // Get the compatible dets on the layer
+        std::vector<pair<const GeomDet *, TrajectoryStateOnSurface>> detsWithStates =
+            detLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
+
+        if (detsWithStates.empty() && barrel) {
+          // Fallback solution using ME2, try again to propagate but using ME2 as reference
+          DetId fallback_id;
+          theta < Geom::pi() / 2. ? fallback_id = CSCDetId(1, 2, 0, 0, 0) : fallback_id = CSCDetId(2, 2, 0, 0, 0);
+          const DetLayer *ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
+
+          tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
+          detsWithStates =
+              ME2DetLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
+        }
+
+        if (!detsWithStates.empty()) {
+          TrajectoryStateOnSurface newTSOS = detsWithStates.front().second;
+          const GeomDet *newTSOSDet = detsWithStates.front().first;
+
+          LogDebug(metname) << "Most compatible det";
+          LogDebug(metname) << debug.dumpMuonId(newTSOSDet->geographicalId());
+
+          if (newTSOS.isValid()) {
+            LogDebug(metname) << "pos: (r=" << newTSOS.globalPosition().mag()
+                              << ", phi=" << newTSOS.globalPosition().phi()
+                              << ", eta=" << newTSOS.globalPosition().eta() << ")";
+            LogDebug(metname) << "mom: (q*pt=" << newTSOS.charge() * newTSOS.globalMomentum().perp()
+                              << ", phi=" << newTSOS.globalMomentum().phi()
+                              << ", eta=" << newTSOS.globalMomentum().eta() << ")";
+
+            const TrajectorySeed *assoOffseed =
+                associateOfflineSeedToL1(offlineSeedHandle, offlineSeedMap, newTSOS, dRcone);
+
+            if (assoOffseed != nullptr) {
+              PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
+              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first,
+                                             tscie = assoOffseed->recHits().second;
+              for (; tsci != tscie; ++tsci) {
+                container.push_back(*tsci);
+              }
+              auto dummyRef = edm::Ref<MuonBxCollection>();
+              output->push_back(
+                  L2MuonTrajectorySeed(seedTSOS,
+                                       container,
+                                       alongMomentum,
+                                       dummyRef));
+            } else {
+              if (useUnassociatedL1) {
+                // convert the TSOS into a PTSOD
+                PTrajectoryStateOnDet const &seedTSOS =
+                    trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
+                auto dummyRef = edm::Ref<MuonBxCollection>();
+                output->push_back(
+                    L2MuonTrajectorySeed(seedTSOS,
+                                         container,
+                                         alongMomentum,
+                                         dummyRef));
+              }
+            }
+          }
+        }
+      } else {
+        // convert the TSOS into a PTSOD
+        PTrajectoryStateOnDet const &seedTSOS = trajectoryStateTransform::persistentState(tsos, theid.rawId());
+        auto dummyRef = edm::Ref<MuonBxCollection>();
+        output->push_back(
+            L2MuonTrajectorySeed(seedTSOS,
+                                 container,
+                                 alongMomentum,
+                                 dummyRef));
+      }
+    }
+  }
+
+  iEvent.put(std::move(output));
+}
+
+// FIXME: does not resolve ambiguities yet!
+const TrajectorySeed *L2MuonSeedGeneratorFromL1TkMu::associateOfflineSeedToL1(
+    edm::Handle<edm::View<TrajectorySeed>> &offseeds,
+    std::vector<int> &offseedMap,
+    TrajectoryStateOnSurface &newTsos,
+    double dRcone) {
+  const std::string metlabel = "Muon|RecoMuon|L2MuonSeedGeneratorFromL1TkMu";
+  MuonPatternRecoDumper debugtmp;
+
+  edm::View<TrajectorySeed>::const_iterator offseed, endOffseed = offseeds->end();
+  const TrajectorySeed *selOffseed = nullptr;
+  double bestDr = 99999.;
+  unsigned int nOffseed(0);
+  int lastOffseed(-1);
+
+  for (offseed = offseeds->begin(); offseed != endOffseed; ++offseed, ++nOffseed) {
+    if (offseedMap[nOffseed] != 0)
+      continue;
+    GlobalPoint glbPos = theService->trackingGeometry()
+                             ->idToDet(offseed->startingState().detId())
+                             ->surface()
+                             .toGlobal(offseed->startingState().parameters().position());
+    GlobalVector glbMom = theService->trackingGeometry()
+                              ->idToDet(offseed->startingState().detId())
+                              ->surface()
+                              .toGlobal(offseed->startingState().parameters().momentum());
+
+    // Preliminary check
+    double preDr = deltaR(newTsos.globalPosition().eta(), newTsos.globalPosition().phi(), glbPos.eta(), glbPos.phi());
+    if (preDr > 1.0)
+      continue;
+
+    const FreeTrajectoryState offseedFTS(
+        glbPos, glbMom, offseed->startingState().parameters().charge(), &*theService->magneticField());
+    TrajectoryStateOnSurface offseedTsos =
+        theService->propagator(thePropagatorName)->propagate(offseedFTS, newTsos.surface());
+    LogDebug(metlabel) << "Offline seed info: Det and State" << std::endl;
+    LogDebug(metlabel) << debugtmp.dumpMuonId(offseed->startingState().detId()) << std::endl;
+    LogDebug(metlabel) << "pos: (r=" << offseedFTS.position().mag() << ", phi=" << offseedFTS.position().phi()
+                       << ", eta=" << offseedFTS.position().eta() << ")" << std::endl;
+    LogDebug(metlabel) << "mom: (q*pt=" << offseedFTS.charge() * offseedFTS.momentum().perp()
+                       << ", phi=" << offseedFTS.momentum().phi() << ", eta=" << offseedFTS.momentum().eta() << ")"
+                       << std::endl
+                       << std::endl;
+
+    if (offseedTsos.isValid()) {
+      LogDebug(metlabel) << "Offline seed info after propagation to L1 layer:" << std::endl;
+      LogDebug(metlabel) << "pos: (r=" << offseedTsos.globalPosition().mag()
+                         << ", phi=" << offseedTsos.globalPosition().phi()
+                         << ", eta=" << offseedTsos.globalPosition().eta() << ")" << std::endl;
+      LogDebug(metlabel) << "mom: (q*pt=" << offseedTsos.charge() * offseedTsos.globalMomentum().perp()
+                         << ", phi=" << offseedTsos.globalMomentum().phi()
+                         << ", eta=" << offseedTsos.globalMomentum().eta() << ")" << std::endl
+                         << std::endl;
+      double newDr = deltaR(newTsos.globalPosition().eta(),
+                            newTsos.globalPosition().phi(),
+                            offseedTsos.globalPosition().eta(),
+                            offseedTsos.globalPosition().phi());
+      LogDebug(metlabel) << "   -- DR = " << newDr << std::endl;
+      if (newDr < dRcone && newDr < bestDr) {
+        LogDebug(metlabel) << "          --> OK! " << newDr << std::endl << std::endl;
+        selOffseed = &*offseed;
+        bestDr = newDr;
+        offseedMap[nOffseed] = 1;
+        if (lastOffseed > -1)
+          offseedMap[lastOffseed] = 0;
+        lastOffseed = nOffseed;
+      } else {
+        LogDebug(metlabel) << "          --> Rejected. " << newDr << std::endl << std::endl;
+      }
+    } else {
+      LogDebug(metlabel) << "Invalid offline seed TSOS after propagation!" << std::endl << std::endl;
+    }
+  }
+
+  return selOffseed;
+}
+

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.cc
@@ -50,8 +50,7 @@ L2MuonSeedGeneratorFromL1TkMu::L2MuonSeedGeneratorFromL1TkMu(const edm::Paramete
       useOfflineSeed(iConfig.getUntrackedParameter<bool>("UseOfflineSeed", false)),
       useUnassociatedL1(iConfig.getParameter<bool>("UseUnassociatedL1")),
       matchingDR(iConfig.getParameter<std::vector<double>>("MatchDR")),
-      etaBins(iConfig.getParameter<std::vector<double>>("EtaMatchingBins"))
-{
+      etaBins(iConfig.getParameter<std::vector<double>>("EtaMatchingBins")) {
   muCollToken_ = consumes<l1t::TkMuonCollection>(theSource);
 
   if (useOfflineSeed) {
@@ -127,7 +126,6 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
   }
 
   for (auto ittkmu = muColl->begin(); ittkmu != muColl->end(); ittkmu++) {
-
     // L1 tracker track
     auto it = ittkmu->trkPtr();
 
@@ -258,8 +256,7 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
     LogDebug(metname) << debug.dumpFTS(state);
 
     // Propagate the state on the MB2/ME2 surface
-    TrajectoryStateOnSurface tsos =
-        theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
+    TrajectoryStateOnSurface tsos = theService->propagator(thePropagatorName)->propagate(state, detLayer->surface());
 
     LogDebug(metname) << "State after the propagation on the layer";
     LogDebug(metname) << debug.dumpLayer(detLayer);
@@ -286,8 +283,7 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
           const DetLayer *ME2DetLayer = theService->detLayerGeometry()->idToLayer(fallback_id);
 
           tsos = theService->propagator(thePropagatorName)->propagate(state, ME2DetLayer->surface());
-          detsWithStates =
-              ME2DetLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
+          detsWithStates = ME2DetLayer->compatibleDets(tsos, *theService->propagator(thePropagatorName), *theEstimator);
         }
 
         if (!detsWithStates.empty()) {
@@ -310,28 +306,19 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
 
             if (assoOffseed != nullptr) {
               PTrajectoryStateOnDet const &seedTSOS = assoOffseed->startingState();
-              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first,
-                                             tscie = assoOffseed->recHits().second;
+              TrajectorySeed::const_iterator tsci = assoOffseed->recHits().first, tscie = assoOffseed->recHits().second;
               for (; tsci != tscie; ++tsci) {
                 container.push_back(*tsci);
               }
               auto dummyRef = edm::Ref<MuonBxCollection>();
-              output->push_back(
-                  L2MuonTrajectorySeed(seedTSOS,
-                                       container,
-                                       alongMomentum,
-                                       dummyRef));
+              output->push_back(L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, dummyRef));
             } else {
               if (useUnassociatedL1) {
                 // convert the TSOS into a PTSOD
                 PTrajectoryStateOnDet const &seedTSOS =
                     trajectoryStateTransform::persistentState(newTSOS, newTSOSDet->geographicalId().rawId());
                 auto dummyRef = edm::Ref<MuonBxCollection>();
-                output->push_back(
-                    L2MuonTrajectorySeed(seedTSOS,
-                                         container,
-                                         alongMomentum,
-                                         dummyRef));
+                output->push_back(L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, dummyRef));
               }
             }
           }
@@ -340,11 +327,7 @@ void L2MuonSeedGeneratorFromL1TkMu::produce(edm::Event &iEvent, const edm::Event
         // convert the TSOS into a PTSOD
         PTrajectoryStateOnDet const &seedTSOS = trajectoryStateTransform::persistentState(tsos, theid.rawId());
         auto dummyRef = edm::Ref<MuonBxCollection>();
-        output->push_back(
-            L2MuonTrajectorySeed(seedTSOS,
-                                 container,
-                                 alongMomentum,
-                                 dummyRef));
+        output->push_back(L2MuonTrajectorySeed(seedTSOS, container, alongMomentum, dummyRef));
       }
     }
   }
@@ -429,4 +412,3 @@ const TrajectorySeed *L2MuonSeedGeneratorFromL1TkMu::associateOfflineSeedToL1(
 
   return selOffseed;
 }
-

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h
@@ -1,0 +1,89 @@
+#ifndef RecoMuon_L2MuonSeedGenerator_L2MuonSeedGeneratorFromL1TkMu_H
+#define RecoMuon_L2MuonSeedGenerator_L2MuonSeedGeneratorFromL1TkMu_H
+
+/*  \class L2MuonSeedGeneratorFromL1TkMu
+ *
+ *   L2 muon seed generator:
+ *   Transform the L1TkMuon informations in seeds
+ *   for the L2 muon reconstruction
+ *   (mimicking L2MuonSeedGeneratorFromL1T)
+ *
+ *    Author: H. Kwon
+ *    Modified by M. Oh
+ */
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+// Data Formats
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
+#include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/GeometrySurface/interface/BoundCylinder.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/L1Trigger/interface/Muon.h"
+
+#include "DataFormats/L1TCorrelator/interface/TkMuon.h"
+#include "DataFormats/L1TCorrelator/interface/TkMuonFwd.h"
+
+#include "CLHEP/Vector/ThreeVector.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
+
+class MuonServiceProxy;
+class MeasurementEstimator;
+class TrajectorySeed;
+class TrajectoryStateOnSurface;
+
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
+
+class L2MuonSeedGeneratorFromL1TkMu : public edm::stream::EDProducer<> {
+public:
+  /// Constructor
+  explicit L2MuonSeedGeneratorFromL1TkMu(const edm::ParameterSet &);
+
+  /// Destructor
+  ~L2MuonSeedGeneratorFromL1TkMu() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  void produce(edm::Event &, const edm::EventSetup &) override;
+
+private:
+  edm::InputTag theSource;
+  edm::InputTag theOfflineSeedLabel;
+  std::string thePropagatorName;
+
+  edm::EDGetTokenT<l1t::TkMuonCollection> muCollToken_;
+  edm::EDGetTokenT<edm::View<TrajectorySeed> > offlineSeedToken_;
+
+  const double theL1MinPt;
+  const double theL1MaxEta;
+  const double theMinPtBarrel;
+  const double theMinPtEndcap;
+  const double theMinPL1Tk;
+  const double theMinPtL1TkBarrel;
+  const bool useOfflineSeed;
+  const bool useUnassociatedL1;
+  std::vector<double> matchingDR;
+  std::vector<double> etaBins;
+
+  /// the event setup proxy, it takes care the services update
+  MuonServiceProxy *theService;
+
+  MeasurementEstimator *theEstimator;
+
+  const TrajectorySeed *associateOfflineSeedToL1(edm::Handle<edm::View<TrajectorySeed> > &,
+                                                 std::vector<int> &,
+                                                 TrajectoryStateOnSurface &,
+                                                 double);
+
+};
+
+#endif

--- a/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h
+++ b/RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h
@@ -83,7 +83,6 @@ private:
                                                  std::vector<int> &,
                                                  TrajectoryStateOnSurface &,
                                                  double);
-
 };
 
 #endif

--- a/RecoMuon/L2MuonSeedGenerator/src/SealModule.cc
+++ b/RecoMuon/L2MuonSeedGenerator/src/SealModule.cc
@@ -4,6 +4,8 @@
 
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGenerator.h"
 #include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1T.h"
+#include "RecoMuon/L2MuonSeedGenerator/src/L2MuonSeedGeneratorFromL1TkMu.h"
 
 DEFINE_FWK_MODULE(L2MuonSeedGenerator);
 DEFINE_FWK_MODULE(L2MuonSeedGeneratorFromL1T);
+DEFINE_FWK_MODULE(L2MuonSeedGeneratorFromL1TkMu);


### PR DESCRIPTION
#### PR description:
This PR adds the following modules (backport of #32699):
- a new L2 muon seed generator from L1TkMuon
- a new L3 muon filter with L1TkMuon
- a new dR filter for MuonRef of L1TkMuon

N.B. To compile it, #32681 should be merged prior to this PR

#### PR validation:
matrix tests (after merging #32681)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:
backport of #32699