### PR TITLE
Phase2-hgx274 Use constexpr rather than const in Geometry/HGCalCommonData

### DIFF
--- a/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
+++ b/Geometry/HGCalCommonData/interface/HGCalGeomTools.h
@@ -10,10 +10,10 @@ public:
   HGCalGeomTools();
   ~HGCalGeomTools() {}
 
-  static const int k_allCorners = 6;
-  static const int k_fiveCorners = 5;
-  static const int k_fourCorners = 4;
-  static const int k_threeCorners = 3;
+  static constexpr int k_allCorners = 6;
+  static constexpr int k_fiveCorners = 5;
+  static constexpr int k_fourCorners = 4;
+  static constexpr int k_threeCorners = 3;
 
   static void radius(double zf,
                      double zb,

--- a/Geometry/HGCalCommonData/interface/HGCalParameters.h
+++ b/Geometry/HGCalCommonData/interface/HGCalParameters.h
@@ -186,14 +186,14 @@ public:
   COND_SERIALIZABLE;
 
 private:
-  const int kMaskZside = 0x1;
-  const int kMaskLayer = 0x7F;
-  const int kMaskSector = 0x3FF;
-  const int kMaskSubSec = 0x1;
-  const int kShiftZside = 19;
-  const int kShiftLayer = 12;
-  const int kShiftSector = 1;
-  const int kShiftSubSec = 0;
+  static constexpr int kMaskZside = 0x1;
+  static constexpr int kMaskLayer = 0x7F;
+  static constexpr int kMaskSector = 0x3FF;
+  static constexpr int kMaskSubSec = 0x1;
+  static constexpr int kShiftZside = 19;
+  static constexpr int kShiftLayer = 12;
+  static constexpr int kShiftSector = 1;
+  static constexpr int kShiftSubSec = 0;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/interface/HGCalWaferMask.h
+++ b/Geometry/HGCalCommonData/interface/HGCalWaferMask.h
@@ -34,7 +34,7 @@ public:
   static std::vector<std::pair<double, double> > waferXY(
       int part, int orient, int zside, double delX, double delY, double xpos, double ypos);
 
-  static const int k_OffsetRotation = 10;
+  static constexpr int k_OffsetRotation = 10;
 };
 
 #endif

--- a/Geometry/HGCalCommonData/plugins/DDHGCalCell.cc
+++ b/Geometry/HGCalCommonData/plugins/DDHGCalCell.cc
@@ -156,11 +156,11 @@ void DDHGCalCell::execute(DDCompactView& cpv) {
                                 << tran << " with " << rot;
 #endif
 
-  static const int ir0[] = {0, 1, 0};
-  static const int ir1[] = {1, 2, 1};
-  static const int ir2[] = {2, 3, 3};
-  static const int ir3[] = {3, 4, 4};
-  static const int ir4[] = {5, 5, 5};
+  static constexpr int ir0[] = {0, 1, 0};
+  static constexpr int ir1[] = {1, 2, 1};
+  static constexpr int ir2[] = {2, 3, 3};
+  static constexpr int ir3[] = {3, 4, 4};
+  static constexpr int ir4[] = {5, 5, 5};
   for (unsigned int i = 0; i < truncCN_.size(); ++i) {
     std::vector<double> xw = {xx[ir0[i]], xx[ir1[i]], xx[ir2[i]], xx[ir3[i]], xx[ir4[i]]};
     std::vector<double> yw = {yy[ir0[i]], yy[ir1[i]], yy[ir2[i]], yy[ir3[i]], yy[ir4[i]]};
@@ -191,11 +191,11 @@ void DDHGCalCell::execute(DDCompactView& cpv) {
 #endif
   }
 
-  static const int ie0[] = {1, 5, 0};
-  static const int ie1[] = {2, 6, 1};
-  static const int ie2[] = {3, 7, 8};
-  static const int ie3[] = {10, 3, 9};
-  static const int ie4[] = {11, 4, 5};
+  static constexpr int ie0[] = {1, 5, 0};
+  static constexpr int ie1[] = {2, 6, 1};
+  static constexpr int ie2[] = {3, 7, 8};
+  static constexpr int ie3[] = {10, 3, 9};
+  static constexpr int ie4[] = {11, 4, 5};
   for (unsigned int i = 0; i < extenCN_.size(); ++i) {
     std::vector<double> xw = {xx[ie0[i]], xx[ie1[i]], xx[ie2[i]], xx[ie3[i]], xx[ie4[i]]};
     std::vector<double> yw = {yy[ie0[i]], yy[ie1[i]], yy[ie2[i]], yy[ie3[i]], yy[ie4[i]]};
@@ -226,11 +226,11 @@ void DDHGCalCell::execute(DDCompactView& cpv) {
 #endif
   }
 
-  static const int ic0[] = {0, 1, 1, 1, 1, 0};
-  static const int ic1[] = {1, 2, 2, 7, 3, 1};
-  static const int ic2[] = {8, 3, 3, 3, 4, 3};
-  static const int ic3[] = {3, 5, 10, 4, 5, 9};
-  static const int ic4[] = {5, 11, 5, 5, 6, 5};
+  static constexpr int ic0[] = {0, 1, 1, 1, 1, 0};
+  static constexpr int ic1[] = {1, 2, 2, 7, 3, 1};
+  static constexpr int ic2[] = {8, 3, 3, 3, 4, 3};
+  static constexpr int ic3[] = {3, 5, 10, 4, 5, 9};
+  static constexpr int ic4[] = {5, 11, 5, 5, 6, 5};
   for (unsigned int i = 0; i < cornrCN_.size(); ++i) {
     std::vector<double> xw = {xx[ic0[i]], xx[ic1[i]], xx[ic2[i]], xx[ic3[i]], xx[ic4[i]]};
     std::vector<double> yw = {yy[ic0[i]], yy[ic1[i]], yy[ic2[i]], yy[ic3[i]], yy[ic4[i]]};

--- a/Geometry/HGCalCommonData/src/FastTimeDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/FastTimeDDDConstants.cc
@@ -100,9 +100,9 @@ std::vector<GlobalPoint> FastTimeDDDConstants::getCorners(int type, int izeta, i
     z = -z;
     dz = -dz;
   }
-  static const int signx[8] = {-1, -1, 1, 1, -1, -1, 1, 1};
-  static const int signy[8] = {-1, 1, 1, -1, -1, 1, 1, -1};
-  static const int signz[8] = {-1, -1, -1, -1, 1, 1, 1, 1};
+  static constexpr int signx[8] = {-1, -1, 1, 1, -1, -1, 1, 1};
+  static constexpr int signy[8] = {-1, 1, 1, -1, -1, 1, 1, -1};
+  static constexpr int signz[8] = {-1, -1, -1, -1, 1, 1, 1, 1};
   std::vector<GlobalPoint> pts;
   for (unsigned int i = 0; i != 8; ++i) {
     GlobalPoint p(x + signx[i] * dx, y + signy[i] * dx, z + signz[i] * dz);

--- a/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
+++ b/Geometry/HGCalCommonData/src/HGCalDDDConstants.cc
@@ -1459,7 +1459,7 @@ void HGCalDDDConstants::cellHex(double xloc, double yloc, int cellType, int& cel
                                   << ":" << Rc << " u0 " << u0 << ":" << cu0 << " v0 " << v0 << ":" << cv0;
 #endif
   bool found(false);
-  static const int shift[3] = {0, 1, -1};
+  static constexpr int shift[3] = {0, 1, -1};
   for (int i1 = 0; i1 < 3; ++i1) {
     cellU = cu0 + shift[i1];
     for (int i2 = 0; i2 < 3; ++i2) {

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -343,28 +343,28 @@ int HGCalWaferMask::getRotation(int zside, int type, int rotn) {
   if ((zside < 0) && (type != HGCalTypes::WaferFull)) {
     if (type == HGCalTypes::WaferFive) {  //WaferFive
       static constexpr int rot1[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner4,
-                                                           HGCalTypes::WaferCorner3,
-                                                           HGCalTypes::WaferCorner2,
-                                                           HGCalTypes::WaferCorner1,
-                                                           HGCalTypes::WaferCorner0,
-                                                           HGCalTypes::WaferCorner5};
+                                                               HGCalTypes::WaferCorner3,
+                                                               HGCalTypes::WaferCorner2,
+                                                               HGCalTypes::WaferCorner1,
+                                                               HGCalTypes::WaferCorner0,
+                                                               HGCalTypes::WaferCorner5};
       newrotn = rot1[rotn];
     } else if ((type == HGCalTypes::WaferThree) || (type == HGCalTypes::WaferSemi) ||
                (type == HGCalTypes::WaferSemi2)) {  //WaferThree/WaferSemi/WaferSemi2
-      static constexpr  int rot2[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner2,
-                                                           HGCalTypes::WaferCorner1,
-                                                           HGCalTypes::WaferCorner0,
-                                                           HGCalTypes::WaferCorner5,
-                                                           HGCalTypes::WaferCorner4,
-                                                           HGCalTypes::WaferCorner3};
+      static constexpr int rot2[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner2,
+                                                               HGCalTypes::WaferCorner1,
+                                                               HGCalTypes::WaferCorner0,
+                                                               HGCalTypes::WaferCorner5,
+                                                               HGCalTypes::WaferCorner4,
+                                                               HGCalTypes::WaferCorner3};
       newrotn = rot2[rotn];
     } else {  //WaferHalf/WaferChopTwo/WaferChopTwoM
-      static constexpr  int rot3[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner3,
-                                                           HGCalTypes::WaferCorner2,
-                                                           HGCalTypes::WaferCorner1,
-                                                           HGCalTypes::WaferCorner0,
-                                                           HGCalTypes::WaferCorner5,
-                                                           HGCalTypes::WaferCorner4};
+      static constexpr int rot3[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner3,
+                                                               HGCalTypes::WaferCorner2,
+                                                               HGCalTypes::WaferCorner1,
+                                                               HGCalTypes::WaferCorner0,
+                                                               HGCalTypes::WaferCorner5,
+                                                               HGCalTypes::WaferCorner4};
       newrotn = rot3[rotn];
     }
   }
@@ -386,8 +386,8 @@ std::pair<int, int> HGCalWaferMask::getTypeMode(const double& xpos,
   int ncor(0), iok(0);
   int type(HGCalTypes::WaferFull), rotn(HGCalTypes::WaferCorner0);
 
-  static constexpr  int corners = 6;
-  static constexpr  int base = 10;
+  static constexpr int corners = 6;
+  static constexpr int base = 10;
   double rin2 = rin * rin;
   double rout2 = rout * rout;
   double dx0[corners] = {
@@ -414,9 +414,9 @@ std::pair<int, int> HGCalWaferMask::getTypeMode(const double& xpos,
     edm::LogVerbatim("HGCalGeom") << "I/p " << xpos << ":" << ypos << ":" << delX << ":" << delY << ":" << rin << ":"
                                   << rout << ":" << wType << ":" << mode << " Corners " << ncor << " iok " << iok;
 
-  static constexpr  int ipat5[corners] = {101111, 110111, 111011, 111101, 111110, 11111};
-  static constexpr  int ipat4[corners] = {100111, 110011, 111001, 111100, 11110, 1111};
-  static constexpr  int ipat3[corners] = {100011, 110001, 111000, 11100, 1110, 111};
+  static constexpr int ipat5[corners] = {101111, 110111, 111011, 111101, 111110, 11111};
+  static constexpr int ipat4[corners] = {100111, 110011, 111001, 111100, 11110, 1111};
+  static constexpr int ipat3[corners] = {100011, 110001, 111000, 11100, 1110, 111};
   double dx1[corners] = {HGCalTypes::c50 * delX,
                          HGCalTypes::c10 * delX,
                          HGCalTypes::c50 * delX,
@@ -545,10 +545,10 @@ bool HGCalWaferMask::goodTypeMode(
     return false;
   double rin2 = rin * rin;
   double rout2 = rout * rout;
-  static constexpr  int corners = HGCalTypes::WaferCornerMax;
-  static constexpr  int corner2 = 2 * HGCalTypes::WaferCornerMax;
-  static constexpr  int base = 10;
-  static constexpr  int base2 = 100;
+  static constexpr int corners = HGCalTypes::WaferCornerMax;
+  static constexpr int corner2 = 2 * HGCalTypes::WaferCornerMax;
+  static constexpr int base = 10;
+  static constexpr int base2 = 100;
   double dx0[corners] = {
       0.0, HGCalTypes::c10 * delX, HGCalTypes::c10 * delX, 0.0, -HGCalTypes::c10 * delX, -HGCalTypes::c10 * delX};
   double dy0[corners] = {-HGCalTypes::c10 * delY,
@@ -593,7 +593,7 @@ bool HGCalWaferMask::goodTypeMode(
   int ncf(-1);
   switch (part) {
     case (HGCalTypes::WaferThree): {
-      static constexpr  int nc0[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr int nc0[corners] = {450, 150, 201, 312, 423, 534};
       int nc = nc0[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -610,8 +610,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferSemi2): {
-      static constexpr  int nc10[corners] = {450, 150, 201, 312, 423, 534};
-      static constexpr  int nc11[corners] = {700, 902, 1104, 106, 308, 510};
+      static constexpr int nc10[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr int nc11[corners] = {700, 902, 1104, 106, 308, 510};
       int nc = nc10[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -641,8 +641,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferSemi): {
-      static constexpr  int nc20[corners] = {450, 150, 201, 312, 423, 534};
-      static constexpr  int nc21[corners] = {30, 14, 25, 30, 41, 52};
+      static constexpr int nc20[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr int nc21[corners] = {30, 14, 25, 30, 41, 52};
       int nc = nc20[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -672,7 +672,7 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferHalf): {
-      static constexpr  int nc3[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr int nc3[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
       int nc = nc3[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -689,8 +689,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferChopTwoM): {
-      static constexpr  int nc40[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
-      static constexpr  int nc41[corners] = {500, 702, 904, 1106, 108, 310};
+      static constexpr int nc40[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr int nc41[corners] = {500, 702, 904, 1106, 108, 310};
       int nc = nc40[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -720,8 +720,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferChopTwo): {
-      static constexpr  int nc50[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
-      static constexpr  int nc51[corners] = {20, 13, 24, 35, 40, 51};
+      static constexpr int nc50[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr int nc51[corners] = {20, 13, 24, 35, 40, 51};
       int nc = nc50[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -751,7 +751,7 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferFive): {
-      static constexpr  int nc6[corners] = {23450, 13450, 24501, 35012, 40123, 51234};
+      static constexpr int nc6[corners] = {23450, 13450, 24501, 35012, 40123, 51234};
       int nc = nc6[rotn];
       for (int k1 = 0; k1 < 5; ++k1) {
         int k = nc % base;

--- a/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
+++ b/Geometry/HGCalCommonData/src/HGCalWaferMask.cc
@@ -342,7 +342,7 @@ int HGCalWaferMask::getRotation(int zside, int type, int rotn) {
   int newrotn(rotn);
   if ((zside < 0) && (type != HGCalTypes::WaferFull)) {
     if (type == HGCalTypes::WaferFive) {  //WaferFive
-      static const int rot1[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner4,
+      static constexpr int rot1[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner4,
                                                            HGCalTypes::WaferCorner3,
                                                            HGCalTypes::WaferCorner2,
                                                            HGCalTypes::WaferCorner1,
@@ -351,7 +351,7 @@ int HGCalWaferMask::getRotation(int zside, int type, int rotn) {
       newrotn = rot1[rotn];
     } else if ((type == HGCalTypes::WaferThree) || (type == HGCalTypes::WaferSemi) ||
                (type == HGCalTypes::WaferSemi2)) {  //WaferThree/WaferSemi/WaferSemi2
-      static const int rot2[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner2,
+      static constexpr  int rot2[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner2,
                                                            HGCalTypes::WaferCorner1,
                                                            HGCalTypes::WaferCorner0,
                                                            HGCalTypes::WaferCorner5,
@@ -359,7 +359,7 @@ int HGCalWaferMask::getRotation(int zside, int type, int rotn) {
                                                            HGCalTypes::WaferCorner3};
       newrotn = rot2[rotn];
     } else {  //WaferHalf/WaferChopTwo/WaferChopTwoM
-      static const int rot3[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner3,
+      static constexpr  int rot3[HGCalTypes::WaferCornerMax] = {HGCalTypes::WaferCorner3,
                                                            HGCalTypes::WaferCorner2,
                                                            HGCalTypes::WaferCorner1,
                                                            HGCalTypes::WaferCorner0,
@@ -386,8 +386,8 @@ std::pair<int, int> HGCalWaferMask::getTypeMode(const double& xpos,
   int ncor(0), iok(0);
   int type(HGCalTypes::WaferFull), rotn(HGCalTypes::WaferCorner0);
 
-  static const int corners = 6;
-  static const int base = 10;
+  static constexpr  int corners = 6;
+  static constexpr  int base = 10;
   double rin2 = rin * rin;
   double rout2 = rout * rout;
   double dx0[corners] = {
@@ -414,9 +414,9 @@ std::pair<int, int> HGCalWaferMask::getTypeMode(const double& xpos,
     edm::LogVerbatim("HGCalGeom") << "I/p " << xpos << ":" << ypos << ":" << delX << ":" << delY << ":" << rin << ":"
                                   << rout << ":" << wType << ":" << mode << " Corners " << ncor << " iok " << iok;
 
-  static const int ipat5[corners] = {101111, 110111, 111011, 111101, 111110, 11111};
-  static const int ipat4[corners] = {100111, 110011, 111001, 111100, 11110, 1111};
-  static const int ipat3[corners] = {100011, 110001, 111000, 11100, 1110, 111};
+  static constexpr  int ipat5[corners] = {101111, 110111, 111011, 111101, 111110, 11111};
+  static constexpr  int ipat4[corners] = {100111, 110011, 111001, 111100, 11110, 1111};
+  static constexpr  int ipat3[corners] = {100011, 110001, 111000, 11100, 1110, 111};
   double dx1[corners] = {HGCalTypes::c50 * delX,
                          HGCalTypes::c10 * delX,
                          HGCalTypes::c50 * delX,
@@ -545,10 +545,10 @@ bool HGCalWaferMask::goodTypeMode(
     return false;
   double rin2 = rin * rin;
   double rout2 = rout * rout;
-  static const int corners = HGCalTypes::WaferCornerMax;
-  static const int corner2 = 2 * HGCalTypes::WaferCornerMax;
-  static const int base = 10;
-  static const int base2 = 100;
+  static constexpr  int corners = HGCalTypes::WaferCornerMax;
+  static constexpr  int corner2 = 2 * HGCalTypes::WaferCornerMax;
+  static constexpr  int base = 10;
+  static constexpr  int base2 = 100;
   double dx0[corners] = {
       0.0, HGCalTypes::c10 * delX, HGCalTypes::c10 * delX, 0.0, -HGCalTypes::c10 * delX, -HGCalTypes::c10 * delX};
   double dy0[corners] = {-HGCalTypes::c10 * delY,
@@ -593,7 +593,7 @@ bool HGCalWaferMask::goodTypeMode(
   int ncf(-1);
   switch (part) {
     case (HGCalTypes::WaferThree): {
-      static const int nc0[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr  int nc0[corners] = {450, 150, 201, 312, 423, 534};
       int nc = nc0[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -610,8 +610,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferSemi2): {
-      static const int nc10[corners] = {450, 150, 201, 312, 423, 534};
-      static const int nc11[corners] = {700, 902, 1104, 106, 308, 510};
+      static constexpr  int nc10[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr  int nc11[corners] = {700, 902, 1104, 106, 308, 510};
       int nc = nc10[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -641,8 +641,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferSemi): {
-      static const int nc20[corners] = {450, 150, 201, 312, 423, 534};
-      static const int nc21[corners] = {30, 14, 25, 30, 41, 52};
+      static constexpr  int nc20[corners] = {450, 150, 201, 312, 423, 534};
+      static constexpr  int nc21[corners] = {30, 14, 25, 30, 41, 52};
       int nc = nc20[rotn];
       for (int k1 = 0; k1 < 3; ++k1) {
         int k = nc % base;
@@ -672,7 +672,7 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferHalf): {
-      static const int nc3[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr  int nc3[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
       int nc = nc3[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -689,8 +689,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferChopTwoM): {
-      static const int nc40[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
-      static const int nc41[corners] = {500, 702, 904, 1106, 108, 310};
+      static constexpr  int nc40[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr  int nc41[corners] = {500, 702, 904, 1106, 108, 310};
       int nc = nc40[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -720,8 +720,8 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferChopTwo): {
-      static const int nc50[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
-      static const int nc51[corners] = {20, 13, 24, 35, 40, 51};
+      static constexpr  int nc50[corners] = {3450, 1450, 2501, 3012, 4123, 5234};
+      static constexpr  int nc51[corners] = {20, 13, 24, 35, 40, 51};
       int nc = nc50[rotn];
       for (int k1 = 0; k1 < 4; ++k1) {
         int k = nc % base;
@@ -751,7 +751,7 @@ bool HGCalWaferMask::goodTypeMode(
       break;
     }
     case (HGCalTypes::WaferFive): {
-      static const int nc6[corners] = {23450, 13450, 24501, 35012, 40123, 51234};
+      static constexpr  int nc6[corners] = {23450, 13450, 24501, 35012, 40123, 51234};
       int nc = nc6[rotn];
       for (int k1 = 0; k1 < 5; ++k1) {
         int k = nc % base;


### PR DESCRIPTION
#### PR description:

Use constexpr rather than const in Geometry/HGCalCommonData

#### PR validation:

Use the runTheMatrix test workflows 

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Nothing special