### PR TITLE
Updates to the L1 prefiring weight producer 

### DIFF
--- a/PhysicsTools/NanoAOD/python/nano_eras_cff.py
+++ b/PhysicsTools/NanoAOD/python/nano_eras_cff.py
@@ -5,6 +5,9 @@ from Configuration.Eras.Modifier_run2_jme_2016_cff import run2_jme_2016
 from Configuration.Eras.Modifier_run2_jme_2017_cff import run2_jme_2017
 from Configuration.Eras.Modifier_run2_muon_2016_cff import run2_muon_2016
 
+from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
+from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
+
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 from Configuration.Eras.Modifier_run2_nanoAOD_92X_cff import run2_nanoAOD_92X
 from Configuration.Eras.Modifier_run2_nanoAOD_94XMiniAODv1_cff import run2_nanoAOD_94XMiniAODv1

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -219,7 +219,13 @@ run2_HLTconditions_2016.toModify(
 )
 
 from PhysicsTools.PatUtils.L1ECALPrefiringWeightProducer_cff import prefiringweight
-run2_HLTconditions_2016.toModify(prefiringweight, DataEra = cms.string("2016BtoH"))
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+from PhysicsTools.NanoAOD.common_cff import *
+run2_jme_2016.toModify( prefiringweight, DataEra = cms.string("2016BtoH"))
+run2_jme_2017.toModify( prefiringweight, DataEra = cms.string("UL2017BtoF"))
+for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
+    modifier.toModify( prefiringweight, DataEra = cms.string("2017BtoF"))
+
 
 l1PreFiringEventWeightTable = cms.EDProducer("GlobalVariablesTableProducer",
     variables = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Modifier_run2_HLTconditions_2016_cff import run2_HLTconditions_2016
-from Configuration.Eras.Modifier_run2_HLTconditions_2017_cff import run2_HLTconditions_2017
-from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
-from PhysicsTools.NanoAOD.common_cff import ExtVar
+from PhysicsTools.NanoAOD.nano_eras_cff import *
+from PhysicsTools.NanoAOD.common_cff import *
 import copy
 
 unpackedPatTrigger = cms.EDProducer("PATTriggerObjectStandAloneUnpacker",
@@ -219,8 +217,6 @@ run2_HLTconditions_2016.toModify(
 )
 
 from PhysicsTools.PatUtils.L1ECALPrefiringWeightProducer_cff import prefiringweight
-from PhysicsTools.NanoAOD.nano_eras_cff import *
-from PhysicsTools.NanoAOD.common_cff import *
 #Next line will be updated once we get UL2016 maps
 run2_jme_2016.toModify( prefiringweight, DataEra = cms.string("2016BtoH"))
 #Next line is for UL2017 maps 
@@ -232,9 +228,6 @@ for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
 #For pre-UL 2016 reprocessing, same thing
 run2_nanoAOD_94X2016.toModify( prefiringweight, DataEra = cms.string("2016BtoH") )
 run2_nanoAOD_94X2016.toModify( prefiringweight, JetMaxMuonFraction = cms.double(-1.) )
-#For first UL reNANOAOD (run2_nanoAOD_106Xv1), same thing
-run2_nanoAOD_106Xv1.toModify( prefiringweight, JetMaxMuonFraction = cms.double(-1.) )
-#One still needs to correct the maps for run2_nanoAOD_106Xv1: it should be "2016BtoH" for 2016 and "2017BtoF" for 2017, not sure how to do that...
 
 l1PreFiringEventWeightTable = cms.EDProducer("GlobalVariablesTableProducer",
     variables = cms.PSet(

--- a/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
+++ b/PhysicsTools/NanoAOD/python/triggerObjects_cff.py
@@ -221,11 +221,20 @@ run2_HLTconditions_2016.toModify(
 from PhysicsTools.PatUtils.L1ECALPrefiringWeightProducer_cff import prefiringweight
 from PhysicsTools.NanoAOD.nano_eras_cff import *
 from PhysicsTools.NanoAOD.common_cff import *
+#Next line will be updated once we get UL2016 maps
 run2_jme_2016.toModify( prefiringweight, DataEra = cms.string("2016BtoH"))
+#Next line is for UL2017 maps 
 run2_jme_2017.toModify( prefiringweight, DataEra = cms.string("UL2017BtoF"))
+#For pre-UL 2017 reprocessing, one should use the original maps and no muon jet protection  
 for modifier in run2_nanoAOD_94XMiniAODv1, run2_nanoAOD_94XMiniAODv2:
     modifier.toModify( prefiringweight, DataEra = cms.string("2017BtoF"))
-
+    modifier.toModify( prefiringweight, JetMaxMuonFraction = cms.double(-1.) )
+#For pre-UL 2016 reprocessing, same thing
+run2_nanoAOD_94X2016.toModify( prefiringweight, DataEra = cms.string("2016BtoH") )
+run2_nanoAOD_94X2016.toModify( prefiringweight, JetMaxMuonFraction = cms.double(-1.) )
+#For first UL reNANOAOD (run2_nanoAOD_106Xv1), same thing
+run2_nanoAOD_106Xv1.toModify( prefiringweight, JetMaxMuonFraction = cms.double(-1.) )
+#One still needs to correct the maps for run2_nanoAOD_106Xv1: it should be "2016BtoH" for 2016 and "2017BtoF" for 2017, not sure how to do that...
 
 l1PreFiringEventWeightTable = cms.EDProducer("GlobalVariablesTableProducer",
     variables = cms.PSet(

--- a/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
@@ -55,6 +55,7 @@ private:
   std::string dataera_;
   bool useEMpt_;
   double prefiringRateSystUnc_;
+  double jetMaxMuonFraction_;
   bool skipwarnings_;
 };
 
@@ -65,6 +66,7 @@ L1ECALPrefiringWeightProducer::L1ECALPrefiringWeightProducer(const edm::Paramete
   dataera_ = iConfig.getParameter<std::string>("DataEra");
   useEMpt_ = iConfig.getParameter<bool>("UseJetEMPt");
   prefiringRateSystUnc_ = iConfig.getParameter<double>("PrefiringRateSystematicUncty");
+  jetMaxMuonFraction_ = iConfig.getParameter<double>("JetMaxMuonFraction");
   skipwarnings_ = iConfig.getParameter<bool>("SkipWarnings");
 
   TFile* file_prefiringmaps_;
@@ -135,7 +137,8 @@ void L1ECALPrefiringWeightProducer::produce(edm::StreamID, edm::Event& iEvent, c
         continue;
       if (fabs(eta_jet) > 3.)
         continue;
-
+      if (jetMaxMuonFraction_ > 0 && jet.muonEnergyFraction() > jetMaxMuonFraction_)
+        continue;
       //Loop over photons to remove overlap
       double nonprefiringprobfromoverlappingphotons = 1.;
       for (const auto& photon : *thePhotons) {
@@ -219,6 +222,7 @@ void L1ECALPrefiringWeightProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::string>("DataEra", "2017BtoF");
   desc.add<bool>("UseJetEMPt", false);
   desc.add<double>("PrefiringRateSystematicUncty", 0.2);
+  desc.add<double>("JetMaxMuonFraction", -1);
   desc.add<bool>("SkipWarnings", true);
   descriptions.add("l1ECALPrefiringWeightProducer", desc);
 }

--- a/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc
@@ -222,7 +222,7 @@ void L1ECALPrefiringWeightProducer::fillDescriptions(edm::ConfigurationDescripti
   desc.add<std::string>("DataEra", "2017BtoF");
   desc.add<bool>("UseJetEMPt", false);
   desc.add<double>("PrefiringRateSystematicUncty", 0.2);
-  desc.add<double>("JetMaxMuonFraction", -1);
+  desc.add<double>("JetMaxMuonFraction", 0.5);
   desc.add<bool>("SkipWarnings", true);
   descriptions.add("l1ECALPrefiringWeightProducer", desc);
 }


### PR DESCRIPTION
#### PR description:

This PR provides updates the L1 prefiring weight producer. 
This is a revised version of https://github.com/cms-sw/cmssw/pull/32542 that includes some update and fixes conflicts with recent commits. 

1. Protection against muon jets ( PhysicsTools/PatUtils/plugins/L1ECALPrefiringWeightProducer.cc )
In the L1 prefiring weight producer, a customized protection is added to veto jets mostly made of muons that have very little chance to prefire (since prefiring is related to the jet EM energy). 
The default setting considers only jets with a muon energy fraction <0.5. A value of -1 can be used to switch off the protection.
Physics wise, the change has often a negligible impact, except for (very) precise measurements including muons in the final states (e.g. Wmass) or final states involving high pt forward muons (e.g. Z'->mumu).

2. Link to new UL2017 maps and enabling/disabling the muon jet protection. (PhysicsTools/NanoAOD/python/triggerObjects_cff.py)  
- New prefiring maps for Ultra Legacy 2017 are now available and merged in:  
https://github.com/cms-data/PhysicsTools-PatUtils/pull/1
- The updated UL2017 maps and the muon jet protection are used by default for next campaigns. 
- Earlier configurations can be retrieved through modifiers. 
- I still have issue figuring out how to properly configure the producer for the modifier "run2_nanoAOD_106Xv1" (since different maps need to be used for 2016 and 2017). 

 
#### PR validation:

Validation of the muon protection (setting JetMaxMuonFraction = 0.5) was performed on a QCD and a high mass Z->mumu samples. 
QCD is untouched, prefiring weights increase as expected in ZMuMu. 
![prefQCDHT500To700](https://user-images.githubusercontent.com/4995867/102618627-6c40e400-413b-11eb-8ddd-8829bc64f7ee.png)
![prefPRzmumum400to800](https://user-images.githubusercontent.com/4995867/102618628-6cd97a80-413b-11eb-9f84-b6102f2d85d4.png)

The new maps were presented at this meeting: 
https://indico.cern.ch/event/985369/#3-ul2017-prefiring-maps-tbc


#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a backport. I understand a backport is needed for 10_6_X. Do we also need one for 11_2? Thanks ! 
