### PR TITLE
Add L1T fractional prescale record

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -12,76 +12,76 @@ autoCond = {
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '113X_mcRun2_startup_v1',
     # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
-    'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v1',
+    'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '113X_mcRun2_design_v1',
+    'run2_design'       :   '113X_mcRun2_design_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, prior to VFP change
-    'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v1',
+    'run2_mc_pre_vfp'   :   '113X_mcRun2_asymptotic_preVFP_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for 2016, after VFP change
-    'run2_mc'           :   '113X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '113X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (cosmics) with starup-like alignment and calibrations for Run2, Strip tracker in peak mode
-    'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v1',
+    'run2_mc_cosmics'   :   '113X_mcRun2cosmics_asymptotic_deco_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '113X_mcRun2_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run2
-    'run2_mc_pa'        :   '113X_mcRun2_pA_v1',
+    'run2_mc_pa'        :   '113X_mcRun2_pA_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '113X_dataRun2_v1',
+    'run1_data'         :   '113X_dataRun2_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '113X_dataRun2_v1',
+    'run2_data'         :   '113X_dataRun2_v2',
     # GlobalTag for Run2 data 2018B relvals only: HEM-15-16 fail
-    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v1',
+    'run2_data_HEfail'  :   '113X_dataRun2_HEfail_v2',
     # GlobalTag for Run2 data relvals: allows customization to run with fixed L1 menu
-    'run2_data_relval'  :   '113X_dataRun2_relval_v1',
+    'run2_data_relval'  :   '113X_dataRun2_relval_v2',
     # GlobalTag for Run2 HI data
-    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v1',
+    'run2_data_promptlike_hi' : '113X_dataRun2_PromptLike_HI_v2',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '101X_dataRun2_HLT_frozen_v11',
     # GlobalTag for Run2 HLT RelVals: customizations to run with fixed L1 Menu
-    'run2_hlt_relval'      :   '103X_dataRun2_HLT_relval_v10',
-    'run2_hlt_relval_hi'   :   '103X_dataRun2_HLT_relval_HI_v6',
+    'run2_hlt_relval'      :   '112X_dataRun2_HLT_relval_v2',
+    'run2_hlt_relval_hi'   :   '112X_dataRun2_HLT_relval_HI_v1',
     # GlobalTag for Run2 HLT for HI (not 2018 HI): it points to the online GT
     'run2_hlt_hi'       :   '101X_dataRun2_HLTHI_frozen_v11',
     # GlobalTag for Run3 data relvals (express GT)
-    'run3_data_express'        :   '111X_dataRun3_Express_v4',
+    'run3_data_express'        :   '112X_dataRun3_Express_v1',
     # GlobalTag for Run3 data relvals
-    'run3_data_promptlike'     :   '111X_dataRun3_Prompt_v5',
+    'run3_data_promptlike'     :   '112X_dataRun3_Prompt_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,~0-centred beamspot)
-    'phase1_2017_design'       :  '113X_mc2017_design_v2',
+    'phase1_2017_design'       :  '113X_mc2017_design_v3',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v2',
+    'phase1_2017_realistic'    :  '113X_mc2017_realistic_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in DECO mode
-    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v2',
+    'phase1_2017_cosmics'      :  '113X_mc2017cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic alignment and calibrations for Phase1 2017 detector, Strip tracker in PEAK mode
-    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v2',
+    'phase1_2017_cosmics_peak' :  '113X_mc2017cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for full Phase1 2018 (and 0,0,0-centred beamspot)
-    'phase1_2018_design'       :  '113X_upgrade2018_design_v2',
+    'phase1_2018_design'       :  '113X_upgrade2018_design_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector
-    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v2',
+    'phase1_2018_realistic'    :  '113X_upgrade2018_realistic_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector for Heavy Ion
-    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v2',
+    'phase1_2018_realistic_hi' :  '113X_upgrade2018_realistic_HI_v3',
     # GlobalTag for MC production with realistic conditions for full Phase1 2018 detector: HEM-15-16 fail
-    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v2',
+    'phase1_2018_realistic_HEfail' :  '113X_upgrade2018_realistic_HEfail_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in DECO mode
-    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v2',
+    'phase1_2018_cosmics'      :  '113X_upgrade2018cosmics_realistic_deco_v3',
     # GlobalTag for MC production (cosmics) with realistic conditions for full Phase1 2018 detector,  Strip tracker in PEAK mode
-    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v2',
+    'phase1_2018_cosmics_peak' :  '113X_upgrade2018cosmics_realistic_peak_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2021
-    'phase1_2021_design'       : '113X_mcRun3_2021_design_v2', # GT containing design conditions for Phase1 2021
+    'phase1_2021_design'       : '113X_mcRun3_2021_design_v4', # GT containing design conditions for Phase1 2021
     # GlobalTag for MC production with realistic conditions for Phase1 2021
-    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v3', # GT containing realistic conditions for Phase1 2021
+    'phase1_2021_realistic'    : '113X_mcRun3_2021_realistic_v4', # GT containing realistic conditions for Phase1 2021
     # GlobalTag for MC production (cosmics) with realistic conditions for Phase1 2021,  Strip tracker in DECO mode
-    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v4',
+    'phase1_2021_cosmics'      : '113X_mcRun3_2021cosmics_realistic_deco_v5',
     # GlobalTag for MC production with realistic conditions for Phase1 2021 detector for Heavy Ion
-    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v3',
+    'phase1_2021_realistic_hi' : '113X_mcRun3_2021_realistic_HI_v4',
     # GlobalTag for MC production with realistic conditions for Phase1 2023
-    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v3', # GT containing realistic conditions for Phase1 2023
+    'phase1_2023_realistic'    : '113X_mcRun3_2023_realistic_v4', # GT containing realistic conditions for Phase1 2023
     # GlobalTag for MC production with realistic conditions for Phase1 2024
-    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v3', # GT containing realistic conditions for Phase1 2024
+    'phase1_2024_realistic'    : '113X_mcRun3_2024_realistic_v4', # GT containing realistic conditions for Phase1 2024
     # GlobalTag for MC production with realistic conditions for Phase2
-    'phase2_realistic'         : '113X_mcRun4_realistic_v2'
+    'phase2_realistic'         : '113X_mcRun4_realistic_v3'
 }
 
 aliases = {

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -11,7 +11,7 @@ autoCond = {
     'run1_mc_pa'        :   '113X_mcRun1_pA_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
     'run2_mc_50ns'      :   '113X_mcRun2_startup_v1',
-    # GlobalTag for MC production (L1 Trigger Stage1) with starup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
+    # GlobalTag for MC production (2015 L1 Trigger Stage1) with startup-like alignment and calibrations for Run2, L1 trigger in Stage1 mode
     'run2_mc_l1stage1'  :   '113X_mcRun2_asymptotic_l1stage1_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   '113X_mcRun2_design_v2',


### PR DESCRIPTION
#### PR description:

This PR adds a fractional prescale record `L1TGlobalPrescalesVetosFract_Stage2_v2_hlt` for data GTs and `L1TGlobalPrescalesVetosFract_passThrough_mc` for MC to accommodate the new fractional L1 prescale functionality.

The GT diffs are as follows:

**Run 2 (L1 trigger stage 1)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_l1stage1_v1/113X_mcRun2_asymptotic_l1stage1_v2

**2016 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_design_v1/113X_mcRun2_design_v2

**2016 realistic pre-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_preVFP_v1/113X_mcRun2_asymptotic_preVFP_v2

**2016 realistic post-VFP era**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_asymptotic_v1/113X_mcRun2_asymptotic_v2

**2016 cosmics (asymptotic conditions)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2cosmics_asymptotic_deco_v1/113X_mcRun2cosmics_asymptotic_deco_v2

**Run 2 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_HeavyIon_v1/113X_mcRun2_HeavyIon_v2

**Run 2 proton-lead**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun2_pA_v1/113X_mcRun2_pA_v2

**Offline data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_v1/113X_dataRun2_v2

**Offline data (HEM failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_HEfail_v1/113X_dataRun2_HEfail_v2

**Offline data relval**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_relval_v1/113X_dataRun2_relval_v2

**Prompt-like HI data**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_dataRun2_PromptLike_HI_v1/113X_dataRun2_PromptLike_HI_v2

**Run 2 HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_v10/112X_dataRun2_HLT_relval_v2

**Run 2 HI HLT RelVals**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/103X_dataRun2_HLT_relval_HI_v6/112X_dataRun2_HLT_relval_HI_v1

**Run 3 data (express)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Express_v4/112X_dataRun3_Express_v1

**Run 3 data (prompt)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/111X_dataRun3_Prompt_v5/112X_dataRun3_Prompt_v1

**2017 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_design_v2/113X_mc2017_design_v3

**2017 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017_realistic_v2/113X_mc2017_realistic_v3

**2017 realistic cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_deco_v2/113X_mc2017cosmics_realistic_deco_v3

**2017 realistic cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mc2017cosmics_realistic_peak_v2/113X_mc2017cosmics_realistic_peak_v3

**2018 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_design_v2/113X_upgrade2018_design_v3

**2018 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_v2/113X_upgrade2018_realistic_v3

**2018 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HI_v2/113X_upgrade2018_realistic_HI_v3

**2018 realistic (HEM15/16 failure)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018_realistic_HEfail_v2/113X_upgrade2018_realistic_HEfail_v3

**2018 cosmics (tracker deco mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_deco_v2/113X_upgrade2018cosmics_realistic_deco_v3

**2018 cosmics (tracker peak mode)**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_upgrade2018cosmics_realistic_peak_v2/113X_upgrade2018cosmics_realistic_peak_v3

**2021 design**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_design_v2/113X_mcRun3_2021_design_v4

**2021 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_v3/113X_mcRun3_2021_realistic_v4

**2021 cosmics**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021cosmics_realistic_deco_v4/113X_mcRun3_2021cosmics_realistic_deco_v5

**2021 heavy ion**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2021_realistic_HI_v3/113X_mcRun3_2021_realistic_HI_v4

**2023 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2023_realistic_v3/113X_mcRun3_2023_realistic_v4

**2024 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun3_2024_realistic_v3/113X_mcRun3_2024_realistic_v4

**Phase 2 realistic**
https://cms-conddb.cern.ch/cmsDbBrowser/diff/Prod/gts/113X_mcRun4_realistic_v2/113X_mcRun4_realistic_v3

#### PR validation:

The tag for data was prepared by ensuring that the fractional prescale payload is consistent with that used for the old, legacy, integral prescales. See the following presentation for details: https://indico.cern.ch/event/974057/#35-integration-of-l1t-new-frac

In addition, technical tests were performed:

`addOnTests -j 8` and `runTheMatrix.py -l limited,1325.516,7.22,136.8642,10424.0,7.21,11224.0,11024.2,7.4,12024.0,7.23,159.0,12834.0 --ibeos`

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

This PR is not a backport but will be backported to 112X for use in the upcoming MWGR.