### PR TITLE
More BuildFiles cleaning

### DIFF
--- a/CalibPPS/ESProducers/BuildFile.xml
+++ b/CalibPPS/ESProducers/BuildFile.xml
@@ -1,9 +1,4 @@
-  <use name="FWCore/Framework"/>
-  <use name="Utilities/Xerces"/>
-  <use name="CondFormats/DataRecord"/>
   <use name="CondFormats/PPSObjects"/>
-  <use name="DataFormats/CTPPSDetId"/>
-  <use name="CondFormats/RunInfo"/>
   <use name="clhep"/>
 <export>
   <lib name="1"/>

--- a/CalibTracker/SiPixelESProducers/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="cuda"/>
-<use name="CalibTracker/Records"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/SiPixelObjects"/>
 <use name="DataFormats/Common"/>
@@ -8,8 +7,6 @@
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/ParameterSet"/>
 <use name="HeterogeneousCore/CUDACore"/>
-<use name="MagneticField/VolumeBasedEngine"/>
-<use name="RecoTracker/Record"/>
 <export>
   <lib name="1"/>
 </export>

--- a/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/plugins/BuildFile.xml
@@ -8,8 +8,8 @@
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="HeterogeneousCore/CUDACore"/>
 <use name="MagneticField/Engine"/>
+<use name="RecoTracker/Record"/>
 <library file="*.cc" name="CalibTrackerSiPixelESProducersPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/CalibTracker/SiPixelESProducers/test/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/test/BuildFile.xml
@@ -1,10 +1,8 @@
 <use name="root"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/PluginManager"/>
-<use name="FWCore/ParameterSet"/>
 <use name="Geometry/Records"/>
 <use name="Geometry/TrackerGeometryBuilder"/>
-<use name="CondFormats/SiPixelObjects"/>
 <use name="CalibTracker/SiPixelESProducers"/>
 <use name="CalibTracker/Records"/>
 <library file="*.cc" name="testCalibTrackerSiPixelESProducers">

--- a/CalibTracker/SiPixelTools/BuildFile.xml
+++ b/CalibTracker/SiPixelTools/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="FWCore/Framework"/>
-<use name="FWCore/ParameterSet"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/SiPixelDigi"/>
 <use name="CondFormats/DataRecord"/>

--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -14,7 +14,6 @@
 <use name="CondFormats/DTObjects"/>
 <use name="CondFormats/ESObjects"/>
 <use name="CondFormats/EcalObjects"/>
-<use name="CondFormats/EgammaObjects"/>
 <use name="CondFormats/GBRForest"/>
 <use name="CondFormats/Luminosity"/>
 <use name="CondFormats/HcalObjects"/>

--- a/DQM/DataScouting/BuildFile.xml
+++ b/DQM/DataScouting/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="DataFormats/Math"/>
-<use name="DataFormats/Candidate"/>
 <use name="DQMServices/Core"/>
 <export>
   <use name="FWCore/Framework"/>

--- a/RecoHGCal/TICL/BuildFile.xml
+++ b/RecoHGCal/TICL/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DataFormats/HGCalReco"/>
 <use name="DataFormats/VertexReco"/>
 <use name="FWCore/PluginManager"/>
-<use name="RecoParticleFlow/PFProducer"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoHGCal/TICL/plugins/BuildFile.xml
+++ b/RecoHGCal/TICL/plugins/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="TrackingTools/Records"/>
 <use name="PhysicsTools/TensorFlow"/>
 <use name="RecoHGCal/TICL"/>
+<use name="RecoParticleFlow/PFProducer"/>
 <library file="*.cc" name="RecoHGCalTICLPlugins">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
+++ b/RecoMuon/L2MuonSeedGenerator/plugins/BuildFile.xml
@@ -8,7 +8,6 @@
     <use name="FWCore/Framework"/>
     <use name="FWCore/MessageLogger"/>
     <use name="FWCore/ParameterSet"/>
-    <use name="FWCore/PluginManager"/>
     <use name="Geometry/CommonDetUnit"/>
     <use name="RecoMuon/TrackingTools"/>
     <use name="TrackingTools/DetLayers"/>


### PR DESCRIPTION
#### PR description:

Another quick BuildFile cleaning PR in the style of many before (for example https://github.com/cms-sw/cmssw/pull/32714).

As always, only the dependencies which are **not included in any of the sources** are removed, so these changes are orthogonal and complementary to the recent PRs which added all packages that are **actually included**.

I also made sure that all of the removed library dependencies that are actually a dependency of the corresponding plugins were transferred to `plugins/BuildFile.xml`.

#### PR validation:

CMSSW compiles. It was checked that all newly added dependencies are actually required by the package with `git grep`.