### PR TITLE
update of GT with HLT JECs for Phase-2

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -79,7 +79,7 @@ autoCond = {
     # GlobalTag for MC production with realistic conditions for Phase1 2024
     'phase1_2024_realistic'    : '111X_mcRun3_2024_realistic_v7', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v3'
+    'phase2_realistic'         : '111X_mcRun4_realistic_T15_v4'
 }
 
 aliases = {


### PR DESCRIPTION
#### PR description:

This PR updates Global Tag with HLT JECs needed for Phase-2 DAQ/HLT TDR studies. 
A presentation was given in the [AlCaDB meeting](https://indico.cern.ch/event/997607/#5-phase-2-hlt-tdr-studies-new) of January 25, 2021. A [request](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/4369.html) was made in AlCaDB Hypernews on January 15, 2021.

Note: this update is for release 11_1_X needed for the Phase-2 DAQ/HLT TDR studies, **not** for master.

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_mcRun4_realistic_T15_v3/111X_mcRun4_realistic_T15_v4

#### PR validation:

Validation presented in the [AlCaDB meeting](https://indico.cern.ch/event/997607/#5-phase-2-hlt-tdr-studies-new) .

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport.  No backport is needed.  This PR will not go to master or other releases.
