### PR TITLE
Sort the imports in the split configurations

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -1035,7 +1035,10 @@ class Process(object):
                 sub = options.targetDirectory + '/' + sub
             files[sub + '/__init__.py'] = ''
 
-        for (name, (subfolder, code)) in six.iteritems(parts):
+        # case insensitive sort by subfolder and module name
+        parts = sorted(parts.items(), key = lambda nsc: (nsc[1][0].lower() if nsc[1][0] else '', nsc[0].lower()))
+
+        for (name, (subfolder, code)) in parts:
             filename = name + '_cfi'
             if options.useSubdirectories and subfolder:
                 filename = subfolder + '/' + filename
@@ -1046,7 +1049,7 @@ class Process(object):
 
         if self.schedule_() is not None:
             options.isCfg = True
-            result += 'process.schedule = ' + self.schedule.dumpPython(options)
+            result += '\nprocess.schedule = ' + self.schedule.dumpPython(options)
 
         imports = specialImportRegistry.getSpecialImports()
         if len(imports) > 0:

--- a/FWCore/ParameterSet/python/SequenceTypes.py
+++ b/FWCore/ParameterSet/python/SequenceTypes.py
@@ -211,7 +211,7 @@ class _SequenceCollection(_Sequenceable):
 
 
 def findDirectDependencies(element, collection):
-    dependencies = []
+    dependencies = set()
     for item in collection:
         # skip null items
         if item is None:
@@ -223,23 +223,23 @@ def findDirectDependencies(element, collection):
         # cms.ignore(module), ~(module)
         elif isinstance(item, (_SequenceIgnore, _SequenceNegation)):
             if isinstance(item._operand, _SequenceCollection):
-                dependencies += item.directDependencies()
+                dependencies.update(item.directDependencies())
                 continue
             t = 'modules'
         # _SequenceCollection
         elif isinstance(item, _SequenceCollection):
-            dependencies += item.directDependencies()
+            dependencies.update(item.directDependencies())
             continue
         # cms.Sequence
         elif isinstance(item, Sequence):
             if not item.hasLabel_():
-                dependencies += item.directDependencies()
+                dependencies.update(item.directDependencies())
                 continue
             t = 'sequences'
         # cms.Task
         elif isinstance(item, Task):
             if not item.hasLabel_():
-                dependencies += item.directDependencies()
+                dependencies.update(item.directDependencies())
                 continue
             t = 'tasks'
         # SequencePlaceholder and TaskPlaceholder do not add an explicit dependency
@@ -249,8 +249,8 @@ def findDirectDependencies(element, collection):
         else:
             sys.stderr.write("Warning: unsupported element '%s' in %s '%s'\n" % (str(item), type(element).__name__, element.label_()))
             continue
-        dependencies.append((t, item.label_()))
-    return dependencies
+        dependencies.add((t, item.label_()))
+    return sorted(dependencies, key = lambda t_item: (t_item[0].lower(), t_item[1].lower().replace('_cfi', '')))
 
 
 class _ModuleSequenceType(_ConfigureComponent, _Labelable):


### PR DESCRIPTION
#### PR description:

When generating a split configuration, sort the import in each file by section and by module name.

For example, before:
```python
from ..modules.l1tPFPuppiHT_cfi import *
from ..modules.l1tPFPuppiHT450off_cfi import *
from ..sequences.HLTParticleFlowSequence_cfi import *
from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
from ..modules.hltPFPuppiHT_cfi import *
from ..modules.hltPFPuppiHT1050_cfi import *
```
after:
```python
from ..modules.hltPFPuppiHT_cfi import *
from ..modules.hltPFPuppiHT1050_cfi import *
from ..modules.l1tPFPuppiHT_cfi import *
from ..modules.l1tPFPuppiHT450off_cfi import *
from ..sequences.HLTAK4PFPuppiJetsReconstruction_cfi import *
from ..sequences.HLTParticleFlowSequence_cfi import *
```

#### PR validation:

None.