### PR TITLE
Updated phase 2 templates with extended angle space, backport of #32220

### DIFF
--- a/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
+++ b/CondFormats/SiPixelTransient/interface/SiPixelTemplateDefs.h
@@ -40,7 +40,7 @@
 #define T2HY 10          // = T2YSIZE/2
 #define T2HYP1 T2HY + 1  // = T2YSIZE/2+1
 #define T2HX 3           // = T2XSIZE/2
-#define TEMP_ENTRY_SIZEX_A 60
-#define TEMP_ENTRY_SIZEX_B 60
-#define TEMP_ENTRY_SIZEY 60
+#define TEMP_ENTRY_SIZEX_A 80
+#define TEMP_ENTRY_SIZEX_B 80
+#define TEMP_ENTRY_SIZEY 100
 #endif

--- a/Configuration/AlCa/python/autoCondPhase2.py
+++ b/Configuration/AlCa/python/autoCondPhase2.py
@@ -52,15 +52,15 @@ allTags["SimLA"] = {
 }
 
 allTags["GenError"] = {
-    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelGenErrorRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelGenErrorRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelGenErrorDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelGenErrorRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 allTags["Template"] = {
-    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v0_mc',SiPixelTemplatesRecord,connectionString, "", "2020-07-24 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
-    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v1_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-08-17 21:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
+    'T15' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T21' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_25x100_v2_mc',SiPixelTemplatesRecord,connectionString, "", "2020-10-16 10:00:00"] ), ),  # cell is 25um (local-x) x 100um (local-y) , VBias=350V
+    'T22' : ( ','.join( [ 'SiPixelTemplateDBObject_phase2_IT_v6.1.5_50x50_v4_mc' ,SiPixelTemplatesRecord,connectionString, "", "2020-10-19 23:00:00"] ), ),  # cell is 50um (local-x) x 50um (local-y) , VBias=350V
 }
 
 ##


### PR DESCRIPTION
backport of https://github.com/cms-sw/cmssw/pull/32220/

#### PR description:

This PR updates the phase2 template and genError objects to have extended angle coverage. This was needed in order to correct a previous issue where there were a good number of hits outside their angle space and lead to poor resolution.
The backport is needed in order to carry out certain performance studies within the phase-2 IT sensor performance Task Force.

#### PR validation:

Results validating these condition changes were shown at the phase 2 simulation meeting [here](https://indico.cern.ch/event/949829/contributions/4116024/attachments/2147562/3620113/2020_11_20_Test_new_CPE.pdf)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This is a verbatim backport of part of https://github.com/cms-sw/cmssw/pull/32220/ (only commit cdc42cea6e803af7ff643cd59dce2c0dfdfda3d0)
