### PR TITLE
Add setStatOverflows to get the mean value including the overflow

### DIFF
--- a/Validation/RecoParticleFlow/plugins/OffsetAnalyzerDQM.cc
+++ b/Validation/RecoParticleFlow/plugins/OffsetAnalyzerDQM.cc
@@ -37,6 +37,7 @@ private:
     virtual void book(DQMStore::IBooker& booker) {
       booker.setCurrentFolder(dir);
       plot = booker.book1D(name, title, nxbins, xlow, xhigh);
+      plot->setStatOverflows(kTRUE);
     }
 
     virtual void fill(float value) {


### PR DESCRIPTION
#### PR description:

It looks like somehow the behavior of getting the mean from the histogram changed. For offset plots, we wanted to get the mean of mu (true number of PU) and npv (number of primary vertex) including the overflow bin, but this wasn't the case any longer, and the code was picking up means from the visible range. This resulted in picking up offset histograms from lower npv than desired.

You can see the change from 11_2_0_pre9 to 11_3_0_pre1:
https://tinyurl.com/y4pudarn

#### PR validation:

Run the validation sequence with this change, and made sure now we can pick up mean including the overview.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not backport.

@bendavid @juska 
