### PR TITLE
Remove a dead assignment in  DQMFEDIntegrityClient, and some little additional cleanup

### DIFF
--- a/DQMServices/Components/plugins/DQMFEDIntegrityClient.cc
+++ b/DQMServices/Components/plugins/DQMFEDIntegrityClient.cc
@@ -180,12 +180,9 @@ void DQMFEDIntegrityClient::fillHistograms() {
     MonitorElement* me = dbe_->get(*ent);
 
     if (TH1F* rootHisto = me->getTH1F()) {
-      int xmin = 0;
       int Nbins = me->getNbinsX();
-
       float entry = 0.;
-
-      xmin = (int)rootHisto->GetXaxis()->GetXmin();
+      int xmin = (int)rootHisto->GetXaxis()->GetXmin();
       if (*ent == "L1T/" + fedFolderName + "/FEDEntries")
         xmin = xmin + 800;
 
@@ -233,25 +230,19 @@ void DQMFEDIntegrityClient::fillHistograms() {
     MonitorElement* meNorm = dbe_->get(*ent);
     //      cout << "Path : " << me->getFullname() << endl;
 
-    int Nbins = me->getNbinsX();
-
     float entry = 0.;
     float norm = 0.;
 
     if (TH1F* rootHisto = me->getTH1F()) {
       if (TH1F* rootHistoNorm = meNorm->getTH1F()) {
-        int xmin = 0;
-        int xmax = 0;
-
-        xmin = (int)rootHisto->GetXaxis()->GetXmin();
+        int Nbins = me->getNbinsX();
+        int xmin = (int)rootHisto->GetXaxis()->GetXmin();
         if (*fat == "L1T/" + fedFolderName + "/FEDFatal")
           xmin = xmin + 800;
-
-        xmax = (int)rootHisto->GetXaxis()->GetXmax();
-        if (*fat == "L1T/" + fedFolderName + "/FEDFatal")
-          xmax = xmax + 800;
-
-        //      cout << "FED ID range : " << xmin << " - " << xmax << endl;
+        //        int xmax = (int)rootHisto->GetXaxis()->GetXmax();
+        //        if (*fat == "L1T/" + fedFolderName + "/FEDFatal")
+        //          xmax = xmax + 800;
+        //        cout << "FED ID range : " << xmin << " - " << xmax << endl;
 
         float binentry = 0.;
         for (int bin = 1; bin <= Nbins; ++bin) {
@@ -307,12 +298,9 @@ void DQMFEDIntegrityClient::fillHistograms() {
     MonitorElement* me = dbe_->get(*non);
 
     if (TH1F* rootHisto = me->getTH1F()) {
-      int xmin = 0;
       int Nbins = me->getNbinsX();
-
       float entry = 0.;
-
-      xmin = (int)rootHisto->GetXaxis()->GetXmin();
+      int xmin = (int)rootHisto->GetXaxis()->GetXmin();
       if (*non == "L1T/" + fedFolderName + "/FEDNonFatal")
         xmin = xmin + 800;
 


### PR DESCRIPTION
#### PR description:

A dead assignment of a variable only used by some commented out part of the code was found by the static analyzer, and it is fixed here. Some additional minor cleanup of the same file is also implemented.

#### PR validation:

It builds