### PR TITLE
[DD4hep] Fix switched names of ECal volumes, first step

### DIFF
--- a/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
+++ b/Geometry/EcalCommonData/plugins/dd4hep/DDEcalBarrelNewAlgo.cc
@@ -2134,7 +2134,8 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
         thickVFE += backCool.vecBackVFELyrThick[iLyr];
       }
       Solid backVFESolid = Box(backCool.barHeight / 2., backCool.barWidth / 2., thickVFE / 2.);
-      Volume backVFELog = ns.addVolume(Volume(myns + backCool.vFEName, backVFESolid, ns.material(backCool.vFEMat)));
+      Volume backVFELog =
+          ns.addVolume(Volume(myns + backCool.backVFEName, backVFESolid, ns.material(backCool.backVFEMat)));
       Position offTra(0, 0, -thickVFE / 2);
       for (unsigned int iLyr(0); iLyr != backCool.vecBackVFELyrThick.size(); ++iLyr) {
         Solid backVFELyrSolid =
@@ -2164,7 +2165,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
 
       const double halfZCoolVFE(thickVFE + backCool.barThick / 2.);
       Solid backCoolVFESolid = Box(backCool.barHeight / 2., backCool.barWidth / 2., halfZCoolVFE);
-      Volume backCoolVFELog = Volume(backCool.backVFEName, backCoolVFESolid, ns.material(backCool.backVFEMat));
+      Volume backCoolVFELog = Volume(backCool.vFEName, backCoolVFESolid, ns.material(backCool.vFEMat));
       if (0 != backCool.barHere) {
         backCoolVFELog.placeVolume(backCoolBarLog, copyOne, Transform3D());
 #ifdef EDM_ML_DEBUG
@@ -2182,7 +2183,7 @@ static long algorithm(dd4hep::Detector& /* description */, cms::DDParsingContext
       }
       backCoolVFELog.placeVolume(backVFELog,
                                  copyTwo,
-                                 Transform3D(myrot(ns, backCool.backVFEName + "Flip", CLHEP::HepRotationX(180_deg)),
+                                 Transform3D(myrot(ns, backCool.vFEName + "Flip", CLHEP::HepRotationX(180_deg)),
                                              Position(0, 0, -backCool.barThick / 2. - thickVFE / 2.)));
 #ifdef EDM_ML_DEBUG
       edm::LogVerbatim("EcalGeom") << DDSplit(backVFELog.name()).first << ":" << copyTwo << " positioned in "


### PR DESCRIPTION
The number of physical volumes produced by Run 3 DD4hep is greater than that produced by the old DD. One problem was that
some VFE ECal volumes had their names switched around in DD4hep compared to the old DD. This PR fixes that mix-up. The number of physical volumes for Run 3 in old DD is 21339. Before this PR, DD4hep produced 21391 volumes. With this PR, this number goes down to 21354. There are still more fixes required to get to an exact match, but this PR provides a first step and provides a starting point for other developers to make more fixes.

#### PR validation:

The numbers of  "ECVFE" and "EVFE" physical volumes from debugging messages were checked before and after this PR using these two test scripts:
```
Geometry/EcalCommonData/test/python/dumpECDDD_cfg.py
Geometry/EcalCommonData/test/python/dumpECDD4Hep_cfg.py
```
Before this PR, the numbers did not match, but after this PR, there was an exact match for these volumes between old DD and DD4hep.

No backport is planned.