### PR TITLE
[DD4hep] Fix DDFilteredView unit test for DD4hep with Geant4 units

### DIFF
--- a/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
+++ b/DetectorDescription/DDCMS/test/DDFilteredView.cppunit.cc
@@ -111,12 +111,13 @@ void testDDFilteredView::checkFilteredView() {
     count++;
   }
 
-  std::cout << "Get LongFL from hf as string values:\n";
+  std::cout << "Get LongFL from hf as numerically evaluated string values:\n";
   count = 0;
   std::vector<std::string> sLongFL = fview.get<std::vector<std::string>>("hf", "LongFL");
   for (auto const& i : sLongFL) {
-    std::cout << "LongFL " << i << " == " << refsLongFL_[count] << "\n";
-    CPPUNIT_ASSERT(abs(std::stod(i) - std::stod(refsLongFL_[count])) < 10e-6);
+    double dblVal = std::stod(i) / dd4hep::cm;  // Convert DD4hep units to cm
+    std::cout << "LongFL " << dblVal << " == " << refsLongFL_[count] << "\n";
+    CPPUNIT_ASSERT(abs(dblVal - std::stod(refsLongFL_[count])) < 10e-6);
     count++;
   }
 


### PR DESCRIPTION
With the switch to DD4hep using the Geant4 units convention, a problem in a `DDFilteredView` unit test was revealed. An earlier change meant that numeric SpecPars with "eval=true" are always evaluated. There was old code in this unit test that assumed unevaluated string values of numerics could be fetched, and this code happened to work as long as the ROOT units convention was in effect. With the units convention change, this code no longer worked and needed a fix.

#### PR validation:

The code was changed to be invariant under units change, so it should work with the new units convention. But my attempts to test with the cmsdist PR were not successful, so that PR will instead need to be tested against this one.

No backport is needed.