### PR TITLE
Add missing FWCore/Utilities dependency to RecoLocalTracker/SiPixelClusterizer plugins and test

### DIFF
--- a/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/plugins/BuildFile.xml
@@ -7,6 +7,7 @@
 <use name="DataFormats/SiPixelCluster"/>
 <use name="EventFilter/SiPixelRawToDigi"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use name="RecoLocalTracker/SiPixelClusterizer"/>
 <use name="RecoTracker/Record"/>

--- a/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
+++ b/RecoLocalTracker/SiPixelClusterizer/test/BuildFile.xml
@@ -9,6 +9,7 @@
 <use name="DataFormats/VertexReco"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
+<use name="FWCore/Utilities"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
 <use name="L1Trigger/GlobalTriggerAnalyzer"/>

--- a/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/test/ReadPixClusters.cc
@@ -18,12 +18,10 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-//#include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-//#include "FWCore/Utilities/interface/EDGetToken.h"  // not needed
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/Common/interface/DetSetVector.h"


### PR DESCRIPTION
#### PR description:

This is the followup to https://github.com/cms-sw/cmssw/pull/32714 requested by @perrotta.

#### PR validation:

CMSSW compiles.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

No backport intended.