### PR TITLE
XrdAdaptor: Fix race condition leading to a crash when doing Prepare …

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -68,14 +68,15 @@ public:
     XrdCl::FileSystem fs(url);
     std::vector<std::string> fileList;
     fileList.push_back(url.GetPath());
-    XrdCl::Buffer *buffer = nullptr;
-    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, buffer);
+    XrdCl::Buffer *raw_buffer = nullptr;
+    auto status = fs.Prepare(fileList, XrdCl::PrepareFlags::Stage, 0, raw_buffer);
+    std::unique_ptr<XrdCl::Buffer> smart_buffer(raw_buffer);
+    raw_buffer = nullptr;
+
     if (!status.IsOK()) {
       edm::LogWarning("StageInError") << "XrdCl::FileSystem::Prepare failed with error '" << status.ToStr()
                                       << "' (errNo = " << status.errNo << ")";
     }
-
-    delete buffer;
   }
 
   bool check(const std::string &proto,


### PR DESCRIPTION
#### PR description:

This pull request fixes a crash in the XrdAdaptor class where the async Prepare request can lead to a SEGV if the corresponding XrdCl::FileSystem is destroyed before the response is processed. This can be easily reproduced in every version of the CMSSW.

This race condition is triggered when the response to the Prepare request is slow and the memory occupied by the file XrdCl::FileSystem object is reused leading to a crash when the XrdCl::FileSystem destructor is called. The XrdCl::FileSystem goes out of scope in the `stagein` method and it is therefore destroyed, but the Prepare response still needs a valid XrdCl::FileSystem object.

An example of a fully reproducible crash:

```
[esindril@lxplus790 CMSSW_11_2_0]> cmsRun miniaodsim_9xx_1.py 

Thu Jan 28 09:50:02 CET 2021
Thread 7 (Thread 0x7f93ef40b700 (LWP 14128)):
#0  0x00007f941e4deb3b in do_futex_wait.constprop () from /usr/lib64/libpthread.so.0
#1  0x00007f941e4debcf in __new_sem_wait_slow.constprop.0 () from /usr/lib64/libpthread.so.0
#2  0x00007f941e4dec6b in sem_wait@@GLIBC_2.2.5 () from /usr/lib64/libpthread.so.0
#3  0x00007f9415ffd816 in XrdCl::JobManager::RunJobs() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#4  0x00007f9415ffd8c9 in RunRunnerThread () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#5  0x00007f941e4d8ea5 in start_thread () from /usr/lib64/libpthread.so.0
#6  0x00007f941e20096d in clone () from /usr/lib64/libc.so.6
Thread 6 (Thread 0x7f93efc0c700 (LWP 14127)):
#0  0x00007f941e1f5c3d in poll () from /usr/lib64/libc.so.6
#1  0x00007f9415b32007 in full_read.constprop () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#2  0x00007f9415b3271c in edm::service::InitRootHandlers::stacktraceFromThread() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#3  0x00007f9415b33444 in sig_dostack_then_abort () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/lib/slc7_amd64_gcc900/pluginFWCoreServicesPlugins.so
#4  <signal handler called>
#5  0x00007f941e138387 in raise () from /usr/lib64/libc.so.6
#6  0x00007f941e139a78 in abort () from /usr/lib64/libc.so.6
#7  0x00007f941eaa4683 in __gnu_cxx::__verbose_terminate_handler () at ../../../../libstdc++-v3/libsupc++/vterminate.cc:95
#8  0x00007f941eab00a6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:48
#9  0x00007f941eab0111 in std::terminate () at ../../../../libstdc++-v3/libsupc++/eh_terminate.cc:58
#10 0x00007f941eab0365 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7f941ebd4f00 <typeinfo for std::bad_alloc>, dest=0x7f941eaae830 <std::bad_alloc::~bad_alloc()>) at ../../../../libstdc++-v3/libsupc++/eh_throw.cc:95
#11 0x00007f941eaa6b69 in std::__throw_bad_alloc () at /data/cmsbld/jenkins/workspace/auto-builds/CMSSW_11_1_0_pre6-slc7_amd64_gcc900/build/CMSSW_11_1_0_pre6-build/BUILD/slc7_amd64_gcc900/external/gcc/9.3.0/gcc-9.3.0/obj/x86_64-unknown-linux-gnu/libstdc++-v3/include/bits/exception.
h:63
#12 0x00007f941f799e2e in handleOOM (size=216172799293652993, nothrow=<optimized out>) at src/jemalloc_cpp.cpp:70
#13 0x00007f9415fa0e3f in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) [clone .constprop.0] () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_
gcc900/lib/libXrdCl.so.2
#14 0x00007f9415fa7deb in XrdCl::FileSystem::AssignLoadBalancer(XrdCl::URL const&) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#15 0x00007f9415fad7ce in XrdCl::AssignLBHandler::HandleResponseWithHosts(XrdCl::XRootDStatus*, XrdCl::AnyObject*, std::vector<XrdCl::HostInfo, std::allocator<XrdCl::HostInfo> >*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/lib
XrdCl.so.2
#16 0x00007f9415fb26f9 in XrdCl::XRootDMsgHandler::HandleResponse() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#17 0x00007f9415fb6b6f in XrdCl::XRootDMsgHandler::Process(XrdCl::Message*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#18 0x00007f9415f9549a in XrdCl::Stream::HandleIncMsgJob::Run(void*) () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#19 0x00007f9415ffd86d in XrdCl::JobManager::RunJobs() () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#20 0x00007f9415ffd8c9 in RunRunnerThread () from /cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0/external/slc7_amd64_gcc900/lib/libXrdCl.so.2
#21 0x00007f941e4d8ea5 in start_thread () from /usr/lib64/libpthread.so.0
#22 0x00007f941e20096d in clone () from /usr/lib64/libc.so.6
Thread 5 (Thread 0x7f93f040d700 (LWP 14126)):
```

Also the crash is easier to reproduce if the Prepare request needs to be redirected to a different server as it is the case in EOS or if the Prepare response is slow.

Given the fact that one needs to wait for the prepare response in the `stagein` part of the code there is absolutely no reason to use the async Prepare interface from XrdCl - so I've modified it to use the synchronous Prepare call.

#### PR validation:

A simple rerun of the test confirms that the fix is working properly.