### PR TITLE
Fix the PFBlockElement casting in PFEGammaAlgo (use the right element type)

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -88,11 +88,11 @@ namespace {
                                const size_t test,
                                const float EoPin_cut = 1.0e6) {
     constexpr reco::PFBlockElement::TrackType ConvType = reco::PFBlockElement::T_FROM_GAMMACONV;
+    auto elemkey = &(block->elements()[key]);
     // this is inside out but I just want something that works right now
-    switch (keytype) {
+    switch (elemkey->type()) {
       case reco::PFBlockElement::GSF: {
-        const reco::PFBlockElementGsfTrack* elemasgsf =
-            docast(const reco::PFBlockElementGsfTrack*, &(block->elements()[key]));
+        const reco::PFBlockElementGsfTrack* elemasgsf = docast(const reco::PFBlockElementGsfTrack*, elemkey);
         if (elemasgsf && valtype == PFBlockElement::ECAL) {
           const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
           float cluster_e = elemasclus->clusterRef()->correctedEnergy();
@@ -104,7 +104,7 @@ namespace {
         }
       } break;
       case reco::PFBlockElement::TRACK: {
-        const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, &(block->elements()[key]));
+        const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, elemkey);
         if (elemaskf && valtype == PFBlockElement::ECAL) {
           const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
           float cluster_e = elemasclus->clusterRef()->correctedEnergy();

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -39,7 +39,7 @@
 #define LOGERR(x) edm::LogError(x)
 #define LOGDRESSED(x) edm::LogInfo(x)
 #else
-#define docast(x, y) reinterpret_cast<x>(y)
+#define docast(x, y) static_cast<x>(y)
 #define LOGVERB(x) LogTrace(x)
 #define LOGWARN(x) edm::LogWarning(x)
 #define LOGERR(x) edm::LogError(x)
@@ -94,7 +94,7 @@ namespace {
       case reco::PFBlockElement::GSF: {
         const reco::PFBlockElementGsfTrack* elemasgsf = docast(const reco::PFBlockElementGsfTrack*, elemkey);
         if (elemasgsf && valtype == PFBlockElement::ECAL) {
-          const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+          const ClusterElement* elemasclus = static_cast<const ClusterElement*>(&(block->elements()[test]));
           float cluster_e = elemasclus->clusterRef()->correctedEnergy();
           float trk_pin = elemasgsf->Pin().P();
           if (cluster_e / trk_pin > EoPin_cut) {
@@ -106,7 +106,7 @@ namespace {
       case reco::PFBlockElement::TRACK: {
         const reco::PFBlockElementTrack* elemaskf = docast(const reco::PFBlockElementTrack*, elemkey);
         if (elemaskf && valtype == PFBlockElement::ECAL) {
-          const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+          const ClusterElement* elemasclus = static_cast<const ClusterElement*>(&(block->elements()[test]));
           float cluster_e = elemasclus->clusterRef()->correctedEnergy();
           float trk_pin = std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
           if (cluster_e / trk_pin > EoPin_cut) {
@@ -148,7 +148,7 @@ namespace {
           if (!useConvs && elemaskf->trackType(ConvType))
             return false;
           if (elemaskf && valtype == PFBlockElement::ECAL) {
-            const ClusterElement* elemasclus = reinterpret_cast<const ClusterElement*>(&(block->elements()[test]));
+            const ClusterElement* elemasclus = static_cast<const ClusterElement*>(&(block->elements()[test]));
             float cluster_e = elemasclus->clusterRef()->correctedEnergy();
             float trk_pin = std::sqrt(elemaskf->trackRef()->innerMomentum().mag2());
             if (cluster_e / trk_pin > EoPin_cut)

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1998,8 +1998,7 @@ void PFEGammaAlgo::unlinkRefinableObjectKFandECALMatchedToHCAL(ProtoEGObject& RO
       if (RO.localMap.contains(ecal->get(), *secd_kf)) {
         auto hcal_matched = std::partition(hcal_begin, hcal_end, tracksToHCALs);
         for (auto hcalclus = hcal_begin; hcalclus != hcal_matched; ++hcalclus) {
-          const reco::PFBlockElementCluster* clusthcal =
-              dynamic_cast<const reco::PFBlockElementCluster*>(hcalclus->get());
+          const reco::PFBlockElementCluster* clusthcal = docast(const reco::PFBlockElementCluster*, hcalclus->get());
           const double hcalenergy = clusthcal->clusterRef()->energy();
           const double hpluse = ecalenergy + hcalenergy;
           const bool isHoHE = ((hcalenergy / hpluse) > 0.1 && goodTrack);


### PR DESCRIPTION
#### PR description:

This is meant to address: #27553.
The problem was happening when, for a given KF track, we look for ECAL elements not used or closer to a GSF track for linking, as far as I understand. The casting of PFBlockElement has been done assuming GSF track even for a KF track. Now, for a KF track, we perform casting assuming a KF track.

#### PR validation:

Under CMSSW_11_3_UBSAN_X_2021-01-22-2300, I made sure we no longer get the error reported in #27553.
Before this change, _float trk_pin = elemasgsf->Pin().P();_ was giving non-sensible numbers because of bad cast. Now, we get realistic trk_pin. At the end, it looks like no change in electrons, because of a very loose EoverP cut used in elementNotCloserToOther.

I checked 1000 ZEE events, and didn't see any change in electrons in miniaod.
Also, jenkins test see no change.

@guitargeek @lgray how does this proposed update look for you?

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not backport.

@bendavid @guitargeek @Dr15Jones @jainshilpi @zeratul87
