### PR TITLE
StatOverflows on PixelPhase1 DQM

### DIFF
--- a/DQM/SiPixelPhase1Common/interface/HistogramManager.h
+++ b/DQM/SiPixelPhase1Common/interface/HistogramManager.h
@@ -103,6 +103,7 @@ public:  // these are available in config as is, and may be used in harvesting.
   int range_y_nbins;
   double range_y_min;
   double range_y_max;
+  bool statsOverflows;
 
   // can be used in "custom" harvesting in online.
   edm::LuminosityBlock const* lumisection = nullptr;

--- a/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
+++ b/DQM/SiPixelPhase1Common/python/HistogramManager_cfi.py
@@ -49,6 +49,9 @@ DefaultHisto = cms.PSet(
   # Setting this to False hides all plots of this HistogramManager. It does not even record any data.
   enabled = cms.bool(True),
 
+  # If this is set to False Overflows will not be used for statistics evaluation (i.e. Mean,RMS)
+  statsOverflows = cms.bool(True),
+
   # a.k.a. online harvesting. Might be useful in offline for custom harvesting,
   # but the main purpose is online, where this is on by default.
   perLumiHarvesting = cms.bool(False),

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -589,18 +589,14 @@ void HistogramManager::executeGroupBy(SummationStep const& step,
     if (!new_histo.me) {
       auto name = makePathName(s, significantvalues, &step);
       iBooker.setCurrentFolder(name.first);
-      if (dynamic_cast<TH1F*>(th1)){
+      if (dynamic_cast<TH1F*>(th1))
         new_histo.me = iBooker.book1D(name.second, (TH1F*)th1);
-      }
-      else if (dynamic_cast<TH2F*>(th1)){
+      else if (dynamic_cast<TH2F*>(th1))
         new_histo.me = iBooker.book2D(name.second, (TH2F*)th1);
-      }
-      else if (dynamic_cast<TProfile*>(th1)){
+      else if (dynamic_cast<TProfile*>(th1))
         new_histo.me = iBooker.bookProfile(name.second, (TProfile*)th1);
-      }
-      else if (dynamic_cast<TProfile2D*>(th1)){
+      else if (dynamic_cast<TProfile2D*>(th1))
         new_histo.me = iBooker.bookProfile2D(name.second, (TProfile2D*)th1);
-      }
       else
         assert(!"No idea how to book this.");
       new_histo.th1 = new_histo.me->getTH1();

--- a/DQM/SiPixelPhase1Common/src/HistogramManager.cc
+++ b/DQM/SiPixelPhase1Common/src/HistogramManager.cc
@@ -296,7 +296,8 @@ void HistogramManager::book(DQMStore::IBooker& iBooker, edm::EventSetup const& i
     GeometryInterface::Value binwidth_y = 0;
     std::string title, xlabel, ylabel, zlabel;
     bool do_profile = false;
-    bool statsOverflows = true;;
+    bool statsOverflows = true;
+    ;
   };
   std::map<GeometryInterface::Values, MEInfo> toBeBooked;
 
@@ -344,7 +345,7 @@ void HistogramManager::book(DQMStore::IBooker& iBooker, edm::EventSetup const& i
         // create new histo
         MEInfo& mei = toBeBooked[significantvalues];
         mei.title = this->title;
-	mei.statsOverflows = this->statsOverflows;
+        mei.statsOverflows = this->statsOverflows;
         if (bookCounters)
           mei.title =
               "Number of " + mei.title + " per Event and " + geometryInterface.pretty(*(s.steps[0].columns.end() - 1));
@@ -605,7 +606,6 @@ void HistogramManager::executeGroupBy(SummationStep const& step,
       new_histo.th1->Add(th1);
     }
     new_histo.me->setStatOverflows(e.second.me->getStatOverflows());
-
   }
   t.swap(out);
 }
@@ -687,7 +687,7 @@ void HistogramManager::executeExtend(SummationStep const& step,
       } else {
         assert(!"Reduction type not supported");
       }
-      new_histo.me->setStatOverflows(e.second.me->getStatOverflows());	  
+      new_histo.me->setStatOverflows(e.second.me->getStatOverflows());
     } else {
       assert(!"2D extend not implemented in harvesting.");
     }

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -427,8 +427,9 @@ namespace dqm::impl {
     virtual void setCanExtend(unsigned int value);
     // We should decide if we support this (or make it default)
     DQM_DEPRECATED
-    virtual void setStatOverflows(bool value);
-
+    virtual void setStatOverflows(unsigned int value);
+    virtual bool getStatOverflows();
+   
     // these should be non-const, since they are potentially not thread-safe
     virtual TObject const *getRootObject() const;
     virtual TH1 *getTH1();

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -427,9 +427,9 @@ namespace dqm::impl {
     virtual void setCanExtend(unsigned int value);
     // We should decide if we support this (or make it default)
     DQM_DEPRECATED
-    virtual void setStatOverflows(unsigned int value);
+    virtual void setStatOverflows(bool value);
     virtual bool getStatOverflows();
-   
+
     // these should be non-const, since they are potentially not thread-safe
     virtual TObject const *getRootObject() const;
     virtual TH1 *getTH1();

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -912,6 +912,15 @@ namespace dqm::impl {
       access.value.object_->SetStatOverflows(TH1::kIgnore);
   }
 
+  bool MonitorElement::getStatOverflows(){
+    auto access = this->accessMut();
+    auto value=access.value.object_->GetStatOverflows();
+    if (value == TH1::kConsider)
+      return true;
+    else
+      return false;
+  }
+
   int64_t MonitorElement::getIntValue() const {
     assert(kind() == Kind::INT);
     auto access = this->access();

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -912,9 +912,9 @@ namespace dqm::impl {
       access.value.object_->SetStatOverflows(TH1::kIgnore);
   }
 
-  bool MonitorElement::getStatOverflows(){
+  bool MonitorElement::getStatOverflows() {
     auto access = this->accessMut();
-    auto value=access.value.object_->GetStatOverflows();
+    auto value = access.value.object_->GetStatOverflows();
     if (value == TH1::kConsider)
       return true;
     else


### PR DESCRIPTION
#### PR description:

After the changes introduced in #32364 there is the need to restore the correct behavior for PixelPhase1 DQM plots. With the changes proposed here this is achieve introducing a statsOverflows flag on HistogramManager class.

#### PR validation:

Tested locally with runTheMatrix, 10824 wf

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Not a Backport and not backport needed
