### PR TITLE
include missing dependencies

### DIFF
--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -9,6 +9,8 @@
 <use name="DataFormats/HcalIsolatedTrack"/>
 <use name="DataFormats/TauReco"/>
 <use name="DataFormats/L1TParticleFlow"/>
+<use name="DataFormats/L1TCorrelator"/>
+<use name="FWCore/MessageLogger"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/L1TParticleFlow/BuildFile.xml
+++ b/DataFormats/L1TParticleFlow/BuildFile.xml
@@ -1,5 +1,9 @@
 <use name="DataFormats/L1Trigger"/>
 <use name="DataFormats/L1TrackTrigger"/>
+<use name="DataFormats/Candidate"/>
+<use name="DataFormats/Common"/>
+<use name="DataFormats/L1TCorrelator"/>
+<use name="FWCore/Utilities"/>
 <use name="rootrflx"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
Adding missing dependencies (packages directly #included but not listed in the BuildFile.xml) which are causing errors in the modules ib.