### PR TITLE
Clean various BuildFiles

### DIFF
--- a/EventFilter/EcalRawToDigi/BuildFile.xml
+++ b/EventFilter/EcalRawToDigi/BuildFile.xml
@@ -1,11 +1,9 @@
 <use name="boost"/>
 <use name="cuda"/>
-<use name="CUDADataFormats/EcalDigi" />
 <use name="CondFormats/EcalObjects"/>
 <use name="DataFormats/EcalDetId"/>
 <use name="DataFormats/EcalDigi"/>
 <use name="DataFormats/EcalRawData"/>
-<use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/FEDRawData"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/MessageLogger"/>

--- a/EventFilter/EcalRawToDigi/bin/BuildFile.xml
+++ b/EventFilter/EcalRawToDigi/bin/BuildFile.xml
@@ -3,5 +3,4 @@
     <use name="rootgraphics"/>
     <use name="DataFormats/Common"/>
     <use name="DataFormats/EcalDigi"/>
-    <use name="DataFormats/EcalDetId"/>
 </bin>

--- a/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
+++ b/GeneratorInterface/ExhumeInterface/test/BuildFile.xml
@@ -2,7 +2,7 @@
 <use name="FWCore/ParameterSet"/>
 <flags EDM_PLUGIN="1"/>
 <library file="ExhumeAnalyzer.cc" name="ExhumeAnalyzer">
-  <use name="DataFormats/Candidate"/>
+  <use name="DataFormats/HepMCCandidate"/>
   <use name="CommonTools/UtilAlgos"/>
   <use name="roothistmatrix"/>
 </library>

--- a/GeneratorInterface/TauolaInterface/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/BuildFile.xml
@@ -1,3 +1,4 @@
+<use name="DataFormats/HepMCCandidate"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>

--- a/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/TauolaInterface/plugins/BuildFile.xml
@@ -17,8 +17,6 @@
   <use name="FWCore/Framework"/>
   <use name="FWCore/ServiceRegistry"/>
   <use name="SimDataFormats/GeneratorProducts"/>
-  <use name="DataFormats/Candidate"/>
-  <use name="DataFormats/HepMCCandidate"/>
   <use name="tauolapp"/>
   <use name="lhapdf"/>
   <use name="root"/>

--- a/Geometry/VeryForwardGeometryBuilder/BuildFile.xml
+++ b/Geometry/VeryForwardGeometryBuilder/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="CondFormats/PPSObjects"/>
 <use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/DetId"/>
-<use name="DataFormats/Math"/>
 <use name="DetectorDescription/Core"/>
 <use name="DetectorDescription/DDCMS"/>
 <use name="FWCore/MessageLogger"/>

--- a/IOMC/EventVertexGenerators/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/BuildFile.xml
@@ -1,15 +1,13 @@
 <flags EDM_PLUGIN="1"/>
+<use name="DataFormats/HepMCCandidate"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="FWCore/Utilities"/>
 <use name="SimDataFormats/GeneratorProducts"/>
-<use name="boost"/>
 <use name="clhep"/>
-<use name="hepmc"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/BeamSpotObjects"/>
 <use name="CondFormats/PPSObjects"/>
 <use name="CondCore/DBOutputService"/>
-<use name="DataFormats/Candidate"/>

--- a/IOMC/EventVertexGenerators/test/BuildFile.xml
+++ b/IOMC/EventVertexGenerators/test/BuildFile.xml
@@ -1,7 +1,6 @@
 <environment>
   <use name="DataFormats/Common"/>
   <use name="FWCore/Framework"/>
-  <use name="boost"/>
   <use name="root"/>
   <use name="SimDataFormats/GeneratorProducts"/>
   <library file="VtxTester.cc" name="VtxSmearingTest">

--- a/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecAlgos/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="clhep"/>
 <use name="cuda"/>
-<use name="CUDADataFormats/EcalRecHitSoA"/>
 <use name="DataFormats/EcalRecHit"/>
 <use name="DataFormats/EcalDigi"/>
 <use name="FWCore/MessageLogger"/>

--- a/RecoLocalCalo/EcalRecProducers/BuildFile.xml
+++ b/RecoLocalCalo/EcalRecProducers/BuildFile.xml
@@ -1,10 +1,6 @@
 <use name="clhep"/>
 <use name="cuda"/>
-<use name="CUDADataFormats/EcalRecHitSoA"/>
-<use name="CondFormats/EcalObjects"/>
 <use name="FWCore/Framework"/>
-<use name="HeterogeneousCore/CUDACore"/>
-<use name="HeterogeneousCore/CUDAUtilities"/>
 
 <export>
   <lib name="1"/>

--- a/RecoLocalTracker/SiPixelClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/BuildFile.xml
@@ -1,7 +1,0 @@
-<use name="cuda"/>
-<use name="CalibTracker/SiPixelESProducers"/>
-<use name="FWCore/Utilities"/>
-<use name="HeterogeneousCore/CUDACore"/>
-<export>
-  <lib name="1"/>
-</export>

--- a/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/BuildFile.xml
@@ -15,8 +15,5 @@
 <use name="TrackingTools/KalmanUpdators"/>
 <use name="TrackingTools/TrajectoryParametrization"/>
 <use name="TrackingTools/TrajectoryState"/>
-<use name="TrackingTools/TrackAssociator"/>
-<use name="Geometry/CommonTopologies"/>
-<use name="DataFormats/L1TrackTrigger"/>
 <use name="clhep"/>
 <flags EDM_PLUGIN="1"/>

--- a/SimPPS/PPSPixelDigiProducer/BuildFile.xml
+++ b/SimPPS/PPSPixelDigiProducer/BuildFile.xml
@@ -1,5 +1,8 @@
+<use name="CondFormats/PPSObjects"/>
+<use name="DataFormats/CTPPSDigi"/>
+<use name="FWCore/ParameterSet"/>
+<use name="Geometry/VeryForwardGeometry"/>
 <use name="SimTracker/Common"/>
-<use name="RecoPPS/Local"/>
 <export>
   <lib name="1"/>
 </export>

--- a/SimPPS/PPSPixelDigiProducer/plugins/BuildFile.xml
+++ b/SimPPS/PPSPixelDigiProducer/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="CommonTools/UtilAlgos"/>
+<use name="CondFormats/DataRecord"/>
 <use name="SimPPS/PPSPixelDigiProducer"/>
 <use name="FWCore/ServiceRegistry"/>
 <library name="SimPPSPixelDigiProducerPlugins" file="*.cc">


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/32688).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

**Note:** This PR suggests to revert the changes of https://github.com/cms-sw/cmssw/pull/32553, https://github.com/cms-sw/cmssw/pull/32554, and https://github.com/cms-sw/cmssw/pull/32555. These PRs introduced dependency lines in the BuildFiles that were not needed by the corresponding build targets themselves, but actually these dependencies were missed in packages further up in the dependency hierarchy. I hope the few additions of `use="DataFormats/HepMCCandidate"` I made at what I think are the correct places would also fix the missing package dependency needed for UBSAN?

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.
