### PR TITLE
TotemDAQMappingESSourceXML Xerces thread safety

### DIFF
--- a/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
+++ b/CalibPPS/ESProducers/plugins/TotemDAQMappingESSourceXML.cc
@@ -28,6 +28,7 @@
 #include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
 #include "CondFormats/PPSObjects/interface/TotemAnalysisMask.h"
 #include "CondFormats/PPSObjects/interface/TotemFramePosition.h"
+#include "Utilities/Xerces/interface/Xerces.h"
 #include "Utilities/Xerces/interface/XercesStrUtils.h"
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
@@ -322,12 +323,7 @@ TotemDAQMappingESSourceXML::produce(const TotemReadoutRcd &) {
   auto mask = std::make_unique<TotemAnalysisMask>();
 
   // initialize Xerces
-  try {
-    XMLPlatformUtils::Initialize();
-  } catch (const XMLException &toCatch) {
-    throw cms::Exception("TotemDAQMappingESSourceXML")
-        << "An XMLException caught with message: " << cms::xerces::toString(toCatch.getMessage()) << ".\n";
-  }
+  cms::concurrency::xercesInitialize();
 
   // load mapping files
   for (const auto &fn : configuration[currentBlock].mappingFileNames)
@@ -338,7 +334,7 @@ TotemDAQMappingESSourceXML::produce(const TotemReadoutRcd &) {
     ParseXML(pMask, CompleteFileName(fn), mapping, mask);
 
   // release Xerces
-  XMLPlatformUtils::Terminate();
+  cms::concurrency::xercesTerminate();
 
   // commit the products
   return edm::es::products(std::move(mapping), std::move(mask));


### PR DESCRIPTION
#### PR description:

`TotemDAQMappingESSourceXML::produce()` calls `XMLPlatformUtils::Initialize()`, which is not thread safe.  This updates it to use the `cms::concurrency` thread-safe version,  copying the pattern in

https://github.com/cms-sw/cmssw/blob/f2e08fd9aec7b9d4dd85790d8e6f3d0601ccc61b/CalibPPS/ESProducers/plugins/CTPPSPixelDAQMappingESSourceXML.cc#L245-L258

With the increased framework concurrency, we are seeing occasional crashes in `TotemDAQMappingESSourceXML`.

#### PR validation:

Compiles (it's a small technical change).