### PR TITLE
Update ECAL spike killer settings for Run 3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -69,7 +69,7 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
     'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -69,17 +69,17 @@ autoCond = {
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
     'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v3', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v2', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v3',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v2',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v2', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v2', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '113X_mcRun4_realistic_v2'
 }


### PR DESCRIPTION
#### PR description:

This PR provides re-optimized ECAL spike killer settings for Run 3. Details of the payloads and their validation can be found in the [presentation at the 18 Jan 2021 AlCaDB meeting](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike).

The GT diffs are as follows:

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_v2/113X_mcRun3_2021_realistic_v3

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021cosmics_realistic_deco_v3/113X_mcRun3_2021cosmics_realistic_deco_v4

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_HI_v2/113X_mcRun3_2021_realistic_HI_v3

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2023_realistic_v2/113X_mcRun3_2023_realistic_v3

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2024_realistic_v2/113X_mcRun3_2024_realistic_v3

#### PR validation:

The payloads were validated by explicitly comparing dumps of the new payload with the old (see [slide 5](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike)) and checking the performance with re-emulated trigger primitives (see [slide 6](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike)).

In addition, a technical test was performed: 

`runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but a backport to 112X has been requested for use in Run 3 MC production.
