### PR TITLE
Update ECAL spike killer settings for Run 3, backport of #32701

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -71,15 +71,15 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
     'phase1_2021_design'       : '112X_mcRun3_2021_design_v12', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v14', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '112X_mcRun3_2021_realistic_v15', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v14',
+    'phase1_2021_cosmics'      : '112X_mcRun3_2021cosmics_realistic_deco_v15',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v14',
+    'phase1_2021_realistic_hi' : '112X_mcRun3_2021_realistic_HI_v15',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v14', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '112X_mcRun3_2023_realistic_v15', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v14', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '112X_mcRun3_2024_realistic_v15', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
     'phase2_realistic'         : '112X_mcRun4_realistic_v5'
 }


### PR DESCRIPTION
#### PR description:
This PR provides re-optimized ECAL spike killer settings for Run 3. Details of the payloads and their validation can be found in the [presentation at the 18 Jan 2021 AlCaDB meeting](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike).

The GT diffs are as follows:

**2021 realistic**
[https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v14/112X_mcRun3_2021_realistic_v15](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_v14/112X_mcRun3_2021_realistic_v15)

**2021 cosmics**
[https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v14/112X_mcRun3_2021cosmics_realistic_deco_v15](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021cosmics_realistic_deco_v14/112X_mcRun3_2021cosmics_realistic_deco_v15)

**2021 heavy ion**
[https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v14/112X_mcRun3_2021_realistic_HI_v15](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2021_realistic_HI_v14/112X_mcRun3_2021_realistic_HI_v15)

**2023 realistic**
[https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v14/112X_mcRun3_2023_realistic_v15
](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2023_realistic_v14/112X_mcRun3_2023_realistic_v15
)
**2024 realistic**
[https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v14/112X_mcRun3_2024_realistic_v15](https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/112X_mcRun3_2024_realistic_v14/112X_mcRun3_2024_realistic_v15)

#### PR validation:

The payloads were validated by explicitly comparing dumps of the new payload with the old (see [slide 5](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike)) and checking the performance with re-emulated trigger primitives (see [slide 6](https://indico.cern.ch/event/994978/#2-updated-tags-for-ecal-spike)).

In addition, a technical test was performed for PR #32701 (not for this PR):

runTheMatrix.py -l limited,12024.0,7.23,159.0,12834.0 --ibeos

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is a backport of #32701 .
