### PR TITLE
removed circular dependence that blocked Ecal Phase 2 Sim workflow

### DIFF
--- a/SimCalorimetry/EcalSimProducers/plugins/EcalLiteDTUPedestalsESProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/plugins/EcalLiteDTUPedestalsESProducer.cc
@@ -21,9 +21,7 @@ public:
   typedef std::unique_ptr<EcalLiteDTUPedestalsMap> ReturnType;
 
   ReturnType produce(const EcalLiteDTUPedestalsRcd& iRecord);
-  //Add 2 nov 2020:
-  edm::ESGetToken<EcalLiteDTUPedestalsMap, EcalLiteDTUPedestalsRcd> pedestalToken_;
-  ///////////////////////////////
+
 private:
   double meanPedestalsGain10_;
   double rmsPedestalsGain10_;
@@ -39,8 +37,7 @@ EcalLiteDTUPedestalsESProducer::EcalLiteDTUPedestalsESProducer(const edm::Parame
   rmsPedestalsGain10_ = p.getParameter<double>("RMSPedestalsGain10");
   meanPedestalsGain1_ = p.getParameter<double>("MeanPedestalsGain1");
   rmsPedestalsGain1_ = p.getParameter<double>("RMSPedestalsGain1");
-  auto cc = setWhatProduced(this);
-  pedestalToken_ = cc.consumes<EcalLiteDTUPedestalsMap>();
+  setWhatProduced(this);
 }
 ////
 EcalLiteDTUPedestalsESProducer::ReturnType EcalLiteDTUPedestalsESProducer::produce(


### PR DESCRIPTION
#### PR description:
A circular dependence in the touched ESProducer got the Ecal Phase2 simulation workflow stuck

#### PR validation:
runTheMatrix.py -w upgrade -l 28234.61 

runs to completion
