### PR TITLE
fix undefined behavior in fmt_test.cppunit

### DIFF
--- a/FWCore/MessageService/test/fmt_test.cppunit.cpp
+++ b/FWCore/MessageService/test/fmt_test.cppunit.cpp
@@ -57,7 +57,7 @@ void test_fmt_external::test_fmt()
   std::apply(print_message, args);
   fmt::memory_buffer buf;
   format_to(buf, "{}", 42);  // replaces itoa(42, buffer, 10)
-  fmt::print(buf.data());
+  fmt::print(to_string(buf));
   format_to(buf, "{:x}", 42);  // replaces itoa(42, buffer, 16)
   fmt::print(to_string(buf));
 }


### PR DESCRIPTION
#### PR description:

`fat::format_to()` doesn't guarantee null-termination, so doing `fmt::print(buf.data())` may print off the end of buffer.  This can result in garbage printouts on some architectures.

#### PR validation:
On slc7_aarch64_gcc9, before:
```
-bash-4.2$ ../test/slc7_aarch64_gcc9/fmt_test.cppunit | cat -v
Running .42 foo42M-^RM-qM-^?^C422a
```
After:
```
-bash-4.2$ ../test/slc7_aarch64_gcc9/fmt_test.cppunit | cat -v
Running .42 foo42422a
```